### PR TITLE
Improve query performance for hive bucketed tables

### DIFF
--- a/presto-hive/create-test.sql
+++ b/presto-hive/create-test.sql
@@ -42,6 +42,51 @@ PARTITIONED BY (ds STRING)
 TBLPROPERTIES ('RETENTION'='-1', 'RETENTION_PLATINUM'='-1')
 ;
 
+CREATE TABLE presto_test_bucketed_by_string_int (
+  t_string STRING,
+  t_tinyint TINYINT,
+  t_smallint SMALLINT,
+  t_int INT,
+  t_bigint BIGINT,
+  t_float FLOAT,
+  t_double DOUBLE
+)
+COMMENT 'Presto test bucketed table'
+PARTITIONED BY (ds STRING, file_format STRING, dummy INT)
+CLUSTERED BY (t_string, t_smallint) INTO 32 BUCKETS
+TBLPROPERTIES ('RETENTION'='-1', 'RETENTION_PLATINUM'='-1')
+;
+
+CREATE TABLE presto_test_bucketed_by_string_smallint (
+  t_string STRING,
+  t_tinyint TINYINT,
+  t_smallint SMALLINT,
+  t_int INT,
+  t_bigint BIGINT,
+  t_float FLOAT,
+  t_double DOUBLE
+)
+COMMENT 'Presto test bucketed table'
+PARTITIONED BY (ds STRING, file_format STRING, dummy INT)
+CLUSTERED BY (t_string, t_smallint) INTO 32 BUCKETS
+TBLPROPERTIES ('RETENTION'='-1', 'RETENTION_PLATINUM'='-1')
+;
+
+CREATE TABLE presto_test_bucketed_by_double_float (
+  t_string STRING,
+  t_tinyint TINYINT,
+  t_smallint SMALLINT,
+  t_int INT,
+  t_bigint BIGINT,
+  t_float FLOAT,
+  t_double DOUBLE
+)
+COMMENT 'Presto test bucketed table'
+PARTITIONED BY (ds STRING, file_format STRING, dummy INT)
+CLUSTERED BY (t_double, t_float) INTO 32 BUCKETS
+TBLPROPERTIES ('RETENTION'='-1', 'RETENTION_PLATINUM'='-1')
+;
+
 CREATE VIEW presto_test_view
 COMMENT 'Presto test view'
 TBLPROPERTIES ('RETENTION'='-1', 'RETENTION_PLATINUM'='-1')
@@ -140,3 +185,22 @@ SELECT 'test' FROM tmp_presto_test LIMIT 100;
 ALTER TABLE presto_test_offline_partition PARTITION (ds='2012-12-30') ENABLE OFFLINE;
 
 DROP TABLE tmp_presto_test;
+
+SET hive.enforce.bucketing = true;
+INSERT OVERWRITE TABLE presto_test_bucketed_by_string_int
+PARTITION(ds='2012-12-29', file_format='text', dummy=3)
+SELECT t_string, t_tinyint, t_smallint, t_int, t_bigint, t_float, t_double
+FROM presto_test
+;
+
+INSERT OVERWRITE TABLE presto_test_bucketed_by_string_smallint
+PARTITION(ds='2012-12-29', file_format='text', dummy=3)
+SELECT t_string, t_tinyint, t_smallint, t_int, t_bigint, t_float, t_double
+FROM presto_test
+;
+
+INSERT OVERWRITE TABLE presto_test_bucketed_by_double_float
+PARTITION(ds='2012-12-29', file_format='text', dummy=3)
+SELECT t_string, t_tinyint, t_smallint, t_int, t_bigint, t_float, t_double
+FROM presto_test
+;

--- a/presto-hive/drop-test.sql
+++ b/presto-hive/drop-test.sql
@@ -12,3 +12,6 @@ ALTER TABLE presto_test_offline_partition PARTITION (ds='2012-12-30') DISABLE OF
 DROP TABLE IF EXISTS presto_test_offline_partition;
 
 DROP VIEW IF EXISTS presto_test_view;
+DROP TABLE IF EXISTS presto_test_bucketed_by_string_int;
+DROP TABLE IF EXISTS presto_test_bucketed_by_string_smallint;
+DROP TABLE IF EXISTS presto_test_bucketed_by_double_float;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartition.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartition.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.Partition;
 import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -31,19 +32,22 @@ public class HivePartition
     private final SchemaTableName tableName;
     private final String partitionId;
     private final Map<ColumnHandle, Object> keys;
+    private final Optional<Integer> bucket;
 
     public HivePartition(SchemaTableName tableName)
     {
         this.tableName = checkNotNull(tableName, "tableName is null");
         this.partitionId = UNPARTITIONED_ID;
         this.keys = ImmutableMap.of();
+        this.bucket = Optional.absent();
     }
 
-    public HivePartition(SchemaTableName tableName, String partitionId, Map<ColumnHandle, Object> keys)
+    public HivePartition(SchemaTableName tableName, String partitionId, Map<ColumnHandle, Object> keys, Optional<Integer> bucket)
     {
         this.tableName = checkNotNull(tableName, "tableName is null");
         this.partitionId = checkNotNull(partitionId, "partitionId is null");
         this.keys = ImmutableMap.copyOf(checkNotNull(keys, "keys is null"));
+        this.bucket = checkNotNull(bucket, "bucket number is null");
     }
 
     public SchemaTableName getTableName()
@@ -61,6 +65,11 @@ public class HivePartition
     public Map<ColumnHandle, Object> getKeys()
     {
         return keys;
+    }
+
+    public Optional<Integer> getBucket()
+    {
+        return bucket;
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import org.apache.hadoop.hive.ql.io.DefaultHivePartitioner;
+import org.apache.hadoop.hive.ql.io.HiveKey;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFHash;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
+import org.testng.annotations.Test;
+
+import static io.airlift.testing.Assertions.assertInstanceOf;
+import static org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredJavaObject;
+import static org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaDoubleObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaFloatObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+import static org.testng.Assert.assertEquals;
+
+public class TestHiveBucketing
+{
+    @Test
+    public void testHashingDouble()
+            throws Exception
+    {
+        DefaultHivePartitioner<HiveKey, Object> partitioner = new DefaultHivePartitioner<>();
+
+        GenericUDFHash udf = new GenericUDFHash();
+        ObjectInspector udfInspector = udf.initialize(new ObjectInspector[] {
+                javaDoubleObjectInspector,
+                javaFloatObjectInspector,
+        });
+        assertInstanceOf(udfInspector, IntObjectInspector.class);
+        IntObjectInspector inspector = (IntObjectInspector) udfInspector;
+
+        Object result = udf.evaluate(new DeferredObject[] {
+                new DeferredJavaObject(492.2d),
+                new DeferredJavaObject((float)491.1000061035156d),
+        });
+        int hash = inspector.get(result);
+
+        HiveKey hiveKey = new HiveKey();
+        hiveKey.setHashCode(hash);
+        int bucket = partitioner.getBucket(hiveKey, null, 32);
+
+        assertEquals(bucket, 13);
+    }
+
+    @Test
+    public void testHashingString()
+            throws Exception
+    {
+        DefaultHivePartitioner<HiveKey, Object> partitioner = new DefaultHivePartitioner<>();
+
+        GenericUDFHash udf = new GenericUDFHash();
+        ObjectInspector udfInspector = udf.initialize(new ObjectInspector[] {
+                javaStringObjectInspector,
+        });
+        assertInstanceOf(udfInspector, IntObjectInspector.class);
+        IntObjectInspector inspector = (IntObjectInspector) udfInspector;
+
+        Object result = udf.evaluate(new DeferredObject[] {
+                new DeferredJavaObject("sequencefile test"),
+        });
+        int hash = inspector.get(result);
+
+        HiveKey hiveKey = new HiveKey();
+        hiveKey.setHashCode(hash);
+        int bucket = partitioner.getBucket(hiveKey, null, 32);
+
+        assertEquals(bucket, 21);
+    }
+}


### PR DESCRIPTION
This optimization is specific to bucketed hive tables. It kicks in only if the query has an equality filter on all the bucket columns of the table. Most bucketed tables have about 1-2 bucket columns. So, the code reuses the some hive code to generate the bucket number. 

I tested this by creating bucketed tables with the following combinations of bucket columns 
1. short
2. int 
3. float, double
4. String
5. long 
6. string, long 

Verified that we get the same results in hive and when queried by presto. 
