### PR TITLE
Add support for DISTINCT in aggregations for simple cases

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/AbstractTestQueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/AbstractTestQueries.java
@@ -302,12 +302,25 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT DISTINCT custkey FROM orders");
     }
 
-    // TODO: we need to properly propagate exceptions with their actual classes
-    @Test(expectedExceptions = Exception.class, expectedExceptionsMessageRegExp = "DISTINCT in aggregation parameters not yet supported")
+    @Test(expectedExceptions = Exception.class, expectedExceptionsMessageRegExp = "All DISTINCT argument lists used in aggregations must match")
+    public void testCountMultipleDifferentDistinct()
+            throws Exception
+    {
+        assertQuery("SELECT COUNT(DISTINCT orderstatus), SUM(DISTINCT custkey) FROM orders");
+    }
+
+    @Test
+    public void testCountMultipleDistinct()
+            throws Exception
+    {
+        assertQuery("SELECT COUNT(DISTINCT custkey), SUM(DISTINCT custkey) FROM orders", "SELECT COUNT(*), SUM(custkey) FROM (SELECT DISTINCT custkey FROM orders) t");
+    }
+
+    @Test
     public void testCountDistinct()
             throws Exception
     {
-        assertQuery("SELECT COUNT(DISTINCT custkey) FROM orders");
+        assertQuery("SELECT COUNT(DISTINCT custkey + 1) FROM orders", "SELECT COUNT(*) FROM (SELECT DISTINCT custkey + 1 FROM orders) t");
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -178,7 +178,7 @@ public class TestAnalyzer
     public void testDistinctAggregations()
             throws Exception
     {
-        assertFails(NOT_SUPPORTED, "SELECT COUNT(DISTINCT a) FROM t1");
+        assertFails(NOT_SUPPORTED, "SELECT COUNT(DISTINCT a), SUM(a) FROM t1");
     }
 
     @Test


### PR DESCRIPTION
Supports COUNT(DISTINCT) and DISTINCT in other aggregations, as long as
there is only one DISTINCT expression, and all the aggregations use this
expression. Also, using it with GROUP BY is not supported yet.
