### PR TITLE
Support multiple ranges in domain when retrieving partitions

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.TupleDomain;
 import com.google.common.collect.ImmutableList;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -258,17 +259,24 @@ public class CassandraSession
         Select partitionKeys = CassandraCqlUtils.selectDistinctFrom(tableHandle, partitionKeyColumns);
         partitionKeys.limit(limit);
         partitionKeys.setFetchSize(fetchSizeForPartitionKeySelect);
-        addWhereClause(partitionKeys.where(), partitionKeyColumns, filterPrefix);
-        ResultSetFuture partitionKeyFuture = session.executeAsync(partitionKeys);
 
         if (!fullPartitionKey) {
+            addWhereClause(partitionKeys.where(), partitionKeyColumns, new ArrayList<Comparable<?>>());
+            ResultSetFuture partitionKeyFuture = session.executeAsync(partitionKeys);
             long count = countFuture.getUninterruptibly().one().getLong(0);
             if (count == limitForPartitionKeySelect) {
                 partitionKeyFuture.cancel(true);
                 return null; // too much effort to query all partition keys
             }
+            else {
+                return partitionKeyFuture.getUninterruptibly();
+            }
         }
-        return partitionKeyFuture.getUninterruptibly();
+        else {
+            addWhereClause(partitionKeys.where(), partitionKeyColumns, filterPrefix);
+            ResultSetFuture partitionKeyFuture = session.executeAsync(partitionKeys);
+            return partitionKeyFuture.getUninterruptibly();
+        }
     }
 
     private void addWhereClause(Where where, List<CassandraColumnHandle> partitionKeyColumns, List<Comparable<?>> filterPrefix)

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSplitManager.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSplitManager.java
@@ -32,14 +32,23 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.Stack;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -86,32 +95,11 @@ public class CassandraSplitManager
         checkNotNull(tableHandle, "tableHandle is null");
         checkNotNull(tupleDomain, "tupleDomain is null");
         CassandraTableHandle cassandraTableHandle = (CassandraTableHandle) tableHandle;
-
         CassandraTable table = schemaProvider.getTable(cassandraTableHandle);
-
         List<CassandraColumnHandle> partitionKeys = table.getPartitionKeyColumns();
-        List<Comparable<?>> filterPrefix = new ArrayList<>();
-        for (int i = 0; i < partitionKeys.size(); i++) {
-            CassandraColumnHandle columnHandle = partitionKeys.get(i);
-
-            // only add to prefix if all previous keys have a value
-            if (filterPrefix.size() == i && !tupleDomain.isNone()) {
-                Domain domain = tupleDomain.getDomains().get(columnHandle);
-                if (domain != null && domain.getRanges().getRangeCount() == 1) {
-                    // We intentionally ignore whether NULL is in the domain since partition keys can never be NULL
-                    Range range = Iterables.getOnlyElement(domain.getRanges());
-                    if (range.isSingleValue()) {
-                        Comparable<?> value = range.getLow().getValue();
-                        checkArgument(value instanceof Boolean || value instanceof String || value instanceof Double || value instanceof Long,
-                                "Only Boolean, String, Double and Long partition keys are supported");
-                        filterPrefix.add(value);
-                    }
-                }
-            }
-        }
 
         // fetch the partitions
-        List<CassandraPartition> allPartitions = schemaProvider.getPartitions(table, filterPrefix);
+        List<CassandraPartition> allPartitions = getAllPartitions(table, tupleDomain);
         log.debug("%s.%s #partitions: %d", cassandraTableHandle.getSchemaName(), cassandraTableHandle.getTableName(), allPartitions.size());
 
         // do a final pass to filter based on fields that could not be used to build the prefix
@@ -129,6 +117,96 @@ public class CassandraSplitManager
         }
 
         return new PartitionResult(partitions, remainingTupleDomain);
+    }
+
+    /** get all partitions for the domain.*/
+    private List<CassandraPartition> getAllPartitions(CassandraTable table, TupleDomain tupleDomain)
+    {
+        List<CassandraColumnHandle> partitionKeys = table.getPartitionKeyColumns();
+        List<Comparable<?>> emptyPrefix = new ArrayList<>();
+        Stack<List<Comparable<?>>> stack = new Stack<>();
+        stack.add(emptyPrefix);
+        boolean partialPartitionKeys = false;
+        if (!tupleDomain.isNone()) {
+            for (int i = 0; i < partitionKeys.size(); i++) {
+                CassandraColumnHandle columnHandle = partitionKeys.get(i);
+                Domain domain = tupleDomain.getDomains().get(columnHandle);
+                if (domain != null) {
+                    List<Range> ranges = domain.getRanges().getRanges();
+                    Stack<List<Comparable<?>>> tempStack = new Stack<>();
+                    while (!stack.isEmpty()) {
+                        if (stack.peek().size() == i) {
+                            List<Comparable<?>> filter = stack.pop();
+                            int j = 0;
+                            //multiple ranges
+                            for (Range range : ranges) {
+                                if (range.isSingleValue()) {
+                                    Comparable<?> value = range.getSingleValue();
+                                    checkArgument(value instanceof Boolean || value instanceof String || value instanceof Double || value instanceof Long,
+                                            "Only Boolean, String, Double and Long partition keys are supported");
+                                    if (j == ranges.size() - 1) {
+                                        filter.add(value);
+                                        tempStack.add(filter);
+                                    }
+                                    else {
+                                        List<Comparable<?>> filterCopy = new ArrayList<>(filter);
+                                        if (filter.size() > 0) {
+                                            Collections.copy(filterCopy, filter);
+                                        }
+                                        filterCopy.add(value);
+                                        tempStack.add(filterCopy);
+                                    }
+                                }
+                            }
+                        }
+                        else {
+                            partialPartitionKeys = true;
+                            break;
+                        }
+                    }
+                    // if there is only partial partition keys, return empty filter
+                    if (partialPartitionKeys) {
+                        stack.clear();
+                        stack.add(emptyPrefix);
+                        break;
+                    }
+                    if (tempStack.size() != 0) {
+                        stack = tempStack;
+                    }
+                }
+                else {
+                    stack.clear();
+                    stack.add(emptyPrefix);
+                    break;
+                }
+            }
+        }
+
+        List<CassandraPartition> allPartitions = new ArrayList<>();
+        ListeningExecutorService service = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(10));
+        List<ListenableFuture<List<CassandraPartition>>> getPartitionResults = Lists.newArrayList();
+        final CassandraTable cassandraTable = table;
+        while (!stack.isEmpty()) {
+            final List<Comparable<?>> filter = stack.pop();
+            getPartitionResults.add(service.submit(new Callable<List<CassandraPartition>>()
+                    {
+                        public List<CassandraPartition> call()
+                        {
+                            return schemaProvider.getPartitions(cassandraTable, filter);
+                        }
+                    }));
+        }
+
+        for (ListenableFuture<List<CassandraPartition>> result : getPartitionResults) {
+            try {
+                Collections.addAll(allPartitions, result.get().toArray(new CassandraPartition[0]));
+            }
+            catch (InterruptedException | ExecutionException e) {
+                log.error("Error in get partitions", e);
+            }
+        }
+
+        return allPartitions;
     }
 
     @Override


### PR DESCRIPTION
It make the selection on full partition keys query directly retrieving the result using partition key query instead of token range query then filter out at Presto side.

e.g. select \* from test where (a=1 or a=2 or a=3) and (b=3 or b=4)

where a and b is the partition keys.
the direct queries are 
select \* from test where a = 1 and b = 3
select \* from test where a = 2 and b = 4
select \* from test where a = 2 and b = 3
select \* from test where a = 2 and b = 4
select \* from test where a = 3 and b = 3
select \* from test where a = 3 and b = 4

instead of select \* from test where token(a,b) > start_token and taken(a,b) <= end_token
then at Presto side, filter the results.
