### PR TITLE
Minor optimization for Hive queries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/QueryDriversOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryDriversOperator.java
@@ -32,11 +32,11 @@ public class QueryDriversOperator
     {
         Preconditions.checkArgument(pageBufferMax > 0, "blockBufferMax must be at least 1");
         Preconditions.checkNotNull(driverProviders, "driverProviders is null");
-        Preconditions.checkArgument(!Iterables.isEmpty(driverProviders), "driverProviders is empty");
 
         this.pageBufferMax = pageBufferMax;
         this.driverProviders = ImmutableList.copyOf(driverProviders);
         tupleInfos = this.driverProviders.get(0).getTupleInfos();
+        Preconditions.checkArgument(!this.driverProviders.isEmpty(), "driverProviders is empty");
     }
 
     @Override


### PR DESCRIPTION
The previous checkArgument for isEmpty was triggering a full round of Hive Metastore accesses on a batch of partitions.
