### PR TITLE
Taking care of boundary case conditions in the TABLESAMPLE operator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementSampleAsFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementSampleAsFilter.java
@@ -50,7 +50,7 @@ public class ImplementSampleAsFilter
         {
             PlanNode rewrittenSource = planRewriter.rewrite(node.getSource(), context);
 
-            ComparisonExpression expression = new ComparisonExpression(ComparisonExpression.Type.LESS_THAN_OR_EQUAL, new FunctionCall(QualifiedName.of("rand"), ImmutableList.<Expression>of()), new DoubleLiteral(Double.toString (node.getSampleRatio())));
+            ComparisonExpression expression = new ComparisonExpression(ComparisonExpression.Type.LESS_THAN, new FunctionCall(QualifiedName.of("rand"), ImmutableList.<Expression>of()), new DoubleLiteral(Double.toString (node.getSampleRatio())));
             return new FilterNode(node.getId(), rewrittenSource, expression);
         }
     }


### PR DESCRIPTION
Changing the comparison expression between `rand()` and `sampleRatio` from `<=` to `<`. `rand()` returns a value between [0,1). So `rand() < 0` will return no values and `rand() < 1` will return all the values.
