### PR TITLE
sql may fail with distinct columns in having statement

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -281,7 +281,7 @@ class QueryPlanner
         // Map from aggregate function arguments to marker symbols, so that we can reuse the markers, if two aggregates have the same argument
         Map<Set<Expression>, Symbol> argumentMarkers = new HashMap<>();
         // Map from aggregate functions to marker symbols
-        ImmutableMap.Builder<Symbol, Symbol> masks = ImmutableMap.builder();
+        Map<Symbol, Symbol> masks = new HashMap<>();
         for (FunctionCall aggregate : Iterables.filter(analysis.getAggregates(node), distinctPredicate())) {
             Set<Expression> args = ImmutableSet.copyOf(aggregate.getArguments());
             Symbol marker = argumentMarkers.get(args);
@@ -318,7 +318,7 @@ class QueryPlanner
             confidence = Double.valueOf(analysis.getQuery().getApproximate().get().getConfidence()) / 100.0;
         }
 
-        return new PlanBuilder(translations, new AggregationNode(idAllocator.getNextId(), subPlan.getRoot(), ImmutableList.copyOf(groupBySymbols), aggregationAssignments.build(), functions.build(), masks.build(), Optional.<Symbol>absent(), confidence));
+        return new PlanBuilder(translations, new AggregationNode(idAllocator.getNextId(), subPlan.getRoot(), ImmutableList.copyOf(groupBySymbols), aggregationAssignments.build(), functions.build(), new ImmutableMap.Builder<Symbol, Symbol>().putAll(masks).build(), Optional.<Symbol>absent(), confidence));
     }
 
     private PlanBuilder window(PlanBuilder subPlan, QuerySpecification node)


### PR DESCRIPTION
```
presto:default> select rank, count(distinct cityid) from dim.city group by rank having count(distinct cityid) > 30;
Query 20140305_114830_00009_jvyte failed: Multiple entries with same key: count_1=cityid$distinct and count_1=cityid$distinct
```
