### PR TITLE
Add exponential backoff when reading from S3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -488,7 +488,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk</artifactId>
-                <version>1.6.12</version>
+                <version>1.7.1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfiguration.java
@@ -44,6 +44,7 @@ public class HdfsConfiguration
     private final boolean s3SslEnabled;
     private final int s3MaxClientRetries;
     private final int s3MaxErrorRetries;
+    private final Duration s3MaxBackoffTime;
     private final Duration s3ConnectTimeout;
     private final File s3StagingDirectory;
     private final List<String> resourcePaths;
@@ -74,6 +75,7 @@ public class HdfsConfiguration
         this.s3SslEnabled = hiveClientConfig.isS3SslEnabled();
         this.s3MaxClientRetries = hiveClientConfig.getS3MaxClientRetries();
         this.s3MaxErrorRetries = hiveClientConfig.getS3MaxErrorRetries();
+        this.s3MaxBackoffTime = hiveClientConfig.getS3MaxBackoffTime();
         this.s3ConnectTimeout = hiveClientConfig.getS3ConnectTimeout();
         this.s3StagingDirectory = hiveClientConfig.getS3StagingDirectory();
         this.resourcePaths = hiveClientConfig.getResourceConfigFiles();
@@ -137,6 +139,7 @@ public class HdfsConfiguration
         config.setBoolean(PrestoS3FileSystem.S3_SSL_ENABLED, s3SslEnabled);
         config.setInt(PrestoS3FileSystem.S3_MAX_CLIENT_RETRIES, s3MaxClientRetries);
         config.setInt(PrestoS3FileSystem.S3_MAX_ERROR_RETRIES, s3MaxErrorRetries);
+        config.set(PrestoS3FileSystem.S3_MAX_BACKOFF_TIME, s3MaxBackoffTime.toString());
         config.set(PrestoS3FileSystem.S3_CONNECT_TIMEOUT, s3ConnectTimeout.toString());
         config.set(PrestoS3FileSystem.S3_STAGING_DIRECTORY, s3StagingDirectory.toString());
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -66,6 +66,7 @@ public class HiveClientConfig
     private boolean s3SslEnabled = true;
     private int s3MaxClientRetries = 3;
     private int s3MaxErrorRetries = 10;
+    private Duration s3MaxBackoffTime = new Duration(10, TimeUnit.MINUTES);
     private Duration s3ConnectTimeout = new Duration(5, TimeUnit.SECONDS);
     private File s3StagingDirectory = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value());
 
@@ -402,6 +403,20 @@ public class HiveClientConfig
     public HiveClientConfig setS3MaxErrorRetries(int s3MaxErrorRetries)
     {
         this.s3MaxErrorRetries = s3MaxErrorRetries;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    @NotNull
+    public Duration getS3MaxBackoffTime()
+    {
+        return s3MaxBackoffTime;
+    }
+
+    @Config("hive.s3.max-backoff-time")
+    public HiveClientConfig setS3MaxBackoffTime(Duration s3MaxBackoffTime)
+    {
+        this.s3MaxBackoffTime = s3MaxBackoffTime;
         return this;
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -63,6 +63,7 @@ public class TestHiveClientConfig
                 .setS3SslEnabled(true)
                 .setS3MaxClientRetries(3)
                 .setS3MaxErrorRetries(10)
+                .setS3MaxBackoffTime(new Duration(10, TimeUnit.MINUTES))
                 .setS3ConnectTimeout(new Duration(5, TimeUnit.SECONDS))
                 .setS3StagingDirectory(new File(StandardSystemProperty.JAVA_IO_TMPDIR.value())));
     }
@@ -96,6 +97,7 @@ public class TestHiveClientConfig
                 .put("hive.s3.ssl.enabled", "false")
                 .put("hive.s3.max-client-retries", "9")
                 .put("hive.s3.max-error-retries", "8")
+                .put("hive.s3.max-backoff-time", "4m")
                 .put("hive.s3.connect-timeout", "8s")
                 .put("hive.s3.staging-directory", "/s3-staging")
                 .build();
@@ -126,6 +128,7 @@ public class TestHiveClientConfig
                 .setS3SslEnabled(false)
                 .setS3MaxClientRetries(9)
                 .setS3MaxErrorRetries(8)
+                .setS3MaxBackoffTime(new Duration(4, TimeUnit.MINUTES))
                 .setS3ConnectTimeout(new Duration(8, TimeUnit.SECONDS))
                 .setS3StagingDirectory(new File("/s3-staging"));
 


### PR DESCRIPTION
Add retry logic for getS3Object and getS3ObjectMetadata
Add exponential backoff when doing retries
Update aws-java-sdk to 1.7.1, which fixed the integer overflow bug in 1.6.x
