### PR TITLE
Improve performance when computing partitions domain summary

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
@@ -235,7 +235,7 @@ public final class DomainTranslator
                             combineConjuncts(leftResult.getRemainingExpression(), rightResult.getRemainingExpression()));
 
                 case OR:
-                    TupleDomain columnUnionedTupleDomain = leftResult.getTupleDomain().columnWiseUnion(rightResult.getTupleDomain());
+                    TupleDomain columnUnionedTupleDomain = TupleDomain.columnWiseUnion(leftResult.getTupleDomain(), rightResult.getTupleDomain());
 
                     // In most cases, the columnUnionedTupleDomain is only a superset of the actual strict union
                     // and so we can return the current node as the remainingExpression so that all bounds will be double checked again at execution time.

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableScanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableScanNode.java
@@ -21,10 +21,12 @@ import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.tree.Expression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import javax.annotation.Nullable;
@@ -140,11 +142,19 @@ public class TableScanNode
             return TupleDomain.all();
         }
 
-        TupleDomain tupleDomain = TupleDomain.none();
-        for (Partition partition : generatedPartitions.get().getPartitions()) {
-            tupleDomain = tupleDomain.columnWiseUnion(partition.getTupleDomain());
+        if (generatedPartitions.get().getPartitions().isEmpty()) {
+            return TupleDomain.none();
         }
-        return tupleDomain;
+
+        List<TupleDomain> domains = Lists.transform(generatedPartitions.get().getPartitions(), new Function<Partition, TupleDomain>()
+        {
+            @Override
+            public TupleDomain apply(Partition input)
+            {
+                return input.getTupleDomain();
+            }
+        });
+        return TupleDomain.columnWiseUnion(domains);
     }
 
     @JsonProperty("partitionDomainSummary")

--- a/presto-main/src/test/java/com/facebook/presto/split/TestNativeSplitManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/split/TestNativeSplitManager.java
@@ -128,7 +128,7 @@ public class TestNativeSplitManager
         assertTrue(partitionResult.getUndeterminedTupleDomain().isAll());
 
         List<Partition> partitions = partitionResult.getPartitions();
-        TupleDomain columnUnionedTupleDomain = partitions.get(0).getTupleDomain().columnWiseUnion(partitions.get(1).getTupleDomain());
+        TupleDomain columnUnionedTupleDomain = TupleDomain.columnWiseUnion(partitions.get(0).getTupleDomain(), partitions.get(1).getTupleDomain());
         assertEquals(columnUnionedTupleDomain, TupleDomain.withColumnDomains(ImmutableMap.of(dsColumnHandle, Domain.create(SortedRangeSet.of(Range.equal("1"), Range.equal("2")), false))));
 
         SplitSource splitSource = nativeSplitManager.getPartitionSplits(tableHandle, partitions);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Domain.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Domain.java
@@ -157,6 +157,22 @@ public final class Domain
         return new Domain(unionRanges, nullAllowed);
     }
 
+    public static Domain union(List<Domain> domains)
+    {
+        if (domains.size() == 1) {
+            return domains.get(0);
+        }
+
+        boolean nullAllowed = false;
+        List<SortedRangeSet> ranges = new ArrayList<>();
+        for (Domain domain : domains) {
+            ranges.add(domain.getRanges());
+            nullAllowed = nullAllowed || domain.nullAllowed;
+        }
+
+        return new Domain(SortedRangeSet.union(ranges), nullAllowed);
+    }
+
     public Domain complement()
     {
         return new Domain(ranges.complement(), !nullAllowed);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SortedRangeSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SortedRangeSet.java
@@ -210,6 +210,24 @@ public final class SortedRangeSet
                 .build();
     }
 
+    public static SortedRangeSet union(Iterable<SortedRangeSet> ranges)
+    {
+        Iterator<SortedRangeSet> iterator = ranges.iterator();
+        if (!iterator.hasNext()) {
+            throw new IllegalArgumentException("ranges must have at least one element");
+        }
+
+        SortedRangeSet first = iterator.next();
+        Builder builder = new Builder(first.type);
+        builder.addAll(first);
+
+        while (iterator.hasNext()) {
+            builder.addAll(iterator.next());
+        }
+
+        return builder.build();
+    }
+
     public SortedRangeSet complement()
     {
         Builder builder = new Builder(type);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/TupleDomain.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/TupleDomain.java
@@ -18,11 +18,15 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Defines a set of valid tuples according to the constraints on each of its constituent columns
@@ -219,6 +223,16 @@ public final class TupleDomain
         return withColumnDomains(intersected);
     }
 
+    public static TupleDomain columnWiseUnion(TupleDomain first, TupleDomain second, TupleDomain... rest)
+    {
+        List<TupleDomain> domains = new ArrayList<>();
+        domains.add(first);
+        domains.add(second);
+        domains.addAll(Arrays.asList(rest));
+
+        return columnWiseUnion(domains);
+    }
+
     /**
      * Returns a TupleDomain in which corresponding column Domains are unioned together.
      *
@@ -232,25 +246,68 @@ public final class TupleDomain
      * not be valid for either TupleDomain X or TupleDomain Y.
      * However, this result is guaranteed to be a superset of the strict union.
      */
-    public TupleDomain columnWiseUnion(TupleDomain other)
+    public static TupleDomain columnWiseUnion(List<TupleDomain> tupleDomains)
     {
-        if (this.isNone()) {
-            return other;
-        }
-        else if (other.isNone()) {
-            return this;
+        if (tupleDomains.isEmpty()) {
+            throw new IllegalArgumentException("tupleDomains must have at least one element");
         }
 
-        // Only columns contained in both TupleDomains will make it into the column-wise union.
-        // This is b/c an unmentioned column is implicitly an "all" Domain and so any union with that "all" Domain will also be the "all" Domain.
-        Map<ColumnHandle, Domain> columnWiseUnioned = new HashMap<>();
-        for (Map.Entry<ColumnHandle, Domain> entry : this.getDomains().entrySet()) {
-            Domain otherDomain = other.getDomains().get(entry.getKey());
-            if (otherDomain != null) {
-                columnWiseUnioned.put(entry.getKey(), entry.getValue().union(otherDomain));
+        if (tupleDomains.size() == 1) {
+            return tupleDomains.get(0);
+        }
+
+        // gather all common columns
+        Set<ColumnHandle> commonColumns = new HashSet<>();
+
+        // first, find a non-none domain
+        boolean allNone = true;
+        Iterator<TupleDomain> domains = tupleDomains.iterator();
+        while (domains.hasNext()) {
+            TupleDomain domain = domains.next();
+            if (!domain.isNone()) {
+                allNone = false;
+                commonColumns.addAll(domain.getDomains().keySet());
+                break;
             }
         }
-        return withColumnDomains(columnWiseUnioned);
+
+        // then, get the common columns
+        while (domains.hasNext()) {
+            TupleDomain domain = domains.next();
+            if (!domain.isNone()) {
+                allNone = false;
+                commonColumns.retainAll(domain.getDomains().keySet());
+            }
+        }
+
+        if (allNone) {
+            return TupleDomain.none();
+        }
+
+        // group domains by column (only for common columns)
+        Map<ColumnHandle, List<Domain>> domainsByColumn = new HashMap<>();
+
+        for (TupleDomain domain : tupleDomains) {
+            if (!domain.isNone()) {
+                for (Map.Entry<ColumnHandle, Domain> entry : domain.getDomains().entrySet()) {
+                    if (commonColumns.contains(entry.getKey())) {
+                        List<Domain> domainForColumn = domainsByColumn.get(entry.getKey());
+                        if (domainForColumn == null) {
+                            domainForColumn = new ArrayList<>();
+                            domainsByColumn.put(entry.getKey(), domainForColumn);
+                        }
+                        domainForColumn.add(entry.getValue());
+                    }
+                }
+            }
+        }
+
+        // finally, do the column-wise union
+        Map<ColumnHandle, Domain> result = new HashMap<>();
+        for (Map.Entry<ColumnHandle, List<Domain>> entry : domainsByColumn.entrySet()) {
+            result.put(entry.getKey(), Domain.union(entry.getValue()));
+        }
+        return withColumnDomains(result);
     }
 
     /**
@@ -268,7 +325,7 @@ public final class TupleDomain
      */
     public boolean contains(TupleDomain other)
     {
-        return other.isNone() || this.columnWiseUnion(other).equals(this);
+        return other.isNone() || columnWiseUnion(this, other).equals(this);
     }
 
     @Override

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestSortedRangeSet.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestSortedRangeSet.java
@@ -301,44 +301,30 @@ public class TestSortedRangeSet
     public void testUnion()
             throws Exception
     {
-        Assert.assertEquals(
-                SortedRangeSet.none(Long.class).union(
-                        SortedRangeSet.none(Long.class)),
-                SortedRangeSet.none(Long.class));
+        assertUnion(SortedRangeSet.none(Long.class), SortedRangeSet.none(Long.class), SortedRangeSet.none(Long.class));
+        assertUnion(SortedRangeSet.all(Long.class), SortedRangeSet.all(Long.class), SortedRangeSet.all(Long.class));
+        assertUnion(SortedRangeSet.none(Long.class), SortedRangeSet.all(Long.class), SortedRangeSet.all(Long.class));
 
-        Assert.assertEquals(
-                SortedRangeSet.all(Long.class).union(
-                        SortedRangeSet.all(Long.class)),
-                SortedRangeSet.all(Long.class));
-
-        Assert.assertEquals(
-                SortedRangeSet.none(Long.class).union(
-                        SortedRangeSet.all(Long.class)),
-                SortedRangeSet.all(Long.class));
-
-        Assert.assertEquals(
-                SortedRangeSet.of(Range.equal(1L), Range.equal(2L)).union(
-                        SortedRangeSet.of(Range.equal(2L), Range.equal(3L))),
+        assertUnion(
+                SortedRangeSet.of(Range.equal(1L), Range.equal(2L)),
+                SortedRangeSet.of(Range.equal(2L), Range.equal(3L)),
                 SortedRangeSet.of(Range.equal(1L), Range.equal(2L), Range.equal(3L)));
 
-        Assert.assertEquals(
-                SortedRangeSet.all(Long.class).union(
-                        SortedRangeSet.of(Range.equal(0L))),
-                SortedRangeSet.all(Long.class));
+        assertUnion(SortedRangeSet.all(Long.class), SortedRangeSet.of(Range.equal(0L)), SortedRangeSet.all(Long.class));
 
-        Assert.assertEquals(
-                SortedRangeSet.of(Range.range(0L, true, 4L, false)).union(
-                        SortedRangeSet.of(Range.greaterThan(3L))),
+        assertUnion(
+                SortedRangeSet.of(Range.range(0L, true, 4L, false)),
+                SortedRangeSet.of(Range.greaterThan(3L)),
                 SortedRangeSet.of(Range.greaterThanOrEqual(0L)));
 
-        Assert.assertEquals(
-                SortedRangeSet.of(Range.greaterThanOrEqual(0L)).union(
-                        SortedRangeSet.of(Range.lessThanOrEqual(0L))),
+        assertUnion(
+                SortedRangeSet.of(Range.greaterThanOrEqual(0L)),
+                SortedRangeSet.of(Range.lessThanOrEqual(0L)),
                 SortedRangeSet.of(Range.all(Long.class)));
 
-        Assert.assertEquals(
-                SortedRangeSet.of(Range.greaterThan(0L)).union(
-                        SortedRangeSet.of(Range.lessThan(0L))),
+        assertUnion(
+                SortedRangeSet.of(Range.greaterThan(0L)),
+                SortedRangeSet.of(Range.lessThan(0L)),
                 SortedRangeSet.singleValue(0L).complement());
     }
 
@@ -453,5 +439,11 @@ public class TestSortedRangeSet
 
         set = SortedRangeSet.of(Range.equal(true), Range.equal(false));
         Assert.assertEquals(set, mapper.readValue(mapper.writeValueAsString(set), SortedRangeSet.class));
+    }
+
+    private void assertUnion(SortedRangeSet first, SortedRangeSet second, SortedRangeSet expected)
+    {
+        Assert.assertEquals(first.union(second), expected);
+        Assert.assertEquals(SortedRangeSet.union(ImmutableList.of(first, second)), expected);
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestTupleDomain.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestTupleDomain.java
@@ -25,6 +25,8 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.util.Map;
 
+import static com.facebook.presto.spi.TupleDomain.columnWiseUnion;
+
 public class TestTupleDomain
 {
     private static final ColumnHandle A = new TestingColumnHandle("a");
@@ -158,20 +160,19 @@ public class TestTupleDomain
                         .put(E, Domain.all(Double.class))
                         .build());
 
-        Assert.assertEquals(tupleDomain1.columnWiseUnion(tupleDomain2), expectedTupleDomain);
+        Assert.assertEquals(columnWiseUnion(tupleDomain1, tupleDomain2), expectedTupleDomain);
     }
 
     @Test
     public void testNoneColumnWiseUnion()
             throws Exception
     {
-        Assert.assertEquals(TupleDomain.none().columnWiseUnion(TupleDomain.all()), TupleDomain.all());
-        Assert.assertEquals(TupleDomain.all().columnWiseUnion(TupleDomain.none()), TupleDomain.all());
-        Assert.assertEquals(TupleDomain.none().columnWiseUnion(TupleDomain.none()), TupleDomain.none());
-        Assert.assertEquals(TupleDomain.withColumnDomains(
-                ImmutableMap.<ColumnHandle, Domain>of(A, Domain.onlyNull(Long.class)))
-                .columnWiseUnion(
-                        TupleDomain.withColumnDomains(ImmutableMap.<ColumnHandle, Domain>of(A, Domain.notNull(Long.class)))),
+        Assert.assertEquals(columnWiseUnion(TupleDomain.none(), TupleDomain.all()), TupleDomain.all());
+        Assert.assertEquals(columnWiseUnion(TupleDomain.all(), TupleDomain.none()), TupleDomain.all());
+        Assert.assertEquals(columnWiseUnion(TupleDomain.none(), TupleDomain.none()), TupleDomain.none());
+        Assert.assertEquals(columnWiseUnion(
+                TupleDomain.withColumnDomains(ImmutableMap.<ColumnHandle, Domain>of(A, Domain.onlyNull(Long.class))),
+                TupleDomain.withColumnDomains(ImmutableMap.<ColumnHandle, Domain>of(A, Domain.notNull(Long.class)))),
                 TupleDomain.all());
     }
 
@@ -191,7 +192,7 @@ public class TestTupleDomain
 
         TupleDomain expectedTupleDomain = TupleDomain.withColumnDomains(ImmutableMap.<ColumnHandle, Domain>of(A, Domain.all(Double.class)));
 
-        Assert.assertEquals(tupleDomain1.columnWiseUnion(tupleDomain2), expectedTupleDomain);
+        Assert.assertEquals(columnWiseUnion(tupleDomain1, tupleDomain2), expectedTupleDomain);
     }
 
     @Test


### PR DESCRIPTION
This brings down the computation time from 70s (for 12k partitions) down to 250ms on my mac.
The previous algorithm was O(N^2) on the number of partitions times some non-obvious factor due
to how SortedRangeSet.union is implemented. There's still some room for improvement there.

Partial fix for https://github.com/facebook/presto/issues/1126
