### PR TITLE
Minor update to the JVM Config section of the deployment instructions

### DIFF
--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -99,7 +99,9 @@ The last option in the above configuration loads the
 patch for the JDK that substantially improves performance when parsing
 floating point numbers. This is important because many Hive file formats
 store floating point values as text. Change the path
-``/var/presto/installation`` to match the Presto installation directory.
+``/var/presto/installation`` to match the Presto installation directory. Please note that
+when using Java 8 this patch is **not** necessary and the PermSize parameter is no longer supported, so
+the ``-XX:PermSize`` and ``-Xbootclasspath`` parameters should be removed from ``etc/jvm.config``.
 
 .. _config_properties:
 


### PR DESCRIPTION
There was a question in the mailing list about a problem a user observed when using Java 8 with the jvm.config in the deployment documentation. The problem was that in Java 8 floatingdecimal patch is not necessary and that the PermSize parameter is not supported. This small patch updates that part of the deployment instructions.
