### PR TITLE
Fix CLI history behavior on user interrupt

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/LineReader.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/LineReader.java
@@ -50,6 +50,8 @@ public class LineReader
             line = super.readLine(prompt, mask);
         }
         catch (UserInterruptException e) {
+            // TODO: remove when fixed in jline: https://github.com/jline/jline2/pull/112
+            getHistory().moveToEnd();
             interrupted = true;
             return null;
         }


### PR DESCRIPTION
This is a temporary fix until a new jline is released.
