### PR TITLE
Add parameter to make AsyncWalker recursing partition directory configurable

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
@@ -164,6 +164,7 @@ public class HiveClient
     private final DataSize maxSplitSize;
     private final DataSize maxInitialSplitSize;
     private final int maxInitialSplits;
+    private final boolean recursiveDirWalkerEnabled = true;
 
     @Inject
     public HiveClient(HiveConnectorId connectorId,
@@ -890,7 +891,8 @@ public class HiveClient
                 maxPartitionBatchSize,
                 hiveTableHandle.getSession(),
                 maxInitialSplitSize,
-                maxInitialSplits).get();
+                maxInitialSplits,
+                recursiveDirWalkerEnabled).get();
     }
 
     private Iterable<Partition> getPartitions(final Table table, final SchemaTableName tableName, List<String> partitionNames)


### PR DESCRIPTION
Found different behavior between Hive and Presto:
if we have:

/table/partition/file1
/table/partition/directory/file2

and the hive metastore points partition to /table/partition

Hive will process only /table/partition/file1

While, Presto will recursively processing all files in any subdirectories, it will process both file1 and file2

This is to make AsyncWalker configurable on whether recursing partition directory or not.
