### PR TITLE
Window function argruments

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionInfo.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.operator.AggregationFunctionDefinition;
+import com.facebook.presto.operator.WindowFunctionDefinition;
 import com.facebook.presto.operator.aggregation.AggregationFunction;
 import com.facebook.presto.operator.window.WindowFunction;
 import com.facebook.presto.spi.type.Type;
@@ -30,6 +31,7 @@ import java.lang.invoke.MethodHandle;
 import java.util.List;
 
 import static com.facebook.presto.operator.AggregationFunctionDefinition.aggregation;
+import static com.facebook.presto.operator.WindowFunctionDefinition.window;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -158,6 +160,12 @@ public final class FunctionInfo
     public Type getIntermediateType()
     {
         return intermediateType;
+    }
+
+    public WindowFunctionDefinition bind(List<Input> inputs)
+    {
+        checkState(isWindow, "not a window function");
+        return window(windowFunction.get(), inputs);
     }
 
     public AggregationFunctionDefinition bind(List<Input> inputs, Optional<Input> mask, Optional<Input> sampleWeight, double confidence)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -28,6 +28,14 @@ import com.facebook.presto.operator.scalar.UrlFunctions;
 import com.facebook.presto.operator.scalar.VarbinaryFunctions;
 import com.facebook.presto.operator.window.CumulativeDistributionFunction;
 import com.facebook.presto.operator.window.DenseRankFunction;
+import com.facebook.presto.operator.window.FirstValueFunction.BigintFirstValueFunction;
+import com.facebook.presto.operator.window.FirstValueFunction.BooleanFirstValueFunction;
+import com.facebook.presto.operator.window.FirstValueFunction.DoubleFirstValueFunction;
+import com.facebook.presto.operator.window.FirstValueFunction.VarcharFirstValueFunction;
+import com.facebook.presto.operator.window.LastValueFunction.BigintLastValueFunction;
+import com.facebook.presto.operator.window.LastValueFunction.BooleanLastValueFunction;
+import com.facebook.presto.operator.window.LastValueFunction.DoubleLastValueFunction;
+import com.facebook.presto.operator.window.LastValueFunction.VarcharLastValueFunction;
 import com.facebook.presto.operator.window.PercentRankFunction;
 import com.facebook.presto.operator.window.RankFunction;
 import com.facebook.presto.operator.window.RowNumberFunction;
@@ -176,6 +184,14 @@ public class FunctionRegistry
                 .window("dense_rank", BIGINT, ImmutableList.<Type>of(), supplier(DenseRankFunction.class))
                 .window("percent_rank", DOUBLE, ImmutableList.<Type>of(), supplier(PercentRankFunction.class))
                 .window("cume_dist", DOUBLE, ImmutableList.<Type>of(), supplier(CumulativeDistributionFunction.class))
+                .window("first_value", BIGINT, ImmutableList.<Type>of(BIGINT), supplier(BigintFirstValueFunction.class))
+                .window("first_value", DOUBLE, ImmutableList.<Type>of(DOUBLE), supplier(DoubleFirstValueFunction.class))
+                .window("first_value", BOOLEAN, ImmutableList.<Type>of(BOOLEAN), supplier(BooleanFirstValueFunction.class))
+                .window("first_value", VARCHAR, ImmutableList.<Type>of(VARCHAR), supplier(VarcharFirstValueFunction.class))
+                .window("last_value", BIGINT, ImmutableList.<Type>of(BIGINT), supplier(BigintLastValueFunction.class))
+                .window("last_value", DOUBLE, ImmutableList.<Type>of(DOUBLE), supplier(DoubleLastValueFunction.class))
+                .window("last_value", BOOLEAN, ImmutableList.<Type>of(BOOLEAN), supplier(BooleanLastValueFunction.class))
+                .window("last_value", VARCHAR, ImmutableList.<Type>of(VARCHAR), supplier(VarcharLastValueFunction.class))
                 .aggregate("count", BIGINT, ImmutableList.<Type>of(), BIGINT, COUNT)
                 .aggregate("count", BIGINT, ImmutableList.of(BOOLEAN), BIGINT, COUNT_BOOLEAN_COLUMN)
                 .aggregate("count", BIGINT, ImmutableList.of(BIGINT), BIGINT, COUNT_LONG_COLUMN)

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -176,6 +176,16 @@ public class PagesIndex
         block.appendTo(blockPosition, output);
     }
 
+    public RandomAccessBlock getSingleValueBlock(int channel, int position)
+    {
+        long pageAddress = valueAddresses.getLong(position);
+
+        RandomAccessBlock block = channels[channel].get(decodeSliceIndex(pageAddress));
+        int blockPosition = decodePosition(pageAddress);
+
+        return block.getSingleValueBlock(blockPosition);
+    }
+
     public boolean equals(int[] channels, int leftPosition, int rightPosition)
     {
         if (leftPosition == rightPosition) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowFunctionDefinition.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowFunctionDefinition.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.operator.window.WindowFunction;
+import com.facebook.presto.sql.tree.Input;
+import com.google.common.base.Preconditions;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class WindowFunctionDefinition
+{
+    public static WindowFunctionDefinition window(WindowFunction function, List<Input> inputs)
+    {
+        Preconditions.checkNotNull(function, "function is null");
+        Preconditions.checkNotNull(inputs, "inputs is null");
+
+        return new WindowFunctionDefinition(function, inputs);
+    }
+
+    public static WindowFunctionDefinition window(WindowFunction function, Input... inputs)
+    {
+        Preconditions.checkNotNull(function, "function is null");
+        Preconditions.checkNotNull(inputs, "inputs is null");
+
+        return window(function, Arrays.asList(inputs));
+    }
+
+    private final WindowFunction function;
+    private final List<Input> inputs;
+
+    WindowFunctionDefinition(WindowFunction function, List<Input> inputs)
+    {
+        this.function = function;
+        this.inputs = inputs;
+    }
+
+    public WindowFunction getFunction()
+    {
+        return function;
+    }
+
+    public List<Input> getInputs()
+    {
+        return inputs;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/CumulativeDistributionFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/CumulativeDistributionFunction.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.window;
 
+import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 
@@ -31,7 +32,7 @@ public class CumulativeDistributionFunction
     }
 
     @Override
-    public void reset(int partitionRowCount)
+    public void reset(int partitionRowCount, PagesIndex pagesIndex, int... argumentChannels)
     {
         totalCount = partitionRowCount;
         count = 0;

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/DenseRankFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/DenseRankFunction.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.window;
 
+import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 
@@ -30,7 +31,7 @@ public class DenseRankFunction
     }
 
     @Override
-    public void reset(int partitionRowCount)
+    public void reset(int partitionRowCount, PagesIndex pagesIndex, int... argumentChannels)
     {
         rank = 0;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/FirstValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/FirstValueFunction.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.window;
+
+import com.facebook.presto.operator.PagesIndex;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.RandomAccessBlock;
+import com.facebook.presto.spi.type.Type;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
+public class FirstValueFunction
+        implements WindowFunction
+{
+    public static class BigintFirstValueFunction
+            extends FirstValueFunction
+    {
+        public BigintFirstValueFunction()
+        {
+            super(BIGINT);
+        }
+    }
+    public static class BooleanFirstValueFunction
+            extends FirstValueFunction
+    {
+        public BooleanFirstValueFunction()
+        {
+            super(BOOLEAN);
+        }
+    }
+    public static class DoubleFirstValueFunction
+            extends FirstValueFunction
+    {
+        public DoubleFirstValueFunction()
+        {
+            super(DOUBLE);
+        }
+    }
+    public static class VarcharFirstValueFunction
+            extends FirstValueFunction
+    {
+        public VarcharFirstValueFunction()
+        {
+            super(VARCHAR);
+        }
+    }
+
+    private final Type type;
+    private int rowCount;
+    protected RandomAccessBlock valueBlock;
+
+    protected FirstValueFunction(Type type)
+    {
+        this.type = type;
+    }
+
+    @Override
+    public Type getType()
+    {
+        return type;
+    }
+
+    @Override
+    public void reset(int partitionRowCount, PagesIndex pagesIndex, int... argumentChannels)
+    {
+        valueBlock = pagesIndex.getSingleValueBlock(argumentChannels[0], rowCount);
+        rowCount += partitionRowCount;
+    }
+
+    @Override
+    public void processRow(BlockBuilder output, boolean newPeerGroup, int peerGroupCount)
+    {
+        valueBlock.appendTo(0, output);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/LastValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/LastValueFunction.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.window;
+
+import com.facebook.presto.operator.PagesIndex;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.RandomAccessBlock;
+import com.facebook.presto.spi.type.Type;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
+public class LastValueFunction
+        implements WindowFunction
+{
+    public static class BigintLastValueFunction
+            extends LastValueFunction
+    {
+        public BigintLastValueFunction()
+        {
+            super(BIGINT);
+        }
+    }
+    public static class BooleanLastValueFunction
+            extends LastValueFunction
+    {
+        public BooleanLastValueFunction()
+        {
+            super(BOOLEAN);
+        }
+    }
+    public static class DoubleLastValueFunction
+            extends LastValueFunction
+    {
+        public DoubleLastValueFunction()
+        {
+            super(DOUBLE);
+        }
+    }
+    public static class VarcharLastValueFunction
+            extends LastValueFunction
+    {
+        public VarcharLastValueFunction()
+        {
+            super(VARCHAR);
+        }
+    }
+
+    private final Type type;
+    private int rowCount;
+    protected RandomAccessBlock valueBlock;
+
+    protected LastValueFunction(Type type)
+    {
+        this.type = type;
+    }
+
+    @Override
+    public Type getType()
+    {
+        return type;
+    }
+
+    @Override
+    public void reset(int partitionRowCount, PagesIndex pagesIndex, int... argumentChannels)
+    {
+        rowCount += partitionRowCount;
+        valueBlock = pagesIndex.getSingleValueBlock(argumentChannels[0], rowCount - 1);
+    }
+
+    @Override
+    public void processRow(BlockBuilder output, boolean newPeerGroup, int peerGroupCount)
+    {
+        valueBlock.appendTo(0, output);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/PercentRankFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/PercentRankFunction.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.window;
 
+import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 
@@ -32,7 +33,7 @@ public class PercentRankFunction
     }
 
     @Override
-    public void reset(int partitionRowCount)
+    public void reset(int partitionRowCount, PagesIndex pagesIndex, int... argumentChannels)
     {
         totalCount = partitionRowCount;
         rank = 0;

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/RankFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/RankFunction.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.window;
 
+import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 
@@ -31,7 +32,7 @@ public class RankFunction
     }
 
     @Override
-    public void reset(int partitionRowCount)
+    public void reset(int partitionRowCount, PagesIndex pagesIndex, int... argumentChannels)
     {
         rank = 0;
         count = 1;

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/RowNumberFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/RowNumberFunction.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.window;
 
+import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 
@@ -30,7 +31,7 @@ public class RowNumberFunction
     }
 
     @Override
-    public void reset(int partitionRowCount)
+    public void reset(int partitionRowCount, PagesIndex pagesIndex, int... argumentChannels)
     {
         rowNumber = 0;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/WindowFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/WindowFunction.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.window;
 
+import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 
@@ -24,8 +25,10 @@ public interface WindowFunction
      * Reset state for a new partition (including the first one).
      *
      * @param partitionRowCount the total number of rows in the new partition
+     * @param pageIndex the pages index which contains sorted values
+     * @param argumentChannels the function arguments' channels
      */
-    void reset(int partitionRowCount);
+    void reset(int partitionRowCount, PagesIndex pageIndex, int... argumentChannels);
 
     /**
      * Process a row by outputting the result of the window function.

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -51,10 +51,10 @@ import com.facebook.presto.operator.SourceOperatorFactory;
 import com.facebook.presto.operator.TableScanOperator.TableScanOperatorFactory;
 import com.facebook.presto.operator.TopNOperator.TopNOperatorFactory;
 import com.facebook.presto.operator.ValuesOperator.ValuesOperatorFactory;
+import com.facebook.presto.operator.WindowFunctionDefinition;
 import com.facebook.presto.operator.WindowOperator.WindowOperatorFactory;
 import com.facebook.presto.operator.index.IndexLookupSourceSupplier;
 import com.facebook.presto.operator.index.IndexSourceOperator;
-import com.facebook.presto.operator.window.WindowFunction;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Index;
 import com.facebook.presto.spi.RecordSink;
@@ -390,12 +390,17 @@ public class LocalExecutionPlanner
                 outputChannels.add(i);
             }
 
-            ImmutableList.Builder<WindowFunction> windowFunctions = ImmutableList.builder();
+            ImmutableList.Builder<WindowFunctionDefinition> windowFunctions = ImmutableList.builder();
             List<Symbol> windowFunctionOutputSymbols = new ArrayList<>();
             for (Map.Entry<Symbol, FunctionCall> entry : node.getWindowFunctions().entrySet()) {
+                ImmutableList.Builder<Input> arguments = ImmutableList.builder();
+                for (Expression argument : entry.getValue().getArguments()) {
+                    Symbol argumentSymbol = Symbol.fromQualifiedName(((QualifiedNameReference) argument).getName());
+                    arguments.add(source.getLayout().get(argumentSymbol));
+                }
                 Symbol symbol = entry.getKey();
                 Signature signature = node.getSignatures().get(symbol);
-                windowFunctions.add(metadata.getExactFunction(signature).getWindowFunction().get());
+                windowFunctions.add(metadata.getExactFunction(signature).bind(arguments.build()));
                 windowFunctionOutputSymbols.add(symbol);
             }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
@@ -16,11 +16,13 @@ package com.facebook.presto.operator;
 import com.facebook.presto.ExceededMemoryLimitException;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.operator.WindowOperator.WindowOperatorFactory;
+import com.facebook.presto.operator.window.FirstValueFunction.VarcharFirstValueFunction;
+import com.facebook.presto.operator.window.LastValueFunction.VarcharLastValueFunction;
 import com.facebook.presto.operator.window.RowNumberFunction;
-import com.facebook.presto.operator.window.WindowFunction;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.sql.tree.Input;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import io.airlift.units.DataSize;
@@ -48,7 +50,13 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 @Test(singleThreaded = true)
 public class TestWindowOperator
 {
-    private static final List<WindowFunction> ROW_NUMBER = ImmutableList.<WindowFunction>of(new RowNumberFunction());
+    private static final List<WindowFunctionDefinition> ROW_NUMBER = ImmutableList.of(WindowFunctionDefinition.window(new RowNumberFunction()));
+    private static final List<WindowFunctionDefinition> FIRST_VALUE
+                = ImmutableList.of(WindowFunctionDefinition.window(new VarcharFirstValueFunction(),
+                                                                    ImmutableList.of(new Input(1))));
+    private static final List<WindowFunctionDefinition> LAST_VALUE
+                = ImmutableList.of(WindowFunctionDefinition.window(new VarcharLastValueFunction(),
+                                                                    ImmutableList.of(new Input(1))));
 
     private ExecutorService executor;
     private DriverContext driverContext;
@@ -212,5 +220,85 @@ public class TestWindowOperator
         Operator operator = operatorFactory.createOperator(driverContext);
 
         toPages(operator, input);
+    }
+
+    @Test
+    public void testFirstValuePartition()
+            throws Exception
+    {
+        // Find path which goes from A to final destination C
+        // So A.B.C and A.C are selected
+        List<Page> input = rowPagesBuilder(VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR)
+                .row("b", "A1", 1, true, "")
+                .row("a", "A2", 1, false, "")
+                .row("a", "B1", 2, true, "")
+                .pageBreak()
+                .row("b", "C1", 2, false, "")
+                .row("a", "C2", 3, true, "")
+                .row("c", "A3", 1, true, "")
+                .build();
+
+        WindowOperatorFactory operatorFactory = new WindowOperatorFactory(
+                0,
+                ImmutableList.of(VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR),
+                Ints.asList(0, 1, 2, 3),
+                FIRST_VALUE,
+                Ints.asList(0),
+                Ints.asList(2),
+                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}),
+                100);
+
+        Operator operator = operatorFactory.createOperator(driverContext);
+
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR)
+                .row("a", "A2", 1, false, "A2")
+                .row("a", "B1", 2, true, "A2")
+                .row("a", "C2", 3, true, "A2")
+                .row("b", "A1", 1, true, "A1")
+                .row("b", "C1", 2, false, "A1")
+                .row("c", "A3", 1, true, "A3")
+                .build();
+
+        assertOperatorEquals(operator, input, expected);
+    }
+
+    @Test
+    public void testLastValuePartition()
+            throws Exception
+    {
+        // Find path which goes from A to final destination C
+        // So A.B.C and A.C are selected
+        List<Page> input = rowPagesBuilder(VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR)
+                .row("b", "A1", 1, true, "")
+                .row("a", "A2", 1, false, "")
+                .row("a", "B1", 2, true, "")
+                .pageBreak()
+                .row("b", "C1", 2, false, "")
+                .row("a", "C2", 3, true, "")
+                .row("c", "A3", 1, true, "")
+                .build();
+
+        WindowOperatorFactory operatorFactory = new WindowOperatorFactory(
+                0,
+                ImmutableList.of(VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR),
+                Ints.asList(0, 1, 2, 3),
+                LAST_VALUE,
+                Ints.asList(0),
+                Ints.asList(2),
+                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}),
+                100);
+
+        Operator operator = operatorFactory.createOperator(driverContext);
+
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR)
+                .row("a", "A2", 1, false, "C2")
+                .row("a", "B1", 2, true, "C2")
+                .row("a", "C2", 3, true, "C2")
+                .row("b", "A1", 1, true, "C1")
+                .row("b", "C1", 2, false, "C1")
+                .row("c", "A3", 1, true, "A3")
+                .build();
+
+        assertOperatorEquals(operator, input, expected);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/TestWindowFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/TestWindowFunctions.java
@@ -267,4 +267,70 @@ public class TestWindowFunctions
                         .build(), queryRunner
         );
     }
+
+    @Test
+    public void testFirstValue()
+    {
+        assertWindowQuery("first_value(orderdate) OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(3, "F", "1993-10-14")
+                        .row(5, "F", "1993-10-14")
+                        .row(6, "F", "1993-10-14")
+                        .row(33, "F", "1993-10-14")
+                        .row(1, "O", "1996-01-02")
+                        .row(2, "O", "1996-01-02")
+                        .row(4, "O", "1996-01-02")
+                        .row(7, "O", "1996-01-02")
+                        .row(32, "O", "1996-01-02")
+                        .row(34, "O", "1996-01-02")
+                        .build(), queryRunner);
+
+        assertWindowQuery("first_value(orderkey) OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3, "F", 3)
+                        .row(5, "F", 3)
+                        .row(6, "F", 3)
+                        .row(33, "F", 3)
+                        .row(1, "O", 1)
+                        .row(2, "O", 1)
+                        .row(4, "O", 1)
+                        .row(7, "O", 1)
+                        .row(32, "O", 1)
+                        .row(34, "O", 1)
+                        .build(), queryRunner);
+
+    }
+
+    @Test
+    public void testLastValue()
+    {
+        assertWindowQuery("last_value(orderdate) OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(3, "F", "1993-10-27")
+                        .row(5, "F", "1993-10-27")
+                        .row(6, "F", "1993-10-27")
+                        .row(33, "F", "1993-10-27")
+                        .row(1, "O", "1998-07-21")
+                        .row(2, "O", "1998-07-21")
+                        .row(4, "O", "1998-07-21")
+                        .row(7, "O", "1998-07-21")
+                        .row(32, "O", "1998-07-21")
+                        .row(34, "O", "1998-07-21")
+                        .build(), queryRunner);
+
+        assertWindowQuery("last_value(orderkey) OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3, "F", 33)
+                        .row(5, "F", 33)
+                        .row(6, "F", 33)
+                        .row(33, "F", 33)
+                        .row(1, "O", 34)
+                        .row(2, "O", 34)
+                        .row(4, "O", 34)
+                        .row(7, "O", 34)
+                        .row(32, "O", 34)
+                        .row(34, "O", 34)
+                        .build(), queryRunner);
+
+    }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1817,6 +1817,50 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testWindowFirstValueFunction()
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT * FROM (\n" +
+                "  SELECT orderkey, orderstatus\n" +
+                "    , first_value(orderkey + 1000) OVER (PARTITION BY orderstatus ORDER BY orderkey) as fvalue\n" +
+                "    FROM (SELECT * FROM orders ORDER BY orderkey LIMIT 10) x\n" +
+                "  ) x\n" +
+                "ORDER BY orderkey LIMIT 5");
+
+        MaterializedResult expected = resultBuilder(getSession(), BIGINT, VARCHAR, BIGINT)
+                .row(1, "O", 1001)
+                .row(2, "O", 1001)
+                .row(3, "F", 1003)
+                .row(4, "O", 1001)
+                .row(5, "F", 1003)
+                .build();
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testWindowLastValueFunction()
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT * FROM (\n" +
+                "  SELECT orderkey, orderstatus\n" +
+                "    , last_value(orderkey + 1000) OVER (PARTITION BY orderstatus ORDER BY orderkey) as lvalue\n" +
+                "    FROM (SELECT * FROM orders ORDER BY orderkey LIMIT 10) x\n" +
+                "  ) x\n" +
+                "ORDER BY orderkey LIMIT 5");
+
+        MaterializedResult expected = resultBuilder(getSession(), BIGINT, VARCHAR, BIGINT)
+                .row(1, "O", 1034)
+                .row(2, "O", 1034)
+                .row(3, "F", 1033)
+                .row(4, "O", 1034)
+                .row(5, "F", 1033)
+                .build();
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
     public void testScalarFunction()
             throws Exception
     {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/CustomRank.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/CustomRank.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.tests;
 
 import com.facebook.presto.operator.window.WindowFunction;
+import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.Type;
@@ -31,7 +32,7 @@ public class CustomRank
     }
 
     @Override
-    public void reset(int partitionRowCount)
+    public void reset(int partitionRowCount, PagesIndex pagesIndex, int... argumentChannels)
     {
         rank = 0;
         count = 1;


### PR DESCRIPTION
The window function cannot accept additional parameters now.

At the first implementation of pull request, I changed processRow so that it can accept additional function parameters. 

But I thought that some window functions might want to lookup other rows within the same partition.

I guess the window function interface could be dramatically changed at a future implementations but hope this pull request to be a start of the changes.   
