### PR TITLE
Parser changes for creating stratified samples with TABLESAMPLE

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/TupleAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/TupleAnalyzer.java
@@ -190,6 +190,11 @@ class TupleAnalyzer
     @Override
     protected TupleDescriptor visitSampledRelation(final SampledRelation relation, AnalysisContext context)
     {
+
+        if (relation.getColumnsToStratifyOn().isPresent()) {
+            throw new SemanticException(NOT_SUPPORTED, relation, "STRATIFY ON is not yet implemented");
+        }
+
         // We use the optimizer to be able to produce a semantic exception if columns are referenced in the expression.
         // We can't do this with the interpreter yet because it's designed for the execution stage and has the wrong shape.
         // So, for now, we punt on supporting non-deterministic functions.

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -127,6 +127,10 @@ class RelationPlanner
     @Override
     protected RelationPlan visitSampledRelation(SampledRelation node, Void context)
     {
+        if (node.getColumnsToStratifyOn().isPresent()) {
+            throw new UnsupportedOperationException("STRATIFY ON is not yet implemented");
+        }
+
         RelationPlan subPlan = process(node.getRelation(), context);
 
         TupleDescriptor outputDescriptor = analysis.getOutputDescriptor(node);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SampleNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SampleNode.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.SampledRelation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/presto-parser/src/main/antlr3/com/facebook/presto/sql/parser/Statement.g
+++ b/presto-parser/src/main/antlr3/com/facebook/presto/sql/parser/Statement.g
@@ -79,6 +79,7 @@ tokens {
     ALIASED_RELATION;
     SAMPLED_RELATION;
     QUERY_SPEC;
+    STRATIFY_ON;
 }
 
 @header {
@@ -281,9 +282,13 @@ sampleType
     | SYSTEM
     ;
 
+stratifyOn
+    : STRATIFY ON '(' expr (',' expr)* ')' -> ^(STRATIFY_ON expr+)
+    ;
+
 tableFactor
     : ( tablePrimary -> tablePrimary )
-      ( TABLESAMPLE sampleType '(' expr ')' -> ^(SAMPLED_RELATION $tableFactor sampleType expr) )?
+      ( TABLESAMPLE sampleType '(' expr ')' stratifyOn? -> ^(SAMPLED_RELATION $tableFactor sampleType expr stratifyOn?) )?
     ;
 
 tablePrimary
@@ -798,6 +803,7 @@ INTERSECT: 'INTERSECT';
 SYSTEM: 'SYSTEM';
 BERNOULLI: 'BERNOULLI';
 TABLESAMPLE: 'TABLESAMPLE';
+STRATIFY: 'STRATIFY';
 
 EQ  : '=';
 NEQ : '<>' | '!=';

--- a/presto-parser/src/main/antlr3/com/facebook/presto/sql/parser/StatementBuilder.g
+++ b/presto-parser/src/main/antlr3/com/facebook/presto/sql/parser/StatementBuilder.g
@@ -220,6 +220,10 @@ sampleType returns [SampledRelation.Type value]
     | SYSTEM    { $value = SampledRelation.Type.SYSTEM; }
     ;
 
+stratifyOn returns [List<Expression> value]
+    : ^(STRATIFY_ON exprList) { $value = $exprList.value; }
+    ;
+
 relationList returns [List<Relation> value = new ArrayList<>()]
     : ( relation { $value.add($relation.value); } )+
     ;
@@ -255,7 +259,7 @@ aliasedRelation returns [AliasedRelation value]
     ;
 
 sampledRelation returns [SampledRelation value]
-    : ^(SAMPLED_RELATION r=relation t=sampleType p=expr) { $value = new SampledRelation($r.value, $t.value, $p.value); }
+    : ^(SAMPLED_RELATION r=relation t=sampleType p=expr st=stratifyOn?) { $value = new SampledRelation($r.value, $t.value, $p.value, Optional.fromNullable($st.value)); }
     ;
 
 aliasedColumns returns [List<String> value]

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -287,8 +287,7 @@ public final class SqlFormatter
         }
 
         @Override
-        protected Void visitSampledRelation(SampledRelation node, Integer indent)
-        {
+        protected Void visitSampledRelation(SampledRelation node, Integer indent) {
             process(node.getRelation(), indent);
 
             builder.append(" TABLESAMPLE ")
@@ -296,6 +295,13 @@ public final class SqlFormatter
                     .append(" (")
                     .append(node.getSamplePercentage())
                     .append(')');
+
+            if (node.getColumnsToStratifyOn().isPresent()) {
+                builder.append(" STRATIFY ON ")
+                        .append(" (")
+                        .append(Joiner.on(",").join(node.getColumnsToStratifyOn().get()));
+                builder.append(')');
+            }
 
             return null;
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -367,6 +367,11 @@ public abstract class DefaultTraversalVisitor<R, C>
     {
         process(node.getRelation(), context);
         process(node.getSamplePercentage(), context);
+        if (node.getColumnsToStratifyOn().isPresent()) {
+            for (Expression expression : node.getColumnsToStratifyOn().get()) {
+                process(expression, context);
+            }
+        }
         return null;
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SampledRelation.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SampledRelation.java
@@ -14,6 +14,10 @@
 package com.facebook.presto.sql.tree;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -29,12 +33,20 @@ public class SampledRelation
     private final Relation relation;
     private final Type type;
     private final Expression samplePercentage;
+    private final Optional<List<Expression>> columnsToStratifyOn;
 
-    public SampledRelation(Relation relation, Type type, Expression samplePercentage)
+    public SampledRelation(Relation relation, Type type, Expression samplePercentage, Optional<List<Expression>> columnsToStratifyOn)
     {
         this.relation = checkNotNull(relation, "relation is null");
         this.type = checkNotNull(type, "type is null");
         this.samplePercentage = checkNotNull(samplePercentage, "samplePercentage is null");
+
+        if (columnsToStratifyOn.isPresent()) {
+            this.columnsToStratifyOn = Optional.<List<Expression>>of(ImmutableList.copyOf(columnsToStratifyOn.get()));
+        } else {
+            this.columnsToStratifyOn = columnsToStratifyOn;
+        }
+
     }
 
     public Relation getRelation()
@@ -52,6 +64,11 @@ public class SampledRelation
         return samplePercentage;
     }
 
+    public Optional<List<Expression>> getColumnsToStratifyOn()
+    {
+        return columnsToStratifyOn;
+    }
+
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context)
     {
@@ -65,6 +82,7 @@ public class SampledRelation
                 .add("relation", relation)
                 .add("type", type)
                 .add("samplePercentage", samplePercentage)
+                .add("columnsToStratifyOn", columnsToStratifyOn)
                 .toString();
     }
 
@@ -80,12 +98,13 @@ public class SampledRelation
         SampledRelation that = (SampledRelation) o;
         return Objects.equal(relation, that.relation) &&
                 Objects.equal(type, that.type) &&
-                Objects.equal(samplePercentage, that.samplePercentage);
+                Objects.equal(samplePercentage, that.samplePercentage) &&
+                Objects.equal(columnsToStratifyOn, that.columnsToStratifyOn);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hashCode(relation, type, samplePercentage);
+        return Objects.hashCode(relation, type, samplePercentage, columnsToStratifyOn);
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/TreePrinter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/TreePrinter.java
@@ -256,7 +256,12 @@ public class TreePrinter
             @Override
             protected Void visitSampledRelation(SampledRelation node, Integer indentLevel)
             {
-                print(indentLevel, "TABLESAMPLE[" + node.getType() + " (" + node.getSamplePercentage() + ")]");
+                String stratifyOn = "";
+                if (node.getColumnsToStratifyOn().isPresent()) {
+                    stratifyOn = " STRATIFY ON (" + node.getColumnsToStratifyOn().get().toString() + ")";
+                }
+
+                print(indentLevel, "TABLESAMPLE[" + node.getType() + " (" + node.getSamplePercentage() + ")" + stratifyOn + "]");
 
                 super.visitSampledRelation(node, indentLevel + 1);
 

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
@@ -86,6 +86,8 @@ public class TestStatementBuilder
 
         printStatement("select * from foo tablesample system (10+1)");
         printStatement("select * from foo tablesample system (10) join bar tablesample bernoulli (30) on a.id = b.id");
+        printStatement("select * from foo tablesample bernoulli (10) stratify on (id)");
+        printStatement("select * from foo tablesample system (50) stratify on (id, name)");
 
         printStatement("create table foo as select * from abc");
     }


### PR DESCRIPTION
This diff adds an optional `STRATIFY ON` clause to `TABLESAMPLE` in the parser.

Examples:

`SELECT * FROM temp TABLESAMPLE BERNOULLI (50) STRATIFY ON (col_A)`
`SELECT * FROM temp TABLESAMPLE SYSTEM (50) STRATIFY ON (col_A, col_B)`
