### PR TITLE
Add a summarized print of TableScanNode TupleDomain to cut down on logging size

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -146,7 +146,7 @@ public class LogicalPlanner
             }
 
             ImmutableList<Symbol> outputSymbols = outputSymbolsBuilder.build();
-            plan = new RelationPlan(new TableScanNode(idAllocator.getNextId(), sourceTableHandle, outputSymbols, inputColumnsBuilder.build(), Optional.<GeneratedPartitions>absent()), new TupleDescriptor(fields.build()), outputSymbols);
+            plan = new RelationPlan(new TableScanNode(idAllocator.getNextId(), sourceTableHandle, outputSymbols, inputColumnsBuilder.build(), null, Optional.<GeneratedPartitions>absent()), new TupleDescriptor(fields.build()), outputSymbols);
 
             targetColumnHandles = columnHandleBuilder.build();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -192,7 +192,7 @@ class QueryPlanner
         }
 
         ImmutableMap<Symbol, ColumnHandle> assignments = columns.build();
-        TableScanNode tableScan = new TableScanNode(idAllocator.getNextId(), table, ImmutableList.copyOf(assignments.keySet()), assignments, Optional.<GeneratedPartitions>absent());
+        TableScanNode tableScan = new TableScanNode(idAllocator.getNextId(), table, ImmutableList.copyOf(assignments.keySet()), assignments, null, Optional.<GeneratedPartitions>absent());
 
         return new RelationPlan(tableScan, new TupleDescriptor(), ImmutableList.<Symbol>of());
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -112,7 +112,7 @@ class RelationPlanner
         }
 
         ImmutableList<Symbol> outputSymbols = outputSymbolsBuilder.build();
-        return new RelationPlan(new TableScanNode(idAllocator.getNextId(), handle, outputSymbols, columns.build(), Optional.<GeneratedPartitions>absent()), descriptor, outputSymbols);
+        return new RelationPlan(new TableScanNode(idAllocator.getNextId(), handle, outputSymbols, columns.build(), null, Optional.<GeneratedPartitions>absent()), descriptor, outputSymbols);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -776,7 +776,9 @@ public class PredicatePushDown
 
             PlanNode output = node;
             if (!node.getGeneratedPartitions().equals(Optional.of(generatedPartitions))) {
-                output = new TableScanNode(node.getId(), node.getTable(), node.getOutputSymbols(), node.getAssignments(), Optional.of(generatedPartitions));
+                // Only overwrite the originalConstraint if it was previously null
+                Expression originalConstraint = node.getOriginalConstraint() == null ? inheritedPredicate : node.getOriginalConstraint();
+                output = new TableScanNode(node.getId(), node.getTable(), node.getOutputSymbols(), node.getAssignments(), originalConstraint, Optional.of(generatedPartitions));
             }
             if (!postScanPredicate.equals(BooleanLiteral.TRUE_LITERAL)) {
                 output = new FilterNode(idAllocator.getNextId(), output, postScanPredicate);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -206,7 +206,7 @@ public class PruneUnreferencedOutputs
             List<Symbol> newOutputSymbols = FluentIterable.from(node.getOutputSymbols())
                     .filter(in(requiredTableScanOutputs))
                     .toList();
-            return new TableScanNode(node.getId(), node.getTable(), newOutputSymbols, node.getAssignments(), node.getGeneratedPartitions());
+            return new TableScanNode(node.getId(), node.getTable(), newOutputSymbols, node.getAssignments(), node.getOriginalConstraint(), node.getGeneratedPartitions());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyExpressions.java
@@ -27,6 +27,7 @@ import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanNodeRewriter;
 import com.facebook.presto.sql.planner.plan.PlanRewriter;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.base.Function;
@@ -88,6 +89,16 @@ public class SimplifyExpressions
                 return source;
             }
             return new FilterNode(node.getId(), source, simplified);
+        }
+
+        @Override
+        public PlanNode rewriteTableScan(TableScanNode node, Void context, PlanRewriter<Void> planRewriter)
+        {
+            Expression originalConstraint = null;
+            if (node.getOriginalConstraint() != null) {
+                originalConstraint = simplifyExpression(node.getOriginalConstraint());
+            }
+            return new TableScanNode(node.getId(), node.getTable(), node.getOutputSymbols(), node.getAssignments(), originalConstraint, node.getGeneratedPartitions());
         }
 
         private Function<Expression, Expression> simplifyExpressionFunction()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TableAliasSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TableAliasSelector.java
@@ -139,7 +139,7 @@ public class TableAliasSelector
                 newAssignmentsBuilder.put(assignmentEntry.getKey(), aliasedColumnHandle);
             }
 
-            return new TableScanNode(node.getId(), aliasTableHandle.get(), node.getOutputSymbols(), newAssignmentsBuilder.build(), node.getGeneratedPartitions());
+            return new TableScanNode(node.getId(), aliasTableHandle.get(), node.getOutputSymbols(), newAssignmentsBuilder.build(), node.getOriginalConstraint(), node.getGeneratedPartitions());
         }
 
         private boolean allNodesPresent(TableHandle tableHandle)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -157,7 +157,11 @@ public class UnaliasSymbolReferences
                 builder.put(canonicalize(entry.getKey()), entry.getValue());
             }
 
-            return new TableScanNode(node.getId(), node.getTable(), canonicalize(node.getOutputSymbols()), builder.build(), node.getGeneratedPartitions());
+            Expression originalConstraint = null;
+            if (node.getOriginalConstraint() != null) {
+                originalConstraint = canonicalize(node.getOriginalConstraint());
+            }
+            return new TableScanNode(node.getId(), node.getTable(), canonicalize(node.getOutputSymbols()), builder.build(), originalConstraint, node.getGeneratedPartitions());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -51,7 +51,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static com.facebook.presto.sql.planner.DomainUtils.printableTupleDomainWithSymbols;
 import static com.google.common.collect.Maps.immutableEnumMap;
 import static java.lang.String.format;
 
@@ -304,7 +303,7 @@ public final class GraphvizPrinter
         @Override
         public Void visitTableScan(TableScanNode node, Void context)
         {
-            printNode(node, format("TableScan[%s]", node.getTable()), format("domain=%s", printableTupleDomainWithSymbols(node.getPartitionsDomainSummary(), node.getAssignments())), NODE_COLORS.get(NodeType.TABLESCAN));
+            printNode(node, format("TableScan[%s]", node.getTable()), format("original constraint=%s", node.getOriginalConstraint()), NODE_COLORS.get(NodeType.TABLESCAN));
             return null;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -203,6 +203,7 @@ public class TestSqlStageExecution
                         tableHandle,
                         ImmutableList.of(symbol),
                         ImmutableMap.of(symbol, columnHandle),
+                        null,
                         Optional.<GeneratedPartitions>absent()),
                 ImmutableMap.<Symbol, Type>of(symbol, Type.VARCHAR),
                 Partitioning.SOURCE,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -129,6 +129,7 @@ public class TestSqlTaskManager
                         tableHandle,
                         ImmutableList.of(symbol),
                         ImmutableMap.of(symbol, columnHandle),
+                        null,
                         Optional.<GeneratedPartitions>absent()),
                 ImmutableMap.<Symbol, Type>of(symbol, Type.VARCHAR),
                 Partitioning.SOURCE,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -108,6 +108,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
+                null,
                 Optional.<GeneratedPartitions>absent()
         );
 
@@ -284,6 +285,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
+                null,
                 Optional.<GeneratedPartitions>absent());
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
         Assert.assertEquals(effectivePredicate, BooleanLiteral.TRUE_LITERAL);
@@ -294,6 +296,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
+                null,
                 Optional.<GeneratedPartitions>of(new GeneratedPartitions(
                         TupleDomain.withColumnDomains(ImmutableMap.<ColumnHandle, Domain>of(scanAssignments.get(A), Domain.singleValue(1L))),
                         ImmutableList.<Partition>of())));
@@ -306,6 +309,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
+                null,
                 Optional.<GeneratedPartitions>of(new GeneratedPartitions(
                         TupleDomain.withColumnDomains(ImmutableMap.<ColumnHandle, Domain>of(scanAssignments.get(A), Domain.singleValue(1L))),
                         ImmutableList.<Partition>of(new DualPartition()))));
@@ -318,6 +322,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
+                null,
                 Optional.<GeneratedPartitions>of(new GeneratedPartitions(
                         TupleDomain.withColumnDomains(ImmutableMap.<ColumnHandle, Domain>of(scanAssignments.get(A), Domain.singleValue(1L))),
                         ImmutableList.<Partition>of(tupleDomainPartition(TupleDomain.withColumnDomains(ImmutableMap.<ColumnHandle, Domain>of(
@@ -332,6 +337,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
+                null,
                 Optional.<GeneratedPartitions>of(new GeneratedPartitions(
                         TupleDomain.all(),
                         ImmutableList.<Partition>of())));
@@ -344,6 +350,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
+                null,
                 Optional.<GeneratedPartitions>of(new GeneratedPartitions(
                         TupleDomain.all(),
                         ImmutableList.<Partition>of(new DualPartition()))));
@@ -356,6 +363,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
+                null,
                 Optional.<GeneratedPartitions>of(new GeneratedPartitions(
                         TupleDomain.all(),
                         ImmutableList.<Partition>of(tupleDomainPartition(TupleDomain.withColumnDomains(ImmutableMap.<ColumnHandle, Domain>of(
@@ -370,6 +378,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.of(A),
                 assignments,
+                null,
                 Optional.<GeneratedPartitions>of(new GeneratedPartitions(
                         TupleDomain.withColumnDomains(ImmutableMap.<ColumnHandle, Domain>of(
                                 scanAssignments.get(A), Domain.singleValue(1L),
@@ -434,6 +443,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(leftAssignments.keySet()),
                 leftAssignments,
+                null,
                 Optional.<GeneratedPartitions>absent()
         );
 
@@ -443,6 +453,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(rightAssignments.keySet()),
                 rightAssignments,
+                null,
                 Optional.<GeneratedPartitions>absent()
         );
 
@@ -485,6 +496,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(leftAssignments.keySet()),
                 leftAssignments,
+                null,
                 Optional.<GeneratedPartitions>absent()
         );
 
@@ -494,6 +506,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(rightAssignments.keySet()),
                 rightAssignments,
+                null,
                 Optional.<GeneratedPartitions>absent()
         );
 
@@ -536,6 +549,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(leftAssignments.keySet()),
                 leftAssignments,
+                null,
                 Optional.<GeneratedPartitions>absent()
         );
 
@@ -545,6 +559,7 @@ public class TestEffectivePredicateExtractor
                 new DualTableHandle("default"),
                 ImmutableList.copyOf(rightAssignments.keySet()),
                 rightAssignments,
+                null,
                 Optional.<GeneratedPartitions>absent()
         );
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Domain.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Domain.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -198,10 +200,13 @@ public final class Domain
     @Override
     public String toString()
     {
-        final StringBuilder sb = new StringBuilder("Domain{");
-        sb.append("ranges=").append(ranges);
-        sb.append(", nullAllowed=").append(nullAllowed);
-        sb.append('}');
-        return sb.toString();
+        List<Object> values = new ArrayList<>();
+        if (nullAllowed) {
+            values.add("NULL");
+        }
+        for (Range range : ranges) {
+            values.add(range);
+        }
+        return values.toString();
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/TupleDomain.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/TupleDomain.java
@@ -299,10 +299,18 @@ public final class TupleDomain
     @Override
     public String toString()
     {
-        final StringBuilder sb = new StringBuilder("TupleDomain{");
-        sb.append("domains=").append(domains);
-        sb.append('}');
-        return sb.toString();
+        StringBuilder builder = new StringBuilder()
+                .append("TupleDomain:");
+        if (isAll()) {
+            builder.append("ALL");
+        }
+        else if (isNone()) {
+            builder.append("NONE");
+        }
+        else {
+            builder.append(domains);
+        }
+        return builder.toString();
     }
 
     // Available for Jackson serialization only!


### PR DESCRIPTION
Formatting:

Where there are a small number of range segments:

presto> explain SELECT ds, id, COUNT(1) AS count FROM table WHERE ds >= '2013-11-15' AND (type='A' OR type='B') GROUP BY ds, id;

---
- Output[ds, id, count]
       id := id
       count := count
  - Aggregate[ds, id] => [ds:varchar, id:varchar, count:bigint]
         count := count("expr")
    - Project => [ds:varchar, id:varchar, expr:bigint]
           expr := 1
      - TableScan[default:default:table, original constrant=(("ds" >= '2013-11-15') AND (("type" = 'A') OR ("type" = 'B'))), domain={ds => Domain{ranges=[[2013-11-15], [2013-11-16], [2013-11-17], [2013-11-18], [2013-11-19], [2013-11-20]], nullAllowed=false}, type => Domain{ranges=[[A], [B]], nullAllowed=false}}] => [id:varchar, ds:varchar]
             id := HiveColumnHandle{clientId=default, name=id, ordinalPosition=1, hiveType=STRING, hiveColumnIndex=6, partitionKey=false}
             ds := HiveColumnHandle{clientId=default, name=ds, ordinalPosition=2, hiveType=STRING, hiveColumnIndex=-1, partitionKey=true}
             type := HiveColumnHandle{clientId=default, name=type, ordinalPosition=3, hiveType=STRING, hiveColumnIndex=-1, partitionKey=true}

(1 row)

When there are a large number of range segments:

presto> explain SELECT ds, id, COUNT(1) AS count FROM table WHERE ds >= '2012-11-15' AND (type='A' OR type='B') GROUP BY ds, id;
##                                                                                                                                                                                                                                                               Query Plan
- Output[ds, id, count]
       id := id
       count := count
  - Aggregate[ds, id] => [ds:varchar, id:varchar, count:bigint]
         count := count("expr")
    - Project => [ds:varchar, id:varchar, expr:bigint]
           expr := 1
      - TableScan[default:default:table, original constrant=(("ds" >= '2012-11-15') AND (("type" = 'A') OR ("type" = 'B'))), domain={ds => Summarized:Domain{ranges=[[2013-08-04, 2013-12-15]], nullAllowed=false}, type => Domain{ranges=[[A], [B]], nullAllowed=false}}] => [id:varchar, ds:varchar]
             id := HiveColumnHandle{clientId=default, name=id, ordinalPosition=1, hiveType=STRING, hiveColumnIndex=1, partitionKey=false}
             ds := HiveColumnHandle{clientId=default, name=ds, ordinalPosition=2, hiveType=STRING, hiveColumnIndex=-1, partitionKey=true}
             type := HiveColumnHandle{clientId=default, name=type, ordinalPosition=3, hiveType=STRING, hiveColumnIndex=-1, partitionKey=true}

(1 row)
