### PR TITLE
Resize groupby ChannelBuilder if there is no space for the frist row

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -263,7 +263,7 @@ public class HashAggregationOperator
                 }
             }));
 
-            this.groupByHash = new GroupByHash(groupByTypes, Ints.toArray(groupByChannels), expectedGroups);
+            this.groupByHash = new GroupByHash(groupByTypes, Ints.toArray(groupByChannels), expectedGroups, memoryManager);
             this.memoryManager = memoryManager;
 
             // wrapper each function with an aggregator

--- a/presto-main/src/test/java/com/facebook/presto/operator/RowPagesBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/RowPagesBuilder.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.block.Block;
 import com.facebook.presto.tuple.TupleInfo;
 import com.google.common.collect.ImmutableList;
 
@@ -53,6 +54,12 @@ public class RowPagesBuilder
         pageBreak();
         Page page = SequencePageBuilder.createSequencePage(tupleInfos, length, initialValues);
         pages.add(page);
+        return this;
+    }
+
+    public RowPagesBuilder addBlocksPage(Block... blocks)
+    {
+        pages.add(new Page(blocks));
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -14,11 +14,13 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.ExceededMemoryLimitException;
+import com.facebook.presto.block.BlockBuilder;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.operator.HashAggregationOperator.HashAggregationOperatorFactory;
 import com.facebook.presto.sql.analyzer.Session;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import com.facebook.presto.sql.tree.Input;
+import com.facebook.presto.tuple.TupleInfo;
 import com.facebook.presto.util.MaterializedResult;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -184,6 +186,67 @@ public class TestHashAggregationOperator
                         aggregation(LONG_SUM, ImmutableList.of(new Input(3)), Optional.<Input>absent(), Optional.<Input>absent(), 1.0),
                         aggregation(LONG_AVERAGE, ImmutableList.of(new Input(3)), Optional.<Input>absent(), Optional.<Input>absent(), 1.0),
                         aggregation(VAR_BINARY_MAX, ImmutableList.of(new Input(2)), Optional.<Input>absent(), Optional.<Input>absent(), 1.0)),
+                100_000);
+
+        Operator operator = operatorFactory.createOperator(driverContext);
+
+        toPages(operator, input);
+    }
+
+    public void testHashBuilderResize()
+    {
+        BlockBuilder builder = new BlockBuilder(TupleInfo.SINGLE_VARBINARY);
+        builder.append(new String(new byte[200_1000])); // this must be larger than DEFAULT_MAX_BLOCK_SIZE, 64K
+        builder.build();
+
+        List<Page> input = rowPagesBuilder(SINGLE_VARBINARY)
+                .addSequencePage(10, 100)
+                .addBlocksPage(builder.build())
+                .addSequencePage(10, 100)
+                .build();
+
+        Session session = new Session("user", "source", "catalog", "schema", "address", "agent");
+        DriverContext driverContext = new TaskContext(new TaskId("query", "stage", "task"), executor, session, new DataSize(3, Unit.MEGABYTE))
+                .addPipelineContext(true, true)
+                .addDriverContext();
+
+        HashAggregationOperatorFactory operatorFactory = new HashAggregationOperatorFactory(
+                0,
+                ImmutableList.of(SINGLE_VARBINARY),
+                Ints.asList(0),
+                Step.SINGLE,
+                ImmutableList.of(aggregation(COUNT, ImmutableList.of(new Input(0)), Optional.<Input>absent(), Optional.<Input>absent(), 1.0)),
+                100_000);
+
+        Operator operator = operatorFactory.createOperator(driverContext);
+
+        toPages(operator, input);
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Could not add row to empty page builder")
+    public void testHashBuilderResizeLimit()
+    {
+        BlockBuilder builder = new BlockBuilder(TupleInfo.SINGLE_VARBINARY);
+        builder.append(new String(new byte[500_1000])); // this must be larger than DEFAULT_MAX_BLOCK_SIZE, 64K
+        builder.build();
+
+        List<Page> input = rowPagesBuilder(SINGLE_VARBINARY)
+                .addSequencePage(10, 100)
+                .addBlocksPage(builder.build())
+                .addSequencePage(10, 100)
+                .build();
+
+        Session session = new Session("user", "source", "catalog", "schema", "address", "agent");
+        DriverContext driverContext = new TaskContext(new TaskId("query", "stage", "task"), executor, session, new DataSize(3, Unit.MEGABYTE))
+                .addPipelineContext(true, true)
+                .addDriverContext();
+
+        HashAggregationOperatorFactory operatorFactory = new HashAggregationOperatorFactory(
+                0,
+                ImmutableList.of(SINGLE_VARBINARY),
+                Ints.asList(0),
+                Step.SINGLE,
+                ImmutableList.of(aggregation(COUNT, ImmutableList.of(new Input(0)), Optional.<Input>absent(), Optional.<Input>absent(), 1.0)),
                 100_000);
 
         Operator operator = operatorFactory.createOperator(driverContext);


### PR DESCRIPTION
Sometimes channels' value size on group by clause can be larger than the default 64K. Rather than raising exception, "Could not add row to empty page builder", it would be good to allocate a larger slice.
