### PR TITLE
implement sys.alias

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/system/AliasSystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/AliasSystemTable.java
@@ -1,0 +1,74 @@
+package com.facebook.presto.connector.system;
+
+import com.facebook.presto.metadata.AliasDao;
+import com.facebook.presto.metadata.TableAlias;
+import com.facebook.presto.spi.ColumnType;
+import com.facebook.presto.spi.InMemoryRecordSet;
+import com.facebook.presto.spi.InMemoryRecordSet.Builder;
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SystemTable;
+import com.facebook.presto.spi.TableMetadata;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static com.facebook.presto.metadata.MetadataUtil.columnTypeGetter;
+import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
+import static com.facebook.presto.spi.ColumnType.STRING;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.transform;
+
+public class AliasSystemTable
+        implements SystemTable
+{
+    public static final SchemaTableName ALIAS_TABLE_NAME = new SchemaTableName("sys", "alias");
+
+    public static final TableMetadata ALIAS_TABLE = tableMetadataBuilder(ALIAS_TABLE_NAME)
+            .column("source_catalog", STRING)
+            .column("table", STRING)
+            .column("destination_catalog", STRING)
+            .column("alias", STRING)
+            .build();
+
+    private final AliasDao aliasDao;
+
+    @Inject
+    public AliasSystemTable(AliasDao aliasDao)
+    {
+        this.aliasDao = checkNotNull(aliasDao, "aliasDao is null");
+    }
+
+    @Override
+    public boolean isDistributed()
+    {
+        return false;
+    }
+
+    @Override
+    public TableMetadata getTableMetadata()
+    {
+        return ALIAS_TABLE;
+    }
+
+    @Override
+    public List<ColumnType> getColumnTypes()
+    {
+        return ImmutableList.copyOf(transform(ALIAS_TABLE.getColumns(), columnTypeGetter()));
+    }
+
+    @Override
+    public RecordCursor cursor()
+    {
+        Builder table = InMemoryRecordSet.builder(ALIAS_TABLE);
+        for (TableAlias tableAlias : aliasDao.getAliases()) {
+            table.addRow(tableAlias.getSourceConnectorId(),
+                    new SchemaTableName(tableAlias.getSourceSchemaName(), tableAlias.getSourceTableName()).toString(),
+                    tableAlias.getDestinationConnectorId(),
+                    new SchemaTableName(tableAlias.getDestinationSchemaName(), tableAlias.getDestinationTableName()).toString());
+        }
+        return table.build().cursor();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemTablesModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemTablesModule.java
@@ -24,5 +24,6 @@ public class SystemTablesModule
         globalTableBinder.addBinding().to(NodesSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(QuerySystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(TaskSystemTable.class).in(Scopes.SINGLETON);
+        globalTableBinder.addBinding().to(AliasSystemTable.class).in(Scopes.SINGLETON);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/AliasDao.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/AliasDao.java
@@ -9,6 +9,7 @@ import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.customizers.Mapper;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public interface AliasDao
@@ -39,6 +40,10 @@ public interface AliasDao
     @SqlQuery("SELECT * FROM alias WHERE source_connector_id = :connectorId AND source_schema_name = :schemaName AND source_table_name = :tableName")
     @Mapper(TableAlias.TableAliasMapper.class)
     TableAlias getAlias(@Bind("connectorId") String connectorId, @Bind("schemaName") String schemaName, @Bind("tableName") String tableName);
+
+    @SqlQuery("SELECT * FROM alias")
+    @Mapper(TableAlias.TableAliasMapper.class)
+    List<TableAlias> getAliases();
 
     public static final class Utils
     {


### PR DESCRIPTION
list all the table aliases in the system.

select \* from sys.alias;
 source_connector_id | source_schema_name |              source_table_name               | destination_connector_id | destination_schema_name | destination_table_name
---------------------+--------------------+----------------------------------------------+--------------------------+-------------------------+------------------------
 ailabs              | bi_carolina        | tmp_presto_polaris_lu_psychographic_segments | default                  | default                 | tpp
(1 row)
