### PR TITLE
Fix regression with VARCHAR partitions in Hive

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
@@ -59,6 +59,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -95,9 +97,9 @@ import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.hive.HiveBucketing.HiveBucket;
 import static com.facebook.presto.hive.HiveBucketing.getHiveBucket;
+import static com.facebook.presto.hive.HiveColumnHandle.SAMPLE_WEIGHT_COLUMN_NAME;
 import static com.facebook.presto.hive.HiveColumnHandle.columnMetadataGetter;
 import static com.facebook.presto.hive.HiveColumnHandle.hiveColumnHandle;
-import static com.facebook.presto.hive.HiveColumnHandle.SAMPLE_WEIGHT_COLUMN_NAME;
 import static com.facebook.presto.hive.HivePartition.UNPARTITIONED_ID;
 import static com.facebook.presto.hive.HiveType.columnTypeToHiveType;
 import static com.facebook.presto.hive.HiveType.getHiveType;
@@ -676,8 +678,8 @@ public class HiveClient
                     Range range = Iterables.getOnlyElement(domain.getRanges());
                     if (range.isSingleValue()) {
                         Comparable<?> value = range.getLow().getValue();
-                        checkArgument(value instanceof Boolean || value instanceof String || value instanceof Double || value instanceof Long,
-                                "Only Boolean, String, Double and Long partition keys are supported");
+                        checkArgument(value instanceof Boolean || value instanceof Slice || value instanceof Double || value instanceof Long,
+                                "Only Boolean, Slice (UTF8 String), Double and Long partition keys are supported");
                         filterPrefix.add(value.toString());
                     }
                 }
@@ -943,7 +945,7 @@ public class HiveClient
                             }
                         }
                         else if (VARCHAR.equals(type)) {
-                            builder.put(columnHandle, value);
+                            builder.put(columnHandle, Slices.utf8Slice(value));
                         }
                     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -45,6 +45,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.net.HostAndPort;
 import io.airlift.log.Logger;
+import io.airlift.slice.Slices;
 import io.airlift.units.Duration;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -153,19 +154,19 @@ public abstract class AbstractTestHiveClient
         partitions = ImmutableSet.<Partition>of(
                 new HivePartition(table,
                         "ds=2012-12-29/file_format=rcfile-text/dummy=0",
-                        ImmutableMap.<ColumnHandle, Comparable<?>>of(dsColumn, "2012-12-29", fileFormatColumn, "rcfile-text", dummyColumn, 0L),
+                        ImmutableMap.<ColumnHandle, Comparable<?>>of(dsColumn, Slices.utf8Slice("2012-12-29"), fileFormatColumn, Slices.utf8Slice("rcfile-text"), dummyColumn, 0L),
                         Optional.<HiveBucket>absent()),
                 new HivePartition(table,
                         "ds=2012-12-29/file_format=rcfile-binary/dummy=2",
-                        ImmutableMap.<ColumnHandle, Comparable<?>>of(dsColumn, "2012-12-29", fileFormatColumn, "rcfile-binary", dummyColumn, 2L),
+                        ImmutableMap.<ColumnHandle, Comparable<?>>of(dsColumn, Slices.utf8Slice("2012-12-29"), fileFormatColumn, Slices.utf8Slice("rcfile-binary"), dummyColumn, 2L),
                         Optional.<HiveBucket>absent()),
                 new HivePartition(table,
                         "ds=2012-12-29/file_format=sequencefile/dummy=4",
-                        ImmutableMap.<ColumnHandle, Comparable<?>>of(dsColumn, "2012-12-29", fileFormatColumn, "sequencefile", dummyColumn, 4L),
+                        ImmutableMap.<ColumnHandle, Comparable<?>>of(dsColumn, Slices.utf8Slice("2012-12-29"), fileFormatColumn, Slices.utf8Slice("sequencefile"), dummyColumn, 4L),
                         Optional.<HiveBucket>absent()),
                 new HivePartition(table,
                         "ds=2012-12-29/file_format=textfile/dummy=6",
-                        ImmutableMap.<ColumnHandle, Comparable<?>>of(dsColumn, "2012-12-29", fileFormatColumn, "textfile", dummyColumn, 6L),
+                        ImmutableMap.<ColumnHandle, Comparable<?>>of(dsColumn, Slices.utf8Slice("2012-12-29"), fileFormatColumn, Slices.utf8Slice("textfile"), dummyColumn, 6L),
                         Optional.<HiveBucket>absent()));
         unpartitionedPartitions = ImmutableSet.<Partition>of(new HivePartition(tableUnpartitioned));
         invalidPartition = new HivePartition(invalidTable, "unknown", ImmutableMap.<ColumnHandle, Comparable<?>>of(), Optional.<HiveBucket>absent());
@@ -447,10 +448,11 @@ public abstract class AbstractTestHiveClient
         ColumnHandle dsColumn = metadata.getColumnHandle(tableHandle, "ds");
         assertNotNull(dsColumn);
 
-        TupleDomain tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.<ColumnHandle, Domain>of(dsColumn, Domain.singleValue("2012-12-30")));
+        Domain domain = Domain.singleValue(Slices.utf8Slice("2012-12-30"));
+        TupleDomain tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.<ColumnHandle, Domain>of(dsColumn, domain));
         PartitionResult partitionResult = splitManager.getPartitions(tableHandle, tupleDomain);
         for (Partition partition : partitionResult.getPartitions()) {
-            if (Domain.singleValue("2012-12-30").equals(partition.getTupleDomain().getDomains().get(dsColumn))) {
+            if (domain.equals(partition.getTupleDomain().getDomains().get(dsColumn))) {
                 try {
                     getSplitCount(splitManager.getPartitionSplits(tableHandle, ImmutableList.of(partition)));
                     fail("Expected PartitionOfflineException");


### PR DESCRIPTION
Fix the Hive connector to return Slice objects for the values of VARCHAR
partition columns instead of String objects. Also fix the Hive tests to
use Slice instead of String.
