### PR TITLE
Test for partitions with multiple splits

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/TestDoubleSplit.java
+++ b/presto-main/src/test/java/com/facebook/presto/TestDoubleSplit.java
@@ -1,0 +1,74 @@
+package com.facebook.presto;
+
+import com.facebook.presto.metadata.QualifiedTableName;
+import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.facebook.presto.tpch.TpchMetadata;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Closer;
+import io.airlift.log.Logging;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Locale;
+
+import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestDoubleSplit
+{
+    public static final int SPLITS_PER_NODE = 2;
+
+    public static final ConnectorSession SESSION = new ConnectorSession("user", "source", "tpch", TpchMetadata.TINY_SCHEMA_NAME, UTC_KEY, Locale.ENGLISH, null, null);
+
+    private final Closer closer = Closer.create();
+
+    private LocalQueryRunner queryRunner;
+
+    @BeforeMethod
+    public void spinUp()
+            throws Exception
+    {
+        Logging.initialize();
+
+        this.queryRunner = closer.register(new LocalQueryRunner(SESSION));
+        // add tpch
+        queryRunner.createCatalog("tpch", new TpchConnectorFactory(queryRunner.getNodeManager(), SPLITS_PER_NODE), ImmutableMap.<String, String>of());
+    }
+
+    @AfterMethod
+    public void tearDown()
+            throws Exception
+    {
+        closer.close();
+    }
+
+    @Test
+    public void testTableExists()
+            throws Exception
+    {
+        QualifiedTableName name = new QualifiedTableName("tpch", TpchMetadata.TINY_SCHEMA_NAME, "nation");
+        Optional<TableHandle> handle = queryRunner.getMetadata().getTableHandle(SESSION, name);
+        assertTrue(handle.isPresent());
+    }
+
+    @Test
+    public void testTableHasData()
+            throws Exception
+    {
+        MaterializedResult result = queryRunner.execute("SELECT count(1) from nation");
+
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(25)
+                .build();
+
+        assertEquals(result, expected);
+    }
+}


### PR DESCRIPTION
Apply this patch. Run the test. It fails with 

```
java.lang.IllegalStateException: split already set
    at com.google.common.base.Preconditions.checkState(Preconditions.java:176)
    at com.facebook.presto.operator.AbstractScanFilterAndProjectOperator.addSplit(AbstractScanFilterAndProjectOperator.java:93)
    at com.facebook.presto.operator.Driver.processNewSource(Driver.java:251)
    at com.facebook.presto.operator.Driver.processNewSources(Driver.java:216)
    at com.facebook.presto.operator.Driver.access$3(Driver.java:197)
    at com.facebook.presto.operator.Driver$DriverLockResult.close(Driver.java:491)
    at com.facebook.presto.operator.Driver.updateSource(Driver.java:194)
    at com.facebook.presto.testing.LocalQueryRunner.createDrivers(LocalQueryRunner.java:400)
    at com.facebook.presto.testing.LocalQueryRunner.execute(LocalQueryRunner.java:289)
    at com.facebook.presto.testing.LocalQueryRunner.execute(LocalQueryRunner.java:280)
    at com.facebook.presto.TestSimple.testTableHasData(TestSimple.java:66)
```

Set the SPLITS_PER_NODE constant value to 1. Rerun the test. It passes.

The LocalQueryRunner seems to be incapable to deal with partitions that have more than one split. 
