### PR TITLE
Cli hangs when the server goes away

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -190,7 +190,7 @@ public class StatementClient
                         response.getStatusMessage()));
             }
         }
-        while ((System.nanoTime() - start) < MINUTES.toNanos(2));
+        while ((System.nanoTime() - start) < MINUTES.toNanos(2) && !isClosed());
 
         gone.set(true);
         throw new RuntimeException("Error fetching next", cause);


### PR DESCRIPTION
Presto cli hangs for a long time when the server goes away. Add a check to see if the client is closed so that we can get out of this state by pressing ctrl-C
