### PR TITLE
Make chr() work with unicode

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -18,7 +18,7 @@ String Functions
     the number of bytes in the UTF-8 representation of the string rather than
     the number of unicode characters.
 
-.. function:: char(n) -> varchar
+.. function:: chr(n) -> varchar
 
     Returns the Unicode code point ``n`` as a single character string.
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -19,11 +19,13 @@ import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.type.SqlType;
 import com.google.common.base.Ascii;
 import com.google.common.base.Charsets;
-import com.google.common.primitives.Ints;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
 import javax.annotation.Nullable;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -31,14 +33,14 @@ public final class StringFunctions
 {
     private StringFunctions() {}
 
-    @Description("convert ASCII character code to string")
+    @Description("convert unicode code point to a string")
     @ScalarFunction
     @SqlType(VarcharType.class)
-    public static Slice chr(@SqlType(BigintType.class) long n)
+    public static Slice chr(@SqlType(BigintType.class) long codepoint)
     {
-        Slice slice = Slices.allocate(1);
-        slice.setByte(0, Ints.saturatedCast(n));
-        return slice;
+        char[] utf16 = Character.toChars((int) codepoint);
+        ByteBuffer utf8 = Charsets.UTF_8.encode(CharBuffer.wrap(utf16));
+        return Slices.wrappedBuffer(utf8.array(), 0, utf8.limit());
     }
 
     @Description("concatenates given strings")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -30,7 +30,8 @@ public class TestStringFunctions
     public void testChr()
     {
         assertFunction("CHR(65)", "A");
-        assertFunction("CHR(65)", "A");
+        assertFunction("CHR(9731)", "\u2603");
+        assertFunction("CHR(131210)", new String(Character.toChars(131210)));
         assertFunction("CHR(0)", "\0");
     }
 


### PR DESCRIPTION
- Update docs to reference chr() instead of char()
- Make chr() work with unicode code points instead of ascii code points to match the documentation
