### PR TITLE
Load balance splits across nodes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/NodeScheduler.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -48,6 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class NodeScheduler
 {
@@ -58,14 +60,21 @@ public class NodeScheduler
     private final int minCandidates;
     private final boolean locationAwareScheduling;
     private final boolean includeCoordinator;
+    private final int maxSplitsPerNode;
+    private final int maxSplitsPerNodePerTaskWhenFull;
+    private final NodeTaskMap nodeTaskMap;
 
     @Inject
-    public NodeScheduler(NodeManager nodeManager, NodeSchedulerConfig config)
+    public NodeScheduler(NodeManager nodeManager, NodeSchedulerConfig config, NodeTaskMap nodeTaskMap)
     {
         this.nodeManager = nodeManager;
         this.minCandidates = config.getMinCandidates();
         this.locationAwareScheduling = config.isLocationAwareSchedulingEnabled();
         this.includeCoordinator = config.isIncludeCoordinator();
+        this.maxSplitsPerNode = config.getMaxSplitsPerNode();
+        this.maxSplitsPerNodePerTaskWhenFull = config.getMaxPendingSplitsPerNodePerTask();
+        this.nodeTaskMap = checkNotNull(nodeTaskMap, "nodeTaskMap is null");
+        checkArgument(maxSplitsPerNode > maxSplitsPerNodePerTaskWhenFull, "maxSplitsPerNode must be > maxSplitsPerNodePerTaskWhenFull");
     }
 
     @Managed
@@ -94,7 +103,7 @@ public class NodeScheduler
         scheduleRandom.set(0);
     }
 
-    public NodeSelector createNodeSelector(final String dataSourceName, Map<Node, RemoteTask> taskMap, int maxPendingSplitsPerTask)
+    public NodeSelector createNodeSelector(final String dataSourceName, Map<Node, RemoteTask> taskMap)
     {
         // this supplier is thread-safe. TODO: this logic should probably move to the scheduler since the choice of which node to run in should be
         // done as close to when the the split is about to be scheduled
@@ -112,7 +121,8 @@ public class NodeScheduler
                     nodes = nodeManager.getActiveDatasourceNodes(dataSourceName);
                 }
                 else {
-                    nodes = FluentIterable.from(nodeManager.getActiveNodes()).filter(new Predicate<Node>() {
+                    nodes = FluentIterable.from(nodeManager.getActiveNodes()).filter(new Predicate<Node>()
+                    {
                         @Override
                         public boolean apply(Node node)
                         {
@@ -141,20 +151,18 @@ public class NodeScheduler
             }
         }, 5, TimeUnit.SECONDS);
 
-        return new NodeSelector(nodeMap, taskMap, maxPendingSplitsPerTask);
+        return new NodeSelector(nodeMap, taskMap);
     }
 
     public class NodeSelector
     {
         private final AtomicReference<Supplier<NodeMap>> nodeMap;
         private final Map<Node, RemoteTask> taskMap;
-        private final int maxPendingSplitsPerTask;
 
-        public NodeSelector(Supplier<NodeMap> nodeMap, Map<Node, RemoteTask> taskMap, int maxPendingSplitsPerTask)
+        public NodeSelector(Supplier<NodeMap> nodeMap, Map<Node, RemoteTask> taskMap)
         {
             this.nodeMap = new AtomicReference<>(nodeMap);
             this.taskMap = taskMap;
-            this.maxPendingSplitsPerTask = maxPendingSplitsPerTask;
         }
 
         public void lockDownNodes()
@@ -180,9 +188,21 @@ public class NodeScheduler
             return ImmutableList.copyOf(FluentIterable.from(lazyShuffle(nodeMap.get().get().getNodesByHostAndPort().values())).limit(limit));
         }
 
+        /**
+         * Identifies the nodes for runnning the specified splits.
+         *
+         * @param splits the splits that need to be assigned to nodes
+         *
+         * @return a multimap from node to splits only for splits for which we could identify a node to schedule on.
+         *      If we cannot find an assignment for a split, it is not included in the map.
+         */
         public Multimap<Node, Split> computeAssignments(Set<Split> splits)
         {
             Multimap<Node, Split> assignment = HashMultimap.create();
+            Map<Node, Integer> assignmentCount = new HashMap<>();
+
+            // maintain a temporary local cache of partitioned splits on the node
+            Map<Node, Integer> splitCountByNode = new HashMap<>();
 
             for (Split split : splits) {
                 List<Node> candidateNodes;
@@ -194,19 +214,40 @@ public class NodeScheduler
                 }
                 checkCondition(!candidateNodes.isEmpty(), NO_NODES_AVAILABLE, "No nodes available to run query");
 
-                Node chosen = null;
-                int min = Integer.MAX_VALUE;
+                // compute and cache number of splits currently assigned to each node
                 for (Node node : candidateNodes) {
-                    RemoteTask task = taskMap.get(node);
-                    int currentSplits = (task == null) ? 0 : task.getQueuedSplits();
-                    int assignedSplits = currentSplits + assignment.get(node).size();
-                    if (assignedSplits < min && assignedSplits < maxPendingSplitsPerTask) {
-                        chosen = node;
-                        min = assignedSplits;
+                    if (!splitCountByNode.containsKey(node)) {
+                        splitCountByNode.put(node, nodeTaskMap.getPartitionedSplitsOnNode(node));
                     }
                 }
-                if (chosen != null) {
-                    assignment.put(chosen, split);
+                Node chosenNode = null;
+                int min = Integer.MAX_VALUE;
+
+                for (Node node : candidateNodes) {
+                    int assignedSplitCount = assignmentCount.containsKey(node) ? assignmentCount.get(node) : 0;
+                    int totalSplitCount = assignedSplitCount + splitCountByNode.get(node);
+
+                    if (totalSplitCount < min && totalSplitCount < maxSplitsPerNode) {
+                        chosenNode = node;
+                        min = totalSplitCount;
+                    }
+                }
+                if (chosenNode == null) {
+                    for (Node node : candidateNodes) {
+                        int assignedSplitCount = assignmentCount.containsKey(node) ? assignmentCount.get(node) : 0;
+                        RemoteTask remoteTask = taskMap.get(node);
+                        int queuedSplitCount = remoteTask == null ? 0 : remoteTask.getQueuedPartitionedSplitCount();
+                        int totalSplitCount = queuedSplitCount + assignedSplitCount;
+                        if (totalSplitCount < min && totalSplitCount < maxSplitsPerNodePerTaskWhenFull) {
+                            chosenNode = node;
+                            min = totalSplitCount;
+                        }
+                    }
+                }
+                if (chosenNode != null) {
+                    assignment.put(chosenNode, split);
+                    int count = assignmentCount.containsKey(chosenNode) ? assignmentCount.get(chosenNode) : 0;
+                    assignmentCount.put(chosenNode, count + 1);
                 }
             }
             return assignment;

--- a/presto-main/src/main/java/com/facebook/presto/execution/NodeSchedulerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/NodeSchedulerConfig.java
@@ -22,6 +22,8 @@ public class NodeSchedulerConfig
     private int minCandidates = 10;
     private boolean locationAwareScheduling = true;
     private boolean includeCoordinator = true;
+    private int maxSplitsPerNode = 100;
+    private int maxPendingSplitsPerNodePerTask = 10;
 
     @Min(1)
     public int getMinCandidates()
@@ -57,6 +59,30 @@ public class NodeSchedulerConfig
     public NodeSchedulerConfig setIncludeCoordinator(boolean includeCoordinator)
     {
         this.includeCoordinator = includeCoordinator;
+        return this;
+    }
+
+    @Config("node-scheduler.max-pending-splits-per-node-per-task")
+    public NodeSchedulerConfig setMaxPendingSplitsPerNodePerTask(int maxPendingSplitsPerNodePerTask)
+    {
+        this.maxPendingSplitsPerNodePerTask = maxPendingSplitsPerNodePerTask;
+        return this;
+    }
+
+    public int getMaxPendingSplitsPerNodePerTask()
+    {
+        return maxPendingSplitsPerNodePerTask;
+    }
+
+    public int getMaxSplitsPerNode()
+    {
+        return maxSplitsPerNode;
+    }
+
+    @Config("node-scheduler.max-splits-per-node")
+    public NodeSchedulerConfig setMaxSplitsPerNode(int maxSplitsPerNode)
+    {
+        this.maxSplitsPerNode = maxSplitsPerNode;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/NodeTaskMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/NodeTaskMap.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.spi.Node;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+@ThreadSafe
+public class NodeTaskMap
+{
+    private final ConcurrentHashMap<Node, NodeTasks> nodeTasksMap = new ConcurrentHashMap<>();
+
+    public void addTask(Node node, RemoteTask task)
+    {
+        NodeTasks nodeTasks = nodeTasksMap.get(node);
+        if (nodeTasks == null) {
+            nodeTasks = addNodeTask(node);
+        }
+        nodeTasks.addTask(task);
+    }
+
+    private NodeTasks addNodeTask(Node node)
+    {
+        NodeTasks newNodeTasks = new NodeTasks();
+        NodeTasks nodeTasks = nodeTasksMap.putIfAbsent(node, newNodeTasks);
+        if (nodeTasks == null) {
+           return newNodeTasks;
+        }
+        return nodeTasks;
+    }
+
+    public int getPartitionedSplitsOnNode(Node node)
+    {
+        NodeTasks nodeTasks = nodeTasksMap.get(node);
+        if (nodeTasks == null) {
+            nodeTasks = addNodeTask(node);
+        }
+        return nodeTasks.getPartitionedSplitCount();
+    }
+
+    private static class NodeTasks
+    {
+        @GuardedBy("this")
+        private final List<RemoteTask> remoteTasks = new ArrayList<>();
+
+        private synchronized int getPartitionedSplitCount()
+        {
+            int partitionedSplitCount = 0;
+            for (RemoteTask task : remoteTasks) {
+                partitionedSplitCount += task.getPartitionedSplitCount();
+            }
+            return partitionedSplitCount;
+        }
+
+        private synchronized void addTask(final RemoteTask task)
+        {
+            remoteTasks.add(task);
+            task.addStateChangeListener(new StateMachine.StateChangeListener<TaskInfo>()
+            {
+                @Override
+                public void stateChanged(TaskInfo taskInfo)
+                {
+                    if (taskInfo.getState().isDone()) {
+                        synchronized (NodeTasks.this) {
+                            remoteTasks.remove(task);
+                        }
+                    }
+                }
+            });
+
+            // Check if task state changes before adding the listener
+            if (task.getTaskInfo().getState().isDone()) {
+                remoteTasks.remove(task);
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
@@ -37,7 +37,9 @@ public interface RemoteTask
 
     void cancel();
 
-    int getQueuedSplits();
+    int getPartitionedSplitCount();
+
+    int getQueuedPartitionedSplitCount();
 
     Duration waitForTaskToFinish(Duration maxWait)
             throws InterruptedException;

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -72,13 +72,13 @@ public class SqlQueryExecution
     private final RemoteTaskFactory remoteTaskFactory;
     private final LocationFactory locationFactory;
     private final int scheduleSplitBatchSize;
-    private final int maxPendingSplitsPerNode;
     private final int initialHashPartitions;
     private final boolean experimentalSyntaxEnabled;
     private final ExecutorService queryExecutor;
 
     private final QueryExplainer queryExplainer;
     private final AtomicReference<SqlStageExecution> outputStage = new AtomicReference<>();
+    private final NodeTaskMap nodeTaskMap;
 
     public SqlQueryExecution(QueryId queryId,
             String query,
@@ -96,7 +96,8 @@ public class SqlQueryExecution
             int maxPendingSplitsPerNode,
             int initialHashPartitions,
             boolean experimentalSyntaxEnabled,
-            ExecutorService queryExecutor)
+            ExecutorService queryExecutor,
+            NodeTaskMap nodeTaskMap)
     {
         try (SetThreadName setThreadName = new SetThreadName("Query-%s", queryId)) {
             this.session = checkNotNull(session, "session is null");
@@ -110,12 +111,10 @@ public class SqlQueryExecution
             this.locationFactory = checkNotNull(locationFactory, "locationFactory is null");
             this.queryExecutor = checkNotNull(queryExecutor, "queryExecutor is null");
             this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
+            this.nodeTaskMap = checkNotNull(nodeTaskMap, "nodeTaskMap is null");
 
             checkArgument(maxPendingSplitsPerNode > 0, "scheduleSplitBatchSize must be greater than 0");
             this.scheduleSplitBatchSize = scheduleSplitBatchSize;
-
-            checkArgument(maxPendingSplitsPerNode > 0, "maxPendingSplitsPerNode must be greater than 0");
-            this.maxPendingSplitsPerNode = maxPendingSplitsPerNode;
 
             checkArgument(initialHashPartitions > 0, "initialHashPartitions must be greater than 0");
             this.initialHashPartitions = initialHashPartitions;
@@ -236,9 +235,9 @@ public class SqlQueryExecution
                 remoteTaskFactory,
                 stateMachine.getSession(),
                 scheduleSplitBatchSize,
-                maxPendingSplitsPerNode,
                 initialHashPartitions,
                 queryExecutor,
+                nodeTaskMap,
                 ROOT_OUTPUT_BUFFERS);
         this.outputStage.set(outputStage);
         outputStage.addStateChangeListener(new StateChangeListener<StageInfo>()
@@ -393,6 +392,7 @@ public class SqlQueryExecution
         private final RemoteTaskFactory remoteTaskFactory;
         private final LocationFactory locationFactory;
         private final ExecutorService executor;
+        private final NodeTaskMap nodeTaskMap;
 
         @Inject
         SqlQueryExecutionFactory(QueryManagerConfig config,
@@ -404,7 +404,8 @@ public class SqlQueryExecution
                 NodeScheduler nodeScheduler,
                 List<PlanOptimizer> planOptimizers,
                 RemoteTaskFactory remoteTaskFactory,
-                @ForQueryExecution ExecutorService executor)
+                @ForQueryExecution ExecutorService executor,
+                NodeTaskMap nodeTaskMap)
         {
             checkNotNull(config, "config is null");
             this.scheduleSplitBatchSize = config.getScheduleSplitBatchSize();
@@ -419,6 +420,7 @@ public class SqlQueryExecution
             this.remoteTaskFactory = checkNotNull(remoteTaskFactory, "remoteTaskFactory is null");
             this.experimentalSyntaxEnabled = checkNotNull(featuresConfig, "featuresConfig is null").isExperimentalSyntaxEnabled();
             this.executor = checkNotNull(executor, "executor is null");
+            this.nodeTaskMap = checkNotNull(nodeTaskMap, "nodeTaskMap is null");
         }
 
         @Override
@@ -440,7 +442,8 @@ public class SqlQueryExecution
                     maxPendingSplitsPerNode,
                     initialHashPartitions,
                     experimentalSyntaxEnabled,
-                    executor);
+                    executor,
+                    nodeTaskMap);
 
             return queryExecution;
         }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -244,7 +244,7 @@ public class SqlTaskExecution
         // start unpartitioned drivers
         List<DriverSplitRunner> runners = new ArrayList<>();
         for (DriverSplitRunnerFactory driverFactory : unpartitionedDriverFactories) {
-            runners.add(driverFactory.createDriverRunner(null));
+            runners.add(driverFactory.createDriverRunner(null, false));
             driverFactory.setNoMoreSplits();
         }
         enqueueDrivers(true, runners);
@@ -344,7 +344,7 @@ public class SqlTaskExecution
                     // only add a split if we have not already scheduled it
                     if (scheduledSplit.getSequenceId() > maxAcknowledgedSplit) {
                         // create a new driver for the split
-                        runners.add(partitionedDriverFactory.createDriverRunner(scheduledSplit));
+                        runners.add(partitionedDriverFactory.createDriverRunner(scheduledSplit, true));
                         newMaxAcknowledgedSplit = max(scheduledSplit.getSequenceId(), newMaxAcknowledgedSplit);
                     }
                 }
@@ -563,12 +563,12 @@ public class SqlTaskExecution
             this.pipelineContext = taskContext.addPipelineContext(driverFactory.isInputDriver(), driverFactory.isOutputDriver());
         }
 
-        private DriverSplitRunner createDriverRunner(@Nullable ScheduledSplit partitionedSplit)
+        private DriverSplitRunner createDriverRunner(@Nullable ScheduledSplit partitionedSplit, boolean partitioned)
         {
             pendingCreation.incrementAndGet();
             // create driver context immediately so the driver existence is recorded in the stats
             // the number of drivers is used to balance work across nodes
-            DriverContext driverContext = pipelineContext.addDriverContext();
+            DriverContext driverContext = pipelineContext.addDriverContext(partitioned);
             return new DriverSplitRunner(this, driverContext, partitionedSplit);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -62,11 +62,13 @@ public class DriverContext
     private final AtomicLong memoryReservation = new AtomicLong();
 
     private final List<OperatorContext> operatorContexts = new CopyOnWriteArrayList<>();
+    private final boolean partitioned;
 
-    public DriverContext(PipelineContext pipelineContext, Executor executor)
+    public DriverContext(PipelineContext pipelineContext, Executor executor, boolean partitioned)
     {
         this.pipelineContext = checkNotNull(pipelineContext, "pipelineContext is null");
         this.executor = checkNotNull(executor, "executor is null");
+        this.partitioned = partitioned;
     }
 
     public TaskId getTaskId()
@@ -304,5 +306,10 @@ public class DriverContext
                 return driverContext.getDriverStats();
             }
         };
+    }
+
+    public boolean isPartitioned()
+    {
+        return partitioned;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
@@ -108,7 +108,12 @@ public class PipelineContext
 
     public DriverContext addDriverContext()
     {
-        DriverContext driverContext = new DriverContext(this, executor);
+        return addDriverContext(false);
+    }
+
+    public DriverContext addDriverContext(boolean partitioned)
+    {
+        DriverContext driverContext = new DriverContext(this, executor, partitioned);
         drivers.add(driverContext);
         return driverContext;
     }
@@ -267,7 +272,9 @@ public class PipelineContext
 
         int totalDriers = completedDrivers.get() + driverContexts.size();
         int queuedDrivers = 0;
+        int queuedPartitionedDrivers = 0;
         int runningDrivers = 0;
+        int runningPartitionedDrivers = 0;
         int completedDrivers = this.completedDrivers.get();
 
         Distribution queuedTime = new Distribution(this.queuedTime);
@@ -296,9 +303,15 @@ public class PipelineContext
 
             if (driverStats.getStartTime() == null) {
                 queuedDrivers++;
+                if (driverContext.isPartitioned()) {
+                    queuedPartitionedDrivers++;
+                }
             }
             else {
                 runningDrivers++;
+                if (driverContext.isPartitioned()) {
+                    runningPartitionedDrivers++;
+                }
             }
 
             queuedTime.add(driverStats.getQueuedTime().roundTo(NANOSECONDS));
@@ -338,7 +351,9 @@ public class PipelineContext
 
                 totalDriers,
                 queuedDrivers,
+                queuedPartitionedDrivers,
                 runningDrivers,
+                runningPartitionedDrivers,
                 completedDrivers,
 
                 new DataSize(memoryReservation.get(), BYTE).convertToMostSuccinctDataSize(),

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineStats.java
@@ -36,7 +36,9 @@ public class PipelineStats
 
     private final int totalDrivers;
     private final int queuedDrivers;
+    private final int queuedPartitionedDrivers;
     private final int runningDrivers;
+    private final int runningPartitionedDrivers;
     private final int completedDrivers;
 
     private final DataSize memoryReservation;
@@ -68,7 +70,9 @@ public class PipelineStats
 
             @JsonProperty("totalDrivers") int totalDrivers,
             @JsonProperty("queuedDrivers") int queuedDrivers,
+            @JsonProperty("queuedPartitionedDrivers") int queuedPartitionedDrivers,
             @JsonProperty("runningDrivers") int runningDrivers,
+            @JsonProperty("runningPartitionedDrivers") int runningPartitionedDrivers,
             @JsonProperty("completedDrivers") int completedDrivers,
 
             @JsonProperty("memoryReservation") DataSize memoryReservation,
@@ -100,8 +104,12 @@ public class PipelineStats
         this.totalDrivers = totalDrivers;
         checkArgument(queuedDrivers >= 0, "queuedDrivers is negative");
         this.queuedDrivers = queuedDrivers;
+        checkArgument(queuedPartitionedDrivers >= 0, "queuedPartitionedDrivers is negative");
+        this.queuedPartitionedDrivers = queuedPartitionedDrivers;
         checkArgument(runningDrivers >= 0, "runningDrivers is negative");
         this.runningDrivers = runningDrivers;
+        checkArgument(runningPartitionedDrivers >= 0, "runningPartitionedDrivers is negative");
+        this.runningPartitionedDrivers = runningPartitionedDrivers;
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
         this.completedDrivers = completedDrivers;
 
@@ -156,9 +164,21 @@ public class PipelineStats
     }
 
     @JsonProperty
+    public int getQueuedPartitionedDrivers()
+    {
+        return queuedPartitionedDrivers;
+    }
+
+    @JsonProperty
     public int getRunningDrivers()
     {
         return runningDrivers;
+    }
+
+    @JsonProperty
+    public int getRunningPartitionedDrivers()
+    {
+        return runningPartitionedDrivers;
     }
 
     @JsonProperty
@@ -264,7 +284,9 @@ public class PipelineStats
                 outputPipeline,
                 totalDrivers,
                 queuedDrivers,
+                queuedPartitionedDrivers,
                 runningDrivers,
+                runningPartitionedDrivers,
                 completedDrivers,
                 memoryReservation,
                 queuedTime,

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -245,7 +245,9 @@ public class TaskContext
 
         int totalDrivers = 0;
         int queuedDrivers = 0;
+        int queuedPartitionedDrivers = 0;
         int runningDrivers = 0;
+        int runningPartitionedDrivers = 0;
         int completedDrivers = 0;
 
         long totalScheduledTime = 0;
@@ -265,7 +267,9 @@ public class TaskContext
         for (PipelineStats pipeline : pipelineStats) {
             totalDrivers += pipeline.getTotalDrivers();
             queuedDrivers += pipeline.getQueuedDrivers();
+            queuedPartitionedDrivers += pipeline.getQueuedPartitionedDrivers();
             runningDrivers += pipeline.getRunningDrivers();
+            runningPartitionedDrivers += pipeline.getRunningPartitionedDrivers();
             completedDrivers += pipeline.getCompletedDrivers();
 
             totalScheduledTime += pipeline.getTotalScheduledTime().roundTo(NANOSECONDS);
@@ -311,7 +315,9 @@ public class TaskContext
                 queuedTime.convertToMostSuccinctTimeUnit(),
                 totalDrivers,
                 queuedDrivers,
+                queuedPartitionedDrivers,
                 runningDrivers,
+                runningPartitionedDrivers,
                 completedDrivers,
                 new DataSize(memoryReservation.get(), BYTE).convertToMostSuccinctDataSize(),
                 new Duration(totalScheduledTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -41,7 +41,9 @@ public class TaskStats
 
     private final int totalDrivers;
     private final int queuedDrivers;
+    private final int queuedPartitionedDrivers;
     private final int runningDrivers;
+    private final int runningPartitionedDrivers;
     private final int completedDrivers;
 
     private final DataSize memoryReservation;
@@ -73,7 +75,9 @@ public class TaskStats
 
             @JsonProperty("totalDrivers") int totalDrivers,
             @JsonProperty("queuedDrivers") int queuedDrivers,
+            @JsonProperty("queuedPartitionedDrivers") int queuedPartitionedDrivers,
             @JsonProperty("runningDrivers") int runningDrivers,
+            @JsonProperty("runningPartitionedDrivers") int runningPartitionedDrivers,
             @JsonProperty("completedDrivers") int completedDrivers,
 
             @JsonProperty("memoryReservation") DataSize memoryReservation,
@@ -105,8 +109,14 @@ public class TaskStats
         this.totalDrivers = totalDrivers;
         checkArgument(queuedDrivers >= 0, "queuedDrivers is negative");
         this.queuedDrivers = queuedDrivers;
+        checkArgument(queuedPartitionedDrivers >= 0, "queuedPartitionedDrivers is negative");
+        this.queuedPartitionedDrivers = queuedPartitionedDrivers;
+
         checkArgument(runningDrivers >= 0, "runningDrivers is negative");
         this.runningDrivers = runningDrivers;
+        checkArgument(runningPartitionedDrivers >= 0, "runningPartitionedDrivers is negative");
+        this.runningPartitionedDrivers = runningPartitionedDrivers;
+
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
         this.completedDrivers = completedDrivers;
 
@@ -267,6 +277,18 @@ public class TaskStats
         return pipelines;
     }
 
+    @JsonProperty
+    public int getQueuedPartitionedDrivers()
+    {
+        return queuedPartitionedDrivers;
+    }
+
+    @JsonProperty
+    public int getRunningPartitionedDrivers()
+    {
+        return runningPartitionedDrivers;
+    }
+
     public TaskStats summarize()
     {
         return new TaskStats(
@@ -278,7 +300,9 @@ public class TaskStats
                 queuedTime,
                 totalDrivers,
                 queuedDrivers,
+                queuedPartitionedDrivers,
                 runningDrivers,
+                runningPartitionedDrivers,
                 completedDrivers,
                 memoryReservation,
                 totalScheduledTime,

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -20,6 +20,7 @@ import com.facebook.presto.execution.DropViewTask;
 import com.facebook.presto.execution.ForQueryExecution;
 import com.facebook.presto.execution.NodeScheduler;
 import com.facebook.presto.execution.NodeSchedulerConfig;
+import com.facebook.presto.execution.NodeTaskMap;
 import com.facebook.presto.execution.QueryExecution;
 import com.facebook.presto.execution.QueryExecutionMBean;
 import com.facebook.presto.execution.QueryIdGenerator;
@@ -100,6 +101,7 @@ public class CoordinatorModule
         binder.bind(NodeManager.class).to(Key.get(InternalNodeManager.class)).in(Scopes.SINGLETON);
         bindConfig(binder).to(NodeSchedulerConfig.class);
         binder.bind(NodeScheduler.class).in(Scopes.SINGLETON);
+        binder.bind(NodeTaskMap.class).in(Scopes.SINGLETON);
         newExporter(binder).export(NodeScheduler.class).withGeneratedName();
 
         // query execution

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTask.java
@@ -276,12 +276,17 @@ public class HttpRemoteTask
     }
 
     @Override
-    public synchronized int getQueuedSplits()
+    public synchronized int getPartitionedSplitCount()
     {
-        try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
-            int pendingSplitCount = pendingSplits.get(planFragment.getPartitionedSource()).size();
-            return pendingSplitCount + taskInfo.get().getStats().getQueuedDrivers();
-        }
+        int splitCount = pendingSplits.get(planFragment.getPartitionedSource()).size();
+        return splitCount + taskInfo.get().getStats().getQueuedPartitionedDrivers() + taskInfo.get().getStats().getRunningPartitionedDrivers();
+    }
+
+    @Override
+    public synchronized int getQueuedPartitionedSplitCount()
+    {
+        int splitCount = pendingSplits.get(planFragment.getPartitionedSource()).size();
+        return splitCount + taskInfo.get().getStats().getQueuedPartitionedDrivers();
     }
 
     @Override
@@ -599,8 +604,8 @@ public class HttpRemoteTask
 
     /**
      * Continuous update loop for task info.  Wait for a short period for task state to change, and
-     * if it does not, return the current state of the task.  This will cause stats to be updated at
-     * a regular interval, and state changes will be immediately recorded.
+     * if it does not, return the current state of the task.  This will cause stats to be updated at a
+     * regular interval, and state changes will be immediately recorded.
      */
     private class ContinuousTaskInfoFetcher
             implements SimpleHttpResponseCallback<TaskInfo>

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.OutputBuffers;
+import com.facebook.presto.metadata.ColumnHandle;
+import com.facebook.presto.metadata.Split;
+import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.TestingColumnHandle;
+import com.facebook.presto.sql.planner.TestingTableHandle;
+import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.google.common.base.Optional;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.joda.time.DateTime;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.facebook.presto.OutputBuffers.INITIAL_EMPTY_OUTPUT_BUFFERS;
+import static com.facebook.presto.execution.StateMachine.StateChangeListener;
+import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.util.Failures.toFailures;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+
+public class MockRemoteTaskFactory
+        implements RemoteTaskFactory
+{
+    private final Executor executor;
+
+    MockRemoteTaskFactory(Executor executor)
+    {
+        this.executor = executor;
+    }
+
+    public RemoteTask createTableScanTask(Node newNode, List<Split> splits)
+    {
+        ConnectorSession session = new ConnectorSession("user", "source", "catalog", "schema", UTC_KEY, Locale.ENGLISH, "address", "agent");
+        TaskId taskId = new TaskId(new StageId("test", "1"), "1");
+        Symbol symbol = new Symbol("column");
+        PlanNodeId tableScanNodeId = new PlanNodeId("test");
+        PlanNodeId sourceId = new PlanNodeId("sourceId");
+        PlanFragment testFragment = new PlanFragment(
+                new PlanFragmentId("test"),
+                new TableScanNode(
+                        new PlanNodeId("test"),
+                        new TableHandle("test", new TestingTableHandle()),
+                        ImmutableList.of(symbol),
+                        ImmutableMap.of(symbol, new ColumnHandle("test", new TestingColumnHandle("column"))),
+                        null,
+                        Optional.<TableScanNode.GeneratedPartitions>absent()),
+                ImmutableMap.<Symbol, Type>of(symbol, VARCHAR),
+                PlanFragment.PlanDistribution.SOURCE,
+                tableScanNodeId,
+                PlanFragment.OutputPartitioning.NONE,
+                ImmutableList.<Symbol>of()
+        );
+
+        ImmutableMultimap.Builder<PlanNodeId, Split> initialSplits = ImmutableMultimap.builder();
+        for (Split sourceSplit : splits) {
+            initialSplits.put(sourceId, sourceSplit);
+        }
+        return createRemoteTask(session, taskId, newNode, testFragment, initialSplits.build(), OutputBuffers.INITIAL_EMPTY_OUTPUT_BUFFERS);
+    }
+
+    @Override
+    public RemoteTask createRemoteTask(
+            ConnectorSession session,
+            TaskId taskId,
+            Node node,
+            PlanFragment fragment,
+            Multimap<PlanNodeId, Split> initialSplits,
+            OutputBuffers outputBuffers)
+    {
+        return new MockRemoteTask(taskId, fragment, executor, initialSplits);
+    }
+
+    private class MockRemoteTask
+            implements RemoteTask
+    {
+        private final AtomicLong nextTaskInfoVersion = new AtomicLong(TaskInfo.STARTING_VERSION);
+
+        private final URI location;
+        private final TaskStateMachine taskStateMachine;
+        private final TaskContext taskContext;
+        private final SharedBuffer sharedBuffer;
+
+        private final PlanFragment fragment;
+
+        @GuardedBy("this")
+        private final Set<PlanNodeId> noMoreSplits = new HashSet<>();
+
+        @GuardedBy("this")
+        private final Multimap<PlanNodeId, Split> splits = HashMultimap.create();
+
+        public MockRemoteTask(TaskId taskId,
+                PlanFragment fragment,
+                Executor executor,
+                Multimap<PlanNodeId, Split> initialSplits)
+        {
+            this.taskStateMachine = new TaskStateMachine(checkNotNull(taskId, "taskId is null"), checkNotNull(executor, "executor is null"));
+
+            ConnectorSession session = new ConnectorSession("user", "source", "catalog", "schema", UTC_KEY, Locale.ENGLISH, "address", "agent");
+            this.taskContext = new TaskContext(taskStateMachine, executor, session, new DataSize(256, MEGABYTE), new DataSize(1, MEGABYTE), true);
+
+            this.location = URI.create("fake://task/" + taskId);
+
+            this.sharedBuffer = new SharedBuffer(taskId, executor, checkNotNull(new DataSize(1, DataSize.Unit.BYTE), "maxBufferSize is null"), INITIAL_EMPTY_OUTPUT_BUFFERS);
+            this.fragment = checkNotNull(fragment, "fragment is null");
+            splits.putAll(initialSplits);
+        }
+
+        @Override
+        public String getNodeId()
+        {
+            return "node";
+        }
+
+        @Override
+        public TaskInfo getTaskInfo()
+        {
+            TaskState state = taskStateMachine.getState();
+            List<ExecutionFailureInfo> failures = ImmutableList.of();
+            if (state == TaskState.FAILED) {
+                failures = toFailures(taskStateMachine.getFailureCauses());
+            }
+
+            return new TaskInfo(
+                    taskStateMachine.getTaskId(),
+                    nextTaskInfoVersion.getAndIncrement(),
+                    state,
+                    location,
+                    DateTime.now(),
+                    sharedBuffer.getInfo(),
+                    ImmutableSet.<PlanNodeId>of(),
+                    taskContext.getTaskStats(),
+                    failures);
+        }
+
+        @Override
+        public void start()
+        {
+        }
+
+        @Override
+        public void addSplits(PlanNodeId sourceId, Iterable<Split> splits)
+        {
+            checkNotNull(splits, "splits is null");
+            for (Split split : splits) {
+                this.splits.put(sourceId, split);
+            }
+        }
+
+        @Override
+        public void noMoreSplits(PlanNodeId sourceId)
+        {
+            noMoreSplits.add(sourceId);
+            if (noMoreSplits.containsAll(fragment.getSources())) {
+                taskStateMachine.finished();
+            }
+        }
+
+        @Override
+        public void setOutputBuffers(OutputBuffers outputBuffers)
+        {
+            sharedBuffer.setOutputBuffers(outputBuffers);
+        }
+
+        @Override
+        public void addStateChangeListener(final StateChangeListener<TaskInfo> stateChangeListener)
+        {
+            taskStateMachine.addStateChangeListener(new StateChangeListener<TaskState>()
+            {
+                @Override
+                public void stateChanged(TaskState newValue)
+                {
+                    stateChangeListener.stateChanged(getTaskInfo());
+                }
+            });
+        }
+
+        @Override
+        public void cancel()
+        {
+            taskStateMachine.cancel();
+        }
+
+        @Override
+        public int getPartitionedSplitCount()
+        {
+            if (taskStateMachine.getState().isDone()) {
+                return 0;
+            }
+            return splits.size();
+        }
+
+        @Override
+        public int getQueuedPartitionedSplitCount()
+        {
+            if (taskStateMachine.getState().isDone()) {
+                return 0;
+            }
+            return splits.size();
+        }
+
+        @Override
+        public Duration waitForTaskToFinish(Duration maxWait)
+                throws InterruptedException
+        {
+            while (true) {
+                TaskState currentState = taskStateMachine.getState();
+                if (maxWait.toMillis() <= 1 || currentState.isDone()) {
+                    return maxWait;
+                }
+                maxWait = taskStateMachine.waitForStateChange(currentState, maxWait);
+            }
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.metadata.InMemoryNodeManager;
+import com.facebook.presto.metadata.NodeVersion;
+import com.facebook.presto.metadata.PrestoNode;
+import com.facebook.presto.metadata.Split;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.Node;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestNodeScheduler
+{
+    private NodeTaskMap nodeTaskMap;
+    private InMemoryNodeManager nodeManager;
+    private NodeScheduler.NodeSelector nodeSelector;
+    private Map<Node, RemoteTask> taskMap;
+    private ExecutorService remoteTaskExecutor;
+
+    @BeforeMethod
+    public void setUp()
+            throws Exception
+    {
+        nodeTaskMap = new NodeTaskMap();
+        nodeManager = new InMemoryNodeManager();
+
+        ImmutableList.Builder<Node> nodeBuilder = ImmutableList.builder();
+        nodeBuilder.add(new PrestoNode("other1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN));
+        nodeBuilder.add(new PrestoNode("other2", URI.create("http://127.0.0.1:12"), NodeVersion.UNKNOWN));
+        nodeBuilder.add(new PrestoNode("other3", URI.create("http://127.0.0.1:13"), NodeVersion.UNKNOWN));
+        ImmutableList<Node> nodes = nodeBuilder.build();
+        nodeManager.addNode("foo", nodes);
+        NodeSchedulerConfig nodeSchedulerConfig = new NodeSchedulerConfig()
+                .setMaxSplitsPerNode(20)
+                .setIncludeCoordinator(false)
+                .setMaxPendingSplitsPerNodePerTask(10);
+
+        NodeScheduler nodeScheduler = new NodeScheduler(nodeManager, nodeSchedulerConfig, nodeTaskMap);
+        // contents of taskMap indicate the node-task map for the current stage
+        taskMap = new HashMap<>();
+        nodeSelector = nodeScheduler.createNodeSelector("foo", taskMap);
+        remoteTaskExecutor = Executors.newCachedThreadPool(daemonThreadsNamed("remoteTaskExecutor"));
+    }
+
+    @AfterMethod
+    public void tearDown()
+            throws Exception
+    {
+        remoteTaskExecutor.shutdown();
+    }
+
+    @Test
+    public void testScheduleLocal()
+            throws Exception
+    {
+        Set<Split> splits = new HashSet<>();
+        Split localSplit = new Split("foo", new TestSplitLocal());
+        splits.add(localSplit);
+        Multimap<Node, Split> assignments = nodeSelector.computeAssignments(splits);
+        Map.Entry<Node, Split> onlyEntry = Iterables.getOnlyElement(assignments.entries());
+        assertEquals(onlyEntry.getKey().getHostAndPort(), localSplit.getAddresses().get(0));
+        assertEquals(onlyEntry.getValue(), localSplit);
+    }
+
+    @Test
+    public void testScheduleRemote()
+            throws Exception
+    {
+        Set<Split> splits = new HashSet<>();
+        splits.add(new Split("foo", new TestSplitRemote()));
+        Multimap<Node, Split> assignments = nodeSelector.computeAssignments(splits);
+        assertEquals(assignments.size(), 1);
+    }
+
+    @Test
+    public void testBasicAssignment()
+            throws Exception
+    {
+        // One split for each node
+        Set<Split> splits = new HashSet<>();
+        for (int i = 0; i < 3; i++) {
+            splits.add(new Split("foo", new TestSplitRemote()));
+        }
+        Multimap<Node, Split> assignments = nodeSelector.computeAssignments(splits);
+        assertEquals(assignments.entries().size(), 3);
+        for (Node node : nodeManager.getActiveDatasourceNodes("foo")) {
+            assertTrue(assignments.keySet().contains(node));
+        }
+    }
+
+    @Test
+    public void testMaxSplitsPerNode()
+            throws Exception
+    {
+        Node newNode = new PrestoNode("other4", URI.create("http://127.0.0.1:14"), NodeVersion.UNKNOWN);
+        nodeManager.addNode("foo", newNode);
+
+        ImmutableList.Builder<Split> initialSplits = ImmutableList.builder();
+        for (int i = 0; i < 10; i++) {
+            initialSplits.add(new Split("foo", new TestSplitRemote()));
+        }
+
+        MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor);
+        // Max out number of splits on node
+        RemoteTask remoteTask1 = remoteTaskFactory.createTableScanTask(newNode, initialSplits.build());
+        nodeTaskMap.addTask(newNode, remoteTask1);
+        RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(newNode, initialSplits.build());
+        nodeTaskMap.addTask(newNode, remoteTask2);
+
+        Set<Split> splits = new HashSet<>();
+        for (int i = 0; i < 5; i++) {
+            splits.add(new Split("foo", new TestSplitRemote()));
+        }
+        Multimap<Node, Split> assignments = nodeSelector.computeAssignments(splits);
+
+        // no split should be assigned to the newNode, as it already has maxNodeSplits assigned to it
+        assertFalse(assignments.keySet().contains(newNode));
+    }
+
+    @Test
+    public void testMaxSplitsPerNodePerTask()
+            throws Exception
+    {
+        Node newNode = new PrestoNode("other4", URI.create("http://127.0.0.1:14"), NodeVersion.UNKNOWN);
+        nodeManager.addNode("foo", newNode);
+
+        ImmutableList.Builder<Split> initialSplits = ImmutableList.builder();
+        for (int i = 0; i < 20; i++) {
+            initialSplits.add(new Split("foo", new TestSplitRemote()));
+        }
+
+        MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor);
+        for (Node node : nodeManager.getActiveDatasourceNodes("foo")) {
+            // Max out number of splits on node
+            RemoteTask remoteTask = remoteTaskFactory.createTableScanTask(node, initialSplits.build());
+            nodeTaskMap.addTask(node, remoteTask);
+        }
+
+        RemoteTask newRemoteTask = remoteTaskFactory.createTableScanTask(newNode, initialSplits.build());
+        // Max out pending splits on new node
+        taskMap.put(newNode, newRemoteTask);
+
+        Set<Split> splits = new HashSet<>();
+        for (int i = 0; i < 5; i++) {
+            splits.add(new Split("foo", new TestSplitRemote()));
+        }
+        Multimap<Node, Split> assignments = nodeSelector.computeAssignments(splits);
+
+        // no split should be assigned to the newNode, as it already has
+        // maxSplitsPerNode + maxSplitsPerNodePerTask assigned to it
+        assertEquals(assignments.keySet().size(), 3); // Splits should be scheduled on the other three nodes
+        assertFalse(assignments.keySet().contains(newNode)); // No splits scheduled on the maxed out node
+    }
+
+    @Test
+    public void testTaskCompletion()
+            throws Exception
+    {
+        MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor);
+        Node chosenNode = Iterables.get(nodeManager.getActiveDatasourceNodes("foo"), 0);
+        RemoteTask remoteTask = remoteTaskFactory.createTableScanTask(chosenNode, ImmutableList.of(new Split("foo", new TestSplitRemote())));
+        nodeTaskMap.addTask(chosenNode, remoteTask);
+        assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(chosenNode), 1);
+        remoteTask.cancel();
+        TimeUnit.MILLISECONDS.sleep(100); // Sleep until cache expires
+        assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(chosenNode), 0);
+    }
+
+    private class TestSplitLocal
+            implements ConnectorSplit
+    {
+        @Override
+        public boolean isRemotelyAccessible()
+        {
+            return false;
+        }
+
+        @Override
+        public List<HostAddress> getAddresses()
+        {
+            return ImmutableList.of(HostAddress.fromString("127.0.0.1:11"));
+        }
+
+        @Override
+        public Object getInfo()
+        {
+            return this;
+        }
+    }
+
+    private class TestSplitRemote
+            implements ConnectorSplit
+    {
+        @Override
+        public boolean isRemotelyAccessible()
+        {
+            return true;
+        }
+
+        @Override
+        public List<HostAddress> getAddresses()
+        {
+            int randomPort = ThreadLocalRandom.current().nextInt(5000);
+            return ImmutableList.of(HostAddress.fromString("127.0.0.1:" + randomPort));
+        }
+
+        @Override
+        public Object getInfo()
+        {
+            return this;
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.testing.ConfigAssertions;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class TestNodeSchedulerConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(NodeSchedulerConfig.class)
+                .setMinCandidates(10)
+                .setMaxSplitsPerNode(100)
+                .setMaxPendingSplitsPerNodePerTask(10)
+                .setIncludeCoordinator(true)
+                .setLocationAwareSchedulingEnabled(true));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("node-scheduler.min-candidates", "11")
+                .put("node-scheduler.location-aware-scheduling-enabled", "false")
+                .put("node-scheduler.include-coordinator", "false")
+                .put("node-scheduler.max-pending-splits-per-node-per-task", "11")
+                .put("node-scheduler.max-splits-per-node", "101")
+                .build();
+
+        NodeSchedulerConfig expected = new NodeSchedulerConfig()
+                .setIncludeCoordinator(false)
+                .setLocationAwareSchedulingEnabled(false)
+                .setMaxSplitsPerNode(101)
+                .setMaxPendingSplitsPerNodePerTask(11)
+                .setMinCandidates(11);
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPipelineStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPipelineStats.java
@@ -35,7 +35,9 @@ public class TestPipelineStats
 
             1,
             2,
+            1,
             3,
+            2,
             4,
 
             new DataSize(5, BYTE),
@@ -78,7 +80,9 @@ public class TestPipelineStats
 
         assertEquals(actual.getTotalDrivers(), 1);
         assertEquals(actual.getQueuedDrivers(), 2);
+        assertEquals(actual.getQueuedPartitionedDrivers(), 1);
         assertEquals(actual.getRunningDrivers(), 3);
+        assertEquals(actual.getRunningPartitionedDrivers(), 2);
         assertEquals(actual.getCompletedDrivers(), 4);
 
         assertEquals(actual.getMemoryReservation(), new DataSize(5, BYTE));

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
@@ -38,7 +38,9 @@ public class TestTaskStats
 
             6,
             7,
+            5,
             8,
+            6,
             10,
 
             new DataSize(11, BYTE),
@@ -80,7 +82,9 @@ public class TestTaskStats
 
         assertEquals(actual.getTotalDrivers(), 6);
         assertEquals(actual.getQueuedDrivers(), 7);
+        assertEquals(actual.getQueuedPartitionedDrivers(), 5);
         assertEquals(actual.getRunningDrivers(), 8);
+        assertEquals(actual.getRunningPartitionedDrivers(), 6);
         assertEquals(actual.getCompletedDrivers(), 10);
 
         assertEquals(actual.getMemoryReservation(), new DataSize(11, BYTE));


### PR DESCRIPTION
The maximum number of splits running on a node are bounded.
In order to avoid starvation of queries with fewer splits, beyond the
maxSplitsPerNode, every node allows a certain number of splits to be
queued per query. The drawback of this approach is that when the system
is heavily loaded (wrt number of queries), then the number of tasks on
each node will increase linearly with the number of queries and each
node will have at least some splits queued for each query. The drawback
is limited only when the system is heavily loaded and is not
any worse off than the current approach.

Pending: Run the verifier. I will do it after the release today. 
