### PR TITLE
Optimize row_number window function 

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -156,6 +156,12 @@ public class DriverContext
         return result;
     }
 
+    public void freeMemory(long bytes)
+    {
+        pipelineContext.freeMemory(bytes);
+        memoryReservation.getAndAdd(-bytes);
+    }
+
     public boolean isCpuTimerEnabled()
     {
         return pipelineContext.isCpuTimerEnabled();

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -201,6 +201,12 @@ public class OperatorContext
         return result;
     }
 
+    public void freeMemory(long bytes)
+    {
+        driverContext.freeMemory(bytes);
+        memoryReservation.getAndAdd(-bytes);
+    }
+
     public synchronized long setMemoryReservation(long newMemoryReservation)
     {
         checkArgument(newMemoryReservation >= 0, "newMemoryReservation is negative");

--- a/presto-main/src/main/java/com/facebook/presto/operator/Page.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Page.java
@@ -95,6 +95,15 @@ public class Page
         return getBlock(channel).isNull(position);
     }
 
+    public Block[] getSingleValueBlocks(int position)
+    {
+        Block[] row = new Block[blocks.length];
+        for (int i = 0; i < blocks.length; i++) {
+            row[i] = blocks[i].getSingleValueBlock(position);
+        }
+        return row;
+    }
+
     @Override
     public String toString()
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
@@ -214,7 +214,7 @@ public class PipelineContext
         return result;
     }
 
-    private synchronized void freeMemory(long bytes)
+    public synchronized void freeMemory(long bytes)
     {
         checkArgument(bytes <= memoryReservation.get(), "tried to free more memory than is reserved");
         taskContext.freeMemory(bytes);

--- a/presto-main/src/main/java/com/facebook/presto/operator/RowComparator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/RowComparator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Comparator;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class RowComparator
+        implements Comparator<Block[]>
+{
+    private final List<Type> sortTypes;
+    private final List<Integer> sortChannels;
+    private final List<SortOrder> sortOrders;
+
+    public RowComparator(List<Type> sortTypes, List<Integer> sortChannels, List<SortOrder> sortOrders)
+    {
+        this.sortTypes = ImmutableList.copyOf(checkNotNull(sortTypes, "sortTypes is null"));
+        this.sortChannels = ImmutableList.copyOf(checkNotNull(sortChannels, "sortChannels is null"));
+        this.sortOrders = ImmutableList.copyOf(checkNotNull(sortOrders, "sortOrders is null"));
+        checkArgument(sortTypes.size() == sortChannels.size(), "sortTypes size (%s) doesn't match sortChannels size (%s)", sortTypes.size(), sortChannels.size());
+        checkArgument(sortChannels.size() == sortOrders.size(), "sortFields size (%s) doesn't match sortOrders size (%s)", sortChannels.size(), sortOrders.size());
+    }
+
+    @Override
+    public int compare(Block[] leftRow, Block[] rightRow)
+    {
+        for (int index = 0; index < sortChannels.size(); index++) {
+            Type type = sortTypes.get(index);
+            int channel = sortChannels.get(index);
+            SortOrder sortOrder = sortOrders.get(index);
+
+            Block left = leftRow[channel];
+            Block right = rightRow[channel];
+
+            int comparison = sortOrder.compareBlockValue(type, left, 0, right, 0);
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        return 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/RowNumberLimitOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/RowNumberLimitOperator.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.util.array.LongBigArray;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+public class RowNumberLimitOperator
+        implements Operator
+{
+    public static class RowNumberLimitOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final List<Type> sourceTypes;
+        private final List<Integer> outputChannels;
+        private final List<Integer> partitionChannels;
+        private final int expectedPositions;
+        private final List<Type> types;
+        private boolean closed;
+
+        private final List<Type> partitionTypes;
+        private final int maxRowCountPerPartition;
+
+        public RowNumberLimitOperatorFactory(
+                int operatorId,
+                List<? extends Type> sourceTypes,
+                List<Integer> outputChannels,
+                List<Integer> partitionChannels,
+                List<? extends Type> partitionTypes,
+                int expectedPositions,
+                int maxRowCountPerPartition)
+        {
+            this.operatorId = operatorId;
+            this.sourceTypes = ImmutableList.copyOf(sourceTypes);
+            this.outputChannels = ImmutableList.copyOf(checkNotNull(outputChannels, "outputChannels is null"));
+            this.partitionChannels = ImmutableList.copyOf(checkNotNull(partitionChannels, "partitionChannels is null"));
+            this.partitionTypes = ImmutableList.copyOf(checkNotNull(partitionTypes, "partitionTypes is null"));
+
+            checkArgument(expectedPositions > 0, "expectedPositions < 0");
+            this.expectedPositions = expectedPositions;
+            checkArgument(maxRowCountPerPartition > 0, "maxRowCountPerPartition < 0");
+            this.maxRowCountPerPartition = maxRowCountPerPartition;
+            this.types = toTypes(sourceTypes, outputChannels);
+        }
+
+        @Override
+        public List<Type> getTypes()
+        {
+            return types;
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, RowNumberLimitOperator.class.getSimpleName());
+            return new RowNumberLimitOperator(
+                    operatorContext,
+                    sourceTypes,
+                    outputChannels,
+                    partitionChannels,
+                    partitionTypes,
+                    expectedPositions,
+                    maxRowCountPerPartition);
+        }
+
+        @Override
+        public void close()
+        {
+            closed = true;
+        }
+    }
+
+    private final OperatorContext operatorContext;
+    private boolean finishing;
+
+    private final PageBuilder pageBuilder;
+    private final int[] outputChannels;
+    private final List<Type> types;
+
+    private GroupByIdBlock partitionIds;
+    private final GroupByHash groupByHash;
+
+    private Page inputPage;
+    private int currentPosition;
+    private final int maxRowCountPerPartition;
+    private final LongBigArray partitionRowCount;
+
+    public RowNumberLimitOperator(
+            OperatorContext operatorContext,
+            List<Type> sourceTypes,
+            List<Integer> outputChannels,
+            List<Integer> partitionChannels,
+            List<Type> partitionTypes,
+            int expectedPositions,
+            int maxRowCountPerPartition)
+    {
+        this.operatorContext = checkNotNull(operatorContext, "operatorContext is null");
+        this.outputChannels = Ints.toArray(outputChannels);
+        this.maxRowCountPerPartition = maxRowCountPerPartition;
+
+        this.partitionRowCount = new LongBigArray(0);
+        this.groupByHash = new GroupByHash(partitionTypes, Ints.toArray(partitionChannels), expectedPositions);
+        this.types = toTypes(sourceTypes, outputChannels);
+        this.pageBuilder = new PageBuilder(types);
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public List<Type> getTypes()
+    {
+        return types;
+    }
+
+    @Override
+    public void finish()
+    {
+        finishing = true;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finishing && pageBuilder.isEmpty();
+    }
+
+    @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return !finishing && inputPage == null;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        checkState(!finishing, "Operator is already finishing");
+        checkNotNull(page, "page is null");
+        checkState(inputPage == null);
+        inputPage = page;
+        partitionIds = groupByHash.getGroupIds(inputPage);
+        partitionRowCount.ensureCapacity(partitionIds.getGroupCount());
+        currentPosition = 0;
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        if (inputPage == null) {
+            return null;
+        }
+
+        while (!pageBuilder.isFull() && currentPosition < inputPage.getPositionCount()) {
+            long partitionId = partitionIds.getGroupId(currentPosition);
+            long rowCount = partitionRowCount.get(partitionId);
+            if (rowCount < maxRowCountPerPartition) {
+                for (int i = 0; i < outputChannels.length; i++) {
+                    int channel = outputChannels[i];
+                    Type type = types.get(channel);
+                    type.appendTo(inputPage.getBlock(channel), currentPosition, pageBuilder.getBlockBuilder(i));
+                }
+                BIGINT.writeLong(pageBuilder.getBlockBuilder(types.size() - 1), rowCount + 1);
+                partitionRowCount.set(partitionId, rowCount + 1);
+            }
+            currentPosition++;
+        }
+        if (currentPosition == inputPage.getPositionCount()) {
+            inputPage = null;
+            currentPosition = 0;
+        }
+
+        if (pageBuilder.isEmpty()) {
+            return null;
+        }
+
+        Page page = pageBuilder.build();
+        pageBuilder.reset();
+        return page;
+    }
+
+    private static List<Type> toTypes(List<? extends Type> sourceTypes, List<Integer> outputChannels)
+    {
+        ImmutableList.Builder<Type> types = ImmutableList.builder();
+        for (int channel : outputChannels) {
+            types.add(sourceTypes.get(channel));
+        }
+        types.add(BIGINT);
+        return types.build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/TopNOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TopNOperator.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -381,42 +380,6 @@ public class TopNOperator
         public DataSize getMaxMemorySize()
         {
             return operatorContext.getMaxMemorySize();
-        }
-    }
-
-    private static class RowComparator
-            implements Comparator<Block[]>
-    {
-        private final List<Type> sortTypes;
-        private final List<Integer> sortChannels;
-        private final List<SortOrder> sortOrders;
-
-        public RowComparator(List<Type> sortTypes, List<Integer> sortChannels, List<SortOrder> sortOrders)
-        {
-            this.sortTypes = ImmutableList.copyOf(checkNotNull(sortTypes, "sortTypes is null"));
-            this.sortChannels = ImmutableList.copyOf(checkNotNull(sortChannels, "sortChannels is null"));
-            this.sortOrders = ImmutableList.copyOf(checkNotNull(sortOrders, "sortOrders is null"));
-            checkArgument(sortTypes.size() == sortChannels.size(), "sortTypes size (%s) doesn't match sortChannels size (%s)", sortTypes.size(), sortChannels.size());
-            checkArgument(sortChannels.size() == sortOrders.size(), "sortFields size (%s) doesn't match sortOrders size (%s)", sortChannels.size(), sortOrders.size());
-        }
-
-        @Override
-        public int compare(Block[] leftRow, Block[] rightRow)
-        {
-            for (int index = 0; index < sortChannels.size(); index++) {
-                Type type = sortTypes.get(index);
-                int channel = sortChannels.get(index);
-                SortOrder sortOrder = sortOrders.get(index);
-
-                Block left = leftRow[channel];
-                Block right = rightRow[channel];
-
-                int comparison = sortOrder.compareBlockValue(type, left, 0, right, 0);
-                if (comparison != 0) {
-                    return comparison;
-                }
-            }
-            return 0;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/TopNRowNumberOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TopNRowNumberOperator.java
@@ -1,0 +1,440 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.ExceededMemoryLimitException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.MinMaxPriorityQueue;
+import com.google.common.collect.Ordering;
+import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.DataSize;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+public class TopNRowNumberOperator
+        implements Operator
+{
+    public static class TopNRowNumberOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+
+        private final List<Type> sourceTypes;
+        private final List<Integer> outputChannels;
+        private final List<Integer> partitionChannels;
+        private final List<Type> partitionTypes;
+        private final List<Integer> sortChannels;
+        private final List<SortOrder> sortOrder;
+        private final int maxRowCountPerPartition;
+        private final int expectedPositions;
+
+        private final List<Type> types;
+        private final List<Type> sortTypes;
+        private boolean closed;
+
+        public TopNRowNumberOperatorFactory(
+                int operatorId,
+                List<? extends Type> sourceTypes,
+                List<Integer> outputChannels,
+                List<Integer> partitionChannels,
+                List<? extends Type> partitionTypes,
+                List<Integer> sortChannels,
+                List<SortOrder> sortOrder,
+                int maxRowCountPerPartition,
+                int expectedPositions)
+        {
+            this.operatorId = operatorId;
+            this.sourceTypes = ImmutableList.copyOf(sourceTypes);
+            this.outputChannels = ImmutableList.copyOf(checkNotNull(outputChannels, "outputChannels is null"));
+            this.partitionChannels = ImmutableList.copyOf(checkNotNull(partitionChannels, "partitionChannels is null"));
+            this.partitionTypes = ImmutableList.copyOf(checkNotNull(partitionTypes, "partitionTypes is null"));
+            this.sortChannels = ImmutableList.copyOf(checkNotNull(sortChannels));
+            this.sortOrder = ImmutableList.copyOf(checkNotNull(sortOrder));
+            checkArgument(maxRowCountPerPartition > 0, "maxRowCountPerPartition must be > 0");
+            this.maxRowCountPerPartition = maxRowCountPerPartition;
+            checkArgument(expectedPositions > 0, "expectedPositions must be > 0");
+            this.expectedPositions = expectedPositions;
+
+            this.types = toTypes(sourceTypes, outputChannels);
+            ImmutableList.Builder<Type> sortTypes = ImmutableList.builder();
+            for (int channel : sortChannels) {
+                sortTypes.add(types.get(channel));
+            }
+            this.sortTypes = sortTypes.build();
+        }
+
+        @Override
+        public List<Type> getTypes()
+        {
+            return types;
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, TopNRowNumberOperator.class.getSimpleName());
+            return new TopNRowNumberOperator(
+                    operatorContext,
+                    sourceTypes,
+                    outputChannels,
+                    partitionChannels,
+                    partitionTypes,
+                    sortChannels,
+                    sortOrder,
+                    sortTypes,
+                    maxRowCountPerPartition,
+                    expectedPositions);
+        }
+
+        @Override
+        public void close()
+        {
+            closed = true;
+        }
+    }
+
+    private static final DataSize OVERHEAD_PER_VALUE = new DataSize(100, DataSize.Unit.BYTE); // for estimating in-memory size. This is a completely arbitrary number
+
+    private final OperatorContext operatorContext;
+    private boolean finishing;
+    private final List<Type> types;
+    private final int[] outputChannels;
+
+    private final List<Integer> sortChannels;
+    private final List<SortOrder> sortOrders;
+    private final List<Type> sortTypes;
+    private final int maxRowCountPerPartition;
+
+    private final MemoryManager memoryManager;
+    private final Map<Long, PartitionBuilder> partitionRows;
+    private Optional<FlushingPartition> flushingPartition;
+    private final PageBuilder pageBuilder;
+    private final GroupByHash groupByHash;
+
+    public TopNRowNumberOperator(
+            OperatorContext operatorContext,
+            List<? extends Type> sourceTypes,
+            List<Integer> outputChannels,
+            List<Integer> partitionChannels,
+            List<Type> partitionTypes,
+            List<Integer> sortChannels,
+            List<SortOrder> sortOrders,
+            List<Type> sortTypes,
+            int maxRowCountPerPartition,
+            int expectedPositions)
+    {
+        this.operatorContext = checkNotNull(operatorContext, "operatorContext is null");
+        this.outputChannels = Ints.toArray(checkNotNull(outputChannels, "outputChannels is null"));
+
+        this.sortChannels = checkNotNull(sortChannels, "sortChannels is null");
+        this.sortOrders = checkNotNull(sortOrders, "sortOrders is null");
+        this.sortTypes = checkNotNull(sortTypes, "sortTypes is null");
+
+        checkArgument(maxRowCountPerPartition > 0, "maxRowCountPerPartition must be > 0");
+        this.maxRowCountPerPartition = maxRowCountPerPartition;
+        checkArgument(expectedPositions > 0, "expectedPositions must be > 0");
+
+        this.types = toTypes(sourceTypes, outputChannels);
+        this.memoryManager = new MemoryManager(operatorContext);
+        this.partitionRows = new HashMap<>();
+        this.groupByHash = new GroupByHash(partitionTypes, Ints.toArray(partitionChannels), expectedPositions);
+        this.flushingPartition = Optional.absent();
+        this.pageBuilder = new PageBuilder(types);
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public List<Type> getTypes()
+    {
+        return types;
+    }
+
+    @Override
+    public void finish()
+    {
+        finishing = true;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finishing && isEmpty();
+    }
+
+    @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return !finishing && !memoryManager.isFull() && !isFlushing();
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        checkState(!finishing, "Operator is already finishing");
+        checkNotNull(page, "page is null");
+        checkState(!isFlushing(), "Cannot add input with the operator is flushing data");
+        processPage(page);
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        if (finishing && !isEmpty()) {
+            return getPage();
+        }
+        return null;
+    }
+
+    private void processPage(Page page)
+    {
+        long groupByHashSize = groupByHash.getEstimatedSize();
+        GroupByIdBlock partitionIds = groupByHash.getGroupIds(page);
+        memoryManager.canUseDelta(groupByHash.getEstimatedSize() - groupByHashSize);
+
+        long sizeDelta = 0;
+        Block[] blocks = page.getBlocks();
+        for (int position = 0; position < page.getPositionCount(); position++) {
+            long partitionId = partitionIds.getGroupId(position);
+            if (!partitionRows.containsKey(partitionId)) {
+                partitionRows.put(partitionId, new PartitionBuilder(sortTypes, sortChannels, sortOrders, maxRowCountPerPartition));
+            }
+            PartitionBuilder partitionBuilder = partitionRows.get(partitionId);
+            if (partitionBuilder.getRowCount() < maxRowCountPerPartition) {
+                Block[] row = page.getSingleValueBlocks(position);
+                sizeDelta += partitionBuilder.addRow(row);
+            }
+            else if (compare(position, blocks, partitionBuilder.peekLastRow()) < 0) {
+                Block[] row = page.getSingleValueBlocks(position);
+                sizeDelta += partitionBuilder.replaceRow(row);
+            }
+        }
+        if (!memoryManager.canUseDelta(sizeDelta)) {
+            throw new ExceededMemoryLimitException(memoryManager.getMaxMemorySize());
+        }
+    }
+
+    private int compare(int position, Block[] blocks, Block[] currentMax)
+    {
+        for (int i = 0; i < sortChannels.size(); i++) {
+            Type type = sortTypes.get(i);
+            int sortChannel = sortChannels.get(i);
+            SortOrder sortOrder = sortOrders.get(i);
+
+            Block block = blocks[sortChannel];
+            Block currentMaxValue = currentMax[sortChannel];
+
+            int compare = sortOrder.compareBlockValue(type, block, position, currentMaxValue, 0);
+            if (compare != 0) {
+                return compare;
+            }
+        }
+        return 0;
+    }
+
+    private Page getPage()
+    {
+        if (!flushingPartition.isPresent()) {
+            flushingPartition = getFlushingPartition();
+        }
+
+        pageBuilder.reset();
+        long sizeDelta = 0;
+        while (!pageBuilder.isFull() && flushingPartition.isPresent()) {
+            FlushingPartition currentFlushingPartition = flushingPartition.get();
+
+            while (!pageBuilder.isFull() && currentFlushingPartition.hasNext()) {
+                Block[] next = currentFlushingPartition.next();
+                sizeDelta += sizeOfRow(next);
+                for (int i = 0; i < outputChannels.length; i++) {
+                    int channel = outputChannels[i];
+                    Type type = types.get(channel);
+                    type.appendTo(next[channel], 0, pageBuilder.getBlockBuilder(i));
+                }
+
+                BIGINT.writeLong(pageBuilder.getBlockBuilder(outputChannels.length), currentFlushingPartition.getRowNumber());
+            }
+            if (!currentFlushingPartition.hasNext()) {
+                flushingPartition = getFlushingPartition();
+            }
+        }
+        if (pageBuilder.isEmpty()) {
+            return null;
+        }
+        Page page = pageBuilder.build();
+        memoryManager.freeMemory(-sizeDelta);
+        return page;
+    }
+
+    private Optional<FlushingPartition> getFlushingPartition()
+    {
+        int maxPartitionSize = 0;
+        PartitionBuilder chosenPartitionBuilder = null;
+        long chosenPartitionId = -1;
+
+        for (Map.Entry<Long, PartitionBuilder> entry : partitionRows.entrySet()) {
+            if (entry.getValue().getRowCount() > maxPartitionSize) {
+                chosenPartitionBuilder = entry.getValue();
+                maxPartitionSize = chosenPartitionBuilder.getRowCount();
+                chosenPartitionId = entry.getKey();
+                if (maxPartitionSize == maxRowCountPerPartition) {
+                    break;
+                }
+            }
+        }
+        if (chosenPartitionBuilder == null) {
+            return Optional.absent();
+        }
+        FlushingPartition flushingPartition = new FlushingPartition(chosenPartitionBuilder.build());
+        partitionRows.remove(chosenPartitionId);
+        return Optional.of(flushingPartition);
+    }
+
+    public boolean isFlushing()
+    {
+        return flushingPartition.isPresent();
+    }
+
+    public boolean isEmpty()
+    {
+        return partitionRows.isEmpty();
+    }
+
+    private static List<Type> toTypes(List<? extends Type> sourceTypes, List<Integer> outputChannels)
+    {
+        ImmutableList.Builder<Type> types = ImmutableList.builder();
+        for (int channel : outputChannels) {
+            types.add(sourceTypes.get(channel));
+        }
+        types.add(BIGINT);
+        return types.build();
+    }
+
+    private static long sizeOfRow(Block[] row)
+    {
+        long size = OVERHEAD_PER_VALUE.toBytes();
+        for (Block value : row) {
+            size += value.getSizeInBytes();
+        }
+        return size;
+    }
+
+    private static class PartitionBuilder
+    {
+        private final MinMaxPriorityQueue<Block[]> candidateRows;
+        private final int maxRowCountPerPartition;
+
+        private PartitionBuilder(List<Type> sortTypes, List<Integer> sortChannels, List<SortOrder> sortOrders, int maxRowCountPerPartition)
+        {
+            this.maxRowCountPerPartition = maxRowCountPerPartition;
+            Ordering<Block[]> comparator = Ordering.from(new RowComparator(sortTypes, sortChannels, sortOrders));
+            this.candidateRows = MinMaxPriorityQueue.orderedBy(comparator).maximumSize(maxRowCountPerPartition).create();
+        }
+
+        private long replaceRow(Block[] row)
+        {
+            checkState(candidateRows.size() == maxRowCountPerPartition);
+            Block[] previousRow = candidateRows.removeLast();
+            long sizeDelta = addRow(row);
+            return sizeDelta - sizeOfRow(previousRow);
+        }
+
+        private long addRow(Block[] row)
+        {
+            checkState(candidateRows.size() < maxRowCountPerPartition);
+            long sizeDelta = sizeOfRow(row);
+            candidateRows.add(row);
+            return sizeDelta;
+        }
+
+        private Iterator<Block[]> build()
+        {
+            ImmutableList.Builder<Block[]> sortedRows = ImmutableList.builder();
+            while (!candidateRows.isEmpty()) {
+                sortedRows.add(candidateRows.poll());
+            }
+            return sortedRows.build().iterator();
+        }
+
+        private int getRowCount()
+        {
+            return candidateRows.size();
+        }
+
+        private Block[] peekLastRow()
+        {
+            return candidateRows.peekLast();
+        }
+    }
+
+    private static class FlushingPartition
+            implements Iterator<Block[]>
+    {
+        private final Iterator<Block[]> outputIterator;
+        private int rowNumber;
+
+        private FlushingPartition(Iterator<Block[]> outputIterator)
+        {
+            this.outputIterator = outputIterator;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return outputIterator.hasNext();
+        }
+
+        @Override
+        public Block[] next()
+        {
+            rowNumber++;
+            return outputIterator.next();
+        }
+
+        @Override
+        public void remove()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        public int getRowNumber()
+        {
+            return rowNumber;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DistributedExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DistributedExecutionPlanner.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.RowNumberLimitNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SinkNode;
@@ -40,6 +41,7 @@ import com.facebook.presto.sql.planner.plan.TableCommitNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.plan.TopNNode;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.google.common.base.Optional;
@@ -187,6 +189,18 @@ public class DistributedExecutionPlanner
 
         @Override
         public Optional<SplitSource> visitWindow(WindowNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Optional<SplitSource> visitRowNumberLimit(RowNumberLimitNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Optional<SplitSource> visitTopNRowNumber(TopNRowNumberNode node, Void context)
         {
             return node.getSource().accept(this, context);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
@@ -31,6 +31,7 @@ import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
 import com.facebook.presto.sql.planner.optimizations.SimplifyExpressions;
 import com.facebook.presto.sql.planner.optimizations.UnaliasSymbolReferences;
+import com.facebook.presto.sql.planner.optimizations.WindowFilterPushDown;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 
@@ -62,6 +63,7 @@ public class PlanOptimizersFactory
                 new UnaliasSymbolReferences(), // Run again because predicate pushdown might add more projections
                 new IndexJoinOptimizer(indexManager), // Run this after projections and filters have been fully simplified and pushed down
                 new CountConstantOptimizer(),
+                new WindowFilterPushDown(metadata), // This must run after PredicatePushDown so that it squashes any successive filter nodes
                 new PruneUnreferencedOutputs(), // Make sure to run this at the end to help clean the plan for logging/execution and not remove info that other optimizers might need at an earlier point
                 new PruneRedundantProjections()); // This MUST run after PruneUnreferencedOutputs as it may introduce new redundant projections
         // TODO: consider adding a formal final plan sanitization optimizer that prepares the plan for transmission/execution/logging

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
@@ -41,6 +41,7 @@ import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.RowNumberLimitNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SinkNode;
@@ -49,6 +50,7 @@ import com.facebook.presto.sql.planner.plan.TableCommitNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.plan.TopNNode;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
@@ -291,7 +293,45 @@ public class PlanPrinter
             for (Map.Entry<Symbol, FunctionCall> entry : node.getWindowFunctions().entrySet()) {
                 print(indent + 2, "%s := %s(%s)", entry.getKey(), entry.getValue().getName(), Joiner.on(", ").join(entry.getValue().getArguments()));
             }
+            return processChildren(node, indent + 1);
+        }
 
+        @Override
+        public Void visitTopNRowNumber(final TopNRowNumberNode node, Integer indent)
+        {
+            List<String> partitionBy = Lists.transform(node.getPartitionBy(), Functions.toStringFunction());
+
+            List<String> orderBy = Lists.transform(node.getOrderBy(), new Function<Symbol, String>()
+            {
+                @Override
+                public String apply(Symbol input)
+                {
+                    return input + " " + node.getOrderings().get(input);
+                }
+            });
+
+            List<String> args = new ArrayList<>();
+            args.add(format("partition by (%s)", Joiner.on(", ").join(partitionBy)));
+            args.add(format("order by (%s)", Joiner.on(", ").join(orderBy)));
+
+            print(indent, "- TopNRowNumber[%s limit %s] => [%s]", Joiner.on(", ").join(args), node.getMaxRowCountPerPartition(), formatOutputs(node.getOutputSymbols()));
+
+            print(indent + 2, "%s := %s", node.getRowNumberSymbol(), "row_number()");
+            return processChildren(node, indent + 1);
+        }
+
+        @Override
+        public Void visitRowNumberLimit(final RowNumberLimitNode node, Integer indent)
+        {
+            List<String> partitionBy = Lists.transform(node.getPartitionBy(), Functions.toStringFunction());
+            List<String> args = new ArrayList<>();
+            if (!partitionBy.isEmpty()) {
+                args.add(format("partition by (%s)", Joiner.on(", ").join(partitionBy)));
+            }
+
+            print(indent, "- RowNumberLimit[%s limit=%s] => [%s]", Joiner.on(", ").join(args), node.getMaxRowCountPerPartition(), formatOutputs(node.getOutputSymbols()));
+
+            print(indent + 2, "%s := %s", node.getRowNumberSymbol(), "row_number()");
             return processChildren(node, indent + 1);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolExtractor.java
@@ -26,6 +26,7 @@ import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.RowNumberLimitNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SinkNode;
@@ -34,6 +35,7 @@ import com.facebook.presto.sql.planner.plan.TableCommitNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.plan.TopNNode;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
@@ -103,6 +105,28 @@ public final class SymbolExtractor
             node.getSource().accept(this, context);
 
             builder.addAll(node.getWindowFunctions().keySet());
+
+            return null;
+        }
+
+        @Override
+        public Void visitTopNRowNumber(TopNRowNumberNode node, Void context)
+        {
+            // visit child
+            node.getSource().accept(this, context);
+
+            builder.add(node.getRowNumberSymbol());
+
+            return null;
+        }
+
+        @Override
+        public Void visitRowNumberLimit(RowNumberLimitNode node, Void context)
+        {
+            // visit child
+            node.getSource().accept(this, context);
+
+            builder.add(node.getRowNumberSymbol());
 
             return null;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.window.RowNumberFunction;
+import com.facebook.presto.operator.window.WindowFunction;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.DependencyExtractor;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanNodeRewriter;
+import com.facebook.presto.sql.planner.plan.PlanRewriter;
+import com.facebook.presto.sql.planner.plan.RowNumberLimitNode;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DefaultExpressionTraversalVisitor;
+import com.facebook.presto.sql.tree.DoubleLiteral;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Literal;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class WindowFilterPushDown
+        extends PlanOptimizer
+{
+    private final Metadata metadata;
+
+    public WindowFilterPushDown(Metadata metadata)
+    {
+        this.metadata = checkNotNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan, ConnectorSession session, Map<Symbol, Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        checkNotNull(plan, "plan is null");
+        checkNotNull(session, "session is null");
+        checkNotNull(types, "types is null");
+        checkNotNull(symbolAllocator, "symbolAllocator is null");
+        checkNotNull(idAllocator, "idAllocator is null");
+
+        return PlanRewriter.rewriteWith(new Rewriter(idAllocator, metadata), plan, null);
+    }
+
+    private static class WindowContext
+    {
+        private final Optional<WindowNode> windowNode;
+        private final Expression expression;
+
+        private WindowContext(Optional<WindowNode> windowNode, Expression expression)
+        {
+            this.windowNode = checkNotNull(windowNode, "windowNode is null");
+            this.expression = checkNotNull(expression, "expression is null");
+        }
+
+        public Optional<WindowNode> getWindowNode()
+        {
+            return windowNode;
+        }
+
+        public Expression getExpression()
+        {
+            return expression;
+        }
+    }
+
+    private static class Rewriter
+            extends PlanNodeRewriter<WindowContext>
+    {
+        private final PlanNodeIdAllocator idAllocator;
+        private final Metadata metadata;
+
+        private Rewriter(PlanNodeIdAllocator idAllocator, Metadata metadata)
+        {
+            this.metadata = checkNotNull(metadata, "metadata is null");
+            this.idAllocator = checkNotNull(idAllocator, "idAllocator is null");
+        }
+
+        @Override
+        public PlanNode rewriteWindow(WindowNode node, WindowContext context, PlanRewriter<WindowContext> planRewriter)
+        {
+            if (context != null && canOptimizeWindowFunction(node, context)) {
+                int limit = extractLimitOptional(node, context.getExpression()).get();
+                if (node.getPartitionBy().isEmpty()) {
+                    WindowContext windowContext = new WindowContext(Optional.of(node), new LongLiteral(String.valueOf(limit)));
+                    PlanNode rewrittenSource = planRewriter.rewrite(node.getSource(), windowContext);
+                    return new WindowNode(idAllocator.getNextId(),
+                            rewrittenSource,
+                            node.getPartitionBy(),
+                            node.getOrderBy(),
+                            node.getOrderings(),
+                            node.getWindowFunctions(),
+                            node.getSignatures());
+                }
+                else if (node.getOrderBy().isEmpty()) {
+                    PlanNode rewrittenSource = planRewriter.rewrite(node.getSource(), null);
+                    return new RowNumberLimitNode(idAllocator.getNextId(),
+                            rewrittenSource,
+                            node.getPartitionBy(),
+                            Iterables.getOnlyElement(node.getWindowFunctions().keySet()),
+                            limit);
+                }
+                else {
+                    PlanNode rewrittenSource = planRewriter.rewrite(node.getSource(), null);
+                    return new TopNRowNumberNode(idAllocator.getNextId(),
+                            rewrittenSource,
+                            node.getPartitionBy(),
+                            node.getOrderBy(),
+                            node.getOrderings(),
+                            Iterables.getOnlyElement(node.getWindowFunctions().keySet()),
+                            limit);
+
+                }
+            }
+            return planRewriter.defaultRewrite(node, null);
+        }
+
+        private boolean canOptimizeWindowFunction(WindowNode node, WindowContext context)
+        {
+            if (node.getWindowFunctions().size() != 1) {
+                return false;
+            }
+            if (!isRowNumberFunction(node)) {
+                return false;
+            }
+
+            if (!filterContainsWindowFunctions(node, context.getExpression())) {
+                return false;
+            }
+
+            Optional<Integer> limit = extractLimitOptional(node, context.getExpression());
+            return limit.isPresent() && limit.get() < Integer.MAX_VALUE;
+        }
+
+        private boolean isRowNumberFunction(WindowNode node)
+        {
+            checkArgument(node.getWindowFunctions().size() == 1);
+            Symbol symbol = Iterables.getOnlyElement(node.getWindowFunctions().entrySet()).getKey();
+            Signature signature = node.getSignatures().get(symbol);
+            WindowFunction function = metadata.getExactFunction(signature).bindWindowFunction(ImmutableList.<Integer>of()).createWindowFunction();
+            return function instanceof RowNumberFunction;
+        }
+
+        private static boolean filterContainsWindowFunctions(WindowNode node, Expression filterPredicate)
+        {
+            Set<Symbol> windowFunctionSymbols = node.getWindowFunctions().keySet();
+            Sets.SetView<Symbol> commonSymbols = Sets.intersection(DependencyExtractor.extractUnique(filterPredicate), windowFunctionSymbols);
+            return !commonSymbols.isEmpty();
+        }
+
+        @Override
+        public PlanNode rewriteLimit(LimitNode node, WindowContext context, PlanRewriter<WindowContext> planRewriter)
+        {
+            if (context != null && context.getExpression() instanceof LongLiteral &&
+                    ((LongLiteral) context.getExpression()).getValue() < node.getCount()) {
+                PlanNode rewrittenSource = planRewriter.rewrite(node.getSource(), context);
+                if (rewrittenSource != node.getSource()) {
+                    return rewrittenSource;
+                }
+            }
+            return planRewriter.defaultRewrite(node, null);
+        }
+
+        @Override
+        public PlanNode rewriteTopN(TopNNode node, WindowContext context, PlanRewriter<WindowContext> planRewriter)
+        {
+            return planRewriter.defaultRewrite(node, null);
+        }
+
+        @Override
+        public PlanNode rewriteTableScan(TableScanNode node, WindowContext context, PlanRewriter<WindowContext> planRewriter)
+        {
+            if (context != null && context.getExpression() instanceof LongLiteral && context.getWindowNode().isPresent()) {
+                PlanNode rewrittenNode = planRewriter.rewrite(node, null);
+                WindowNode windowNode = context.getWindowNode().get();
+                if (windowNode.getOrderBy().isEmpty()) {
+                    return new LimitNode(idAllocator.getNextId(), rewrittenNode, ((LongLiteral) context.getExpression()).getValue());
+                }
+                else {
+                    return new TopNNode(
+                            idAllocator.getNextId(),
+                            rewrittenNode,
+                            ((LongLiteral) context.getExpression()).getValue(),
+                            windowNode.getOrderBy(),
+                            windowNode.getOrderings(),
+                            false);
+                }
+            }
+            return planRewriter.defaultRewrite(node, null);
+        }
+
+        @Override
+        public PlanNode rewriteFilter(FilterNode node, WindowContext context, PlanRewriter<WindowContext> planRewriter)
+        {
+            WindowContext sourceContext = new WindowContext(Optional.<WindowNode>absent(), node.getPredicate());
+            PlanNode rewrittenSource = planRewriter.rewrite(node.getSource(), sourceContext);
+            if (rewrittenSource != node.getSource()) {
+                return rewrittenSource;
+            }
+            return planRewriter.defaultRewrite(node, null);
+        }
+    }
+
+    private static Optional<Integer> extractLimitOptional(WindowNode node, Expression filterPredicate)
+    {
+        Symbol rowNumberSymbol = Iterables.getOnlyElement(node.getWindowFunctions().entrySet()).getKey();
+        return WindowLimitExtractor.extract(filterPredicate, rowNumberSymbol);
+    }
+
+    public static final class WindowLimitExtractor
+    {
+        private WindowLimitExtractor() {}
+
+        public static Optional<Integer> extract(Expression expression, Symbol rowNumberSymbol)
+        {
+            Visitor visitor = new Visitor();
+            Long limit = visitor.process(expression, rowNumberSymbol);
+            if (limit == null) {
+                return Optional.absent();
+            }
+            else {
+                checkArgument(limit < Integer.MAX_VALUE, "filter on row_number greater than allowed value");
+
+                return Optional.of(limit.intValue());
+            }
+        }
+
+        private static class Visitor
+                extends DefaultExpressionTraversalVisitor<Long, Symbol>
+        {
+            @Override
+            protected Long visitComparisonExpression(ComparisonExpression node, Symbol rowNumberSymbol)
+            {
+                QualifiedNameReference reference = extractReference(node);
+                Literal literal = extractLiteral(node);
+                if (!Symbol.fromQualifiedName(reference.getName()).equals(rowNumberSymbol)) {
+                    return null;
+                }
+
+                if (node.getLeft() instanceof QualifiedNameReference && node.getRight() instanceof Literal) {
+                    if (node.getType() == ComparisonExpression.Type.LESS_THAN_OR_EQUAL) {
+                        return extractValue(literal);
+                    }
+                    else if (node.getType() == ComparisonExpression.Type.LESS_THAN) {
+                        return extractValue(literal) - 1;
+                    }
+                }
+                else if (node.getLeft() instanceof Literal && node.getRight() instanceof QualifiedNameReference) {
+                    if (node.getType() == ComparisonExpression.Type.GREATER_THAN_OR_EQUAL) {
+                        return extractValue(literal);
+                    }
+                    else if (node.getType() == ComparisonExpression.Type.GREATER_THAN) {
+                        return extractValue(literal) - 1;
+                    }
+                }
+                return null;
+            }
+        }
+
+        private static QualifiedNameReference extractReference(ComparisonExpression expression)
+        {
+            if (expression.getLeft() instanceof QualifiedNameReference) {
+                return (QualifiedNameReference) expression.getLeft();
+            }
+            else if (expression.getRight() instanceof QualifiedNameReference) {
+                return (QualifiedNameReference) expression.getRight();
+            }
+            throw new IllegalArgumentException("Comparison does not have a child of type QualifiedNameReference");
+        }
+
+        private static Literal extractLiteral(ComparisonExpression expression)
+        {
+            if (expression.getLeft() instanceof Literal) {
+                return (Literal) expression.getLeft();
+            }
+            else if (expression.getRight() instanceof Literal) {
+                return (Literal) expression.getRight();
+            }
+            throw new IllegalArgumentException("Comparison does not have a child of type Literal");
+        }
+
+        private static long extractValue(Literal literal)
+        {
+            if (literal instanceof DoubleLiteral) {
+                return (long) ((DoubleLiteral) literal).getValue();
+            }
+            if (literal instanceof LongLiteral) {
+                return ((LongLiteral) literal).getValue();
+            }
+            throw new IllegalArgumentException("Row number compared to non numeric literal");
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNode.java
@@ -35,6 +35,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
         @JsonSubTypes.Type(value = MarkDistinctNode.class, name = "markDistinct"),
         @JsonSubTypes.Type(value = FilterNode.class, name = "filter"),
         @JsonSubTypes.Type(value = WindowNode.class, name = "window"),
+        @JsonSubTypes.Type(value = RowNumberLimitNode.class, name = "rowNumberLimit"),
+        @JsonSubTypes.Type(value = TopNRowNumberNode.class, name = "topnRowNumber"),
         @JsonSubTypes.Type(value = LimitNode.class, name = "limit"),
         @JsonSubTypes.Type(value = DistinctLimitNode.class, name = "distinctlimit"),
         @JsonSubTypes.Type(value = TopNNode.class, name = "topn"),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNodeRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNodeRewriter.java
@@ -100,6 +100,16 @@ public class PlanNodeRewriter<C>
         return rewriteNode(node, context, planRewriter);
     }
 
+    public PlanNode rewriteTopNRowNumber(TopNRowNumberNode node, C context, PlanRewriter<C> planRewriter)
+    {
+        return rewriteNode(node, context, planRewriter);
+    }
+
+    public PlanNode rewriteRowNumberLimit(RowNumberLimitNode node, C context, PlanRewriter<C> planRewriter)
+    {
+        return rewriteNode(node, context, planRewriter);
+    }
+
     public PlanNode rewriteOutput(OutputNode node, C context, PlanRewriter<C> planRewriter)
     {
         return rewriteNode(node, context, planRewriter);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanRewriter.java
@@ -149,6 +149,49 @@ public final class PlanRewriter<C>
         }
 
         @Override
+        public PlanNode visitRowNumberLimit(RowNumberLimitNode node, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                PlanNode result = nodeRewriter.rewriteRowNumberLimit(node, context.get(), PlanRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            PlanNode source = rewrite(node.getSource(), context.get());
+
+            if (source != node.getSource()) {
+                return new RowNumberLimitNode(node.getId(), source, node.getPartitionBy(), node.getRowNumberSymbol(), node.getMaxRowCountPerPartition());
+            }
+
+            return node;
+        }
+
+        @Override
+        public PlanNode visitTopNRowNumber(TopNRowNumberNode node, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                PlanNode result = nodeRewriter.rewriteTopNRowNumber(node, context.get(), PlanRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            PlanNode source = rewrite(node.getSource(), context.get());
+
+            if (source != node.getSource()) {
+                return new TopNRowNumberNode(node.getId(),
+                        source,
+                        node.getPartitionBy(),
+                        node.getOrderBy(),
+                        node.getOrderings(),
+                        node.getRowNumberSymbol(),
+                        node.getMaxRowCountPerPartition());
+            }
+            return node;
+        }
+
+        @Override
         public PlanNode visitFilter(FilterNode node, Context<C> context)
         {
             if (!context.isDefaultRewrite()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanVisitor.java
@@ -129,4 +129,14 @@ public class PlanVisitor<C, R>
     {
         return visitPlan(node, context);
     }
+
+    public R visitRowNumberLimit(RowNumberLimitNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
+
+    public R visitTopNRowNumber(TopNRowNumberNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RowNumberLimitNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RowNumberLimitNode.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.concat;
+
+@Immutable
+public final class RowNumberLimitNode
+        extends PlanNode
+{
+    private final PlanNode source;
+    private final List<Symbol> partitionBy;
+    private final int maxRowCountPerPartition;
+    private final Symbol rowNumberSymbol;
+
+    @JsonCreator
+    public RowNumberLimitNode(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("source") PlanNode source,
+            @JsonProperty("partitionBy") List<Symbol> partitionBy,
+            @JsonProperty("rowNumberSymbol") Symbol rowNumberSymbol,
+            @JsonProperty("maxRowCountPerPartition") int maxRowCountPerPartition)
+    {
+        super(id);
+
+        checkNotNull(source, "source is null");
+        checkNotNull(partitionBy, "partitionBy is null");
+        checkArgument(!partitionBy.isEmpty(), "partitionBy is empty");
+        checkNotNull(rowNumberSymbol, "rowNumberSymbol is null");
+        checkArgument(maxRowCountPerPartition > 0, "maxRowCountPerPartition must be > 0");
+
+        this.source = source;
+        this.partitionBy = ImmutableList.copyOf(partitionBy);
+        this.rowNumberSymbol = rowNumberSymbol;
+        this.maxRowCountPerPartition = maxRowCountPerPartition;
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return ImmutableList.of(source);
+    }
+
+    @Override
+    public List<Symbol> getOutputSymbols()
+    {
+        return ImmutableList.copyOf(concat(source.getOutputSymbols(), ImmutableList.of(rowNumberSymbol)));
+    }
+
+    @JsonProperty
+    public PlanNode getSource()
+    {
+        return source;
+    }
+
+    @JsonProperty
+    public List<Symbol> getPartitionBy()
+    {
+        return partitionBy;
+    }
+
+    @JsonProperty
+    public Symbol getRowNumberSymbol()
+    {
+        return rowNumberSymbol;
+    }
+
+    @JsonProperty
+    public int getMaxRowCountPerPartition()
+    {
+        return maxRowCountPerPartition;
+    }
+
+    @Override
+    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    {
+        return visitor.visitRowNumberLimit(this, context);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TopNRowNumberNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TopNRowNumberNode.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.sql.planner.Symbol;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.concat;
+
+@Immutable
+public final class TopNRowNumberNode
+        extends PlanNode
+{
+    private final PlanNode source;
+    private final List<Symbol> partitionBy;
+    private final List<Symbol> orderBy;
+    private final Map<Symbol, SortOrder> orderings;
+    private final Symbol rowNumberSymbol;
+    private final int maxRowCountPerPartition;
+
+    @JsonCreator
+    public TopNRowNumberNode(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("source") PlanNode source,
+            @JsonProperty("partitionBy") List<Symbol> partitionBy,
+            @JsonProperty("orderBy") List<Symbol> orderBy,
+            @JsonProperty("orderings") Map<Symbol, SortOrder> orderings,
+            @JsonProperty("rowNumberSymbol") Symbol rowNumberSymbol,
+            @JsonProperty("maxRowCountPerPartition") int maxRowCountPerPartition)
+    {
+        super(id);
+        checkNotNull(source, "source is null");
+        checkNotNull(partitionBy, "partitionBy is null");
+        checkArgument(!partitionBy.isEmpty(), "partitionBy is empty");
+        checkNotNull(orderBy, "orderBy is null");
+        checkNotNull(orderings, "orderings is null");
+        checkArgument(orderings.size() == orderBy.size(), "orderBy and orderings sizes don't match");
+        checkNotNull(rowNumberSymbol, "rowNumberSymbol is null");
+        checkArgument(maxRowCountPerPartition > 0, "maxRowCountPerPartition must be > 0");
+
+        this.source = source;
+        this.partitionBy = ImmutableList.copyOf(partitionBy);
+        this.orderBy = ImmutableList.copyOf(orderBy);
+        this.orderings = ImmutableMap.copyOf(orderings);
+        this.rowNumberSymbol = rowNumberSymbol;
+        this.maxRowCountPerPartition = maxRowCountPerPartition;
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return ImmutableList.of(source);
+    }
+
+    @Override
+    public List<Symbol> getOutputSymbols()
+    {
+        return ImmutableList.copyOf(concat(source.getOutputSymbols(), ImmutableList.of(rowNumberSymbol)));
+    }
+
+    @JsonProperty
+    public PlanNode getSource()
+    {
+        return source;
+    }
+
+    @JsonProperty
+    public List<Symbol> getPartitionBy()
+    {
+        return partitionBy;
+    }
+
+    @JsonProperty
+    public List<Symbol> getOrderBy()
+    {
+        return orderBy;
+    }
+
+    @JsonProperty
+    public Map<Symbol, SortOrder> getOrderings()
+    {
+        return orderings;
+    }
+
+    @JsonProperty
+    public Symbol getRowNumberSymbol()
+    {
+        return rowNumberSymbol;
+    }
+
+    @JsonProperty
+    public int getMaxRowCountPerPartition()
+    {
+        return maxRowCountPerPartition;
+    }
+
+    @Override
+    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    {
+        return visitor.visitTopNRowNumber(this, context);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
@@ -165,7 +165,7 @@ public class MaterializedResult
         public Builder page(Page page)
         {
             checkNotNull(page, "page is null");
-            checkArgument(page.getChannelCount() == types.size(), "Expected a page with %s columns, but got %s columns", page.getChannelCount(), types.size());
+            checkArgument(page.getChannelCount() == types.size(), "Expected a page with %s columns, but got %s columns", types.size(), page.getChannelCount());
 
             for (int position = 0; position < page.getPositionCount(); position++) {
                 List<Object> values = new ArrayList<>(page.getChannelCount());

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -30,11 +30,13 @@ import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.RowNumberLimitNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SinkNode;
 import com.facebook.presto.sql.planner.plan.SortNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.TopNNode;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
@@ -224,6 +226,26 @@ public final class GraphvizPrinter
         public Void visitWindow(WindowNode node, Void context)
         {
             printNode(node, "Window", format("partition by = %s|order by = %s", Joiner.on(", ").join(node.getPartitionBy()), Joiner.on(", ").join(node.getOrderBy())), NODE_COLORS.get(NodeType.WINDOW));
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Void visitRowNumberLimit(RowNumberLimitNode node, Void context)
+        {
+            printNode(node,
+                    "RowNumberLimit",
+                    format("partition by = %s|row_number limit %s", Joiner.on(", ").join(node.getPartitionBy()), node.getMaxRowCountPerPartition()),
+                    NODE_COLORS.get(NodeType.WINDOW));
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Void visitTopNRowNumber(TopNRowNumberNode node, Void context)
+        {
+            printNode(node,
+                    "TopNRowNumber",
+                    format("partition by = %s|order by = %s|n = %s", Joiner.on(", ").join(node.getPartitionBy()), Joiner.on(", ").join(node.getOrderBy()), node.getMaxRowCountPerPartition()),
+                    NODE_COLORS.get(NodeType.WINDOW));
             return node.getSource().accept(this, context);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/util/JsonPlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/JsonPlanPrinter.java
@@ -35,6 +35,7 @@ import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.RowNumberLimitNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SinkNode;
 import com.facebook.presto.sql.planner.plan.SortNode;
@@ -42,6 +43,7 @@ import com.facebook.presto.sql.planner.plan.TableCommitNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.plan.TopNNode;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.google.common.base.Optional;
@@ -133,6 +135,18 @@ public final class JsonPlanPrinter
 
         @Override
         public Void visitWindow(final WindowNode node, Void context)
+        {
+            return processChildren(node);
+        }
+
+        @Override
+        public Void visitRowNumberLimit(final RowNumberLimitNode node, Void context)
+        {
+            return processChildren(node);
+        }
+
+        @Override
+        public Void visitTopNRowNumber(final TopNRowNumberNode node, Void context)
         {
             return processChildren(node);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
@@ -18,8 +18,8 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.util.IterableTransformer;
 import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.util.IterableTransformer;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberLimitOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberLimitOperator.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.util.IterableTransformer;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.primitives.Ints;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+
+import static com.facebook.presto.operator.OperatorAssertion.toMaterializedResult;
+import static com.facebook.presto.operator.OperatorAssertion.toPages;
+import static com.facebook.presto.operator.RowPagesBuilder.rowPagesBuilder;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestRowNumberLimitOperator
+{
+    private ExecutorService executor;
+    private DriverContext driverContext;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        executor = newCachedThreadPool(daemonThreadsNamed("test"));
+        ConnectorSession session = new ConnectorSession("user", "source", "catalog", "schema", UTC_KEY, Locale.ENGLISH, "address", "agent");
+        driverContext = new TaskContext(new TaskId("query", "stage", "task"), executor, session)
+                .addPipelineContext(true, true)
+                .addDriverContext();
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testRowNumberPartitionedLimit()
+            throws Exception
+    {
+        List<Page> input = rowPagesBuilder(BIGINT, DOUBLE)
+                .row(1, 0.3)
+                .row(2, 0.2)
+                .row(3, 0.1)
+                .row(3, 0.19)
+                .pageBreak()
+                .row(1, 0.4)
+                .pageBreak()
+                .row(1, 0.5)
+                .row(1, 0.6)
+                .row(2, 0.7)
+                .row(2, 0.8)
+                .row(2, 0.9)
+                .build();
+
+        RowNumberLimitOperator.RowNumberLimitOperatorFactory operatorFactory = new RowNumberLimitOperator.RowNumberLimitOperatorFactory(
+                0,
+                ImmutableList.of(BIGINT, DOUBLE),
+                Ints.asList(1, 0),
+                Ints.asList(0),
+                ImmutableList.of(BIGINT),
+                10,
+                3);
+
+        Operator operator = operatorFactory.createOperator(driverContext);
+
+        MaterializedResult expectedPartition1 = resultBuilder(driverContext.getSession(), DOUBLE, BIGINT)
+                .row(0.3, 1)
+                .row(0.4, 1)
+                .row(0.5, 1)
+                .row(0.6, 1)
+                .build();
+
+        MaterializedResult expectedPartition2 = resultBuilder(driverContext.getSession(), DOUBLE, BIGINT)
+                .row(0.2, 2)
+                .row(0.7, 2)
+                .row(0.8, 2)
+                .row(0.9, 2)
+                .build();
+
+        MaterializedResult expectedPartition3 = resultBuilder(driverContext.getSession(), DOUBLE, BIGINT)
+                .row(0.1, 3)
+                .row(0.19, 3)
+                .build();
+
+        List<Page> pages = toPages(operator, input);
+        Block rowNumberColumn = getRowNumberColumn(pages);
+        assertEquals(rowNumberColumn.getPositionCount(), 8);
+        // Check that all row numbers generated are <= 3
+        for (int i = 0; i < rowNumberColumn.getPositionCount(); i++) {
+            assertTrue(rowNumberColumn.getLong(i, 0) <= 3);
+        }
+
+        pages = stripRowNumberColumn(pages);
+        MaterializedResult actual = toMaterializedResult(operator.getOperatorContext().getSession(), ImmutableList.<Type>of(DOUBLE, BIGINT), pages);
+        assertEquals(actual.getTypes(), expectedPartition1.getTypes());
+        ImmutableSet<?> actualSet = ImmutableSet.copyOf(actual.getMaterializedRows());
+        ImmutableSet<?> expectedPartition1Set = ImmutableSet.copyOf(expectedPartition1.getMaterializedRows());
+        ImmutableSet<?> expectedPartition2Set = ImmutableSet.copyOf(expectedPartition2.getMaterializedRows());
+        ImmutableSet<?> expectedPartition3Set = ImmutableSet.copyOf(expectedPartition3.getMaterializedRows());
+        assertEquals(Sets.intersection(expectedPartition1Set, actualSet).size(), 3);
+        assertEquals(Sets.intersection(expectedPartition2Set, actualSet).size(), 3);
+        assertEquals(Sets.intersection(expectedPartition3Set, actualSet).size(), 2);
+    }
+
+    private static Block getRowNumberColumn(List<Page> pages)
+    {
+        BlockBuilder builder = BIGINT.createBlockBuilder(new BlockBuilderStatus());
+        for (Page page : pages) {
+            int rowNumberChannel = page.getChannelCount() - 1;
+            for (int i = 0; i < page.getPositionCount(); i++) {
+                BIGINT.writeLong(builder, page.getLong(BIGINT, rowNumberChannel, i));
+            }
+        }
+        return builder.build();
+    }
+
+    private static List<Page> stripRowNumberColumn(List<Page> input)
+    {
+        return IterableTransformer.on(input).transform(new Function<Page, Page>()
+        {
+            @Override
+            public Page apply(Page page)
+            {
+                Block[] blocks = new Block[page.getChannelCount() - 1];
+                System.arraycopy(page.getBlocks(), 0, blocks, 0, page.getChannelCount() - 1);
+                return new Page(blocks);
+            }
+        }).list();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTopNRowNumberOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTopNRowNumberOperator.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.testing.MaterializedResult;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+
+import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
+import static com.facebook.presto.operator.RowPagesBuilder.rowPagesBuilder;
+import static com.facebook.presto.operator.TopNRowNumberOperator.TopNRowNumberOperatorFactory;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+
+@Test(singleThreaded = true)
+public class TestTopNRowNumberOperator
+{
+    private ExecutorService executor;
+    private DriverContext driverContext;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        executor = newCachedThreadPool(daemonThreadsNamed("test"));
+        ConnectorSession session = new ConnectorSession("user", "source", "catalog", "schema", UTC_KEY, Locale.ENGLISH, "address", "agent");
+        driverContext = new TaskContext(new TaskId("query", "stage", "task"), executor, session)
+                .addPipelineContext(true, true)
+                .addDriverContext();
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testTopNRowNumber()
+            throws Exception
+    {
+        List<Page> input = rowPagesBuilder(BIGINT, DOUBLE)
+                .row(1, 0.3)
+                .row(2, 0.2)
+                .row(3, 0.1)
+                .row(3, 0.91)
+                .pageBreak()
+                .row(1, 0.4)
+                .pageBreak()
+                .row(1, 0.5)
+                .row(1, 0.6)
+                .row(2, 0.7)
+                .row(2, 0.8)
+                .pageBreak()
+                .row(2, 0.9)
+                .build();
+
+        TopNRowNumberOperatorFactory operatorFactory = new TopNRowNumberOperatorFactory(
+                0,
+                ImmutableList.of(BIGINT, DOUBLE),
+                Ints.asList(1, 0),
+                Ints.asList(0),
+                ImmutableList.of(BIGINT),
+                Ints.asList(1),
+                ImmutableList.of(SortOrder.ASC_NULLS_LAST),
+                3,
+                10);
+
+        Operator operator = operatorFactory.createOperator(driverContext);
+
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), DOUBLE, BIGINT, BIGINT)
+                .row(0.3, 1, 1)
+                .row(0.4, 1, 2)
+                .row(0.5, 1, 3)
+                .row(0.2, 2, 1)
+                .row(0.7, 2, 2)
+                .row(0.8, 2, 3)
+                .row(0.1, 3, 1)
+                .row(0.91, 3, 2)
+                .build();
+
+        assertOperatorEquals(operator, input, expected);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilderStatus.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilderStatus.java
@@ -46,6 +46,11 @@ public class BlockBuilderStatus
         return maxBlockSizeInBytes;
     }
 
+    public int getMaxPageSizeInBytes()
+    {
+        return maxPageSizeInBytes;
+    }
+
     public boolean isEmpty()
     {
         return currentSize == 0;

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1756,6 +1756,71 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testRowNumberLimit()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT orderkey, orderstatus FROM (\n" +
+                "   SELECT row_number() OVER () rn, orderkey, orderstatus\n" +
+                "   FROM orders\n" +
+                ") WHERE rn <= 5\n");
+        MaterializedResult all = computeExpected("SELECT orderkey, orderstatus FROM ORDERS", actual.getTypes());
+
+        assertEquals(actual.getMaterializedRows().size(), 5);
+        assertTrue(all.getMaterializedRows().containsAll(actual.getMaterializedRows()));
+    }
+
+    @Test
+    public void testPartitionedRowNumberLimit()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT orderkey, orderstatus FROM (\n" +
+                "   SELECT row_number() OVER (PARTITION BY orderstatus) rn, orderkey, orderstatus\n" +
+                "   FROM orders\n" +
+                ") WHERE rn <= 5\n");
+        MaterializedResult all = computeExpected("SELECT orderkey, orderstatus FROM ORDERS", actual.getTypes());
+
+        // there are 3 distinct orderstatus, so expect 15 rows.
+        assertEquals(actual.getMaterializedRows().size(), 15);
+        assertTrue(all.getMaterializedRows().containsAll(actual.getMaterializedRows()));
+    }
+
+    @Test
+    public void testTopNUnpartitionedWindow()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT * FROM (\n" +
+                "   SELECT row_number() OVER (ORDER BY orderkey) rn, orderkey, orderstatus\n" +
+                "   FROM orders\n" +
+                ") WHERE rn <= 5\n");
+        String sql = "SELECT row_number() OVER (), orderkey, orderstatus FROM orders ORDER BY orderkey LIMIT 5";
+        MaterializedResult expected = computeExpected(sql, actual.getTypes());
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testTopNPartitionedWindow()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT * FROM (\n" +
+                "   SELECT row_number() OVER (PARTITION BY orderstatus ORDER BY orderkey) rn, orderkey, orderstatus\n" +
+                "   FROM orders\n" +
+                ") WHERE rn <= 2\n");
+        MaterializedResult expected = resultBuilder(getSession(), BIGINT, BIGINT, VARCHAR)
+                .row(1, 1, "O")
+                .row(2, 2, "O")
+                .row(1, 3, "F")
+                .row(2, 5, "F")
+                .row(1, 65, "P")
+                .row(2, 197, "P")
+                .build();
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
     public void testWindowFunctionWithGroupBy()
             throws Exception
     {


### PR DESCRIPTION
Identify the query shape with a filter on the row_number() and rewrite it for optimal execution.
Examples of query shapes affected by this: 
https://gist.github.com/nileema/71d0099d804a10cb172b

Note: Optimization applies only if the all the following criteria are met: 
1. There is a single row number function in the query 
2. The filter is a simple comparison with a literal (compound expressions are not supported in this revision) 
3. The filter operation is directly above the window  function
