### PR TITLE
Window function should be able to run on distributed nodes

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/AbstractTestQueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/AbstractTestQueries.java
@@ -2943,7 +2943,7 @@ public abstract class AbstractTestQueries
                 "  SELECT orderstatus, clerk, sum(totalprice) sales\n" +
                 "  FROM orders\n" +
                 "  GROUP BY orderstatus, clerk\n" +
-                ")";
+                ") order by clerk";
 
         assertEquals(computeActual(sql), computeActual(sql.replace("custom_rank", "rank")));
     }


### PR DESCRIPTION
Window function can cause memory or CPU pressure if it is executed on a single node.

When it runs on distributed nodes and has _partition by_ clause , function execution should be run on distributed nodes also.
