### PR TITLE
Fix incorrect output from SHOW SCHEMAS

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -193,12 +193,12 @@ public class ConnectorManager
         if (catalogName != null) {
             metadataManager.addConnectorMetadata(connectorId, catalogName, connectorMetadata);
 
-            metadataManager.addInternalSchemaMetadata(makeInformationSchemaConnectorId(connectorId), new InformationSchemaMetadata(catalogName));
+            metadataManager.addInformationSchemaMetadata(makeInformationSchemaConnectorId(connectorId), catalogName, new InformationSchemaMetadata(catalogName));
             splitManager.addConnectorSplitManager(makeInformationSchemaConnectorId(connectorId), new InformationSchemaSplitManager(nodeManager));
             dataStreamManager.addConnectorDataStreamProvider(makeInformationSchemaConnectorId(connectorId), new InformationSchemaDataStreamProvider(metadataManager, splitManager));
         }
         else {
-            metadataManager.addInternalSchemaMetadata(connectorId, connectorMetadata);
+            metadataManager.addGlobalSchemaMetadata(connectorId, connectorMetadata);
         }
 
         splitManager.addConnectorSplitManager(connectorId, connectorSplitManager);

--- a/presto-main/src/main/java/com/facebook/presto/connector/dual/DualMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/dual/DualMetadata.java
@@ -42,7 +42,7 @@ public class DualMetadata
 
     static {
         DUAL_METADATA_MANAGER = new MetadataManager(new FeaturesConfig(), new TypeRegistry());
-        DUAL_METADATA_MANAGER.addInternalSchemaMetadata(DualConnector.CONNECTOR_ID, new DualMetadata());
+        DUAL_METADATA_MANAGER.addGlobalSchemaMetadata(DualConnector.CONNECTOR_ID, new DualMetadata());
     }
 
     public static final String NAME = "dual";

--- a/presto-main/src/test/java/com/facebook/presto/AbstractTestQueryFramework.java
+++ b/presto-main/src/test/java/com/facebook/presto/AbstractTestQueryFramework.java
@@ -390,7 +390,7 @@ public abstract class AbstractTestQueryFramework
     private QueryExplainer getQueryExplainer()
     {
         MetadataManager metadata = new MetadataManager(new FeaturesConfig().setExperimentalSyntaxEnabled(true), new TypeRegistry());
-        metadata.addInternalSchemaMetadata(DualConnector.CONNECTOR_ID, new DualMetadata());
+        metadata.addGlobalSchemaMetadata(DualConnector.CONNECTOR_ID, new DualMetadata());
         SplitManager splitManager = new SplitManager();
         splitManager.addConnectorSplitManager(DualConnector.CONNECTOR_ID, new DualSplitManager(new InMemoryNodeManager()));
         IndexManager indexManager = new IndexManager();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -103,7 +103,7 @@ public class TestSqlStageExecution
             throws Exception
     {
         metadata = new MetadataManager(new FeaturesConfig(), new TypeRegistry());
-        metadata.addInternalSchemaMetadata(DualConnector.CONNECTOR_ID, new DualMetadata());
+        metadata.addGlobalSchemaMetadata(DualConnector.CONNECTOR_ID, new DualMetadata());
     }
 
     @Test
@@ -209,7 +209,7 @@ public class TestSqlStageExecution
         SqlStageExecution stageExecution = null;
         try {
             MetadataManager metadata = new MetadataManager(new FeaturesConfig(), new TypeRegistry());
-            metadata.addInternalSchemaMetadata(DualConnector.CONNECTOR_ID, new DualMetadata());
+            metadata.addGlobalSchemaMetadata(DualConnector.CONNECTOR_ID, new DualMetadata());
 
             StageExecutionPlan joinPlan = createJoinPlan("A", metadata);
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -104,7 +104,7 @@ public class TestSqlTaskExecution
         Symbol symbol = new Symbol(DualMetadata.COLUMN_NAME);
 
         MetadataManager metadata = new MetadataManager(new FeaturesConfig(), new TypeRegistry());
-        metadata.addInternalSchemaMetadata(DualConnector.CONNECTOR_ID, dualMetadata);
+        metadata.addGlobalSchemaMetadata(DualConnector.CONNECTOR_ID, dualMetadata);
 
         DualSplitManager dualSplitManager = new DualSplitManager(new InMemoryNodeManager());
         ConnectorPartitionResult partitionResult = dualSplitManager.getPartitions(tableHandle.getConnectorHandle(), TupleDomain.<ConnectorColumnHandle>all());

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -109,7 +109,7 @@ public class TestSqlTaskManager
         symbol = new Symbol(DualMetadata.COLUMN_NAME);
 
         MetadataManager metadata = new MetadataManager(new FeaturesConfig(), new TypeRegistry());
-        metadata.addInternalSchemaMetadata(DualConnector.CONNECTOR_ID, dualMetadata);
+        metadata.addGlobalSchemaMetadata(DualConnector.CONNECTOR_ID, dualMetadata);
 
         DualSplitManager dualSplitManager = new DualSplitManager(new InMemoryNodeManager());
         ConnectorPartitionResult partitionResult = dualSplitManager.getPartitions(tableHandle.getConnectorHandle(), TupleDomain.<ConnectorColumnHandle>all());

--- a/presto-server/src/test/java/com/facebook/presto/server/TestDistributedQueries.java
+++ b/presto-server/src/test/java/com/facebook/presto/server/TestDistributedQueries.java
@@ -37,6 +37,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
 import io.airlift.http.client.AsyncHttpClient;
 import io.airlift.http.client.HttpClientConfig;
@@ -59,6 +60,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.INFORMATION_SCHEMA;
 import static com.facebook.presto.spi.Session.DEFAULT_CATALOG;
 import static com.facebook.presto.spi.Session.DEFAULT_SCHEMA;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -104,6 +106,15 @@ public class TestDistributedQueries
     private List<TestingPrestoServer> servers;
     private AsyncHttpClient httpClient;
     private TestingDiscoveryServer discoveryServer;
+
+    @Test
+    public void testShowSchemasFromOther()
+            throws Exception
+    {
+        MaterializedResult result = computeActual(format("SHOW SCHEMAS FROM tpch"));
+        ImmutableSet<String> schemaNames = ImmutableSet.copyOf(transform(result.getMaterializedRows(), onlyColumnGetter()));
+        assertTrue(schemaNames.containsAll(ImmutableSet.of(INFORMATION_SCHEMA, "sys", "tiny")));
+    }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "statement is too large \\(stack overflow during analysis\\)")
     public void testLargeQueryFailure()


### PR DESCRIPTION
There was a bug in the way MetadataManager keeps track and resolves information schema
connector registrations that caused the wrong ConnectorMetadata to be picked. As a result,
SHOW SCHEMAS would display schemas from another catalog.
