### PR TITLE
Make surefire pass user.timezone=UTC via command line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration combine.children="append">
-                        <argLine>-Xmx2g -Xms2g -XX:MaxPermSize=512m</argLine>
+                        <argLine>-Duser.timezone=UTC -Xmx2g -Xms2g -XX:MaxPermSize=512m</argLine>
                         <parallel>methods</parallel>
                         <threadCount>2</threadCount>
                         <perCoreThreadCount>true</perCoreThreadCount>


### PR DESCRIPTION
Airbase configures the surefire plugin to set user.timezone=UTC via a
systemPropertyVariable option. The plugin seems to pass those variables to
the tests by calling System.setProperty() before the test is invoked.

In Java 8, java.util.TimeZone is initialized before any user code runs, which
results in the property set by surefire to be ignored.

To illustrate, the following code produces different results in Java 7 vs 8:

```
System.setProperty("user.timezone", "UTC");
System.out.println(java.util.TimeZone.getDefault().getID());
```

Java 7 prints:

```
UTC
```

Java 8 prints (on my machine):

```
America/Los_Angeles
```
