### PR TITLE
Use faster implementation of Murmur3 for approx_distinct

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>slice</artifactId>
-                <version>0.2</version>
+                <version>0.4</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Noticeable speedup in approx_distinct benchmarks:

Before:

```
     sql_approx_count_distinct_long ::  118.746 cpu ms :: in  1.5M,  12.9MB,   12.6M/s,   108MB/s :: out     1,      9B,       8/s,     75B/s
   sql_approx_count_distinct_double ::  119.971 cpu ms :: in  1.5M,  12.9MB,   12.5M/s,   107MB/s :: out     1,      9B,       8/s,     75B/s
sql_approx_count_distinct_varbinary ::  163.847 cpu ms :: in  1.5M,  21.5MB,   9.15M/s,   131MB/s :: out     1,      9B,       6/s,     54B/s
```

After:

```
     sql_approx_count_distinct_long ::   32.761 cpu ms :: in  1.5M,  12.9MB,   45.8M/s,   393MB/s :: out     1,      9B,      30/s,    274B/s
   sql_approx_count_distinct_double ::   34.674 cpu ms :: in  1.5M,  12.9MB,   43.3M/s,   371MB/s :: out     1,      9B,      28/s,    259B/s
sql_approx_count_distinct_varbinary ::   79.983 cpu ms :: in  1.5M,  21.5MB,   18.8M/s,   268MB/s :: out     1,      9B,      12/s,    112B/s
```
