### PR TITLE
Rename analyzer.approximate-queries-enabled

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -78,7 +78,7 @@ public class SqlQueryExecution
     private final int scheduleSplitBatchSize;
     private final int maxPendingSplitsPerNode;
     private final int initialHashPartitions;
-    private final boolean approximateQueriesEnabled;
+    private final boolean experimentalSyntaxEnabled;
     private final ExecutorService queryExecutor;
     private final ShardManager shardManager;
 
@@ -99,7 +99,7 @@ public class SqlQueryExecution
             int scheduleSplitBatchSize,
             int maxPendingSplitsPerNode,
             int initialHashPartitions,
-            boolean approximateQueriesEnabled,
+            boolean experimentalSyntaxEnabled,
             ExecutorService queryExecutor,
             ShardManager shardManager)
     {
@@ -113,7 +113,7 @@ public class SqlQueryExecution
             this.locationFactory = checkNotNull(locationFactory, "locationFactory is null");
             this.queryExecutor = checkNotNull(queryExecutor, "queryExecutor is null");
             this.shardManager = checkNotNull(shardManager, "shardManager is null");
-            this.approximateQueriesEnabled = approximateQueriesEnabled;
+            this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
 
             checkArgument(maxPendingSplitsPerNode > 0, "scheduleSplitBatchSize must be greater than 0");
             this.scheduleSplitBatchSize = scheduleSplitBatchSize;
@@ -130,7 +130,7 @@ public class SqlQueryExecution
             checkNotNull(self, "self is null");
             this.stateMachine = new QueryStateMachine(queryId, query, session, self, queryExecutor);
 
-            this.queryExplainer = new QueryExplainer(session, planOptimizers, metadata, approximateQueriesEnabled);
+            this.queryExplainer = new QueryExplainer(session, planOptimizers, metadata, experimentalSyntaxEnabled);
         }
     }
 
@@ -198,7 +198,7 @@ public class SqlQueryExecution
         long analysisStart = System.nanoTime();
 
         // analyze query
-        Analyzer analyzer = new Analyzer(stateMachine.getSession(), metadata, Optional.of(queryExplainer), approximateQueriesEnabled);
+        Analyzer analyzer = new Analyzer(stateMachine.getSession(), metadata, Optional.of(queryExplainer), experimentalSyntaxEnabled);
 
         Analysis analysis = analyzer.analyze(statement);
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
@@ -388,7 +388,7 @@ public class SqlQueryExecution
         private final int scheduleSplitBatchSize;
         private final int maxPendingSplitsPerNode;
         private final int initialHashPartitions;
-        private final boolean approximateQueriesEnabled;
+        private final boolean experimentalSyntaxEnabled;
         private final Metadata metadata;
         private final SplitManager splitManager;
         private final NodeScheduler nodeScheduler;
@@ -422,7 +422,7 @@ public class SqlQueryExecution
             this.planOptimizers = checkNotNull(planOptimizers, "planOptimizers is null");
             this.remoteTaskFactory = checkNotNull(remoteTaskFactory, "remoteTaskFactory is null");
             this.shardManager = checkNotNull(shardManager, "shardManager is null");
-            this.approximateQueriesEnabled = checkNotNull(analyzerConfig, "analyzerConfig is null").isApproximateQueriesEnabled();
+            this.experimentalSyntaxEnabled = checkNotNull(analyzerConfig, "analyzerConfig is null").isExperimentalSyntaxEnabled();
 
             this.executor = Executors.newCachedThreadPool(threadsNamed("query-scheduler-%d"));
             this.executorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) executor);
@@ -452,7 +452,7 @@ public class SqlQueryExecution
                     scheduleSplitBatchSize,
                     maxPendingSplitsPerNode,
                     initialHashPartitions,
-                    approximateQueriesEnabled,
+                    experimentalSyntaxEnabled,
                     executor,
                     shardManager);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -35,20 +35,20 @@ public class Analyzer
     private final Metadata metadata;
     private final Session session;
     private final Optional<QueryExplainer> queryExplainer;
-    private final boolean approximateQueriesEnabled;
+    private final boolean experimentalSyntaxEnabled;
 
-    public Analyzer(Session session, Metadata metadata, Optional<QueryExplainer> queryExplainer, boolean approximateQueriesEnabled)
+    public Analyzer(Session session, Metadata metadata, Optional<QueryExplainer> queryExplainer, boolean experimentalSyntaxEnabled)
     {
         this.session = checkNotNull(session, "session is null");
         this.metadata = checkNotNull(metadata, "metadata is null");
         this.queryExplainer = checkNotNull(queryExplainer, "query explainer is null");
-        this.approximateQueriesEnabled = approximateQueriesEnabled;
+        this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
     }
 
     public Analysis analyze(Statement statement)
     {
         Analysis analysis = new Analysis();
-        StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, session, approximateQueriesEnabled, queryExplainer);
+        StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, session, experimentalSyntaxEnabled, queryExplainer);
         TupleDescriptor outputDescriptor = analyzer.process(statement, new AnalysisContext());
         analysis.setOutputDescriptor(outputDescriptor);
         return analysis;
@@ -69,9 +69,9 @@ public class Analyzer
         }
     }
 
-    static ExpressionAnalysis analyzeExpression(Session session, Metadata metadata, TupleDescriptor tupleDescriptor, Analysis analysis, boolean approximateQueriesEnabled, AnalysisContext context, Expression expression)
+    static ExpressionAnalysis analyzeExpression(Session session, Metadata metadata, TupleDescriptor tupleDescriptor, Analysis analysis, boolean experimentalSyntaxEnabled, AnalysisContext context, Expression expression)
     {
-        ExpressionAnalyzer analyzer = new ExpressionAnalyzer(analysis, session, metadata, approximateQueriesEnabled);
+        ExpressionAnalyzer analyzer = new ExpressionAnalyzer(analysis, session, metadata, experimentalSyntaxEnabled);
         Type type = analyzer.analyze(expression, tupleDescriptor, context);
 
         analysis.addFunctionInfos(analyzer.getResolvedFunctions());

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AnalyzerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AnalyzerConfig.java
@@ -17,17 +17,17 @@ import io.airlift.configuration.Config;
 
 public class AnalyzerConfig
 {
-    private boolean approximateQueriesEnabled;
+    private boolean experimentalSyntaxEnabled;
 
-    @Config("analyzer.approximate-queries-enabled")
-    public AnalyzerConfig setApproximateQueriesEnabled(boolean enabled)
+    @Config("analyzer.experimental-syntax-enabled")
+    public AnalyzerConfig setExperimentalSyntaxEnabled(boolean enabled)
     {
-        approximateQueriesEnabled = enabled;
+        experimentalSyntaxEnabled = enabled;
         return this;
     }
 
-    public boolean isApproximateQueriesEnabled()
+    public boolean isExperimentalSyntaxEnabled()
     {
-        return approximateQueriesEnabled;
+        return experimentalSyntaxEnabled;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -80,18 +80,18 @@ public class ExpressionAnalyzer
     private final Analysis analysis;
     private final Session session;
     private final Metadata metadata;
-    private final boolean approximateQueriesEnabled;
+    private final boolean experimentalSyntaxEnabled;
     private final Map<QualifiedName, Integer> resolvedNames = new HashMap<>();
     private final IdentityHashMap<FunctionCall, FunctionInfo> resolvedFunctions = new IdentityHashMap<>();
     private final IdentityHashMap<Expression, Type> subExpressionTypes = new IdentityHashMap<>();
     private final Set<InPredicate> subqueryInPredicates = Collections.newSetFromMap(new IdentityHashMap<InPredicate, Boolean>());
 
-    public ExpressionAnalyzer(Analysis analysis, Session session, Metadata metadata, boolean approximateQueriesEnabled)
+    public ExpressionAnalyzer(Analysis analysis, Session session, Metadata metadata, boolean experimentalSyntaxEnabled)
     {
         this.analysis = checkNotNull(analysis, "analysis is null");
         this.session = checkNotNull(session, "session is null");
         this.metadata = checkNotNull(metadata, "metadata is null");
-        this.approximateQueriesEnabled = approximateQueriesEnabled;
+        this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
     }
 
     public Map<QualifiedName, Integer> getResolvedNames()
@@ -583,7 +583,7 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitSubqueryExpression(SubqueryExpression node, AnalysisContext context)
         {
-            StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, session, approximateQueriesEnabled, Optional.<QueryExplainer>absent());
+            StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, session, experimentalSyntaxEnabled, Optional.<QueryExplainer>absent());
             TupleDescriptor descriptor = analyzer.process(node.getQuery(), context);
 
             // Scalar subqueries should only produce one column

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -34,17 +34,17 @@ public class QueryExplainer
     public final Session session;
     public final List<PlanOptimizer> planOptimizers;
     public final Metadata metadata;
-    public final boolean approximateQueriesEnabled;
+    public final boolean experimentalSyntaxEnabled;
 
     public QueryExplainer(Session session,
             List<PlanOptimizer> planOptimizers,
             Metadata metadata,
-            boolean approximateQueriesEnabled)
+            boolean experimentalSyntaxEnabled)
     {
         this.session = checkNotNull(session, "session is null");
         this.planOptimizers = checkNotNull(planOptimizers, "planOptimizers is null");
         this.metadata = checkNotNull(metadata, "metadata is null");
-        this.approximateQueriesEnabled = approximateQueriesEnabled;
+        this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
     }
 
     public String getPlan(Statement statement, ExplainType.Type planType)
@@ -82,7 +82,7 @@ public class QueryExplainer
     private Plan getLogicalPlan(Statement statement)
     {
         // analyze statement
-        Analyzer analyzer = new Analyzer(session, metadata, Optional.of(this), approximateQueriesEnabled);
+        Analyzer analyzer = new Analyzer(session, metadata, Optional.of(this), experimentalSyntaxEnabled);
 
         Analysis analysis = analyzer.analyze(statement);
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
@@ -95,7 +95,7 @@ public class QueryExplainer
     private SubPlan getDistributedPlan(Statement statement)
     {
         // analyze statement
-        Analyzer analyzer = new Analyzer(session, metadata, Optional.of(this), approximateQueriesEnabled);
+        Analyzer analyzer = new Analyzer(session, metadata, Optional.of(this), experimentalSyntaxEnabled);
 
         Analysis analysis = analyzer.analyze(statement);
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -93,14 +93,14 @@ class StatementAnalyzer
     private final Metadata metadata;
     private final Session session;
     private final Optional<QueryExplainer> queryExplainer;
-    private final boolean approximateQueriesEnabled;
+    private final boolean experimentalSyntaxEnabled;
 
-    public StatementAnalyzer(Analysis analysis, Metadata metadata, Session session, boolean approximateQueriesEnabled, Optional<QueryExplainer> queryExplainer)
+    public StatementAnalyzer(Analysis analysis, Metadata metadata, Session session, boolean experimentalSyntaxEnabled, Optional<QueryExplainer> queryExplainer)
     {
         this.analysis = checkNotNull(analysis, "analysis is null");
         this.metadata = checkNotNull(metadata, "metadata is null");
         this.session = checkNotNull(session, "session is null");
-        this.approximateQueriesEnabled = approximateQueriesEnabled;
+        this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
         this.queryExplainer = checkNotNull(queryExplainer, "queryExplainer is null");
     }
 
@@ -443,7 +443,7 @@ class StatementAnalyzer
         AnalysisContext context = new AnalysisContext(parentContext);
 
         if (node.getApproximate().isPresent()) {
-            if (!approximateQueriesEnabled) {
+            if (!experimentalSyntaxEnabled) {
                 throw new SemanticException(NOT_SUPPORTED, node, "approximate queries are not enabled");
             }
             context.setApproximate(true);
@@ -451,7 +451,7 @@ class StatementAnalyzer
 
         analyzeWith(node, context);
 
-        TupleAnalyzer analyzer = new TupleAnalyzer(analysis, session, metadata, approximateQueriesEnabled);
+        TupleAnalyzer analyzer = new TupleAnalyzer(analysis, session, metadata, experimentalSyntaxEnabled);
         TupleDescriptor descriptor = analyzer.process(node.getQueryBody(), context);
         analyzeOrderBy(node, descriptor, context);
 
@@ -525,7 +525,7 @@ class StatementAnalyzer
                 else {
                     // otherwise, just use the expression as is
                     orderByField = new FieldOrExpression(expression);
-                    ExpressionAnalysis expressionAnalysis = Analyzer.analyzeExpression(session, metadata, tupleDescriptor, analysis, approximateQueriesEnabled, context, orderByField.getExpression());
+                    ExpressionAnalysis expressionAnalysis = Analyzer.analyzeExpression(session, metadata, tupleDescriptor, analysis, experimentalSyntaxEnabled, context, orderByField.getExpression());
                     analysis.addInPredicates(node, expressionAnalysis.getSubqueryInPredicates());
                 }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/TupleAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/TupleAnalyzer.java
@@ -99,9 +99,9 @@ class TupleAnalyzer
     private final Analysis analysis;
     private final Session session;
     private final Metadata metadata;
-    private final boolean approximateQueriesEnabled;
+    private final boolean experimentalSyntaxEnabled;
 
-    public TupleAnalyzer(Analysis analysis, Session session, Metadata metadata, boolean approximateQueriesEnabled)
+    public TupleAnalyzer(Analysis analysis, Session session, Metadata metadata, boolean experimentalSyntaxEnabled)
     {
         checkNotNull(analysis, "analysis is null");
         checkNotNull(session, "session is null");
@@ -110,7 +110,7 @@ class TupleAnalyzer
         this.analysis = analysis;
         this.session = session;
         this.metadata = metadata;
-        this.approximateQueriesEnabled = approximateQueriesEnabled;
+        this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
     }
 
     @Override
@@ -231,7 +231,7 @@ class TupleAnalyzer
             throw new SemanticException(SemanticErrorCode.SAMPLE_PERCENTAGE_OUT_OF_RANGE, relation.getSamplePercentage(), "Sample percentage must be less than or equal to 100");
         }
 
-        if (relation.isRescaled() && !approximateQueriesEnabled) {
+        if (relation.isRescaled() && !experimentalSyntaxEnabled) {
             throw new SemanticException(NOT_SUPPORTED, relation, "Rescaling is not enabled");
         }
 
@@ -246,7 +246,7 @@ class TupleAnalyzer
     @Override
     protected TupleDescriptor visitTableSubquery(TableSubquery node, AnalysisContext context)
     {
-        StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, session, approximateQueriesEnabled, Optional.<QueryExplainer>absent());
+        StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, session, experimentalSyntaxEnabled, Optional.<QueryExplainer>absent());
         TupleDescriptor descriptor = analyzer.process(node.getQuery(), context);
 
         analysis.setOutputDescriptor(node, descriptor);
@@ -285,7 +285,7 @@ class TupleAnalyzer
     {
         checkState(node.getRelations().size() >= 2);
 
-        TupleAnalyzer analyzer = new TupleAnalyzer(analysis, session, metadata, approximateQueriesEnabled);
+        TupleAnalyzer analyzer = new TupleAnalyzer(analysis, session, metadata, experimentalSyntaxEnabled);
 
         // Use the first descriptor as the output descriptor for the UNION
         TupleDescriptor outputDescriptor = analyzer.process(node.getRelations().get(0), context);
@@ -355,8 +355,8 @@ class TupleAnalyzer
                 Expression leftExpression = new QualifiedNameReference(QualifiedName.of(column));
                 Expression rightExpression = new QualifiedNameReference(QualifiedName.of(column));
 
-                ExpressionAnalysis leftExpressionAnalysis = Analyzer.analyzeExpression(session, metadata, left, analysis, approximateQueriesEnabled, context, leftExpression);
-                ExpressionAnalysis rightExpressionAnalysis = Analyzer.analyzeExpression(session, metadata, right, analysis, approximateQueriesEnabled, context, rightExpression);
+                ExpressionAnalysis leftExpressionAnalysis = Analyzer.analyzeExpression(session, metadata, left, analysis, experimentalSyntaxEnabled, context, leftExpression);
+                ExpressionAnalysis rightExpressionAnalysis = Analyzer.analyzeExpression(session, metadata, right, analysis, experimentalSyntaxEnabled, context, rightExpression);
                 checkState(leftExpressionAnalysis.getSubqueryInPredicates().isEmpty(), "INVARIANT");
                 checkState(rightExpressionAnalysis.getSubqueryInPredicates().isEmpty(), "INVARIANT");
 
@@ -370,7 +370,7 @@ class TupleAnalyzer
 
             // ensure all names can be resolved, types match, etc (we don't need to record resolved names, subexpression types, etc. because
             // we do it further down when after we determine which subexpressions apply to left vs right tuple)
-            ExpressionAnalyzer analyzer = new ExpressionAnalyzer(analysis, session, metadata, approximateQueriesEnabled);
+            ExpressionAnalyzer analyzer = new ExpressionAnalyzer(analysis, session, metadata, experimentalSyntaxEnabled);
             analyzer.analyze(expression, output, context);
 
             Analyzer.verifyNoAggregatesOrWindowFunctions(metadata, expression, "JOIN");
@@ -421,8 +421,8 @@ class TupleAnalyzer
                 }
 
                 // analyze the clauses to record the types of all subexpressions and resolve names against the left/right underlying tuples
-                ExpressionAnalysis leftExpressionAnalysis = Analyzer.analyzeExpression(session, metadata, left, analysis, approximateQueriesEnabled, context, leftExpression);
-                ExpressionAnalysis rightExpressionAnalysis = Analyzer.analyzeExpression(session, metadata, right, analysis, approximateQueriesEnabled, context, rightExpression);
+                ExpressionAnalysis leftExpressionAnalysis = Analyzer.analyzeExpression(session, metadata, left, analysis, experimentalSyntaxEnabled, context, leftExpression);
+                ExpressionAnalysis rightExpressionAnalysis = Analyzer.analyzeExpression(session, metadata, right, analysis, experimentalSyntaxEnabled, context, rightExpression);
                 analysis.addJoinInPredicates(node, new Analysis.JoinInPredicates(leftExpressionAnalysis.getSubqueryInPredicates(), rightExpressionAnalysis.getSubqueryInPredicates()));
 
                 clauses.add(new EquiJoinClause(leftExpression, rightExpression));
@@ -507,7 +507,7 @@ class TupleAnalyzer
         if (node.getHaving().isPresent()) {
             Expression predicate = node.getHaving().get();
 
-            ExpressionAnalysis expressionAnalysis = Analyzer.analyzeExpression(session, metadata, tupleDescriptor, analysis, approximateQueriesEnabled, context, predicate);
+            ExpressionAnalysis expressionAnalysis = Analyzer.analyzeExpression(session, metadata, tupleDescriptor, analysis, experimentalSyntaxEnabled, context, predicate);
             analysis.addInPredicates(node, expressionAnalysis.getSubqueryInPredicates());
 
             if (expressionAnalysis.getType() != Type.BOOLEAN && expressionAnalysis.getType() != Type.NULL) {
@@ -572,7 +572,7 @@ class TupleAnalyzer
                 }
 
                 if (orderByExpression.isExpression()) {
-                    ExpressionAnalysis expressionAnalysis = Analyzer.analyzeExpression(session, metadata, tupleDescriptor, analysis, approximateQueriesEnabled, context, orderByExpression.getExpression());
+                    ExpressionAnalysis expressionAnalysis = Analyzer.analyzeExpression(session, metadata, tupleDescriptor, analysis, experimentalSyntaxEnabled, context, orderByExpression.getExpression());
                     analysis.addInPredicates(node, expressionAnalysis.getSubqueryInPredicates());
                 }
 
@@ -607,7 +607,7 @@ class TupleAnalyzer
                     groupByExpression = outputExpressions.get((int) (ordinal - 1));
                 }
                 else {
-                    ExpressionAnalysis expressionAnalysis = Analyzer.analyzeExpression(session, metadata, tupleDescriptor, analysis, approximateQueriesEnabled, context, expression);
+                    ExpressionAnalysis expressionAnalysis = Analyzer.analyzeExpression(session, metadata, tupleDescriptor, analysis, experimentalSyntaxEnabled, context, expression);
                     analysis.addInPredicates(node, expressionAnalysis.getSubqueryInPredicates());
                     groupByExpression = new FieldOrExpression(expression);
                 }
@@ -681,7 +681,7 @@ class TupleAnalyzer
             }
             else if (item instanceof SingleColumn) {
                 SingleColumn column = (SingleColumn) item;
-                ExpressionAnalysis expressionAnalysis = Analyzer.analyzeExpression(session, metadata, tupleDescriptor, analysis, approximateQueriesEnabled, context, column.getExpression());
+                ExpressionAnalysis expressionAnalysis = Analyzer.analyzeExpression(session, metadata, tupleDescriptor, analysis, experimentalSyntaxEnabled, context, column.getExpression());
                 analysis.addInPredicates(node, expressionAnalysis.getSubqueryInPredicates());
                 outputExpressionBuilder.add(new FieldOrExpression(column.getExpression()));
             }
@@ -703,7 +703,7 @@ class TupleAnalyzer
 
             Analyzer.verifyNoAggregatesOrWindowFunctions(metadata, predicate, "WHERE");
 
-            ExpressionAnalysis expressionAnalysis = Analyzer.analyzeExpression(session, metadata, tupleDescriptor, analysis, approximateQueriesEnabled, context, predicate);
+            ExpressionAnalysis expressionAnalysis = Analyzer.analyzeExpression(session, metadata, tupleDescriptor, analysis, experimentalSyntaxEnabled, context, predicate);
             analysis.addInPredicates(node, expressionAnalysis.getSubqueryInPredicates());
 
             if (expressionAnalysis.getType() != Type.BOOLEAN && expressionAnalysis.getType() != Type.NULL) {
@@ -719,7 +719,7 @@ class TupleAnalyzer
         TupleDescriptor fromDescriptor = new TupleDescriptor();
 
         if (node.getFrom() != null && !node.getFrom().isEmpty()) {
-            TupleAnalyzer analyzer = new TupleAnalyzer(analysis, session, metadata, approximateQueriesEnabled);
+            TupleAnalyzer analyzer = new TupleAnalyzer(analysis, session, metadata, experimentalSyntaxEnabled);
             if (node.getFrom().size() != 1) {
                 throw new SemanticException(NOT_SUPPORTED, node, "Implicit cross joins are not yet supported; use CROSS JOIN");
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
@@ -51,8 +51,8 @@ public class PlanOptimizersFactory
                 new SetFlatteningOptimizer(),
                 new MaterializeSamplePullUp(),
                 new LimitPushDown(), // Run the LimitPushDown after flattening set operators to make it easier to do the set flattening
-                new PredicatePushDown(metadata, splitManager, analyzerConfig.isApproximateQueriesEnabled()),
-                new PredicatePushDown(metadata, splitManager, analyzerConfig.isApproximateQueriesEnabled()), // Run predicate push down one more time in case we can leverage new information from generated partitions
+                new PredicatePushDown(metadata, splitManager, analyzerConfig.isExperimentalSyntaxEnabled()),
+                new PredicatePushDown(metadata, splitManager, analyzerConfig.isExperimentalSyntaxEnabled()), // Run predicate push down one more time in case we can leverage new information from generated partitions
                 new MergeProjections(),
                 new SimplifyExpressions(metadata), // Re-run the SimplifyExpressions to simplify any recomposed expressions from other optimizations
                 new UnaliasSymbolReferences(), // Run again because predicate pushdown might add more projections

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -114,13 +114,13 @@ public class PredicatePushDown
 
     private final Metadata metadata;
     private final SplitManager splitManager;
-    private final boolean approximateQueriesEnabled;
+    private final boolean experimentalSyntaxEnabled;
 
-    public PredicatePushDown(Metadata metadata, SplitManager splitManager, boolean approximateQueriesEnabled)
+    public PredicatePushDown(Metadata metadata, SplitManager splitManager, boolean experimentalSyntaxEnabled)
     {
         this.metadata = checkNotNull(metadata, "metadata is null");
         this.splitManager = checkNotNull(splitManager, "splitManager is null");
-        this.approximateQueriesEnabled = approximateQueriesEnabled;
+        this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
     }
 
     @Override
@@ -131,7 +131,7 @@ public class PredicatePushDown
         checkNotNull(types, "types is null");
         checkNotNull(idAllocator, "idAllocator is null");
 
-        return PlanRewriter.rewriteWith(new Rewriter(symbolAllocator, idAllocator, metadata, splitManager, session, approximateQueriesEnabled), plan, BooleanLiteral.TRUE_LITERAL);
+        return PlanRewriter.rewriteWith(new Rewriter(symbolAllocator, idAllocator, metadata, splitManager, session, experimentalSyntaxEnabled), plan, BooleanLiteral.TRUE_LITERAL);
     }
 
     private static class Rewriter
@@ -142,16 +142,16 @@ public class PredicatePushDown
         private final Metadata metadata;
         private final SplitManager splitManager;
         private final Session session;
-        private final boolean approximateQueriesEnabled;
+        private final boolean experimentalSyntaxEnabled;
 
-        private Rewriter(SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, Metadata metadata, SplitManager splitManager, Session session, boolean approximateQueriesEnabled)
+        private Rewriter(SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, Metadata metadata, SplitManager splitManager, Session session, boolean experimentalSyntaxEnabled)
         {
             this.symbolAllocator = checkNotNull(symbolAllocator, "symbolAllocator is null");
             this.idAllocator = checkNotNull(idAllocator, "idAllocator is null");
             this.metadata = checkNotNull(metadata, "metadata is null");
             this.splitManager = checkNotNull(splitManager, "splitManager is null");
             this.session = checkNotNull(session, "session is null");
-            this.approximateQueriesEnabled = approximateQueriesEnabled;
+            this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
         }
 
         @Override
@@ -563,7 +563,7 @@ public class PredicatePushDown
         // TODO: temporary addition to infer result type from expression. fix this with the new planner refactoring (martint)
         private Type extractType(Expression expression)
         {
-            ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(new Analysis(), session, metadata, approximateQueriesEnabled);
+            ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(new Analysis(), session, metadata, experimentalSyntaxEnabled);
             List<Field> fields = IterableTransformer.<Symbol>on(DependencyExtractor.extractUnique(expression))
                     .transform(new Function<Symbol, Field>()
                     {

--- a/presto-main/src/test/java/com/facebook/presto/AbstractTestQueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/AbstractTestQueries.java
@@ -3288,8 +3288,8 @@ public abstract class AbstractTestQueries
         MetadataManager metadata = new MetadataManager();
         metadata.addInternalSchemaMetadata(MetadataManager.INTERNAL_CONNECTOR_ID, new DualMetadata());
         SplitManager splitManager = new SplitManager(ImmutableSet.<ConnectorSplitManager>of(new DualSplitManager(new InMemoryNodeManager())));
-        AnalyzerConfig analyzerConfig = new AnalyzerConfig().setApproximateQueriesEnabled(true);
+        AnalyzerConfig analyzerConfig = new AnalyzerConfig().setExperimentalSyntaxEnabled(true);
         List<PlanOptimizer> optimizers = new PlanOptimizersFactory(metadata, splitManager, analyzerConfig).get();
-        return new QueryExplainer(session, optimizers, metadata, analyzerConfig.isApproximateQueriesEnabled());
+        return new QueryExplainer(session, optimizers, metadata, analyzerConfig.isExperimentalSyntaxEnabled());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzerConfig.java
@@ -28,18 +28,18 @@ public class TestAnalyzerConfig
     public void testDefaults()
     {
         assertRecordedDefaults(ConfigAssertions.recordDefaults(AnalyzerConfig.class)
-                .setApproximateQueriesEnabled(false));
+                .setExperimentalSyntaxEnabled(false));
     }
 
     @Test
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("analyzer.approximate-queries-enabled", "true")
+                .put("analyzer.experimental-syntax-enabled", "true")
                 .build();
 
         AnalyzerConfig expected = new AnalyzerConfig()
-                .setApproximateQueriesEnabled(true);
+                .setExperimentalSyntaxEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/util/LocalQueryRunner.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/LocalQueryRunner.java
@@ -279,11 +279,11 @@ public class LocalQueryRunner
         }
 
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
-        AnalyzerConfig analyzerConfig = new AnalyzerConfig().setApproximateQueriesEnabled(true);
+        AnalyzerConfig analyzerConfig = new AnalyzerConfig().setExperimentalSyntaxEnabled(true);
         PlanOptimizersFactory planOptimizersFactory = new PlanOptimizersFactory(metadata, splitManager, analyzerConfig);
 
-        QueryExplainer queryExplainer = new QueryExplainer(session, planOptimizersFactory.get(), metadata, analyzerConfig.isApproximateQueriesEnabled());
-        Analyzer analyzer = new Analyzer(session, metadata, Optional.of(queryExplainer), analyzerConfig.isApproximateQueriesEnabled());
+        QueryExplainer queryExplainer = new QueryExplainer(session, planOptimizersFactory.get(), metadata, analyzerConfig.isExperimentalSyntaxEnabled());
+        Analyzer analyzer = new Analyzer(session, metadata, Optional.of(queryExplainer), analyzerConfig.isExperimentalSyntaxEnabled());
 
         Analysis analysis = analyzer.analyze(statement);
 

--- a/presto-server/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-server/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -82,7 +82,7 @@ public class TestingPrestoServer
                 .put("presto-metastore.db.type", "h2")
                 .put("presto-metastore.db.filename", baseDataDir.resolve("db/MetaStore").toString())
                 .put("presto.version", "testversion")
-                .put("analyzer.approximate-queries-enabled", "true");
+                .put("analyzer.experimental-syntax-enabled", "true");
 
         if (coordinator) {
             // TODO: enable failure detector


### PR DESCRIPTION
Change name of config flag to analyzer.experimental-syntax-enabled,
since it's used to gate more than just approximate queries (rescaled
sampling)
