### PR TITLE
Improve encapsulation of native connector interfaces

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/NativeConnectorId.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/NativeConnectorId.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.google.common.base.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public final class NativeConnectorId
+{
+    private final String id;
+
+    public NativeConnectorId(String id)
+    {
+        this.id = checkNotNull(id, "id is null");
+    }
+
+    @Override
+    public String toString()
+    {
+        return id;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        NativeConnectorId other = (NativeConnectorId) obj;
+        return Objects.equal(this.id, other.id);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/split/NativeSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/NativeSplitManager.java
@@ -13,13 +13,13 @@
  */
 package com.facebook.presto.split;
 
-import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.NativeMetadata;
 import com.facebook.presto.metadata.NativeTableHandle;
 import com.facebook.presto.metadata.ShardManager;
-import com.facebook.presto.metadata.TableMetadata;
 import com.facebook.presto.metadata.TablePartition;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplitManager;
+import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.FixedSplitSource;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Node;
@@ -67,10 +67,10 @@ public class NativeSplitManager
 
     private final NodeManager nodeManager;
     private final ShardManager shardManager;
-    private final Metadata metadata;
+    private final NativeMetadata metadata;
 
     @Inject
-    public NativeSplitManager(NodeManager nodeManager, ShardManager shardManager, Metadata metadata)
+    public NativeSplitManager(NodeManager nodeManager, ShardManager shardManager, NativeMetadata metadata)
     {
         this.nodeManager = checkNotNull(nodeManager, "nodeManager is null");
         this.shardManager = checkNotNull(shardManager, "shardManager is null");
@@ -97,7 +97,7 @@ public class NativeSplitManager
 
         checkArgument(tableHandle instanceof NativeTableHandle, "Table must be a native table");
 
-        TableMetadata tableMetadata = metadata.getTableMetadata(tableHandle);
+        ConnectorTableMetadata tableMetadata = metadata.getTableMetadata(tableHandle);
 
         checkState(tableMetadata != null, "no metadata for %s found", tableHandle);
 

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestNativeMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestNativeMetadata.java
@@ -53,7 +53,7 @@ public class TestNativeMetadata
     {
         IDBI dbi = new DBI("jdbc:h2:mem:test" + System.nanoTime());
         dummyHandle = dbi.open();
-        metadata = new NativeMetadata("default", dbi, new DatabaseShardManager(dbi));
+        metadata = new NativeMetadata(new NativeConnectorId("default"), dbi, new DatabaseShardManager(dbi));
     }
 
     @AfterMethod

--- a/presto-main/src/test/java/com/facebook/presto/split/TestNativeSplitManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/split/TestNativeSplitManager.java
@@ -15,13 +15,12 @@ package com.facebook.presto.split;
 
 import com.facebook.presto.metadata.DatabaseShardManager;
 import com.facebook.presto.metadata.InMemoryNodeManager;
-import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder;
+import com.facebook.presto.metadata.NativeConnectorId;
 import com.facebook.presto.metadata.NativeMetadata;
 import com.facebook.presto.metadata.PrestoNode;
 import com.facebook.presto.metadata.NodeVersion;
 import com.facebook.presto.metadata.ShardManager;
-import com.facebook.presto.metadata.TableMetadata;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Domain;
@@ -81,11 +80,10 @@ public class TestNativeSplitManager
         String nodeName = UUID.randomUUID().toString();
         nodeManager.addNode("native", new PrestoNode(nodeName, new URI("http://127.0.0.1/"), NodeVersion.UNKNOWN));
 
-        MetadataManager metadataManager = new MetadataManager();
-        metadataManager.addConnectorMetadata("local", "local", new NativeMetadata("native", dbi, shardManager));
+        NativeMetadata metadata = new NativeMetadata(new NativeConnectorId("native"), dbi, shardManager);
 
-        tableHandle = metadataManager.createTable("local", new TableMetadata("local", TEST_TABLE));
-        dsColumnHandle = metadataManager.getColumnHandle(tableHandle, "ds").get();
+        tableHandle = metadata.createTable(TEST_TABLE);
+        dsColumnHandle = metadata.getColumnHandle(tableHandle, "ds");
 
         UUID shardUuid1 = UUID.randomUUID();
         UUID shardUuid2 = UUID.randomUUID();
@@ -110,7 +108,7 @@ public class TestNativeSplitManager
                         .put(shardUuid4, nodeName)
                         .build());
 
-        nativeSplitManager = new NativeSplitManager(nodeManager, shardManager, metadataManager);
+        nativeSplitManager = new NativeSplitManager(nodeManager, shardManager, metadata);
     }
 
     @AfterMethod

--- a/presto-server/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-server/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -38,6 +38,8 @@ import com.facebook.presto.metadata.DiscoveryNodeManager;
 import com.facebook.presto.metadata.ForMetadata;
 import com.facebook.presto.metadata.ForShardCleaner;
 import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.metadata.NativeConnectorId;
+import com.facebook.presto.metadata.NativeMetadata;
 import com.facebook.presto.metadata.NativeRecordSinkProvider;
 import com.facebook.presto.metadata.ShardCleaner;
 import com.facebook.presto.metadata.ShardCleanerConfig;
@@ -103,6 +105,8 @@ public class CoordinatorModule
         bindConfig(binder).to(QueryManagerConfig.class);
 
         // native
+        binder.bind(NativeConnectorId.class).toInstance(new NativeConnectorId("default"));
+        binder.bind(NativeMetadata.class).in(Scopes.SINGLETON);
         binder.bind(NativeSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(NativeDataStreamProvider.class).in(Scopes.SINGLETON);
         binder.bind(NativeRecordSinkProvider.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
- Inject NativeMetadata into NativeConnectorFactory, just like DataStreamProvider et al.
- Make NativeSplitManager depend on the connector-specific NativeMetadata instead of global Metadata
