### PR TITLE
Tablesample system implementation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/TupleAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/TupleAnalyzer.java
@@ -190,10 +190,6 @@ class TupleAnalyzer
     @Override
     protected TupleDescriptor visitSampledRelation(final SampledRelation relation, AnalysisContext context)
     {
-        if (relation.getType() == SampledRelation.Type.SYSTEM) {
-            throw new SemanticException(NOT_SUPPORTED, relation, "TABLESAMPLE SYSTEM not yet implemented");
-        }
-
         // We use the optimizer to be able to produce a semantic exception if columns are referenced in the expression.
         // We can't do this with the interpreter yet because it's designed for the execution stage and has the wrong shape.
         // So, for now, we punt on supporting non-deterministic functions.

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DistributedLogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DistributedLogicalPlanner.java
@@ -169,7 +169,7 @@ public class DistributedLogicalPlanner
         public SubPlanBuilder visitSample(SampleNode node, Void context)
         {
             SubPlanBuilder current = node.getSource().accept(this, context);
-            current.setRoot(new SampleNode(node.getId(), current.getRoot(), node.getSampleRatio()));
+            current.setRoot(new SampleNode(node.getId(), current.getRoot(), node.getSampleRatio(), node.getSampleType()));
             return current;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -61,6 +61,7 @@ import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SinkNode;
 import com.facebook.presto.sql.planner.plan.SortNode;
@@ -459,6 +460,16 @@ public class LocalExecutionPlanner
             }
 
             return planGroupByAggregation(node, source, context);
+        }
+
+        @Override
+        public PhysicalOperation visitSample(SampleNode node, LocalExecutionPlanContext context)
+        {
+            // For system sample, the splits are already filtered out, so no specific action needs to be taken here
+            if (node.getSampleType() == SampleNode.Type.SYSTEM) {
+                return node.getSource().accept(this, context);
+            }
+            throw new UnsupportedOperationException("not yet implemented");
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -127,16 +127,14 @@ class RelationPlanner
     @Override
     protected RelationPlan visitSampledRelation(SampledRelation node, Void context)
     {
-        if (node.getType() == SampledRelation.Type.SYSTEM) {
-            throw new UnsupportedOperationException("TABLESAMPLE SYSTEM not yet implemented");
-        }
-
         RelationPlan subPlan = process(node.getRelation(), context);
 
         TupleDescriptor outputDescriptor = analysis.getOutputDescriptor(node);
         double ratio = analysis.getSampleRatio(node);
-
-        return new RelationPlan(new SampleNode(idAllocator.getNextId(), subPlan.getRoot(), ratio), outputDescriptor, subPlan.getOutputSymbols());
+        return new RelationPlan(
+                new SampleNode(idAllocator.getNextId(), subPlan.getRoot(), ratio, SampleNode.Type.typeConvert(node.getType())),
+                outputDescriptor,
+                subPlan.getOutputSymbols());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementSampleAsFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementSampleAsFilter.java
@@ -18,9 +18,16 @@ import com.facebook.presto.sql.analyzer.Type;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
-import com.facebook.presto.sql.planner.plan.*;
-import com.facebook.presto.sql.tree.*;
-import com.google.common.base.Preconditions;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanNodeRewriter;
+import com.facebook.presto.sql.planner.plan.PlanRewriter;
+import com.facebook.presto.sql.planner.plan.SampleNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DoubleLiteral;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.QualifiedName;
 import com.google.common.collect.ImmutableList;
 
 import java.util.Map;
@@ -48,10 +55,16 @@ public class ImplementSampleAsFilter
         @Override
         public PlanNode rewriteSample(SampleNode node, Void context, PlanRewriter<Void> planRewriter)
         {
-            PlanNode rewrittenSource = planRewriter.rewrite(node.getSource(), context);
+            if (node.getSampleType() == SampleNode.Type.BERNOULLI) {
+                PlanNode rewrittenSource = planRewriter.rewrite(node.getSource(), context);
 
-            ComparisonExpression expression = new ComparisonExpression(ComparisonExpression.Type.LESS_THAN, new FunctionCall(QualifiedName.of("rand"), ImmutableList.<Expression>of()), new DoubleLiteral(Double.toString (node.getSampleRatio())));
-            return new FilterNode(node.getId(), rewrittenSource, expression);
+                ComparisonExpression expression = new ComparisonExpression(ComparisonExpression.Type.LESS_THAN, new FunctionCall(QualifiedName.of("rand"), ImmutableList.<Expression>of()), new DoubleLiteral(Double.toString (node.getSampleRatio())));
+                return new FilterNode(node.getId(), rewrittenSource, expression);
+            }
+            else if (node.getSampleType() == SampleNode.Type.SYSTEM) {
+                return rewriteNode(node, context, planRewriter);
+            }
+            throw new UnsupportedOperationException("not yet implemented");
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanRewriter.java
@@ -161,7 +161,7 @@ public final class PlanRewriter<C>
             PlanNode source = rewrite(node.getSource(), context.get());
 
             if (source != node.getSource()) {
-                return new SampleNode(node.getId(), source, node.getSampleRatio());
+                return new SampleNode(node.getId(), source, node.getSampleRatio(), node.getSampleType());
             }
 
             return node;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SampleNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SampleNode.java
@@ -14,12 +14,13 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.SampledRelation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
 import javax.annotation.concurrent.Immutable;
+
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -31,20 +32,40 @@ public class SampleNode
 {
     private final PlanNode source;
     private final double sampleRatio;
+    private final Type sampleType;
+
+    public enum Type
+    {
+        BERNOULLI,
+        SYSTEM;
+
+        public static Type typeConvert(SampledRelation.Type sampleType)
+        {
+            switch (sampleType) {
+                case BERNOULLI:
+                    return Type.BERNOULLI;
+                case SYSTEM:
+                    return Type.SYSTEM;
+                default:
+                    throw new UnsupportedOperationException("Unsupported sample type: " + sampleType);
+            }
+        }
+    }
 
     @JsonCreator
     public SampleNode(
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("sampleRatio") double sampleRatio)
+            @JsonProperty("sampleRatio") double sampleRatio,
+            @JsonProperty("sampleType") Type sampleType)
     {
         super(id);
 
-        checkNotNull(source, "source is null");
         checkArgument(sampleRatio >= 0.0 && sampleRatio <= 1.0, "sample ratio must be between 0 and 1");
 
-        this.source = source;
-        this.sampleRatio = sampleRatio;
+        this.sampleType = checkNotNull(sampleType, "sample type is null");
+        this.source = checkNotNull(source, "source is null");
+        this.sampleRatio = checkNotNull(sampleRatio, "sample ratio is null");
     }
 
     @Override
@@ -53,14 +74,22 @@ public class SampleNode
         return ImmutableList.of(source);
     }
 
+    @JsonProperty
     public PlanNode getSource()
     {
         return source;
     }
 
+    @JsonProperty
     public double getSampleRatio()
     {
         return sampleRatio;
+    }
+
+    @JsonProperty
+    public Type getSampleType()
+    {
+        return sampleType;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/AbstractTestQueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/AbstractTestQueries.java
@@ -2591,6 +2591,28 @@ public abstract class AbstractTestQueries
         assertTrue(mean > 0.45 && mean < 0.55, String.format("Expected mean sampling rate to be ~0.5, but was %s", mean));
     }
 
+    @Test
+    public void testTableSampleSystem()
+            throws Exception
+    {
+        MaterializedResult randomSample = computeActual("SELECT * FROM orders TABLESAMPLE SYSTEM (50)");
+        MaterializedResult all = computeExpected("SELECT * FROM orders", randomSample.getTupleInfo());
+
+        assertTrue(randomSample.getMaterializedTuples().size() <= all.getMaterializedTuples().size());
+    }
+
+    @Test
+    public void testTableSampleSystemBoundaryValues()
+            throws Exception
+    {
+        MaterializedResult fullSample = computeActual("SELECT * FROM orders TABLESAMPLE SYSTEM (100)");
+        MaterializedResult emptySample = computeActual("SELECT * FROM orders TABLESAMPLE SYSTEM (0)");
+        MaterializedResult all = computeExpected("SELECT * FROM orders", fullSample.getTupleInfo());
+
+        assertTrue(all.getMaterializedTuples().containsAll(fullSample.getMaterializedTuples()));
+        assertEquals(emptySample.getMaterializedTuples().size(), 0);
+    }
+
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "\\QUnexpected parameters (bigint) for function length. Expected: length(varchar)\\E")
     public void testFunctionNotRegistered()
     {


### PR DESCRIPTION
Reworked the system table sample code based on the recent changes. Sending this as a new pull request as it differs considerably from the original pull request. 

Tested this on the benchmark cluster, by running 
select \* from presto_test tablesample system(0) - no rows
select \* from presto_test tablesample system(50) - anywhere between 0 to 300 rows for mutiple runs 
select \* from presto_test tablesample system(100) - all rows (300). 
