### PR TITLE
Fix EffectivePredicateExtractor range summary bug

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -191,10 +191,15 @@ public class EffectivePredicateExtractor
             public Domain apply(Domain domain)
             {
                 // Retain nullability, but collapse each SortedRangeSet into a single span
-                return Domain.create(SortedRangeSet.of(domain.getRanges().getSpan()), domain.isNullAllowed());
+                return Domain.create(getSortedRangeSpan(domain.getRanges()), domain.isNullAllowed());
             }
         });
         return TupleDomain.withColumnDomains(spannedDomains);
+    }
+
+    private static SortedRangeSet getSortedRangeSpan(SortedRangeSet rangeSet)
+    {
+        return rangeSet.isNone() ? SortedRangeSet.none(rangeSet.getType()) : SortedRangeSet.of(rangeSet.getSpan());
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/AbstractTestQueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/AbstractTestQueries.java
@@ -1633,6 +1633,16 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testJoinEffectivePredicateWithNoRanges()
+            throws Exception
+    {
+        assertQuery("" +
+                "SELECT * FROM orders a " +
+                "   JOIN (SELECT * FROM orders WHERE orderkey IS NULL) b " +
+                "   ON a.orderkey = b.orderkey");
+    }
+
+    @Test
     public void testColumnAliases()
             throws Exception
     {


### PR DESCRIPTION
Occurs when the RangeSet has no ranges.
