### PR TITLE
Fix NULLIF semantics

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -302,19 +302,7 @@ public class TestExpressionCompiler
 
                 Object expectedNullIf = nullIf(left, right);
                 for (String expression : generateExpression("nullif(%s, %s)", left, right)) {
-                    try {
-                        Object actual = functionAssertions.selectSingleValue(expression);
-                        if (!Objects.equals(actual, expectedNullIf)) {
-                            if (left != null && right == null) {
-                                expectedNullIf = ((Number) expectedNullIf).doubleValue();
-                                actual = ((Number) expectedNullIf).doubleValue();
-                            }
-                            assertEquals(actual, expectedNullIf, expression);
-                        }
-                    }
-                    catch (RuntimeException e) {
-                        throw new RuntimeException("Error processing " + expression, e);
-                    }
+                    functionAssertions.assertFunction(expression, expectedNullIf);
                 }
 
                 assertExecute(generateExpression("%s is distinct from %s", left, right), !Objects.equals(left == null ? null : left.doubleValue(), right));
@@ -416,13 +404,11 @@ public class TestExpressionCompiler
             return left;
         }
 
-        if (left instanceof Double || right instanceof Double) {
-            if (((Number) left).doubleValue() == ((Number) right).doubleValue()) {
-                return null;
-            }
-            return ((Number) left).doubleValue();
+        if (left.equals(right)) {
+            return null;
         }
-        else if (left.equals(right)) {
+
+        if ((left instanceof Double || right instanceof Double) && ((Number) left).doubleValue() == ((Number) right).doubleValue()) {
             return null;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestInterpretedProjectionFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestInterpretedProjectionFunction.java
@@ -122,7 +122,7 @@ public class TestInterpretedProjectionFunction
         assertProjection("NULLIF('foo', 'foo')", null);
 
         assertProjection("NULLIF(42, 87)", 42L);
-        assertProjection("NULLIF(42, 22.2)", 42.0);
+        assertProjection("NULLIF(42, 22.2)", 42L);
         assertProjection("NULLIF(42.42, 22.2)", 42.42);
         assertProjection("NULLIF('foo', 'bar')", "foo");
 


### PR DESCRIPTION
NULLIF now correctly returns a result with the type of the first argument. For instance:

```
NULLIF(1.0, 2) => 1.0
NULLIF(1, 2.0) => 1
```

Previously, the type of the result was the common supertype of both arguments
