### PR TITLE
DriverContext.getOperatorPreAllocatedMemory uses parent context's getOperatorPreAllocatedMemory

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -142,7 +142,7 @@ public class DriverContext
 
     public DataSize getOperatorPreAllocatedMemory()
     {
-        return pipelineContext.getMaxMemorySize();
+        return pipelineContext.getOperatorPreAllocatedMemory();
     }
 
     public boolean reserveMemory(long bytes)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -196,6 +196,7 @@ public class TestHashAggregationOperator
         toPages(operator, input);
     }
 
+    @Test
     public void testHashBuilderResize()
     {
         BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus());
@@ -209,7 +210,7 @@ public class TestHashAggregationOperator
                 .build();
 
         ConnectorSession session = new ConnectorSession("user", "source", "catalog", "schema", UTC_KEY, Locale.ENGLISH, "address", "agent");
-        DriverContext driverContext = new TaskContext(new TaskId("query", "stage", "task"), executor, session, new DataSize(3, Unit.MEGABYTE))
+        DriverContext driverContext = new TaskContext(new TaskId("query", "stage", "task"), executor, session, new DataSize(10, Unit.MEGABYTE))
                 .addPipelineContext(true, true)
                 .addDriverContext();
 


### PR DESCRIPTION
I might be wrong and might not understand internal correctly, but if pipelineContext.getMaxMemorySize() is used for DriverContext.getOperatorPreAllocatedMemory, a driver might consumer more memory than expected. 

At the MemoryManager, memorySize seems to be easily negative value.

```
    // remove the pre-allocated memory from this size
    memorySize -= operatorContext.getOperatorPreAllocatedMemory().toBytes();

    long delta = memorySize - currentMemoryReservation;
    if (delta <= 0) {
        return true;
    }
```
