### PR TITLE
Remove potential deadlock with broken connectors

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -17,6 +17,7 @@ import com.facebook.presto.ScheduledSplit;
 import com.facebook.presto.TaskSource;
 import com.facebook.presto.spi.Split;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
@@ -24,18 +25,30 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+//
+// NOTE:  As a general strategy the methods should "stage" a change and only
+// process the actual change before lock release (DriverLockResult.close()).
+// The assures that only one thread will be working with the operators at a
+// time and state changer threads are not blocked.
+//
 public class Driver
 {
     private static final Logger log = Logger.get(Driver.class);
@@ -43,6 +56,22 @@ public class Driver
     private final DriverContext driverContext;
     private final List<Operator> operators;
     private final Map<PlanNodeId, SourceOperator> sourceOperators;
+    private final ConcurrentMap<PlanNodeId, TaskSource> newSources = new ConcurrentHashMap<>();
+
+    private final AtomicReference<State> state = new AtomicReference<>(State.ALIVE);
+
+    private final ReentrantLock exclusiveLock = new ReentrantLock();
+
+    @GuardedBy("this")
+    private Thread lockHolder;
+
+    @GuardedBy("exclusiveLock")
+    private Map<PlanNodeId, TaskSource> currentSources = new ConcurrentHashMap<>();
+
+    private enum State
+    {
+        ALIVE, NEED_DESTRUCTION, DESTROYED
+    }
 
     public Driver(DriverContext driverContext, Operator firstOperator, Operator... otherOperators)
     {
@@ -69,31 +98,6 @@ public class Driver
         this.sourceOperators = sourceOperators.build();
     }
 
-    public synchronized void close()
-    {
-        try {
-            for (Operator operator : operators) {
-                operator.finish();
-            }
-        }
-        finally {
-            for (Operator operator : operators) {
-                if (operator instanceof AutoCloseable) {
-                    try {
-                        ((AutoCloseable) operator).close();
-                    }
-                    catch (Exception e) {
-                        if (e instanceof InterruptedException) {
-                            Thread.currentThread().interrupt();
-                        }
-                        log.error(e, "Error closing operator %s for task %s", operator.getOperatorContext().getOperatorId(), driverContext.getTaskId());
-                    }
-                }
-            }
-            driverContext.finished();
-        }
-    }
-
     public DriverContext getDriverContext()
     {
         return driverContext;
@@ -104,21 +108,125 @@ public class Driver
         return sourceOperators.keySet();
     }
 
-    private final ConcurrentMap<PlanNodeId, TaskSource> sources = new ConcurrentHashMap<>();
-
-    public synchronized void updateSource(TaskSource source)
+    public void close()
     {
-        // does this driver have an operator for the specified source?
-        PlanNodeId sourceId = source.getPlanNodeId();
-        if (!sourceOperators.containsKey(sourceId)) {
+        // mark the service for destruction
+        if (!state.compareAndSet(State.ALIVE, State.NEED_DESTRUCTION)) {
             return;
         }
 
+        // if we can get the lock, attempt a clean shutdown; otherwise someone else will shutdown
+        try (DriverLockResult lockResult = tryLockAndProcessPendingStateChanges(0, TimeUnit.MILLISECONDS)) {
+            // if we did not get the lock, interrupt the lock holder
+            if (!lockResult.wasAcquired()) {
+                // there is a benign race condition here were the lock holder
+                // can be change between attempting to get lock and grabbing
+                // the synchronized lock here, but in either case we want to
+                // interrupt the lock holder thread
+                synchronized (this) {
+                    if (lockHolder != null) {
+                        lockHolder.interrupt();
+                    }
+                }
+            }
+
+            // clean shutdown is automatically triggered during lock release
+        }
+    }
+
+    public boolean isFinished()
+    {
+        checkLockNotHeld("Can not check finished status while holding the driver lock");
+
+        // if we can get the lock, attempt a clean shutdown; otherwise someone else will shutdown
+        try (DriverLockResult lockResult = tryLockAndProcessPendingStateChanges(0, TimeUnit.MILLISECONDS)) {
+            if (lockResult.wasAcquired()) {
+                boolean finished = state.get() != State.ALIVE || driverContext.isDone() || operators.get(operators.size() - 1).isFinished();
+                if (finished) {
+                    state.compareAndSet(State.ALIVE, State.NEED_DESTRUCTION);
+                }
+                return finished;
+            }
+            else {
+                // did not get the lock, so we can't check operators, or destroy
+                return state.get() != State.ALIVE || driverContext.isDone();
+            }
+        }
+    }
+
+    public void updateSource(TaskSource source)
+    {
+        checkLockNotHeld("Can not update sources while holding the driver lock");
+
+        // does this driver have an operator for the specified source?
+        if (!sourceOperators.containsKey(source.getPlanNodeId())) {
+            return;
+        }
+
+        // stage the new updates
+        while (true) {
+            // attempt to update directly to the new source
+            TaskSource currentNewSource = newSources.putIfAbsent(source.getPlanNodeId(), source);
+
+            // if update succeeded, just break
+            if (currentNewSource == null) {
+                break;
+            }
+
+            // merge source into the current new source
+            TaskSource newSource = currentNewSource.update(source);
+
+            // if this is not a new source, just return
+            if (newSource == currentNewSource) {
+                break;
+            }
+
+            // attempt to replace the currentNewSource with the new source
+            if (newSources.replace(source.getPlanNodeId(), currentNewSource, newSource)) {
+                break;
+            }
+
+            // someone else updated while we were processing
+        }
+
+        // attempt to get the lock and process the updates we staged above
+        // updates will be processed in close if and only if we got the lock
+        tryLockAndProcessPendingStateChanges(0, TimeUnit.MILLISECONDS).close();
+    }
+
+    private void processNewSources()
+    {
+        checkLockHeld("Lock must be held to call processNewSources");
+
+        // only update if the driver is still alive
+        if (state.get() != State.ALIVE) {
+            return;
+        }
+
+        // copy the pending sources
+        // it is ok to "miss" a source added during the copy as it will be
+        // handled on the next call to this method
+        Map<PlanNodeId, TaskSource> sources = new HashMap<>(newSources);
+        for (Entry<PlanNodeId, TaskSource> entry : sources.entrySet()) {
+            // Remove the entries we are going to process from the newSources map.
+            // It is ok if someone already updated the entry; we will catch it on
+            // the next iteration.
+            newSources.remove(entry.getKey(), entry.getValue());
+
+            processNewSource(entry.getValue());
+        }
+    }
+
+    private void processNewSource(TaskSource source)
+    {
+        checkLockHeld("Lock must be held to call processNewSources");
+
         // create new source
         Set<ScheduledSplit> newSplits;
-        TaskSource currentSource = sources.get(sourceId);
+        TaskSource currentSource = currentSources.get(source.getPlanNodeId());
         if (currentSource == null) {
             newSplits = source.getSplits();
+            currentSources.put(source.getPlanNodeId(), source);
         }
         else {
             // merge the current source and the specified source
@@ -131,98 +239,30 @@ public class Driver
 
             // find the new splits to add
             newSplits = Sets.difference(newSource.getSplits(), currentSource.getSplits());
-            sources.put(sourceId, newSource);
+            currentSources.put(source.getPlanNodeId(), newSource);
         }
 
         // add new splits
         for (ScheduledSplit newSplit : newSplits) {
-            addSplit(sourceId, newSplit.getSplit());
+            Split split = newSplit.getSplit();
+
+            SourceOperator sourceOperator = sourceOperators.get(source.getPlanNodeId());
+            if (sourceOperator != null) {
+                sourceOperator.addSplit(split);
+            }
         }
 
         // set no more splits
         if (source.isNoMoreSplits()) {
-            sourceOperators.get(sourceId).noMoreSplits();
-        }
-    }
-
-    private synchronized void addSplit(PlanNodeId sourceId, Split split)
-    {
-        checkNotNull(sourceId, "sourceId is null");
-        checkNotNull(split, "split is null");
-
-        SourceOperator sourceOperator = sourceOperators.get(sourceId);
-        if (sourceOperator != null) {
-            sourceOperator.addSplit(split);
-        }
-    }
-
-    public synchronized boolean isFinished()
-    {
-        boolean finished = driverContext.isDone() || operators.get(operators.size() - 1).isFinished();
-        if (finished) {
-            close();
-        }
-        return finished;
-    }
-
-    public synchronized ListenableFuture<?> process()
-    {
-        driverContext.start();
-
-        try {
-            for (int i = 0; i < operators.size() - 1 && !driverContext.isDone(); i++) {
-                // check if current operator is blocked
-                Operator current = operators.get(i);
-                ListenableFuture<?> blocked = current.isBlocked();
-                if (!blocked.isDone()) {
-                    current.getOperatorContext().recordBlocked(blocked);
-                    return blocked;
-                }
-
-                // check if next operator is blocked
-                Operator next = operators.get(i + 1);
-                blocked = next.isBlocked();
-                if (!blocked.isDone()) {
-                    next.getOperatorContext().recordBlocked(blocked);
-                    return blocked;
-                }
-
-                // if current operator is finished...
-                if (current.isFinished()) {
-                    // let next operator know there will be no more data
-                    next.getOperatorContext().startIntervalTimer();
-                    next.finish();
-                    next.getOperatorContext().recordFinish();
-                }
-                else {
-                    // if next operator needs input...
-                    if (next.needsInput()) {
-                        // get an output page from current operator
-                        current.getOperatorContext().startIntervalTimer();
-                        Page page = current.getOutput();
-                        current.getOperatorContext().recordGetOutput(page);
-
-                        // if we got an output page, add it to the next operator
-                        if (page != null) {
-                            next.getOperatorContext().startIntervalTimer();
-                            next.addInput(page);
-                            next.getOperatorContext().recordAddInput(page);
-                        }
-                    }
-                }
-            }
-            return NOT_BLOCKED;
-        }
-        catch (Throwable t) {
-            driverContext.failed(t);
-            throw t;
+            sourceOperators.get(source.getPlanNodeId()).noMoreSplits();
         }
     }
 
     public ListenableFuture<?> processFor(Duration duration)
     {
+        checkLockNotHeld("Can not process for a duration while holding the driver lock");
+
         checkNotNull(duration, "duration is null");
-        checkState(!Thread.holdsLock(this), "Can not process for a duration while holding a lock on the %s", getClass().getSimpleName());
 
         long maxRuntime = duration.roundTo(TimeUnit.NANOSECONDS);
 
@@ -236,5 +276,230 @@ public class Driver
         while (System.nanoTime() - start < maxRuntime && !isFinished());
 
         return NOT_BLOCKED;
+    }
+
+    public ListenableFuture<?> process()
+    {
+        checkLockNotHeld("Can not process while holding the driver lock");
+
+        try (DriverLockResult lockResult = tryLockAndProcessPendingStateChanges(100, TimeUnit.MILLISECONDS)) {
+            try {
+                if (!lockResult.wasAcquired()) {
+                    // this is unlikely to happen unless the driver is being
+                    // destroyed and in that case the caller should notice notice
+                    // this state change by calling isFinished
+                    return NOT_BLOCKED;
+                }
+
+                driverContext.start();
+
+                if (!newSources.isEmpty()) {
+                    processNewSources();
+                }
+
+                for (int i = 0; i < operators.size() - 1 && !driverContext.isDone(); i++) {
+                    // check if current operator is blocked
+                    Operator current = operators.get(i);
+                    ListenableFuture<?> blocked = current.isBlocked();
+                    if (!blocked.isDone()) {
+                        current.getOperatorContext().recordBlocked(blocked);
+                        return blocked;
+                    }
+
+                    // check if next operator is blocked
+                    Operator next = operators.get(i + 1);
+                    blocked = next.isBlocked();
+                    if (!blocked.isDone()) {
+                        next.getOperatorContext().recordBlocked(blocked);
+                        return blocked;
+                    }
+
+                    // if current operator is finished...
+                    if (current.isFinished()) {
+                        // let next operator know there will be no more data
+                        next.getOperatorContext().startIntervalTimer();
+                        next.finish();
+                        next.getOperatorContext().recordFinish();
+                    }
+                    else {
+                        // if next operator needs input...
+                        if (next.needsInput()) {
+                            // get an output page from current operator
+                            current.getOperatorContext().startIntervalTimer();
+                            Page page = current.getOutput();
+                            current.getOperatorContext().recordGetOutput(page);
+
+                            // if we got an output page, add it to the next operator
+                            if (page != null) {
+                                next.getOperatorContext().startIntervalTimer();
+                                next.addInput(page);
+                                next.getOperatorContext().recordAddInput(page);
+                            }
+                        }
+                    }
+                }
+                return NOT_BLOCKED;
+            }
+            catch (Throwable t) {
+                driverContext.failed(t);
+                throw t;
+            }
+        }
+    }
+
+    private void destroyIfNecessary()
+    {
+        checkLockHeld("Lock must be held to call destroyIfNecessary");
+
+        if (!state.compareAndSet(State.NEED_DESTRUCTION, State.DESTROYED)) {
+            return;
+        }
+
+        Throwable inFlightException = null;
+        try {
+            // call finish on every operator; if error occurs, just bail out; we will still call close
+            for (Operator operator : operators) {
+                operator.finish();
+            }
+        }
+        catch (Throwable t) {
+            // record in flight exception so we can add suppressed exceptions below
+            inFlightException = t;
+            throw t;
+        }
+        finally {
+            // record the current interrupted status (and clear the flag); we'll reset it later
+            boolean wasInterrupted = Thread.interrupted();
+
+            // if we get an error while closing a driver, record it and we will throw it at the end
+            try {
+                for (Operator operator : operators) {
+                    if (operator instanceof AutoCloseable) {
+                        try {
+                            ((AutoCloseable) operator).close();
+                        }
+                        catch (InterruptedException t) {
+                            // don't record the stack
+                            wasInterrupted = true;
+                        }
+                        catch (Throwable t) {
+                            inFlightException = addSuppressedException(
+                                    inFlightException,
+                                    t,
+                                    "Error closing operator %s for task %s",
+                                    operator.getOperatorContext().getOperatorId(),
+                                    driverContext.getTaskId());
+                        }
+                    }
+                }
+                driverContext.finished();
+            }
+            catch (Throwable t) {
+                // this shouldn't happen but be safe
+                inFlightException = addSuppressedException(
+                        inFlightException,
+                        t,
+                        "Error destroying driver for task %s",
+                        driverContext.getTaskId());
+            }
+            finally {
+                // reset the interrupted flag
+                if (wasInterrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            if (inFlightException != null) {
+                // this will always be an Error or Runtime
+                throw Throwables.propagate(inFlightException);
+            }
+        }
+    }
+
+    private Throwable addSuppressedException(Throwable inFlightException, Throwable newException, String message, Object... args)
+    {
+        if (newException instanceof Error) {
+            if (inFlightException == null) {
+                inFlightException = newException;
+            }
+            else {
+                inFlightException.addSuppressed(newException);
+            }
+        }
+        else {
+            // log normal exceptions instead of rethrowing them
+            log.error(newException, message, args);
+        }
+        return inFlightException;
+    }
+
+    private DriverLockResult tryLockAndProcessPendingStateChanges(int timeout, TimeUnit unit)
+    {
+        checkLockNotHeld("Can not acquire the driver lock while already holding the driver lock");
+
+        return new DriverLockResult(timeout, unit);
+    }
+
+    private synchronized void checkLockNotHeld(String message)
+    {
+        checkState(Thread.currentThread() != lockHolder, message);
+    }
+
+    private synchronized void checkLockHeld(String message)
+    {
+        checkState(Thread.currentThread() == lockHolder, message);
+    }
+
+    private class DriverLockResult
+            implements AutoCloseable
+    {
+        private final boolean acquired;
+
+        private DriverLockResult(int timeout, TimeUnit unit)
+        {
+            boolean acquired = false;
+            try {
+                acquired = exclusiveLock.tryLock(timeout, unit);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            this.acquired = acquired;
+
+            if (acquired) {
+                synchronized (Driver.this) {
+                    lockHolder = Thread.currentThread();
+                }
+            }
+        }
+
+        public boolean wasAcquired()
+        {
+            return acquired;
+        }
+
+        @Override
+        public void close()
+        {
+            if (!acquired) {
+                return;
+            }
+
+            // before releasing the lock, process any new sources and/or destroy the driver
+            try {
+                try {
+                    processNewSources();
+                }
+                finally {
+                    destroyIfNecessary();
+                }
+            }
+            finally {
+                synchronized (Driver.this) {
+                    lockHolder = null;
+                }
+                exclusiveLock.unlock();
+            }
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -23,6 +23,8 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.joda.time.DateTime;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
@@ -39,6 +41,7 @@ import static com.google.common.collect.Iterables.transform;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
+@ThreadSafe
 public class DriverContext
 {
     private final PipelineContext pipelineContext;

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -176,6 +176,7 @@ public class TableScanOperator
     @Override
     public ListenableFuture<?> isBlocked()
     {
+        // todo should be blocked until split is added
         return NOT_BLOCKED;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -1,0 +1,425 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.ScheduledSplit;
+import com.facebook.presto.TaskSource;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.Split;
+import com.facebook.presto.split.DataStreamProvider;
+import com.facebook.presto.sql.analyzer.Session;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.tuple.TupleInfo;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.Duration;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.facebook.presto.operator.RowPagesBuilder.rowPagesBuilder;
+import static com.facebook.presto.tuple.TupleInfo.SINGLE_LONG;
+import static com.facebook.presto.tuple.TupleInfo.SINGLE_VARBINARY;
+import static com.facebook.presto.util.Threads.daemonThreadsNamed;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.getRootCause;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+@Test(singleThreaded = true)
+public class TestDriver
+{
+    private ExecutorService executor;
+    private DriverContext driverContext;
+
+    @BeforeMethod
+    public void setUp()
+            throws Exception
+    {
+        executor = newCachedThreadPool(daemonThreadsNamed("test"));
+        Session session = new Session("user", "source", "catalog", "schema", "address", "agent");
+        driverContext = new TaskContext(new TaskId("query", "stage", "task"), executor, session)
+                .addPipelineContext(true, true)
+                .addDriverContext();
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testNormalFinish()
+    {
+        ValuesOperator source = new ValuesOperator(driverContext.addOperatorContext(0, "values"), rowPagesBuilder(SINGLE_VARBINARY, SINGLE_LONG, SINGLE_LONG)
+                .addSequencePage(10, 20, 30, 40)
+                .build());
+
+        MaterializingOperator sink = createSinkOperator(source);
+        Driver driver = new Driver(driverContext, source, sink);
+
+        assertSame(driver.getDriverContext(), driverContext);
+
+        assertFalse(driver.isFinished());
+        ListenableFuture<?> blocked = driver.processFor(new Duration(1, TimeUnit.SECONDS));
+        assertTrue(blocked.isDone());
+        assertTrue(driver.isFinished());
+
+        assertTrue(sink.isFinished());
+        assertTrue(source.isFinished());
+    }
+
+    @Test
+    public void testAbruptFinish()
+    {
+        ValuesOperator source = new ValuesOperator(driverContext.addOperatorContext(0, "values"), rowPagesBuilder(SINGLE_VARBINARY, SINGLE_LONG, SINGLE_LONG)
+                .addSequencePage(10, 20, 30, 40)
+                .build());
+
+        MaterializingOperator sink = createSinkOperator(source);
+        Driver driver = new Driver(driverContext, source, sink);
+
+        assertSame(driver.getDriverContext(), driverContext);
+
+        assertFalse(driver.isFinished());
+        driver.close();
+        assertTrue(driver.isFinished());
+
+        assertTrue(sink.isFinished());
+        assertTrue(source.isFinished());
+    }
+
+    @Test
+    public void testAddSourceFinish()
+    {
+        PlanNodeId sourceId = new PlanNodeId("source");
+        TableScanOperator source = new TableScanOperator(driverContext.addOperatorContext(99, "values"),
+                sourceId,
+                new DataStreamProvider()
+                {
+                    @Override
+                    public Operator createNewDataStream(OperatorContext operatorContext, Split split, List<ColumnHandle> columns)
+                    {
+                        return new ValuesOperator(driverContext.addOperatorContext(0, "values"), rowPagesBuilder(SINGLE_VARBINARY, SINGLE_LONG, SINGLE_LONG)
+                                .addSequencePage(10, 20, 30, 40)
+                                .build());
+                    }
+                },
+                ImmutableList.of(SINGLE_VARBINARY, SINGLE_LONG, SINGLE_LONG),
+                ImmutableList.<ColumnHandle>of());
+
+        MaterializingOperator sink = createSinkOperator(source);
+        Driver driver = new Driver(driverContext, source, sink);
+
+        assertSame(driver.getDriverContext(), driverContext);
+
+        assertFalse(driver.isFinished());
+        // todo TableScanOperator should be blocked until split is set
+        assertTrue(driver.processFor(new Duration(1, TimeUnit.MILLISECONDS)).isDone());
+        assertFalse(driver.isFinished());
+
+        driver.updateSource(new TaskSource(sourceId, ImmutableSet.of(new ScheduledSplit(0, new MockSplit())), true));
+
+        assertFalse(driver.isFinished());
+        assertTrue(driver.processFor(new Duration(1, TimeUnit.SECONDS)).isDone());
+        assertTrue(driver.isFinished());
+
+        assertTrue(sink.isFinished());
+        assertTrue(source.isFinished());
+    }
+
+    @Test
+    public void testBrokenOperatorCloseWhileProcessing()
+            throws Exception
+    {
+        BrokenOperator brokenOperator = new BrokenOperator(driverContext.addOperatorContext(0, "source"), false);
+        final Driver driver = new Driver(driverContext, brokenOperator, createSinkOperator(brokenOperator));
+
+        assertSame(driver.getDriverContext(), driverContext);
+
+        // block thread in operator processing
+        Future<Boolean> driverProcessFor = executor.submit(new Callable<Boolean>()
+        {
+            @Override
+            public Boolean call()
+                    throws Exception
+            {
+                return driver.processFor(new Duration(1, TimeUnit.MILLISECONDS)).isDone();
+            }
+        });
+        brokenOperator.waitForLocked();
+
+        driver.close();
+        assertTrue(driver.isFinished());
+
+        try {
+            driverProcessFor.get(1, TimeUnit.SECONDS);
+            fail("Expected InterruptedException");
+        }
+        catch (ExecutionException e) {
+            checkArgument(getRootCause(e) instanceof InterruptedException, "Expected root cause exception to be an instance of InterruptedException");
+        }
+    }
+
+    @Test
+    public void testBrokenOperatorProcessWhileClosing()
+            throws Exception
+    {
+        BrokenOperator brokenOperator = new BrokenOperator(driverContext.addOperatorContext(0, "source"));
+        final Driver driver = new Driver(driverContext, brokenOperator, createSinkOperator(brokenOperator));
+
+        assertSame(driver.getDriverContext(), driverContext);
+
+        // block thread in operator close
+        Future<Boolean> driverClose = executor.submit(new Callable<Boolean>()
+        {
+            @Override
+            public Boolean call()
+                    throws Exception
+            {
+                driver.close();
+                return true;
+            }
+        });
+        brokenOperator.waitForLocked();
+
+        assertTrue(driver.processFor(new Duration(1, TimeUnit.MILLISECONDS)).isDone());
+        assertTrue(driver.isFinished());
+
+        brokenOperator.unlock();
+
+        assertTrue(driverClose.get());
+    }
+
+    @Test
+    public void testBrokenOperatorAddSource()
+            throws Exception
+    {
+        PlanNodeId sourceId = new PlanNodeId("source");
+        TableScanOperator source = new TableScanOperator(driverContext.addOperatorContext(99, "values"),
+                sourceId,
+                new DataStreamProvider()
+                {
+                    @Override
+                    public Operator createNewDataStream(OperatorContext operatorContext, Split split, List<ColumnHandle> columns)
+                    {
+                        return new ValuesOperator(driverContext.addOperatorContext(0, "values"), rowPagesBuilder(SINGLE_VARBINARY, SINGLE_LONG, SINGLE_LONG)
+                                .addSequencePage(10, 20, 30, 40)
+                                .build());
+                    }
+                },
+                ImmutableList.of(SINGLE_VARBINARY, SINGLE_LONG, SINGLE_LONG),
+                ImmutableList.<ColumnHandle>of());
+
+        BrokenOperator brokenOperator = new BrokenOperator(driverContext.addOperatorContext(0, "source"));
+        final Driver driver = new Driver(driverContext, source, brokenOperator);
+
+        // block thread in operator processing
+        Future<Boolean> driverProcessFor = executor.submit(new Callable<Boolean>()
+        {
+            @Override
+            public Boolean call()
+                    throws Exception
+            {
+                return driver.processFor(new Duration(1, TimeUnit.MILLISECONDS)).isDone();
+            }
+        });
+        brokenOperator.waitForLocked();
+
+        assertSame(driver.getDriverContext(), driverContext);
+
+        assertFalse(driver.isFinished());
+        // todo TableScanOperator should be blocked until split is set
+        assertTrue(driver.processFor(new Duration(1, TimeUnit.MILLISECONDS)).isDone());
+        assertFalse(driver.isFinished());
+
+        driver.updateSource(new TaskSource(sourceId, ImmutableSet.of(new ScheduledSplit(0, new MockSplit())), true));
+
+        assertFalse(driver.isFinished());
+        assertTrue(driver.processFor(new Duration(1, TimeUnit.SECONDS)).isDone());
+        assertFalse(driver.isFinished());
+
+        driver.close();
+        assertTrue(driver.isFinished());
+
+        try {
+            driverProcessFor.get(1, TimeUnit.SECONDS);
+            fail("Expected InterruptedException");
+        }
+        catch (ExecutionException e) {
+            checkArgument(getRootCause(e) instanceof InterruptedException, "Expected root cause exception to be an instance of InterruptedException");
+        }
+    }
+
+    private MaterializingOperator createSinkOperator(Operator source)
+    {
+        return new MaterializingOperator(driverContext.addOperatorContext(1, "sink"), source.getTupleInfos());
+    }
+
+    private static class BrokenOperator
+            implements Operator, Closeable
+    {
+        private final OperatorContext operatorContext;
+        private final ReentrantLock lock = new ReentrantLock();
+        private final CountDownLatch lockedLatch = new CountDownLatch(1);
+        private final CountDownLatch unlockLatch = new CountDownLatch(1);
+        private final boolean lockForClose;
+
+        private BrokenOperator(OperatorContext operatorContext)
+        {
+            this(operatorContext, false);
+        }
+
+        private BrokenOperator(OperatorContext operatorContext, boolean lockForClose)
+        {
+            this.operatorContext = operatorContext;
+            this.lockForClose = lockForClose;
+        }
+
+        @Override
+        public OperatorContext getOperatorContext()
+        {
+            return operatorContext;
+        }
+
+        public void unlock()
+        {
+            unlockLatch.countDown();
+        }
+
+        private void waitForLocked()
+        {
+            try {
+                assertTrue(lockedLatch.await(10, TimeUnit.SECONDS));
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted", e);
+            }
+        }
+
+        private void waitForUnlock()
+        {
+            try {
+                assertTrue(lock.tryLock(1, TimeUnit.SECONDS));
+                try {
+                    lockedLatch.countDown();
+                    assertTrue(unlockLatch.await(5, TimeUnit.SECONDS));
+                }
+                finally {
+                    lock.unlock();
+                }
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted", e);
+            }
+        }
+
+        @Override
+        public List<TupleInfo> getTupleInfos()
+        {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public void finish()
+        {
+            waitForUnlock();
+        }
+
+        @Override
+        public boolean isFinished()
+        {
+            waitForUnlock();
+            return true;
+        }
+
+        @Override
+        public ListenableFuture<?> isBlocked()
+        {
+            waitForUnlock();
+            return NOT_BLOCKED;
+        }
+
+        @Override
+        public boolean needsInput()
+        {
+            waitForUnlock();
+            return false;
+        }
+
+        @Override
+        public void addInput(Page page)
+        {
+            waitForUnlock();
+        }
+
+        @Override
+        public Page getOutput()
+        {
+            waitForUnlock();
+            return null;
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            if (lockForClose) {
+                waitForUnlock();
+            }
+        }
+    }
+
+    private static class MockSplit
+            implements Split
+    {
+        @Override
+        public boolean isRemotelyAccessible()
+        {
+            return false;
+        }
+
+        @Override
+        public List<HostAddress> getAddresses()
+        {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public Object getInfo()
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Replace synchronized lock with a custom lock with timeout support

For close and updateSource stage change and then attempt to acquire
lock.  If lock is acquired, process change; otherwise lock holder
will process change before releasing lock.

For close, if lock can not be acquired, interrupt lock holder.
