### PR TITLE
Plugins should not enforce dependencies

### DIFF
--- a/presto-hive-plugin/pom.xml
+++ b/presto-hive-plugin/pom.xml
@@ -16,6 +16,7 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-hive</artifactId>
+            <optional>true</optional>
             <scope>runtime</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This allows IDEs to ignore dependencies for plugins and make the
plugin system work if run from the IDE.
