### PR TITLE
Bug fix: keep original domains as remaining if use token range query (unpartitioned)

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSplitManager.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSplitManager.java
@@ -130,7 +130,7 @@ public class CassandraSplitManager
                 @SuppressWarnings({"rawtypes", "unchecked"})
                 List<ColumnHandle> partitionColumns = (List) partitionKeys;
                 remainingTupleDomain = TupleDomain.withColumnDomains(Maps.filterKeys(tupleDomain.getDomains(), not(in(partitionColumns))));
-            }            
+            }
         }
 
         return new PartitionResult(partitions, remainingTupleDomain);


### PR DESCRIPTION
When use token range query, it is unpartitioned, so we need push back original domain as remaining domains to presto.
