### PR TITLE
Decrease maven & tests heap size.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 env:
   global:
-    - MAVEN_OPTS="-XX:MaxPermSize=512m -Xmx2g"
+    - MAVEN_OPTS="-Xmx1g -XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops"

--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration combine.children="append">
-                        <argLine>-Duser.timezone=${test.timezone} -Xmx2g -Xms2g -XX:MaxPermSize=512m</argLine>
+                        <argLine>-Duser.timezone=${test.timezone} -Xmx1800m -Xms1800m -XX:PermSize=200m -XX:MaxPermSize=400m -XX:NewRatio=1 -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops -XX:+UseParNewGC -XX:SurvivorRatio=5 -XX:MaxTenuringThreshold=25 -XX:CMSInitiatingOccupancyFraction=85</argLine>
                         <parallel>methods</parallel>
                         <threadCount>8</threadCount>
                         <systemPropertyVariables>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -323,6 +323,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <excludedGroups>hive</excludedGroups>
+                    <threadCount>2</threadCount>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
I spent quite a bit of time trying to profile the tests in order to cut GC pauses & reduce the heap slightly.  It may or may not make the build succeed more.

It seems odd to set such a large heap for maven.  The total available memory is 3GB, so the heap + perm shouldn't exceed that limit.  I've set `Xmx` for maven to 1g, which (I hope) will stop the random OOMs.  This actually over-subscribes the memory somewhat (if you include the tests), but we should be able to get away with it.
