### PR TITLE
Refresh PrestoWebUI every 30 seconds, instead of 1 second

### DIFF
--- a/presto-server/src/main/resources/webapp/index.html
+++ b/presto-server/src/main/resources/webapp/index.html
@@ -213,7 +213,7 @@ function flatten(array)
     return [].concat.apply([], array);
 }
 
-setInterval(function () { redraw(); }, 1000);
+setInterval(function () { redraw(); }, 30000);
 
 redraw();
 


### PR DESCRIPTION
Refreshing PrestoWebUI every 1 second consumes so much bandwidth and CPU, since we keep all query related info. Set it to be 30 seconds could be much better.
