### PR TITLE
Fix race condition in HttpRemoteTask

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTask.java
@@ -379,9 +379,11 @@ public class HttpRemoteTask
         currentRequest = future;
         currentRequestStartNanos = System.nanoTime();
 
-        Futures.addCallback(future, new SimpleHttpResponseHandler<>(new UpdateResponseHandler(sources), request.getUri()), executor);
-
+        // The needsUpdate flag needs to be set to false BEFORE adding the Future callback since callback might change the flag value
+        // and does so without grabbing the instance lock.
         needsUpdate.set(false);
+
+        Futures.addCallback(future, new SimpleHttpResponseHandler<>(new UpdateResponseHandler(sources), request.getUri()), executor);
     }
 
     private synchronized List<TaskSource> getSources()


### PR DESCRIPTION
There is a race condition in HttpRemoteTask where it can race on setting the value of the needsUpdate flag. The potential result of this is that we can silently drop a failed HTTP request and not notify any of the callers.
