### PR TITLE
Truncate SQL query text in index page

### DIFF
--- a/presto-server/src/main/resources/webapp/index.html
+++ b/presto-server/src/main/resources/webapp/index.html
@@ -118,10 +118,15 @@ function renderDoneQueries(queries)
                       var splits = queryInfo.queryStats.totalDrivers;
                       var completedSplits = queryInfo.queryStats.completedDrivers;
 
+                      var query = queryInfo.query;
+                      if (query.length > 200) {
+                          query = query.substring(0, 200) + "...";
+                      }
+
                       return [
                           queryInfo.queryId,
                           queryInfo.queryStats.elapsedTime,
-                          queryInfo.query,
+                          query,
                           queryInfo.session.source,
                           queryInfo.session.user,
                           queryInfo.state,


### PR DESCRIPTION
Large queries make the table hard to navigate.
