### PR TITLE
Starting documentation for built-in schemas and catalogs: tpch, sys,

### DIFF
--- a/presto-docs/src/main/sphinx/catalog.rst
+++ b/presto-docs/src/main/sphinx/catalog.rst
@@ -1,0 +1,10 @@
+***************
+Presto Catalogs
+***************
+
+.. toctree::
+    :maxdepth: 1
+
+    catalog/jmx
+    catalog/sys
+    catalog/tpch

--- a/presto-docs/src/main/sphinx/catalog/jmx.rst
+++ b/presto-docs/src/main/sphinx/catalog/jmx.rst
@@ -1,0 +1,34 @@
+===========
+JMX Catalog
+===========
+
+The JMX catalog provides the ability to query JMX information from all
+nodes in a Presto cluster.
+
+Configuration
+-------------
+
+To configure the JMX connector create a properties file named
+``jmx.properties`` in the ``etc/catalog`` directory with the following
+content:
+
+.. code-block:: none
+    
+    connector.name=jmx
+
+Note that the JMX connector ships with Presto. No plugins or
+connectors need to be installed to activate the JMX connector.
+
+Using the JMX Schema
+--------------------
+
+While JMX is configured as a catalog there is really just one schema
+named "jmx" within this catalog. To use the jmx schema, run:
+
+.. code-block:: none
+
+    use schema jmx
+
+Running ``show tables`` will show you every JMX MBean available across
+JVMs in a Presto cluster.
+

--- a/presto-docs/src/main/sphinx/catalog/sys.rst
+++ b/presto-docs/src/main/sphinx/catalog/sys.rst
@@ -1,0 +1,63 @@
+==============
+System Schema
+==============
+
+The System schema (sys) provides information and statistics about
+catalogs, queries, nodes, and tasks running in a Presto cluster.
+
+
+Configuration
+-------------
+
+The System schema doesn't need to be configured, it is an implicit
+catalog running in every instance of Presto. The ``sys`` schema is
+present regardless of the currently selected catalog.
+
+Using the System Schema
+-----------------------
+
+To use the System schema, run the following command.
+
+.. code-block:: none
+
+    use schema sys
+
+
+System Schema Tables
+--------------------
+
+Running ``show tables`` against the ``sys`` schema will list four
+tables:
+
+``sys.catalog``
+
+    The ``catalog`` table contains two columns ``catalog_name`` and
+    ``catalog_id``. Use this table to find the list of configured
+    catalogs.
+
+``sys.node``
+
+    The ``node`` table contains four columns ``node_id``,
+    ``http_uri``, ``node_version``, and ``is_active``. Query this
+    table to see the status of your Presto cluster and how many nodes
+    are available to run queries.
+
+``sys.query``
+
+    The ``query`` table contains information about queries run on a
+    Presto cluster.  From this table you can find out the ``node_id``,
+    ``query_id``, ``state``, and ``query`` syntax used to run a
+    query. You can also find out performance information about a query
+    including how long the query was queued and analyzed as well as
+    the id of the user who ran the query.
+
+``sys.task``
+
+    The ``task`` table contains information about tasks involved in a
+    Presto query.  You can find out how many tasks were involved in a
+    query, where they were executed, and how many rows and bytes each
+    task processed.
+
+
+
+

--- a/presto-docs/src/main/sphinx/catalog/tpch.rst
+++ b/presto-docs/src/main/sphinx/catalog/tpch.rst
@@ -1,0 +1,51 @@
+============
+TPCH Catalog
+============
+
+The TPCH catalog provides a set of schemas to support the TPC
+Benchmark™H (TPC-H). TPC-H is a database benchmark used to measure the
+performance of highly-complex decision support databases.
+
+This catalog can also be used to test the capabilities and query
+syntax of Presto without configuring access to a real data
+source. When you query a schema in the TPCH catalog, the catalog is
+generating random data as it is needed.
+
+Configuration
+-------------
+
+To configure the TPCH connector create a properties file named
+``tpch.properties`` in the ``etc/catalog`` directory with the
+following content:
+
+.. code-block:: none
+    
+    connector.name=tpch
+
+Using a TPCH Schema
+-------------------
+
+The TPCH catalog supplies several schemas. To get a list of TPCH
+schemas, run the following command:
+
+.. code-block:: none
+
+    presto:jmx> use catalog tpch;
+    presto:jmx> show schemas;
+           Schema       
+    --------------------
+     information_schema 
+     sf1                
+     sf100              
+     sf1000             
+     sf10000            
+     sf100000           
+     sf300              
+     sf3000             
+     sf30000            
+     sys                
+     tiny               
+    (11 rows)
+
+Each schema displayed in the list of TPCH schemas shown above provides
+the same set of tables with a different number of rows.

--- a/presto-docs/src/main/sphinx/index.rst
+++ b/presto-docs/src/main/sphinx/index.rst
@@ -12,3 +12,4 @@ Presto Documentation
     sql
     migration
     release
+    catalogs


### PR DESCRIPTION
and jmx.  This is essential information for new Preso users, but it is
currently only available in a smattering of posts on the Presto Google
group.  This pull requests adds some basic information into the
documentation.  Each section needs to be developed, but this is a good
starting point.
