### PR TITLE
Upgrade to latest airlift with latest jackson and switch to more efficient json

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>library</artifactId>
-        <version>0.68</version>
+        <version>0.69-SNAPSHOT</version>
     </parent>
 
     <distributionManagement>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>library</artifactId>
-        <version>0.68</version>
+        <version>0.69-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>rest-server-base</artifactId>
-        <version>0.68</version>
+        <version>0.69-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -136,6 +136,16 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>dbpool</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonExtract.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonExtract.java
@@ -250,9 +250,7 @@ public class JsonExtract
                 throw new JsonParseException("Expected a Json object", jsonParser.getCurrentLocation());
             }
 
-            // TODO: switch to the much more efficient nextFieldName method when https://github.com/FasterXML/jackson-core/issues/38 gets deployed
-            //while (!jsonParser.nextFieldName(fieldName)) {
-            while (jsonParser.nextToken() != JsonToken.FIELD_NAME || !fieldName.getValue().equals(jsonParser.getCurrentName())) {
+            while (!jsonParser.nextFieldName(fieldName)) {
                 if (!jsonParser.hasCurrentToken()) {
                     throw new JsonParseException("Unexpected end of object", jsonParser.getCurrentLocation());
                 }

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>library</artifactId>
-        <version>0.68</version>
+        <version>0.69-SNAPSHOT</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
jackson 1.9.12 fixes the bug we were seeing with nextFieldName method from jackson. The code no longer hangs when there is a space before a colon.

The JSON parsing function in Presto should be substantially more perfomant now.
