### PR TITLE
re-introduce table writer predicate

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DistributedExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DistributedExecutionPlanner.java
@@ -184,7 +184,7 @@ public class DistributedExecutionPlanner
             TableWriter tableWriter = new TableWriter(node, shardManager);
 
             // get source splits
-            NodeSplits nodeSplits = node.getSource().accept(this, tableWriterPartitionPredicate);
+            NodeSplits nodeSplits = node.getSource().accept(this, tableWriter.getPartitionPredicate());
             checkState(nodeSplits.dataSource.isPresent(), "No splits present for import");
             DataSource dataSource = nodeSplits.dataSource.get();
 


### PR DESCRIPTION
was dropped in refactoring, needed to prune already loaded partitions when running REFRESH MATERIALIZED VIEW.
