### PR TITLE
BlockBuilder should use underlying slice size

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
@@ -44,7 +44,7 @@ public class GroupByHash
     private final List<Type> types;
     private final int[] channels;
 
-    private final List<PageBuilder> pages;
+    private final ObjectArrayList<PageBuilder> pages;
 
     private long completedPagesMemorySize;
 
@@ -82,7 +82,7 @@ public class GroupByHash
 
     public long getEstimatedSize()
     {
-        return completedPagesMemorySize + pages.get(pages.size() - 1).getMemorySize() + sizeOf(key) + sizeOf(value) + groupAddress.sizeOf();
+        return sizeOf(pages.elements()) + completedPagesMemorySize + pages.get(pages.size() - 1).getMemorySize() + sizeOf(key) + sizeOf(value) + groupAddress.sizeOf();
     }
 
     public List<Type> getTypes()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -72,7 +72,7 @@ public class FixedWidthBlockBuilder
     @Override
     public int getSizeInBytes()
     {
-        return sliceOutput.size();
+        return getRawSlice().length();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -84,7 +84,7 @@ public class VariableWidthBlockBuilder
     @Override
     public int getSizeInBytes()
     {
-        return sliceOutput.size();
+        return getRawSlice().length();
     }
 
     @Override


### PR DESCRIPTION
To calculate exact memory usages, FixedWidthBlockBuilder and VariableWidthBlockBuilder should return underlying slice size.

Even though PageBuilder list could be negligible compared to other array fields, it would have take growing spaces in a way.
