### PR TITLE
Let each type decide coerce and common super type

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -143,16 +143,8 @@ import static com.facebook.presto.operator.aggregation.ApproximateCountAggregati
 import static com.facebook.presto.operator.aggregation.CountAggregation.COUNT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
-import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
-import static com.facebook.presto.spi.type.TimeType.TIME;
-import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
-import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.facebook.presto.type.JsonPathType.JSON_PATH;
-import static com.facebook.presto.type.LikePatternType.LIKE_PATTERN;
-import static com.facebook.presto.type.RegexpType.REGEXP;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
@@ -440,40 +432,8 @@ public class FunctionRegistry
         if (actualType.equals(UNKNOWN)) {
             return true;
         }
-        // widen bigint to double
-        if (actualType.equals(BIGINT) && expectedType.equals(DOUBLE)) {
-            return true;
-        }
-        // widen date to timestamp
-        if (actualType.equals(DATE) && expectedType.equals(TIMESTAMP)) {
-            return true;
-        }
-        // widen date to timestamp with time zone
-        if (actualType.equals(DATE) && expectedType.equals(TIMESTAMP_WITH_TIME_ZONE)) {
-            return true;
-        }
-        // widen time to time with time zone
-        if (actualType.equals(TIME) && expectedType.equals(TIME_WITH_TIME_ZONE)) {
-            return true;
-        }
-        // widen timestamp to timestamp with time zone
-        if (actualType.equals(TIMESTAMP) && expectedType.equals(TIMESTAMP_WITH_TIME_ZONE)) {
-            return true;
-        }
 
-        if (actualType.equals(VARCHAR) && expectedType.equals(REGEXP)) {
-            return true;
-        }
-
-        if (actualType.equals(VARCHAR) && expectedType.equals(LIKE_PATTERN)) {
-            return true;
-        }
-
-        if (actualType.equals(VARCHAR) && expectedType.equals(JSON_PATH)) {
-            return true;
-        }
-
-        return false;
+        return expectedType.canCoerceFrom(actualType);
     }
 
     public static Optional<Type> getCommonSuperType(Type firstType, Type secondType)
@@ -490,19 +450,7 @@ public class FunctionRegistry
             return Optional.of(firstType);
         }
 
-        if ((firstType.equals(BIGINT) || firstType.equals(DOUBLE)) && (secondType.equals(BIGINT) || secondType.equals(DOUBLE))) {
-            return Optional.<Type>of(DOUBLE);
-        }
-
-        if ((firstType.equals(TIME) || firstType.equals(TIME_WITH_TIME_ZONE)) && (secondType.equals(TIME) || secondType.equals(TIME_WITH_TIME_ZONE))) {
-            return Optional.<Type>of(TIME_WITH_TIME_ZONE);
-        }
-
-        if ((firstType.equals(TIMESTAMP) || firstType.equals(TIMESTAMP_WITH_TIME_ZONE)) && (secondType.equals(TIMESTAMP) || secondType.equals(TIMESTAMP_WITH_TIME_ZONE))) {
-            return Optional.<Type>of(TIMESTAMP_WITH_TIME_ZONE);
-        }
-
-        return Optional.absent();
+        return Optional.fromNullable(firstType.getCommonSuperType(secondType));
     }
 
     private static List<Type> parameterTypes(Method method)

--- a/presto-main/src/main/java/com/facebook/presto/type/ColorType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ColorType.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
 import com.facebook.presto.spi.type.FixedWidthType;
+import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
@@ -57,9 +58,21 @@ public class ColorType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return long.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/type/JsonPathType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/JsonPathType.java
@@ -23,6 +23,8 @@ import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
 public class JsonPathType
         implements Type
 {
@@ -52,9 +54,25 @@ public class JsonPathType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        if (type.equals(VARCHAR)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return JsonPath.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/type/LikePatternType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LikePatternType.java
@@ -23,6 +23,8 @@ import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import org.joni.Regex;
 
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
 public class LikePatternType
         implements Type
 {
@@ -52,9 +54,25 @@ public class LikePatternType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        if (type.equals(VARCHAR)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return Regex.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/type/RegexpType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RegexpType.java
@@ -24,6 +24,8 @@ import io.airlift.slice.Slice;
 
 import java.util.regex.Pattern;
 
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
 public class RegexpType
     implements Type
 {
@@ -53,9 +55,25 @@ public class RegexpType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        if (type.equals(VARCHAR)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return Pattern.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/type/UnknownType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/UnknownType.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
 import com.facebook.presto.spi.type.FixedWidthType;
+import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 
 public final class UnknownType
@@ -49,9 +50,21 @@ public final class UnknownType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return void.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override

--- a/presto-ml/src/main/java/com/facebook/presto/ml/type/ModelType.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/type/ModelType.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
+import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VariableWidthType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.airlift.slice.Slice;
@@ -59,9 +60,21 @@ public class ModelType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return Slice.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BigintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BigintType.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
 import io.airlift.slice.Slice;
 
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 
 public final class BigintType
@@ -55,9 +56,25 @@ public final class BigintType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return long.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        if (type.equals(DOUBLE)) {
+            return DOUBLE;
+        }
+
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
@@ -55,9 +55,21 @@ public final class BooleanType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return boolean.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DateType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DateType.java
@@ -64,9 +64,21 @@ public final class DateType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return long.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
 import io.airlift.slice.Slice;
 
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
 
 public final class DoubleType
@@ -52,6 +53,26 @@ public final class DoubleType
     public boolean isOrderable()
     {
         return true;
+    }
+
+    @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        if (type.equals(BIGINT)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        if (type.equals(BIGINT)) {
+            return DOUBLE;
+        }
+
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/HyperLogLogType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/HyperLogLogType.java
@@ -58,9 +58,21 @@ public class HyperLogLogType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return Slice.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/IntervalDayTimeType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/IntervalDayTimeType.java
@@ -55,9 +55,21 @@ public final class IntervalDayTimeType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return long.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/IntervalYearMonthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/IntervalYearMonthType.java
@@ -55,9 +55,21 @@ public final class IntervalYearMonthType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return long.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeType.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
 import io.airlift.slice.Slice;
 
+import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 
 //
@@ -59,9 +60,25 @@ public final class TimeType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return long.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        if (type.equals(TIME_WITH_TIME_ZONE)) {
+            return TIME_WITH_TIME_ZONE;
+        }
+
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeWithTimeZoneType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeWithTimeZoneType.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
 import io.airlift.slice.Slice;
 
 import static com.facebook.presto.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static com.facebook.presto.spi.type.TimeType.TIME;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 
 public final class TimeWithTimeZoneType
@@ -56,9 +57,29 @@ public final class TimeWithTimeZoneType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        if (type.equals(TIME)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return long.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        if (type.equals(TIME)) {
+            return TIME_WITH_TIME_ZONE;
+        }
+
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampType.java
@@ -20,6 +20,8 @@ import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
 import io.airlift.slice.Slice;
 
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 
 //
@@ -59,9 +61,29 @@ public final class TimestampType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        if (type.equals(DATE)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return long.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
+            return TIMESTAMP_WITH_TIME_ZONE;
+        }
+
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampWithTimeZoneType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampWithTimeZoneType.java
@@ -21,6 +21,8 @@ import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
 import io.airlift.slice.Slice;
 
 import static com.facebook.presto.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 
 public final class TimestampWithTimeZoneType
@@ -56,9 +58,29 @@ public final class TimestampWithTimeZoneType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        if (type.equals(DATE) || type.equals(TIMESTAMP)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return long.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        if (type.equals(TIMESTAMP)) {
+            return TIMESTAMP_WITH_TIME_ZONE;
+        }
+
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/Type.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/Type.java
@@ -40,6 +40,11 @@ public interface Type
     boolean isOrderable();
 
     /**
+     * True if the type is coerce-able from the given type.
+     */
+    boolean canCoerceFrom(Type type);
+
+    /**
      * Gets the Java class type used to represent this value on the stack during
      * expression execution. This value is used to determine which method should
      * be called on Cursor, RecordSet or RandomAccessBlock to fetch a value of
@@ -48,6 +53,13 @@ public interface Type
      * Currently, this must be boolean, long, double, or Slice.
      */
     Class<?> getJavaType();
+
+    /**
+     * Gets the common super type between the type and the given type.
+     *
+     * Returns null, if there's no common
+     */
+    Type getCommonSuperType(Type type);
 
     /**
      * Creates a block builder for this type. This is the builder used to

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/VarbinaryType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/VarbinaryType.java
@@ -55,9 +55,21 @@ public class VarbinaryType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return Slice.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/VarcharType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/VarcharType.java
@@ -56,9 +56,21 @@ public class VarcharType
     }
 
     @Override
+    public boolean canCoerceFrom(Type type)
+    {
+        return false;
+    }
+
+    @Override
     public Class<?> getJavaType()
     {
         return Slice.class;
+    }
+
+    @Override
+    public Type getCommonSuperType(Type type)
+    {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
When adding a type from plugin, the type need to supply
whether it can coerce from given type and have a common super type

For example, if we add a CustomRegexpType and related UDFs, the `FunctionRegistry` need to know the type can coerce from `VARCHAR`
