### PR TITLE
Add machine learning functions plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <module>presto-client</module>
         <module>presto-parser</module>
         <module>presto-main</module>
+        <module>presto-ml</module>
         <module>presto-jdbc</module>
         <module>presto-cli</module>
         <module>presto-server</module>
@@ -364,6 +365,12 @@
                 <groupId>org.jruby.joni</groupId>
                 <artifactId>joni</artifactId>
                 <version>2.0.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>tw.edu.ntu.csie</groupId>
+                <artifactId>libsvm</artifactId>
+                <version>3.17</version>
             </dependency>
 
             <dependency>

--- a/presto-ml/pom.xml
+++ b/presto-ml/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.69-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-ml</artifactId>
+    <description>Presto - Machine Learning Plugin</description>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>tw.edu.ntu.csie</groupId>
+            <artifactId>libsvm</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <descriptors>
+                        <descriptor>src/main/assembly/plugin.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/presto-ml/src/main/assembly/plugin.xml
+++ b/presto-ml/src/main/assembly/plugin.xml
@@ -1,0 +1,21 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>distribution</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <baseDirectory>/</baseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <scope>runtime</scope>
+            <outputFileNameMapping>${artifact.artifactId}-${artifact.baseVersion}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>
+            <includes>
+                <include>*:jar:*</include>
+            </includes>
+            <excludes>
+                <exclude>*:sources</exclude>
+            </excludes>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/presto-ml/src/main/java/com/facebook/presto/ml/AbstractSvmModel.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/AbstractSvmModel.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.google.common.base.Throwables;
+import com.google.common.io.Files;
+import libsvm.svm;
+import libsvm.svm_model;
+import libsvm.svm_node;
+import libsvm.svm_parameter;
+import libsvm.svm_problem;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.SortedMap;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public abstract class AbstractSvmModel
+        implements Model
+{
+    protected svm_model model;
+
+    protected AbstractSvmModel()
+    {
+    }
+
+    protected AbstractSvmModel(svm_model model)
+    {
+        this.model = checkNotNull(model, "model is null");
+    }
+
+    @Override
+    public byte[] getSerializedData()
+    {
+        File file = null;
+        try {
+            // libsvm doesn't have a method to serialize the model into a buffer, so write it out to a file and then read it back in
+            file = File.createTempFile("svm", null);
+            svm.svm_save_model(file.getAbsolutePath(), model);
+            return Files.toByteArray(file);
+        }
+        catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+        finally {
+            if (file != null) {
+                file.delete();
+            }
+        }
+    }
+
+    @Override
+    public void train(Dataset dataset)
+    {
+        svm_parameter param = new svm_parameter();
+        // default values
+        param.svm_type = getLibsvmType();
+        param.kernel_type = svm_parameter.LINEAR;
+        param.degree = 3;
+        param.gamma = 0;
+        param.coef0 = 0;
+        param.nu = 0.5;
+        param.cache_size = 100;
+        param.C = 1;
+        param.eps = 0.1;
+        param.p = 0.1;
+        param.shrinking = 1;
+        param.probability = 0;
+        param.nr_weight = 0;
+        param.weight_label = new int[0];
+        param.weight = new double[0];
+
+        svm_problem problem = toSvmProblem(dataset);
+
+        //TODO: we should probably run this in another thread, and put a bound on the running time
+        model = svm.svm_train(problem, param);
+    }
+
+    protected abstract int getLibsvmType();
+
+    private static svm_problem toSvmProblem(Dataset dataset)
+    {
+        svm_problem problem = new svm_problem();
+        List<Double> labels = dataset.getLabels();
+        problem.l = labels.size();
+        problem.y = new double[labels.size()];
+        for (int i = 0; i < labels.size(); i++) {
+            problem.y[i] = labels.get(i);
+        }
+        problem.x = new svm_node[labels.size()][];
+        for (int i = 0; i < dataset.getDatapoints().size(); i++) {
+            problem.x[i] = toSvmNodes(dataset.getDatapoints().get(i));
+        }
+        return problem;
+    }
+
+    protected static svm_node[] toSvmNodes(FeatureVector features)
+    {
+        svm_node[] nodes = new svm_node[features.size()];
+        int i = 0;
+        // Features map is sorted, so we can just flatten it to a list for libsvm
+        for (SortedMap.Entry<Integer, Double> feature : features.getFeatures().entrySet()) {
+            nodes[i] = new svm_node();
+            nodes[i].index = feature.getKey();
+            nodes[i].value = feature.getValue();
+            i++;
+        }
+
+        return nodes;
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/Classifier.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/Classifier.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+public interface Classifier
+        extends Model
+{
+    int classify(FeatureVector features);
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/ClassifierFeatureTransformer.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/ClassifierFeatureTransformer.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.facebook.presto.ml.type.ClassifierType;
+import com.facebook.presto.ml.type.ModelType;
+
+import java.util.List;
+
+import static com.facebook.presto.util.Types.checkType;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ClassifierFeatureTransformer
+        implements Classifier
+{
+    private final Classifier classifier;
+    private final FeatureTransformation transformation;
+
+    public ClassifierFeatureTransformer(Classifier classifier, FeatureTransformation transformation)
+    {
+        this.classifier = checkNotNull(classifier, "classifier is is null");
+        this.transformation = checkNotNull(transformation, "transformation is null");
+    }
+
+    @Override
+    public ModelType getType()
+    {
+        return ClassifierType.CLASSIFIER;
+    }
+
+    @Override
+    public byte[] getSerializedData()
+    {
+        return ModelUtils.serializeModels(classifier, transformation);
+    }
+
+    public static ClassifierFeatureTransformer deserialize(byte[] data)
+    {
+        List<Model> models = ModelUtils.deserializeModels(data);
+
+        return new ClassifierFeatureTransformer(checkType(models.get(0), Classifier.class, "model 0"), checkType(models.get(1), FeatureTransformation.class, "model 1"));
+    }
+
+    @Override
+    public int classify(FeatureVector features)
+    {
+        return classifier.classify(transformation.transform(features));
+    }
+
+    @Override
+    public void train(Dataset dataset)
+    {
+        transformation.train(dataset);
+        classifier.train(transformation.transform(dataset));
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/Dataset.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/Dataset.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class Dataset
+{
+    private final List<FeatureVector> datapoints;
+    private final List<Double> labels;
+
+    public Dataset(List<Double> labels, List<FeatureVector> datapoints)
+    {
+        checkNotNull(datapoints, "datapoints is null");
+        checkNotNull(labels, "labels is null");
+        checkArgument(datapoints.size() == labels.size(), "datapoints and labels have different sizes");
+        this.labels = ImmutableList.copyOf(labels);
+        this.datapoints = ImmutableList.copyOf(datapoints);
+    }
+
+    public List<FeatureVector> getDatapoints()
+    {
+        return datapoints;
+    }
+
+    public List<Double> getLabels()
+    {
+        return labels;
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/EvaluateClassifierPredictionsAggregation.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/EvaluateClassifierPredictionsAggregation.java
@@ -1,0 +1,330 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.facebook.presto.operator.GroupByIdBlock;
+import com.facebook.presto.operator.Page;
+import com.facebook.presto.operator.aggregation.Accumulator;
+import com.facebook.presto.operator.aggregation.AggregationFunction;
+import com.facebook.presto.operator.aggregation.GroupedAccumulator;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.BlockCursor;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.util.array.LongBigArray;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+
+public class EvaluateClassifierPredictionsAggregation
+        implements AggregationFunction
+{
+    @Override
+    public List<Type> getParameterTypes()
+    {
+        return ImmutableList.<Type>of(BIGINT, BIGINT);
+    }
+
+    @Override
+    public Type getFinalType()
+    {
+        return VARCHAR;
+    }
+
+    @Override
+    public Type getIntermediateType()
+    {
+        return VARCHAR;
+    }
+
+    @Override
+    public boolean isDecomposable()
+    {
+        return true;
+    }
+
+    @Override
+    public Accumulator createAggregation(Optional<Integer> maskChannel, Optional<Integer> sampleWeight, double confidence, int... argumentChannels)
+    {
+        checkArgument(!maskChannel.isPresent(), "masking is not supported");
+        checkArgument(confidence == 1, "approximation is not supported");
+        checkArgument(!sampleWeight.isPresent(), "sample weight is not supported");
+        return new EvaluatePredictionsAccumulator(argumentChannels[0], argumentChannels[1]);
+    }
+
+    @Override
+    public Accumulator createIntermediateAggregation(double confidence)
+    {
+        checkArgument(confidence == 1, "approximation is not supported");
+        return new EvaluatePredictionsAccumulator(-1, -1);
+    }
+
+    public static class EvaluatePredictionsAccumulator
+            implements Accumulator
+    {
+        private final int labelChannel;
+        private final int predictionChannel;
+
+        private long truePositives;
+        private long falsePositives;
+        private long trueNegatives;
+        private long falseNegatives;
+
+        public EvaluatePredictionsAccumulator(int labelChannel, int predictionChannel)
+        {
+            this.labelChannel = labelChannel;
+            this.predictionChannel = predictionChannel;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return 0;
+        }
+
+        @Override
+        public Type getFinalType()
+        {
+            return VARCHAR;
+        }
+
+        @Override
+        public Type getIntermediateType()
+        {
+            return VARCHAR;
+        }
+
+        @Override
+        public void addInput(Page page)
+        {
+            BlockCursor labelCursor = page.getBlock(labelChannel).cursor();
+            BlockCursor predictionCursor = page.getBlock(predictionChannel).cursor();
+
+            while (labelCursor.advanceNextPosition()) {
+                checkState(predictionCursor.advanceNextPosition());
+                long predicted = predictionCursor.getLong();
+                long label = labelCursor.getLong();
+                checkArgument(predicted == 1 || predicted == 0, "evaluate_predictions only supports binary classifiers");
+                checkArgument(label == 1 || label == 0, "evaluate_predictions only supports binary classifiers");
+
+                if (label == 1) {
+                    if (predicted == 1) {
+                        truePositives++;
+                    }
+                    else {
+                        falseNegatives++;
+                    }
+                }
+                else {
+                    if (predicted == 0) {
+                        trueNegatives++;
+                    }
+                    else {
+                        falsePositives++;
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void addIntermediate(Block block)
+        {
+            BlockCursor cursor = block.cursor();
+            checkState(cursor.advanceNextPosition());
+            Slice slice = cursor.getSlice();
+            checkState(!cursor.advanceNextPosition());
+            truePositives += slice.getLong(0);
+            falsePositives += slice.getLong(SIZE_OF_LONG);
+            trueNegatives += slice.getLong(2 * SIZE_OF_LONG);
+            falseNegatives += slice.getLong(3 * SIZE_OF_LONG);
+        }
+
+        @Override
+        public Block evaluateIntermediate()
+        {
+            BlockBuilder builder = getIntermediateType().createBlockBuilder(new BlockBuilderStatus());
+            return builder.appendSlice(createIntermediate(truePositives, falsePositives, trueNegatives, falseNegatives)).build();
+        }
+
+        @Override
+        public Block evaluateFinal()
+        {
+            StringBuilder sb = new StringBuilder();
+            long correct = trueNegatives + truePositives;
+            long total = truePositives + trueNegatives + falsePositives + falseNegatives;
+            sb.append(String.format("Accuracy: %d/%d (%.2f%%)\n", correct, total, 100.0 * correct / (double) total));
+            sb.append(String.format("Precision: %d/%d (%.2f%%)\n", truePositives, truePositives + falsePositives, 100.0 * truePositives / (double) (truePositives + falsePositives)));
+            sb.append(String.format("Recall: %d/%d (%.2f%%)", truePositives, truePositives + falseNegatives, 100.0 * truePositives / (double) (truePositives + falseNegatives)));
+
+            BlockBuilder builder = getFinalType().createBlockBuilder(new BlockBuilderStatus());
+            builder.appendSlice(Slices.utf8Slice(sb.toString()));
+            return builder.build();
+        }
+    }
+
+    @Override
+    public GroupedAccumulator createGroupedAggregation(Optional<Integer> maskChannel, Optional<Integer> sampleWeight, double confidence, int... argumentChannels)
+    {
+        checkArgument(!maskChannel.isPresent(), "masking is not supported");
+        checkArgument(confidence == 1, "approximation is not supported");
+        checkArgument(!sampleWeight.isPresent(), "sample weight is not supported");
+        return new EvaluatePredictionsGroupedAccumulator(argumentChannels[0], argumentChannels[1]);
+    }
+
+    @Override
+    public GroupedAccumulator createGroupedIntermediateAggregation(double confidence)
+    {
+        checkArgument(confidence == 1, "approximation is not supported");
+        return new EvaluatePredictionsGroupedAccumulator(-1, -1);
+    }
+
+    public static class EvaluatePredictionsGroupedAccumulator
+            implements GroupedAccumulator
+    {
+        private final int labelChannel;
+        private final int predictionChannel;
+
+        private final LongBigArray truePositives = new LongBigArray();
+        private final LongBigArray falsePositives = new LongBigArray();
+        private final LongBigArray trueNegatives = new LongBigArray();
+        private final LongBigArray falseNegatives = new LongBigArray();
+
+        public EvaluatePredictionsGroupedAccumulator(int labelChannel, int predictionChannel)
+        {
+            this.labelChannel = labelChannel;
+            this.predictionChannel = predictionChannel;
+        }
+
+        @Override
+        public Type getFinalType()
+        {
+            return VARCHAR;
+        }
+
+        @Override
+        public Type getIntermediateType()
+        {
+            return VARCHAR;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return truePositives.sizeOf() + falsePositives.sizeOf() + trueNegatives.sizeOf() + falseNegatives.sizeOf();
+        }
+
+        @Override
+        public void addInput(GroupByIdBlock groupIdsBlock, Page page)
+        {
+            truePositives.ensureCapacity(groupIdsBlock.getGroupCount());
+            falsePositives.ensureCapacity(groupIdsBlock.getGroupCount());
+            trueNegatives.ensureCapacity(groupIdsBlock.getGroupCount());
+            falseNegatives.ensureCapacity(groupIdsBlock.getGroupCount());
+
+            BlockCursor labelCursor = page.getBlock(labelChannel).cursor();
+            BlockCursor predictionCursor = page.getBlock(predictionChannel).cursor();
+
+            for (int position = 0; position < groupIdsBlock.getPositionCount(); position++) {
+                long groupId = groupIdsBlock.getGroupId(position);
+                checkState(labelCursor.advanceNextPosition());
+                checkState(predictionCursor.advanceNextPosition());
+                long predicted = predictionCursor.getLong();
+                long label = labelCursor.getLong();
+                checkArgument(predicted == 1 || predicted == 0, "evaluate_predictions only supports binary classifiers");
+                checkArgument(label == 1 || label == 0, "evaluate_predictions only supports binary classifiers");
+
+                if (label == 1) {
+                    if (predicted == 1) {
+                        truePositives.increment(groupId);
+                    }
+                    else {
+                        falseNegatives.increment(groupId);
+                    }
+                }
+                else {
+                    if (predicted == 0) {
+                        trueNegatives.increment(groupId);
+                    }
+                    else {
+                        falsePositives.increment(groupId);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void addIntermediate(GroupByIdBlock groupIdsBlock, Block block)
+        {
+            truePositives.ensureCapacity(groupIdsBlock.getGroupCount());
+            falsePositives.ensureCapacity(groupIdsBlock.getGroupCount());
+            trueNegatives.ensureCapacity(groupIdsBlock.getGroupCount());
+            falseNegatives.ensureCapacity(groupIdsBlock.getGroupCount());
+
+            BlockCursor cursor = block.cursor();
+            for (int position = 0; position < groupIdsBlock.getPositionCount(); position++) {
+                checkState(cursor.advanceNextPosition());
+                long groupId = groupIdsBlock.getGroupId(position);
+                Slice slice = cursor.getSlice();
+                truePositives.add(groupId, slice.getLong(0));
+                falsePositives.add(groupId, slice.getLong(SIZE_OF_LONG));
+                trueNegatives.add(groupId, slice.getLong(2 * SIZE_OF_LONG));
+                falseNegatives.add(groupId, slice.getLong(3 * SIZE_OF_LONG));
+            }
+            checkState(!cursor.advanceNextPosition());
+        }
+
+        @Override
+        public void evaluateIntermediate(int groupId, BlockBuilder output)
+        {
+            output.appendSlice(createIntermediate(truePositives.get(groupId), falsePositives.get(groupId), trueNegatives.get(groupId), falseNegatives.get(groupId))).build();
+        }
+
+        @Override
+        public void evaluateFinal(int groupId, BlockBuilder output)
+        {
+            output.appendSlice(Slices.utf8Slice(formatResults(truePositives.get(groupId), falsePositives.get(groupId), trueNegatives.get(groupId), falseNegatives.get(groupId))));
+        }
+    }
+
+    public static String formatResults(long truePositives, long falsePositives, long trueNegatives, long falseNegatives)
+    {
+        StringBuilder sb = new StringBuilder();
+        long correct = trueNegatives + truePositives;
+        long total = truePositives + trueNegatives + falsePositives + falseNegatives;
+        sb.append(String.format("Accuracy: %d/%d (%.2f%%), ", correct, total, 100.0 * correct / (double) total));
+        sb.append(String.format("Precision: %d/%d (%.2f%%), ", truePositives, truePositives + falsePositives, 100.0 * truePositives / (double) (truePositives + falsePositives)));
+        sb.append(String.format("Recall: %d/%d (%.2f%%)", truePositives, truePositives + falseNegatives, 100.0 * truePositives / (double) (truePositives + falseNegatives)));
+        return sb.toString();
+    }
+
+    public static Slice createIntermediate(long truePositives, long falsePositives, long trueNegatives, long falseNegatives)
+    {
+        Slice slice = Slices.allocate(4 * SIZE_OF_LONG);
+        slice.setLong(0, truePositives);
+        slice.setLong(SIZE_OF_LONG, falsePositives);
+        slice.setLong(2 * SIZE_OF_LONG, trueNegatives);
+        slice.setLong(3 * SIZE_OF_LONG, falseNegatives);
+        return slice;
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/FeatureTransformation.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/FeatureTransformation.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+public interface FeatureTransformation
+    extends Model
+{
+    FeatureVector transform(FeatureVector features);
+
+    Dataset transform(Dataset dataset);
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/FeatureVector.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/FeatureVector.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSortedMap;
+
+import java.util.Map;
+import java.util.SortedMap;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+
+public class FeatureVector
+{
+    //TODO replace this with a more efficient data structure
+    private final SortedMap<Integer, Double> features;
+
+    @VisibleForTesting
+    public FeatureVector(int feature, double value)
+    {
+        this.features = ImmutableSortedMap.of(feature, value);
+    }
+
+    public FeatureVector(Map<Integer, Double> features)
+    {
+        this.features = ImmutableSortedMap.copyOf(features);
+    }
+
+    public SortedMap<Integer, Double> getFeatures()
+    {
+        return features;
+    }
+
+    public int size()
+    {
+        return features.size();
+    }
+
+    public long getEstimatedSize()
+    {
+        return (SIZE_OF_DOUBLE + SIZE_OF_INT + 3 * 3 * SIZE_OF_LONG) * (long) size();
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/FeatureVectorUnitNormalizer.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/FeatureVectorUnitNormalizer.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.facebook.presto.ml.type.ModelType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Normalizes features by making every feature vector unit length.
+ *
+ * NOTE: This is generally not a good way to normalize features, and is mainly provided as an example.
+ */
+public class FeatureVectorUnitNormalizer
+        extends AbstractFeatureTransformation
+{
+    @Override
+    public ModelType getType()
+    {
+        return ModelType.MODEL;
+    }
+
+    @Override
+    public byte[] getSerializedData()
+    {
+        // This transformation has no state
+        return new byte[0];
+    }
+
+    public static FeatureVectorUnitNormalizer deserialize(byte[] modelData)
+    {
+        checkArgument(modelData.length == 0, "modelData should be empty");
+        return new FeatureVectorUnitNormalizer();
+    }
+
+    @Override
+    public void train(Dataset dataset)
+    {
+        // Do nothing, since this transformation is stateless
+    }
+
+    @Override
+    public FeatureVector transform(FeatureVector features)
+    {
+        double sumSquares = 0;
+        for (Double value : features.getFeatures().values()) {
+            sumSquares += value * value;
+        }
+        double magnitude = Math.sqrt(sumSquares);
+        Map<Integer, Double> transformed = new HashMap<>();
+        for (Map.Entry<Integer, Double> entry : features.getFeatures().entrySet()) {
+            transformed.put(entry.getKey(), entry.getValue() / magnitude);
+        }
+        return new FeatureVector(transformed);
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/LearnAggregation.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/LearnAggregation.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.facebook.presto.operator.Page;
+import com.facebook.presto.operator.aggregation.Accumulator;
+import com.facebook.presto.operator.aggregation.AggregationFunction;
+import com.facebook.presto.operator.aggregation.GroupedAccumulator;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.BlockCursor;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.math.DoubleMath;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+
+public class LearnAggregation
+        implements AggregationFunction
+{
+    private final Type modelType;
+    private final Type labelType;
+
+    public LearnAggregation(Type modelType, Type labelType)
+    {
+        this.modelType = modelType;
+        this.labelType = labelType;
+    }
+
+    @Override
+    public List<Type> getParameterTypes()
+    {
+        return ImmutableList.of(labelType, VARCHAR);
+    }
+
+    @Override
+    public Type getFinalType()
+    {
+        return modelType;
+    }
+
+    @Override
+    public Type getIntermediateType()
+    {
+        throw new UnsupportedOperationException("LEARN must run on a single machine");
+    }
+
+    @Override
+    public boolean isDecomposable()
+    {
+        return false;
+    }
+
+    @Override
+    public Accumulator createAggregation(Optional<Integer> maskChannel, Optional<Integer> sampleWeight, double confidence, int... argumentChannels)
+    {
+        checkArgument(!maskChannel.isPresent(), "masking is not supported");
+        checkArgument(confidence == 1, "approximation is not supported");
+        checkArgument(!sampleWeight.isPresent(), "sample weight is not supported");
+        return new LearnAccumulator(argumentChannels[0], argumentChannels[1], labelType == BIGINT);
+    }
+
+    @Override
+    public Accumulator createIntermediateAggregation(double confidence)
+    {
+        throw new UnsupportedOperationException("LEARN must run on a single machine");
+    }
+
+    @Override
+    public GroupedAccumulator createGroupedAggregation(Optional<Integer> maskChannel, Optional<Integer> sampleWeight, double confidence, int... argumentChannels)
+    {
+        throw new UnsupportedOperationException("LEARN doesn't support GROUP BY");
+    }
+
+    @Override
+    public GroupedAccumulator createGroupedIntermediateAggregation(double confidence)
+    {
+        throw new UnsupportedOperationException("LEARN doesn't support GROUP BY");
+    }
+
+    public static class LearnAccumulator
+            implements Accumulator
+    {
+        private final int labelChannel;
+        private final int featuresChannel;
+        private final boolean labelIsLong;
+        //TODO: these could get very big, so they should be reported like the estimated memory for GroupedAccumulator
+        private final List<Double> labels = new ArrayList<>();
+        private final List<FeatureVector> rows = new ArrayList<>();
+
+        public LearnAccumulator(int labelChannel, int featuresChannel, boolean labelIsLong)
+        {
+            this.labelChannel = labelChannel;
+            this.featuresChannel = featuresChannel;
+            this.labelIsLong = labelIsLong;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            long size = SIZE_OF_DOUBLE * (long) labels.size();
+            for (FeatureVector vector : rows) {
+                size += vector.getEstimatedSize();
+            }
+            return size;
+        }
+
+        @Override
+        public Type getFinalType()
+        {
+            return VARCHAR;
+        }
+
+        @Override
+        public Type getIntermediateType()
+        {
+            throw new UnsupportedOperationException("LEARN must run on a single machine");
+        }
+
+        @Override
+        public void addInput(Page page)
+        {
+            BlockCursor cursor = page.getBlock(labelChannel).cursor();
+            while (cursor.advanceNextPosition()) {
+                if (labelIsLong) {
+                    labels.add((double) cursor.getLong());
+                }
+                else {
+                    labels.add(cursor.getDouble());
+                }
+            }
+
+            cursor = page.getBlock(featuresChannel).cursor();
+            while (cursor.advanceNextPosition()) {
+                rows.add(ModelUtils.jsonToFeatures(cursor.getSlice()));
+            }
+        }
+
+        @Override
+        public void addIntermediate(Block block)
+        {
+            throw new UnsupportedOperationException("LEARN must run on a single machine");
+        }
+
+        @Override
+        public Block evaluateIntermediate()
+        {
+            throw new UnsupportedOperationException("LEARN must run on a single machine");
+        }
+
+        @Override
+        public Block evaluateFinal()
+        {
+            Dataset dataset = new Dataset(labels, rows);
+
+            // Heuristic to decide if this is a classification or a regression problem
+            boolean regression = ImmutableSet.copyOf(labels).size() > 100;
+            for (double label : labels) {
+                if (!DoubleMath.isMathematicalInteger(label)) {
+                    regression = true;
+                    break;
+                }
+            }
+
+            Model model;
+
+            if (regression) {
+                model = new RegressorFeatureTransformer(new SvmRegressor(), new FeatureVectorUnitNormalizer());
+            }
+            else {
+                model = new ClassifierFeatureTransformer(new SvmClassifier(), new FeatureVectorUnitNormalizer());
+            }
+
+            model.train(dataset);
+
+            BlockBuilder builder = getFinalType().createBlockBuilder(new BlockBuilderStatus());
+            builder.appendSlice(ModelUtils.serialize(model));
+
+            return builder.build();
+        }
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/MLFunctionFactory.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/MLFunctionFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.facebook.presto.metadata.FunctionFactory;
+import com.facebook.presto.metadata.FunctionInfo;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.metadata.FunctionRegistry.FunctionListBuilder;
+import static com.facebook.presto.ml.type.ClassifierType.CLASSIFIER;
+import static com.facebook.presto.ml.type.RegressorType.REGRESSOR;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+
+public class MLFunctionFactory
+        implements FunctionFactory
+{
+    private static final List<FunctionInfo> FUNCTIONS = new FunctionListBuilder()
+            .aggregate("learn_classifier", CLASSIFIER, ImmutableList.of(BIGINT, VARCHAR), UNKNOWN, new LearnAggregation(CLASSIFIER, BIGINT))
+            .aggregate("learn_classifier", CLASSIFIER, ImmutableList.of(DOUBLE, VARCHAR), UNKNOWN, new LearnAggregation(CLASSIFIER, DOUBLE))
+            .aggregate("learn_regressor", REGRESSOR, ImmutableList.of(BIGINT, VARCHAR), UNKNOWN, new LearnAggregation(REGRESSOR, BIGINT))
+            .aggregate("learn_regressor", REGRESSOR, ImmutableList.of(DOUBLE, VARCHAR), UNKNOWN, new LearnAggregation(REGRESSOR, DOUBLE))
+            .aggregate("evaluate_classifier_predictions", VARCHAR, ImmutableList.of(BIGINT, BIGINT), UNKNOWN, new EvaluateClassifierPredictionsAggregation())
+            .scalar(MLFunctions.class)
+            .getFunctions();
+
+    @Override
+    public List<FunctionInfo> listFunctions()
+    {
+        return FUNCTIONS;
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/MLFunctions.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/MLFunctions.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.facebook.presto.ml.type.ClassifierType;
+import com.facebook.presto.ml.type.RegressorType;
+import com.facebook.presto.operator.scalar.ScalarFunction;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.type.SqlType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.hash.HashCode;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.facebook.presto.ml.type.ClassifierType.CLASSIFIER;
+import static com.facebook.presto.ml.type.RegressorType.REGRESSOR;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class MLFunctions
+{
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Cache<HashCode, Model> MODEL_CACHE = CacheBuilder.newBuilder().maximumSize(5).build();
+
+    private MLFunctions()
+    {
+    }
+
+    @ScalarFunction
+    @SqlType(BigintType.class)
+    public static long classify(@SqlType(VarcharType.class) Slice featuresMap, @SqlType(ClassifierType.class) Slice modelSlice)
+    {
+        FeatureVector features = ModelUtils.jsonToFeatures(featuresMap);
+        Model model = getOrLoadModel(modelSlice);
+        checkArgument(model instanceof Classifier && model.getType().equals(CLASSIFIER), "model is not a classifier");
+        return ((Classifier) model).classify(features);
+    }
+
+    @ScalarFunction
+    @SqlType(DoubleType.class)
+    public static double regress(@SqlType(VarcharType.class) Slice featuresMap, @SqlType(RegressorType.class) Slice modelSlice)
+    {
+        FeatureVector features = ModelUtils.jsonToFeatures(featuresMap);
+        Model model = getOrLoadModel(modelSlice);
+        checkArgument(model instanceof Regressor && model.getType().equals(REGRESSOR), "model is not a regressor");
+        return ((Regressor) model).regress(features);
+    }
+
+    private static Model getOrLoadModel(Slice slice)
+    {
+        HashCode modelHash = ModelUtils.modelHash(slice);
+
+        Model model = MODEL_CACHE.getIfPresent(modelHash);
+        if (model == null) {
+            model = ModelUtils.deserialize(slice);
+            MODEL_CACHE.put(modelHash, model);
+        }
+
+        return model;
+    }
+
+    @ScalarFunction
+    @SqlType(VarcharType.class)
+    public static Slice features(@SqlType(DoubleType.class) double f1)
+    {
+        return featuresHelper(f1);
+    }
+
+    @ScalarFunction
+    @SqlType(VarcharType.class)
+    public static Slice features(@SqlType(DoubleType.class) double f1, @SqlType(DoubleType.class) double f2)
+    {
+        return featuresHelper(f1, f2);
+    }
+
+    @ScalarFunction
+    @SqlType(VarcharType.class)
+    public static Slice features(@SqlType(DoubleType.class) double f1, @SqlType(DoubleType.class) double f2, @SqlType(DoubleType.class) double f3)
+    {
+        return featuresHelper(f1, f2, f3);
+    }
+
+    @ScalarFunction
+    @SqlType(VarcharType.class)
+    public static Slice features(@SqlType(DoubleType.class) double f1, @SqlType(DoubleType.class) double f2, @SqlType(DoubleType.class) double f3, @SqlType(DoubleType.class) double f4)
+    {
+        return featuresHelper(f1, f2, f3, f4);
+    }
+
+    @ScalarFunction
+    @SqlType(VarcharType.class)
+    public static Slice features(@SqlType(DoubleType.class) double f1, @SqlType(DoubleType.class) double f2, @SqlType(DoubleType.class) double f3, @SqlType(DoubleType.class) double f4, @SqlType(DoubleType.class) double f5)
+    {
+        return featuresHelper(f1, f2, f3, f4, f5);
+    }
+
+    @ScalarFunction
+    @SqlType(VarcharType.class)
+    public static Slice features(@SqlType(DoubleType.class) double f1, @SqlType(DoubleType.class) double f2, @SqlType(DoubleType.class) double f3, @SqlType(DoubleType.class) double f4, @SqlType(DoubleType.class) double f5, @SqlType(DoubleType.class) double f6)
+    {
+        return featuresHelper(f1, f2, f3, f4, f5, f6);
+    }
+
+    @ScalarFunction
+    @SqlType(VarcharType.class)
+    public static Slice features(@SqlType(DoubleType.class) double f1, @SqlType(DoubleType.class) double f2, @SqlType(DoubleType.class) double f3, @SqlType(DoubleType.class) double f4, @SqlType(DoubleType.class) double f5, @SqlType(DoubleType.class) double f6, @SqlType(DoubleType.class) double f7)
+    {
+        return featuresHelper(f1, f2, f3, f4, f5, f6, f7);
+    }
+
+    @ScalarFunction
+    @SqlType(VarcharType.class)
+    public static Slice features(@SqlType(DoubleType.class) double f1, @SqlType(DoubleType.class) double f2, @SqlType(DoubleType.class) double f3, @SqlType(DoubleType.class) double f4, @SqlType(DoubleType.class) double f5, @SqlType(DoubleType.class) double f6, @SqlType(DoubleType.class) double f7, @SqlType(DoubleType.class) double f8)
+    {
+        return featuresHelper(f1, f2, f3, f4, f5, f6, f7, f8);
+    }
+
+    @ScalarFunction
+    @SqlType(VarcharType.class)
+    public static Slice features(@SqlType(DoubleType.class) double f1, @SqlType(DoubleType.class) double f2, @SqlType(DoubleType.class) double f3, @SqlType(DoubleType.class) double f4, @SqlType(DoubleType.class) double f5, @SqlType(DoubleType.class) double f6, @SqlType(DoubleType.class) double f7, @SqlType(DoubleType.class) double f8, @SqlType(DoubleType.class) double f9)
+    {
+        return featuresHelper(f1, f2, f3, f4, f5, f6, f7, f8, f9);
+    }
+
+    @ScalarFunction
+    @SqlType(VarcharType.class)
+    public static Slice features(@SqlType(DoubleType.class) double f1, @SqlType(DoubleType.class) double f2, @SqlType(DoubleType.class) double f3, @SqlType(DoubleType.class) double f4, @SqlType(DoubleType.class) double f5, @SqlType(DoubleType.class) double f6, @SqlType(DoubleType.class) double f7, @SqlType(DoubleType.class) double f8, @SqlType(DoubleType.class) double f9, @SqlType(DoubleType.class) double f10)
+    {
+        return featuresHelper(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10);
+    }
+
+    private static Slice featuresHelper(double... features)
+    {
+        Map<Integer, Double> featureMap = new HashMap<>();
+
+        for (int i = 0; i < features.length; i++) {
+            featureMap.put(i, features[i]);
+        }
+
+        try {
+            return Slices.utf8Slice(OBJECT_MAPPER.writeValueAsString(featureMap));
+        }
+        catch (JsonProcessingException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/MLPlugin.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/MLPlugin.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.metadata.FunctionFactory;
+import com.facebook.presto.ml.type.ClassifierType;
+import com.facebook.presto.ml.type.ModelType;
+import com.facebook.presto.ml.type.RegressorType;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class MLPlugin
+        implements Plugin
+{
+    private Map<String, String> optionalConfig = ImmutableMap.of();
+
+    @Override
+    public synchronized void setOptionalConfig(Map<String, String> optionalConfig)
+    {
+        this.optionalConfig = ImmutableMap.copyOf(checkNotNull(optionalConfig, "optionalConfig is null"));
+    }
+
+    public synchronized Map<String, String> getOptionalConfig()
+    {
+        return optionalConfig;
+    }
+
+    @Inject
+    public void setBlockEncodingManager(BlockEncodingManager blockEncodingManager)
+    {
+        checkNotNull(blockEncodingManager, "blockEncodingManager is null");
+        blockEncodingManager.addBlockEncodingFactory(ModelType.BLOCK_ENCODING_FACTORY);
+        blockEncodingManager.addBlockEncodingFactory(ClassifierType.BLOCK_ENCODING_FACTORY);
+        blockEncodingManager.addBlockEncodingFactory(RegressorType.BLOCK_ENCODING_FACTORY);
+    }
+
+    @Override
+    public synchronized <T> List<T> getServices(Class<T> type)
+    {
+        if (type == FunctionFactory.class) {
+            return ImmutableList.of(type.cast(new MLFunctionFactory()));
+        }
+        else if (type == Type.class) {
+            return ImmutableList.of(type.cast(ModelType.MODEL), type.cast(ClassifierType.CLASSIFIER), type.cast(RegressorType.REGRESSOR));
+        }
+        return ImmutableList.of();
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/Model.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/Model.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.facebook.presto.ml.type.ModelType;
+
+public interface Model
+{
+    ModelType getType();
+
+    byte[] getSerializedData();
+
+    void train(Dataset dataset);
+
+    /**
+     * Models must also provide a public static deserialization method, which accepts a byte[] returned from getSerializedData
+     */
+    // TODO replace this with a ModelFactory interface
+    //static Model deserialize(byte[] data)
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/ModelUtils.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/ModelUtils.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.fasterxml.jackson.core.JsonFactory.Feature.CANONICALIZE_FIELD_NAMES;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static java.lang.String.format;
+
+public final class ModelUtils
+{
+    private static final JsonFactory JSON_FACTORY = new JsonFactory()
+            .disable(CANONICALIZE_FIELD_NAMES);
+
+    private static final int VERSION_OFFSET = 0;
+    private static final int HASH_OFFSET = VERSION_OFFSET + SIZE_OF_INT;
+    private static final int ALGORITHM_OFFSET = HASH_OFFSET + 32;
+    private static final int HYPERPARAMETER_LENGTH_OFFSET = ALGORITHM_OFFSET + SIZE_OF_INT;
+    private static final int HYPERPARAMETERS_OFFSET = HYPERPARAMETER_LENGTH_OFFSET +  SIZE_OF_INT;
+
+    private static final int CURRENT_FORMAT_VERSION = 1;
+
+    // These ids are serialized to disk. Do not change them.
+    @VisibleForTesting
+    static final BiMap<? extends Class<? extends Model>, Integer> MODEL_SERIALIZATION_IDS = ImmutableBiMap.of(
+            SvmClassifier.class, 1,
+            SvmRegressor.class, 2,
+            FeatureVectorUnitNormalizer.class, 3,
+            ClassifierFeatureTransformer.class, 4,
+            RegressorFeatureTransformer.class, 5);
+
+    private ModelUtils()
+    {
+    }
+
+    /**
+     * Serializes the model using the following format
+     * int: format version
+     * byte[32]: SHA256 hash of all following data
+     * int: id of algorithm
+     * int: length of hyperparameters section
+     * byte[]: hyperparameters (currently not used)
+     * long: length of data section
+     * byte[]: model data
+     *
+     * note: all multibyte values are in little endian
+     */
+    public static Slice serialize(Model model)
+    {
+        checkNotNull(model, "model is null");
+        Integer id = MODEL_SERIALIZATION_IDS.get(model.getClass());
+        checkNotNull(id, "id is null");
+        int size = HYPERPARAMETERS_OFFSET;
+
+        // hyperparameters aren't implemented yet
+        byte[] hyperparameters = new byte[0];
+        size += hyperparameters.length;
+
+        int dataLengthOffset = size;
+        size += SIZE_OF_LONG;
+        int dataOffset = size;
+        byte[] data = model.getSerializedData();
+        size += data.length;
+
+        Slice slice = Slices.allocate(size);
+        slice.setInt(VERSION_OFFSET, CURRENT_FORMAT_VERSION);
+        slice.setInt(ALGORITHM_OFFSET, id);
+        slice.setInt(HYPERPARAMETER_LENGTH_OFFSET, hyperparameters.length);
+        slice.setBytes(HYPERPARAMETERS_OFFSET, hyperparameters);
+        slice.setLong(dataLengthOffset, data.length);
+        slice.setBytes(dataOffset, data);
+
+        byte[] modelHash = Hashing.sha256().hashBytes(slice.getBytes(ALGORITHM_OFFSET, slice.length() - ALGORITHM_OFFSET)).asBytes();
+        checkState(modelHash.length == 32, "sha256 hash code expected to be 32 bytes");
+        slice.setBytes(HASH_OFFSET, modelHash);
+
+        return slice;
+    }
+
+    public static HashCode modelHash(Slice slice)
+    {
+        return HashCode.fromBytes(slice.getBytes(HASH_OFFSET, 32));
+    }
+
+    public static Model deserialize(byte[] data)
+    {
+        return deserialize(Slices.wrappedBuffer(data));
+    }
+
+    public static Model deserialize(Slice slice)
+    {
+        int version = slice.getInt(VERSION_OFFSET);
+        checkArgument(version == CURRENT_FORMAT_VERSION, format("Unsupported version: %d", version));
+
+        byte[] modelHashBytes = slice.getBytes(HASH_OFFSET, 32);
+        HashCode expectedHash = HashCode.fromBytes(modelHashBytes);
+        HashCode actualHash = Hashing.sha256().hashBytes(slice.getBytes(ALGORITHM_OFFSET, slice.length() - ALGORITHM_OFFSET));
+        checkArgument(actualHash.equals(expectedHash), "model hash does not match data");
+
+        int id = slice.getInt(ALGORITHM_OFFSET);
+        Class<? extends Model> algorithm = MODEL_SERIALIZATION_IDS.inverse().get(id);
+        checkNotNull(algorithm, "Unsupported algorith %d", id);
+
+        int hyperparameterLength = slice.getInt(HYPERPARAMETER_LENGTH_OFFSET);
+
+        byte[] hyperparameterBytes = slice.getBytes(HYPERPARAMETERS_OFFSET, hyperparameterLength);
+
+        int dataLengthOffset = HYPERPARAMETERS_OFFSET + hyperparameterLength;
+        long dataLength = slice.getLong(dataLengthOffset);
+
+        int dataOffset = dataLengthOffset + SIZE_OF_LONG;
+        byte[] data = slice.getBytes(dataOffset, (int) dataLength);
+
+        try {
+            Method deserialize = algorithm.getMethod("deserialize", byte[].class);
+            return (Model) deserialize.invoke(null, new Object[] {data});
+        }
+        catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    public static byte[] serializeModels(Model...models)
+    {
+        List<byte[]> serializedModels = new ArrayList<>();
+        int size = SIZE_OF_INT + SIZE_OF_INT * models.length;
+
+        for (Model model : models) {
+            byte[] bytes = serialize(model).getBytes();
+            size += bytes.length;
+            serializedModels.add(bytes);
+        }
+
+        Slice slice = Slices.allocate(size);
+        slice.setInt(0, models.length);
+        for (int i = 0; i < models.length; i++) {
+            slice.setInt(SIZE_OF_INT * (i + 1), serializedModels.get(i).length);
+        }
+
+        int offset = SIZE_OF_INT + SIZE_OF_INT * models.length;
+        for (byte[] bytes : serializedModels) {
+            slice.setBytes(offset, bytes);
+            offset += bytes.length;
+        }
+
+        return slice.getBytes();
+    }
+
+    public static List<Model> deserializeModels(byte[] bytes)
+    {
+        Slice slice = Slices.wrappedBuffer(bytes);
+        int numModels = slice.getInt(0);
+
+        int offset = SIZE_OF_INT + SIZE_OF_INT * numModels;
+        ImmutableList.Builder<Model> models = ImmutableList.builder();
+        for (int i = 0; i < numModels; i++) {
+            int length = slice.getInt(SIZE_OF_INT * (i + 1));
+            models.add(deserialize(slice.getBytes(offset, length)));
+            offset += length;
+        }
+
+        return models.build();
+    }
+
+    //TODO: instead of having this function, we should add feature extractors that extend Model and extract features from Strings
+    public static FeatureVector jsonToFeatures(Slice json)
+    {
+        Map<Integer, Double> features = new HashMap<>();
+        try (JsonParser parser = JSON_FACTORY.createJsonParser(json.getInput())) {
+            if (parser.nextToken() != JsonToken.START_OBJECT) {
+                throw new RuntimeException("Bad row. Expected a json object");
+            }
+
+            while (true) {
+                JsonToken token = parser.nextValue();
+                if (token == null) {
+                    throw new RuntimeException("Bad row. Expected a json object");
+                }
+                if (token == JsonToken.END_OBJECT) {
+                    break;
+                }
+                int key = Integer.parseInt(parser.getCurrentName());
+                double value = parser.getDoubleValue();
+                features.put(key, value);
+            }
+        }
+        catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+        catch (RuntimeException e) {
+            throw new RuntimeException(format("Bad features: %s", json.toStringUtf8()), e);
+        }
+
+        return new FeatureVector(features);
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/Regressor.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/Regressor.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+public interface Regressor
+        extends Model
+{
+    double regress(FeatureVector features);
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/RegressorFeatureTransformer.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/RegressorFeatureTransformer.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.facebook.presto.ml.type.ModelType;
+import com.facebook.presto.ml.type.RegressorType;
+
+import java.util.List;
+
+import static com.facebook.presto.util.Types.checkType;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class RegressorFeatureTransformer
+        implements Regressor
+{
+    private final Regressor regressor;
+    private final FeatureTransformation transformation;
+
+    public RegressorFeatureTransformer(Regressor regressor, FeatureTransformation transformation)
+    {
+        this.regressor = checkNotNull(regressor, "regressor is null");
+        this.transformation = checkNotNull(transformation, "transformation is null");
+    }
+
+    @Override
+    public ModelType getType()
+    {
+        return RegressorType.REGRESSOR;
+    }
+
+    @Override
+    public byte[] getSerializedData()
+    {
+        return ModelUtils.serializeModels(regressor, transformation);
+    }
+
+    public static RegressorFeatureTransformer deserialize(byte[] data)
+    {
+        List<Model> models = ModelUtils.deserializeModels(data);
+
+        return new RegressorFeatureTransformer(checkType(models.get(0), Regressor.class, "model 0"), checkType(models.get(1), FeatureTransformation.class, "model 1"));
+    }
+
+    @Override
+    public double regress(FeatureVector features)
+    {
+        return regressor.regress(transformation.transform(features));
+    }
+
+    @Override
+    public void train(Dataset dataset)
+    {
+        transformation.train(dataset);
+        regressor.train(transformation.transform(dataset));
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/SvmClassifier.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/SvmClassifier.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.facebook.presto.ml.type.ModelType;
+import com.google.common.base.Throwables;
+import libsvm.svm;
+import libsvm.svm_model;
+import libsvm.svm_parameter;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import static com.facebook.presto.ml.type.ClassifierType.CLASSIFIER;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class SvmClassifier
+        extends AbstractSvmModel
+        implements Classifier
+{
+    public SvmClassifier()
+    {
+    }
+
+    private SvmClassifier(svm_model model)
+    {
+        super(model);
+    }
+
+    public static SvmClassifier deserialize(byte[] modelData)
+    {
+        // TODO do something with the hyperparameters
+        try {
+            svm_model model = svm.svm_load_model(new BufferedReader(new InputStreamReader(new ByteArrayInputStream(modelData))));
+            return new SvmClassifier(model);
+        }
+        catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public int classify(FeatureVector features)
+    {
+        checkNotNull(model, "model is null");
+        return (int) svm.svm_predict(model, toSvmNodes(features));
+    }
+
+    @Override
+    public ModelType getType()
+    {
+        return CLASSIFIER;
+    }
+
+    @Override
+    protected int getLibsvmType()
+    {
+        return svm_parameter.C_SVC;
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/SvmRegressor.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/SvmRegressor.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import com.facebook.presto.ml.type.ModelType;
+import com.google.common.base.Throwables;
+import libsvm.svm;
+import libsvm.svm_model;
+import libsvm.svm_parameter;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import static com.facebook.presto.ml.type.RegressorType.REGRESSOR;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class SvmRegressor
+        extends AbstractSvmModel
+        implements Regressor
+{
+    public SvmRegressor()
+    {
+    }
+
+    private SvmRegressor(svm_model model)
+    {
+        super(model);
+    }
+
+    public static SvmRegressor deserialize(byte[] modelData)
+    {
+        // TODO do something with the hyperparameters
+        try {
+            svm_model model = svm.svm_load_model(new BufferedReader(new InputStreamReader(new ByteArrayInputStream(modelData))));
+            return new SvmRegressor(model);
+        }
+        catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public double regress(FeatureVector features)
+    {
+        checkNotNull(model, "model is null");
+        return svm.svm_predict(model, toSvmNodes(features));
+    }
+
+    @Override
+    public ModelType getType()
+    {
+        return REGRESSOR;
+    }
+
+    @Override
+    protected int getLibsvmType()
+    {
+        return svm_parameter.NU_SVR;
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/type/ClassifierType.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/type/ClassifierType.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml.type;
+
+import com.facebook.presto.spi.block.BlockEncodingFactory;
+import com.facebook.presto.spi.block.VariableWidthBlockEncoding;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+// Layout is <size>:<model>, where
+//   size: is an int describing the length of the model bytes
+//   model: is the serialized model
+public class ClassifierType
+        extends ModelType
+{
+    public static final ClassifierType CLASSIFIER = new ClassifierType();
+
+    public static final BlockEncodingFactory<?> BLOCK_ENCODING_FACTORY = new VariableWidthBlockEncoding.VariableWidthBlockEncodingFactory(CLASSIFIER);
+
+    @JsonCreator
+    public ClassifierType()
+    {
+    }
+
+    public static ClassifierType getInstance()
+    {
+        return CLASSIFIER;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "Classifier";
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/type/ModelType.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/type/ModelType.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml.type;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.BlockCursor;
+import com.facebook.presto.spi.block.BlockEncodingFactory;
+import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
+import com.facebook.presto.spi.block.VariableWidthBlockEncoding;
+import com.facebook.presto.spi.type.VariableWidthType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+
+// Layout is <size>:<model>, where
+//   size: is an int describing the length of the model bytes
+//   model: is the serialized model
+public class ModelType
+        implements VariableWidthType
+{
+    public static final ModelType MODEL = new ModelType();
+
+    public static final BlockEncodingFactory<?> BLOCK_ENCODING_FACTORY = new VariableWidthBlockEncoding.VariableWidthBlockEncodingFactory(MODEL);
+
+    @JsonCreator
+    public ModelType()
+    {
+    }
+
+    public static ModelType getInstance()
+    {
+        return MODEL;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "Model";
+    }
+
+    @Override
+    public Class<?> getJavaType()
+    {
+        return Slice.class;
+    }
+
+    @Override
+    public int getLength(Slice slice, int offset)
+    {
+        return getValueSize(slice, offset) + SIZE_OF_INT;
+    }
+
+    @Override
+    public Slice getSlice(Slice slice, int offset)
+    {
+        return slice.slice(offset + SIZE_OF_INT, getValueSize(slice, offset));
+    }
+
+    @Override
+    public int writeSlice(SliceOutput sliceOutput, Slice value, int offset, int length)
+    {
+        sliceOutput.writeInt(length);
+        sliceOutput.writeBytes(value, offset, length);
+        return length + SIZE_OF_INT;
+    }
+
+    @Override
+    public boolean equalTo(Slice leftSlice, int leftOffset, Slice rightSlice, int rightOffset)
+    {
+        throw new UnsupportedOperationException(String.format("%s type is not comparable", getName()));
+    }
+
+    @Override
+    public boolean equalTo(Slice leftSlice, int leftOffset, BlockCursor rightCursor)
+    {
+        throw new UnsupportedOperationException(String.format("%s type is not comparable", getName()));
+    }
+
+    @Override
+    public int hash(Slice slice, int offset)
+    {
+        throw new UnsupportedOperationException(String.format("%s type is not comparable", getName()));
+    }
+
+    @Override
+    public int compareTo(Slice leftSlice, int leftOffset, Slice rightSlice, int rightOffset)
+    {
+        throw new UnsupportedOperationException(String.format("%s type is not ordered", getName()));
+    }
+
+    @Override
+    public void appendTo(Slice slice, int offset, BlockBuilder blockBuilder)
+    {
+        int length = getValueSize(slice, offset);
+        blockBuilder.appendSlice(slice, offset + SIZE_OF_INT, length);
+    }
+
+    @Override
+    public void appendTo(Slice slice, int offset, SliceOutput sliceOutput)
+    {
+        // copy full value including length
+        int length = getLength(slice, offset);
+        sliceOutput.writeBytes(slice, offset, length);
+    }
+
+    @Override
+    public Object getObjectValue(ConnectorSession session, Slice slice, int offset)
+    {
+        return String.format("<%s>", getName());
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus)
+    {
+        return new VariableWidthBlockBuilder(this, blockBuilderStatus);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getClass().hashCode();
+    }
+
+    private static int getValueSize(Slice slice, int offset)
+    {
+        return slice.getInt(offset);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getName();
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/type/RegressorType.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/type/RegressorType.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml.type;
+
+import com.facebook.presto.spi.block.BlockEncodingFactory;
+import com.facebook.presto.spi.block.VariableWidthBlockEncoding;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+// Layout is <size>:<model>, where
+//   size: is an int describing the length of the model bytes
+//   model: is the serialized model
+public class RegressorType
+        extends ModelType
+{
+    public static final RegressorType REGRESSOR = new RegressorType();
+
+    public static final BlockEncodingFactory<?> BLOCK_ENCODING_FACTORY = new VariableWidthBlockEncoding.VariableWidthBlockEncodingFactory(REGRESSOR);
+
+    @JsonCreator
+    public RegressorType()
+    {
+    }
+
+    public static RegressorType getInstance()
+    {
+        return REGRESSOR;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "Regressor";
+    }
+}

--- a/presto-ml/src/main/resources/META-INF/services/com.facebook.presto.spi.Plugin
+++ b/presto-ml/src/main/resources/META-INF/services/com.facebook.presto.spi.Plugin
@@ -1,0 +1,1 @@
+com.facebook.presto.ml.MLPlugin

--- a/presto-ml/src/test/java/com/facebook/presto/ml/TestModelSerialization.java
+++ b/presto-ml/src/test/java/com/facebook/presto/ml/TestModelSerialization.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ml;
+
+import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestModelSerialization
+{
+    @Test
+    public void testSvmClassifier()
+    {
+        Model model = new SvmClassifier();
+        model.train(getDataset());
+        Slice serialized = ModelUtils.serialize(model);
+        Model deserialized = ModelUtils.deserialize(serialized);
+        assertNotNull(deserialized, "deserialization failed");
+        assertTrue(deserialized instanceof SvmClassifier, "deserialized model is not a svm");
+    }
+
+    @Test
+    public void testSvmRegressor()
+    {
+        Model model = new SvmRegressor();
+        model.train(getDataset());
+        Slice serialized = ModelUtils.serialize(model);
+        Model deserialized = ModelUtils.deserialize(serialized);
+        assertNotNull(deserialized, "deserialization failed");
+        assertTrue(deserialized instanceof SvmRegressor, "deserialized model is not a svm");
+    }
+
+    @Test
+    public void testRegressorFeatureTransformer()
+    {
+        Model model = new RegressorFeatureTransformer(new SvmRegressor(), new FeatureVectorUnitNormalizer());
+        model.train(getDataset());
+        Slice serialized = ModelUtils.serialize(model);
+        Model deserialized = ModelUtils.deserialize(serialized);
+        assertNotNull(deserialized, "deserialization failed");
+        assertTrue(deserialized instanceof RegressorFeatureTransformer, "deserialized model is not a regressor feature transformer");
+    }
+
+    @Test
+    public void testClassifierFeatureTransformer()
+    {
+        Model model = new ClassifierFeatureTransformer(new SvmClassifier(), new FeatureVectorUnitNormalizer());
+        model.train(getDataset());
+        Slice serialized = ModelUtils.serialize(model);
+        Model deserialized = ModelUtils.deserialize(serialized);
+        assertNotNull(deserialized, "deserialization failed");
+        assertTrue(deserialized instanceof ClassifierFeatureTransformer, "deserialized model is not a classifier feature transformer");
+    }
+
+    @Test
+    public void testSerializationIds()
+    {
+        assertEquals((int) ModelUtils.MODEL_SERIALIZATION_IDS.get(SvmClassifier.class), 1);
+        assertEquals((int) ModelUtils.MODEL_SERIALIZATION_IDS.get(SvmRegressor.class), 2);
+        assertEquals((int) ModelUtils.MODEL_SERIALIZATION_IDS.get(FeatureVectorUnitNormalizer.class), 3);
+        assertEquals((int) ModelUtils.MODEL_SERIALIZATION_IDS.get(ClassifierFeatureTransformer.class), 4);
+        assertEquals((int) ModelUtils.MODEL_SERIALIZATION_IDS.get(RegressorFeatureTransformer.class), 5);
+    }
+
+    private static Dataset getDataset()
+    {
+        int datapoints = 100;
+        List<Double> labels = new ArrayList<>();
+        List<FeatureVector> features = new ArrayList<>();
+        Random rand = new Random(0);
+        for (int i = 0; i < datapoints; i++) {
+            double label = rand.nextDouble() < 0.5 ? 0 : 1;
+            labels.add(label);
+            features.add(new FeatureVector(0, label + rand.nextGaussian()));
+        }
+
+        return new Dataset(labels, features);
+    }
+}


### PR DESCRIPTION
Add functions to train and use machine learning models (classifiers and
regressors) in Presto. This is currently only a proof of concept, and is
not ready for use in production. Example usage is as follows:

``` sql
SELECT evaluate_classifier_predictions(label, classify(features, model))
FROM (
    SELECT learn_classifier(label, features) AS model
    FROM my_training_data;
)
CROSS JOIN my_validation_data;
```
