### PR TITLE
Improve support for numeric fields in json extract

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonPathTokenizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonPathTokenizer.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.AbstractIterator;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.Character.isLetterOrDigit;
+import static java.lang.Character.isWhitespace;
+import static java.lang.String.format;
+
+public class JsonPathTokenizer
+        extends AbstractIterator<String>
+{
+    private static final char QUOTE = '\"';
+    private static final char DOT = '.';
+    private static final char OPEN_BRACKET = '[';
+    private static final char CLOSE_BRACKET = ']';
+    private static final char UNICODE_CARET = '\u2038';
+
+    private final String path;
+    private int index;
+
+    public JsonPathTokenizer(String path)
+    {
+        this.path = checkNotNull(path, "path is null");
+
+        // skip the start token
+        match('$');
+    }
+
+    @Override
+    protected String computeNext()
+    {
+        skipWhitespace();
+        if (!hasNextCharacter()) {
+            return endOfData();
+        }
+
+        if (tryMatch(DOT)) {
+            return matchUnquotedToken();
+        }
+
+        if (tryMatch(OPEN_BRACKET)) {
+            String token = tryMatch(QUOTE) ? matchQuotedToken() : matchUnquotedToken();
+
+            match(CLOSE_BRACKET);
+            return token;
+        }
+
+        throw invalidJsonPath();
+    }
+
+    private String matchUnquotedToken()
+    {
+        skipWhitespace();
+
+        // seek until we see a special character or whitespace
+        int start = index;
+        while (hasNextCharacter() && isLetterOrDigit(peekCharacter())) {
+            nextCharacter();
+        }
+        int end = index;
+
+        String token = path.substring(start, end);
+
+        // an empty unquoted token is not allowed
+        if (token.isEmpty()) {
+            throw invalidJsonPath();
+        }
+
+        return token;
+    }
+
+    private String matchQuotedToken()
+    {
+        // quote has already been matched
+
+        // seek until we see the close quote
+        int start = index;
+        while (hasNextCharacter() && peekCharacter() != QUOTE) {
+            nextCharacter();
+        }
+        int end = index;
+
+        String token = path.substring(start, end);
+
+        match(QUOTE);
+        return token;
+    }
+
+    private boolean hasNextCharacter()
+    {
+        return index < path.length();
+    }
+
+    private void match(char expected)
+    {
+        if (!tryMatch(expected)) {
+            throw invalidJsonPath();
+        }
+    }
+
+    private boolean tryMatch(char expected)
+    {
+        skipWhitespace();
+
+        if (peekCharacter() != expected) {
+            return false;
+        }
+        index++;
+        return true;
+    }
+
+    private void skipWhitespace()
+    {
+        while (hasNextCharacter() && isWhitespace(peekCharacter())) {
+            index++;
+        }
+    }
+
+    private void nextCharacter()
+    {
+        index++;
+    }
+
+    private char peekCharacter()
+    {
+        return path.charAt(index);
+    }
+
+    public PrestoException invalidJsonPath()
+    {
+        return new PrestoException(INVALID_FUNCTION_ARGUMENT.toErrorCode(), format("Invalid JSON path: '%s'", path));
+    }
+
+    @Override
+    public String toString()
+    {
+        return path.substring(0, index) + UNICODE_CARET + path.substring(index);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
@@ -23,14 +23,13 @@ import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.List;
 
-import static com.facebook.presto.operator.scalar.JsonExtract.ArrayElementJsonExtractor;
 import static com.facebook.presto.operator.scalar.JsonExtract.JsonExtractor;
 import static com.facebook.presto.operator.scalar.JsonExtract.JsonValueJsonExtractor;
 import static com.facebook.presto.operator.scalar.JsonExtract.ObjectFieldJsonExtractor;
 import static com.facebook.presto.operator.scalar.JsonExtract.ScalarValueJsonExtractor;
 import static com.facebook.presto.operator.scalar.JsonExtract.generateExtractor;
-import static com.facebook.presto.operator.scalar.JsonExtract.tokenizePath;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -42,18 +41,33 @@ public class TestJsonExtract
     public void testJsonTokenizer()
     {
         assertEquals(tokenizePath("$"), ImmutableList.of());
+        assertEquals(tokenizePath("$"), ImmutableList.of());
         assertEquals(tokenizePath("$.foo"), ImmutableList.of("foo"));
         assertEquals(tokenizePath("$[\"foo\"]"), ImmutableList.of("foo"));
         assertEquals(tokenizePath("$[\"foo.bar\"]"), ImmutableList.of("foo.bar"));
-        assertEquals(tokenizePath("$[42]"), ImmutableList.of(42));
+        assertEquals(tokenizePath("$[42]"), ImmutableList.of("42"));
+        assertEquals(tokenizePath("$.42"), ImmutableList.of("42"));
+        assertEquals(tokenizePath("$.42.63"), ImmutableList.of("42", "63"));
+        assertEquals(tokenizePath("$.foo.42.bar.63"), ImmutableList.of("foo", "42", "bar", "63"));
         assertEquals(tokenizePath("$.x.foo"), ImmutableList.of("x", "foo"));
         assertEquals(tokenizePath("$.x[\"foo\"]"), ImmutableList.of("x", "foo"));
-        assertEquals(tokenizePath("$.x[42]"), ImmutableList.of("x", 42));
+        assertEquals(tokenizePath("$.x[42]"), ImmutableList.of("x", "42"));
+
+        assertEquals(tokenizePath("  $  "), ImmutableList.of());
+        assertEquals(tokenizePath("  $  .  foo  "), ImmutableList.of("foo"));
+        assertEquals(tokenizePath("  $  [  \"foo\"  ]  "), ImmutableList.of("foo"));
+        assertEquals(tokenizePath("  $  [  \"foo.bar\"  ]  "), ImmutableList.of("foo.bar"));
+        assertEquals(tokenizePath("  $  [  42  ]  "), ImmutableList.of("42"));
+        assertEquals(tokenizePath("  $  .  42  "), ImmutableList.of("42"));
+        assertEquals(tokenizePath("  $  .  42  .  42  "), ImmutableList.of("42", "42"));
+        assertEquals(tokenizePath("  $  .  x  .  foo  "), ImmutableList.of("x", "foo"));
+        assertEquals(tokenizePath("  $  .  x  [  \"foo\"  ]  "), ImmutableList.of("x", "foo"));
+        assertEquals(tokenizePath("  $  .  x  [  42  ]  "), ImmutableList.of("x", "42"));
+
+        assertEquals(tokenizePath("\t$\r.\nfoo\u3000"), ImmutableList.of("foo"));
 
         assertPathToken("foo");
 
-        assertQuotedPathToken("42");
-        assertQuotedPathToken("1.1");
         assertQuotedPathToken("-1.1");
         assertQuotedPathToken("!@#$%^&*()[]{}/?'");
         assertQuotedPathToken("ab\\u0001c");
@@ -144,8 +158,8 @@ public class TestJsonExtract
     public void testArrayElementJsonExtractor()
             throws Exception
     {
-        ArrayElementJsonExtractor<Slice> firstExtractor = new ArrayElementJsonExtractor<>(0, new ScalarValueJsonExtractor());
-        ArrayElementJsonExtractor<Slice> secondExtractor = new ArrayElementJsonExtractor<>(1, new ScalarValueJsonExtractor());
+        ObjectFieldJsonExtractor<Slice> firstExtractor = new ObjectFieldJsonExtractor<>("0", new ScalarValueJsonExtractor());
+        ObjectFieldJsonExtractor<Slice> secondExtractor = new ObjectFieldJsonExtractor<>("1", new ScalarValueJsonExtractor());
 
         assertEquals(doExtract(firstExtractor, "[]"), null);
         assertEquals(doExtract(firstExtractor, "[1, 2, 3]"), "1");
@@ -178,6 +192,8 @@ public class TestJsonExtract
         assertEquals(doScalarExtract("{}", "$"), null);
         assertEquals(doScalarExtract("{\"fuu\": {\"bar\": 1}}", "$.fuu"), null); // Null b/c value is complex type
         assertEquals(doScalarExtract("{\"fuu\": 1}", "$.fuu"), "1");
+        assertEquals(doScalarExtract("{\"fuu\": 1}", "$[fuu]"), "1");
+        assertEquals(doScalarExtract("{\"fuu\": 1}", "$[\"fuu\"]"), "1");
         assertEquals(doScalarExtract("{\"fuu\": null}", "$.fuu"), null);
         assertEquals(doScalarExtract("{\"fuu\": 1}", "$.bar"), null);
         assertEquals(doScalarExtract("{\"fuu\": [\"\\u0001\"]}", "$.fuu[0]"), "\001"); // Test escaped characters
@@ -192,6 +208,19 @@ public class TestJsonExtract
         assertEquals(doScalarExtract("\"abc\"", "$"), "abc");
         assertEquals(doScalarExtract("123", "$"), "123");
         assertEquals(doScalarExtract("null", "$"), null);
+
+        // Test numeric path expression matches arrays and objects
+        assertEquals(doScalarExtract("[0, 1, 2]", "$.1"), "1");
+        assertEquals(doScalarExtract("[0, 1, 2]", "$[1]"), "1");
+        assertEquals(doScalarExtract("[0, 1, 2]", "$[\"1\"]"), "1");
+        assertEquals(doScalarExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2, }", "$.1"), "1");
+        assertEquals(doScalarExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2, }", "$[1]"), "1");
+        assertEquals(doScalarExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2, }", "$[\"1\"]"), "1");
+
+        // Test fields starting with a digit
+        assertEquals(doScalarExtract("{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2, }", "$.30day"), "1");
+        assertEquals(doScalarExtract("{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2, }", "$[30day]"), "1");
+        assertEquals(doScalarExtract("{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2, }", "$[\"30day\"]"), "1");
     }
 
     @Test
@@ -201,6 +230,8 @@ public class TestJsonExtract
         assertEquals(doJsonExtract("{}", "$"), "{}");
         assertEquals(doJsonExtract("{\"fuu\": {\"bar\": 1}}", "$.fuu"), "{\"bar\":1}");
         assertEquals(doJsonExtract("{\"fuu\": 1}", "$.fuu"), "1");
+        assertEquals(doJsonExtract("{\"fuu\": 1}", "$[fuu]"), "1");
+        assertEquals(doJsonExtract("{\"fuu\": 1}", "$[\"fuu\"]"), "1");
         assertEquals(doJsonExtract("{\"fuu\": null}", "$.fuu"), "null");
         assertEquals(doJsonExtract("{\"fuu\": 1}", "$.bar"), null);
         assertEquals(doJsonExtract("{\"fuu\": [\"\\u0001\"]}", "$.fuu[0]"), "\"\\u0001\""); // Test escaped characters
@@ -247,6 +278,20 @@ public class TestJsonExtract
         // Test extraction using  mix of bracket and dot notation json path with special json characters in path
         assertEquals(doJsonExtract("{\"@$fuu\": {\"bar\": 1}}", "$[\"@$fuu\"].bar"), "1");
         assertEquals(doJsonExtract("{\",fuu\": {\"bar\": [\"\\u0001\"]}}", "$[\",fuu\"].bar[0]"), "\"\\u0001\""); // Test escaped characters
+
+
+        // Test numeric path expression matches arrays and objects
+        assertEquals(doJsonExtract("[0, 1, 2]", "$.1"), "1");
+        assertEquals(doJsonExtract("[0, 1, 2]", "$[1]"), "1");
+        assertEquals(doJsonExtract("[0, 1, 2]", "$[\"1\"]"), "1");
+        assertEquals(doJsonExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2, }", "$.1"), "1");
+        assertEquals(doJsonExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2, }", "$[1]"), "1");
+        assertEquals(doJsonExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2, }", "$[\"1\"]"), "1");
+
+        // Test fields starting with a digit
+        assertEquals(doJsonExtract("{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2, }", "$.30day"), "1");
+        assertEquals(doJsonExtract("{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2, }", "$[30day]"), "1");
+        assertEquals(doJsonExtract("{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2, }", "$[\"30day\"]"), "1");
     }
 
     @Test(expectedExceptions = PrestoException.class)
@@ -292,5 +337,10 @@ public class TestJsonExtract
     {
         Slice value = JsonExtract.extract(Slices.utf8Slice(inputJson), generateExtractor(jsonPath, new JsonValueJsonExtractor()));
         return (value == null) ? null : value.toString(Charsets.UTF_8);
+    }
+
+    private static List<String> tokenizePath(String path)
+    {
+        return ImmutableList.copyOf(new JsonPathTokenizer(path));
     }
 }


### PR DESCRIPTION
Allow numeric fields without quoting in path expressions
Numeric fields match both array elements and object fields
