### PR TITLE
Fix bug in Benchmark data generation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/TupleInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/TupleInfo.java
@@ -153,12 +153,12 @@ public class TupleInfo
         this(asList(types));
     }
 
-    public TupleInfo(List<Type> types)
+    public TupleInfo(Iterable<Type> typeIterable)
     {
-        checkNotNull(types, "types is null");
+        checkNotNull(typeIterable, "typeIterable is null");
 //        Preconditions.checkArgument(!types.isEmpty(), "types is empty");
 
-        this.types = ImmutableList.copyOf(types);
+        this.types = ImmutableList.copyOf(typeIterable);
 
         int[] offsets = new int[types.size() + 1];
 


### PR DESCRIPTION
Summary:
So I finally tracked down why so many of our benchmarks seemed to have taken such a huge performance hit.
It turns out there is was a bug in the data import code that caused the wrong column to be used which had
different performance characteristic. This change returns it back to the correct and previous behavior.
Local tests have shown that this is was the cause of the seeming perf degredation in our benchmark suite.
