### PR TITLE
Always call LifeCycleManager.stop()

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/PrestoVerifier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/PrestoVerifier.java
@@ -69,38 +69,41 @@ public class PrestoVerifier
         Bootstrap app = new Bootstrap(builder.build());
         Injector injector = app.strictConfig().initialize();
 
-        VerifierConfig config = injector.getInstance(VerifierConfig.class);
-        injector.injectMembers(this);
-        Set<String> supportedEventClients = injector.getInstance(Key.get(new TypeLiteral<Set<String>>() {}, Names.named(SUPPORTED_EVENT_CLIENTS)));
-        for (String clientType : config.getEventClients()) {
-            checkArgument(supportedEventClients.contains(clientType), "Unsupported event client: %s", clientType);
-        }
-        Set<EventClient> eventClients = injector.getInstance(Key.get(new TypeLiteral<Set<EventClient>>() {}));
-
-        VerifierDao dao = new DBI(config.getQueryDatabase()).onDemand(VerifierDao.class);
-        List<QueryPair> queries = dao.getQueriesBySuite(config.getSuite(), config.getMaxQueries());
-
-        queries = applyOverrides(config, queries);
-        queries = filterQueries(queries);
-
-        // Load jdbc drivers if needed
-        if (config.getAdditionalJdbcDriverPath() != null) {
-            List<URL> urlList = getUrls(config.getAdditionalJdbcDriverPath());
-            URL[] urls = new URL[urlList.size()];
-            urlList.toArray(urls);
-            if (config.getTestJdbcDriverName() != null) {
-                loadJdbcDriver(urls, config.getTestJdbcDriverName());
+        try {
+            VerifierConfig config = injector.getInstance(VerifierConfig.class);
+            injector.injectMembers(this);
+            Set<String> supportedEventClients = injector.getInstance(Key.get(new TypeLiteral<Set<String>>() {}, Names.named(SUPPORTED_EVENT_CLIENTS)));
+            for (String clientType : config.getEventClients()) {
+                checkArgument(supportedEventClients.contains(clientType), "Unsupported event client: %s", clientType);
             }
-            if (config.getControlJdbcDriverName() != null) {
-                loadJdbcDriver(urls, config.getControlJdbcDriverName());
+            Set<EventClient> eventClients = injector.getInstance(Key.get(new TypeLiteral<Set<EventClient>>() {}));
+
+            VerifierDao dao = new DBI(config.getQueryDatabase()).onDemand(VerifierDao.class);
+            List<QueryPair> queries = dao.getQueriesBySuite(config.getSuite(), config.getMaxQueries());
+
+            queries = applyOverrides(config, queries);
+            queries = filterQueries(queries);
+
+            // Load jdbc drivers if needed
+            if (config.getAdditionalJdbcDriverPath() != null) {
+                List<URL> urlList = getUrls(config.getAdditionalJdbcDriverPath());
+                URL[] urls = new URL[urlList.size()];
+                urlList.toArray(urls);
+                if (config.getTestJdbcDriverName() != null) {
+                    loadJdbcDriver(urls, config.getTestJdbcDriverName());
+                }
+                if (config.getControlJdbcDriverName() != null) {
+                    loadJdbcDriver(urls, config.getControlJdbcDriverName());
+                }
             }
+
+            // TODO: construct this with Guice
+            Verifier verifier = new Verifier(System.out, config, eventClients);
+            verifier.run(queries);
         }
-
-        // TODO: construct this with Guice
-        Verifier verifier = new Verifier(System.out, config, eventClients);
-        verifier.run(queries);
-
-        injector.getInstance(LifeCycleManager.class).stop();
+        finally {
+            injector.getInstance(LifeCycleManager.class).stop();
+        }
     }
 
     private static void loadJdbcDriver(URL[] urls, String jdbcClassName)


### PR DESCRIPTION
Fixes a liveness failure in the verifier, where it might never exit if
an exception is thrown
