### PR TITLE
Split up QueryManagerConfig

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -14,8 +14,6 @@
 package com.facebook.presto.execution;
 
 import io.airlift.configuration.Config;
-import io.airlift.units.DataSize;
-import io.airlift.units.DataSize.Unit;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
@@ -26,37 +24,15 @@ import java.util.concurrent.TimeUnit;
 
 public class QueryManagerConfig
 {
-    private DataSize maxTaskMemoryUsage = new DataSize(256, Unit.MEGABYTE);
-    private DataSize operatorPreAllocatedMemory = new DataSize(16, Unit.MEGABYTE);
     private int maxPendingSplitsPerNode = 100;
-    private int maxShardProcessorThreads = Runtime.getRuntime().availableProcessors() * 4;
-    private DataSize sinkMaxBufferSize = new DataSize(32, Unit.MEGABYTE);
     private Duration maxQueryAge = new Duration(15, TimeUnit.MINUTES);
     private int maxQueryHistory = 100;
     private Duration clientTimeout = new Duration(5, TimeUnit.MINUTES);
-    private Duration infoMaxAge = new Duration(15, TimeUnit.MINUTES);
-
-    private DataSize exchangeMaxBufferSize = new DataSize(32, Unit.MEGABYTE);
-    private int exchangeConcurrentRequestMultiplier = 3;
 
     private int queryManagerExecutorPoolSize = 5;
 
     private int remoteTaskMaxConsecutiveErrorCount = 10;
     private Duration remoteTaskMinErrorDuration = new Duration(2, TimeUnit.MINUTES);
-
-    private boolean taskCpuTimerEnabled = true;
-
-    public boolean isTaskCpuTimerEnabled()
-    {
-        return taskCpuTimerEnabled;
-    }
-
-    @Config("task.cpu-timer-enabled")
-    public QueryManagerConfig setTaskCpuTimerEnabled(boolean taskCpuTimerEnabled)
-    {
-        this.taskCpuTimerEnabled = taskCpuTimerEnabled;
-        return this;
-    }
 
     @Min(1)
     public int getMaxPendingSplitsPerNode()
@@ -68,58 +44,6 @@ public class QueryManagerConfig
     public QueryManagerConfig setMaxPendingSplitsPerNode(int maxPendingSplitsPerNode)
     {
         this.maxPendingSplitsPerNode = maxPendingSplitsPerNode;
-        return this;
-    }
-
-    @NotNull
-    public DataSize getMaxTaskMemoryUsage()
-    {
-        return maxTaskMemoryUsage;
-    }
-
-    @Config("task.max-memory")
-    public QueryManagerConfig setMaxTaskMemoryUsage(DataSize maxTaskMemoryUsage)
-    {
-        this.maxTaskMemoryUsage = maxTaskMemoryUsage;
-        return this;
-    }
-
-    @NotNull
-    public DataSize getOperatorPreAllocatedMemory()
-    {
-        return operatorPreAllocatedMemory;
-    }
-
-    @Config("task.operator-pre-allocated-memory")
-    public QueryManagerConfig setOperatorPreAllocatedMemory(DataSize operatorPreAllocatedMemory)
-    {
-        this.operatorPreAllocatedMemory = operatorPreAllocatedMemory;
-        return this;
-    }
-
-    @Min(1)
-    public int getMaxShardProcessorThreads()
-    {
-        return maxShardProcessorThreads;
-    }
-
-    @Config("query.shard.max-threads")
-    public QueryManagerConfig setMaxShardProcessorThreads(int maxShardProcessorThreads)
-    {
-        this.maxShardProcessorThreads = maxShardProcessorThreads;
-        return this;
-    }
-
-    @NotNull
-    public DataSize getSinkMaxBufferSize()
-    {
-        return sinkMaxBufferSize;
-    }
-
-    @Config("sink.max-buffer-size")
-    public QueryManagerConfig setSinkMaxBufferSize(DataSize sinkMaxBufferSize)
-    {
-        this.sinkMaxBufferSize = sinkMaxBufferSize;
         return this;
     }
 
@@ -160,45 +84,6 @@ public class QueryManagerConfig
     public QueryManagerConfig setClientTimeout(Duration clientTimeout)
     {
         this.clientTimeout = clientTimeout;
-        return this;
-    }
-
-    @NotNull
-    public Duration getInfoMaxAge()
-    {
-        return infoMaxAge;
-    }
-
-    @Config("query.info.max-age")
-    public QueryManagerConfig setInfoMaxAge(Duration infoMaxAge)
-    {
-        this.infoMaxAge = infoMaxAge;
-        return this;
-    }
-
-    @NotNull
-    public DataSize getExchangeMaxBufferSize()
-    {
-        return exchangeMaxBufferSize;
-    }
-
-    @Config("exchange.max-buffer-size")
-    public QueryManagerConfig setExchangeMaxBufferSize(DataSize exchangeMaxBufferSize)
-    {
-        this.exchangeMaxBufferSize = exchangeMaxBufferSize;
-        return this;
-    }
-
-    @Min(1)
-    public int getExchangeConcurrentRequestMultiplier()
-    {
-        return exchangeConcurrentRequestMultiplier;
-    }
-
-    @Config("exchange.concurrent-request-multiplier")
-    public QueryManagerConfig setExchangeConcurrentRequestMultiplier(int exchangeConcurrentRequestMultiplier)
-    {
-        this.exchangeConcurrentRequestMultiplier = exchangeConcurrentRequestMultiplier;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -103,7 +103,7 @@ public class SqlTaskManager
             LocationFactory locationFactory,
             TaskExecutor taskExecutor,
             QueryMonitor queryMonitor,
-            QueryManagerConfig config)
+            TaskManagerConfig config)
     {
         this.planner = checkNotNull(planner, "planner is null");
         this.locationFactory = checkNotNull(locationFactory, "locationFactory is null");

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskExecutor.java
@@ -99,7 +99,7 @@ public class TaskExecutor
     private boolean closed;
 
     @Inject
-    public TaskExecutor(QueryManagerConfig config)
+    public TaskExecutor(TaskManagerConfig config)
     {
         this(checkNotNull(config, "config is null").getMaxShardProcessorThreads());
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import io.airlift.configuration.Config;
+import io.airlift.units.DataSize;
+import io.airlift.units.DataSize.Unit;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
+
+public class TaskManagerConfig
+{
+    private boolean taskCpuTimerEnabled = true;
+    private DataSize maxTaskMemoryUsage = new DataSize(256, Unit.MEGABYTE);
+    private DataSize operatorPreAllocatedMemory = new DataSize(16, Unit.MEGABYTE);
+    private int maxShardProcessorThreads = Runtime.getRuntime().availableProcessors() * 4;
+
+    private DataSize sinkMaxBufferSize = new DataSize(32, Unit.MEGABYTE);
+
+    private Duration clientTimeout = new Duration(5, TimeUnit.MINUTES);
+    private Duration infoMaxAge = new Duration(15, TimeUnit.MINUTES);
+
+    public boolean isTaskCpuTimerEnabled()
+    {
+        return taskCpuTimerEnabled;
+    }
+
+    @Config("task.cpu-timer-enabled")
+    public TaskManagerConfig setTaskCpuTimerEnabled(boolean taskCpuTimerEnabled)
+    {
+        this.taskCpuTimerEnabled = taskCpuTimerEnabled;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getMaxTaskMemoryUsage()
+    {
+        return maxTaskMemoryUsage;
+    }
+
+    @Config("task.max-memory")
+    public TaskManagerConfig setMaxTaskMemoryUsage(DataSize maxTaskMemoryUsage)
+    {
+        this.maxTaskMemoryUsage = maxTaskMemoryUsage;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getOperatorPreAllocatedMemory()
+    {
+        return operatorPreAllocatedMemory;
+    }
+
+    @Config("task.operator-pre-allocated-memory")
+    public TaskManagerConfig setOperatorPreAllocatedMemory(DataSize operatorPreAllocatedMemory)
+    {
+        this.operatorPreAllocatedMemory = operatorPreAllocatedMemory;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxShardProcessorThreads()
+    {
+        return maxShardProcessorThreads;
+    }
+
+    @Config("task.shard.max-threads")
+    public TaskManagerConfig setMaxShardProcessorThreads(int maxShardProcessorThreads)
+    {
+        this.maxShardProcessorThreads = maxShardProcessorThreads;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getSinkMaxBufferSize()
+    {
+        return sinkMaxBufferSize;
+    }
+
+    @Config("sink.max-buffer-size")
+    public TaskManagerConfig setSinkMaxBufferSize(DataSize sinkMaxBufferSize)
+    {
+        this.sinkMaxBufferSize = sinkMaxBufferSize;
+        return this;
+    }
+
+    @MinDuration("5s")
+    @NotNull
+    public Duration getClientTimeout()
+    {
+        return clientTimeout;
+    }
+
+    @Config("task.client.timeout")
+    public TaskManagerConfig setClientTimeout(Duration clientTimeout)
+    {
+        this.clientTimeout = clientTimeout;
+        return this;
+    }
+
+    @NotNull
+    public Duration getInfoMaxAge()
+    {
+        return infoMaxAge;
+    }
+
+    @Config("task.info.max-age")
+    public TaskManagerConfig setInfoMaxAge(Duration infoMaxAge)
+    {
+        this.infoMaxAge = infoMaxAge;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import io.airlift.configuration.Config;
+import io.airlift.units.DataSize;
+import io.airlift.units.DataSize.Unit;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+public class ExchangeClientConfig
+{
+    private DataSize exchangeMaxBufferSize = new DataSize(32, Unit.MEGABYTE);
+    private int exchangeConcurrentRequestMultiplier = 3;
+
+    @NotNull
+    public DataSize getExchangeMaxBufferSize()
+    {
+        return exchangeMaxBufferSize;
+    }
+
+    @Config("exchange.max-buffer-size")
+    public ExchangeClientConfig setExchangeMaxBufferSize(DataSize exchangeMaxBufferSize)
+    {
+        this.exchangeMaxBufferSize = exchangeMaxBufferSize;
+        return this;
+    }
+
+    @Min(1)
+    public int getExchangeConcurrentRequestMultiplier()
+    {
+        return exchangeConcurrentRequestMultiplier;
+    }
+
+    @Config("exchange.concurrent-request-multiplier")
+    public ExchangeClientConfig setExchangeConcurrentRequestMultiplier(int exchangeConcurrentRequestMultiplier)
+    {
+        this.exchangeConcurrentRequestMultiplier = exchangeConcurrentRequestMultiplier;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientFactory.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator;
 
-import com.facebook.presto.execution.QueryManagerConfig;
 import com.google.common.base.Supplier;
 import io.airlift.http.client.AsyncHttpClient;
 import io.airlift.units.DataSize;
@@ -36,11 +35,11 @@ public class ExchangeClientFactory
     private final Executor executor;
 
     @Inject
-    public ExchangeClientFactory(QueryManagerConfig queryManagerConfig, @ForExchange AsyncHttpClient httpClient, @ForExchange Executor executor)
+    public ExchangeClientFactory(ExchangeClientConfig config, @ForExchange AsyncHttpClient httpClient, @ForExchange Executor executor)
     {
-        this(queryManagerConfig.getExchangeMaxBufferSize(),
+        this(config.getExchangeMaxBufferSize(),
                 new DataSize(10, Unit.MEGABYTE),
-                queryManagerConfig.getExchangeConcurrentRequestMultiplier(),
+                config.getExchangeConcurrentRequestMultiplier(),
                 httpClient,
                 executor);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -15,8 +15,6 @@ package com.facebook.presto.execution;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.configuration.testing.ConfigAssertions;
-import io.airlift.units.DataSize;
-import io.airlift.units.DataSize.Unit;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
@@ -29,19 +27,11 @@ public class TestQueryManagerConfig
     public void testDefaults()
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(QueryManagerConfig.class)
-                .setTaskCpuTimerEnabled(true)
-                .setMaxShardProcessorThreads(Runtime.getRuntime().availableProcessors() * 4)
                 .setMaxQueryAge(new Duration(15, TimeUnit.MINUTES))
                 .setMaxQueryHistory(100)
-                .setInfoMaxAge(new Duration(15, TimeUnit.MINUTES))
                 .setClientTimeout(new Duration(5, TimeUnit.MINUTES))
-                .setMaxTaskMemoryUsage(new DataSize(256, Unit.MEGABYTE))
-                .setOperatorPreAllocatedMemory(new DataSize(16, Unit.MEGABYTE))
                 .setMaxPendingSplitsPerNode(100)
-                .setExchangeMaxBufferSize(new DataSize(32, Unit.MEGABYTE))
-                .setExchangeConcurrentRequestMultiplier(3)
                 .setQueryManagerExecutorPoolSize(5)
-                .setSinkMaxBufferSize(new DataSize(32, Unit.MEGABYTE))
                 .setRemoteTaskMaxConsecutiveErrorCount(10)
                 .setRemoteTaskMinErrorDuration(new Duration(2, TimeUnit.MINUTES)));
     }
@@ -50,37 +40,21 @@ public class TestQueryManagerConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("task.cpu-timer-enabled", "false")
-                .put("task.max-memory", "2GB")
-                .put("task.operator-pre-allocated-memory", "2MB")
-                .put("query.shard.max-threads", "3")
-                .put("query.info.max-age", "22m")
                 .put("query.client.timeout", "10s")
                 .put("query.max-age", "30s")
                 .put("query.max-history", "10")
                 .put("query.max-pending-splits-per-node", "33")
                 .put("query.manager-executor-pool-size", "11")
-                .put("sink.max-buffer-size", "42MB")
-                .put("exchange.max-buffer-size", "1GB")
-                .put("exchange.concurrent-request-multiplier", "13")
                 .put("query.remote-task.max-consecutive-error-count", "300")
                 .put("query.remote-task.min-error-duration", "30s")
                 .build();
 
         QueryManagerConfig expected = new QueryManagerConfig()
-                .setTaskCpuTimerEnabled(false)
-                .setMaxTaskMemoryUsage(new DataSize(2, Unit.GIGABYTE))
-                .setOperatorPreAllocatedMemory(new DataSize(2, Unit.MEGABYTE))
-                .setMaxShardProcessorThreads(3)
                 .setMaxQueryAge(new Duration(30, TimeUnit.SECONDS))
                 .setMaxQueryHistory(10)
-                .setInfoMaxAge(new Duration(22, TimeUnit.MINUTES))
                 .setClientTimeout(new Duration(10, TimeUnit.SECONDS))
                 .setMaxPendingSplitsPerNode(33)
-                .setExchangeMaxBufferSize(new DataSize(1, Unit.GIGABYTE))
-                .setExchangeConcurrentRequestMultiplier(13)
                 .setQueryManagerExecutorPoolSize(11)
-                .setSinkMaxBufferSize(new DataSize(42, Unit.MEGABYTE))
                 .setRemoteTaskMaxConsecutiveErrorCount(300)
                 .setRemoteTaskMinErrorDuration(new Duration(30, TimeUnit.SECONDS));
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -113,7 +113,7 @@ public class TestSqlTaskManager
                 new MockLocationFactory(),
                 taskExecutor,
                 new QueryMonitor(new ObjectMapperProvider().get(), new NullEventClient(), new NodeInfo("test")),
-                new QueryManagerConfig());
+                new TaskManagerConfig());
 
         tableScanNodeId = new PlanNodeId("tableScan");
         testFragment = new PlanFragment(new PlanFragmentId("fragment"),
@@ -247,7 +247,7 @@ public class TestSqlTaskManager
                 new MockLocationFactory(),
                 taskExecutor,
                 new QueryMonitor(new ObjectMapperProvider().get(), new NullEventClient(), new NodeInfo("test")),
-                new QueryManagerConfig().setInfoMaxAge(new Duration(5, TimeUnit.MILLISECONDS)));
+                new TaskManagerConfig().setInfoMaxAge(new Duration(5, TimeUnit.MILLISECONDS)));
 
         TaskInfo taskInfo = sqlTaskManager.updateTask(session,
                 taskId,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.units.DataSize.Unit;
+
+public class TestTaskManagerConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(TaskManagerConfig.class)
+                .setTaskCpuTimerEnabled(true)
+                .setMaxShardProcessorThreads(Runtime.getRuntime().availableProcessors() * 4)
+                .setInfoMaxAge(new Duration(15, TimeUnit.MINUTES))
+                .setClientTimeout(new Duration(5, TimeUnit.MINUTES))
+                .setMaxTaskMemoryUsage(new DataSize(256, Unit.MEGABYTE))
+                .setOperatorPreAllocatedMemory(new DataSize(16, Unit.MEGABYTE))
+                .setSinkMaxBufferSize(new DataSize(32, Unit.MEGABYTE)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("task.cpu-timer-enabled", "false")
+                .put("task.max-memory", "2GB")
+                .put("task.operator-pre-allocated-memory", "2MB")
+                .put("task.shard.max-threads", "3")
+                .put("task.info.max-age", "22m")
+                .put("task.client.timeout", "10s")
+                .put("sink.max-buffer-size", "42MB")
+                .build();
+
+        TaskManagerConfig expected = new TaskManagerConfig()
+                .setTaskCpuTimerEnabled(false)
+                .setMaxTaskMemoryUsage(new DataSize(2, Unit.GIGABYTE))
+                .setOperatorPreAllocatedMemory(new DataSize(2, Unit.MEGABYTE))
+                .setMaxShardProcessorThreads(3)
+                .setInfoMaxAge(new Duration(22, TimeUnit.MINUTES))
+                .setClientTimeout(new Duration(10, TimeUnit.SECONDS))
+                .setSinkMaxBufferSize(new DataSize(42, Unit.MEGABYTE));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClientConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClientConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.units.DataSize.Unit;
+
+public class TestExchangeClientConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(ExchangeClientConfig.class)
+                .setExchangeMaxBufferSize(new DataSize(32, Unit.MEGABYTE))
+                .setExchangeConcurrentRequestMultiplier(3));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("exchange.max-buffer-size", "1GB")
+                .put("exchange.concurrent-request-multiplier", "13")
+                .build();
+
+        ExchangeClientConfig expected = new ExchangeClientConfig()
+                .setExchangeMaxBufferSize(new DataSize(1, Unit.GIGABYTE))
+                .setExchangeConcurrentRequestMultiplier(13);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-server/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-server/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -21,6 +21,7 @@ import com.facebook.presto.execution.NodeSchedulerConfig;
 import com.facebook.presto.execution.QueryExecution;
 import com.facebook.presto.execution.QueryIdGenerator;
 import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.SqlQueryExecution;
 import com.facebook.presto.execution.SqlQueryManager;
 import com.facebook.presto.guice.AbstractConfigurationAwareModule;
@@ -93,6 +94,7 @@ public class CoordinatorModule
         binder.bind(QueryIdGenerator.class).in(Scopes.SINGLETON);
         binder.bind(QueryManager.class).to(SqlQueryManager.class).in(Scopes.SINGLETON);
         newExporter(binder).export(QueryManager.class).withGeneratedName();
+        bindConfig(binder).to(QueryManagerConfig.class);
 
         // native
         binder.bind(NativeSplitManager.class).in(Scopes.SINGLETON);

--- a/presto-server/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-server/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -26,12 +26,12 @@ import com.facebook.presto.event.query.QueryMonitor;
 import com.facebook.presto.event.query.SplitCompletionEvent;
 import com.facebook.presto.execution.LocationFactory;
 import com.facebook.presto.execution.QueryInfo;
-import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.RemoteTaskFactory;
 import com.facebook.presto.execution.SqlTaskManager;
 import com.facebook.presto.execution.TaskExecutor;
 import com.facebook.presto.execution.TaskInfo;
 import com.facebook.presto.execution.TaskManager;
+import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.failureDetector.FailureDetector;
 import com.facebook.presto.failureDetector.FailureDetectorModule;
 import com.facebook.presto.guice.AbstractConfigurationAwareModule;
@@ -48,6 +48,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.NodeVersion;
 import com.facebook.presto.operator.ExchangeClient;
+import com.facebook.presto.operator.ExchangeClientConfig;
 import com.facebook.presto.operator.ExchangeClientFactory;
 import com.facebook.presto.operator.ForExchange;
 import com.facebook.presto.operator.ForScheduler;
@@ -117,9 +118,6 @@ public class ServerMainModule
 
         bindFailureDetector(binder, serverConfig.isCoordinator());
 
-        // query manager
-        bindConfig(binder).to(QueryManagerConfig.class);
-
         // task execution
         binder.bind(TaskResource.class).in(Scopes.SINGLETON);
         binder.bind(TaskManager.class).to(SqlTaskManager.class).in(Scopes.SINGLETON);
@@ -128,6 +126,7 @@ public class ServerMainModule
         newExporter(binder).export(TaskExecutor.class).withGeneratedName();
         binder.bind(LocalExecutionPlanner.class).in(Scopes.SINGLETON);
         binder.bind(ExpressionCompiler.class).in(Scopes.SINGLETON);
+        bindConfig(binder).to(TaskManagerConfig.class);
 
         jsonCodecBinder(binder).bindJsonCodec(TaskInfo.class);
         binder.bind(PagesMapper.class).in(Scopes.SINGLETON);
@@ -135,6 +134,7 @@ public class ServerMainModule
         // exchange client
         binder.bind(new TypeLiteral<Supplier<ExchangeClient>>() {}).to(ExchangeClientFactory.class).in(Scopes.SINGLETON);
         httpClientBinder(binder).bindAsyncHttpClient("exchange", ForExchange.class).withTracing();
+        bindConfig(binder).to(ExchangeClientConfig.class);
 
         // execution
         binder.bind(LocationFactory.class).to(HttpLocationFactory.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
This renames the following property:

  `query.shard.max-threads` -> `task.shard.max-threads`

Additionally, a new config property `task.info.max-age` is split out
from the `query.info.max-age` property. The task property controls
how often the coordinator must heartbeat tasks on the workers. The
query property controls how often the end user (statement client)
must heartbeat the query on the coordinator.
