### PR TITLE
Move Input from client to presto-main

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/Input.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/Input.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.client;
+package com.facebook.presto.execution;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.client.FailureInfo;
-import com.facebook.presto.client.Input;
 import com.facebook.presto.sql.analyzer.Session;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.client.FailureInfo;
-import com.facebook.presto.client.Input;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.sql.analyzer.Session;
 import com.google.common.base.Preconditions;

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -15,7 +15,6 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.UnpartitionedPagePartitionFunction;
-import com.facebook.presto.client.Input;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.importer.PeriodicImportManager;
 import com.facebook.presto.metadata.Metadata;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/InputExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/InputExtractor.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.sql.planner;
 
-import com.facebook.presto.client.Input;
+import com.facebook.presto.execution.Input;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableMetadata;
 import com.facebook.presto.spi.ColumnHandle;

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestInput.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestInput.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.client;
+package com.facebook.presto.execution;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.json.JsonCodec;


### PR DESCRIPTION
It's not needed by the client (yet). We may move it back later if we decide to expose
this info to clients in a structural way
