### PR TITLE
Add javax.annotation to PARENT_FIRST_CLASSES

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -69,6 +69,7 @@ public class PluginManager
             .add("com.fasterxml.jackson")
             .add("io.airlift.slice")
             .add("javax.inject")
+            .add("javax.annotation")
             .build();
 
     private static final Logger log = Logger.get(PluginManager.class);


### PR DESCRIPTION
When this is omitted the PostConstruct methods are not called. 
