### PR TITLE
Implement DROP TABLE in HIVE connector.

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
@@ -145,6 +145,7 @@ public class HiveClient
     private final int maxSplitIteratorThreads;
     private final int minPartitionBatchSize;
     private final int maxPartitionBatchSize;
+    private final boolean allowDropTable;
     private final CachingHiveMetastore metastore;
     private final NamenodeStats namenodeStats;
     private final HdfsEnvironment hdfsEnvironment;
@@ -177,7 +178,8 @@ public class HiveClient
                 hiveClientConfig.getMinPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionBatchSize(),
                 hiveClientConfig.getMaxInitialSplitSize(),
-                hiveClientConfig.getMaxInitialSplits());
+                hiveClientConfig.getMaxInitialSplits(),
+                hiveClientConfig.getAllowDropTable());
     }
 
     public HiveClient(HiveConnectorId connectorId,
@@ -193,7 +195,8 @@ public class HiveClient
             int minPartitionBatchSize,
             int maxPartitionBatchSize,
             DataSize maxInitialSplitSize,
-            int maxInitialSplits)
+            int maxInitialSplits,
+            boolean allowDropTable)
     {
         this.connectorId = checkNotNull(connectorId, "connectorId is null").toString();
 
@@ -205,6 +208,7 @@ public class HiveClient
         this.maxPartitionBatchSize = maxPartitionBatchSize;
         this.maxInitialSplitSize = checkNotNull(maxInitialSplitSize, "maxInitialSplitSize is null");
         this.maxInitialSplits = maxInitialSplits;
+        this.allowDropTable = allowDropTable;
 
         this.metastore = checkNotNull(metastore, "metastore is null");
         this.hdfsEnvironment = checkNotNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -412,7 +416,24 @@ public class HiveClient
     @Override
     public void dropTable(ConnectorTableHandle tableHandle)
     {
-        throw new UnsupportedOperationException();
+        HiveTableHandle handle = checkType(tableHandle, HiveTableHandle.class, "tableHandle");
+        SchemaTableName tableName = getTableName(tableHandle);
+
+        // Check that drop table is enable
+        if (!allowDropTable) {
+            throw new RuntimeException(format("Unable to drop table '%s': drop table is disabled for hive connector", handle.getTableName()));
+        }
+        try {
+            Table table = metastore.getTable(handle.getSchemaName(), handle.getTableName());
+            // Check that table owner is the session user
+            if (!handle.getSession().getUser().contentEquals(table.getOwner())) {
+                throw new RuntimeException(format("Unable to drop table '%s': owner of the table is different from session user", table));
+            }
+            metastore.dropTable(handle.getSchemaName(), handle.getTableName());
+        }
+        catch (NoSuchObjectException e) {
+            throw new TableNotFoundException(tableName);
+        }
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -47,6 +47,7 @@ public class HiveClientConfig
     private int maxPartitionBatchSize = 100;
     private int maxInitialSplits = 200;
     private DataSize maxInitialSplitSize;
+    private boolean allowDropTable = false;
 
     private Duration metastoreCacheTtl = new Duration(1, TimeUnit.HOURS);
     private Duration metastoreRefreshInterval = new Duration(2, TimeUnit.MINUTES);
@@ -416,6 +417,19 @@ public class HiveClientConfig
     public HiveClientConfig setS3StagingDirectory(File s3StagingDirectory)
     {
         this.s3StagingDirectory = s3StagingDirectory;
+        return this;
+    }
+
+    public boolean getAllowDropTable()
+    {
+        return this.allowDropTable;
+    }
+
+    @Config("hive.allow-drop-table")
+    @ConfigDescription("Allow hive connector to drop table")
+    public HiveClientConfig setAllowDropTable(boolean allowDropTable)
+    {
+        this.allowDropTable = allowDropTable;
         return this;
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -212,7 +212,8 @@ public abstract class AbstractTestHiveClient
                 hiveClientConfig.getMinPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionBatchSize(),
                 hiveClientConfig.getMaxInitialSplitSize(),
-                hiveClientConfig.getMaxInitialSplits());
+                hiveClientConfig.getMaxInitialSplits(),
+                false);
 
         metadata = client;
         splitManager = client;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -63,7 +63,8 @@ public class TestHiveClientConfig
                 .setS3MaxClientRetries(3)
                 .setS3MaxErrorRetries(10)
                 .setS3ConnectTimeout(new Duration(5, TimeUnit.SECONDS))
-                .setS3StagingDirectory(new File(StandardSystemProperty.JAVA_IO_TMPDIR.value())));
+                .setS3StagingDirectory(new File(StandardSystemProperty.JAVA_IO_TMPDIR.value()))
+                .setAllowDropTable(false));
     }
 
     @Test
@@ -96,6 +97,7 @@ public class TestHiveClientConfig
                 .put("hive.s3.max-error-retries", "8")
                 .put("hive.s3.connect-timeout", "8s")
                 .put("hive.s3.staging-directory", "/s3-staging")
+                .put("hive.allow-drop-table", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -124,7 +126,8 @@ public class TestHiveClientConfig
                 .setS3MaxClientRetries(9)
                 .setS3MaxErrorRetries(8)
                 .setS3ConnectTimeout(new Duration(8, TimeUnit.SECONDS))
-                .setS3StagingDirectory(new File("/s3-staging"));
+                .setS3StagingDirectory(new File("/s3-staging"))
+                .setAllowDropTable(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Enable `DROP TABLE` in HIVE connector.

Add option `hive.allow-drop-table` that enable or disable this feature.
In this pull request, Presto check that only tables owned by the current user can be dropped.
