### PR TITLE
Long/Double Approximate Average Operators

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -75,10 +75,12 @@ import static com.facebook.presto.operator.aggregation.BooleanMinAggregation.BOO
 import static com.facebook.presto.operator.aggregation.CountAggregation.COUNT;
 import static com.facebook.presto.operator.aggregation.CountColumnAggregation.COUNT_COLUMN;
 import static com.facebook.presto.operator.aggregation.CountIfAggregation.COUNT_IF;
+import static com.facebook.presto.operator.aggregation.DoubleApproximateAverageAggregation.DOUBLE_APPROX_AVERAGE;
 import static com.facebook.presto.operator.aggregation.DoubleAverageAggregation.DOUBLE_AVERAGE;
 import static com.facebook.presto.operator.aggregation.DoubleMaxAggregation.DOUBLE_MAX;
 import static com.facebook.presto.operator.aggregation.DoubleMinAggregation.DOUBLE_MIN;
 import static com.facebook.presto.operator.aggregation.DoubleSumAggregation.DOUBLE_SUM;
+import static com.facebook.presto.operator.aggregation.LongApproximateAverageAggregation.LONG_APPROX_AVERAGE;
 import static com.facebook.presto.operator.aggregation.LongAverageAggregation.LONG_AVERAGE;
 import static com.facebook.presto.operator.aggregation.LongMaxAggregation.LONG_MAX;
 import static com.facebook.presto.operator.aggregation.LongMinAggregation.LONG_MIN;
@@ -146,6 +148,8 @@ public class FunctionRegistry
                 .aggregate("approx_percentile", LONG, ImmutableList.of(LONG, LONG, DOUBLE), STRING, LongApproximatePercentileWeightedAggregation.INSTANCE)
                 .aggregate("approx_percentile", DOUBLE, ImmutableList.of(DOUBLE, DOUBLE), STRING, DoubleApproximatePercentileAggregation.INSTANCE)
                 .aggregate("approx_percentile", DOUBLE, ImmutableList.of(DOUBLE, LONG, DOUBLE), STRING, DoubleApproximatePercentileWeightedAggregation.INSTANCE)
+                .aggregate("approx_avg", STRING, ImmutableList.of(LONG), STRING, LONG_APPROX_AVERAGE)
+                .aggregate("approx_avg", STRING, ImmutableList.of(DOUBLE), STRING, DOUBLE_APPROX_AVERAGE)
                 .scalar(StringFunctions.class)
                 .scalar(RegexpFunctions.class)
                 .scalar(UrlFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleApproximateAverageAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleApproximateAverageAggregation.java
@@ -1,0 +1,212 @@
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.block.Block;
+import com.facebook.presto.block.BlockBuilder;
+import com.facebook.presto.block.BlockCursor;
+import com.facebook.presto.tuple.TupleInfo;
+import com.facebook.presto.tuple.TupleInfo.Type;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import static com.facebook.presto.tuple.TupleInfo.SINGLE_VARBINARY;
+
+public class DoubleApproximateAverageAggregation
+        implements FixedWidthAggregationFunction
+{
+    public static final DoubleApproximateAverageAggregation DOUBLE_APPROX_AVERAGE = new DoubleApproximateAverageAggregation();
+
+    /**
+     * Describes the tuple used by to calculate the variance.
+     */
+    static final TupleInfo APPROX_AVG_CONTEXT_INFO = new TupleInfo(
+            Type.FIXED_INT_64,  // n
+            Type.DOUBLE,        // mean
+            Type.DOUBLE);       // m2
+
+    @Override
+    public int getFixedSize()
+    {
+        return APPROX_AVG_CONTEXT_INFO.getFixedSize();
+    }
+
+    @Override
+    public TupleInfo getFinalTupleInfo()
+    {
+        //TODO: This must be fixed when we have primitive error types implemented
+        return SINGLE_VARBINARY;
+    }
+
+    @Override
+    public TupleInfo getIntermediateTupleInfo()
+    {
+        return SINGLE_VARBINARY;
+    }
+
+    @Override
+    public void initialize(Slice valueSlice, int valueOffset)
+    {
+        // mark value null
+
+        APPROX_AVG_CONTEXT_INFO.setNull(valueSlice, valueOffset, 0);
+
+        APPROX_AVG_CONTEXT_INFO.setNotNull(valueSlice, valueOffset, 1);
+        APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 1, 0);
+
+        APPROX_AVG_CONTEXT_INFO.setNotNull(valueSlice, valueOffset, 2);
+        APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 2, 0);
+
+    }
+
+    @Override
+    public void addInput(BlockCursor cursor, int field, Slice valueSlice, int valueOffset)
+    {
+        boolean hasValue = !APPROX_AVG_CONTEXT_INFO.isNull(valueSlice, valueOffset, 0);
+
+        if (cursor.isNull(field)) {
+            return;
+        }
+
+        long count = hasValue ? APPROX_AVG_CONTEXT_INFO.getLong(valueSlice, valueOffset, 0) : 0;
+        double mean = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 1);
+        double m2 = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 2);
+
+        count++;
+        double x = cursor.getDouble(field);
+        double delta = x - mean;
+        mean += (delta / count);
+        m2 += (delta * (x - mean));
+
+        if (!hasValue) {
+            APPROX_AVG_CONTEXT_INFO.setNotNull(valueSlice, valueOffset, 0);
+        }
+
+        APPROX_AVG_CONTEXT_INFO.setLong(valueSlice, valueOffset, 0, count);
+        APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 1, mean);
+        APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 2, m2);
+
+    }
+
+    @Override
+    public void addInput(int positionCount, Block block, int field, Slice valueSlice, int valueOffset)
+    {
+        boolean hasValue = !APPROX_AVG_CONTEXT_INFO.isNull(valueSlice, valueOffset, 0);
+        long count = hasValue ? APPROX_AVG_CONTEXT_INFO.getLong(valueSlice, valueOffset, 0) : 0;
+        double mean = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 1);
+        double m2 = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 2);
+
+        BlockCursor cursor = block.cursor();
+
+        while (cursor.advanceNextPosition()) {
+            if (cursor.isNull(field)) {
+                continue;
+            }
+
+            // There is now at least one value present.
+            hasValue = true;
+
+            count++;
+            double x = cursor.getDouble(field);
+            double delta = x - mean;
+            mean += (delta / count);
+            m2 += (delta * (x - mean));
+        }
+
+        if (hasValue) {
+            APPROX_AVG_CONTEXT_INFO.setNotNull(valueSlice, valueOffset, 0);
+            APPROX_AVG_CONTEXT_INFO.setLong(valueSlice, valueOffset, 0, count);
+            APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 1, mean);
+            APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 2, m2);
+        }
+
+    }
+
+    @Override
+    public void addIntermediate(BlockCursor cursor, int field, Slice valueSlice, int valueOffset)
+    {
+        if (cursor.isNull(field)) {
+            return;
+        }
+
+        Slice otherVariance = cursor.getSlice(field);
+        long otherCount = APPROX_AVG_CONTEXT_INFO.getLong(otherVariance, 0);
+        double otherMean = APPROX_AVG_CONTEXT_INFO.getDouble(otherVariance, 1);
+        double otherM2 = APPROX_AVG_CONTEXT_INFO.getDouble(otherVariance, 2);
+
+        long totalCount;
+        double totalMean;
+        double totalM2;
+
+        if (APPROX_AVG_CONTEXT_INFO.isNull(valueSlice, valueOffset, 0)) {
+            totalCount = otherCount;
+            totalMean = otherMean;
+            totalM2 = otherM2;
+        }
+        else {
+            long count = APPROX_AVG_CONTEXT_INFO.getLong(valueSlice, valueOffset, 0);
+            double mean = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 1);
+            double m2 = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 2);
+
+            double delta = otherMean - mean;
+
+            totalCount = count + otherCount;
+
+            // Use numerically stable variant
+            totalMean = ((count * mean) + (otherCount * otherMean)) / totalCount;
+            totalM2 = m2 + otherM2 + ((delta * delta) * (count * otherCount)) / totalCount;
+        }
+
+        APPROX_AVG_CONTEXT_INFO.setNotNull(valueSlice, valueOffset, 0);
+        APPROX_AVG_CONTEXT_INFO.setLong(valueSlice, valueOffset, 0, totalCount);
+        APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 1, totalMean);
+        APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 2, totalM2);
+    }
+
+    @Override
+    public void evaluateIntermediate(Slice valueSlice, int valueOffset, BlockBuilder output)
+    {
+        boolean isEmpty = APPROX_AVG_CONTEXT_INFO.isNull(valueSlice, valueOffset, 0);
+        if (isEmpty) {
+            output.appendNull();
+            return;
+        }
+
+        long count = APPROX_AVG_CONTEXT_INFO.getLong(valueSlice, valueOffset, 0);
+        double mean = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 1);
+        double m2 = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 2);
+
+        Slice intermediateValue = Slices.allocate(APPROX_AVG_CONTEXT_INFO.getFixedSize());
+        APPROX_AVG_CONTEXT_INFO.setNotNull(intermediateValue, 0);
+        APPROX_AVG_CONTEXT_INFO.setLong(intermediateValue, 0, count);
+        APPROX_AVG_CONTEXT_INFO.setDouble(intermediateValue, 1, mean);
+        APPROX_AVG_CONTEXT_INFO.setDouble(intermediateValue, 2, m2);
+
+        output.append(intermediateValue);
+    }
+
+    @Override
+    public void evaluateFinal(Slice valueSlice, int valueOffset, BlockBuilder output)
+    {
+        if (!APPROX_AVG_CONTEXT_INFO.isNull(valueSlice, valueOffset, 0)) {
+
+            long count = APPROX_AVG_CONTEXT_INFO.getLong(valueSlice, valueOffset, 0);
+            double mean = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 1);
+            double m2 = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 2);
+            double variance = m2/count;
+
+            // The multiplier 2.575 corresponds to the z-score of 99% confidence interval
+            // (http://upload.wikimedia.org/wikipedia/commons/b/bb/Normal_distribution_and_scales.gif)
+            double zScore = 2.575;
+
+            // Error bars at 99% confidence interval
+            StringBuilder sb = new StringBuilder();
+            sb.append(mean);
+            sb.append(" +/- ");
+            sb.append(zScore * Math.sqrt(variance / count));
+
+            output.append(sb.toString());
+
+        } else {
+            output.appendNull();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/LongApproximateAverageAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/LongApproximateAverageAggregation.java
@@ -1,0 +1,212 @@
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.block.Block;
+import com.facebook.presto.block.BlockBuilder;
+import com.facebook.presto.block.BlockCursor;
+import com.facebook.presto.tuple.TupleInfo;
+import com.facebook.presto.tuple.TupleInfo.Type;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import static com.facebook.presto.tuple.TupleInfo.SINGLE_VARBINARY;
+
+public class LongApproximateAverageAggregation
+        implements FixedWidthAggregationFunction
+{
+    public static final LongApproximateAverageAggregation LONG_APPROX_AVERAGE = new LongApproximateAverageAggregation();
+
+    /**
+     * Describes the tuple used by to calculate the variance.
+     */
+    static final TupleInfo APPROX_AVG_CONTEXT_INFO = new TupleInfo(
+            Type.FIXED_INT_64,  // n
+            Type.DOUBLE,        // mean
+            Type.DOUBLE);       // m2
+
+    @Override
+    public int getFixedSize()
+    {
+        return APPROX_AVG_CONTEXT_INFO.getFixedSize();
+    }
+
+    @Override
+    public TupleInfo getFinalTupleInfo()
+    {
+        //TODO: This must be fixed when we have primitive error types implemented
+        return SINGLE_VARBINARY;
+    }
+
+    @Override
+    public TupleInfo getIntermediateTupleInfo()
+    {
+        return SINGLE_VARBINARY;
+    }
+
+    @Override
+    public void initialize(Slice valueSlice, int valueOffset)
+    {
+        // mark value null
+
+        APPROX_AVG_CONTEXT_INFO.setNull(valueSlice, valueOffset, 0);
+
+        APPROX_AVG_CONTEXT_INFO.setNotNull(valueSlice, valueOffset, 1);
+        APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 1, 0);
+
+        APPROX_AVG_CONTEXT_INFO.setNotNull(valueSlice, valueOffset, 2);
+        APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 2, 0);
+
+    }
+
+    @Override
+    public void addInput(BlockCursor cursor, int field, Slice valueSlice, int valueOffset)
+    {
+        boolean hasValue = !APPROX_AVG_CONTEXT_INFO.isNull(valueSlice, valueOffset, 0);
+
+        if (cursor.isNull(field)) {
+            return;
+        }
+
+        long count = hasValue ? APPROX_AVG_CONTEXT_INFO.getLong(valueSlice, valueOffset, 0) : 0;
+        double mean = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 1);
+        double m2 = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 2);
+
+        count++;
+        double x = cursor.getLong(field);
+        double delta = x - mean;
+        mean += (delta / count);
+        m2 += (delta * (x - mean));
+
+        if (!hasValue) {
+            APPROX_AVG_CONTEXT_INFO.setNotNull(valueSlice, valueOffset, 0);
+        }
+
+        APPROX_AVG_CONTEXT_INFO.setLong(valueSlice, valueOffset, 0, count);
+        APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 1, mean);
+        APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 2, m2);
+
+    }
+
+    @Override
+    public void addInput(int positionCount, Block block, int field, Slice valueSlice, int valueOffset)
+    {
+        boolean hasValue = !APPROX_AVG_CONTEXT_INFO.isNull(valueSlice, valueOffset, 0);
+        long count = hasValue ? APPROX_AVG_CONTEXT_INFO.getLong(valueSlice, valueOffset, 0) : 0;
+        double mean = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 1);
+        double m2 = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 2);
+
+        BlockCursor cursor = block.cursor();
+
+        while (cursor.advanceNextPosition()) {
+            if (cursor.isNull(field)) {
+                continue;
+            }
+
+            // There is now at least one value present.
+            hasValue = true;
+
+            count++;
+            double x = cursor.getLong(field);
+            double delta = x - mean;
+            mean += (delta / count);
+            m2 += (delta * (x - mean));
+        }
+
+        if (hasValue) {
+            APPROX_AVG_CONTEXT_INFO.setNotNull(valueSlice, valueOffset, 0);
+            APPROX_AVG_CONTEXT_INFO.setLong(valueSlice, valueOffset, 0, count);
+            APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 1, mean);
+            APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 2, m2);
+        }
+
+    }
+
+    @Override
+    public void addIntermediate(BlockCursor cursor, int field, Slice valueSlice, int valueOffset)
+    {
+        if (cursor.isNull(field)) {
+            return;
+        }
+
+        Slice otherVariance = cursor.getSlice(field);
+        long otherCount = APPROX_AVG_CONTEXT_INFO.getLong(otherVariance, 0);
+        double otherMean = APPROX_AVG_CONTEXT_INFO.getDouble(otherVariance, 1);
+        double otherM2 = APPROX_AVG_CONTEXT_INFO.getDouble(otherVariance, 2);
+
+        long totalCount;
+        double totalMean;
+        double totalM2;
+
+        if (APPROX_AVG_CONTEXT_INFO.isNull(valueSlice, valueOffset, 0)) {
+            totalCount = otherCount;
+            totalMean = otherMean;
+            totalM2 = otherM2;
+        }
+        else {
+            long count = APPROX_AVG_CONTEXT_INFO.getLong(valueSlice, valueOffset, 0);
+            double mean = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 1);
+            double m2 = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 2);
+
+            double delta = otherMean - mean;
+
+            totalCount = count + otherCount;
+
+            // Use numerically stable variant
+            totalMean = ((count * mean) + (otherCount * otherMean)) / totalCount;
+            totalM2 = m2 + otherM2 + ((delta * delta) * (count * otherCount)) / totalCount;
+        }
+
+        APPROX_AVG_CONTEXT_INFO.setNotNull(valueSlice, valueOffset, 0);
+        APPROX_AVG_CONTEXT_INFO.setLong(valueSlice, valueOffset, 0, totalCount);
+        APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 1, totalMean);
+        APPROX_AVG_CONTEXT_INFO.setDouble(valueSlice, valueOffset, 2, totalM2);
+    }
+
+    @Override
+    public void evaluateIntermediate(Slice valueSlice, int valueOffset, BlockBuilder output)
+    {
+        boolean isEmpty = APPROX_AVG_CONTEXT_INFO.isNull(valueSlice, valueOffset, 0);
+        if (isEmpty) {
+            output.appendNull();
+            return;
+        }
+
+        long count = APPROX_AVG_CONTEXT_INFO.getLong(valueSlice, valueOffset, 0);
+        double mean = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 1);
+        double m2 = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 2);
+
+        Slice intermediateValue = Slices.allocate(APPROX_AVG_CONTEXT_INFO.getFixedSize());
+        APPROX_AVG_CONTEXT_INFO.setNotNull(intermediateValue, 0);
+        APPROX_AVG_CONTEXT_INFO.setLong(intermediateValue, 0, count);
+        APPROX_AVG_CONTEXT_INFO.setDouble(intermediateValue, 1, mean);
+        APPROX_AVG_CONTEXT_INFO.setDouble(intermediateValue, 2, m2);
+
+        output.append(intermediateValue);
+    }
+
+    @Override
+    public void evaluateFinal(Slice valueSlice, int valueOffset, BlockBuilder output)
+    {
+        if (!APPROX_AVG_CONTEXT_INFO.isNull(valueSlice, valueOffset, 0)) {
+
+            long count = APPROX_AVG_CONTEXT_INFO.getLong(valueSlice, valueOffset, 0);
+            double mean = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 1);
+            double m2 = APPROX_AVG_CONTEXT_INFO.getDouble(valueSlice, valueOffset, 2);
+            double variance = m2/count;
+
+            // The multiplier 2.575 corresponds to the z-score of 99% confidence interval
+            // (http://upload.wikimedia.org/wikipedia/commons/b/bb/Normal_distribution_and_scales.gif)
+            double zScore = 2.575;
+
+            // Error bars at 99% confidence interval
+            StringBuilder sb = new StringBuilder();
+            sb.append(mean);
+            sb.append(" +/- ");
+            sb.append(zScore * Math.sqrt(variance / count));
+
+            output.append(sb.toString());
+
+        } else {
+            output.appendNull();
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleApproximateAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleApproximateAverageAggregation.java
@@ -1,0 +1,56 @@
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.block.Block;
+import com.facebook.presto.block.BlockBuilder;
+
+import static com.facebook.presto.operator.aggregation.DoubleApproximateAverageAggregation.DOUBLE_APPROX_AVERAGE;
+import static com.facebook.presto.tuple.TupleInfo.SINGLE_DOUBLE;
+
+public class TestDoubleApproximateAverageAggregation
+    extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block getSequenceBlock(int start, int length)
+    {
+        BlockBuilder blockBuilder = new BlockBuilder(SINGLE_DOUBLE);
+        for (int i = start; i < start + length; i++) {
+            blockBuilder.append((double) i);
+        }
+        return blockBuilder.build();
+    }
+
+    @Override
+    public AggregationFunction getFunction()
+    {
+        return DOUBLE_APPROX_AVERAGE;
+    }
+
+    @Override
+    public String getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double sum = 0;
+        for (int i = start; i < start + length; i++) {
+            sum += i;
+        }
+
+        double mean = sum/length;
+        double m2 = 0.0;
+        for (int i = start; i < start + length; i++) {
+            m2 += (i - mean) * (i - mean);
+        }
+
+        double variance = m2/length;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(mean);
+        sb.append(" +/- ");
+        sb.append((2.575 * Math.sqrt(variance / length)));
+
+        return sb.toString();
+    }
+
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongApproximateAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongApproximateAverageAggregation.java
@@ -1,0 +1,55 @@
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.block.Block;
+import com.facebook.presto.block.BlockBuilder;
+
+import static com.facebook.presto.operator.aggregation.LongApproximateAverageAggregation.LONG_APPROX_AVERAGE;
+import static com.facebook.presto.tuple.TupleInfo.SINGLE_LONG;
+
+public class TestLongApproximateAverageAggregation
+    extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block getSequenceBlock(int start, int length)
+    {
+        BlockBuilder blockBuilder = new BlockBuilder(SINGLE_LONG);
+        for (int i = start; i < start + length; i++) {
+            blockBuilder.append(i);
+        }
+        return blockBuilder.build();
+    }
+
+    @Override
+    public AggregationFunction getFunction()
+    {
+        return LONG_APPROX_AVERAGE;
+    }
+
+    @Override
+    public String getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double sum = 0;
+        for (int i = start; i < start + length; i++) {
+            sum += i;
+        }
+
+        double mean = sum/length;
+        double m2 = 0.0;
+        for (int i = start; i < start + length; i++) {
+            m2 += (i - mean) * (i - mean);
+        }
+
+        double variance = m2/length;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(mean);
+        sb.append(" +/- ");
+        sb.append((2.575 * Math.sqrt(variance / length)));
+
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
This diff adds the long/double approximate average operators along with the appropriate test classes. Usage:  

`select approx_avg(foo) from Table` returns a string of the form `approximate_answer +/- error` at `99% confidence interval`.
