### PR TITLE
Fix typo in TimeZoneKey

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeZoneKey.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeZoneKey.java
@@ -231,7 +231,7 @@ public final class TimeZoneKey
 
         }
 
-        if (zoneId.equals("+00:00") | zoneId.equals("-00:00")) {
+        if (zoneId.equals("+00:00") || zoneId.equals("-00:00")) {
             return "UTC";
         }
         return zoneId;


### PR DESCRIPTION
Replaced `|` with `||`. I think using `|` is a typo since it's not-short-circuit logic and does not make sense here. 
