### PR TITLE
Remove support for implicit cross joins

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/TupleAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/TupleAnalyzer.java
@@ -90,7 +90,6 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.ORDER_BY_MUST_B
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TYPE_MISMATCH;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.WILDCARD_WITHOUT_FROM;
 import static com.facebook.presto.sql.tree.FunctionCall.distinctPredicate;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.elementsEqual;
@@ -714,8 +713,10 @@ class TupleAnalyzer
         TupleDescriptor fromDescriptor = new TupleDescriptor();
 
         if (node.getFrom() != null && !node.getFrom().isEmpty()) {
-            checkArgument(node.getFrom().size() == 1, "Operation not supported");
             TupleAnalyzer analyzer = new TupleAnalyzer(analysis, session, metadata);
+            if (node.getFrom().size() != 1) {
+                throw new SemanticException(NOT_SUPPORTED, node, "Implicit cross joins are not yet supported; use CROSS JOIN");
+            }
             fromDescriptor = analyzer.process(Iterables.getOnlyElement(node.getFrom()), context);
         }
         return fromDescriptor;

--- a/presto-main/src/test/java/com/facebook/presto/AbstractTestQueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/AbstractTestQueries.java
@@ -2257,8 +2257,8 @@ public abstract class AbstractTestQueries
                 "CROSS JOIN (SELECT * FROM lineitem ORDER BY orderkey LIMIT 5) b");
     }
 
-    @Test
-    public void testImplicitJoin()
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Implicit cross joins are not yet supported; use CROSS JOIN")
+    public void testImplicitCrossJoin()
             throws Exception
     {
         assertQuery("" +

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -256,6 +256,12 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testImplicitCrossJoinNotSupported()
+    {
+        assertFails(NOT_SUPPORTED, "SELECT * FROM a, b");
+    }
+
+    @Test
     public void testNaturalJoinNotSupported()
             throws Exception
     {

--- a/presto-parser/src/main/antlr3/com/facebook/presto/sql/parser/Statement.g
+++ b/presto-parser/src/main/antlr3/com/facebook/presto/sql/parser/Statement.g
@@ -221,14 +221,7 @@ selectClause
     ;
 
 fromClause
-    // TODO: support implicit cross joins properly in the engine
-    //: FROM tableRef (',' tableRef)* -> ^(FROM tableRef+)
-    : FROM fromList -> ^(FROM fromList)
-    ;
-
-fromList
-    : ( tableRef -> tableRef )
-      ( ',' tableRef -> ^(CROSS_JOIN $fromList tableRef) )*
+    : FROM tableRef (',' tableRef)* -> ^(FROM tableRef+)
     ;
 
 whereClause


### PR DESCRIPTION
The pre-ANSI join syntax makes it very easy to accidentally perform a
cross join when an inner join was intended, not to mention resulting in
harder to read queries, so we need a way to disable it via configuration.
