### PR TITLE
Fix race condition when updating sources

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -457,6 +457,11 @@ public class Driver
 
         private DriverLockResult(int timeout, TimeUnit unit)
         {
+            acquired = tryAcquire(timeout, unit);
+        }
+
+        private boolean tryAcquire(int timeout, TimeUnit unit)
+        {
             boolean acquired = false;
             try {
                 acquired = exclusiveLock.tryLock(timeout, unit);
@@ -464,13 +469,14 @@ public class Driver
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
-            this.acquired = acquired;
 
             if (acquired) {
                 synchronized (Driver.this) {
                     lockHolder = Thread.currentThread();
                 }
             }
+
+            return acquired;
         }
 
         public boolean wasAcquired()
@@ -485,20 +491,30 @@ public class Driver
                 return;
             }
 
-            // before releasing the lock, process any new sources and/or destroy the driver
-            try {
+            boolean done = false;
+            while (!done) {
+                done = true;
+                // before releasing the lock, process any new sources and/or destroy the driver
                 try {
-                    processNewSources();
+                    try {
+                        processNewSources();
+                    }
+                    finally {
+                        destroyIfNecessary();
+                    }
                 }
                 finally {
-                    destroyIfNecessary();
+                    synchronized (Driver.this) {
+                        lockHolder = null;
+                    }
+                    exclusiveLock.unlock();
+
+                    // if new sources were added after we processed them, go around and try again
+                    // in case someone else failed to acquire the lock and as a result won't update them
+                    if (!newSources.isEmpty() && state.get() == State.ALIVE && tryAcquire(0, TimeUnit.MILLISECONDS)) {
+                        done = false;
+                    }
                 }
-            }
-            finally {
-                synchronized (Driver.this) {
-                    lockHolder = null;
-                }
-                exclusiveLock.unlock();
             }
         }
     }


### PR DESCRIPTION
The current implementation has a potential race condition under the following scenario:

```
Task updater              Driver

                          acquire lock
                          process new sources
                          ...
                          process new sources in lock release code
add new source
fail to acquire lock
 (sources not processed)
                          release lock
```

This results in new sources not being processed and the query getting stuck
if the task updater never call update sources again and the driver becomes
blocked because data from all current exchanges are consumed
