### PR TITLE
Make ChannelSet immutable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HashSemiJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashSemiJoinOperator.java
@@ -164,15 +164,13 @@ public class HashSemiJoinOperator
         BlockCursor probeJoinCursor = probeJoinBlock.cursor();
 
         // update hashing strategy to use probe cursor
-        channelSet.setCurrentValue(probeJoinCursor);
-
         for (int position = 0; position < page.getPositionCount(); position++) {
             checkState(probeJoinCursor.advanceNextPosition());
             if (probeJoinCursor.isNull()) {
                 blockBuilder.appendNull();
             }
             else {
-                boolean contains = channelSet.containsCurrentValue();
+                boolean contains = channelSet.contains(position, probeJoinBlock);
                 if (!contains && channelSet.containsNull()) {
                     blockBuilder.appendNull();
                 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/SetBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SetBuilderOperator.java
@@ -13,13 +13,11 @@
  */
 package com.facebook.presto.operator;
 
-import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.operator.ChannelSet.ChannelSetBuilder;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
@@ -51,14 +49,7 @@ public class SetBuilderOperator
 
         public ListenableFuture<ChannelSet> getChannelSet()
         {
-            return Futures.transform(channelSetFuture, new Function<ChannelSet, ChannelSet>()
-            {
-                @Override
-                public ChannelSet apply(ChannelSet channelSet)
-                {
-                    return new ChannelSet(channelSet);
-                }
-            });
+            return channelSetFuture;
         }
 
         void setChannelSet(ChannelSet channelSet)


### PR DESCRIPTION
Only last commit is new.  Other commits are from #1379 

Rewrite ChannelSet using GroupByHash as a template

Before:

```
sql_semijoin_in :: 1905.036 cpu ms :: in  7.5M,  64.4MB,   3.94M/s,  33.8MB/s :: out    3M,  25.8MB,   1.58M/s,  13.5MB/s
```

After:

```
sql_semijoin_in :: 1222.121 cpu ms :: in  7.5M,  64.4MB,   6.14M/s,  52.7MB/s :: out    3M,  25.8MB,   2.46M/s,  21.1MB/s
```
