### PR TITLE
Update provisio plugin to 0.1.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -740,7 +740,7 @@
             <plugin>
                 <groupId>io.takari.maven.plugins</groupId>
                 <artifactId>provisio-maven-plugin</artifactId>
-                <version>0.1.9</version>
+                <version>0.1.11</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>


### PR DESCRIPTION
This fixes an issue where the executable flags for the launcher were't being preserved
