### PR TITLE
Truncate SQL query text in index page (take 2)

### DIFF
--- a/presto-server/src/main/resources/webapp/index.html
+++ b/presto-server/src/main/resources/webapp/index.html
@@ -174,10 +174,15 @@ function renderRunningQueries(queries)
                       var runningSplits = queryInfo.queryStats.runningDrivers;
                       var queuedSplits = queryInfo.queryStats.queuedDrivers;
 
+                      var query = queryInfo.query;
+                      if (query.length > 200) {
+                          query = query.substring(0, 200) + "...";
+                      }
+
                       return [
                           queryInfo.queryId,
                           queryInfo.queryStats.elapsedTime,
-                          queryInfo.query,
+                          query,
                           queryInfo.session.source,
                           queryInfo.session.user,
                           queryInfo.state,


### PR DESCRIPTION
Forgot to apply the change to the "running" queries table :(
