### PR TITLE
Optimize json_size function

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonExtract.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonExtract.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.io.SerializedString;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Splitter;
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
@@ -41,6 +42,7 @@ import static com.facebook.presto.util.Failures.checkCondition;
 import static com.fasterxml.jackson.core.JsonFactory.Feature.CANONICALIZE_FIELD_NAMES;
 import static com.fasterxml.jackson.core.JsonToken.END_ARRAY;
 import static com.fasterxml.jackson.core.JsonToken.END_OBJECT;
+import static com.fasterxml.jackson.core.JsonToken.FIELD_NAME;
 import static com.fasterxml.jackson.core.JsonToken.START_ARRAY;
 import static com.fasterxml.jackson.core.JsonToken.START_OBJECT;
 import static com.fasterxml.jackson.core.JsonToken.VALUE_NULL;
@@ -116,9 +118,29 @@ public final class JsonExtract
     private static final JsonFactory JSON_FACTORY = new JsonFactory()
             .disable(CANONICALIZE_FIELD_NAMES);
 
-    // Stand-in caches for compiled JSON paths until we have something more formalized
-    private static final JsonExtractCache SCALAR_CACHE = new JsonExtractCache(20, true);
-    private static final JsonExtractCache JSON_CACHE = new JsonExtractCache(20, false);
+    private static final JsonExtractCache<Slice> SCALAR_CACHE = new JsonExtractCache<>(20, new Supplier<JsonExtractor<Slice>>() {
+        @Override
+        public JsonExtractor<Slice> get()
+        {
+            return new ScalarValueJsonExtractor();
+        }
+    });
+
+    private static final JsonExtractCache<Slice> JSON_CACHE = new JsonExtractCache<>(20, new Supplier<JsonExtractor<Slice>>() {
+        @Override
+        public JsonExtractor<Slice> get()
+        {
+            return new JsonValueJsonExtractor();
+        }
+    });
+
+    private static final JsonExtractCache<Long> JSON_SIZE_CACHE = new JsonExtractCache<>(20, new Supplier<JsonExtractor<Long>>() {
+        @Override
+        public JsonExtractor<Long> get()
+        {
+            return new JsonSizeExtractor();
+        }
+    });
 
     private JsonExtract() {}
 
@@ -152,7 +174,7 @@ public final class JsonExtract
         return extract(JSON_CACHE, jsonInput, jsonPath);
     }
 
-    public static Slice extract(ThreadLocalCache<Slice, JsonExtractor> cache, @Nullable Slice jsonInput, Slice jsonPath)
+    public static Slice extract(ThreadLocalCache<Slice, JsonExtractor<Slice>> cache, @Nullable Slice jsonInput, Slice jsonPath)
             throws IOException
     {
         checkNotNull(jsonPath, "jsonPath is null");
@@ -169,7 +191,7 @@ public final class JsonExtract
         }
     }
 
-    public static Slice extract(Slice jsonInput, JsonExtractor jsonExtractor)
+    public static Slice extract(Slice jsonInput, JsonExtractor<Slice> jsonExtractor)
             throws IOException
     {
         try {
@@ -182,7 +204,57 @@ public final class JsonExtract
     }
 
     @VisibleForTesting
-    static Slice extractInternal(Slice jsonInput, JsonExtractor jsonExtractor)
+    static Slice extractInternal(Slice jsonInput, JsonExtractor<Slice> jsonExtractor)
+            throws IOException
+    {
+        checkNotNull(jsonInput, "jsonInput is null");
+        try (JsonParser jsonParser = JSON_FACTORY.createJsonParser(jsonInput.getInput())) {
+            // Initialize by advancing to first token and make sure it exists
+            if (jsonParser.nextToken() == null) {
+                throw new JsonParseException("Missing starting token", jsonParser.getCurrentLocation());
+            }
+
+            return jsonExtractor.extract(jsonParser);
+        }
+    }
+
+    public static Long extractSize(Slice jsonInput, Slice jsonPath)
+            throws IOException
+    {
+        return extractSize(JSON_SIZE_CACHE, jsonInput, jsonPath);
+    }
+
+    public static Long extractSize(ThreadLocalCache<Slice, JsonExtractor<Long>> cache, @Nullable Slice jsonInput, Slice jsonPath)
+            throws IOException
+    {
+        checkNotNull(jsonPath, "jsonPath is null");
+        if (jsonInput == null) {
+            return null;
+        }
+
+        try {
+            return extractSizeInternal(jsonInput, cache.get(jsonPath));
+        }
+        catch (JsonParseException e) {
+            // Return null if we failed to parse something
+            return null;
+        }
+    }
+
+    public static Long extractSize(Slice jsonInput, JsonExtractor<Long> jsonExtractor)
+            throws IOException
+    {
+        try {
+            return extractSizeInternal(jsonInput, jsonExtractor);
+        }
+        catch (JsonParseException e) {
+            // Return null if we failed to parse something
+            return null;
+        }
+    }
+
+    @VisibleForTesting
+    static Long extractSizeInternal(Slice jsonInput, JsonExtractor<Long> jsonExtractor)
             throws IOException
     {
         checkNotNull(jsonInput, "jsonInput is null");
@@ -207,33 +279,33 @@ public final class JsonExtract
         return DOT_SPLITTER.split(path);
     }
 
-    public static JsonExtractor generateExtractor(String path, boolean scalarValue)
+    public static <T> JsonExtractor<T> generateExtractor(String path, JsonExtractor<T> rootExtractor)
     {
         Iterator<String> iterator = tokenizePath(path).iterator();
         checkCondition(iterator.hasNext() && iterator.next().equals("$"), INVALID_FUNCTION_ARGUMENT, "JSON path must begin with root: '$'");
-        return generateExtractor(iterator, scalarValue);
+        return generateExtractor(iterator, rootExtractor);
     }
 
-    private static JsonExtractor generateExtractor(Iterator<String> filters, boolean scalarValue)
+    private static <T> JsonExtractor<T> generateExtractor(Iterator<String> filters, JsonExtractor<T> rootExtractor)
     {
         if (!filters.hasNext()) {
-            return scalarValue ? new ScalarValueJsonExtractor() : new JsonValueJsonExtractor();
+            return rootExtractor;
         }
 
         String filter = filters.next();
         if (filter.startsWith("[")) {
             int index = Integer.parseInt(filter.substring(1).trim());
-            return new ArrayElementJsonExtractor(index, generateExtractor(filters, scalarValue));
+            return new ArrayElementJsonExtractor<>(index, generateExtractor(filters, rootExtractor));
         }
         else {
-            return new ObjectFieldJsonExtractor(filter, generateExtractor(filters, scalarValue));
+            return new ObjectFieldJsonExtractor<>(filter, generateExtractor(filters, rootExtractor));
         }
     }
 
-    public interface JsonExtractor
+    public interface JsonExtractor<T>
     {
         /**
-         * Executes the extraction on the existing content of the JasonParser and outputs the value as a Slice.
+         * Executes the extraction on the existing content of the JasonParser and outputs the match.
          * <p/>
          * Notes:
          * <ul>
@@ -241,26 +313,26 @@ public final class JsonExtract
          * <li>INVARIANT: when extract() returns, the current token of the parser will be the LAST token of the value</li>
          * </ul>
          *
-         * @return Slice of the value, or null if not applicable
+         * @return the value, or null if not applicable
          */
-        Slice extract(JsonParser jsonParser)
+        T extract(JsonParser jsonParser)
                 throws IOException;
     }
 
-    public static class ObjectFieldJsonExtractor
-            implements JsonExtractor
+    public static class ObjectFieldJsonExtractor<T>
+            implements JsonExtractor<T>
     {
         private final SerializedString fieldName;
-        private final JsonExtractor delegate;
+        private final JsonExtractor<? extends T> delegate;
 
-        public ObjectFieldJsonExtractor(String fieldName, JsonExtractor delegate)
+        public ObjectFieldJsonExtractor(String fieldName, JsonExtractor<? extends T> delegate)
         {
             this.fieldName = new SerializedString(checkNotNull(fieldName, "fieldName is null"));
             this.delegate = checkNotNull(delegate, "delegate is null");
         }
 
         @Override
-        public Slice extract(JsonParser jsonParser)
+        public T extract(JsonParser jsonParser)
                 throws IOException
         {
             if (jsonParser.getCurrentToken() != START_OBJECT) {
@@ -284,13 +356,13 @@ public final class JsonExtract
         }
     }
 
-    public static class ArrayElementJsonExtractor
-            implements JsonExtractor
+    public static class ArrayElementJsonExtractor<T>
+            implements JsonExtractor<T>
     {
         private final int index;
-        private final JsonExtractor delegate;
+        private final JsonExtractor<? extends T> delegate;
 
-        public ArrayElementJsonExtractor(int index, JsonExtractor delegate)
+        public ArrayElementJsonExtractor(int index, JsonExtractor<? extends T> delegate)
         {
             checkArgument(index >= 0, "index must be greater than or equal to zero: %s", index);
             checkNotNull(delegate, "delegate is null");
@@ -299,7 +371,7 @@ public final class JsonExtract
         }
 
         @Override
-        public Slice extract(JsonParser jsonParser)
+        public T extract(JsonParser jsonParser)
                 throws IOException
         {
             if (jsonParser.getCurrentToken() != START_ARRAY) {
@@ -328,7 +400,7 @@ public final class JsonExtract
     }
 
     public static class ScalarValueJsonExtractor
-            implements JsonExtractor
+            implements JsonExtractor<Slice>
     {
         @Override
         public Slice extract(JsonParser jsonParser)
@@ -346,7 +418,7 @@ public final class JsonExtract
     }
 
     public static class JsonValueJsonExtractor
-            implements JsonExtractor
+            implements JsonExtractor<Slice>
     {
         @Override
         public Slice extract(JsonParser jsonParser)
@@ -361,6 +433,56 @@ public final class JsonExtract
                 jsonGenerator.copyCurrentStructure(jsonParser);
             }
             return dynamicSliceOutput.slice();
+        }
+    }
+
+    public static class JsonSizeExtractor
+            implements JsonExtractor<Long>
+    {
+        @Override
+        public Long extract(JsonParser jsonParser)
+                throws IOException
+        {
+            if (!jsonParser.hasCurrentToken()) {
+                throw new JsonParseException("Unexpected end of value", jsonParser.getCurrentLocation());
+            }
+
+            if (jsonParser.getCurrentToken() == START_ARRAY) {
+                long length = 0;
+                while (true) {
+                    JsonToken token = jsonParser.nextToken();
+                    if (token == null) {
+                        return null;
+                    }
+                    if (token == END_ARRAY) {
+                        return length;
+                    }
+                    jsonParser.skipChildren();
+
+                    length++;
+                }
+            }
+            else if (jsonParser.getCurrentToken() == START_OBJECT) {
+                long length = 0;
+                while (true) {
+                    JsonToken token = jsonParser.nextToken();
+                    if (token == null) {
+                        return null;
+                    }
+                    if (token == END_OBJECT) {
+                        return length;
+                    }
+
+                    if (token == FIELD_NAME) {
+                        length++;
+                    } else {
+                        jsonParser.skipChildren();
+                    }
+                }
+            }
+            else {
+                return 0L;
+            }
         }
     }
 
@@ -381,21 +503,21 @@ public final class JsonExtract
         }
     }
 
-    public static class JsonExtractCache
-            extends ThreadLocalCache<Slice, JsonExtractor>
+    public static class JsonExtractCache<T>
+            extends ThreadLocalCache<Slice, JsonExtractor<T>>
     {
-        private final boolean isScalarValue;
+        private final Supplier<JsonExtractor<T>> rootSupplier;
 
-        public JsonExtractCache(int sizePerThread, boolean isScalarValue)
+        public JsonExtractCache(int maxSizePerThread, Supplier<JsonExtractor<T>> rootSupplier)
         {
-            super(sizePerThread);
-            this.isScalarValue = isScalarValue;
+            super(maxSizePerThread);
+            this.rootSupplier = rootSupplier;
         }
 
         @Override
-        protected JsonExtractor load(Slice jsonPath)
+        protected JsonExtractor<T> load(Slice jsonPath)
         {
-            return generateExtractor(jsonPath.toString(Charsets.UTF_8), isScalarValue);
+            return generateExtractor(jsonPath.toString(Charsets.UTF_8), rootSupplier.get());
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
@@ -34,7 +34,7 @@ import static org.testng.Assert.assertEquals;
 public class TestJsonExtract
 {
     @Test
-    public void testScalarVaueJsonExtractor()
+    public void testScalarValueJsonExtractor()
             throws Exception
     {
         ScalarValueJsonExtractor extractor = new ScalarValueJsonExtractor();
@@ -57,7 +57,7 @@ public class TestJsonExtract
     }
 
     @Test
-    public void testJsonVaueJsonExtractor()
+    public void testJsonValueJsonExtractor()
             throws Exception
     {
         JsonValueJsonExtractor extractor = new JsonValueJsonExtractor();
@@ -83,8 +83,8 @@ public class TestJsonExtract
     public void testArrayElementJsonExtractor()
             throws Exception
     {
-        ArrayElementJsonExtractor firstExtractor = new ArrayElementJsonExtractor(0, new ScalarValueJsonExtractor());
-        ArrayElementJsonExtractor secondExtractor = new ArrayElementJsonExtractor(1, new ScalarValueJsonExtractor());
+        ArrayElementJsonExtractor<Slice> firstExtractor = new ArrayElementJsonExtractor<>(0, new ScalarValueJsonExtractor());
+        ArrayElementJsonExtractor<Slice> secondExtractor = new ArrayElementJsonExtractor<>(1, new ScalarValueJsonExtractor());
 
         assertEquals(doExtract(firstExtractor, "[]"), null);
         assertEquals(doExtract(firstExtractor, "[1, 2, 3]"), "1");
@@ -100,7 +100,7 @@ public class TestJsonExtract
     public void testObjectFieldJsonExtractor()
             throws Exception
     {
-        ObjectFieldJsonExtractor extractor = new ObjectFieldJsonExtractor("fuu", new ScalarValueJsonExtractor());
+        ObjectFieldJsonExtractor<Slice> extractor = new ObjectFieldJsonExtractor<>("fuu", new ScalarValueJsonExtractor());
 
         assertEquals(doExtract(extractor, "{}"), null);
         assertEquals(doExtract(extractor, "{\"a\": 1}"), null);
@@ -176,7 +176,7 @@ public class TestJsonExtract
         doScalarExtract("{}", "$.bar[2][-1]");
     }
 
-    private static String doExtract(JsonExtractor jsonExtractor, String json)
+    private static String doExtract(JsonExtractor<Slice> jsonExtractor, String json)
             throws IOException
     {
         JsonFactory jsonFactory = new JsonFactory();
@@ -189,14 +189,14 @@ public class TestJsonExtract
     private static String doScalarExtract(String inputJson, String jsonPath)
             throws IOException
     {
-        Slice value = JsonExtract.extractInternal(Slices.wrappedBuffer(inputJson.getBytes(Charsets.UTF_8)), generateExtractor(jsonPath, true));
+        Slice value = JsonExtract.extractInternal(Slices.wrappedBuffer(inputJson.getBytes(Charsets.UTF_8)), generateExtractor(jsonPath, new ScalarValueJsonExtractor()));
         return (value == null) ? null : value.toString(Charsets.UTF_8);
     }
 
     private static String doJsonExtract(String inputJson, String jsonPath)
             throws IOException
     {
-        Slice value = JsonExtract.extractInternal(Slices.wrappedBuffer(inputJson.getBytes(Charsets.UTF_8)), generateExtractor(jsonPath, false));
+        Slice value = JsonExtract.extractInternal(Slices.wrappedBuffer(inputJson.getBytes(Charsets.UTF_8)), generateExtractor(jsonPath, new JsonValueJsonExtractor()));
         return (value == null) ? null : value.toString(Charsets.UTF_8);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonFunctions.java
@@ -149,10 +149,11 @@ public class TestJsonFunctions
     {
         assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$"), 1);
         assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x"), 2);
+        assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : [1,2,3], \"c\" : {\"w\":9}} }", "$.x"), 3);
         assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.a"), 0);
         assertFunction(format("JSON_SIZE('%s', '%s')", "[1,2,3]", "$"), 3);
         assertFunction(format("JSON_SIZE(null, '%s')", "$"), null);
-        assertFunction(format("JSON_SIZE('%s', '%s')", "[1,2,3]", "INVALID_JSON"), null);
+        assertFunction(format("JSON_SIZE('%s', '%s')", "INVALID_JSON", "$"), null);
         assertFunction(format("JSON_SIZE('%s', null)", "[1,2,3]"), null);
     }
 


### PR DESCRIPTION
Avoid extra round trip by performing size directly in extract code
Use function binder to cache patterns in call site
