### PR TITLE
Only announce coordinator if configured as one

### DIFF
--- a/presto-server/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-server/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -82,9 +82,9 @@ public class CoordinatorModule
     @Override
     protected void setup(Binder binder)
     {
-        httpServerBinder(binder).bindResource("/", "webapp").withWelcomeFile("index.html");
+        // TODO: currently, this module is ALWAYS installed (even for non-coordinators)
 
-        discoveryBinder(binder).bindHttpAnnouncement("presto-coordinator");
+        httpServerBinder(binder).bindResource("/", "webapp").withWelcomeFile("index.html");
 
         discoveryBinder(binder).bindSelector("presto");
 

--- a/presto-server/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-server/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -116,6 +116,10 @@ public class ServerMainModule
         // TODO: this should only be installed if this is a coordinator
         install(new CoordinatorModule());
 
+        if (serverConfig.isCoordinator()) {
+            discoveryBinder(binder).bindHttpAnnouncement("presto-coordinator");
+        }
+
         bindFailureDetector(binder, serverConfig.isCoordinator());
 
         // task execution


### PR DESCRIPTION
This fixes a bug introduced in the CoordinatorModule refactoring
that causes every node to announce itself as a coordinator.
