### PR TITLE
Added tests for ensuring statistical correctness of approx_avg()

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
@@ -217,7 +217,7 @@ public abstract class AbstractTestAggregationFunction
      * <p/>
      * Fields 0 to "field - 1" are set to null
      */
-    private Block createCompositeTupleBlock(Block sequenceBlock, int field)
+    protected Block createCompositeTupleBlock(Block sequenceBlock, int field)
     {
         TupleInfo.Type[] types = new TupleInfo.Type[field + 1];
         Arrays.fill(types, TupleInfo.Type.VARIABLE_BINARY);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestApproximateAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestApproximateAggregationFunction.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.block.Block;
+import com.facebook.presto.block.BlockAssertions;
+import com.facebook.presto.block.BlockBuilder;
+import com.facebook.presto.block.BlockCursor;
+import com.facebook.presto.operator.AggregationOperator;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.tree.Input;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import java.util.*;
+
+import static com.facebook.presto.operator.AggregationFunctionDefinition.aggregation;
+import static com.facebook.presto.operator.AggregationOperator.createAggregator;
+import static com.facebook.presto.tuple.TupleInfo.SINGLE_DOUBLE;
+import static com.facebook.presto.tuple.TupleInfo.SINGLE_LONG;
+import static com.facebook.presto.tuple.TupleInfo.SINGLE_VARBINARY;
+import static org.testng.Assert.assertTrue;
+
+public abstract class AbstractTestApproximateAggregationFunction
+        extends AbstractTestAggregationFunction
+{
+
+    public <T> Block getSequenceBlock(Iterable<T> list)
+    {
+        BlockBuilder blockBuilder;
+
+        if (Iterables.get(list, 0) instanceof Long) {
+            blockBuilder = new BlockBuilder(SINGLE_LONG);
+        } else if (Iterables.get(list, 0) instanceof Double) {
+            blockBuilder = new BlockBuilder(SINGLE_DOUBLE);
+        } else {
+            blockBuilder = new BlockBuilder(SINGLE_VARBINARY);
+        }
+
+        for (Object i : list) {
+            if (i instanceof Long) {
+                blockBuilder.append((Long) i);
+            } else if (i instanceof Double) {
+                blockBuilder.append((Double) i);
+            }
+        }
+
+        return blockBuilder.build();
+    }
+
+    /**
+     * This method tests the correctness of the closed-form error estimates for
+     * average function on given data. We first calculate the true average: actualAvg
+     * and then create 1,000 samples from original data (samplingRatio = 0.1) and compute
+     * the approxAvg (with error bars) on each. The test passes if at least 99% of all
+     * runs contain the true answer within the range [ApproxAvg - error, ApproxAvg + error]
+     * @param inputList
+     * @throws Exception
+     */
+    public void testCorrectnessOfErrorFunction(List<Number> inputList)
+            throws Exception
+    {
+        //Compute Actual Value using list
+        double actualSum = 0;
+        for (Number value : inputList) {
+            actualSum += value.doubleValue();
+        }
+
+        double actualAvg = actualSum / inputList.size();
+
+        int inRange = 0;
+        int numberOfRuns = 1000;
+        double sampleRatio = 0.1;
+
+        for (int i = 0; i < numberOfRuns; i++) {
+            //Compute Sampled Value using sampledList (numberOfRuns times)
+            Iterable<Number> sampledList = Iterables.limit(shuffle(inputList), (int) (inputList.size() * sampleRatio));
+
+            BlockCursor cursor = createCompositeTupleBlock(getSequenceBlock(sampledList), 0).cursor();
+            AggregationOperator.Aggregator function = createAggregator(aggregation(getFunction(),
+                    new Input(0, 0)), AggregationNode.Step.SINGLE);
+
+            for (int j = 0; j < (int) (inputList.size() * sampleRatio); j++) {
+                assertTrue(cursor.advanceNextPosition());
+                function.addValue(cursor);
+            }
+
+            String approxValue = BlockAssertions.toValues(function.getResult()).get(0).get(0).toString();
+            double approxAvg = Double.parseDouble(approxValue.split(" ")[0]);
+            double error = Double.parseDouble(approxValue.split(" ")[2]);
+
+            //Check if actual answer lies within [approxAnswer - error, approxAnswer + error]
+            if ((approxAvg - error <= actualAvg) && (approxAvg + error >= actualAvg)) {
+                inRange++;
+            }
+        }
+
+        double confidence = 0.99; //i.e., a confidence of 99%
+        assertTrue(inRange >= confidence * numberOfRuns);
+    }
+
+    protected static List<Number> shuffle(Iterable<Number> iterable)
+    {
+        List<Number> list = Lists.newArrayList(iterable);
+        Collections.shuffle(list, new Random(1));
+        return list;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleApproximateAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleApproximateAverageAggregation.java
@@ -15,12 +15,17 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.block.Block;
 import com.facebook.presto.block.BlockBuilder;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 import static com.facebook.presto.operator.aggregation.DoubleApproximateAverageAggregation.DOUBLE_APPROX_AVERAGE;
 import static com.facebook.presto.tuple.TupleInfo.SINGLE_DOUBLE;
 
 public class TestDoubleApproximateAverageAggregation
-        extends AbstractTestAggregationFunction
+        extends AbstractTestApproximateAggregationFunction
 {
     @Override
     public Block getSequenceBlock(int start, int length)
@@ -66,4 +71,31 @@ public class TestDoubleApproximateAverageAggregation
         return sb.toString();
     }
 
+    @Test
+    public void testCorrectnessOnGaussianData()
+            throws Exception
+    {
+        int originalDataSize = 100;
+        Random distribution = new Random(0);
+        List<Number> list = new ArrayList<>();
+        for (int i = 0; i < originalDataSize; i++) {
+            list.add(distribution.nextGaussian());
+        }
+
+        testCorrectnessOfErrorFunction(list);
+    }
+
+    @Test
+    public void testCorrectnessOnUniformData()
+            throws Exception
+    {
+        int originalDataSize = 100;
+        Random distribution = new Random(0);
+        List<Number> list = new ArrayList<>();
+        for (int i = 0; i < originalDataSize; i++) {
+            list.add(distribution.nextDouble() * 1000);
+        }
+
+        testCorrectnessOfErrorFunction(list);
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongApproximateAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongApproximateAverageAggregation.java
@@ -16,11 +16,17 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.block.Block;
 import com.facebook.presto.block.BlockBuilder;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.testng.annotations.Test;
+
 import static com.facebook.presto.operator.aggregation.LongApproximateAverageAggregation.LONG_APPROX_AVERAGE;
 import static com.facebook.presto.tuple.TupleInfo.SINGLE_LONG;
 
 public class TestLongApproximateAverageAggregation
-        extends AbstractTestAggregationFunction
+        extends AbstractTestApproximateAggregationFunction
 {
     @Override
     public Block getSequenceBlock(int start, int length)
@@ -65,4 +71,33 @@ public class TestLongApproximateAverageAggregation
 
         return sb.toString();
     }
+
+    @Test
+    public void testCorrectnessOnGaussianData()
+            throws Exception
+    {
+        int originalDataSize = 100;
+        Random distribution = new Random(0);
+        List<Number> list = new ArrayList<>();
+        for (int i = 0; i < originalDataSize; i++) {
+            list.add((long) distribution.nextGaussian() * 100);
+        }
+
+        testCorrectnessOfErrorFunction(list);
+    }
+
+    @Test
+    public void testCorrectnessOnUniformData()
+            throws Exception
+    {
+        int originalDataSize = 100;
+        Random distribution = new Random(0);
+        List<Number> list = new ArrayList<>();
+        for (int i = 0; i < originalDataSize; i++) {
+            list.add((long) distribution.nextDouble() * 100);
+        }
+
+        testCorrectnessOfErrorFunction(list);
+    }
 }
+


### PR DESCRIPTION
This diff consists of some additional tests that ensure the statistical correctness of `approx_avg()` function. The tests generate a sequence of tuples with a `gaussian` and `uniform` distribution and make sure that the true answer lies within the `approximate answer +/- error bars` produced by a number of 10% samples, 99% of the time.

I have explicitly seeded the distribution and sample generators to make the output of the tests deterministic.
