### PR TITLE
Make cpu time tracking in OperatorStats configurable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -46,6 +46,20 @@ public class QueryManagerConfig
     private int remoteTaskMaxConsecutiveErrorCount = 10;
     private Duration remoteTaskMinErrorDuration = new Duration(2, TimeUnit.MINUTES);
 
+    private boolean taskCpuTimerEnabled = true;
+
+    public boolean isTaskCpuTimerEnabled()
+    {
+        return taskCpuTimerEnabled;
+    }
+
+    @Config("task.cpu-timer-enabled")
+    public QueryManagerConfig setTaskCpuTimerEnabled(boolean taskCpuTimerEnabled)
+    {
+        this.taskCpuTimerEnabled = taskCpuTimerEnabled;
+        return this;
+    }
+
     public boolean isCoordinator()
     {
         return coordinator;

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -118,7 +118,8 @@ public class SqlTaskExecution
             ExecutorService notificationExecutor,
             DataSize maxTaskMemoryUsage,
             DataSize operatorPreAllocatedMemory,
-            QueryMonitor queryMonitor)
+            QueryMonitor queryMonitor,
+            boolean cpuTimerEnabled)
     {
         SqlTaskExecution task = new SqlTaskExecution(session,
                 taskId,
@@ -130,7 +131,8 @@ public class SqlTaskExecution
                 maxTaskMemoryUsage,
                 operatorPreAllocatedMemory,
                 queryMonitor,
-                notificationExecutor
+                notificationExecutor,
+                cpuTimerEnabled
         );
 
         try (SetThreadName setThreadName = new SetThreadName("Task-%s", taskId)) {
@@ -149,7 +151,8 @@ public class SqlTaskExecution
             DataSize maxTaskMemoryUsage,
             DataSize operatorPreAllocatedMemory,
             QueryMonitor queryMonitor,
-            Executor notificationExecutor)
+            Executor notificationExecutor,
+            boolean cpuTimerEnabled)
     {
         try (SetThreadName setThreadName = new SetThreadName("Task-%s", taskId)) {
             this.taskId = checkNotNull(taskId, "taskId is null");
@@ -173,7 +176,7 @@ public class SqlTaskExecution
                     session,
                     checkNotNull(maxTaskMemoryUsage, "maxTaskMemoryUsage is null"),
                     checkNotNull(operatorPreAllocatedMemory, "operatorPreAllocatedMemory is null"),
-                    true);
+                    cpuTimerEnabled);
 
             this.sharedBuffer = new SharedBuffer(checkNotNull(maxBufferSize, "maxBufferSize is null"));
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -80,6 +80,7 @@ public class SqlTaskManager
     private final DataSize operatorPreAllocatedMemory;
     private final Duration infoCacheTime;
     private final Duration clientTimeout;
+    private final boolean cpuTimerEnabled;
 
     private final ConcurrentMap<TaskId, TaskInfo> taskInfos = new ConcurrentHashMap<>();
     private final ConcurrentMap<TaskId, TaskExecution> tasks = new ConcurrentHashMap<>();
@@ -115,6 +116,7 @@ public class SqlTaskManager
         this.operatorPreAllocatedMemory = config.getOperatorPreAllocatedMemory();
         this.infoCacheTime = config.getInfoMaxAge();
         this.clientTimeout = config.getClientTimeout();
+        this.cpuTimerEnabled = config.isTaskCpuTimerEnabled();
 
         taskNotificationExecutor = Executors.newCachedThreadPool(threadsNamed("task-notification-%d"));
         taskNotificationExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) taskNotificationExecutor);
@@ -304,7 +306,8 @@ public class SqlTaskManager
                         taskNotificationExecutor,
                         maxTaskMemoryUsage,
                         operatorPreAllocatedMemory,
-                        queryMonitor
+                        queryMonitor,
+                        cpuTimerEnabled
                 );
                 tasks.put(taskId, taskExecution);
             }
@@ -389,7 +392,7 @@ public class SqlTaskManager
                         null,
                         maxTaskMemoryUsage,
                         operatorPreAllocatedMemory,
-                        true);
+                        cpuTimerEnabled);
 
                 taskInfo = new TaskInfo(taskId,
                         Long.MAX_VALUE,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -30,6 +30,7 @@ public class TestQueryManagerConfig
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(QueryManagerConfig.class)
                 .setCoordinator(true)
+                .setTaskCpuTimerEnabled(true)
                 .setMaxShardProcessorThreads(Runtime.getRuntime().availableProcessors() * 4)
                 .setMaxQueryAge(new Duration(15, TimeUnit.MINUTES))
                 .setMaxQueryHistory(100)
@@ -51,6 +52,7 @@ public class TestQueryManagerConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("coordinator", "false")
+                .put("task.cpu-timer-enabled", "false")
                 .put("task.max-memory", "2GB")
                 .put("task.operator-pre-allocated-memory", "2MB")
                 .put("query.shard.max-threads", "3")
@@ -69,6 +71,7 @@ public class TestQueryManagerConfig
 
         QueryManagerConfig expected = new QueryManagerConfig()
                 .setCoordinator(false)
+                .setTaskCpuTimerEnabled(false)
                 .setMaxTaskMemoryUsage(new DataSize(2, Unit.GIGABYTE))
                 .setOperatorPreAllocatedMemory(new DataSize(2, Unit.MEGABYTE))
                 .setMaxShardProcessorThreads(3)


### PR DESCRIPTION
Added task.cpu-timer-enabled, which can be used to turn off cpu time tracking
