### PR TITLE
Change memory allocation policy when growing slices.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/slice/Slices.java
+++ b/presto-main/src/main/java/com/facebook/presto/slice/Slices.java
@@ -49,6 +49,9 @@ public final class Slices
     {
     }
 
+    private static final int SLICE_ALLOC_THRESHOLD = 524_288; // 2^19
+    private static final double SLICE_ALLOW_SKEW = 1.25; // must be > 1!
+
     public static Slice ensureSize(Slice existingSlice, int minWritableBytes)
     {
         if (existingSlice == null) {
@@ -68,7 +71,12 @@ public final class Slices
         }
         int minNewCapacity = existingSlice.length() + minWritableBytes;
         while (newCapacity < minNewCapacity) {
-            newCapacity <<= 1;
+            if (newCapacity < SLICE_ALLOC_THRESHOLD) {
+                newCapacity <<= 1;
+            }
+            else {
+                newCapacity *= SLICE_ALLOW_SKEW;
+            }
         }
 
         Slice newSlice = Slices.allocate(newCapacity);


### PR DESCRIPTION
Change the memory allocation policy when a slice needs memory beyond a
given threshold (512k). Switch from doubling the current buffer size
to an increase by 25%. Using this policy, a buffer of 512k that needs
to hold 600k will grow only to 640k, not 1024k.

Benchmarks seem to imply that queries run slightly faster:

original:

```
                      count_agg ::    0.086 cpu ms :: in  1.5M,  12.9MB,   17.4B/s,   146GB/s :: out     1,      9B,   11.6K/s,   102KB/s
                 double_sum_agg ::   10.211 cpu ms :: in  1.5M,  12.9MB,    147M/s,  1.23GB/s :: out     1,      9B,      97/s,    881B/s
                       hash_agg ::  184.440 cpu ms :: in  1.5M,  21.5MB,   8.13M/s,   116MB/s :: out     3,     45B,      16/s,    243B/s
               predicate_filter ::   99.070 cpu ms :: in  1.5M,  12.9MB,   15.1M/s,   130MB/s :: out 1.29M,  11.1MB,     13M/s,   112MB/s
                     raw_stream ::    3.577 cpu ms :: in  1.5M,  12.9MB,    419M/s,  3.52GB/s :: out  1.5M,  12.9MB,    419M/s,  3.52GB/s
                         top100 ::   33.175 cpu ms :: in  1.5M,  12.9MB,   45.2M/s,   388MB/s :: out   100,    900B,   3.01K/s,  26.5KB/s
         in_memory_orderby_1.5M :: 1527.672 cpu ms :: in  1.5M,  41.5MB,    982K/s,  27.2MB/s :: out  1.5M,  28.6MB,    982K/s,  18.7MB/s
                     hash_build ::  566.392 cpu ms :: in  1.5M,  25.8MB,   2.65M/s,  45.5MB/s :: out     0,      0B,       0/s,      0B/s
                      hash_join :: 1645.129 cpu ms :: in    6M,   103MB,   3.65M/s,  62.6MB/s :: out    6M,   206MB,   3.65M/s,   125MB/s
            hash_build_and_join :: 2005.875 cpu ms :: in  1.5M,   129MB,    748K/s,  64.2MB/s :: out    6M,   206MB,   2.99M/s,   103MB/s
sql_groupby_agg_with_arithmetic :: 2057.132 cpu ms :: in    6M,   137MB,   2.92M/s,  66.8MB/s :: out     2,     30B,       0/s,     14B/s
                  sql_count_agg ::    0.131 cpu ms :: in  1.5M,  12.9MB,   11.4B/s,  95.9GB/s :: out     1,      9B,   7.63K/s,  67.1KB/s
             sql_double_sum_agg ::   10.315 cpu ms :: in  1.5M,  12.9MB,    145M/s,  1.22GB/s :: out     1,      9B,      96/s,    872B/s
          sql_count_with_filter ::  163.948 cpu ms :: in  1.5M,  8.58MB,   9.15M/s,  52.4MB/s :: out     1,      9B,       6/s,     54B/s
                sql_groupby_agg ::  191.831 cpu ms :: in  1.5M,  21.5MB,   7.82M/s,   112MB/s :: out     3,     45B,      15/s,    234B/s
           sql_predicate_filter ::  154.564 cpu ms :: in  1.5M,  12.9MB,    9.7M/s,  83.3MB/s :: out 1.29M,  11.1MB,   8.34M/s,  71.6MB/s
                 sql_raw_stream ::    3.649 cpu ms :: in  1.5M,  12.9MB,    411M/s,  3.45GB/s :: out  1.5M,  12.9MB,    411M/s,  3.45GB/s
                    sql_top_100 ::   33.660 cpu ms :: in  1.5M,  12.9MB,   44.6M/s,   383MB/s :: out   100,    900B,   2.97K/s,  26.1KB/s
                  sql_hash_join :: 1979.658 cpu ms :: in    6M,   129MB,   3.03M/s,  65.1MB/s :: out    6M,   206MB,   3.03M/s,   104MB/s
              sql_varbinary_max ::  173.180 cpu ms :: in    6M,  97.3MB,   34.7M/s,   562MB/s :: out     1,     21B,       5/s,    121B/s
             sql_distinct_multi ::  424.781 cpu ms :: in  1.5M,  27.8MB,   3.53M/s,  65.3MB/s :: out     5,     97B,      11/s,    228B/s
            sql_distinct_single ::  126.152 cpu ms :: in  1.5M,  8.58MB,   11.9M/s,    68MB/s :: out     1,      6B,       7/s,     47B/s
               sql_tpch_query_1 :: 15379.948 cpu ms :: in    6M,   361MB,    390K/s,  23.4MB/s :: out     4,    336B,       0/s,     21B/s
             stat_long_variance ::   17.611 cpu ms :: in  1.5M,  12.9MB,   85.2M/s,   731MB/s :: out     1,      9B,      56/s,    511B/s
         stat_long_variance_pop ::   17.593 cpu ms :: in  1.5M,  12.9MB,   85.3M/s,   732MB/s :: out     1,      9B,      56/s,    511B/s
           stat_double_variance ::   17.744 cpu ms :: in  1.5M,  12.9MB,   84.5M/s,   726MB/s :: out     1,      9B,      56/s,    507B/s
       stat_double_variance_pop ::   18.162 cpu ms :: in  1.5M,  12.9MB,   82.6M/s,   709MB/s :: out     1,      9B,      55/s,    495B/s
               stat_long_stddev ::   19.123 cpu ms :: in  1.5M,  12.9MB,   78.4M/s,   673MB/s :: out     1,      9B,      52/s,    470B/s
           stat_long_stddev_pop ::   18.837 cpu ms :: in  1.5M,  12.9MB,   79.6M/s,   684MB/s :: out     1,      9B,      53/s,    477B/s
             stat_double_stddev ::   17.624 cpu ms :: in  1.5M,  12.9MB,   85.1M/s,   731MB/s :: out     1,      9B,      56/s,    510B/s
         stat_double_stddev_pop ::   18.902 cpu ms :: in  1.5M,  12.9MB,   79.4M/s,   681MB/s :: out     1,      9B,      52/s,    476B/s
 sql_approx_count_distinct_long ::  139.656 cpu ms :: in  1.5M,  12.9MB,   10.7M/s,  92.2MB/s :: out     1,      9B,       7/s,     64B/s
```

   sql_approx_count_distinct_double ::  156.869 cpu ms :: in  1.5M,  12.9MB,   9.56M/s,  82.1MB/s :: out     1,      9B,       6/s,     57B/s
sql_approx_count_distinct_varbinary ::  242.097 cpu ms :: in  1.5M,  21.5MB,    6.2M/s,  88.6MB/s :: out     1,      9B,       4/s,     37B/s

with this change:

```
                      count_agg ::    0.081 cpu ms :: in  1.5M,  12.9MB,   18.5B/s,   155GB/s :: out     1,      9B,   12.3K/s,   108KB/s
                 double_sum_agg ::   10.186 cpu ms :: in  1.5M,  12.9MB,    147M/s,  1.23GB/s :: out     1,      9B,      98/s,    883B/s
                       hash_agg ::  182.666 cpu ms :: in  1.5M,  21.5MB,   8.21M/s,   117MB/s :: out     3,     45B,      16/s,    246B/s
               predicate_filter ::   98.264 cpu ms :: in  1.5M,  12.9MB,   15.3M/s,   131MB/s :: out 1.29M,  11.1MB,   13.1M/s,   113MB/s
                     raw_stream ::    3.598 cpu ms :: in  1.5M,  12.9MB,    417M/s,  3.49GB/s :: out  1.5M,  12.9MB,    417M/s,  3.49GB/s
                         top100 ::   33.915 cpu ms :: in  1.5M,  12.9MB,   44.2M/s,   380MB/s :: out   100,    900B,   2.95K/s,  25.9KB/s
         in_memory_orderby_1.5M :: 1517.990 cpu ms :: in  1.5M,  41.5MB,    988K/s,  27.3MB/s :: out  1.5M,  28.6MB,    988K/s,  18.8MB/s
                     hash_build ::  557.322 cpu ms :: in  1.5M,  25.8MB,   2.69M/s,  46.2MB/s :: out     0,      0B,       0/s,      0B/s
                      hash_join :: 1605.892 cpu ms :: in    6M,   103MB,   3.74M/s,  64.2MB/s :: out    6M,   206MB,   3.74M/s,   128MB/s
            hash_build_and_join :: 1950.674 cpu ms :: in  1.5M,   129MB,    769K/s,    66MB/s :: out    6M,   206MB,   3.08M/s,   106MB/s
sql_groupby_agg_with_arithmetic :: 2007.107 cpu ms :: in    6M,   137MB,   2.99M/s,  68.4MB/s :: out     2,     30B,       0/s,     14B/s
                  sql_count_agg ::    0.121 cpu ms :: in  1.5M,  12.9MB,   12.4B/s,   104GB/s :: out     1,      9B,   8.24K/s,  72.4KB/s
             sql_double_sum_agg ::   10.238 cpu ms :: in  1.5M,  12.9MB,    147M/s,  1.23GB/s :: out     1,      9B,      97/s,    879B/s
          sql_count_with_filter ::  158.863 cpu ms :: in  1.5M,  8.58MB,   9.44M/s,    54MB/s :: out     1,      9B,       6/s,     56B/s
                sql_groupby_agg ::  186.075 cpu ms :: in  1.5M,  21.5MB,   8.06M/s,   115MB/s :: out     3,     45B,      16/s,    241B/s
           sql_predicate_filter ::  152.790 cpu ms :: in  1.5M,  12.9MB,   9.82M/s,  84.3MB/s :: out 1.29M,  11.1MB,   8.44M/s,  72.4MB/s
                 sql_raw_stream ::    3.702 cpu ms :: in  1.5M,  12.9MB,    405M/s,   3.4GB/s :: out  1.5M,  12.9MB,    405M/s,   3.4GB/s
                    sql_top_100 ::   34.809 cpu ms :: in  1.5M,  12.9MB,   43.1M/s,   370MB/s :: out   100,    900B,   2.87K/s,  25.2KB/s
                  sql_hash_join :: 1992.505 cpu ms :: in    6M,   129MB,   3.01M/s,  64.6MB/s :: out    6M,   206MB,   3.01M/s,   103MB/s
              sql_varbinary_max ::  176.755 cpu ms :: in    6M,  97.3MB,     34M/s,   550MB/s :: out     1,     21B,       5/s,    118B/s
             sql_distinct_multi ::  416.329 cpu ms :: in  1.5M,  27.8MB,    3.6M/s,  66.7MB/s :: out     5,     97B,      12/s,    232B/s
            sql_distinct_single ::  130.377 cpu ms :: in  1.5M,  8.58MB,   11.5M/s,  65.8MB/s :: out     1,      6B,       7/s,     46B/s
               sql_tpch_query_1 :: 15415.718 cpu ms :: in    6M,   361MB,    389K/s,  23.4MB/s :: out     4,    336B,       0/s,     21B/s
             stat_long_variance ::   17.385 cpu ms :: in  1.5M,  12.9MB,   86.3M/s,   741MB/s :: out     1,      9B,      57/s,    517B/s
         stat_long_variance_pop ::   17.379 cpu ms :: in  1.5M,  12.9MB,   86.3M/s,   741MB/s :: out     1,      9B,      57/s,    517B/s
           stat_double_variance ::   17.366 cpu ms :: in  1.5M,  12.9MB,   86.4M/s,   741MB/s :: out     1,      9B,      57/s,    518B/s
       stat_double_variance_pop ::   17.378 cpu ms :: in  1.5M,  12.9MB,   86.3M/s,   741MB/s :: out     1,      9B,      57/s,    517B/s
               stat_long_stddev ::   17.433 cpu ms :: in  1.5M,  12.9MB,     86M/s,   739MB/s :: out     1,      9B,      57/s,    516B/s
           stat_long_stddev_pop ::   17.483 cpu ms :: in  1.5M,  12.9MB,   85.8M/s,   736MB/s :: out     1,      9B,      57/s,    514B/s
             stat_double_stddev ::   17.445 cpu ms :: in  1.5M,  12.9MB,     86M/s,   738MB/s :: out     1,      9B,      57/s,    515B/s
         stat_double_stddev_pop ::   17.490 cpu ms :: in  1.5M,  12.9MB,   85.8M/s,   736MB/s :: out     1,      9B,      57/s,    514B/s
 sql_approx_count_distinct_long ::  129.374 cpu ms :: in  1.5M,  12.9MB,   11.6M/s,  99.5MB/s :: out     1,      9B,       7/s,     69B/s
```

   sql_approx_count_distinct_double ::  141.799 cpu ms :: in  1.5M,  12.9MB,   10.6M/s,  90.8MB/s :: out     1,      9B,       7/s,     63B/s
sql_approx_count_distinct_varbinary ::  210.820 cpu ms :: in  1.5M,  21.5MB,   7.12M/s,   102MB/s :: out     1,      9B,       4/s,     42B/s
