### PR TITLE
Fix some warnings flagged by Eclipse.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountAggregation.java
@@ -71,7 +71,7 @@ public class ApproximateCountAggregation
     }
 
     @Override
-    public ApproximateCountGroupedAccumulator createGroupedAggregation(Optional<Integer> maskChannel, Optional<Integer> sampleWeightChannel, double confidence, int[] argumentChannels)
+    public ApproximateCountGroupedAccumulator createGroupedAggregation(Optional<Integer> maskChannel, Optional<Integer> sampleWeightChannel, double confidence, int... argumentChannels)
     {
         checkArgument(sampleWeightChannel.isPresent(), "sampleWeightChannel missing");
         return new ApproximateCountGroupedAccumulator(maskChannel, sampleWeightChannel.get(), confidence);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoubleSumAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoubleSumAggregation.java
@@ -263,7 +263,7 @@ public class ApproximateDoubleSumAggregation
 
     public static Slice createIntermediate(long count, double sum, OnlineVarianceCalculator calculator)
     {
-        Slice slice = Slices.allocate(SIZE_OF_LONG + SIZE_OF_DOUBLE + calculator.sizeOf());
+        Slice slice = Slices.allocate(SIZE_OF_LONG + SIZE_OF_DOUBLE + OnlineVarianceCalculator.sizeOf());
         slice.setLong(COUNT_OFFSET, count);
         slice.setDouble(SUM_OFFSET, sum);
         calculator.serializeTo(slice, VARIANCE_OFFSET);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongSumAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongSumAggregation.java
@@ -263,7 +263,7 @@ public class ApproximateLongSumAggregation
 
     public static Slice createIntermediate(long count, long sum, OnlineVarianceCalculator calculator)
     {
-        Slice slice = Slices.allocate(2 * SIZE_OF_LONG + calculator.sizeOf());
+        Slice slice = Slices.allocate(2 * SIZE_OF_LONG + OnlineVarianceCalculator.sizeOf());
         slice.setLong(COUNT_OFFSET, count);
         slice.setLong(SUM_OFFSET, sum);
         calculator.serializeTo(slice, VARIANCE_OFFSET);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximatePercentileAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximatePercentileAggregation.java
@@ -74,7 +74,7 @@ public class ApproximatePercentileAggregation
     }
 
     @Override
-    public ApproximatePercentileGroupedAccumulator createGroupedAggregation(Optional<Integer> maskChannel, Optional<Integer> sampleWeightChannel, double confidence, int[] argumentChannels)
+    public ApproximatePercentileGroupedAccumulator createGroupedAggregation(Optional<Integer> maskChannel, Optional<Integer> sampleWeightChannel, double confidence, int... argumentChannels)
     {
         checkArgument(confidence == 1.0, "approximate percentile does not support approximate queries");
         return new ApproximatePercentileGroupedAccumulator(argumentChannels[0], argumentChannels[1], parameterType, maskChannel, sampleWeightChannel);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximatePercentileWeightedAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximatePercentileWeightedAggregation.java
@@ -72,7 +72,7 @@ public class ApproximatePercentileWeightedAggregation
     }
 
     @Override
-    public ApproximatePercentileWeightedGroupedAccumulator createGroupedAggregation(Optional<Integer> maskChannel, Optional<Integer> sampleWeightChannel, double confidence, int[] argumentChannels)
+    public ApproximatePercentileWeightedGroupedAccumulator createGroupedAggregation(Optional<Integer> maskChannel, Optional<Integer> sampleWeightChannel, double confidence, int... argumentChannels)
     {
         checkArgument(confidence == 1.0, "approximate weighted percentile does not support approximate queries");
         return new ApproximatePercentileWeightedGroupedAccumulator(argumentChannels[0], argumentChannels[1], argumentChannels[2], parameterType, maskChannel, sampleWeightChannel);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountAggregation.java
@@ -60,7 +60,7 @@ public class CountAggregation
     }
 
     @Override
-    public CountGroupedAccumulator createGroupedAggregation(Optional<Integer> maskChannel, Optional<Integer> sampleWeightChannel, double confidence, int[] argumentChannels)
+    public CountGroupedAccumulator createGroupedAggregation(Optional<Integer> maskChannel, Optional<Integer> sampleWeightChannel, double confidence, int... argumentChannels)
     {
         checkArgument(confidence == 1.0, "count does not support approximate queries");
         return new CountGroupedAccumulator(maskChannel, sampleWeightChannel);


### PR DESCRIPTION
- static member access
- overriding varargs with []
