### PR TITLE
Add --source option to CLI

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -28,6 +28,9 @@ public class ClientOptions
     @Option(name = "--user", title = "user", description = "Username")
     public String user = System.getProperty("user.name");
 
+    @Option(name = "--source", title = "source", description = "Name of source making query")
+    public String source = "presto-cli";
+
     @Option(name = "--catalog", title = "catalog", description = "Default catalog")
     public String catalog = "default";
 
@@ -58,7 +61,7 @@ public class ClientOptions
 
     public ClientSession toClientSession()
     {
-        return new ClientSession(parseServer(server), user, "presto-cli", catalog, schema, debug);
+        return new ClientSession(parseServer(server), user, source, catalog, schema, debug);
     }
 
     private static URI parseServer(String s)

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
@@ -25,6 +25,16 @@ public class TestClientOptions
     {
         ClientSession session = new ClientOptions().toClientSession();
         assertEquals(session.getServer().toString(), "http://localhost:8080");
+        assertEquals(session.getSource(), "presto-cli");
+    }
+
+    @Test
+    public void testSource()
+    {
+        ClientOptions options = new ClientOptions();
+        options.source = "test";
+        ClientSession session = options.toClientSession();
+        assertEquals(session.getSource(), "test");
     }
 
     @Test


### PR DESCRIPTION
This lets you set the source of the query for logging purposes. Tested
by running the CLI with --help to make sure the option showed up, and
added a unit test
