### PR TITLE
Add event logging for split completion

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
@@ -1,27 +1,27 @@
 package com.facebook.presto.event.query;
 
 import com.facebook.presto.execution.ExecutionStats;
-import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.execution.QueryInfo;
-import com.facebook.presto.execution.StageInfo;
+import com.facebook.presto.execution.TaskInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import io.airlift.event.client.EventClient;
-import io.airlift.json.JsonCodec;
 
 import static com.facebook.presto.execution.StageInfo.globalExecutionStats;
+import static com.facebook.presto.operator.OperatorStats.SplitExecutionStats;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class QueryMonitor
 {
-    private final JsonCodec<StageInfo> stageInfoCodec;
-    private final JsonCodec<FailureInfo> failureInfoCodec;
+    private final ObjectMapper objectMapper;
     private final EventClient eventClient;
 
     @Inject
-    public QueryMonitor(JsonCodec<StageInfo> stageInfoCodec, JsonCodec<FailureInfo> failureInfoCodec, EventClient eventClient)
+    public QueryMonitor(ObjectMapper objectMapper, EventClient eventClient)
     {
-        this.stageInfoCodec = checkNotNull(stageInfoCodec, "stageInfoCodec is null");
-        this.failureInfoCodec = checkNotNull(failureInfoCodec, "failureInfoCodec is null");
+        this.objectMapper = checkNotNull(objectMapper, "objectMapper is null");
         this.eventClient = checkNotNull(eventClient, "eventClient is null");
     }
 
@@ -42,31 +42,61 @@ public class QueryMonitor
 
     public void completionEvent(QueryInfo queryInfo)
     {
-        ExecutionStats globalExecutionStats = globalExecutionStats(queryInfo.getOutputStage());
-        eventClient.post(
-                new QueryCompletionEvent(
-                        queryInfo.getQueryId(),
-                        queryInfo.getSession().getUser(),
-                        queryInfo.getSession().getCatalog(),
-                        queryInfo.getSession().getSchema(),
-                        queryInfo.getState(),
-                        queryInfo.getSelf(),
-                        queryInfo.getFieldNames(),
-                        queryInfo.getQuery(),
-                        queryInfo.getQueryStats().getCreateTime(),
-                        queryInfo.getQueryStats().getExecutionStartTime(),
-                        queryInfo.getQueryStats().getEndTime(),
-                        queryInfo.getQueryStats().getQueuedTime(),
-                        queryInfo.getQueryStats().getAnalysisTime(),
-                        queryInfo.getQueryStats().getDistributedPlanningTime(),
-                        globalExecutionStats.getSplitWallTime(),
-                        globalExecutionStats.getSplitCpuTime(),
-                        globalExecutionStats.getCompletedDataSize(),
-                        globalExecutionStats.getCompletedPositionCount(),
-                        globalExecutionStats.getSplits(),
-                        stageInfoCodec.toJson(queryInfo.getOutputStage()),
-                        failureInfoCodec.toJson(queryInfo.getFailureInfo())
-                )
-        );
+        try {
+            ExecutionStats globalExecutionStats = globalExecutionStats(queryInfo.getOutputStage());
+            eventClient.post(
+                    new QueryCompletionEvent(
+                            queryInfo.getQueryId(),
+                            queryInfo.getSession().getUser(),
+                            queryInfo.getSession().getCatalog(),
+                            queryInfo.getSession().getSchema(),
+                            queryInfo.getState(),
+                            queryInfo.getSelf(),
+                            queryInfo.getFieldNames(),
+                            queryInfo.getQuery(),
+                            queryInfo.getQueryStats().getCreateTime(),
+                            queryInfo.getQueryStats().getExecutionStartTime(),
+                            queryInfo.getQueryStats().getEndTime(),
+                            queryInfo.getQueryStats().getQueuedTime(),
+                            queryInfo.getQueryStats().getAnalysisTime(),
+                            queryInfo.getQueryStats().getDistributedPlanningTime(),
+                            globalExecutionStats.getSplitWallTime(),
+                            globalExecutionStats.getSplitCpuTime(),
+                            globalExecutionStats.getCompletedDataSize(),
+                            globalExecutionStats.getCompletedPositionCount(),
+                            globalExecutionStats.getSplits(),
+                            objectMapper.writeValueAsString(queryInfo.getOutputStage()),
+                            objectMapper.writeValueAsString(queryInfo.getFailureInfo())
+                    )
+            );
+        }
+        catch (JsonProcessingException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    public void splitCompletionEvent(TaskInfo taskInfo, SplitExecutionStats splitExecutionStats)
+    {
+        try {
+            eventClient.post(
+                    new SplitCompletionEvent(
+                            taskInfo.getQueryId(),
+                            taskInfo.getStageId(),
+                            taskInfo.getTaskId(),
+                            splitExecutionStats.getExecutionStartTime(),
+                            splitExecutionStats.getTimeToFirstByte(),
+                            splitExecutionStats.getTimeToLastByte(),
+                            splitExecutionStats.getCompletedDataSize(),
+                            splitExecutionStats.getCompletedPositions(),
+                            splitExecutionStats.getWall(),
+                            splitExecutionStats.getCpu(),
+                            splitExecutionStats.getUser(),
+                            objectMapper.writeValueAsString(splitExecutionStats.getSplitInfo())
+                    )
+            );
+        }
+        catch (JsonProcessingException e) {
+            throw Throwables.propagate(e);
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/event/query/SplitCompletionEvent.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/SplitCompletionEvent.java
@@ -1,0 +1,223 @@
+package com.facebook.presto.event.query;
+
+import com.google.common.base.Preconditions;
+import io.airlift.event.client.EventField;
+import io.airlift.event.client.EventType;
+import io.airlift.units.Duration;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import static com.facebook.presto.operator.OperatorStats.SmallCounterStat.SmallCounterStatSnapshot;
+
+@Immutable
+@EventType("SplitCompletion")
+public class SplitCompletionEvent
+{
+    private final String queryId;
+    private final String stageId;
+    private final String taskId;
+
+    private final DateTime executionStartTime;
+
+    private final Long timeToFirstByteMs;
+    private final Long timeToLastByteMs;
+
+    private final SmallCounterStatSnapshot completedDataSize;
+    private final SmallCounterStatSnapshot completedPositions;
+
+    private final Long wallTimeMs;
+    private final Long cpuTimeMs;
+    private final Long userTimeMs;
+
+    private final String splitInfoJson;
+
+    public SplitCompletionEvent(
+            String queryId,
+            String stageId,
+            String taskId,
+            @Nullable DateTime executionStartTime,
+            @Nullable Duration timeToFirstByte,
+            @Nullable Duration timeToLastByte,
+            SmallCounterStatSnapshot completedDataSize,
+            SmallCounterStatSnapshot completedPositions,
+            @Nullable Duration wallTime,
+            @Nullable Duration cpuTime,
+            @Nullable Duration userTime,
+            String splitInfoJson)
+    {
+        Preconditions.checkNotNull(queryId, "queryId is null");
+        Preconditions.checkNotNull(stageId, "stageId is null");
+        Preconditions.checkNotNull(taskId, "taskId is null");
+        Preconditions.checkNotNull(completedDataSize, "completedDataSize is null");
+        Preconditions.checkNotNull(completedPositions, "completedPositions is null");
+        Preconditions.checkNotNull(splitInfoJson, "splitInfoJson is null");
+
+        this.queryId = queryId;
+        this.stageId = stageId;
+        this.taskId = taskId;
+        this.executionStartTime = executionStartTime;
+        this.timeToFirstByteMs = durationToMillis(timeToFirstByte);
+        this.timeToLastByteMs = durationToMillis(timeToLastByte);
+        this.completedDataSize = completedDataSize;
+        this.completedPositions = completedPositions;
+        this.wallTimeMs = durationToMillis(wallTime);
+        this.cpuTimeMs = durationToMillis(cpuTime);
+        this.userTimeMs = durationToMillis(userTime);
+        this.splitInfoJson = splitInfoJson;
+    }
+
+    @Nullable
+    private static Long durationToMillis(@Nullable Duration duration)
+    {
+        if (duration == null) {
+            return null;
+        }
+        return (long) duration.toMillis();
+    }
+
+    @EventField
+    public String getQueryId()
+    {
+        return queryId;
+    }
+
+    @EventField
+    public String getStageId()
+    {
+        return stageId;
+    }
+
+    @EventField
+    public String getTaskId()
+    {
+        return taskId;
+    }
+
+    @EventField
+    public DateTime getExecutionStartTime()
+    {
+        return executionStartTime;
+    }
+
+    @EventField
+    public Long getTimeToFirstByteMs()
+    {
+        return timeToFirstByteMs;
+    }
+
+    @EventField
+    public Long getTimeToLastByteMs()
+    {
+        return timeToLastByteMs;
+    }
+
+    @EventField
+    public long getCompletedDataSizeTotal()
+    {
+        return completedDataSize.getTotalCount();
+    }
+
+    @EventField
+    public double getCompletedDataSizeCountTenSec()
+    {
+        return completedDataSize.getTenSeconds().getCount();
+    }
+
+    @EventField
+    public double getCompletedDataSizeRateTenSec()
+    {
+        return completedDataSize.getTenSeconds().getRate();
+    }
+
+    @EventField
+    public double getCompletedDataSizeCountThirtySec()
+    {
+        return completedDataSize.getThirtySeconds().getCount();
+    }
+
+    @EventField
+    public double getCompletedDataSizeRateThirtySec()
+    {
+        return completedDataSize.getThirtySeconds().getRate();
+    }
+
+    @EventField
+    public double getCompletedDataSizeCountOneMin()
+    {
+        return completedDataSize.getOneMinute().getCount();
+    }
+
+    @EventField
+    public double getCompletedDataSizeRateOneMin()
+    {
+        return completedDataSize.getOneMinute().getRate();
+    }
+
+    @EventField
+    public long getCompletedPositionsTotal()
+    {
+        return completedPositions.getTotalCount();
+    }
+
+    @EventField
+    public double getCompletedPositionsCountTenSec()
+    {
+        return completedPositions.getTenSeconds().getCount();
+    }
+
+    @EventField
+    public double getCompletedPositionsRateTenSec()
+    {
+        return completedPositions.getTenSeconds().getRate();
+    }
+
+    @EventField
+    public double getCompletedPositionsCountThirtySec()
+    {
+        return completedPositions.getThirtySeconds().getCount();
+    }
+
+    @EventField
+    public double getCompletedPositionsRateThirtySec()
+    {
+        return completedPositions.getThirtySeconds().getRate();
+    }
+
+    @EventField
+    public double getCompletedPositionsCountOneMin()
+    {
+        return completedPositions.getOneMinute().getCount();
+    }
+
+    @EventField
+    public double getCompletedPositionsRateOneMin()
+    {
+        return completedPositions.getOneMinute().getRate();
+    }
+
+    @EventField
+    public Long getWallTimeMs()
+    {
+        return wallTimeMs;
+    }
+
+    @EventField
+    public Long getCpuTimeMs()
+    {
+        return cpuTimeMs;
+    }
+
+    @EventField
+    public Long getUserTimeMs()
+    {
+        return userTimeMs;
+    }
+
+    @EventField
+    public String getSplitInfoJson()
+    {
+        return splitInfoJson;
+    }
+}

--- a/presto-server/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-server/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -8,6 +8,7 @@ import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.event.query.QueryCompletionEvent;
 import com.facebook.presto.event.query.QueryCreatedEvent;
 import com.facebook.presto.event.query.QueryMonitor;
+import com.facebook.presto.event.query.SplitCompletionEvent;
 import com.facebook.presto.execution.CreateOrReplaceMaterializedViewExecution.CreateOrReplaceMaterializedViewExecutionFactory;
 import com.facebook.presto.execution.DropTableExecution.DropTableExecutionFactory;
 import com.facebook.presto.execution.LocationFactory;
@@ -178,11 +179,10 @@ public class ServerMainModule
         jsonBinder(binder).addDeserializerBinding(Expression.class).to(ExpressionDeserializer.class);
         jsonBinder(binder).addDeserializerBinding(FunctionCall.class).to(FunctionCallDeserializer.class);
 
-        jsonCodecBinder(binder).bindJsonCodec(StageInfo.class);
-        jsonCodecBinder(binder).bindJsonCodec(FailureInfo.class);
         binder.bind(QueryMonitor.class).in(Scopes.SINGLETON);
         eventBinder(binder).bindEventClient(QueryCreatedEvent.class);
         eventBinder(binder).bindEventClient(QueryCompletionEvent.class);
+        eventBinder(binder).bindEventClient(SplitCompletionEvent.class);
 
         discoveryBinder(binder).bindSelector("presto");
 


### PR DESCRIPTION
The nectar payload in scribe will look like this:

{
  "completed_positions_rate_ten_sec": 437,
  "completed_data_size_count_one_min": 1026901,
  "event_type": "SplitCompletion",
  "task_id": "2.1.0",
  "completed_data_size_total": 1026901,
  "time_to_last_byte_ms": 24719,
  "event_uuid": "fffb559f-7db3-40bb-aad4-56e001f1dbc8",
  "completed_positions_count_ten_sec": 4370,
  "time_to_first_byte_ms": 24716,
  "completed_data_size_rate_thirty_sec": 34230.033333333,
  "query_id": "2",
  "execution_start_time": "2013-04-09T22:40:23.309Z",
  "wall_time_ms": 24720,
  "completed_positions_rate_one_min": 72.833333333333,
  "completed_data_size_count_ten_sec": 1026901,
  "completed_positions_count_thirty_sec": 4370,
  "completed_positions_count_one_min": 4370,
  "cpu_time_ms": 210,
  "split_info_json": "[{\"path\":\"hdfs:\/\/dfs1.data.facebook.com:9000\/user\/facebook\/warehouse\/ad_account_bass_ad_obj_map\/ds=2013-04-06\/000000_0\",\"start\":0,\"length\":49792606,\"hosts\":[\"hadoop2913.snc5.facebook.com.\/10.38.208.27\",\"hadoop417.snc5.facebook.com.\/10.38.27.21\",\"hadoop1829.snc5.facebook.com.\/10.38.106.27\"]}]",
  "completed_positions_total": 4370,
  "completed_data_size_count_thirty_sec": 1026901,
  "user_time_ms": 199,
  "event_time": "2013-04-09T22:40:48.033Z",
  "completed_data_size_rate_ten_sec": 102690.1,
  "completed_positions_rate_thirty_sec": 145.66666666667,
  "completed_data_size_rate_one_min": 17115.016666667,
  "event_host": "ehwang-mbp.local",
  "stage_id": "2.1"
}
