### PR TITLE
Fix hash aggregation operator slice sizing bug

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -308,7 +308,7 @@ public class HashAggregationOperator
             this.channel = channel;
             this.step = step;
             this.fixedWidthSize = this.function.getFixedSize();
-            this.sliceSize = (int) (BlockBuilder.DEFAULT_MAX_BLOCK_SIZE.toBytes() / fixedWidthSize);
+            this.sliceSize = (int) (BlockBuilder.DEFAULT_MAX_BLOCK_SIZE.toBytes() / fixedWidthSize) * fixedWidthSize;
             Slice slice = Slices.allocate(sliceSize);
             slices.add(slice);
             currentMaxPosition = sliceSize / fixedWidthSize;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -178,6 +178,28 @@ public class TestHashAggregationOperator
     }
 
     @Test
+    public void testMultiSliceAggregationOutput()
+    {
+        long fixedWidthSize = new TupleInfo(TupleInfo.Type.FIXED_INT_64, TupleInfo.Type.DOUBLE).getFixedSize();
+        int multiSlicePositionCount = (int) (BlockBuilder.DEFAULT_MAX_BLOCK_SIZE.toBytes() / fixedWidthSize) * 2;
+        Operator source = createOperator(
+                new Page(
+                        BlockAssertions.createStringSequenceBlock(0, multiSlicePositionCount),
+                        BlockAssertions.createLongSequenceBlock(0, multiSlicePositionCount))
+        );
+
+        HashAggregationOperator actual = new HashAggregationOperator(source,
+                1,
+                Step.SINGLE,
+                ImmutableList.of(aggregation(COUNT, 0),
+                        aggregation(LONG_AVERAGE, 1)),
+                100_000,
+                new DataSize(100, Unit.MEGABYTE));
+
+        actual.iterator(new OperatorStats()).next();
+    }
+
+    @Test
     public void testCancel()
             throws Exception
     {


### PR DESCRIPTION
Fixes this:

presto> select ds, stddev(cpu_msec) from
hive_silver.default.hivedba_query_stats group by ds limit 20;
Query 0 failed:
Task 0.0.0 failed:
java.lang.IndexOutOfBoundsException: end index (2625) must not be greater
than size (2621)
    at
com.google.common.base.Preconditions.checkPositionIndexes(Preconditions.jav
a:388)
    at com.facebook.presto.slice.Slice.checkIndexLength(Slice.java:914)
    at com.facebook.presto.slice.Slice.setDouble(Slice.java:480)
    at com.facebook.presto.tuple.TupleInfo.setDouble(TupleInfo.java:337)
    at
com.facebook.presto.operator.aggregation.AbstractVarianceAggregation.initia
lize(AbstractVarianceAggregation.java:69)
    at
com.facebook.presto.operator.HashAggregationOperator$FixedWidthAggregator.i
nitialize(HashAggregationOperator.java:350)
    at
com.facebook.presto.operator.HashAggregationOperator$HashAggregationIterato
r.aggregate(HashAggregationOperator.java:191)
    at
com.facebook.presto.operator.HashAggregationOperator$HashAggregationIterato
r.computeNext(HashAggregationOperator.java:234)
    at
com.facebook.presto.operator.AbstractPageIterator.tryToComputeNext(Abstract
PageIterator.java:137)
    at
com.facebook.presto.operator.AbstractPageIterator.hasNext(AbstractPageItera
tor.java:130)
    at
com.facebook.presto.operator.FilterAndProjectOperator$FilterAndProjectItera
tor.computeNext(FilterAndProjectOperator.java:84)
    at
com.facebook.presto.operator.AbstractPageIterator.tryToComputeNext(Abstract
PageIterator.java:137)
    at
com.facebook.presto.operator.AbstractPageIterator.hasNext(AbstractPageItera
tor.java:130)
    at
com.facebook.presto.operator.LimitOperator$LimitIterator.computeNext(LimitO
perator.java:60)
    at
com.facebook.presto.operator.AbstractPageIterator.tryToComputeNext(Abstract
PageIterator.java:137)
    at
com.facebook.presto.operator.AbstractPageIterator.hasNext(AbstractPageItera
tor.java:130)
    at
com.facebook.presto.execution.SqlTaskExecution$SplitWorker.call(SqlTaskExec
ution.java:269)
    at
com.facebook.presto.execution.SqlTaskExecution.run(SqlTaskExecution.java:12
6)
    at
com.facebook.presto.execution.SqlTaskManager$TaskStarter.run(SqlTaskManager
.java:282)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1
110)
    at
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:
603)
    at java.lang.Thread.run(Thread.java:722)
java.lang.IndexOutOfBoundsException: end index (2625) must not be greater
than size (2621)
    at
com.google.common.base.Preconditions.checkPositionIndexes(Preconditions.jav
a:388)
    at com.facebook.presto.slice.Slice.checkIndexLength(Slice.java:914)
    at com.facebook.presto.slice.Slice.setDouble(Slice.java:480)
    at com.facebook.presto.tuple.TupleInfo.setDouble(TupleInfo.java:337)
    at
com.facebook.presto.operator.aggregation.AbstractVarianceAggregation.initia
lize(AbstractVarianceAggregation.java:69)
    at
com.facebook.presto.operator.HashAggregationOperator$FixedWidthAggregator.i
nitialize(HashAggregationOperator.java:350)
    at
com.facebook.presto.operator.HashAggregationOperator$HashAggregationIterato
r.aggregate(HashAggregationOperator.java:191)
    at
com.facebook.presto.operator.HashAggregationOperator$HashAggregationIterato
r.computeNext(HashAggregationOperator.java:234)
    at
com.facebook.presto.operator.AbstractPageIterator.tryToComputeNext(Abstract
PageIterator.java:137)
    at
com.facebook.presto.operator.AbstractPageIterator.hasNext(AbstractPageItera
tor.java:130)
    at
com.facebook.presto.operator.FilterAndProjectOperator$FilterAndProjectItera
tor.computeNext(FilterAndProjectOperator.java:84)
    at
com.facebook.presto.operator.AbstractPageIterator.tryToComputeNext(Abstract
PageIterator.java:137)
    at
com.facebook.presto.operator.AbstractPageIterator.hasNext(AbstractPageItera
tor.java:130)
    at
com.facebook.presto.operator.LimitOperator$LimitIterator.computeNext(LimitO
perator.java:60)
    at
com.facebook.presto.operator.AbstractPageIterator.tryToComputeNext(Abstract
PageIterator.java:137)
    at
com.facebook.presto.operator.AbstractPageIterator.hasNext(AbstractPageItera
tor.java:130)
    at
com.facebook.presto.execution.SqlTaskExecution$SplitWorker.call(SqlTaskExec
ution.java:269)
    at
com.facebook.presto.execution.SqlTaskExecution.run(SqlTaskExecution.java:12
6)
    at
com.facebook.presto.execution.SqlTaskManager$TaskStarter.run(SqlTaskManager
.java:282)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1
110)
    at
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:
603)
    at java.lang.Thread.run(Thread.java:722)
