### PR TITLE
Fix Hive connector partition lookup

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
@@ -679,7 +679,12 @@ public class HiveClient
                         Comparable<?> value = range.getLow().getValue();
                         checkArgument(value instanceof Boolean || value instanceof Slice || value instanceof Double || value instanceof Long,
                                 "Only Boolean, Slice (UTF8 String), Double and Long partition keys are supported");
-                        filterPrefix.add(value.toString());
+                        if (value instanceof Slice) {
+                            filterPrefix.add(((Slice) value).toStringUtf8());
+                        }
+                        else {
+                            filterPrefix.add(value.toString());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Use Slice.toStringUtf8() instead of .toString(). This fixes an issue where
all queries to the Hive connector that used a WHERE clause on a string
partition column would return no results.
