### PR TITLE
Remove automatic column addition for empty scan

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursor.java
@@ -110,7 +110,6 @@ class ColumnarBinaryHiveRecordCursor<K>
         checkNotNull(splitSchema, "splitSchema is null");
         checkNotNull(partitionKeys, "partitionKeys is null");
         checkNotNull(columns, "columns is null");
-        checkArgument(!columns.isEmpty(), "columns is empty");
         checkNotNull(sessionTimeZone, "sessionTimeZone is null");
 
         this.recordReader = recordReader;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursor.java
@@ -103,7 +103,6 @@ class ColumnarTextHiveRecordCursor<K>
         checkNotNull(splitSchema, "splitSchema is null");
         checkNotNull(partitionKeys, "partitionKeys is null");
         checkNotNull(columns, "columns is null");
-        checkArgument(!columns.isEmpty(), "columns is empty");
         checkNotNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
         checkNotNull(sessionTimeZone, "sessionTimeZone is null");
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
@@ -105,7 +105,6 @@ class GenericHiveRecordCursor<K, V extends Writable>
         checkNotNull(splitSchema, "splitSchema is null");
         checkNotNull(partitionKeys, "partitionKeys is null");
         checkNotNull(columns, "columns is null");
-        checkArgument(!columns.isEmpty(), "columns is empty");
         checkNotNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
         checkNotNull(sessionTimeZone, "sessionTimeZone is null");
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/AlignmentOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/AlignmentOperator.java
@@ -100,7 +100,7 @@ public class AlignmentOperator
     @Override
     public void addInput(Page page)
     {
-        throw new UnsupportedOperationException(getClass().getName() + " can not take input");
+        throw new UnsupportedOperationException(getClass().getName() + " cannot take input");
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/RecordProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/RecordProjectOperator.java
@@ -128,6 +128,7 @@ public class RecordProjectOperator
                     break;
                 }
 
+                pageBuilder.declarePosition();
                 for (int column = 0; column < types.size(); column++) {
                     BlockBuilder output = pageBuilder.getBlockBuilder(column);
                     if (cursor.isNull(column)) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/SampleOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SampleOperator.java
@@ -154,7 +154,9 @@ public class SampleOperator
                 }
 
                 if (repeats > 0) {
-                    for (int channel = 0; channel < page.getChannelCount(); channel++) {
+                    // copy input values to output page
+                    // NOTE: last output type is sample weight so we skip it
+                    for (int channel = 0; channel < types.size() - 1; channel++) {
                         Type type = types.get(channel);
                         type.appendTo(page.getBlock(channel), position, pageBuilder.getBlockBuilder(channel));
                     }

--- a/presto-main/src/main/java/com/facebook/presto/split/DataStreamManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/DataStreamManager.java
@@ -51,7 +51,6 @@ public class DataStreamManager
         checkNotNull(operatorContext, "operatorContext is null");
         checkNotNull(split, "split is null");
         checkNotNull(columns, "columns is null");
-        checkArgument(!columns.isEmpty(), "no columns specified");
 
         List<ConnectorColumnHandle> handles = Lists.transform(columns, connectorHandleGetter());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -59,12 +59,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.sql.planner.plan.JoinNode.EquiJoinClause.leftGetter;
 import static com.facebook.presto.sql.planner.plan.JoinNode.EquiJoinClause.rightGetter;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.in;
 import static com.google.common.collect.Iterables.concat;
 
@@ -247,19 +244,6 @@ public class PruneUnreferencedOutputs
             Set<Symbol> requiredTableScanOutputs = FluentIterable.from(expectedOutputs)
                     .filter(in(node.getOutputSymbols()))
                     .toSet();
-            if (requiredTableScanOutputs.isEmpty()) {
-                for (Symbol symbol : node.getOutputSymbols()) {
-                    Type type = types.get(symbol);
-                    if (type.equals(BIGINT) || type.equals(DOUBLE)) {
-                        requiredTableScanOutputs = ImmutableSet.of(symbol);
-                        break;
-                    }
-                }
-                if (requiredTableScanOutputs.isEmpty()) {
-                    requiredTableScanOutputs = ImmutableSet.of(node.getOutputSymbols().get(0));
-                }
-            }
-            checkState(!requiredTableScanOutputs.isEmpty());
 
             List<Symbol> newOutputSymbols = FluentIterable.from(node.getOutputSymbols())
                     .filter(in(requiredTableScanOutputs))

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableScanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableScanNode.java
@@ -90,7 +90,6 @@ public class TableScanNode
         checkNotNull(outputSymbols, "outputSymbols is null");
         checkNotNull(assignments, "assignments is null");
         checkArgument(assignments.keySet().containsAll(outputSymbols), "assignments does not cover all of outputSymbols");
-        checkArgument(!assignments.isEmpty(), "assignments is empty");
         checkNotNull(summarizedPartition, "summarizedPartition is null");
 
         this.table = table;

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/NoColumnsOperator.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/NoColumnsOperator.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor;
+
+import com.facebook.presto.operator.Operator;
+import com.facebook.presto.operator.OperatorContext;
+import com.facebook.presto.operator.Page;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class NoColumnsOperator
+        implements Operator
+{
+    private final OperatorContext operatorContext;
+    private final Iterator<Integer> positionCounts;
+
+    private boolean finished;
+
+    public NoColumnsOperator(OperatorContext operatorContext, Iterable<Integer> positionCounts)
+    {
+        this.operatorContext = checkNotNull(operatorContext, "operatorContext is null");
+        this.positionCounts = positionCounts.iterator();
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public List<Type> getTypes()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public void finish()
+    {
+        finished = true;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finished;
+    }
+
+    @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return false;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        throw new UnsupportedOperationException(getClass().getName() + " cannot take input");
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        if (finished) {
+            return null;
+        }
+
+        if (!positionCounts.hasNext()) {
+            finished = true;
+            return null;
+        }
+
+        return new Page(positionCounts.next());
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplit.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplit.java
@@ -30,16 +30,20 @@ public class RaptorSplit
 {
     private final UUID shardUuid;
     private final List<HostAddress> addresses;
+    private final RaptorColumnHandle countColumnHandle;
 
     @JsonCreator
     public RaptorSplit(
             @JsonProperty("shardUuid") UUID shardUuid,
-            @JsonProperty("addresses") List<HostAddress> addresses)
+            @JsonProperty("addresses") List<HostAddress> addresses,
+            @JsonProperty("countColumnHandle") RaptorColumnHandle countColumnHandle)
     {
         this.shardUuid = checkNotNull(shardUuid, "shardUuid is null");
 
         checkNotNull(addresses, "addresses is null");
         this.addresses = ImmutableList.copyOf(addresses);
+
+        this.countColumnHandle = checkNotNull(countColumnHandle, "countColumnHandle is null");
     }
 
     @Override
@@ -60,6 +64,12 @@ public class RaptorSplit
     public UUID getShardUuid()
     {
         return shardUuid;
+    }
+
+    @JsonProperty
+    public RaptorColumnHandle getCountColumnHandle()
+    {
+        return countColumnHandle;
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplitManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplitManager.java
@@ -112,6 +112,8 @@ public class RaptorSplitManager
     {
         Stopwatch splitTimer = Stopwatch.createStarted();
 
+        RaptorTableHandle raptorTableHandle = checkType(tableHandle, RaptorTableHandle.class, "tableHandle");
+
         checkNotNull(partitions, "partitions is null");
         if (partitions.isEmpty()) {
             return new FixedSplitSource(connectorId, ImmutableList.<ConnectorSplit>of());
@@ -121,7 +123,7 @@ public class RaptorSplitManager
 
         List<ConnectorSplit> splits = new ArrayList<>();
 
-        Multimap<Long, Entry<UUID, String>> partitionShardNodes = shardManager.getShardNodesByPartition(tableHandle);
+        Multimap<Long, Entry<UUID, String>> partitionShardNodes = shardManager.getShardNodesByPartition(raptorTableHandle);
 
         for (ConnectorPartition partition : partitions) {
             RaptorPartition raptorPartition = checkType(partition, RaptorPartition.class, "partition");
@@ -134,7 +136,7 @@ public class RaptorSplitManager
             for (Map.Entry<UUID, Collection<String>> entry : shardNodes.build().asMap().entrySet()) {
                 List<HostAddress> addresses = getAddressesForNodes(nodesById, entry.getValue());
                 checkState(!addresses.isEmpty(), "no host for shard %s found: %s", entry.getKey(), entry.getValue());
-                ConnectorSplit split = new RaptorSplit(entry.getKey(), addresses);
+                ConnectorSplit split = new RaptorSplit(entry.getKey(), addresses, raptorTableHandle.getCountColumnHandle());
                 splits.add(split);
             }
         }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorTableHandle.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorTableHandle.java
@@ -32,6 +32,7 @@ public final class RaptorTableHandle
     private final String schemaName;
     private final String tableName;
     private final long tableId;
+    private final RaptorColumnHandle countColumnHandle;
     @Nullable
     private final RaptorColumnHandle sampleWeightColumnHandle;
 
@@ -41,6 +42,7 @@ public final class RaptorTableHandle
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("tableId") long tableId,
+            @JsonProperty("countColumnHandle") RaptorColumnHandle countColumnHandle,
             @JsonProperty("sampleWeightColumnHandle") RaptorColumnHandle sampleWeightColumnHandle)
     {
         this.connectorId = checkNotNull(connectorId, "connectorId is null");
@@ -49,6 +51,8 @@ public final class RaptorTableHandle
 
         checkArgument(tableId > 0, "tableId must be greater than zero");
         this.tableId = tableId;
+
+        this.countColumnHandle = checkNotNull(countColumnHandle, "countColumnHandle is null");
         this.sampleWeightColumnHandle = sampleWeightColumnHandle;
     }
 
@@ -74,6 +78,12 @@ public final class RaptorTableHandle
     public long getTableId()
     {
         return tableId;
+    }
+
+    @JsonProperty
+    public RaptorColumnHandle getCountColumnHandle()
+    {
+        return countColumnHandle;
     }
 
     @JsonProperty

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.raptor.metadata;
 
+import com.facebook.presto.raptor.RaptorColumnHandle;
 import com.facebook.presto.raptor.RaptorTableHandle;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.PartitionKey;
@@ -35,6 +36,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
@@ -69,7 +71,7 @@ public class TestDatabaseShardManager
             throws Exception
     {
         long tableId = 1;
-        ConnectorTableHandle tableHandle = new RaptorTableHandle("test", "demo", "test", tableId, null);
+        ConnectorTableHandle tableHandle = new RaptorTableHandle("test", "demo", "test", tableId, new RaptorColumnHandle("test", "foo", 1, BIGINT), null);
         UUID shardId1 = UUID.randomUUID();
         UUID shardId2 = UUID.randomUUID();
 

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchRecordSetProvider.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchRecordSetProvider.java
@@ -26,8 +26,6 @@ import java.util.List;
 
 import static com.facebook.presto.tpch.TpchRecordSet.createTpchRecordSet;
 import static com.facebook.presto.tpch.Types.checkType;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class TpchRecordSetProvider
         implements ConnectorRecordSetProvider
@@ -36,9 +34,6 @@ public class TpchRecordSetProvider
     public RecordSet getRecordSet(ConnectorSplit split, List<? extends ConnectorColumnHandle> columns)
     {
         TpchSplit tpchSplit = checkType(split, TpchSplit.class, "split");
-
-        checkNotNull(columns, "columns is null");
-        checkArgument(!columns.isEmpty(), "must provide at least one column");
 
         String tableName = tpchSplit.getTableHandle().getTableName();
 


### PR DESCRIPTION
Originally a column had to be selected to scan a table, so we always added a "cheap" column to scan.  When we removed this restriction we forgot to remove the code that automatically added a column to an empty table scan. For the Raptor connector, we must still choose a "cheap" column, but this is an internal detail of the Raptor connector.
