### PR TITLE
Fix hang in coordinator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/NodeTaskMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/NodeTaskMap.java
@@ -27,13 +27,22 @@ public class NodeTaskMap
 {
     private final ConcurrentMap<Node, NodeTasks> tasksByNode = new ConcurrentHashMap<>();
 
-    public synchronized void addTask(Node node, RemoteTask task)
+    public synchronized void addTask(final Node node, final RemoteTask task)
     {
         NodeTasks tasks = tasksByNode.get(node);
         if (tasks == null) {
             tasks = new NodeTasks(node);
             tasksByNode.put(node, tasks);
         }
+        task.addStateChangeListener(new StateMachine.StateChangeListener<TaskInfo>() {
+            @Override
+            public void stateChanged(TaskInfo newValue)
+            {
+                if (newValue.getState().isDone()) {
+                    tasksByNode.remove(node, task);
+                }
+            }
+        });
         tasks.addTask(task);
     }
 


### PR DESCRIPTION
Tasks were only being removed from the NodeTaskMap when GC ran. This
caused queries to run slower and slower, as finished tasks piled up.
