### PR TITLE
Fix incorrect parsing of function arguments

### DIFF
--- a/presto-parser/src/main/antlr3/com/facebook/presto/sql/parser/Statement.g
+++ b/presto-parser/src/main/antlr3/com/facebook/presto/sql/parser/Statement.g
@@ -443,8 +443,8 @@ exprPrimary
 
 qnameOrFunction
     : (qname -> qname)
-      ( ('(' '*' ')' over?                          -> ^(FUNCTION_CALL $qnameOrFunction over?))
-      | ('(' setQuant? expr? (',' expr)* ')' over?  -> ^(FUNCTION_CALL $qnameOrFunction over? setQuant? expr*))
+      ( '(' '*' ')' over?                            -> ^(FUNCTION_CALL $qnameOrFunction over?)
+      | '(' (setQuant? expr (',' expr)*)? ')' over?  -> ^(FUNCTION_CALL $qnameOrFunction over? setQuant? expr*)
       )?
     ;
 

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -442,6 +442,24 @@ public class TestSqlParser
         sqlParser.createStatement("select * from foo:bar");
     }
 
+    @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "\\Qline 1:11: mismatched input '(' expecting EOF\\E")
+    public void testInvalidArguments()
+    {
+        SQL_PARSER.createStatement("select foo(,1)");
+    }
+
+    @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "\\Qline 1:20: no viable alternative at input ')'\\E")
+    public void testInvalidArguments2()
+    {
+        SQL_PARSER.createStatement("select foo(DISTINCT)");
+    }
+
+    @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "\\Qline 1:21: no viable alternative at input ','\\E")
+    public void testInvalidArguments3()
+    {
+        SQL_PARSER.createStatement("select foo(DISTINCT ,1)");
+    }
+
     @SuppressWarnings("deprecation")
     @Test
     public void testAllowIdentifierAtSign()


### PR DESCRIPTION
The current parser incorrectly allows function calls with the following syntax:

```
foo(,1,2)
foo(DISTINCT ,x)
foo(DISTINCT)
```
