### PR TITLE
#1286. Support sample node in explain statement

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
@@ -42,6 +42,7 @@ import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SinkNode;
 import com.facebook.presto.sql.planner.plan.SortNode;
@@ -447,6 +448,14 @@ public class PlanPrinter
             print(indent, "- TableCommit[%s] => [%s]", node.getTarget(), formatOutputs(node.getOutputSymbols()));
 
             return processChildren(node, indent + 1);
+        }
+
+        @Override
+        public Void visitSample(SampleNode node, Integer indent)
+        {
+          print(indent, "- Sample[%s] => [%s]", node.getSampleRatio(), formatOutputs(node.getOutputSymbols()));
+
+          return processChildren(node, indent + 1);
         }
 
         @Override


### PR DESCRIPTION
After the fix:

```
presto:default> explain select * from nation tablesample system(50);
                                                                    Query Plan                                                         
---------------------------------------------------------------------------------------------------------------------------------------
 - Output[n_nationkey, n_name, n_regionkey, n_comment]                                                                                 
         n_nationkey := n                                                                                                              
         n_name := n_1                                                                                                                 
         n_regionkey := n_2                                                                                                            
         n_comment := n_3                                                                                                              
     - Sample[0.5] => [n:bigint, n_1:varchar, n_2:bigint, n_3:varchar]                                                                 
         - TableScan[hive:default:nation, original constraint=true] => [n:bigint, n_1:varchar, n_2:bigint, n_3:varchar]                
                 n := HiveColumnHandle{clientId=hive, name=n_nationkey, ordinalPosition=0, hiveType=INT, hiveColumnIndex=0, partitionKe
                 n_1 := HiveColumnHandle{clientId=hive, name=n_name, ordinalPosition=1, hiveType=STRING, hiveColumnIndex=1, partitionKe
                 n_2 := HiveColumnHandle{clientId=hive, name=n_regionkey, ordinalPosition=2, hiveType=INT, hiveColumnIndex=2, partition
                 n_3 := HiveColumnHandle{clientId=hive, name=n_comment, ordinalPosition=3, hiveType=STRING, hiveColumnIndex=3, partitio

(1 row)
```

Are there any explain unit tests I can add this to? Couldn't find any.
