### PR TITLE
Reduce the number of expected groups

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -811,7 +811,7 @@ public class LocalExecutionPlanner
                     Iterables.getOnlyElement(getChannelsForSymbols(groupBySymbols, source.getLayout())),
                     node.getStep(),
                     functionDefinitions,
-                    100_000,
+                    10_000,
                     maxOperatorMemoryUsage);
 
             return new PhysicalOperation(aggregationOperator, outputMappings.build());


### PR DESCRIPTION
The current value of 100k means that each aggregation requires at least 400 KB of memory. For a query running ~120 splits per node, this adds up.
