### PR TITLE
Deprecate the datasources configuration property

### DIFF
--- a/presto-cassandra/README.md
+++ b/presto-cassandra/README.md
@@ -8,17 +8,7 @@ Please note that this plugin is still in early stage.
 After installation of Presto, you need to deploy to plugin to every presto node.
 
 - On all presto nodes (server & worker nodes):
-  - create a directory `PRESTO_HOME/plugin/cassandra`
-  - unpack the `presto-cassandra-x.xx.zip` file into this directory
   - add `cassandra.properties` to `PRESTO_HOME/etc/catalog` (example see below)
-- On all worker nodes:
-  - change `PRESTO_HOME/etc/config.properties`, add `cassandra` as data source
-
-```
-...
-datasources=jmx,hive,cassandra
-...
-```
 
 ## Configuration
 The configuration for the Cassandra plugin is set in `PRESTO_HOME/etc/catalog/cassandra.properties`

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -115,7 +115,6 @@ The following is a minimal configuration for the coordinator:
 .. code-block:: none
 
     coordinator=true
-    datasources=jmx
     http-server.http.port=8080
     task.max-memory=1GB
     discovery-server.enabled=true
@@ -126,20 +125,11 @@ And this is a minimal configuration for the workers:
 .. code-block:: none
 
     coordinator=false
-    datasources=jmx,hive
     http-server.http.port=8080
     task.max-memory=1GB
     discovery.uri=http://example.net:8080
 
 These properties require some explanation:
-
-* ``datasources``:
-  Specifies the list of catalog names that may have splits processed
-  on this node. Both the coordinator and workers have ``jmx`` enabled
-  because the JMX catalog enables querying JMX properties from all nodes.
-  However, only the workers have ``hive`` enabled, because we do not want
-  to process Hive splits on the coordinator, as this can interfere with
-  query coordination and slow down everything.
 
 * ``http-server.http.port``:
   Specifies the port for the HTTP server. Presto uses HTTP for all

--- a/presto-server/etc/config.properties
+++ b/presto-server/etc/config.properties
@@ -16,9 +16,6 @@ scheduler.http-client.max-connections-per-server=1000
 scheduler.http-client.connect-timeout=1m
 scheduler.http-client.read-timeout=1m
 
-
-datasources=default, hive, jmx, example, tpch
-
 query.client.timeout=5m
 query.max-age=30m
 

--- a/presto-server/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-server/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -45,11 +45,13 @@ public class ServerConfig
         return this;
     }
 
+    @Deprecated
     public String getDataSources()
     {
         return dataSources;
     }
 
+    @Deprecated
     @Config("datasources")
     public ServerConfig setDataSources(String dataSources)
     {

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchSplitManager.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchSplitManager.java
@@ -76,7 +76,7 @@ public class TpchSplitManager
         TpchTableHandle tableHandle = ((TpchPartition) partition).getTable();
 
         Set<Node> nodes = nodeManager.getActiveDatasourceNodes(connectorId);
-        checkState(!nodes.isEmpty(), "No TPCH nodes available: Add '%s' to the datasources property of each worker node", connectorId);
+        checkState(!nodes.isEmpty(), "No TPCH nodes available");
 
         int totalParts = nodes.size() * splitsPerNode;
         int partNumber = 0;


### PR DESCRIPTION
This property, if not set, is now configured automatically at startup based on
the list of installed catalogs.  This will be completely removed later.
