### PR TITLE
AWS SDK throws an AbortedException on PrestoS3InputStream.close()

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.amazonaws.AbortedException;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
@@ -612,7 +613,12 @@ public class PrestoS3FileSystem
                 throws IOException
         {
             if (in != null) {
-                in.abort();
+                try {
+                    in.abort();
+                }
+                catch (AbortedException e) {
+                    //The SDK throws AbortedException for the interrupted threads.
+                }
                 in = null;
             }
         }


### PR DESCRIPTION
During my tests with the 0.76 release I noticed that the AWS SDK version (1.8.9.1) used in Presto throws an `AbortedException` for interrupted threads when `PrestoS3FileSystem` closes a `PrestoS3InputStream` with the `abort()` call. We weren't seeing these exceptions with the previous AWS SDK version used (1.7.2). This PR is a simple change to catch that exception.

```
2014-09-26T12:47:11.690-0700    ERROR   SplitRunner-4-61    com.facebook.presto.execution.TaskExecutor  Error processing Split 20140926_194710_00003_8hzsd.1.0-0 (start = 1411760830670, wall = 1011 ms, cpu = 0 ms, calls = 1)
com.amazonaws.AbortedException:
    at com.amazonaws.internal.SdkFilterInputStream.abortIfNeeded(SdkFilterInputStream.java:52) ~[na:na]
    at com.amazonaws.internal.SdkFilterInputStream.close(SdkFilterInputStream.java:91) ~[na:na]
    at com.amazonaws.event.ProgressInputStream.close(ProgressInputStream.java:182) ~[na:na]
    at com.amazonaws.internal.SdkFilterInputStream.close(SdkFilterInputStream.java:90) ~[na:na]
    at com.amazonaws.internal.SdkFilterInputStream.close(SdkFilterInputStream.java:90) ~[na:na]
    at com.amazonaws.internal.SdkFilterInputStream.close(SdkFilterInputStream.java:90) ~[na:na]
    at com.amazonaws.event.ProgressInputStream.close(ProgressInputStream.java:182) ~[na:na]
    at com.amazonaws.internal.SdkFilterInputStream.close(SdkFilterInputStream.java:90) ~[na:na]
    at com.amazonaws.internal.SdkFilterInputStream.close(SdkFilterInputStream.java:90) ~[na:na]
    at com.amazonaws.services.s3.model.S3ObjectInputStream.abort(S3ObjectInputStream.java:93) ~[na:na]
    at com.facebook.presto.hive.PrestoS3FileSystem$PrestoS3InputStream.closeStream(PrestoS3FileSystem.java:648) ~[na:na]
    at com.facebook.presto.hive.PrestoS3FileSystem$PrestoS3InputStream.close(PrestoS3FileSystem.java:511) ~[na:na]
    at java.io.BufferedInputStream.close(BufferedInputStream.java:472) ~[na:1.7.0_60]
    at java.io.FilterInputStream.close(FilterInputStream.java:181) ~[na:1.7.0_60]
    at org.apache.hadoop.io.SequenceFile$Reader.close(SequenceFile.java:1999) ~[na:na]
    at org.apache.hadoop.mapred.SequenceFileRecordReader.close(SequenceFileRecordReader.java:131) ~[na:na]
    at com.facebook.presto.hive.GenericHiveRecordCursor.close(GenericHiveRecordCursor.java:478) ~[na:na]
    at com.facebook.presto.operator.RecordProjectOperator.close(RecordProjectOperator.java:89) ~[presto-main-0.76.jar:0.76]
    at com.facebook.presto.operator.RecordProjectOperator.finish(RecordProjectOperator.java:82) ~[presto-main-0.76.jar:0.76]
    at com.facebook.presto.operator.TableScanOperator.finish(TableScanOperator.java:170) ~[presto-main-0.76.jar:0.76]
    at com.facebook.presto.operator.Driver.destroyIfNecessary(Driver.java:362) ~[presto-main-0.76.jar:0.76]
    at com.facebook.presto.operator.Driver.access$400(Driver.java:52) ~[presto-main-0.76.jar:0.76]
    at com.facebook.presto.operator.Driver$DriverLockResult.close(Driver.java:494) ~[presto-main-0.76.jar:0.76]
    at com.facebook.presto.operator.Driver.process(Driver.java:347) ~[presto-main-0.76.jar:0.76]
    at com.facebook.presto.operator.Driver.processFor(Driver.java:271) ~[presto-main-0.76.jar:0.76]
    at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:541) ~[presto-main-0.76.jar:0.76]
    at com.facebook.presto.execution.TaskExecutor$PrioritizedSplitRunner.process(TaskExecutor.java:444) ~[presto-main-0.76.jar:0.76]
    at com.facebook.presto.execution.TaskExecutor$Runner.run(TaskExecutor.java:578) ~[presto-main-0.76.jar:0.76]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_60]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_60]
    at java.lang.Thread.run(Thread.java:745) [na:1.7.0_60]
```
