### PR TITLE
Session carries arbitrary optional key value pairs

### DIFF
--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
@@ -15,6 +15,7 @@ package com.facebook.presto.cli;
 
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -80,6 +81,15 @@ public class TestClientOptions
         ClientOptions options = new ClientOptions();
         options.server = "x:y";
         options.toClientSession();
+    }
+
+    @Test
+    public void testExtraOptions()
+    {
+        ClientOptions options = new ClientOptions();
+        options.options = "name1:value1,name2:value2";
+        ClientSession session = options.toClientSession();
+        assertEquals(session.getOptions(), ImmutableMap.<String, String>of("name1", "value1", "name2", "value2"));
     }
 
     @Test

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.client;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
 
 import java.net.URI;
+import java.util.Map;
 import java.util.Locale;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -29,6 +31,7 @@ public class ClientSession
     private final String schema;
     private final String timeZoneId;
     private final Locale locale;
+    private final Map<String, String> options;
     private final boolean debug;
 
     public static ClientSession withCatalog(ClientSession session, String catalog)
@@ -41,6 +44,7 @@ public class ClientSession
                 session.getSchema(),
                 session.getTimeZoneId(),
                 session.getLocale(),
+                session.getOptions(),
                 session.isDebug());
     }
 
@@ -54,10 +58,16 @@ public class ClientSession
                 schema,
                 session.getTimeZoneId(),
                 session.getLocale(),
+                session.getOptions(),
                 session.isDebug());
     }
 
     public ClientSession(URI server, String user, String source, String catalog, String schema, String timeZoneId, Locale locale, boolean debug)
+    {
+        this(server, user, source, catalog, schema, timeZoneId, locale, ImmutableMap.<String, String>of(), debug);
+    }
+
+    public ClientSession(URI server, String user, String source, String catalog, String schema, String timeZoneId, Locale locale, Map<String, String> options, boolean debug)
     {
         this.server = checkNotNull(server, "server is null");
         this.user = user;
@@ -67,6 +77,7 @@ public class ClientSession
         this.locale = locale;
         this.timeZoneId = checkNotNull(timeZoneId, "timeZoneId is null");
         this.debug = debug;
+        this.options = checkNotNull(options, "options is null");
     }
 
     public URI getServer()
@@ -109,6 +120,11 @@ public class ClientSession
         return debug;
     }
 
+    public Map<String, String> getOptions()
+    {
+        return ImmutableMap.copyOf(options);
+    }
+
     @Override
     public String toString()
     {
@@ -120,6 +136,7 @@ public class ClientSession
                 .add("timeZone", timeZoneId)
                 .add("locale", locale)
                 .add("debug", debug)
+                .add("options", options)
                 .toString();
     }
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -28,5 +28,7 @@ public final class PrestoHeaders
     public static final String PRESTO_PAGE_TOKEN = "X-Presto-Page-Sequence-Id";
     public static final String PRESTO_PAGE_NEXT_TOKEN = "X-Presto-Page-End-Sequence-Id";
 
+    public static final String PRESTO_OPTION_PREFIX = "X-Presto-Option-";
+
     private PrestoHeaders() {}
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -27,6 +27,7 @@ import java.io.Closeable;
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -103,6 +104,11 @@ public class StatementClient
         builder.setHeader(PrestoHeaders.PRESTO_TIME_ZONE, session.getTimeZoneId());
         builder.setHeader(PrestoHeaders.PRESTO_LANGUAGE, session.getLocale().toLanguageTag());
         builder.setHeader(USER_AGENT, USER_AGENT_VALUE);
+
+        Map<String, String> options = session.getOptions();
+        for (String name : options.keySet()) {
+            builder.setHeader(PrestoHeaders.PRESTO_OPTION_PREFIX + name, options.get(name));
+        }
 
         return builder.build();
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestJsonHiveHandles.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestJsonHiveHandles.java
@@ -46,6 +46,7 @@ public class TestJsonHiveHandles
                     .put("timeZoneKey", (int) SESSION.getTimeZoneKey().getKey())
                     .put("locale", SESSION.getLocale().toString())
                     .put("startTime", SESSION.getStartTime())
+                    .put("options", SESSION.getOptions())
                     .build());
 
     private static final Map<String, Object> COLUMN_HANDLE_AS_MAP = ImmutableMap.<String, Object>builder()

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestJsonTableHandle.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestJsonTableHandle.java
@@ -76,6 +76,7 @@ public class TestJsonTableHandle
                     .put("timeZoneKey", (int) SESSION.getTimeZoneKey().getKey())
                     .put("locale", SESSION.getLocale().toString())
                     .put("startTime", SESSION.getStartTime())
+                    .put("options", SESSION.getOptions())
                     .build(),
             "catalogName", "information_schema_catalog",
             "schemaName", "information_schema_schema",

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -17,7 +17,9 @@ import com.facebook.presto.spi.type.TimeZoneKey;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,10 +34,21 @@ public class ConnectorSession
     private final String catalog;
     private final String schema;
     private final long startTime;
+    private final Map<String, String> options;
 
     public ConnectorSession(String user, String source, String catalog, String schema, TimeZoneKey timeZoneKey, Locale locale, String remoteUserAddress, String userAgent)
     {
         this(user, source, catalog, schema, timeZoneKey, locale, remoteUserAddress, userAgent, System.currentTimeMillis());
+    }
+
+    public ConnectorSession(String user, String source, String catalog, String schema, TimeZoneKey timeZoneKey, Locale locale, String remoteUserAddress, String userAgent, Map<String, String> options)
+    {
+        this(user, source, catalog, schema, timeZoneKey, locale, remoteUserAddress, userAgent, System.currentTimeMillis(), options);
+    }
+
+    public ConnectorSession(String user, String source, String catalog, String schema, TimeZoneKey timeZoneKey, Locale locale, String remoteUserAddress, String userAgent, long startTime)
+    {
+        this(user, source, catalog, schema, timeZoneKey, locale, remoteUserAddress, userAgent, startTime, new HashMap<String, String>());
     }
 
     @JsonCreator
@@ -48,7 +61,8 @@ public class ConnectorSession
             @JsonProperty("locale") Locale locale,
             @JsonProperty("remoteUserAddress") String remoteUserAddress,
             @JsonProperty("userAgent") String userAgent,
-            @JsonProperty("startTime") long startTime)
+            @JsonProperty("startTime") long startTime,
+            @JsonProperty("options") Map<String, String> options)
     {
         this.user = user;
         this.source = source;
@@ -59,6 +73,7 @@ public class ConnectorSession
         this.remoteUserAddress = remoteUserAddress;
         this.userAgent = userAgent;
         this.startTime = startTime;
+        this.options = options;
     }
 
     @JsonProperty
@@ -123,6 +138,12 @@ public class ConnectorSession
         return startTime;
     }
 
+    @JsonProperty
+    public Map<String, String> getOptions()
+    {
+        return options;
+    }
+
     @Override
     public String toString()
     {
@@ -136,6 +157,7 @@ public class ConnectorSession
         builder.append(", timeZoneKey=").append(timeZoneKey);
         builder.append(", locale=").append(locale);
         builder.append(", startTime=").append(startTime);
+        builder.append(", options='").append(options.toString()).append('\'');
         builder.append('}');
         return builder.toString();
     }


### PR DESCRIPTION
After Presto-0.66, ConnectorSession is under the api project and transparent between a client and plugin. This was exciting improvement so that a plugin can act differently based on ConnectorSession, it means based on User.

Base on that, we might also want to pass arbitrary optional values to a plugin for various purpose. For example, we might want to pass additional user properties, price plan, a secure token or a metadata information etc, more than the user identity. Sure a plugin might fetch additional information from the user identity, but there would be a security issue and it would not easy to shared these information between the coordinator and the workers.

As 'x-amz-meta-_' http header does in Amazon S3 access, if Presto can send optional values as a form of HTTP header with 'X-Presto-Option-_' and store onto the ConnectorSession, a plugin should have more fine grained control with addition values.

At the presto-cli, we could specify them with new command line option, 

```
./presto-cli --catalog=tpch --schema=tpch --user=userid --options=name1:value1,name2:value2"
```

One minor thing we should keep in mind is HTTP header name must be case insensitive. So name1 and NAME1 will be treated same and stored as lower case at the ConnectorSession.
