### PR TITLE
Add support for selecting with qualified wildcard from anonymous columns

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/compiler/NamedSlot.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/compiler/NamedSlot.java
@@ -9,21 +9,29 @@ import javax.annotation.Nullable;
 
 public class NamedSlot
 {
-    private final Optional<QualifiedName> name;
+    private final Optional<QualifiedName> prefix;
+    private final Optional<String> attribute;
     private final Slot slot;
 
-    public NamedSlot(Optional<QualifiedName> name, Slot slot)
+    public NamedSlot(Optional<QualifiedName> prefix, Optional<String> attribute, Slot slot)
     {
-        Preconditions.checkNotNull(name, "name is null");
+        Preconditions.checkNotNull(prefix, "prefix is null");
+        Preconditions.checkNotNull(attribute, "attribute is null");
         Preconditions.checkNotNull(slot, "slot is null");
 
-        this.name = name;
+        this.prefix = prefix;
+        this.attribute = attribute;
         this.slot = slot;
     }
 
-    public Optional<QualifiedName> getName()
+    public Optional<QualifiedName> getPrefix()
     {
-        return name;
+        return prefix;
+    }
+
+    public Optional<String> getAttribute()
+    {
+        return attribute;
     }
 
     public Slot getSlot()
@@ -33,9 +41,9 @@ public class NamedSlot
 
     public String toString()
     {
-        return String.format("%s:%s", name.or(QualifiedName.of("<anonymous>")), slot.getType());
+        return String.format("%s.%s:%s", prefix, attribute.or("<anonymous>"), slot.getType());
     }
-    
+
     public static Function<NamedSlot, QualifiedName> nameGetter()
     {
         return new Function<NamedSlot, QualifiedName>()
@@ -43,21 +51,20 @@ public class NamedSlot
             @Override
             public QualifiedName apply(NamedSlot input)
             {
-                return input.getName().get();
+                return QualifiedName.of(input.getPrefix().get(), input.getAttribute().get());
             }
         };
     }
 
-    public static Function<NamedSlot, Optional<QualifiedName>> optionalNameGetter()
+    public static Function<NamedSlot, Optional<String>> attributeGetter()
     {
-        return new Function<NamedSlot, Optional<QualifiedName>>()
+        return new Function<NamedSlot, Optional<String>>()
         {
             @Override
-            public Optional<QualifiedName> apply(NamedSlot input)
+            public Optional<String> apply(NamedSlot input)
             {
-                return input.getName();
+               return input.getAttribute();
             }
         };
     }
-
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Planner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Planner.java
@@ -55,9 +55,11 @@ public class Planner
     {
         PlanNode result = createQueryPlan(query, analysis);
 
+        int i = 0;
         ImmutableList.Builder<String> names = ImmutableList.builder();
-        for (Optional<QualifiedName> name : analysis.getOutputDescriptor().getNames()) {
-            names.add(name.or(QualifiedName.of("col")).getSuffix());
+        for (Optional<String> name : analysis.getOutputDescriptor().getAttributes()) {
+            names.add(name.or("_col" + i));
+            i++;
         }
 
         return new OutputPlan(result, names.build());
@@ -203,9 +205,10 @@ public class Planner
 
         for (NamedSlot namedSlot : slots) {
             Slot slot = namedSlot.getSlot();
-            QualifiedName name = namedSlot.getName().get();
+            QualifiedName tableName = namedSlot.getPrefix().get();
+            String attribute = namedSlot.getAttribute().get();
 
-            ColumnScan scan = new ColumnScan(name.getParts().get(0), name.getParts().get(1), name.getParts().get(2), name.getParts().get(3), slot);
+            ColumnScan scan = new ColumnScan(tableName.getParts().get(0), tableName.getParts().get(1), tableName.getParts().get(2), attribute, slot);
             sources.add(scan);
             outputs.add(slot);
         }

--- a/presto-main/src/test/java/com/facebook/presto/TestQueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/TestQueries.java
@@ -275,6 +275,16 @@ public class TestQueries
     }
 
     @Test
+    public void testQualifiedWildcardFromInlineView()
+            throws Exception
+    {
+        List<Tuple> expected = computeExpected("SELECT T.* FROM (SELECT orderkey + custkey FROM ORDERS) T", FIXED_INT_64);
+        List<Tuple> actual = computeActual("SELECT T.* FROM (SELECT orderkey + custkey FROM ORDERS) T");
+
+        assertEqualsIgnoreOrder(actual, expected);
+    }
+
+    @Test
     public void testQualifiedWildcard()
     {
         List<Tuple> expected = computeExpected("SELECT orderkey, custkey, totalprice, orderdate, orderstatus, orderpriority, clerk, shippriority, comment FROM ORDERS",


### PR DESCRIPTION
Queries of this form are now resolved correctly:

``` sql
SELECT T.*
FROM (
    SELECT a + b
    FROM U
) T
```

Note that the expression "a + b" doesn't have an alias
