### PR TITLE
Fix locale to en_US for datetime functions to be independent from runtime environments

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -450,7 +450,7 @@ public final class DateTimeFunctions
     public static long parseDatetime(Session session, Slice datetime, Slice formatString)
     {
         String pattern = formatString.toString(Charsets.UTF_8);
-        DateTimeFormatter formatter = DateTimeFormat.forPattern(pattern).withChronology(getChronology(session.getTimeZoneKey())).withOffsetParsed().withLocale(Locale.US);
+        DateTimeFormatter formatter = DateTimeFormat.forPattern(pattern).withChronology(getChronology(session.getTimeZoneKey())).withOffsetParsed().withLocale(session.getLocale());
 
         String datetimeString = datetime.toString(Charsets.UTF_8);
         DateTime dateTime = formatter.parseDateTime(datetimeString);
@@ -461,20 +461,20 @@ public final class DateTimeFunctions
     @ScalarFunction
     public static Slice formatDatetime(Session session, @SqlType(TimestampType.class) long timestamp, Slice formatString)
     {
-        return formatDatetime(getChronology(session.getTimeZoneKey()), timestamp, formatString);
+        return formatDatetime(getChronology(session.getTimeZoneKey()), session.getLocale(), timestamp, formatString);
     }
 
     @Description("formats the given time by the given format")
     @ScalarFunction("format_datetime")
-    public static Slice formatDatetimeWithTimeZone(@SqlType(TimestampWithTimeZoneType.class) long timestampWithTimeZone, Slice formatString)
+    public static Slice formatDatetimeWithTimeZone(Session session, @SqlType(TimestampWithTimeZoneType.class) long timestampWithTimeZone, Slice formatString)
     {
-        return formatDatetime(unpackChronology(timestampWithTimeZone), unpackMillisUtc(timestampWithTimeZone), formatString);
+        return formatDatetime(unpackChronology(timestampWithTimeZone), session.getLocale(), unpackMillisUtc(timestampWithTimeZone), formatString);
     }
 
-    private static Slice formatDatetime(ISOChronology chronology, long timestamp, Slice formatString)
+    private static Slice formatDatetime(ISOChronology chronology, Locale locale, long timestamp, Slice formatString)
     {
         String pattern = formatString.toString(Charsets.UTF_8);
-        DateTimeFormatter formatter = DateTimeFormat.forPattern(pattern).withChronology(chronology).withLocale(Locale.US);
+        DateTimeFormatter formatter = DateTimeFormat.forPattern(pattern).withChronology(chronology).withLocale(locale);
 
         String datetimeString = formatter.print(timestamp);
         return Slices.wrappedBuffer(datetimeString.getBytes(Charsets.UTF_8));
@@ -483,18 +483,18 @@ public final class DateTimeFunctions
     @ScalarFunction
     public static Slice dateFormat(Session session, @SqlType(TimestampType.class) long timestamp, Slice formatString)
     {
-        return dateFormat(getChronology(session.getTimeZoneKey()), timestamp, formatString);
+        return dateFormat(getChronology(session.getTimeZoneKey()), session.getLocale(), timestamp, formatString);
     }
 
     @ScalarFunction("date_format")
-    public static Slice dateFormatWithTimeZone(@SqlType(TimestampWithTimeZoneType.class) long timestampWithTimeZone, Slice formatString)
+    public static Slice dateFormatWithTimeZone(Session session, @SqlType(TimestampWithTimeZoneType.class) long timestampWithTimeZone, Slice formatString)
     {
-        return dateFormat(unpackChronology(timestampWithTimeZone), unpackMillisUtc(timestampWithTimeZone), formatString);
+        return dateFormat(unpackChronology(timestampWithTimeZone), session.getLocale(), unpackMillisUtc(timestampWithTimeZone), formatString);
     }
 
-    private static Slice dateFormat(ISOChronology chronology, long timestamp, Slice formatString)
+    private static Slice dateFormat(ISOChronology chronology, Locale locale, long timestamp, Slice formatString)
     {
-        DateTimeFormatter formatter = DATETIME_FORMATTER_CACHE.get(formatString).withChronology(chronology).withLocale(Locale.US);
+        DateTimeFormatter formatter = DATETIME_FORMATTER_CACHE.get(formatString).withChronology(chronology).withLocale(locale);
         return Slices.copiedBuffer(formatter.print(timestamp), Charsets.UTF_8);
     }
 
@@ -502,7 +502,7 @@ public final class DateTimeFunctions
     @SqlType(TimestampType.class)
     public static long dateParse(Session session, Slice dateTime, Slice formatString)
     {
-        DateTimeFormatter formatter = DATETIME_FORMATTER_CACHE.get(formatString).withChronology(getChronology(session.getTimeZoneKey())).withLocale(Locale.US);
+        DateTimeFormatter formatter = DATETIME_FORMATTER_CACHE.get(formatString).withChronology(getChronology(session.getTimeZoneKey())).withLocale(session.getLocale());
         return formatter.parseMillis(dateTime.toString(Charsets.UTF_8));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUnixTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUnixTimeFunctions.java
@@ -585,6 +585,27 @@ public class TestUnixTimeFunctions
         assertFunction("date_parse('2013 14', '%Y %y')", toTimestamp(new DateTime(2014, 1, 1, 0, 0, 0, 0, DATE_TIME_ZONE)));
     }
 
+    @Test
+    public void testLocale()
+    {
+        Locale locale = Locale.JAPANESE;
+        session = new Session("user", "test", DEFAULT_CATALOG, DEFAULT_SCHEMA, TIME_ZONE_KEY, locale, null, null);
+
+        functionAssertions = new FunctionAssertions(session);
+
+        String dateTimeLiteral = "TIMESTAMP '2001-01-09 13:04:05.321'";
+
+        assertFunction("date_format(" + dateTimeLiteral + ", '%a')", "火");
+        assertFunction("date_format(" + dateTimeLiteral + ", '%W')", "火曜日");
+        assertFunction("date_format(" + dateTimeLiteral + ", '%p')", "午後");
+        assertFunction("date_format(" + dateTimeLiteral + ", '%r')", "01:04:05 午後");
+        assertFunction("date_format(" + dateTimeLiteral + ", '%b')", "1");
+        assertFunction("date_format(" + dateTimeLiteral + ", '%M')", "1月");
+
+        assertFunction("date_parse('2013-05-17 12:35:10 午後', '%Y-%m-%d %h:%i:%s %p')", toTimestamp(new DateTime(2013, 5, 17, 12, 35, 10, 0, DATE_TIME_ZONE)));
+        assertFunction("date_parse('2013-05-17 12:35:10 午前', '%Y-%m-%d %h:%i:%s %p')", toTimestamp(new DateTime(2013, 5, 17, 0, 35, 10, 0, DATE_TIME_ZONE)));
+    }
+
     private void assertFunction(String projection, Object expected)
     {
         functionAssertions.assertFunction(projection, expected);


### PR DESCRIPTION
TestUnixTimeFunctions.testDateFormat and TestUnixTimeFunctions.testDateParse tests fail if we run tests on a machine whose system locale is not en_US because some formats of DateTimeFormatter depend on the default locale of the runtime environment.

This change makes format_datetime, date_format, and date_parse functions independent from the runtime environment.
### How to reproduce

``` sh
_JAVA_OPTIONS="-Duser.language=ja -Duser.country=JP" mvn test -Dtest=TestUnixTimeFunctions -DfailIfNoTests=false
```
