### PR TITLE
[hdfs] Load HDFS files if necessary due to federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Then add the following to the list of VM options:
 
     -Dhive.metastore.thrift.client.socks-proxy=localhost:1080
 
+### Using HDFS with Federation
+
+If your Hive metastore references files stored on a federated HDFS, then you should provide the federation
+information as a VM option:
+
+    -Dhive.config.resources=/etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
+
 ### Running CLI
 
 Start the CLI to connect to the server and run SQL queries:
@@ -177,6 +184,11 @@ Create `etc/catalog/hive.properties` with the following contents to mount the `h
 
     connector.name=hive-cdh4
     hive.metastore.uri=thrift://example.net:9083
+
+If you're using HDFS with federation, then you should also include the following line pointing to the configuration
+files, describing your federated setup:
+
+    hive.config.resources=/etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
 
 You can have as many catalogs as you need, so if you have additional Hive clusters, simply add another properties file to `etc/catalog` with a different name (making sure it ends in `.properties`).
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfiguration.java
@@ -39,9 +39,7 @@ public class HdfsConfiguration
     private final Duration dfsConnectTimeout;
     private final int dfsConnectMaxRetries;
     private final String domainSocketPath;
-    private final String resourcePaths;
-
-    private static final Splitter RESOURCE_CONFIGURATIONS_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+    private final List<String> resourcePaths;
 
     @SuppressWarnings("ThreadLocalNotStaticFinal")
     private final ThreadLocal<Configuration> hadoopConfiguration = new ThreadLocal<Configuration>()
@@ -78,9 +76,7 @@ public class HdfsConfiguration
     {
         Configuration config = new Configuration();
 
-        if (this.resourcePaths != null) {
-            List<String> resourcePaths = Lists.newArrayList(
-                    RESOURCE_CONFIGURATIONS_SPLITTER.split(this.resourcePaths));
+        if (resourcePaths != null) {
             for (String resourcePath: resourcePaths) {
                 config.addResource(new Path(resourcePath));
             }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -24,7 +24,6 @@ import io.airlift.units.MinDuration;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
-
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -48,7 +47,8 @@ public class HiveClientConfig
 
     private String domainSocketPath;
 
-    private String resourceConfigurationFiles = null;
+    private List<String> resourceConfigurationFiles = null;
+    private static final Splitter RESOURCE_CONFIGURATIONS_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
     @NotNull
     public DataSize getMaxSplitSize()
@@ -179,12 +179,20 @@ public class HiveClientConfig
         return this;
     }
 
-    public String getResourceConfigurationFiles() {
+    public List<String> getResourceConfigurationFiles() {
         return resourceConfigurationFiles;
     }
 
     @Config("hive.config.resources")
     public HiveClientConfig setResourceConfigurationFiles(String resourceConfigurationFiles) {
+        if (resourceConfigurationFiles != null) {
+            this.resourceConfigurationFiles = Lists.newArrayList(
+                    RESOURCE_CONFIGURATIONS_SPLITTER.split(resourceConfigurationFiles));
+        }
+        return this;
+    }
+
+    public HiveClientConfig setResourceConfigurationFiles(List<String> resourceConfigurationFiles) {
         this.resourceConfigurationFiles = resourceConfigurationFiles;
         return this;
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -45,7 +45,7 @@ public class TestHiveClientConfig
                 .setDfsConnectTimeout(new Duration(500, TimeUnit.MILLISECONDS))
                 .setDfsConnectMaxRetries(5)
                 .setFileSystemCacheTtl(new Duration(1, TimeUnit.DAYS))
-                .setResourceConfigurationFiles(null)
+                .setResourceConfigurationFiles((String) null)
                 .setDomainSocketPath(null));
     }
 

--- a/presto-server/etc/catalog/hive.properties
+++ b/presto-server/etc/catalog/hive.properties
@@ -1,3 +1,1 @@
 connector.name=hive-cdh4
-
-hive.config.resources=/etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml


### PR DESCRIPTION
This PR allows the user to specify 0 or more additional configuration files that are necessary for communicating with HDFS. This is especially necessary with our configuration, as we run HDFS federated. Without the additional information available in `core-site.xml` and `hdfs-site.xml`, Presto fails to communicate with HDFS. With the ability to load these configuration files, Presto works splendidly with a federated HDFS.
