### PR TITLE
update maven version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See the [User Manual](http://prestodb.io/docs/current/) for deployment instructi
 
 * Mac OS X or Linux
 * Java 7, 64-bit
-* Maven 3 (for building)
+* Maven 3.1.1+ (for building)
 * Python 2.4+ (for running with the launcher script)
 
 ## Building Presto


### PR DESCRIPTION
Building with maven 3.0.x will throw error as follow:

[WARNING] Rule 1: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message:
Detected Maven Version: 3.0.x is not in the allowed range 3.1.1.
