### PR TITLE
Don't generate so many invokedynamic callsite names

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/ByteCodeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/ByteCodeUtils.java
@@ -183,7 +183,7 @@ public final class ByteCodeUtils
                 index++;
             }
         }
-        block.append(invoke(context, binding));
+        block.append(invoke(context, binding, function.getSignature().toString()));
 
         if (function.isNullable()) {
             if (unboxedReturnType.isPrimitive()) {
@@ -242,10 +242,10 @@ public final class ByteCodeUtils
         return IfStatement.ifStatementBuilder(context).condition(condition).ifTrue(wasNull).ifFalse(notNull).build();
     }
 
-    public static ByteCodeNode invoke(CompilerContext context, Binding binding)
+    public static ByteCodeNode invoke(CompilerContext context, Binding binding, String name)
     {
         return new Block(context)
-                .invokeDynamic("call_" + binding.getBindingId(), binding.getType(), binding.getBindingId());
+                .invokeDynamic(name, binding.getType(), binding.getBindingId());
     }
 
     public static void setCallSitesField(Class<?> clazz, Map<Long, MethodHandle> callSites)
@@ -282,7 +282,7 @@ public final class ByteCodeUtils
                                 .pop())
                         .ifFalse(new Block(context)
                                 .comment(type.getName() + "." + name + "(output, " + type.getJavaType().getSimpleName() + ")")
-                                .append(invoke(context, callSiteBinder.bind(target.bindTo(type)))))
+                                .append(invoke(context, callSiteBinder.bind(target.bindTo(type)), name)))
                         .build());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/ExpressionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/ExpressionCompiler.java
@@ -155,7 +155,7 @@ public class ExpressionCompiler
         CompilerContext context = new CompilerContext(BOOTSTRAP_METHOD);
         classDefinition.declareMethod(context, a(PUBLIC), "toString", type(String.class))
                 .getBody()
-                .append(invoke(context, callSiteBinder.bind(string, String.class)))
+                .append(invoke(context, callSiteBinder.bind(string, String.class), "toString"))
                 .retObject();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/InCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/InCodeGenerator.java
@@ -121,7 +121,7 @@ public class InCodeGenerator
             switchBlock = new Block(context)
                     .comment("lookupSwitch(hashCode(<stackValue>))")
                     .dup(javaType)
-                    .append(invoke(generatorContext.getContext(), hashCodeBinding))
+                    .append(invoke(generatorContext.getContext(), hashCodeBinding, hashCodeFunction.getSignature().toString()))
                     .longToInt()
                     .append(switchBuilder.build())
                     .append(switchCaseBlocks);
@@ -230,7 +230,7 @@ public class InCodeGenerator
                         .putVariable(caseWasNull)
                         .append(ifWasNullPopAndGoto(context, elseLabel, void.class, type.getJavaType(), type.getJavaType()));
             }
-            condition.append(invoke(generatorContext.getContext(), equalsFunction));
+            condition.append(invoke(generatorContext.getContext(), equalsFunction, operator.getSignature().toString()));
             test.condition(condition);
 
             test.ifTrue(new Block(context).gotoLabel(matchLabel));

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/IsDistinctFromCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/IsDistinctFromCodeGenerator.java
@@ -55,7 +55,7 @@ public class IsDistinctFromCodeGenerator
 
         ByteCodeNode equalsCall = new Block(context)
                 .comment("equals(%s, %s)", leftType, rightType)
-                .append(invoke(generatorContext.getContext(), binding));
+                .append(invoke(generatorContext.getContext(), binding, operator.getSignature().toString()));
 
         Block block = new Block(context)
                 .comment("IS DISTINCT FROM")

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageProcessorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageProcessorCompiler.java
@@ -331,8 +331,8 @@ public class PageProcessorCompiler
                         .pushJavaDefault(javaType);
 
                 MethodHandle target;
+                String methodName = "get" + Primitives.wrap(javaType).getSimpleName();
                 try {
-                    String methodName = "get" + Primitives.wrap(javaType).getSimpleName();
                     target = MethodHandles.lookup().findVirtual(type.getClass(), methodName, MethodType.methodType(javaType, com.facebook.presto.spi.block.Block.class, int.class));
                 }
                 catch (ReflectiveOperationException e) {
@@ -342,7 +342,7 @@ public class PageProcessorCompiler
                 Block isNotNull = new Block(context)
                         .getVariable("block_" + field)
                         .getVariable(positionVariable)
-                        .append(invoke(context, callSiteBinder.bind(target.bindTo(type))));
+                        .append(invoke(context, callSiteBinder.bind(target.bindTo(type)), methodName));
 
                 return new IfStatement(context, isNullCheck, isNull, isNotNull);
             }


### PR DESCRIPTION
Java 7 doesn't seem to like too many unique callsite names in a single class (Java 8 works ok, though)
It causes execution for queries with many projections to fail with:

```
Exception in thread "main" java.lang.BootstrapMethodError: call site initialization exception
    at java.lang.invoke.CallSite.makeSite(CallSite.java:298)
    at java.lang.invoke.MethodHandleNatives.linkCallSite(MethodHandleNatives.java:295)
    at Runnable_1.run404(Unknown Source)
    at Runnable_1.run(Unknown Source)
    at com.facebook.indytest.Main.main(Main.java:8)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:134)
Caused by: java.lang.NullPointerException
    at sun.invoke.util.ValueConversions.unboxInteger(ValueConversions.java:77)
    at java.lang.invoke.CallSite.makeSite(CallSite.java:282)
    ... 9 more
```

For future reference, here's a stand-alone test case that reproduces the issue: https://github.com/martint/indytest
