### PR TITLE
replace hardcoded metadata selection with map driven by a map binder

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cron/CronDao.java
+++ b/presto-main/src/main/java/com/facebook/presto/cron/CronDao.java
@@ -1,0 +1,48 @@
+package com.facebook.presto.cron;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.BindBean;
+import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.Mapper;
+
+import java.util.List;
+
+public interface CronDao
+{
+    @SqlUpdate("CREATE TABLE IF NOT EXISTS jobs (\n" +
+            "  job_id BIGINT PRIMARY KEY AUTO_INCREMENT,\n" +
+            "  src_catalog_name VARCHAR(255) NOT NULL,\n" +
+            "  src_schema_name VARCHAR(255) NOT NULL,\n" +
+            "  src_table_name VARCHAR(255) NOT NULL,\n" +
+            "  dst_catalog_name VARCHAR(255) NOT NULL,\n" +
+            "  dst_schema_name VARCHAR(255) NOT NULL,\n" +
+            "  dst_table_name VARCHAR(255) NOT NULL,\n" +
+            "  job_interval INT NOT NULL,\n" +
+            "  modified TIMESTAMP NOT NULL DEFAULT NOW()\n" +
+            ")")
+    void createJobsTable();
+
+    @SqlUpdate("INSERT INTO jobs (src_catalog_name, src_schema_name, src_table_name,\n" +
+               "dst_catalog_name, dst_schema_name, dst_table_name, job_interval)\n" +
+               "VALUES (:srcCatalogName, :srcSchemaName, :srcTableName,\n" +
+               ":dstCatalogName, :dstSchemaName, :dstTableName, :interval)")
+    @GetGeneratedKeys
+    long insertJob(@BindBean CronJob job);
+
+    @SqlUpdate("DELETE FROM jobs\n" +
+            "WHERE job_id = :jobId\n")
+    void dropJob(@Bind("jobId") long jobId);
+
+    @SqlQuery("SELECT COUNT(*) FROM jobs")
+    long getJobCount();
+
+    @SqlQuery("SELECT * FROM jobs WHERE job_id = :jobId")
+    @Mapper(PersistentCronJob.PersistentCronJobMapper.class)
+    PersistentCronJob getJob(@Bind("jobId") long jobId);
+
+    @SqlQuery("SELECT * FROM jobs")
+    @Mapper(PersistentCronJob.PersistentCronJobMapper.class)
+    List<PersistentCronJob> getJobs();
+}

--- a/presto-main/src/main/java/com/facebook/presto/cron/CronJob.java
+++ b/presto-main/src/main/java/com/facebook/presto/cron/CronJob.java
@@ -1,0 +1,122 @@
+package com.facebook.presto.cron;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+public class CronJob
+{
+    private final String srcCatalogName;
+    private final String srcSchemaName;
+    private final String srcTableName;
+    private final String dstCatalogName;
+    private final String dstSchemaName;
+    private final String dstTableName;
+    private final long interval;
+
+    @JsonCreator
+    public CronJob(@JsonProperty("srcCatalogName") String srcCatalogName,
+            @JsonProperty("srcSchemaName") String srcSchemaName,
+            @JsonProperty("srcTableName") String srcTableName,
+            @JsonProperty("dstCatalogName") String dstCatalogName,
+            @JsonProperty("dstSchemaName") String dstSchemaName,
+            @JsonProperty("dstTableName") String dstTableName,
+            @JsonProperty("interval") long interval)
+    {
+        this.srcCatalogName = srcCatalogName;
+        this.srcSchemaName = srcSchemaName;
+        this.srcTableName = srcTableName;
+
+        this.dstCatalogName = dstCatalogName;
+        this.dstSchemaName = dstSchemaName;
+        this.dstTableName = dstTableName;
+
+        this.interval = interval;
+    }
+
+    @JsonProperty
+    public String getSrcCatalogName()
+    {
+        return srcCatalogName;
+    }
+
+    @JsonProperty
+    public String getSrcSchemaName()
+    {
+        return srcSchemaName;
+    }
+
+    @JsonProperty
+    public String getSrcTableName()
+    {
+        return srcTableName;
+    }
+
+    @JsonProperty
+    public String getDstCatalogName()
+    {
+        return dstCatalogName;
+    }
+
+    @JsonProperty
+    public String getDstSchemaName()
+    {
+        return dstSchemaName;
+    }
+
+    @JsonProperty
+    public String getDstTableName()
+    {
+        return dstTableName;
+    }
+
+    @JsonProperty
+    public long getInterval()
+    {
+        return interval;
+    }
+
+    @Override
+    public String toString()
+    {
+        return Objects.toStringHelper(this)
+                .add("srcCatalogName", srcCatalogName)
+                .add("srcSchemaName", srcSchemaName)
+                .add("srcTableName", srcTableName)
+                .add("dstCatalogName", dstCatalogName)
+                .add("dstSchemaName", dstSchemaName)
+                .add("dstTableName", dstTableName)
+                .add("interval", interval)
+                .toString();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(srcCatalogName, srcSchemaName, srcTableName,
+                dstCatalogName, dstSchemaName, dstTableName,
+                interval);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        else if (obj == null) {
+            return false;
+        }
+        else if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CronJob other = (CronJob) obj;
+        return Objects.equal(srcCatalogName, other.srcCatalogName)
+                && Objects.equal(srcSchemaName, other.srcSchemaName)
+                && Objects.equal(srcTableName, other.srcTableName)
+                && Objects.equal(dstCatalogName, other.dstCatalogName)
+                && Objects.equal(dstSchemaName, other.dstSchemaName)
+                && Objects.equal(dstTableName, other.dstTableName)
+                && Objects.equal(interval, other.interval);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cron/CronJobResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/cron/CronJobResource.java
@@ -1,0 +1,83 @@
+package com.facebook.presto.cron;
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+
+import java.net.URI;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+
+@Path("/v1/cron/jobs")
+@Singleton
+@Produces(MediaType.APPLICATION_JSON)
+public class CronJobResource
+{
+    private final CronManager cronManager;
+
+    @Inject
+    public CronJobResource(CronManager cronManager)
+    {
+        this.cronManager = checkNotNull(cronManager, "cronManager is null");
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response createJob(CronJob job, @Context UriInfo uriInfo)
+    {
+        long id = cronManager.insertJob(job);
+
+        URI pagesUri = uriBuilderFrom(uriInfo.getRequestUri()).appendPath(Long.toString(id)).build();
+        return Response.created(pagesUri).build();
+    }
+
+    @DELETE
+    @Path("{jobId: \\d+}")
+    public Response dropJob(@PathParam("jobId") long jobId)
+    {
+        cronManager.dropJob(jobId);
+
+        return Response.status(Status.ACCEPTED).build();
+    }
+
+    @GET
+    @Path("{jobId: \\d+}")
+    public Response getJob(@PathParam("jobId") long jobId)
+    {
+        CronJob job = cronManager.getJob(jobId);
+        if (job == null) {
+            return Response.status(Status.NOT_FOUND).build();
+        }
+        else {
+            return Response.ok(job).build();
+        }
+    }
+
+    @GET
+    @Path("all")
+    public Response getAllJobs()
+    {
+        return Response.ok(ImmutableMap.of("jobs",cronManager.getJobs())).build();
+    }
+
+    @GET
+    @Path("count")
+    public Response getJobCount()
+    {
+        return Response.ok(ImmutableMap.of("count", cronManager.getJobCount())).build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cron/CronManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/cron/CronManager.java
@@ -1,0 +1,77 @@
+package com.facebook.presto.cron;
+
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import org.skife.jdbi.v2.IDBI;
+import org.skife.jdbi.v2.exceptions.UnableToObtainConnectionException;
+
+import javax.inject.Singleton;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Singleton
+public class CronManager
+{
+    private static final Logger log = Logger.get(CronManager.class);
+
+    private final CronDao dao;
+
+    @Inject
+    public CronManager(@ForCron IDBI schedulerDbi)
+            throws InterruptedException
+    {
+        this.dao = schedulerDbi.onDemand(CronDao.class);
+
+        createTablesWithRetry();
+    }
+
+    public long insertJob(CronJob job)
+    {
+        return dao.insertJob(job);
+    }
+
+    public void dropJob(long jobId)
+    {
+        dao.dropJob(jobId);
+    }
+
+    public long getJobCount()
+    {
+        return dao.getJobCount();
+    }
+
+    public CronJob getJob(long jobId)
+    {
+        return dao.getJob(jobId);
+    }
+
+    public List<PersistentCronJob> getJobs()
+    {
+        return dao.getJobs();
+    }
+
+    private void createTablesWithRetry()
+            throws InterruptedException
+    {
+        Duration delay = new Duration(10, TimeUnit.SECONDS);
+        while (true) {
+            try {
+                createTables();
+                return;
+            }
+            catch (UnableToObtainConnectionException e) {
+                log.warn("Failed to connect to database. Will retry again in %s. Exception: %s", delay, e.getMessage());
+                Thread.sleep((long) delay.toMillis());
+            }
+        }
+    }
+
+    private void createTables()
+    {
+        dao.createJobsTable();
+    }
+}
+
+

--- a/presto-main/src/main/java/com/facebook/presto/cron/ForCron.java
+++ b/presto-main/src/main/java/com/facebook/presto/cron/ForCron.java
@@ -1,0 +1,17 @@
+package com.facebook.presto.cron;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForCron
+{
+}

--- a/presto-main/src/main/java/com/facebook/presto/cron/PersistentCronJob.java
+++ b/presto-main/src/main/java/com/facebook/presto/cron/PersistentCronJob.java
@@ -1,0 +1,96 @@
+package com.facebook.presto.cron;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+public class PersistentCronJob extends CronJob
+{
+    private final long jobId;
+    private final Timestamp modified;
+
+    public PersistentCronJob(long jobId,
+                             Timestamp modified,
+                             String srcCatalogName,
+                             String srcSchemaName,
+                             String srcTableName,
+                             String dstCatalogName,
+                             String dstSchemaName,
+                             String dstTableName,
+                             long interval)
+    {
+        super(srcCatalogName, srcSchemaName, srcTableName, dstCatalogName, dstSchemaName, dstTableName, interval);
+
+        this.jobId = jobId;
+        this.modified = modified;
+    }
+
+    @JsonProperty
+    public long getJobId()
+    {
+        return jobId;
+    }
+
+    @JsonIgnore
+    public Timestamp getModified()
+    {
+        return modified;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return 31 * super.hashCode() + Objects.hashCode(jobId, modified);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        else if (!super.equals(obj)) {
+            return false;
+        }
+        else if (getClass() != obj.getClass()) {
+            return false;
+        }
+        PersistentCronJob other = (PersistentCronJob) obj;
+        return Objects.equal(jobId, other.jobId)
+                && Objects.equal(modified, other.modified);
+    }
+
+    @Override
+    public String toString()
+    {
+        return Objects.toStringHelper(this)
+                .add("modified", modified)
+                .add("jobId", jobId)
+                .toString();
+    }
+
+    public static class PersistentCronJobMapper implements ResultSetMapper<PersistentCronJob>
+    {
+        @Override
+        public PersistentCronJob map(int index, ResultSet r, StatementContext ctx)
+                throws SQLException
+        {
+            return new PersistentCronJob(
+                r.getLong("job_id"),
+                r.getTimestamp("modified"),
+                r.getString("src_catalog_name"),
+                r.getString("src_schema_name"),
+                r.getString("src_table_name"),
+                r.getString("dst_catalog_name"),
+                r.getString("dst_schema_name"),
+                r.getString("dst_table_name"),
+                r.getLong("job_interval"));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cron/TestCronDao.java
+++ b/presto-main/src/test/java/com/facebook/presto/cron/TestCronDao.java
@@ -1,0 +1,87 @@
+package com.facebook.presto.cron;
+
+import io.airlift.dbpool.H2EmbeddedDataSource;
+import io.airlift.dbpool.H2EmbeddedDataSourceConfig;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.sql.DataSource;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestCronDao
+{
+    CronDao dao;
+    Handle handle;
+
+    @BeforeMethod
+    public void setup() throws Exception
+    {
+        H2EmbeddedDataSourceConfig dataSourceConfig = new H2EmbeddedDataSourceConfig().setFilename("mem:");
+        DataSource dataSource = new H2EmbeddedDataSource(dataSourceConfig);
+        DBI h2Dbi = new DBI(dataSource);
+        handle = h2Dbi.open();
+        dao = handle.attach(CronDao.class);
+    }
+
+    @AfterMethod
+    public void teardown()
+    {
+        handle.close();
+    }
+
+    @Test
+    public void testTableCreation()
+    {
+        dao.createJobsTable();
+
+        assertEquals(dao.getJobCount(), 0);
+    }
+
+    @Test
+    public void testJobCreation()
+    {
+        dao.createJobsTable();
+        assertEquals(dao.getJobCount(), 0);
+
+        CronJob dummyJob = new CronJob("ss", "sc", "st", "ds", "dc", "dt", 20);
+        long jobId = dao.insertJob(dummyJob);
+        assertEquals(jobId, 1);
+
+        assertEquals(dao.getJobCount(), 1);
+
+        PersistentCronJob storedJob = dao.getJob(jobId);
+        assertCronjobsEqual(storedJob, dummyJob);
+    }
+
+    @Test
+    public void testJobDeletion()
+    {
+        dao.createJobsTable();
+        assertEquals(dao.getJobCount(), 0);
+
+        CronJob dummyJob = new CronJob("ss", "sc", "st", "ds", "dc", "dt", 20);
+        long jobId = dao.insertJob(dummyJob);
+        assertEquals(jobId, 1);
+        assertEquals(dao.getJobCount(), 1);
+
+        dao.dropJob(jobId);
+        assertEquals(dao.getJobCount(), 0);
+    }
+
+    private void assertCronjobsEqual(CronJob job1, CronJob job2)
+    {
+        assertNotNull(job1, "job1 was null");
+        assertNotNull(job2, "job2 was null");
+        assertEquals(job1.getSrcCatalogName(), job2.getSrcCatalogName(), "srcCatalogName");
+        assertEquals(job1.getSrcSchemaName(), job2.getSrcSchemaName(), "srcCatalogName");
+        assertEquals(job1.getSrcTableName(), job2.getSrcTableName(), "srcCatalogName");
+        assertEquals(job1.getDstCatalogName(), job2.getDstCatalogName(), "srcCatalogName");
+        assertEquals(job1.getDstSchemaName(), job2.getDstSchemaName(), "srcCatalogName");
+        assertEquals(job1.getDstTableName(), job2.getDstTableName(), "srcCatalogName");
+    }
+}


### PR DESCRIPTION
Allows adding new metadata types in other modules (the enum
still binds all the pieces tightly together, though).
