### PR TITLE
Add missing presto-main dependency to presto-server

### DIFF
--- a/presto-server/pom.xml
+++ b/presto-server/pom.xml
@@ -21,6 +21,11 @@
     <dependencies>
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-raptor</artifactId>
             <version>${project.version}</version>
             <type>zip</type>


### PR DESCRIPTION
This was missed in the refactoring that moved the server code to presto-main.
As a result, the server fails to start when run via the launcher
