### PR TITLE
Migrate Tpch test data system to be compliant with Metadata and DataStreamProvider

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/LegacyStorageManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/LegacyStorageManager.java
@@ -1,8 +1,10 @@
 package com.facebook.presto.metadata;
 
-import com.facebook.presto.block.BlockIterable;
+import com.facebook.presto.operator.Operator;
+
+import java.util.List;
 
 public interface LegacyStorageManager
 {
-    BlockIterable getBlocks(String databaseName, String tableName, int fieldIndex);
+    Operator getOperator(String databaseName, String tableName, List<Integer> fieldIndexes);
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/StaticQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StaticQueryManager.java
@@ -81,7 +81,6 @@ public class StaticQueryManager
     private final ImportClientFactory importClientFactory;
     private final ImportManager importManager;
     private final Metadata metadata;
-    private final LegacyStorageManager storageManager;
     private final DataStreamProvider dataStreamProvider;
     private final SplitManager splitManager;
     private final JsonCodec<QueryFragmentRequest> queryFragmentRequestJsonCodec;
@@ -98,12 +97,11 @@ public class StaticQueryManager
             ImportClientFactory importClientFactory,
             ImportManager importManager,
             Metadata metadata,
-            LegacyStorageManager storageManager,
             DataStreamProvider dataStreamProvider,
             SplitManager splitManager,
             JsonCodec<QueryFragmentRequest> queryFragmentRequestJsonCodec)
     {
-        this(20, importClientFactory, importManager, metadata, storageManager, dataStreamProvider, splitManager, queryFragmentRequestJsonCodec);
+        this(20, importClientFactory, importManager, metadata, dataStreamProvider, splitManager, queryFragmentRequestJsonCodec);
     }
 
     public StaticQueryManager(
@@ -111,7 +109,6 @@ public class StaticQueryManager
             ImportClientFactory importClientFactory,
             ImportManager importManager,
             Metadata metadata,
-            LegacyStorageManager storageManager,
             DataStreamProvider dataStreamProvider,
             SplitManager splitManager,
             JsonCodec<QueryFragmentRequest> queryFragmentRequestJsonCodec)
@@ -123,7 +120,6 @@ public class StaticQueryManager
         this.importClientFactory = importClientFactory;
         this.importManager = importManager;
         this.metadata = metadata;
-        this.storageManager = storageManager;
         this.dataStreamProvider = dataStreamProvider;
         this.splitManager = splitManager;
         this.queryFragmentRequestJsonCodec = queryFragmentRequestJsonCodec;
@@ -155,7 +151,6 @@ public class StaticQueryManager
                     }
                 }));
                 queryTask = new ImportDelimited(queryState,
-                        storageManager,
                         strings.get(1),
                         strings.get(2),
                         new TupleInfo(types),
@@ -467,14 +462,12 @@ public class StaticQueryManager
         private static final ImmutableList<TupleInfo> TUPLE_INFOS = ImmutableList.of(SINGLE_LONG);
 
         private final QueryState queryState;
-        private final LegacyStorageManager storageManager;
         private final String databaseName;
         private final String tableName;
         private final RecordProjectOperator source;
 
         public ImportDelimited(
                 QueryState queryState,
-                LegacyStorageManager storageManager,
                 String databaseName,
                 String tableName,
                 TupleInfo tupleInfo,
@@ -482,7 +475,6 @@ public class StaticQueryManager
                 Splitter splitter)
         {
             this.queryState = queryState;
-            this.storageManager = storageManager;
             this.databaseName = databaseName;
             this.tableName = tableName;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/compiler/SessionMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/compiler/SessionMetadata.java
@@ -18,10 +18,25 @@ public class SessionMetadata
     public static final String DEFAULT_SCHEMA = "default";
 
     private final Metadata metadata;
+    private String currentCatalog;
+    private String currentSchema;
+
+    public SessionMetadata(Metadata metadata, String currentCatalog, String currentSchema)
+    {
+        this.metadata = checkNotNull(metadata, "metadata is null");
+        this.currentCatalog = checkNotNull(currentCatalog, "currentCatalog is null");
+        this.currentSchema = checkNotNull(currentSchema, "currentSchema is null");
+    }
 
     public SessionMetadata(Metadata metadata)
     {
-        this.metadata = checkNotNull(metadata, "metadata is null");
+        this(metadata, DEFAULT_CATALOG, DEFAULT_SCHEMA);
+    }
+
+    public void using(String catalogName, String schemaName)
+    {
+        currentCatalog = catalogName;
+        currentSchema = schemaName;
     }
 
     public FunctionInfo getFunction(QualifiedName name, List<Type> parameterTypes)
@@ -35,20 +50,20 @@ public class SessionMetadata
 
         List<String> parts = Lists.reverse(name.getParts());
         String tableName = parts.get(0);
-        String schemaName = (parts.size() > 1) ? parts.get(1) : DEFAULT_SCHEMA;
-        String catalogName = (parts.size() > 2) ? parts.get(2) : DEFAULT_CATALOG;
+        String schemaName = (parts.size() > 1) ? parts.get(1) : currentSchema;
+        String catalogName = (parts.size() > 2) ? parts.get(2) : currentCatalog;
 
         TableMetadata table = metadata.getTable(catalogName, schemaName, tableName);
         checkArgument(table != null, "Table '%s.%s.%s' not defined", catalogName, schemaName, tableName);
         return table;
     }
 
-    private static QualifiedName qualifiedTableName(TableMetadata table)
+    private QualifiedName qualifiedTableName(TableMetadata table)
     {
-        if (!table.getCatalogName().equals(DEFAULT_CATALOG)) {
+        if (!table.getCatalogName().equals(currentCatalog)) {
             return QualifiedName.of(table.getCatalogName(), table.getSchemaName(), table.getTableName());
         }
-        if (!table.getSchemaName().equals(DEFAULT_SCHEMA)) {
+        if (!table.getSchemaName().equals(currentSchema)) {
             return QualifiedName.of(table.getSchemaName(), table.getTableName());
         }
         return QualifiedName.of(table.getTableName());

--- a/presto-main/src/test/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
@@ -26,17 +26,9 @@ public abstract class AbstractOperatorBenchmark
 {
     private static final TpchDataProvider TPCH_DATA_PROVIDER = new CachingTpchDataProvider(new GeneratingTpchDataProvider());
 
-    private final TpchDataProvider tpchDataProvider;
-
-    protected AbstractOperatorBenchmark(String benchmarkName, int warmupIterations, int measuredIterations, TpchDataProvider tpchDataProvider)
-    {
-        super(benchmarkName, warmupIterations, measuredIterations);
-        this.tpchDataProvider = tpchDataProvider;
-    }
-
     protected AbstractOperatorBenchmark(String benchmarkName, int warmupIterations, int measuredIterations)
     {
-        this(benchmarkName, warmupIterations, measuredIterations, TPCH_DATA_PROVIDER);
+        super(benchmarkName, warmupIterations, measuredIterations);
     }
 
     @Override
@@ -45,14 +37,14 @@ public abstract class AbstractOperatorBenchmark
         return "input_rows_per_second";
     }
 
-    protected abstract Operator createBenchmarkedOperator(TpchBlocksProvider inputStreamProvider);
+    protected abstract Operator createBenchmarkedOperator(TpchBlocksProvider blocksProvider);
 
     @Override
     protected Map<String, Long> runOnce()
     {
         long start = System.nanoTime();
 
-        StatsTpchBlocksProvider statsTpchBlocksProvider = new StatsTpchBlocksProvider(tpchDataProvider);
+        StatsTpchBlocksProvider statsTpchBlocksProvider = new StatsTpchBlocksProvider(TPCH_DATA_PROVIDER);
         MetricRecordingTpchBlocksProvider metricRecordingTpchBlocksProvider = new MetricRecordingTpchBlocksProvider(statsTpchBlocksProvider);
 
         Operator operator = createBenchmarkedOperator(metricRecordingTpchBlocksProvider);

--- a/presto-main/src/test/java/com/facebook/presto/benchmark/AbstractSqlBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/benchmark/AbstractSqlBenchmark.java
@@ -1,13 +1,7 @@
 package com.facebook.presto.benchmark;
 
-import com.facebook.presto.block.BlockIterable;
-import com.facebook.presto.metadata.ColumnMetadata;
 import com.facebook.presto.metadata.LegacyStorageManager;
-import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.metadata.TableMetadata;
-import com.facebook.presto.metadata.TestingMetadata;
 import com.facebook.presto.operator.Operator;
-import com.facebook.presto.serde.BlocksFileEncoding;
 import com.facebook.presto.sql.compiler.AnalysisResult;
 import com.facebook.presto.sql.compiler.Analyzer;
 import com.facebook.presto.sql.compiler.SessionMetadata;
@@ -19,15 +13,12 @@ import com.facebook.presto.sql.planner.Planner;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.tpch.TpchBlocksProvider;
+import com.facebook.presto.tpch.TpchDataStreamProvider;
+import com.facebook.presto.tpch.TpchLegacyStorageManagerAdapter;
 import com.facebook.presto.tpch.TpchSchema;
-import com.facebook.presto.tuple.TupleInfo;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import org.antlr.runtime.RecognitionException;
 import org.intellij.lang.annotations.Language;
-
-import java.util.List;
 
 public abstract class AbstractSqlBenchmark
         extends AbstractOperatorBenchmark
@@ -39,46 +30,11 @@ public abstract class AbstractSqlBenchmark
     {
         super(benchmarkName, warmupIterations, measuredIterations);
 
-        Metadata metadata = new TestingMetadata();
-        List<TableMetadata> tables = ImmutableList.of(
-                new TableMetadata(SessionMetadata.DEFAULT_CATALOG, SessionMetadata.DEFAULT_SCHEMA, "ORDERS",
-                        ImmutableList.of(
-                                new ColumnMetadata("orderkey", TupleInfo.Type.FIXED_INT_64),
-                                new ColumnMetadata("custkey", TupleInfo.Type.FIXED_INT_64),
-                                new ColumnMetadata("orderstatus", TupleInfo.Type.VARIABLE_BINARY),
-                                new ColumnMetadata("totalprice", TupleInfo.Type.DOUBLE),
-                                new ColumnMetadata("orderdate", TupleInfo.Type.VARIABLE_BINARY),
-                                new ColumnMetadata("orderpriority", TupleInfo.Type.VARIABLE_BINARY),
-                                new ColumnMetadata("clerk", TupleInfo.Type.VARIABLE_BINARY),
-                                new ColumnMetadata("shippriority", TupleInfo.Type.VARIABLE_BINARY),
-                                new ColumnMetadata("comment", TupleInfo.Type.VARIABLE_BINARY))),
-                new TableMetadata(SessionMetadata.DEFAULT_CATALOG, SessionMetadata.DEFAULT_SCHEMA, "LINEITEM",
-                        ImmutableList.of(
-                                new ColumnMetadata("orderkey", TupleInfo.Type.FIXED_INT_64),
-                                new ColumnMetadata("partkey", TupleInfo.Type.FIXED_INT_64),
-                                new ColumnMetadata("suppkey", TupleInfo.Type.FIXED_INT_64),
-                                new ColumnMetadata("linenumber", TupleInfo.Type.FIXED_INT_64),
-                                new ColumnMetadata("quantity", TupleInfo.Type.FIXED_INT_64),
-                                new ColumnMetadata("extendedprice", TupleInfo.Type.DOUBLE),
-                                new ColumnMetadata("discount", TupleInfo.Type.DOUBLE),
-                                new ColumnMetadata("tax", TupleInfo.Type.DOUBLE),
-                                new ColumnMetadata("returnflag", TupleInfo.Type.VARIABLE_BINARY),
-                                new ColumnMetadata("linestatus", TupleInfo.Type.VARIABLE_BINARY),
-                                new ColumnMetadata("shipdate", TupleInfo.Type.VARIABLE_BINARY),
-                                new ColumnMetadata("commitdate", TupleInfo.Type.VARIABLE_BINARY),
-                                new ColumnMetadata("receiptdate", TupleInfo.Type.VARIABLE_BINARY),
-                                new ColumnMetadata("shipinstruct", TupleInfo.Type.VARIABLE_BINARY),
-                                new ColumnMetadata("shipmode", TupleInfo.Type.VARIABLE_BINARY),
-                                new ColumnMetadata("comment", TupleInfo.Type.VARIABLE_BINARY))));
-
-        for (TableMetadata table : tables) {
-            metadata.createTable(table);
-        }
-
         try {
             Statement statement = SqlParser.createStatement(query);
 
-            sessionMetadata = new SessionMetadata(metadata);
+            sessionMetadata = new SessionMetadata(TpchSchema.createMetadata());
+            sessionMetadata.using(TpchSchema.CATALOG_NAME, TpchSchema.SCHEMA_NAME);
             AnalysisResult analysis = new Analyzer(sessionMetadata).analyze(statement);
             plan = new Planner().plan((Query) statement, analysis);
 
@@ -92,35 +48,7 @@ public abstract class AbstractSqlBenchmark
     @Override
     protected Operator createBenchmarkedOperator(final TpchBlocksProvider provider)
     {
-        LegacyStorageManager storage = new LegacyStorageManager()
-        {
-            @Override
-            public BlockIterable getBlocks(String databaseName, String tableName, int fieldIndex)
-            {
-                Preconditions.checkArgument(SessionMetadata.DEFAULT_CATALOG.equals(databaseName), "Unknown database: %s", databaseName);
-
-                TpchSchema.Column[] columns;
-                switch (tableName) {
-                    case "orders":
-                        columns = TpchSchema.Orders.values();
-                        break;
-                    case "lineitem":
-                        columns = TpchSchema.LineItem.values();
-                        break;
-                    default:
-                        throw new IllegalArgumentException("Unknown table: " + tableName);
-                }
-
-                for (TpchSchema.Column column : columns) {
-                    if (column.getIndex() == fieldIndex) {
-                        return provider.getBlocks(column, BlocksFileEncoding.RAW);
-                    }
-                }
-
-                throw new IllegalArgumentException("Unknown field index: " + fieldIndex);
-            }
-        };
-
+        LegacyStorageManager storage = new TpchLegacyStorageManagerAdapter(new TpchDataStreamProvider(provider));
         ExecutionPlanner executionPlanner = new ExecutionPlanner(sessionMetadata, storage);
         return executionPlanner.plan(plan);
     }

--- a/presto-main/src/test/java/com/facebook/presto/benchmark/CountAggregationBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/benchmark/CountAggregationBenchmark.java
@@ -6,13 +6,16 @@ import com.facebook.presto.operator.AlignmentOperator;
 import com.facebook.presto.operator.Operator;
 import com.facebook.presto.serde.BlocksFileEncoding;
 import com.facebook.presto.tpch.TpchBlocksProvider;
-import com.facebook.presto.tpch.TpchSchema.Orders;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
 import com.facebook.presto.tuple.TupleInfo.Type;
 import com.google.common.collect.ImmutableList;
 
 import static com.facebook.presto.operator.ProjectionFunctions.singleColumn;
 import static com.facebook.presto.operator.aggregation.AggregationFunctions.singleNodeAggregation;
 import static com.facebook.presto.operator.aggregation.CountAggregation.countAggregation;
+import static com.facebook.presto.tpch.TpchSchema.columnHandle;
+import static com.facebook.presto.tpch.TpchSchema.tableHandle;
 
 public class CountAggregationBenchmark
         extends AbstractOperatorBenchmark
@@ -23,10 +26,12 @@ public class CountAggregationBenchmark
     }
 
     @Override
-    protected Operator createBenchmarkedOperator(TpchBlocksProvider inputStreamProvider)
+    protected Operator createBenchmarkedOperator(TpchBlocksProvider blocksProvider)
     {
-        BlockIterable orderKey = inputStreamProvider.getBlocks(Orders.ORDERKEY, BlocksFileEncoding.RAW);
-        AlignmentOperator alignmentOperator = new AlignmentOperator(orderKey);
+        TpchTableHandle orders = tableHandle("orders");
+        TpchColumnHandle orderkey = columnHandle(orders, "orderkey");
+        BlockIterable blockIterable = blocksProvider.getBlocks(orders, orderkey, BlocksFileEncoding.RAW);
+        AlignmentOperator alignmentOperator = new AlignmentOperator(blockIterable);
         return new AggregationOperator(alignmentOperator, ImmutableList.of(singleNodeAggregation(countAggregation(0, 0))), ImmutableList.of(singleColumn(Type.FIXED_INT_64, 0, 0)));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/benchmark/DoubleSumAggregationBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/benchmark/DoubleSumAggregationBenchmark.java
@@ -6,13 +6,16 @@ import com.facebook.presto.operator.AlignmentOperator;
 import com.facebook.presto.operator.Operator;
 import com.facebook.presto.serde.BlocksFileEncoding;
 import com.facebook.presto.tpch.TpchBlocksProvider;
-import com.facebook.presto.tpch.TpchSchema.Orders;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
 import com.facebook.presto.tuple.TupleInfo.Type;
 import com.google.common.collect.ImmutableList;
 
 import static com.facebook.presto.operator.ProjectionFunctions.singleColumn;
 import static com.facebook.presto.operator.aggregation.AggregationFunctions.singleNodeAggregation;
 import static com.facebook.presto.operator.aggregation.DoubleSumAggregation.doubleSumAggregation;
+import static com.facebook.presto.tpch.TpchSchema.columnHandle;
+import static com.facebook.presto.tpch.TpchSchema.tableHandle;
 
 public class DoubleSumAggregationBenchmark
         extends AbstractOperatorBenchmark
@@ -23,10 +26,12 @@ public class DoubleSumAggregationBenchmark
     }
 
     @Override
-    protected Operator createBenchmarkedOperator(TpchBlocksProvider inputStreamProvider)
+    protected Operator createBenchmarkedOperator(TpchBlocksProvider blocksProvider)
     {
-        BlockIterable totalPrice = inputStreamProvider.getBlocks(Orders.TOTALPRICE, BlocksFileEncoding.RAW);
-        AlignmentOperator alignmentOperator = new AlignmentOperator(totalPrice);
+        TpchTableHandle orders = tableHandle("orders");
+        TpchColumnHandle totalprice = columnHandle(orders, "totalprice");
+        BlockIterable blockIterable = blocksProvider.getBlocks(orders, totalprice, BlocksFileEncoding.RAW);
+        AlignmentOperator alignmentOperator = new AlignmentOperator(blockIterable);
         return new AggregationOperator(alignmentOperator,
                 ImmutableList.of(singleNodeAggregation(doubleSumAggregation(0, 0))),
                 ImmutableList.of(singleColumn(Type.DOUBLE, 0, 0)));

--- a/presto-main/src/test/java/com/facebook/presto/benchmark/PredicateFilterBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/benchmark/PredicateFilterBenchmark.java
@@ -7,11 +7,14 @@ import com.facebook.presto.operator.FilterFunction;
 import com.facebook.presto.operator.Operator;
 import com.facebook.presto.serde.BlocksFileEncoding;
 import com.facebook.presto.tpch.TpchBlocksProvider;
-import com.facebook.presto.tpch.TpchSchema.Orders;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
 import com.facebook.presto.tuple.TupleInfo.Type;
 import com.facebook.presto.tuple.TupleReadable;
 
 import static com.facebook.presto.operator.ProjectionFunctions.singleColumn;
+import static com.facebook.presto.tpch.TpchSchema.columnHandle;
+import static com.facebook.presto.tpch.TpchSchema.tableHandle;
 
 public class PredicateFilterBenchmark
         extends AbstractOperatorBenchmark
@@ -22,10 +25,12 @@ public class PredicateFilterBenchmark
     }
 
     @Override
-    protected Operator createBenchmarkedOperator(TpchBlocksProvider inputStreamProvider)
+    protected Operator createBenchmarkedOperator(TpchBlocksProvider blocksProvider)
     {
-        BlockIterable totalPrice = inputStreamProvider.getBlocks(Orders.TOTALPRICE, BlocksFileEncoding.RAW);
-        AlignmentOperator alignmentOperator = new AlignmentOperator(totalPrice);
+        TpchTableHandle orders = tableHandle("orders");
+        TpchColumnHandle totalprice = columnHandle(orders, "totalprice");
+        BlockIterable blockIterable = blocksProvider.getBlocks(orders, totalprice, BlocksFileEncoding.RAW);
+        AlignmentOperator alignmentOperator = new AlignmentOperator(blockIterable);
         return new FilterAndProjectOperator(alignmentOperator, new DoubleFilter(50000.00), singleColumn(Type.DOUBLE, 0, 0) );
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/benchmark/RawStreamingBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/benchmark/RawStreamingBenchmark.java
@@ -4,8 +4,12 @@ import com.facebook.presto.block.BlockIterable;
 import com.facebook.presto.operator.AlignmentOperator;
 import com.facebook.presto.operator.Operator;
 import com.facebook.presto.serde.BlocksFileEncoding;
-import com.facebook.presto.tpch.TpchSchema.Orders;
 import com.facebook.presto.tpch.TpchBlocksProvider;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
+
+import static com.facebook.presto.tpch.TpchSchema.columnHandle;
+import static com.facebook.presto.tpch.TpchSchema.tableHandle;
 
 public class RawStreamingBenchmark
         extends AbstractOperatorBenchmark
@@ -16,10 +20,12 @@ public class RawStreamingBenchmark
     }
 
     @Override
-    protected Operator createBenchmarkedOperator(TpchBlocksProvider inputStreamProvider)
+    protected Operator createBenchmarkedOperator(TpchBlocksProvider blocksProvider)
     {
-        BlockIterable totalPrice = inputStreamProvider.getBlocks(Orders.TOTALPRICE, BlocksFileEncoding.RAW);
-        return new AlignmentOperator(totalPrice);
+        TpchTableHandle orders = tableHandle("orders");
+        TpchColumnHandle totalprice = columnHandle(orders, "totalprice");
+        BlockIterable blockIterable = blocksProvider.getBlocks(orders, totalprice, BlocksFileEncoding.RAW);
+        return new AlignmentOperator(blockIterable);
     }
 
     public static void main(String[] args)

--- a/presto-main/src/test/java/com/facebook/presto/tpch/CachingTpchDataProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/tpch/CachingTpchDataProvider.java
@@ -1,8 +1,6 @@
 package com.facebook.presto.tpch;
 
 import com.facebook.presto.serde.BlocksFileEncoding;
-import com.facebook.presto.tpch.TpchSchema.Column;
-import com.google.common.base.Preconditions;
 
 import java.io.File;
 import java.util.HashMap;
@@ -22,16 +20,17 @@ public class CachingTpchDataProvider
     }
 
     @Override
-    public File getColumnFile(Column column, BlocksFileEncoding encoding)
+    public File getDataFile(TpchTableHandle tableHandle, TpchColumnHandle columnHandle, BlocksFileEncoding encoding)
     {
-        Preconditions.checkNotNull(column, "column is null");
-        Preconditions.checkNotNull(encoding, "encoding is null");
+        checkNotNull(tableHandle, "tableHandle is null");
+        checkNotNull(columnHandle, "columnHandle is null");
+        checkNotNull(encoding, "encoding is null");
 
         // Hack: Use the serdeName as the unique identifier of the serializer
-        TpchColumnRequest columnRequest = new TpchColumnRequest(column, encoding.getName());
+        TpchColumnRequest columnRequest = new TpchColumnRequest(tableHandle, columnHandle, encoding.getName());
         File file = localFileCache.get(columnRequest);
         if (file == null) {
-            file = delegate.getColumnFile(column, encoding);
+            file = delegate.getDataFile(tableHandle, columnHandle, encoding);
             localFileCache.put(columnRequest, file);
         }
         return file;
@@ -39,25 +38,38 @@ public class CachingTpchDataProvider
 
     private static final class TpchColumnRequest
     {
-        private final TpchSchema.Column column;
+        private final TpchTableHandle tableHandle;
+        private final TpchColumnHandle columnHandle;
         private final String serdeName;
 
-        private TpchColumnRequest(TpchSchema.Column column, String serdeName)
+        private TpchColumnRequest(TpchTableHandle tableHandle, TpchColumnHandle columnHandle, String serdeName)
         {
-            this.column = checkNotNull(column, "column is null");
-            this.serdeName = checkNotNull(serdeName, "serdeName is null");
+            this.tableHandle =  checkNotNull(tableHandle, "tableHandle is null");
+            this.columnHandle =  checkNotNull(columnHandle, "columnHandle is null");
+            this.serdeName =  checkNotNull(serdeName, "serdeName is null");
         }
 
         @Override
         public boolean equals(Object o)
         {
-            if (this == o) return true;
-            if (!(o instanceof TpchColumnRequest)) return false;
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof TpchColumnRequest)) {
+                return false;
+            }
 
             TpchColumnRequest that = (TpchColumnRequest) o;
 
-            if (!column.equals(that.column)) return false;
-            if (!serdeName.equals(that.serdeName)) return false;
+            if (!columnHandle.equals(that.columnHandle)) {
+                return false;
+            }
+            if (!serdeName.equals(that.serdeName)) {
+                return false;
+            }
+            if (!tableHandle.equals(that.tableHandle)) {
+                return false;
+            }
 
             return true;
         }
@@ -65,7 +77,8 @@ public class CachingTpchDataProvider
         @Override
         public int hashCode()
         {
-            int result = column.hashCode();
+            int result = tableHandle.hashCode();
+            result = 31 * result + columnHandle.hashCode();
             result = 31 * result + serdeName.hashCode();
             return result;
         }

--- a/presto-main/src/test/java/com/facebook/presto/tpch/MetricRecordingTpchBlocksProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/tpch/MetricRecordingTpchBlocksProvider.java
@@ -2,7 +2,6 @@ package com.facebook.presto.tpch;
 
 import com.facebook.presto.block.BlockIterable;
 import com.facebook.presto.serde.BlocksFileEncoding;
-import com.facebook.presto.tpch.TpchSchema.Column;
 import com.google.common.base.Preconditions;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -22,14 +21,15 @@ public class MetricRecordingTpchBlocksProvider
     }
 
     @Override
-    public BlockIterable getBlocks(Column column, BlocksFileEncoding encoding)
+    public BlockIterable getBlocks(TpchTableHandle tableHandle, TpchColumnHandle columnHandle, BlocksFileEncoding encoding)
     {
-        Preconditions.checkNotNull(column, "column is null");
+        Preconditions.checkNotNull(tableHandle, "tableHandle is null");
+        Preconditions.checkNotNull(columnHandle, "columnHandle is null");
         Preconditions.checkNotNull(encoding, "encoding is null");
         long start = System.nanoTime();
         try {
-            BlockIterable blocks = tpchBlocksProvider.getBlocks(column, encoding);
-            cumulativeDataByteSize += tpchBlocksProvider.getColumnDataSize(column, encoding).toBytes();
+            BlockIterable blocks = tpchBlocksProvider.getBlocks(tableHandle, columnHandle, encoding);
+            cumulativeDataByteSize += tpchBlocksProvider.getColumnDataSize(tableHandle, columnHandle, encoding).toBytes();
             return blocks;
         } finally {
             dataFetchElapsedMillis += Duration.nanosSince(start).toMillis();
@@ -37,9 +37,9 @@ public class MetricRecordingTpchBlocksProvider
     }
 
     @Override
-    public DataSize getColumnDataSize(Column column, BlocksFileEncoding encoding)
+    public DataSize getColumnDataSize(TpchTableHandle tableHandle, TpchColumnHandle columnHandle, BlocksFileEncoding encoding)
     {
-        return tpchBlocksProvider.getColumnDataSize(column, encoding);
+        return tpchBlocksProvider.getColumnDataSize(tableHandle, columnHandle, encoding);
     }
 
     public Duration getDataFetchElapsedTime()

--- a/presto-main/src/test/java/com/facebook/presto/tpch/StatsTpchBlocksProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/tpch/StatsTpchBlocksProvider.java
@@ -3,12 +3,12 @@
  */
 package com.facebook.presto.tpch;
 
+import com.facebook.presto.block.BlockIterable;
 import com.facebook.presto.serde.BlocksFileEncoding;
 import com.facebook.presto.serde.BlocksFileReader;
 import com.facebook.presto.serde.BlocksFileStats;
 import com.facebook.presto.slice.Slice;
 import com.facebook.presto.slice.Slices;
-import com.facebook.presto.tpch.TpchSchema.Column;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -44,27 +44,28 @@ public class StatsTpchBlocksProvider
     }
 
     @Override
-    public BlocksFileReader getBlocks(Column column, BlocksFileEncoding encoding)
+    public BlockIterable  getBlocks(TpchTableHandle tableHandle, TpchColumnHandle columnHandle, BlocksFileEncoding encoding)
     {
-        Slice slice = getColumnSlice(column, encoding);
+        Slice slice = getColumnSlice(tableHandle, columnHandle, encoding);
         BlocksFileReader blocks = BlocksFileReader.readBlocks(slice);
         statsBuilder.add(blocks.getStats());
         return blocks;
     }
 
     @Override
-    public DataSize getColumnDataSize(Column column, BlocksFileEncoding encoding)
+    public DataSize getColumnDataSize(TpchTableHandle tableHandle, TpchColumnHandle columnHandle, BlocksFileEncoding encoding)
     {
-        Slice slice = getColumnSlice(column, encoding);
+        Slice slice = getColumnSlice(tableHandle, columnHandle, encoding);
         return new DataSize(slice.length(), Unit.BYTE);
     }
 
-    private Slice getColumnSlice(Column column, BlocksFileEncoding encoding)
+    private Slice getColumnSlice(TpchTableHandle tableHandle, TpchColumnHandle columnHandle, BlocksFileEncoding encoding)
     {
-        checkNotNull(column, "column is null");
+        checkNotNull(tableHandle, "tableHandle is null");
+        checkNotNull(columnHandle, "columnHandle is null");
         checkNotNull(encoding, "encoding is null");
 
-        File columnFile = tpchDataProvider.getColumnFile(column, encoding);
+        File columnFile = tpchDataProvider.getDataFile(tableHandle, columnHandle, encoding);
         return mappedFileCache.getUnchecked(columnFile.getAbsolutePath());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/tpch/TpchBlocksProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/tpch/TpchBlocksProvider.java
@@ -2,12 +2,11 @@ package com.facebook.presto.tpch;
 
 import com.facebook.presto.block.BlockIterable;
 import com.facebook.presto.serde.BlocksFileEncoding;
-import com.facebook.presto.tpch.TpchSchema.Column;
 import io.airlift.units.DataSize;
 
 public interface TpchBlocksProvider
 {
-    BlockIterable getBlocks(TpchSchema.Column column, BlocksFileEncoding encoding);
+    BlockIterable getBlocks(TpchTableHandle tableHandle, TpchColumnHandle columnHandle, BlocksFileEncoding encoding);
 
-    DataSize getColumnDataSize(Column column, BlocksFileEncoding encoding);
+    DataSize getColumnDataSize(TpchTableHandle tableHandle, TpchColumnHandle columnHandle, BlocksFileEncoding encoding);
 }

--- a/presto-main/src/test/java/com/facebook/presto/tpch/TpchColumnHandle.java
+++ b/presto-main/src/test/java/com/facebook/presto/tpch/TpchColumnHandle.java
@@ -1,0 +1,74 @@
+package com.facebook.presto.tpch;
+
+import com.facebook.presto.metadata.ColumnHandle;
+import com.facebook.presto.metadata.DataSourceType;
+import com.facebook.presto.tuple.TupleInfo;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class TpchColumnHandle
+    implements ColumnHandle
+{
+    private final int fieldIndex;
+    private final TupleInfo.Type type;
+
+    @JsonCreator
+    public TpchColumnHandle(@JsonProperty("fieldIndex") int fieldIndex, @JsonProperty("type") TupleInfo.Type type)
+    {
+        checkArgument(fieldIndex >= 0, "fieldIndex must be at least zero");
+        checkNotNull(type, "type is null");
+        this.fieldIndex = fieldIndex;
+        this.type = type;
+    }
+
+    @Override
+    public DataSourceType getDataSourceType()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @JsonProperty
+    public int getFieldIndex()
+    {
+        return fieldIndex;
+    }
+
+    @JsonProperty
+    public TupleInfo.Type getType()
+    {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TpchColumnHandle)) {
+            return false;
+        }
+
+        TpchColumnHandle that = (TpchColumnHandle) o;
+
+        if (fieldIndex != that.fieldIndex) {
+            return false;
+        }
+        if (type != that.type) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = fieldIndex;
+        result = 31 * result + type.hashCode();
+        return result;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/tpch/TpchDataProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/tpch/TpchDataProvider.java
@@ -6,5 +6,5 @@ import java.io.File;
 
 public interface TpchDataProvider
 {
-    File getColumnFile(TpchSchema.Column column, BlocksFileEncoding encoding);
+    File getDataFile(TpchTableHandle tableHandle, TpchColumnHandle columnHandle, BlocksFileEncoding encoding);
 }

--- a/presto-main/src/test/java/com/facebook/presto/tpch/TpchDataStreamProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/tpch/TpchDataStreamProvider.java
@@ -1,0 +1,47 @@
+package com.facebook.presto.tpch;
+
+import com.facebook.presto.block.BlockIterable;
+import com.facebook.presto.metadata.ColumnHandle;
+import com.facebook.presto.operator.AlignmentOperator;
+import com.facebook.presto.operator.Operator;
+import com.facebook.presto.serde.BlocksFileEncoding;
+import com.facebook.presto.split.DataStreamProvider;
+import com.facebook.presto.split.Split;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class TpchDataStreamProvider
+    implements DataStreamProvider
+{
+    private final TpchBlocksProvider tpchBlocksProvider;
+
+    public TpchDataStreamProvider(TpchBlocksProvider tpchBlocksProvider)
+    {
+        this.tpchBlocksProvider = Preconditions.checkNotNull(tpchBlocksProvider, "tpchBlocksProvider is null");
+    }
+
+    @Override
+    public Operator createDataStream(Split split, List<ColumnHandle> columns)
+    {
+        checkNotNull(split, "split is null");
+        checkArgument(split instanceof TpchSplit, "Split must be of type TpchSplit, not %s", split.getClass().getName());
+        assert split instanceof TpchSplit; // // IDEA-60343
+        checkNotNull(columns, "columns is null");
+        checkArgument(!columns.isEmpty(), "must provide at least one column");
+
+        TpchSplit tpchSplit = (TpchSplit) split;
+
+        ImmutableList.Builder<BlockIterable> builder = ImmutableList.builder();
+        for (ColumnHandle column : columns) {
+            checkArgument(column instanceof TpchColumnHandle, "column must be of type TpchColumnHandle, not %s", column.getClass().getName());
+            assert column instanceof TpchColumnHandle; // // IDEA-60343
+            builder.add(tpchBlocksProvider.getBlocks(tpchSplit.getTableHandle(), (TpchColumnHandle) column, BlocksFileEncoding.RAW));
+        }
+        return new AlignmentOperator(builder.build());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/tpch/TpchLegacyStorageManagerAdapter.java
+++ b/presto-main/src/test/java/com/facebook/presto/tpch/TpchLegacyStorageManagerAdapter.java
@@ -1,0 +1,38 @@
+package com.facebook.presto.tpch;
+
+import com.facebook.presto.metadata.ColumnHandle;
+import com.facebook.presto.metadata.LegacyStorageManager;
+import com.facebook.presto.operator.Operator;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.tpch.TpchSchema.columnHandle;
+import static com.facebook.presto.tpch.TpchSchema.tableHandle;
+import static com.google.common.base.Preconditions.checkArgument;
+
+// TODO: get rid of this hack when ExecutionPlanner switches to DataStreamProvider!
+public class TpchLegacyStorageManagerAdapter
+    implements LegacyStorageManager
+{
+    private final TpchDataStreamProvider tpchDataStreamProvider;
+
+    public TpchLegacyStorageManagerAdapter(TpchDataStreamProvider tpchDataStreamProvider)
+    {
+        this.tpchDataStreamProvider = Preconditions.checkNotNull(tpchDataStreamProvider, "tpchDataStreamProvider is null");
+    }
+
+    @Override
+    public Operator getOperator(String databaseName, String tableName, List<Integer> fieldIndexes)
+    {
+        checkArgument(databaseName.equals(TpchSchema.SCHEMA_NAME));
+        ImmutableList.Builder<ColumnHandle> builder = ImmutableList.builder();
+        TpchTableHandle tableHandle = tableHandle(tableName);
+        for (Integer fieldIndex : fieldIndexes) {
+            builder.add(columnHandle(tableHandle, fieldIndex));
+        }
+
+        return tpchDataStreamProvider.createDataStream(new TpchSplit(tableHandle), builder.build());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/tpch/TpchSplit.java
+++ b/presto-main/src/test/java/com/facebook/presto/tpch/TpchSplit.java
@@ -1,0 +1,57 @@
+package com.facebook.presto.tpch;
+
+import com.facebook.presto.metadata.DataSourceType;
+import com.facebook.presto.split.Split;
+import com.google.common.base.Preconditions;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+// Right now, splits are just the entire TPCH table
+public class TpchSplit
+    implements Split
+{
+    private final TpchTableHandle tableHandle;
+
+    @JsonCreator
+    public TpchSplit(@JsonProperty("tableHandle") TpchTableHandle tableHandle)
+    {
+        this.tableHandle = Preconditions.checkNotNull(tableHandle, "tableHandle is null");
+    }
+
+    @Override
+    public DataSourceType getDataSourceType()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @JsonProperty
+    public TpchTableHandle getTableHandle()
+    {
+        return tableHandle;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TpchSplit)) {
+            return false;
+        }
+
+        TpchSplit tpchSplit = (TpchSplit) o;
+
+        if (!tableHandle.equals(tpchSplit.tableHandle)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return tableHandle.hashCode();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/tpch/TpchTableHandle.java
+++ b/presto-main/src/test/java/com/facebook/presto/tpch/TpchTableHandle.java
@@ -1,0 +1,56 @@
+package com.facebook.presto.tpch;
+
+import com.facebook.presto.metadata.DataSourceType;
+import com.facebook.presto.metadata.TableHandle;
+import com.google.common.base.Preconditions;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+public class TpchTableHandle
+    implements TableHandle
+{
+    private final String tableName;
+
+    @JsonCreator
+    public TpchTableHandle(@JsonProperty("tableName") String tableName)
+    {
+        this.tableName = Preconditions.checkNotNull(tableName, "tableName is null");
+    }
+
+    @Override
+    public DataSourceType getDataSourceType()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TpchTableHandle)) {
+            return false;
+        }
+
+        TpchTableHandle that = (TpchTableHandle) o;
+
+        if (!tableName.equals(that.tableName)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return tableName.hashCode();
+    }
+}


### PR DESCRIPTION
- This affects the benchmark code as well as the TestQueries.
- There is currently a temporary hack with the LegacyStorageManager to allow it to interface with the ExecutionPlanner, but all those hacks should be removed once ExecutionPlanner switches to using DataStreamProviders.
