### PR TITLE
HiveClient.listTableColumns exclude views instead of throwing HiveViewNotSupportedException

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
@@ -397,6 +397,9 @@ public class HiveClient
             try {
                 columns.put(tableName, getTableMetadata(tableName).getColumns());
             }
+            catch (HiveViewNotSupportedException e) {
+                // view is not supported
+            }
             catch (TableNotFoundException e) {
                 // table disappeared during listing operation
             }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -825,6 +825,13 @@ public abstract class AbstractTestHiveClient
     }
 
     @Test
+    public void testHiveViewsHaveNoColumns()
+            throws Exception
+    {
+        assertEquals(metadata.listTableColumns(SESSION, new SchemaTablePrefix(view.getSchemaName(), view.getTableName())), ImmutableMap.of());
+    }
+
+    @Test
     public void testTableCreation()
             throws Exception
     {


### PR DESCRIPTION
Select from information_schema.columns fails with "Hive views are not supported" message if Hive has a VIEW.
This patch changes HiveClient.listTableColumns to exclude VIEW.
Related to https://github.com/treasure-data/prestogres/issues/12
