### PR TITLE
Fix bug when rewriting NegativeExpression

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/tree/TreeRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/tree/TreeRewriter.java
@@ -197,6 +197,11 @@ public final class TreeRewriter<C>
                 }
             }
 
+            Expression child = rewrite(node.getValue(), context.get());
+            if (child != node.getValue()) {
+                return new NegativeExpression(child);
+            }
+
             return node;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/TestQueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/TestQueries.java
@@ -107,6 +107,13 @@ public class TestQueries
     private TpchDataStreamProvider dataProvider;
 
     @Test
+    public void testArithmeticNegation()
+            throws Exception
+    {
+        assertQuery("SELECT -custkey FROM orders");
+    }
+
+    @Test
     public void testDistinct()
             throws Exception
     {


### PR DESCRIPTION
It was discarding the rewritten subexpression of arithmetic negations
