### PR TITLE
Fix parallel test failure

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -43,7 +43,6 @@ import static org.joda.time.Weeks.weeksBetween;
 import static org.joda.time.Years.yearsBetween;
 import static org.testng.Assert.assertEquals;
 
-@Test(singleThreaded = true)
 public class TestDateTimeFunctions
 {
     private static final TimeZoneKey TIME_ZONE_KEY = getTimeZoneKey("Asia/Kathmandu");
@@ -619,31 +618,31 @@ public class TestDateTimeFunctions
     public void testLocale()
     {
         Locale locale = Locale.JAPANESE;
-        session = new ConnectorSession("user", "test", "catalog", "schema", TIME_ZONE_KEY, locale, null, null);
+        ConnectorSession localeSession = new ConnectorSession("user", "test", "catalog", "schema", TIME_ZONE_KEY, locale, null, null);
 
-        functionAssertions = new FunctionAssertions(session);
+        FunctionAssertions localeAssertions = new FunctionAssertions(localeSession);
 
         String dateTimeLiteral = "TIMESTAMP '2001-01-09 13:04:05.321'";
 
-        assertFunction("date_format(" + dateTimeLiteral + ", '%a')", "火");
-        assertFunction("date_format(" + dateTimeLiteral + ", '%W')", "火曜日");
-        assertFunction("date_format(" + dateTimeLiteral + ", '%p')", "午後");
-        assertFunction("date_format(" + dateTimeLiteral + ", '%r')", "01:04:05 午後");
-        assertFunction("date_format(" + dateTimeLiteral + ", '%b')", "1");
-        assertFunction("date_format(" + dateTimeLiteral + ", '%M')", "1月");
+        localeAssertions.assertFunction("date_format(" + dateTimeLiteral + ", '%a')", "火");
+        localeAssertions.assertFunction("date_format(" + dateTimeLiteral + ", '%W')", "火曜日");
+        localeAssertions.assertFunction("date_format(" + dateTimeLiteral + ", '%p')", "午後");
+        localeAssertions.assertFunction("date_format(" + dateTimeLiteral + ", '%r')", "01:04:05 午後");
+        localeAssertions.assertFunction("date_format(" + dateTimeLiteral + ", '%b')", "1");
+        localeAssertions.assertFunction("date_format(" + dateTimeLiteral + ", '%M')", "1月");
 
-        assertFunction("format_datetime(" + dateTimeLiteral + ", 'EEE')", "火");
-        assertFunction("format_datetime(" + dateTimeLiteral + ", 'EEEE')", "火曜日");
-        assertFunction("format_datetime(" + dateTimeLiteral + ", 'a')", "午後");
-        assertFunction("format_datetime(" + dateTimeLiteral + ", 'MMM')", "1");
-        assertFunction("format_datetime(" + dateTimeLiteral + ", 'MMMM')", "1月");
+        localeAssertions.assertFunction("format_datetime(" + dateTimeLiteral + ", 'EEE')", "火");
+        localeAssertions.assertFunction("format_datetime(" + dateTimeLiteral + ", 'EEEE')", "火曜日");
+        localeAssertions.assertFunction("format_datetime(" + dateTimeLiteral + ", 'a')", "午後");
+        localeAssertions.assertFunction("format_datetime(" + dateTimeLiteral + ", 'MMM')", "1");
+        localeAssertions.assertFunction("format_datetime(" + dateTimeLiteral + ", 'MMMM')", "1月");
 
-        assertFunction("date_parse('2013-05-17 12:35:10 午後', '%Y-%m-%d %h:%i:%s %p')", toTimestamp(new DateTime(2013, 5, 17, 12, 35, 10, 0, DATE_TIME_ZONE)));
-        assertFunction("date_parse('2013-05-17 12:35:10 午前', '%Y-%m-%d %h:%i:%s %p')", toTimestamp(new DateTime(2013, 5, 17, 0, 35, 10, 0, DATE_TIME_ZONE)));
+        localeAssertions.assertFunction("date_parse('2013-05-17 12:35:10 午後', '%Y-%m-%d %h:%i:%s %p')", toTimestamp(new DateTime(2013, 5, 17, 12, 35, 10, 0, DATE_TIME_ZONE), localeSession));
+        localeAssertions.assertFunction("date_parse('2013-05-17 12:35:10 午前', '%Y-%m-%d %h:%i:%s %p')", toTimestamp(new DateTime(2013, 5, 17, 0, 35, 10, 0, DATE_TIME_ZONE), localeSession));
 
-        assertFunction("parse_datetime('2013-05-17 12:35:10 午後', 'yyyy-MM-dd hh:mm:ss a')",
+        localeAssertions.assertFunction("parse_datetime('2013-05-17 12:35:10 午後', 'yyyy-MM-dd hh:mm:ss a')",
                 toTimestampWithTimeZone(new DateTime(2013, 5, 17, 12, 35, 10, 0, DATE_TIME_ZONE)));
-        assertFunction("parse_datetime('2013-05-17 12:35:10 午前', 'yyyy-MM-dd hh:mm:ss aaa')",
+        localeAssertions.assertFunction("parse_datetime('2013-05-17 12:35:10 午前', 'yyyy-MM-dd hh:mm:ss aaa')",
                 toTimestampWithTimeZone(new DateTime(2013, 5, 17, 0, 35, 10, 0, DATE_TIME_ZONE)));
     }
 
@@ -685,6 +684,11 @@ public class TestDateTimeFunctions
     private SqlTimestamp toTimestamp(DateTime dateTime)
     {
         return new SqlTimestamp(dateTime.getMillis(), session.getTimeZoneKey());
+    }
+
+    private SqlTimestamp toTimestamp(DateTime dateTime, ConnectorSession connectorSession)
+    {
+        return new SqlTimestamp(dateTime.getMillis(), connectorSession.getTimeZoneKey());
     }
 
     private SqlTimestampWithTimeZone toTimestampWithTimeZone(DateTime dateTime)


### PR DESCRIPTION
testLocale caused parallel test failure because it modify the private fields, session and functionAssertions. This is fine for singleThreaded test, but it would be better a test not to modify the fields. By using local variables when it needs to change these value, tests methods can be run in parallel.
