### PR TITLE
Quote identifiers when formatting expressions

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -336,6 +336,13 @@ public class TestExpressionInterpreter
     }
 
     @Test
+    public void testReservedWithDoubleQuotes()
+            throws Exception
+    {
+        assertOptimizedEquals("\"time\"", "\"time\"");
+    }
+
+    @Test
     public void testSearchCase()
             throws Exception
     {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -153,7 +153,7 @@ public final class ExpressionFormatter
         @Override
         protected String visitQualifiedNameReference(QualifiedNameReference node, Void context)
         {
-            return node.getName().toString();
+            return '"' + node.getName().toString() + '"';
         }
 
         @Override


### PR DESCRIPTION
This is to avoid issues with identifiers that are also SQL keywords
