### PR TITLE
Fix for all columns with alias

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -209,12 +209,7 @@ public final class SqlFormatter
         @Override
         protected Void visitAllColumns(AllColumns node, Integer context)
         {
-            if (node.getPrefix().isPresent()) {
-                builder.append(node.getPrefix().isPresent())
-                        .append('.');
-            }
-
-            builder.append('*');
+            builder.append(node.toString());
 
             return null;
         }


### PR DESCRIPTION
For selecting all columns with alias (eg: SELECT A.\* FROM orders a) we were building it as select true.\* 
use the node.toString instead which implements this correctly. 
