### PR TITLE
Added retries to avoid not enough replicas Exception

### DIFF
--- a/presto-cassandra/README.md
+++ b/presto-cassandra/README.md
@@ -107,8 +107,8 @@ cassandra.client.connect-timeout=5000
 
 # RetryPolicy; PeakNetworkTrafficRetryPloicy may help on "not enough replicas" exception
 # (advanced)
-# Options: DefaultRetryPolicy, PeakNetworkTrafficRetryPolicy, DowngradingConsistencyRetryPolicy, FallthroughRetryPolicy
-cassandra.retrypolicyclass=DefaultRetryPolicy
+# Options: DEFAULT, PEAK_NETWORK, DOWNGRADING_CONSISTENCY, FALLTHROUGH
+cassandra.retrypolicyclass=DEFAULT
 
 ## Notes
 - only tested with Apache Cassandra 2.0.3 (but probably works for Cassandra 1.2.x too)

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.cassandra;
 
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.SocketOptions;
+import com.facebook.presto.cassandra.CassandraClientModule.RetryPolicyClass;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
@@ -59,7 +60,7 @@ public class CassandraClientConfig
     private int clientReadTimeout = SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS;
     private int clientConnectTimeout = SocketOptions.DEFAULT_CONNECT_TIMEOUT_MILLIS;
     private Integer clientSoLinger;
-    private String retryPolicyClass = "com.datastax.driver.core.policies.DefaultRetryPolicy";
+    private RetryPolicyClass retryPolicyClass = RetryPolicyClass.DEFAULT;
 
     @Min(0)
     public int getLimitForPartitionKeySelect()
@@ -336,13 +337,13 @@ public class CassandraClientConfig
         return this;
     }
 
-    public String getRetryPolicyClass()
+    public RetryPolicyClass getRetryPolicyClass()
     {
         return retryPolicyClass;
     }
 
     @Config("cassandra.retrypolicyclass")
-    public CassandraClientConfig setRetryPolicyClass(String retryPolicyClass)
+    public CassandraClientConfig setRetryPolicyClass(RetryPolicyClass retryPolicyClass)
     {
         this.retryPolicyClass = retryPolicyClass;
         return this;

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/PeakNetworkTrafficRetryPolicy.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/PeakNetworkTrafficRetryPolicy.java
@@ -19,13 +19,9 @@ import com.datastax.driver.core.WriteType;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
 import com.datastax.driver.core.policies.RetryPolicy;
 
-import io.airlift.log.Logger;
-
 public class PeakNetworkTrafficRetryPolicy implements RetryPolicy
 {
     public static final PeakNetworkTrafficRetryPolicy INSTANCE = new PeakNetworkTrafficRetryPolicy();
-
-    private static final Logger log = Logger.get(PeakNetworkTrafficRetryPolicy.class);
 
     private PeakNetworkTrafficRetryPolicy() {}
 
@@ -44,7 +40,8 @@ public class PeakNetworkTrafficRetryPolicy implements RetryPolicy
                 Thread.sleep(1000);
             }
             catch (InterruptedException e) {
-                log.error("Sleeping 1s has been interrupted, retry was " + nbRetry, e);
+                Thread.currentThread().interrupt();
+                RetryDecision.rethrow();
             }
             return RetryDecision.retry(cl);
         }


### PR DESCRIPTION
We encountered Exceptions stating that there would not be enough replicas available to fullfill the current request. Therefore i added a new RetryPolicy (PeakNetwork) which allows to retry those requests, which helped. Btw.: the datastax code mentions that this would not make sense as the retry would never succeed. However, our experience tells us differently, so i suppose we encounter a specific case not happening too often and i therefore sticked with the defaultpolicy to be the default in Presto.
