### PR TITLE
allow empty address lists in native split

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/split/NativeSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/NativeSplit.java
@@ -24,8 +24,7 @@ public class NativeSplit
         checkArgument(shardId >= 0, "shard id must be at least zero");
         this.shardId = shardId;
 
-        checkNotNull(addresses, "hosts is null");
-        checkArgument(!addresses.isEmpty(), "hosts is empty");
+        checkNotNull(addresses, "addresses is null");
         this.addresses = ImmutableList.copyOf(addresses);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/split/NativeSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/NativeSplitManager.java
@@ -126,6 +126,7 @@ public class NativeSplitManager
 
             for (Map.Entry<Long, Collection<String>> entry : shardNodes.build().asMap().entrySet()) {
                 List<HostAddress> addresses = getAddressesForNodes(nodesById, entry.getValue());
+                checkState(addresses.size() > 0, "no host for shard %s found", entry.getKey());
                 Split split = new NativeSplit(entry.getKey(), addresses);
                 splits.add(split);
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/TableWriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/TableWriter.java
@@ -2,6 +2,7 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.metadata.ShardManager;
 import com.facebook.presto.operator.TableWriterResult;
+import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Partition;
 import com.facebook.presto.spi.PartitionKey;
 import com.facebook.presto.spi.PartitionedSplit;
@@ -214,7 +215,7 @@ public class TableWriter
             if (sourceIterator.hasNext()) {
                 Split sourceSplit = sourceIterator.next();
 
-                NativeSplit writingSplit = new NativeSplit(shardManager.allocateShard(tableWriterNode.getTable()), sourceSplit.getAddresses());
+                NativeSplit writingSplit = new NativeSplit(shardManager.allocateShard(tableWriterNode.getTable()), ImmutableList.<HostAddress>of());
 
                 String partition = "unpartitioned";
                 boolean lastSplit = false;


### PR DESCRIPTION
NativeSplit only needs an address when reading data. When data is
written, the node that will hold the data will be known only after the
data was written (and the split was consumed). This was masked till
now by using the list of addresses from the source split (the hdfs
nodes that hold the source data) but the raid changes now may return
empty lists.

Fix is to allow empty lists, set the list explicitly to empty when
creating a write split and check to make sure that the list of
addresses returned in the native split manager is not empty.
