### PR TITLE
control cassandra-client side timeouts in catalog/cassandra.config file

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.cassandra;
 
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.SocketOptions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.Duration;
@@ -54,6 +56,9 @@ public class CassandraClientConfig
     private boolean allowDropTable;
     private String username;
     private String password;
+    private int clientReadTimeout = SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS;
+    private int clientConnectTimeout = SocketOptions.DEFAULT_CONNECT_TIMEOUT_MILLIS;
+    private Integer clientSoLinger = null;
 
     @Min(0)
     public int getLimitForPartitionKeySelect()
@@ -78,6 +83,45 @@ public class CassandraClientConfig
     public CassandraClientConfig setMaxSchemaRefreshThreads(int maxSchemaRefreshThreads)
     {
         this.maxSchemaRefreshThreads = maxSchemaRefreshThreads;
+        return this;
+    }
+
+    @Min(1)
+    public int getClientReadTimeout()
+    {
+        return clientReadTimeout;
+    }
+
+    @Config("cassandra.client-read-timeout")
+    public CassandraClientConfig setClientReadTimeout(int clientReadTimeout)
+    {
+        this.clientReadTimeout = clientReadTimeout;
+        return this;
+    }
+
+    @Min(1)
+    public int getClientConnectTimeout()
+    {
+        return clientConnectTimeout;
+    }
+
+    @Config("cassandra.client-connect-timeout")
+    public CassandraClientConfig setClientConnectTimeout(int clientConnectTimeout)
+    {
+        this.clientConnectTimeout = clientConnectTimeout;
+        return this;
+    }
+
+    @Min(0)
+    public Integer getClientSoLinger()
+    {
+        return clientSoLinger;
+    }
+
+    @Config("cassandra.client-so-linger")
+    public CassandraClientConfig setClientSoLinger(int clientSoLinger)
+    {
+        this.clientSoLinger = clientSoLinger;
         return this;
     }
 


### PR DESCRIPTION
While using large column families we were facing client side timeout after planning. Increasing the client side socket timeout for the Datastax driver helped us out. To use this one the following new config params have been introduced into the cassandra catalog config:
cassandra.client-read-timeout, which can be used to set the socket read timeout in ms. Be aware that this is on a per host basis, i.e. the whole thing times out after #(hosts)*timeout
cassandra.client-connect-timeout, which can be used accordingly to set the connection timeout.
PS: i have signed the facebook code agreement stuff
