### PR TITLE
using multiple column-indexes together in a single CQL-query Cassandra

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSplitManager.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSplitManager.java
@@ -129,12 +129,13 @@ public class CassandraSplitManager
                 CassandraColumnHandle column = (CassandraColumnHandle) entry.getKey();
                 Domain domain = entry.getValue();
                 if (column.isIndexed() && domain.isSingleValue()) {
+                    if (sb.length() > 0) {
+                        sb.append(" AND ");
+                    }
                     sb.append(CassandraCqlUtils.validColumnName(column.getName()))
                       .append(" = ")
                       .append(CassandraCqlUtils.cqlValue(toCQLCompatibleString(entry.getValue().getSingleValue()), column.getCassandraType()));
                     indexedColumns.add(column);
-                    // Only one indexed column predicate can be pushed down.
-                    break;
                 }
             }
             if (sb.length() > 0) {
@@ -277,7 +278,7 @@ public class CassandraSplitManager
 
     private static String buildTokenCondition(String tokenExpression, String startToken, String endToken)
     {
-        return tokenExpression + " > " + startToken + " AND " + tokenExpression + " <= " + endToken;
+        return tokenExpression + " > " + startToken + " AND " + tokenExpression + " <= " + endToken + " ALLOW FILTERING";
     }
 
     private List<ConnectorSplit> getSplitsForPartitions(CassandraTableHandle cassTableHandle, List<ConnectorPartition> partitions)


### PR DESCRIPTION
Dear @alexliu68 , dear @dain 
this PR patches CassandrSplitManager to include multiple domains by using "AND". However I found a note in the code stating that "Only one indexed column predicate can be pushed down.". According to http://www.datastax.com/documentation/cql/3.0/cql/ddl/ddl_using_multiple_indexes.html multiple indexes are possible in CQL. According to https://github.com/facebook/presto/blob/master/presto-spi/src/main/java/com/facebook/presto/spi/TupleDomain.java#L39 it seems that TupleDomains can be anded. What do you think? Regards, Andi
