### PR TITLE
Update jmxutils to 1.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+
+            <dependency>
+                <groupId>org.weakref</groupId>
+                <artifactId>jmxutils</artifactId>
+                <version>1.15</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This fixes an issue when registering duplicate mbean names
