### PR TITLE
Fix NullPointerException onSuccess callback

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -418,7 +418,7 @@ public class SqlTaskExecution
 
                         checkTaskCompletion();
 
-                        queryMonitor.splitCompletionEvent(taskId, splitRunner.getDriverContext().getDriverStats());
+                        queryMonitor.splitCompletionEvent(taskId, getDriverStats());
                     }
                 }
 
@@ -431,19 +431,24 @@ public class SqlTaskExecution
                         // record driver is finished
                         remainingDrivers.decrementAndGet();
 
-                        DriverContext driverContext = splitRunner.getDriverContext();
-                        DriverStats driverStats;
-                        if (driverContext != null) {
-                            driverStats = driverContext.getDriverStats();
-                        }
-                        else {
-                            // split runner did not start successfully
-                            driverStats = new DriverStats();
-                        }
-
                         // fire failed event with cause
-                        queryMonitor.splitFailedEvent(taskId, driverStats, cause);
+                        queryMonitor.splitFailedEvent(taskId, getDriverStats(), cause);
                     }
+                }
+
+                private DriverStats getDriverStats()
+                {
+                    DriverContext driverContext = splitRunner.getDriverContext();
+                    DriverStats driverStats;
+                    if (driverContext != null) {
+                        driverStats = driverContext.getDriverStats();
+                    }
+                    else {
+                        // split runner did not start successfully
+                        driverStats = new DriverStats();
+                    }
+
+                    return driverStats;
                 }
             }, notificationExecutor);
         }


### PR DESCRIPTION
On an exception during the `Driver.process`, `driverContext.failed` is invoked. Then through the state changed callback,`TaskHandle.destory` is invoked, so all the running and queued splits that belong to the task are closed finally. As the result, there would be in the situation that "closed called before creating driver". 

The issue here is that `onSuccess` callback is still invoked in the situation. We should check spitRunner's driver is created or not as like `onFailure` callback.

```
2014-06-10T00:27:45.254+0000     INFO   task-notification-0 stderr  java.lang.NullPointerException
2014-06-10T00:27:45.254+0000     INFO   task-notification-0 stderr      at com.facebook.presto.execution.SqlTaskExecution$3.onSuccess(SqlTaskExecution.java:421)
2014-06-10T00:27:45.254+0000     INFO   task-notification-0 stderr      at com.google.common.util.concurrent.Futures$4.run(Futures.java:1181)
2014-06-10T00:27:45.254+0000     INFO   task-notification-0 stderr      at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
2014-06-10T00:27:45.255+0000     INFO   task-notification-0 stderr      at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
2014-06-10T00:27:45.255+0000     INFO   task-notification-0 stderr      at java.lang.Thread.run(Thread.java:744)
```
