### PR TITLE
Parallelize test queries in presto-main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration combine.children="append">
-                        <argLine>-Xmx2g -Xms2g</argLine>
+                        <argLine>-Xmx2g -Xms2g -XX:MaxPermSize=512m</argLine>
                     </configuration>
                 </plugin>
 

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -304,6 +304,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <excludedGroups>hive</excludedGroups>
+                    <parallel>methods</parallel>
+                    <threadCount>2</threadCount>
+                    <perCoreThreadCount>true</perCoreThreadCount>
                 </configuration>
             </plugin>
         </plugins>

--- a/presto-main/src/test/java/com/facebook/presto/block/dictionary/TestPackedLongSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/dictionary/TestPackedLongSerde.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+@Test(singleThreaded = true)
 public class TestPackedLongSerde
 {
     private SliceOutput sliceOutput;

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -85,6 +85,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
+@Test(singleThreaded = true)
 public class TestSqlStageExecution
 {
     public static final Session SESSION = new Session("user", "source", "catalog", "schema", "address", "agent");

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -73,6 +73,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public class TestSqlTaskExecution
 {
     private TaskExecutor taskExecutor;

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -74,6 +74,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+@Test(singleThreaded = true)
 public class TestSqlTaskManager
 {
     private SqlTaskManager sqlTaskManager;

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestDatabaseLocalStorageManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestDatabaseLocalStorageManager.java
@@ -51,6 +51,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public class TestDatabaseLocalStorageManager
 {
     private Handle dummyHandle;

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestDatabaseShardManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestDatabaseShardManager.java
@@ -39,6 +39,7 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public class TestDatabaseShardManager
 {
     private Handle dummyHandle;

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestDiscoveryNodeManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestDiscoveryNodeManager.java
@@ -36,6 +36,7 @@ import static io.airlift.testing.Assertions.assertEqualsIgnoreOrder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
 
+@Test(singleThreaded = true)
 public class TestDiscoveryNodeManager
 {
     private final NodeInfo nodeInfo = new NodeInfo("test");

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestJsonTableHandle.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestJsonTableHandle.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-@Test
+@Test(singleThreaded = true)
 public class TestJsonTableHandle
 {
     private static final Map<String, Object> NATIVE_AS_MAP = ImmutableMap.<String, Object>of("type", "native",

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestNativeMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestNativeMetadata.java
@@ -40,6 +40,7 @@ import static io.airlift.testing.Assertions.assertInstanceOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
+@Test(singleThreaded = true)
 public class TestNativeMetadata
 {
     private static final SchemaTableName DEFAULT_TEST_ORDERS = new SchemaTableName("test", "orders");

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestShardManagerDao.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestShardManagerDao.java
@@ -38,6 +38,7 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
+@Test(singleThreaded = true)
 public class TestShardManagerDao
 {
     private ShardManagerDao dao;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.util.MaterializedResult.resultBuilder;
 import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
+@Test(singleThreaded = true)
 public class TestAggregationOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAlignmentOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAlignmentOperator.java
@@ -37,6 +37,7 @@ import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.testng.Assert.assertEquals;
 
+@Test(singleThreaded = true)
 public class TestAlignmentOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDistinctLimitOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDistinctLimitOperator.java
@@ -30,6 +30,7 @@ import static com.facebook.presto.util.MaterializedResult.resultBuilder;
 import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
+@Test(singleThreaded = true)
 public class TestDistinctLimitOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
@@ -38,6 +38,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public class TestExchangeClient
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
@@ -63,6 +63,7 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
+@Test(singleThreaded = true)
 public class TestExchangeOperator
 {
     private static final List<TupleInfo> TUPLE_INFOS = ImmutableList.of(SINGLE_VARBINARY);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFilterAndProjectOperator.java
@@ -39,6 +39,7 @@ import static com.facebook.presto.tuple.TupleInfo.Type.VARIABLE_BINARY;
 import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
+@Test(singleThreaded = true)
 public class TestFilterAndProjectOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -54,6 +54,7 @@ import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.testng.Assert.assertEquals;
 
+@Test(singleThreaded = true)
 public class TestHashAggregationOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
+@Test(singleThreaded = true)
 public class TestHashJoinOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
+@Test(singleThreaded = true)
 public class TestHashSemiJoinOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestLimitOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestLimitOperator.java
@@ -31,6 +31,7 @@ import static com.facebook.presto.tuple.TupleInfo.SINGLE_LONG;
 import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
+@Test(singleThreaded = true)
 public class TestLimitOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMarkDistinctOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMarkDistinctOperator.java
@@ -34,6 +34,7 @@ import static com.facebook.presto.util.MaterializedResult.resultBuilder;
 import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
+@Test(singleThreaded = true)
 public class TestMarkDistinctOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMaterializeSampleOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMaterializeSampleOperator.java
@@ -32,6 +32,7 @@ import static com.facebook.presto.util.MaterializedResult.resultBuilder;
 import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
+@Test(singleThreaded = true)
 public class TestMaterializeSampleOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOrderByOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOrderByOperator.java
@@ -40,6 +40,7 @@ import static com.facebook.presto.util.MaterializedResult.resultBuilder;
 import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
+@Test(singleThreaded = true)
 public class TestOrderByOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestRecordProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestRecordProjectOperator.java
@@ -37,6 +37,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
+@Test(singleThreaded = true)
 public class TestRecordProjectOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTopNOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTopNOperator.java
@@ -42,6 +42,7 @@ import static com.facebook.presto.util.MaterializedResult.resultBuilder;
 import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
+@Test(singleThreaded = true)
 public class TestTopNOperator
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.util.MaterializedResult.resultBuilder;
 import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
+@Test(singleThreaded = true)
 public class TestWindowOperator
 {
     private static final List<WindowFunction> ROW_NUMBER = ImmutableList.<WindowFunction>of(new RowNumberFunction());

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/TestWindowFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/TestWindowFunctions.java
@@ -28,6 +28,7 @@ import static com.facebook.presto.util.MaterializedResult.resultBuilder;
 import static com.facebook.presto.util.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
+@Test(singleThreaded = true)
 public class TestWindowFunctions
 {
     private ExecutorService executor;

--- a/presto-main/src/test/java/com/facebook/presto/split/TestNativeSplitManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/split/TestNativeSplitManager.java
@@ -53,6 +53,7 @@ import static com.facebook.presto.spi.ColumnType.STRING;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public class TestNativeSplitManager
 {
     private static final ConnectorTableMetadata TEST_TABLE = TableMetadataBuilder.tableMetadataBuilder("demo", "test_table")

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -50,6 +50,7 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.WILDCARD_WITHOU
 import static java.lang.String.format;
 import static org.testng.Assert.fail;
 
+@Test(singleThreaded = true)
 public class TestAnalyzer
 {
     private Analyzer analyzer;

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -68,6 +68,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public class TestExpressionCompiler
 {
     private static final Boolean[] booleanValues = {true, false, null};

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -70,6 +70,7 @@ import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.or;
 import static com.facebook.presto.sql.planner.plan.TableScanNode.GeneratedPartitions;
 
+@Test(singleThreaded = true)
 public class TestEffectivePredicateExtractor
 {
     private static final Symbol A = new Symbol("a");


### PR DESCRIPTION
Make all unit tests in presto-main run in parallel by default, and
annotate non-threadsafe tests with singleThreaded=true
