### PR TITLE
Replace all toUpperCase and toLowerCase using default locale

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -67,6 +67,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Maps.fromProperties;
 import static java.util.Collections.nCopies;
+import static java.util.Locale.ENGLISH;
 
 public class BaseJdbcClient
         implements JdbcClient
@@ -117,7 +118,7 @@ public class BaseJdbcClient
                 ResultSet resultSet = connection.getMetaData().getSchemas()) {
             ImmutableSet.Builder<String> schemaNames = ImmutableSet.builder();
             while (resultSet.next()) {
-                String schemaName = resultSet.getString("TABLE_SCHEM").toLowerCase();
+                String schemaName = resultSet.getString("TABLE_SCHEM").toLowerCase(ENGLISH);
                 // skip internal schemas
                 if (!schemaName.equals("information_schema")) {
                     schemaNames.add(schemaName);
@@ -136,7 +137,7 @@ public class BaseJdbcClient
         try (Connection connection = driver.connect(connectionUrl, connectionProperties)) {
             DatabaseMetaData metadata = connection.getMetaData();
             if (metadata.storesUpperCaseIdentifiers() && (schema != null)) {
-                schema = schema.toUpperCase();
+                schema = schema.toUpperCase(ENGLISH);
             }
             try (ResultSet resultSet = getTables(connection, schema, null)) {
                 ImmutableList.Builder<SchemaTableName> list = ImmutableList.builder();
@@ -160,8 +161,8 @@ public class BaseJdbcClient
             String jdbcSchemaName = schemaTableName.getSchemaName();
             String jdbcTableName = schemaTableName.getTableName();
             if (metadata.storesUpperCaseIdentifiers()) {
-                jdbcSchemaName = jdbcSchemaName.toUpperCase();
-                jdbcTableName = jdbcTableName.toUpperCase();
+                jdbcSchemaName = jdbcSchemaName.toUpperCase(ENGLISH);
+                jdbcTableName = jdbcTableName.toUpperCase(ENGLISH);
             }
             try (ResultSet resultSet = getTables(connection, jdbcSchemaName, jdbcTableName)) {
                 List<JdbcTableHandle> tableHandles = new ArrayList<>();
@@ -284,8 +285,8 @@ public class BaseJdbcClient
         try (Connection connection = driver.connect(connectionUrl, connectionProperties)) {
             boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
             if (uppercase) {
-                schema = schema.toUpperCase();
-                table = table.toUpperCase();
+                schema = schema.toUpperCase(ENGLISH);
+                table = table.toUpperCase(ENGLISH);
             }
             String catalog = connection.getCatalog();
 
@@ -300,7 +301,7 @@ public class BaseJdbcClient
             for (ColumnMetadata column : tableMetadata.getColumns()) {
                 String columnName = column.getName();
                 if (uppercase) {
-                    columnName = columnName.toUpperCase();
+                    columnName = columnName.toUpperCase(ENGLISH);
                 }
                 columnNames.add(columnName);
                 columnTypes.add(column.getType());
@@ -377,8 +378,8 @@ public class BaseJdbcClient
             throws SQLException
     {
         return new SchemaTableName(
-                resultSet.getString("TABLE_SCHEM").toLowerCase(),
-                resultSet.getString("TABLE_NAME").toLowerCase());
+                resultSet.getString("TABLE_SCHEM").toLowerCase(ENGLISH),
+                resultSet.getString("TABLE_NAME").toLowerCase(ENGLISH));
     }
 
     protected void execute(Connection connection, String query)

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/MetadataUtil.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/MetadataUtil.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 
 final class MetadataUtil
@@ -61,7 +62,7 @@ final class MetadataUtil
         @Override
         protected Type _deserialize(String value, DeserializationContext context)
         {
-            Type type = types.get(value.toLowerCase());
+            Type type = types.get(value.toLowerCase(ENGLISH));
             checkArgument(type != null, "Unknown type %s", value);
             return type;
         }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcClient.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcClient.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.plugin.jdbc.TestingDatabase.CONNECTOR_ID;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -63,7 +64,7 @@ public class TestJdbcClient
         SchemaTableName schemaTableName = new SchemaTableName("example", "numbers");
         JdbcTableHandle table = jdbcClient.getTableHandle(schemaTableName);
         assertNotNull(table, "table is null");
-        assertEquals(table.getCatalogName(), catalogName.toUpperCase());
+        assertEquals(table.getCatalogName(), catalogName.toUpperCase(ENGLISH));
         assertEquals(table.getSchemaName(), "EXAMPLE");
         assertEquals(table.getTableName(), "NUMBERS");
         assertEquals(table.getSchemaTableName(), schemaTableName);

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CachingCassandraSchemaProvider.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CachingCassandraSchemaProvider.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.cassandra.RetryDriver.retry;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -238,13 +239,13 @@ public class CachingCassandraSchemaProvider
 
     public String getCaseSensitiveSchemaName(String caseInsensitiveName)
     {
-        String caseSensitiveSchemaName = getCacheValue(schemaNamesCache, "", RuntimeException.class).get(caseInsensitiveName.toLowerCase());
+        String caseSensitiveSchemaName = getCacheValue(schemaNamesCache, "", RuntimeException.class).get(caseInsensitiveName.toLowerCase(ENGLISH));
         return caseSensitiveSchemaName == null ? caseInsensitiveName : caseSensitiveSchemaName;
     }
 
     public String getCaseSensitiveTableName(SchemaTableName schemaTableName)
     {
-        String  caseSensitiveTableName = getCacheValue(tableNamesCache, schemaTableName.getSchemaName(), SchemaNotFoundException.class).get(schemaTableName.getTableName().toLowerCase());
+        String  caseSensitiveTableName = getCacheValue(tableNamesCache, schemaTableName.getSchemaName(), SchemaNotFoundException.class).get(schemaTableName.getTableName().toLowerCase(ENGLISH));
         return caseSensitiveTableName == null ? schemaTableName.getTableName() : caseSensitiveTableName;
     }
 
@@ -340,7 +341,7 @@ public class CachingCassandraSchemaProvider
             @Override
             public String apply(String str)
             {
-                return str.toLowerCase();
+                return str.toLowerCase(ENGLISH);
             }
         };
     }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
@@ -50,6 +50,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Iterables.transform;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Locale.ENGLISH;
 
 public class CassandraMetadata
         implements ConnectorMetadata
@@ -123,7 +124,7 @@ public class CassandraMetadata
         for (String schemaName : listSchemas(session, schemaNameOrNull)) {
             try {
                 for (String tableName : schemaProvider.getAllTables(schemaName)) {
-                    tableNames.add(new SchemaTableName(schemaName, tableName.toLowerCase()));
+                    tableNames.add(new SchemaTableName(schemaName, tableName.toLowerCase(ENGLISH)));
                 }
             }
             catch (SchemaNotFoundException e) {
@@ -159,7 +160,7 @@ public class CassandraMetadata
         ImmutableMap.Builder<String, ConnectorColumnHandle> columnHandles = ImmutableMap.builder();
         for (CassandraColumnHandle columnHandle : table.getColumns()) {
             if (includeSampleWeight || !columnHandle.getName().equals(SAMPLE_WEIGHT_COLUMN_NAME)) {
-                columnHandles.put(CassandraCqlUtils.cqlNameToSqlName(columnHandle.getName()).toLowerCase(), columnHandle);
+                columnHandles.put(CassandraCqlUtils.cqlNameToSqlName(columnHandle.getName()).toLowerCase(ENGLISH), columnHandle);
             }
         }
         return columnHandles.build();
@@ -263,7 +264,7 @@ public class CassandraMetadata
         List<Type> types = columnTypes.build();
         StringBuilder queryBuilder = new StringBuilder(String.format("CREATE TABLE \"%s\".\"%s\"(id uuid primary key", schemaName, tableName));
         if (tableMetadata.isSampled()) {
-            queryBuilder.append(", ").append(SAMPLE_WEIGHT_COLUMN_NAME).append(" ").append(BIGINT.name().toLowerCase());
+            queryBuilder.append(", ").append(SAMPLE_WEIGHT_COLUMN_NAME).append(" ").append(BIGINT.name().toLowerCase(ENGLISH));
             columnExtra.add(new ExtraColumnMetadata(SAMPLE_WEIGHT_COLUMN_NAME, true));
         }
         for (int i = 0; i < columns.size(); i++) {
@@ -272,7 +273,7 @@ public class CassandraMetadata
             queryBuilder.append(", ")
                     .append(name)
                     .append(" ")
-                    .append(toCassandraType(type).name().toLowerCase());
+                    .append(toCassandraType(type).name().toLowerCase(ENGLISH));
         }
         queryBuilder.append(") ");
 

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/util/CassandraCqlUtils.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/util/CassandraCqlUtils.java
@@ -28,6 +28,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static java.util.Locale.ENGLISH;
+
 public final class CassandraCqlUtils
 {
     private CassandraCqlUtils()
@@ -70,11 +72,11 @@ public final class CassandraCqlUtils
 
     private static String validIdentifier(String identifier)
     {
-        if (!identifier.equals(identifier.toLowerCase())) {
+        if (!identifier.equals(identifier.toLowerCase(ENGLISH))) {
             return quoteIdentifier(identifier);
         }
 
-        if (keywords.contains(identifier.toUpperCase())) {
+        if (keywords.contains(identifier.toUpperCase(ENGLISH))) {
             return quoteIdentifier(identifier);
         }
         return identifier;

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
@@ -72,6 +72,7 @@ import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.testing.Assertions.assertInstanceOf;
+import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -146,7 +147,7 @@ public class TestCassandraConnector
             throws Exception
     {
         List<String> databases = metadata.listSchemaNames(SESSION);
-        assertTrue(databases.contains(database.toLowerCase()));
+        assertTrue(databases.contains(database.toLowerCase(ENGLISH)));
     }
 
     @Test

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -22,6 +22,8 @@ import java.net.URISyntaxException;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import static java.util.Locale.ENGLISH;
+
 public class ClientOptions
 {
     @Option(name = "--server", title = "server", description = "Presto server location (default: localhost:8080)")
@@ -68,7 +70,7 @@ public class ClientOptions
 
     public static URI parseServer(String server)
     {
-        server = server.toLowerCase();
+        server = server.toLowerCase(ENGLISH);
         if (server.startsWith("http://") || server.startsWith("https://")) {
             return URI.create(server);
         }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -49,6 +49,7 @@ import static com.facebook.presto.sql.parser.StatementSplitter.squeezeStatement;
 import static com.google.common.io.ByteStreams.nullOutputStream;
 import static io.airlift.log.Logging.Level;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static jline.internal.Configuration.getUserHome;
 
 @Command(name = "presto", description = "Presto interactive console")
@@ -142,7 +143,7 @@ public class Console
                     if (command.endsWith(";")) {
                         command = command.substring(0, command.length() - 1).trim();
                     }
-                    switch (command.toLowerCase()) {
+                    switch (command.toLowerCase(ENGLISH)) {
                         case "exit":
                         case "quit":
                             return;

--- a/presto-example-http/src/test/java/com/facebook/presto/example/MetadataUtil.java
+++ b/presto-example-http/src/test/java/com/facebook/presto/example/MetadataUtil.java
@@ -30,6 +30,7 @@ import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static io.airlift.json.JsonCodec.listJsonCodec;
+import static java.util.Locale.ENGLISH;
 
 public final class MetadataUtil
 {
@@ -67,7 +68,7 @@ public final class MetadataUtil
         @Override
         protected Type _deserialize(String value, DeserializationContext context)
         {
-            Type type = types.get(value.toLowerCase());
+            Type type = types.get(value.toLowerCase(ENGLISH));
             if (type == null) {
                 throw new IllegalArgumentException(String.valueOf("Unknown type " + value));
             }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -83,6 +83,7 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -1460,7 +1461,7 @@ public abstract class AbstractTestHiveClient
 
     private static String randomName()
     {
-        return UUID.randomUUID().toString().toLowerCase().replace("-", "");
+        return UUID.randomUUID().toString().toLowerCase(ENGLISH).replace("-", "");
     }
 
     private static Function<ColumnMetadata, String> columnNameGetter()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -53,6 +53,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -76,7 +77,7 @@ public abstract class AbstractTestHiveClientS3
         database = databaseName;
         tableS3 = new SchemaTableName(database, "presto_test_s3");
 
-        String random = UUID.randomUUID().toString().toLowerCase().replace("-", "");
+        String random = UUID.randomUUID().toString().toLowerCase(ENGLISH).replace("-", "");
         temporaryCreateTable = new SchemaTableName(database, "tmp_presto_test_create_s3_" + random);
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
@@ -65,6 +65,7 @@ import static com.google.common.base.Throwables.propagateIfInstanceOf;
 import static com.google.common.collect.Iterators.concat;
 import static com.google.common.collect.Iterators.transform;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 
 public class PrestoResultSet
         implements ResultSet
@@ -1690,7 +1691,7 @@ public class PrestoResultSet
         if (label == null) {
             throw new SQLException("Column label is null");
         }
-        Integer index = fieldMap.get(label.toLowerCase());
+        Integer index = fieldMap.get(label.toLowerCase(ENGLISH));
         if (index == null) {
             throw new SQLException("Invalid column label: " + label);
         }
@@ -1768,7 +1769,7 @@ public class PrestoResultSet
     {
         Map<String, Integer> map = new HashMap<>();
         for (int i = 0; i < columns.size(); i++) {
-            String name = columns.get(i).getName().toLowerCase();
+            String name = columns.get(i).getName().toLowerCase(ENGLISH);
             if (!map.containsKey(name)) {
                 map.put(name, i + 1);
             }
@@ -1786,7 +1787,7 @@ public class PrestoResultSet
                     .setTableName("") // TODO
                     .setColumnLabel(column.getName())
                     .setColumnName(column.getName()) // TODO
-                    .setColumnTypeName(column.getType().toUpperCase())
+                    .setColumnTypeName(column.getType().toUpperCase(ENGLISH))
                     .setNullable(ResultSetMetaData.columnNullableUnknown)
                     .setCurrency(false);
             setTypeInfo(builder, column.getType());

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/KafkaQueryRunner.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/KafkaQueryRunner.java
@@ -96,13 +96,13 @@ public final class KafkaQueryRunner
     {
         long start = System.nanoTime();
         log.info("Running import for %s", table.getTableName());
-        TestUtils.loadTpchTopic(embeddedKafka, prestoClient, kafkaTopicName(table), new QualifiedTableName("tpch", TINY_SCHEMA_NAME, table.getTableName().toLowerCase()));
+        TestUtils.loadTpchTopic(embeddedKafka, prestoClient, kafkaTopicName(table), new QualifiedTableName("tpch", TINY_SCHEMA_NAME, table.getTableName().toLowerCase(ENGLISH)));
         log.info("Imported %s in %s", 0, table.getTableName(), nanosSince(start).convertToMostSuccinctTimeUnit());
     }
 
     private static String kafkaTopicName(TpchTable<?> table)
     {
-        return TPCH_SCHEMA + "." + table.getTableName().toLowerCase();
+        return TPCH_SCHEMA + "." + table.getTableName().toLowerCase(ENGLISH);
     }
 
     private static Map<SchemaTableName, KafkaTopicDescription> createTpchTopicDescriptions(Metadata metadata, Iterable<TpchTable<?>> tables)

--- a/presto-main/src/main/java/com/facebook/presto/byteCode/Access.java
+++ b/presto-main/src/main/java/com/facebook/presto/byteCode/Access.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.EnumSet;
 
+import static java.util.Locale.ENGLISH;
 import static org.objectweb.asm.Opcodes.ACC_ABSTRACT;
 import static org.objectweb.asm.Opcodes.ACC_ANNOTATION;
 import static org.objectweb.asm.Opcodes.ACC_BRIDGE;
@@ -72,7 +73,7 @@ public enum Access
     @Override
     public String toString()
     {
-        return super.name().toLowerCase();
+        return super.name().toLowerCase(ENGLISH);
     }
 
     public static EnumSet<Access> a(Access... access)

--- a/presto-main/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
@@ -47,6 +47,7 @@ import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.util.Types.checkType;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Locale.ENGLISH;
 import static javax.management.ObjectName.WILDCARD;
 
 public class JmxMetadata
@@ -114,7 +115,7 @@ public class JmxMetadata
         Builder<SchemaTableName> tableNames = ImmutableList.builder();
         for (ObjectName objectName : mbeanServer.queryNames(WILDCARD, null)) {
             // todo remove lower case when presto supports mixed case names
-            tableNames.add(new SchemaTableName(SCHEMA_NAME, objectName.toString().toLowerCase()));
+            tableNames.add(new SchemaTableName(SCHEMA_NAME, objectName.toString().toLowerCase(ENGLISH)));
         }
         return tableNames.build();
     }
@@ -134,7 +135,7 @@ public class JmxMetadata
             @Override
             public String apply(JmxColumnHandle input)
             {
-                return input.getColumnName().toLowerCase();
+                return input.getColumnName().toLowerCase(ENGLISH);
             }
         }));
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -41,6 +41,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.in;
 import static com.google.common.base.Predicates.not;
 import static java.util.Arrays.asList;
+import static java.util.Locale.ENGLISH;
 
 @ThreadSafe
 public final class DiscoveryNodeManager
@@ -113,7 +114,7 @@ public final class DiscoveryNodeManager
                     // record available active nodes organized by data source
                     String dataSources = service.getProperties().get("datasources");
                     if (dataSources != null) {
-                        dataSources = dataSources.toLowerCase();
+                        dataSources = dataSources.toLowerCase(ENGLISH);
                         for (String dataSource : DATASOURCES_SPLITTER.split(dataSources)) {
                             byDataSourceBuilder.put(dataSource, node);
                         }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
@@ -57,6 +57,7 @@ import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.util.Locale.ENGLISH;
 
 public class FunctionListBuilder
 {
@@ -113,7 +114,7 @@ public class FunctionListBuilder
     public FunctionListBuilder aggregate(InternalAggregationFunction function)
     {
         String name = function.name();
-        name = name.toLowerCase();
+        name = name.toLowerCase(ENGLISH);
 
         String description = getDescription(function.getClass());
         Signature signature = new Signature(name, function.getFinalType().getName(), Lists.transform(ImmutableList.copyOf(function.getParameterTypes()), nameGetter()));
@@ -179,7 +180,7 @@ public class FunctionListBuilder
         SqlType returnTypeAnnotation = method.getAnnotation(SqlType.class);
         checkArgument(returnTypeAnnotation != null, "Method %s return type does not have a @SqlType annotation", method);
         Type returnType = type(typeManager, returnTypeAnnotation);
-        Signature signature = new Signature(name.toLowerCase(), returnType.getName(), Lists.transform(parameterTypes(typeManager, method), nameGetter()));
+        Signature signature = new Signature(name.toLowerCase(ENGLISH), returnType.getName(), Lists.transform(parameterTypes(typeManager, method), nameGetter()));
 
         verifyMethodSignature(method, signature.getReturnType(), signature.getArgumentTypes(), typeManager);
 
@@ -187,7 +188,7 @@ public class FunctionListBuilder
 
         scalar(signature, methodHandle, scalarFunction.deterministic(), getDescription(method), scalarFunction.hidden(), method.isAnnotationPresent(Nullable.class), nullableArguments);
         for (String alias : scalarFunction.alias()) {
-            scalar(signature.withAlias(alias.toLowerCase()), methodHandle, scalarFunction.deterministic(), getDescription(method), scalarFunction.hidden(), method.isAnnotationPresent(Nullable.class), nullableArguments);
+            scalar(signature.withAlias(alias.toLowerCase(ENGLISH)), methodHandle, scalarFunction.deterministic(), getDescription(method), scalarFunction.hidden(), method.isAnnotationPresent(Nullable.class), nullableArguments);
         }
         return true;
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUtil.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Locale.ENGLISH;
 
 public final class MetadataUtil
 {
@@ -91,7 +92,7 @@ public final class MetadataUtil
     public static String checkLowerCase(String value, String name)
     {
         checkNotNull(value, "%s is null", name);
-        checkArgument(value.equals(value.toLowerCase()), "%s is not lowercase", name);
+        checkArgument(value.equals(value.toLowerCase(ENGLISH)), "%s is not lowercase", name);
         return value;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Locale.ENGLISH;
 
 public final class AggregationUtils
 {
@@ -79,7 +80,7 @@ public final class AggregationUtils
         for (Type inputType : inputTypes) {
             sb.append(CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_CAMEL, inputType.getName()));
         }
-        sb.append(CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, baseName.toLowerCase()));
+        sb.append(CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, baseName.toLowerCase(ENGLISH)));
 
         return sb.toString();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -45,6 +45,7 @@ import static com.facebook.presto.type.DateTimeOperators.modulo24Hour;
 import static com.facebook.presto.util.DateTimeZoneIndex.extractZoneOffsetMinutes;
 import static com.facebook.presto.util.DateTimeZoneIndex.getChronology;
 import static com.facebook.presto.util.DateTimeZoneIndex.unpackChronology;
+import static java.util.Locale.ENGLISH;
 
 public final class DateTimeFunctions
 {
@@ -336,7 +337,7 @@ public final class DateTimeFunctions
 
     private static DateTimeField getDateField(ISOChronology chronology, Slice unit)
     {
-        String unitString = unit.toString(Charsets.UTF_8).toLowerCase();
+        String unitString = unit.toString(Charsets.UTF_8).toLowerCase(ENGLISH);
         switch (unitString) {
             case "day":
                 return chronology.dayOfMonth();
@@ -355,7 +356,7 @@ public final class DateTimeFunctions
 
     private static DateTimeField getTimeField(ISOChronology chronology, Slice unit)
     {
-        String unitString = unit.toString(Charsets.UTF_8).toLowerCase();
+        String unitString = unit.toString(Charsets.UTF_8).toLowerCase(ENGLISH);
         switch (unitString) {
             case "second":
                 return chronology.secondOfMinute();
@@ -370,7 +371,7 @@ public final class DateTimeFunctions
 
     private static DateTimeField getTimestampField(ISOChronology chronology, Slice unit)
     {
-        String unitString = unit.toString(Charsets.UTF_8).toLowerCase();
+        String unitString = unit.toString(Charsets.UTF_8).toLowerCase(ENGLISH);
         switch (unitString) {
             case "second":
                 return chronology.secondOfMinute();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolAllocator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolAllocator.java
@@ -23,6 +23,8 @@ import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Locale.ENGLISH;
+
 public class SymbolAllocator
 {
     private final Map<Symbol, Type> symbols = new HashMap<>();
@@ -37,7 +39,7 @@ public class SymbolAllocator
         Preconditions.checkNotNull(nameHint, "name is null");
 
         // TODO: workaround for the fact that QualifiedName lowercases parts
-        nameHint = nameHint.toLowerCase();
+        nameHint = nameHint.toLowerCase(ENGLISH);
 
         if (nameHint.contains("_")) {
             nameHint = nameHint.substring(0, nameHint.indexOf("_"));

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -53,6 +53,7 @@ import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Locale.ENGLISH;
 
 @ThreadSafe
 public final class TypeRegistry
@@ -72,7 +73,7 @@ public final class TypeRegistry
         checkNotNull(types, "types is null");
 
         // Manually register UNKNOWN type without a verifyTypeClass call since it is a special type that can not be used by functions
-        this.types.put(UNKNOWN.getName().toLowerCase(), UNKNOWN);
+        this.types.put(UNKNOWN.getName().toLowerCase(ENGLISH), UNKNOWN);
 
         // always add the built-in types; Presto will not function without these
         addType(BOOLEAN);
@@ -103,7 +104,7 @@ public final class TypeRegistry
     @Override
     public Type getType(String typeName)
     {
-        String key = typeName.toLowerCase();
+        String key = typeName.toLowerCase(ENGLISH);
         Type type = types.get(key);
         if (type == null) {
             instantiateParametricType(key);
@@ -119,11 +120,11 @@ public final class TypeRegistry
             @Override
             public String apply(String input)
             {
-                return input.toLowerCase();
+                return input.toLowerCase(ENGLISH);
             }
         }).toList();
 
-        return getType(parametricTypeName.toLowerCase() + "<" + Joiner.on(",").join(lowerCaseTypeNames) + ">");
+        return getType(parametricTypeName.toLowerCase(ENGLISH) + "<" + Joiner.on(",").join(lowerCaseTypeNames) + ">");
     }
 
     private synchronized void instantiateParametricType(String typeName)
@@ -155,7 +156,7 @@ public final class TypeRegistry
     public void addType(Type type)
     {
         verifyTypeClass(type);
-        Type existingType = types.putIfAbsent(type.getName().toLowerCase(), type);
+        Type existingType = types.putIfAbsent(type.getName().toLowerCase(ENGLISH), type);
         checkState(existingType == null || existingType.equals(type), "Type %s is already registered", type.getName());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/util/MoreFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/MoreFunctions.java
@@ -19,6 +19,8 @@ import javax.annotation.Nullable;
 
 import java.util.Map;
 
+import static java.util.Locale.ENGLISH;
+
 public final class MoreFunctions
 {
     private MoreFunctions() {}
@@ -30,7 +32,7 @@ public final class MoreFunctions
             @Override
             public String apply(String s)
             {
-                return s.toLowerCase();
+                return s.toLowerCase(ENGLISH);
             }
         };
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -58,6 +58,7 @@ import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionT
 import static com.facebook.presto.sql.planner.ExpressionInterpreter.expressionInterpreter;
 import static com.facebook.presto.sql.planner.ExpressionInterpreter.expressionOptimizer;
 import static com.google.common.base.Charsets.UTF_8;
+import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 
 public class TestExpressionInterpreter
@@ -847,7 +848,7 @@ public class TestExpressionInterpreter
             @Override
             public Object getValue(Symbol symbol)
             {
-                switch (symbol.getName().toLowerCase()) {
+                switch (symbol.getName().toLowerCase(ENGLISH)) {
                     case "bound_long":
                         return 1234L;
                     case "bound_string":

--- a/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
@@ -28,6 +28,7 @@ import static com.facebook.presto.spi.type.TimeZoneKey.isUtcZoneId;
 import static com.facebook.presto.util.DateTimeZoneIndex.getDateTimeZone;
 import static com.facebook.presto.util.DateTimeZoneIndex.packDateTimeWithZone;
 import static com.facebook.presto.util.DateTimeZoneIndex.unpackDateTimeZone;
+import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 
 public class TestTimeZoneUtils
@@ -41,7 +42,7 @@ public class TestTimeZoneUtils
         TreeSet<String> jdkZones = new TreeSet<>(Arrays.asList(TimeZone.getAvailableIDs()));
 
         for (String zoneId : new TreeSet<>(Sets.intersection(jodaZones, jdkZones))) {
-            if (zoneId.toLowerCase().startsWith("etc/") || zoneId.toLowerCase().startsWith("gmt")) {
+            if (zoneId.toLowerCase(ENGLISH).startsWith("etc/") || zoneId.toLowerCase(ENGLISH).startsWith("gmt")) {
                 continue;
             }
             DateTimeZone dateTimeZone = DateTimeZone.forID(zoneId);

--- a/presto-ml/src/main/java/com/facebook/presto/ml/LibSvmUtils.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/LibSvmUtils.java
@@ -21,6 +21,7 @@ import libsvm.svm_parameter;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 
 public final class LibSvmUtils
 {
@@ -84,7 +85,7 @@ public final class LibSvmUtils
 
     private static int parseKernelType(String value)
     {
-        switch (value.toLowerCase()) {
+        switch (value.toLowerCase(ENGLISH)) {
             case "linear":
                 return svm_parameter.LINEAR;
             case "poly":

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -29,6 +29,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Set;
 
+import static java.util.Locale.ENGLISH;
+
 public class MySqlClient
         extends BaseJdbcClient
 {
@@ -48,7 +50,7 @@ public class MySqlClient
                 ResultSet resultSet = connection.getMetaData().getCatalogs()) {
             ImmutableSet.Builder<String> schemaNames = ImmutableSet.builder();
             while (resultSet.next()) {
-                String schemaName = resultSet.getString("TABLE_CAT").toLowerCase();
+                String schemaName = resultSet.getString("TABLE_CAT").toLowerCase(ENGLISH);
                 // skip internal schemas
                 if (!schemaName.equals("information_schema") && !schemaName.equals("mysql")) {
                     schemaNames.add(schemaName);
@@ -75,8 +77,8 @@ public class MySqlClient
     {
         // MySQL uses catalogs instead of schemas
         return new SchemaTableName(
-                resultSet.getString("TABLE_CAT").toLowerCase(),
-                resultSet.getString("TABLE_NAME").toLowerCase());
+                resultSet.getString("TABLE_CAT").toLowerCase(ENGLISH),
+                resultSet.getString("TABLE_NAME").toLowerCase(ENGLISH));
 
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/BooleanLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/BooleanLiteral.java
@@ -16,6 +16,8 @@ package com.facebook.presto.sql.tree;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import static java.util.Locale.ENGLISH;
+
 public class BooleanLiteral
         extends Literal
 {
@@ -27,9 +29,9 @@ public class BooleanLiteral
     public BooleanLiteral(String value)
     {
         Preconditions.checkNotNull(value, "value is null");
-        Preconditions.checkArgument(value.toLowerCase().equals("true") || value.toLowerCase().equals("false"));
+        Preconditions.checkArgument(value.toLowerCase(ENGLISH).equals("true") || value.toLowerCase(ENGLISH).equals("false"));
 
-        this.value = value.toLowerCase().equals("true");
+        this.value = value.toLowerCase(ENGLISH).equals("true");
     }
 
     public boolean getValue()

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cast.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cast.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.tree;
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Locale.ENGLISH;
 
 public final class Cast
         extends Expression
@@ -35,7 +36,7 @@ public final class Cast
         checkNotNull(type, "type is null");
 
         this.expression = expression;
-        this.type = type.toUpperCase();
+        this.type = type.toUpperCase(ENGLISH);
         this.safe = safe;
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QualifiedName.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QualifiedName.java
@@ -27,6 +27,8 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 
+import static java.util.Locale.ENGLISH;
+
 public class QualifiedName
 {
     private final List<String> parts;
@@ -189,7 +191,7 @@ public class QualifiedName
             @Override
             public String apply(String s)
             {
-                return s.toLowerCase();
+                return s.toLowerCase(ENGLISH);
             }
         };
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/DatabaseLocalStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/DatabaseLocalStorageManager.java
@@ -61,6 +61,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static java.lang.String.format;
 import static java.nio.file.Files.createDirectories;
+import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 
 public class DatabaseLocalStorageManager
@@ -286,7 +287,7 @@ public class DatabaseLocalStorageManager
     @VisibleForTesting
     static File getShardPath(File baseDir, UUID shardUuid)
     {
-        String uuid = shardUuid.toString().toLowerCase();
+        String uuid = shardUuid.toString().toLowerCase(ENGLISH);
         return baseDir.toPath()
                 .resolve(uuid.substring(0, 2))
                 .resolve(uuid.substring(2, 4))

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ColumnMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ColumnMetadata.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.type.Type;
 
 import java.util.Objects;
 
+import static java.util.Locale.ENGLISH;
+
 public class ColumnMetadata
 {
     private final String name;
@@ -43,7 +45,7 @@ public class ColumnMetadata
             throw new IllegalArgumentException("ordinalPosition is negative");
         }
 
-        this.name = name.toLowerCase();
+        this.name = name.toLowerCase(ENGLISH);
         this.type = type;
         this.ordinalPosition = ordinalPosition;
         this.partitionKey = partitionKey;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeZoneKey.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeZoneKey.java
@@ -31,6 +31,7 @@ import java.util.TreeMap;
 import static java.lang.Character.isDigit;
 import static java.lang.Math.abs;
 import static java.lang.Math.max;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public final class TimeZoneKey
@@ -68,7 +69,7 @@ public final class TimeZoneKey
             }
 
             Map<String, TimeZoneKey> zoneIdToKey = new TreeMap<>();
-            zoneIdToKey.put(UTC_KEY.getId().toLowerCase(), UTC_KEY);
+            zoneIdToKey.put(UTC_KEY.getId().toLowerCase(ENGLISH), UTC_KEY);
 
             short maxZoneKey = 0;
             for (Entry<Object, Object> entry : data.entrySet()) {
@@ -76,7 +77,7 @@ public final class TimeZoneKey
                 String zoneId = ((String) entry.getValue()).trim();
 
                 maxZoneKey = (short) max(maxZoneKey, zoneKey);
-                zoneIdToKey.put(zoneId.toLowerCase(), new TimeZoneKey(zoneId, zoneKey));
+                zoneIdToKey.put(zoneId.toLowerCase(ENGLISH), new TimeZoneKey(zoneId, zoneKey));
             }
 
             MAX_TIME_ZONE_KEY = maxZoneKey;
@@ -119,7 +120,7 @@ public final class TimeZoneKey
         requireNonNull(zoneId, "Zone id is null");
         checkArgument(!zoneId.isEmpty(), "Zone id is an empty string");
 
-        TimeZoneKey zoneKey = ZONE_ID_TO_KEY.get(zoneId.toLowerCase());
+        TimeZoneKey zoneKey = ZONE_ID_TO_KEY.get(zoneId.toLowerCase(ENGLISH));
         if (zoneKey == null) {
             zoneKey = ZONE_ID_TO_KEY.get(normalizeZoneId(zoneId));
         }
@@ -199,7 +200,7 @@ public final class TimeZoneKey
 
     private static String normalizeZoneId(String originalZoneId)
     {
-        String zoneId = originalZoneId.toLowerCase();
+        String zoneId = originalZoneId.toLowerCase(ENGLISH);
 
         if (zoneId.startsWith("etc/")) {
             zoneId = zoneId.substring(4);

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTimeZoneKey.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTimeZoneKey.java
@@ -24,6 +24,7 @@ import java.util.SortedSet;
 
 import static com.facebook.presto.spi.type.TimeZoneKey.MAX_TIME_ZONE_KEY;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
@@ -133,8 +134,8 @@ public class TestTimeZoneKey
         for (TimeZoneKey timeZoneKey : TimeZoneKey.getTimeZoneKeys()) {
             assertSame(TimeZoneKey.getTimeZoneKey(timeZoneKey.getKey()), timeZoneKey);
             assertSame(TimeZoneKey.getTimeZoneKey(timeZoneKey.getId()), timeZoneKey);
-            assertSame(TimeZoneKey.getTimeZoneKey(timeZoneKey.getId().toUpperCase()), timeZoneKey);
-            assertSame(TimeZoneKey.getTimeZoneKey(timeZoneKey.getId().toLowerCase()), timeZoneKey);
+            assertSame(TimeZoneKey.getTimeZoneKey(timeZoneKey.getId().toUpperCase(ENGLISH)), timeZoneKey);
+            assertSame(TimeZoneKey.getTimeZoneKey(timeZoneKey.getId().toLowerCase(ENGLISH)), timeZoneKey);
         }
     }
 

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -22,6 +22,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
@@ -55,11 +56,11 @@ public class TestTypeSignature
             @Override
             public String apply(String input)
             {
-                return input.toLowerCase();
+                return input.toLowerCase(ENGLISH);
             }
         }).toList();
 
-        String typeName = base.toLowerCase();
+        String typeName = base.toLowerCase(ENGLISH);
         if (!parameters.isEmpty()) {
             typeName += "<" + Joiner.on(",").join(lowerCaseTypeNames) + ">";
         }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -31,6 +31,7 @@ import java.util.List;
 import static com.facebook.presto.util.Types.checkType;
 import static io.airlift.units.Duration.nanosSince;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -137,7 +138,7 @@ public final class QueryAssertions
         log.info("Loading data from %s.%s...", sourceCatalog, sourceSchema);
         long startTime = System.nanoTime();
         for (TpchTable<?> table : tables) {
-            copyTable(queryRunner, sourceCatalog, sourceSchema, table.getTableName().toLowerCase(), session);
+            copyTable(queryRunner, sourceCatalog, sourceSchema, table.getTableName().toLowerCase(ENGLISH), session);
         }
         log.info("Loading from %s.%s complete in %s", sourceCatalog, sourceSchema, nanosSince(startTime).toString(SECONDS));
     }


### PR DESCRIPTION
Replace with explicit Locale.ENGLISH; this fixes quirky bugs in languages (such as Turkish) where lowercase mappings are not as intuitive as in, say, english.
