### PR TITLE
json_tuple implementation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/json.rst
+++ b/presto-docs/src/main/sphinx/functions/json.rst
@@ -63,3 +63,11 @@ JSON Functions
         SELECT json_size('{ "x": {"a": 1, "b": 2} }', '$.x'); => 2
         SELECT json_size('{ "x": [1, 2, 3] }', '$.x'); => 2
         SELECT json_size('{ "x": {"a": 1, "b": 2} }', '$.x.a'); => 0
+
+.. function:: json_extract_multiple(json, json_fields) -> varchar
+
+    Extracts the specified json_fields from the given ``json`` string
+    and returns them as another json string. ::
+
+        SELECT json_extract_multiple('{ "x": "a", "y": "b", "z": "c"}', '["x", "z"]'); => {"x": "a", "z": "c"}
+        SELECT json_extract_multiple('{ "x": 1, "y": 2, "z": 3, "t": [1,2,3] }',  '["x", "t"]'); => {"x":1, "t":[1,2,3]}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
@@ -23,15 +23,23 @@ import com.facebook.presto.type.SqlType;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.primitives.Doubles;
 import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.fasterxml.jackson.core.JsonFactory.Feature.CANONICALIZE_FIELD_NAMES;
 import static com.fasterxml.jackson.core.JsonParser.NumberType;
@@ -294,5 +302,66 @@ public final class JsonFunctions
     public static Long jsonSize(@SqlType(VarcharType.class) Slice json, @SqlType(JsonPathType.class) JsonPath jsonPath)
     {
         return JsonExtract.extract(json, jsonPath.getSizeExtractor());
+    }
+
+    /**
+     * Until presto supports table generating functions, this is a workaround to support extracting multiple fields from a json string
+     * Presto also doesn't support variable length arguments so keys will be a string representation of an array of keys to extract, e.g., ["a", "b", "c.d"]
+     */
+    @ScalarFunction()
+    @SqlType(VarcharType.class)
+    public static Slice jsonExtractMultiple(@SqlType(VarcharType.class) Slice json, @SqlType(VarcharType.class) Slice keys)
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode newNode = mapper.createObjectNode();
+        try {
+            JsonNode rootNode = mapper.readTree(json.getInput());
+            String [] keys2Extract = ArrayStringHelper.toStringArray(keys.toString(Charsets.UTF_8));
+            for (String key : keys2Extract) {
+                    JsonNode node = rootNode.get(key);
+                    if (node != null) {
+                        newNode.put(key, node);
+                    }
+            }
+        }
+        catch (IOException e) {
+            return null;
+        }
+
+        if (newNode.size() == 0) {
+            return null;
+        }
+        else {
+            return Slices.wrappedBuffer(newNode.toString().getBytes(Charsets.UTF_8));
+        }
+    }
+
+    @VisibleForTesting
+    public static class ArrayStringHelper
+    {
+        /**
+         * Input string has brackets and double quotes around individual array elements ["a", "b", "c.d"]
+         *
+         * @param stringRepr
+         * @return a string array created from the given stringRepr
+         */
+        public static String[] toStringArray(String stringRepr)
+        {
+            int len = stringRepr.length();
+            if (stringRepr.charAt(0) != '[' || stringRepr.charAt(len - 1) != ']') {
+                throw new IllegalArgumentException("Input string should have opening and closing brackets, e.g., [\"a\", \"b\", \"c.d\"]");
+            }
+            stringRepr = stringRepr.substring(1, len - 1);
+
+            List<String> matches = new ArrayList<String>();
+            //first split considering anything in double quotes
+            Pattern regex = Pattern.compile("\\s\"']+|\"[^\"]*\"");
+            Matcher regexMatcher = regex.matcher(stringRepr);
+            while (regexMatcher.find()) {
+                String stripped = regexMatcher.group().replaceAll("^\"|\"$", ""); //get rid of double quotes
+                matches.add(stripped);
+            }
+            return matches.toArray(new String[matches.size()]);
+        }
     }
 }


### PR DESCRIPTION
This pull request implements a json_tuple function that's similar to Hive's, except that this one is **not** a table generating function (issue #1377). Instead, this function returns a json string created out of the user specified fields as the second argument to the function, and then the user can continue processing that json with additional json_extract calls (see 2nd example below).

**Example:**

presto:default> select json_tuple('{ "x": 1, "y": 2, "z": { "x": "inner_x_val" }, "t": [1,2,3] }', '["x", "t"]');   // extract the keys 'x' and 't'
**>>** {"x":1,"t":[1,2,3]}

presto:default> select json_extract( json_tuple('{ "x": 1, "y": 2, "z": { "x": "inner_x_val" }, "t": [1,2,3] }', '["x", "t"]'), '$.t[0]' ); //get the first element of t
**>>** 1
