### PR TITLE
Record "started" counter for queries that fail to parse

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -350,6 +350,7 @@ public class SqlQueryManager
         QueryExecution execution = new FailedQueryExecution(queryId, query, session, self, queryExecutor, cause);
 
         queries.put(queryId, execution);
+        stats.queryStarted();
         queryMonitor.createdEvent(execution.getQueryInfo());
         queryMonitor.completionEvent(execution.getQueryInfo());
         stats.queryFinished(execution.getQueryInfo());


### PR DESCRIPTION
In the last release we started tracking parsing failures for error categorization,
but the change was missing the call to increment the started counter.

As a result, the started and completed counters get permanently out of sync
and cause the number of running queries to be reported as 0.

Fixes https://github.com/facebook/presto/issues/1130
