### PR TITLE
Configure AmazonS3Client SOCKET_TIMEOUT

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfiguration.java
@@ -49,6 +49,7 @@ public class HdfsConfiguration
     private final File s3StagingDirectory;
     private final List<String> resourcePaths;
     private final boolean verifyChecksum;
+    private final Duration s3SocketTimeout;
 
     @SuppressWarnings("ThreadLocalNotStaticFinal")
     private final ThreadLocal<Configuration> hadoopConfiguration = new ThreadLocal<Configuration>()
@@ -81,6 +82,7 @@ public class HdfsConfiguration
         this.s3StagingDirectory = hiveClientConfig.getS3StagingDirectory();
         this.resourcePaths = hiveClientConfig.getResourceConfigFiles();
         this.verifyChecksum = hiveClientConfig.isVerifyChecksum();
+        this.s3SocketTimeout = hiveClientConfig.getS3SocketTimeout();
     }
 
     public boolean verifyChecksum()
@@ -149,6 +151,7 @@ public class HdfsConfiguration
         config.set(PrestoS3FileSystem.S3_MAX_BACKOFF_TIME, s3MaxBackoffTime.toString());
         config.set(PrestoS3FileSystem.S3_CONNECT_TIMEOUT, s3ConnectTimeout.toString());
         config.set(PrestoS3FileSystem.S3_STAGING_DIRECTORY, s3StagingDirectory.toString());
+        config.setInt(PrestoS3FileSystem.S3_SOCKET_TIMEOUT, Ints.checkedCast(s3SocketTimeout.toMillis()));
 
         updateConfiguration(config);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -70,6 +70,7 @@ public class HiveClientConfig
     private int s3MaxErrorRetries = 10;
     private Duration s3MaxBackoffTime = new Duration(10, TimeUnit.MINUTES);
     private Duration s3ConnectTimeout = new Duration(5, TimeUnit.SECONDS);
+    private Duration s3SocketTimeout = new Duration(5, TimeUnit.SECONDS);
     private File s3StagingDirectory = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value());
 
     private HiveStorageFormat hiveStorageFormat = HiveStorageFormat.RCBINARY;
@@ -458,6 +459,20 @@ public class HiveClientConfig
     public HiveClientConfig setS3MaxBackoffTime(Duration s3MaxBackoffTime)
     {
         this.s3MaxBackoffTime = s3MaxBackoffTime;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    @NotNull
+    public Duration getS3SocketTimeout()
+    {
+        return s3SocketTimeout;
+    }
+
+    @Config("hive.s3.socket-timeout")
+    public HiveClientConfig setS3SocketTimeout(Duration s3SocketTimeout)
+    {
+        this.s3SocketTimeout = s3SocketTimeout;
         return this;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -85,6 +85,7 @@ public class PrestoS3FileSystem
     public static final String S3_MAX_CLIENT_RETRIES = "presto.s3.max-client-retries";
     public static final String S3_MAX_BACKOFF_TIME = "presto.s3.max-backoff-time";
     public static final String S3_CONNECT_TIMEOUT = "presto.s3.connect-timeout";
+    public static final String S3_SOCKET_TIMEOUT = "presto.s3.socket-timeout";
     public static final String S3_STAGING_DIRECTORY = "presto.s3.staging-directory";
 
     private static final Logger log = Logger.get(PrestoS3FileSystem.class);
@@ -116,11 +117,13 @@ public class PrestoS3FileSystem
         int maxErrorRetries = conf.getInt(S3_MAX_ERROR_RETRIES, defaults.getS3MaxErrorRetries());
         boolean sslEnabled = conf.getBoolean(S3_SSL_ENABLED, defaults.isS3SslEnabled());
         Duration connectTimeout = Duration.valueOf(conf.get(S3_CONNECT_TIMEOUT, defaults.getS3ConnectTimeout().toString()));
+        int socketTimeout = conf.getInt(S3_SOCKET_TIMEOUT, Ints.checkedCast(defaults.getS3SocketTimeout().toMillis()));
 
         ClientConfiguration configuration = new ClientConfiguration();
         configuration.setMaxErrorRetry(maxErrorRetries);
         configuration.setProtocol(sslEnabled ? Protocol.HTTPS : Protocol.HTTP);
         configuration.setConnectionTimeout(Ints.checkedCast(connectTimeout.toMillis()));
+        configuration.setSocketTimeout(socketTimeout);
 
         this.s3 = new AmazonS3Client(getAwsCredentials(uri, conf), configuration);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -68,6 +68,7 @@ public class TestHiveClientConfig
                 .setS3MaxErrorRetries(10)
                 .setS3MaxBackoffTime(new Duration(10, TimeUnit.MINUTES))
                 .setS3ConnectTimeout(new Duration(5, TimeUnit.SECONDS))
+                .setS3SocketTimeout(new Duration(5, TimeUnit.SECONDS))
                 .setS3StagingDirectory(new File(StandardSystemProperty.JAVA_IO_TMPDIR.value())));
     }
 
@@ -105,6 +106,7 @@ public class TestHiveClientConfig
                 .put("hive.s3.max-error-retries", "8")
                 .put("hive.s3.max-backoff-time", "4m")
                 .put("hive.s3.connect-timeout", "8s")
+                .put("hive.s3.socket-timeout", "4m")
                 .put("hive.s3.staging-directory", "/s3-staging")
                 .build();
 
@@ -139,6 +141,7 @@ public class TestHiveClientConfig
                 .setS3MaxErrorRetries(8)
                 .setS3MaxBackoffTime(new Duration(4, TimeUnit.MINUTES))
                 .setS3ConnectTimeout(new Duration(8, TimeUnit.SECONDS))
+                .setS3SocketTimeout(new Duration(4, TimeUnit.MINUTES))
                 .setS3StagingDirectory(new File("/s3-staging"));
 
         ConfigAssertions.assertFullMapping(properties, expected);


### PR DESCRIPTION
When reading large files from S3, occasionally PrestoS3FileSystem get:
java.net.SocketTimeoutException: Read timed out

By configuring AmazonS3Client SOCKET_TIMEOUT, we could get rid of the socket timeout.
