### PR TITLE
Update provisio for correct ordering for parallel builds.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -618,12 +618,6 @@
                     <version>1.0.3</version>
                 </plugin>
 
-                <plugin>
-                    <groupId>io.takari.maven.plugins</groupId>
-                    <artifactId>provisio-maven-plugin</artifactId>
-                    <version>0.1.6</version>
-                </plugin>
-
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
                 <plugin>
                     <!--suppress MavenModelInspection -->
@@ -739,6 +733,14 @@
                 <version>0.1.5</version>
                 <extensions>true</extensions>
             </plugin>
+            
+            <plugin>
+                <groupId>io.takari.maven.plugins</groupId>
+                <artifactId>provisio-maven-plugin</artifactId>
+                <version>0.1.7</version>
+                <extensions>true</extensions>
+            </plugin>
+            
         </plugins>
     </build>
 

--- a/presto-server/pom.xml
+++ b/presto-server/pom.xml
@@ -15,20 +15,11 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.check.skip-duplicate-finder>true</air.check.skip-duplicate-finder>
+        <air.check.skip-dependency>true</air.check.skip-dependency>
         <air.check.skip-dependency-version-check>true</air.check.skip-dependency-version-check>
-
         <!-- Launcher properties -->
         <main-class>com.facebook.presto.server.PrestoServer</main-class>
         <process-name>${project.artifactId}</process-name>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.takari.maven.plugins</groupId>
-                <artifactId>provisio-maven-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
The graph edges were being created using GAC, but inside the reactor they need to be
created using GA in order to affect the reactor sorting (correct toposorting). With this
change projects can be built in parallel, correctly.

I have also turned off the dependency checking as the dependencies are synthesized from
looking at the provisioning descriptor and will be analyzed and deemed extraneous. None
of the dependencies will link to any classes because this project is purely an assembly
so what is required is for the provisioning descriptor to decide.
