### PR TITLE
Improve node scheduling logic

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/NodeSchedulerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/NodeSchedulerConfig.java
@@ -1,0 +1,23 @@
+package com.facebook.presto.execution;
+
+import io.airlift.configuration.Config;
+
+import javax.validation.constraints.Min;
+
+public class NodeSchedulerConfig
+{
+    private int minCandidates = 10;
+
+    @Min(1)
+    public int getMinCandidates()
+    {
+        return minCandidates;
+    }
+
+    @Config("node-scheduler.min-candidates")
+    public NodeSchedulerConfig setMinCandidates(int candidates)
+    {
+        this.minCandidates = candidates;
+        return this;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -72,7 +72,7 @@ public class TestSqlStageExecution
             stageExecution = new SqlStageExecution(new QueryId("query"),
                     new MockLocationFactory(),
                     joinPlan,
-                    new NodeScheduler(nodeManager), new MockRemoteTaskFactory(executor),
+                    new NodeScheduler(nodeManager, new NodeSchedulerConfig()), new MockRemoteTaskFactory(executor),
                     SESSION,
                     1,
                     executor);

--- a/presto-server/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-server/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -19,6 +19,7 @@ import com.facebook.presto.execution.DropAliasExecution.DropAliasExecutionFactor
 import com.facebook.presto.execution.DropTableExecution.DropTableExecutionFactory;
 import com.facebook.presto.execution.LocationFactory;
 import com.facebook.presto.execution.NodeScheduler;
+import com.facebook.presto.execution.NodeSchedulerConfig;
 import com.facebook.presto.execution.QueryExecution.QueryExecutionFactory;
 import com.facebook.presto.execution.QueryIdGenerator;
 import com.facebook.presto.execution.QueryInfo;
@@ -222,6 +223,7 @@ public class ServerMainModule
         discoveryBinder(binder).bindSelector("presto");
 
         binder.bind(NodeManager.class).to(DiscoveryNodeManager.class).in(Scopes.SINGLETON);
+        bindConfig(binder).to(NodeSchedulerConfig.class);
         binder.bind(NodeScheduler.class).in(Scopes.SINGLETON);
         ExportBinder.newExporter(binder).export(NodeScheduler.class).withGeneratedName();
         binder.bind(ShardManager.class).to(DatabaseShardManager.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
- Change node scheduling logic to use exact matching hosts if there are enough of them, and only fall back to nodes in the same rack if there aren't enough matches.
- Also add a config flag to set the number of candidate nodes for each split considered by the scheduler
