### PR TITLE
Add switches to skip and ignore checkstyle.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,9 @@
         <air.check.skip-extended>true</air.check.skip-extended>
         <air.check.skip-license>false</air.check.skip-license>
 
+        <air.check.fail-checkstyle>true</air.check.fail-checkstyle>
+        <air.check.skip-checkstyle>fail</air.check.skip-checkstyle>
+
         <dep.antlr.version>3.4</dep.antlr.version>
         <dep.slice.version>0.6</dep.slice.version>
         <dep.airlift.version>0.90</dep.airlift.version>
@@ -645,6 +648,8 @@
                             <goal>check</goal>
                         </goals>
                         <configuration>
+                            <skip>${air.check.skip-checkstyle}</skip>
+                            <failOnViolation>${air.check.fail-checkstyle}</failOnViolation>
                             <consoleOutput>true</consoleOutput>
                             <includeTestSourceDirectory>true</includeTestSourceDirectory>
                             <configLocation>${air.main.basedir}/src/checkstyle/checks.xml</configLocation>


### PR DESCRIPTION
This should probably go to airbase in the long run. This allows a
submodule to set air.check.fail-checkstyle to false for development,
therefore no longer need to constantly reformat and optimize the code
while developing.
