### PR TITLE
Add config to disable proximity scheduling

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/NodeSchedulerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/NodeSchedulerConfig.java
@@ -20,6 +20,7 @@ import javax.validation.constraints.Min;
 public class NodeSchedulerConfig
 {
     private int minCandidates = 10;
+    private boolean locationAwareScheduling = true;
 
     @Min(1)
     public int getMinCandidates()
@@ -31,6 +32,18 @@ public class NodeSchedulerConfig
     public NodeSchedulerConfig setMinCandidates(int candidates)
     {
         this.minCandidates = candidates;
+        return this;
+    }
+
+    public boolean isLocationAwareSchedulingEnabled()
+    {
+        return locationAwareScheduling;
+    }
+
+    @Config("node-scheduler.location-aware-scheduling-enabled")
+    public NodeSchedulerConfig setLocationAwareSchedulingEnabled(boolean locationAwareScheduling)
+    {
+        this.locationAwareScheduling = locationAwareScheduling;
         return this;
     }
 }


### PR DESCRIPTION
Add a config parameter to disable scheduling based on proximity. This will enable us to remove a variable and help us drill down into the cause of uneven split distribution. 
