### PR TITLE
Fix Exception self-suppression

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveRecordCursor.java
@@ -41,7 +41,10 @@ public abstract class HiveRecordCursor
             close();
         }
         catch (RuntimeException e) {
-            throwable.addSuppressed(e);
+            // Self-suppression not permitted
+            if (throwable != e) {
+                throwable.addSuppressed(e);
+            }
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -424,7 +424,10 @@ public class Driver
                 inFlightException = newException;
             }
             else {
-                inFlightException.addSuppressed(newException);
+                // Self-suppression not permitted
+                if (inFlightException != newException) {
+                    inFlightException.addSuppressed(newException);
+                }
             }
         }
         else {


### PR DESCRIPTION
An exception can not add itself to the suppression list.  This can happen
when code throws the same exception instance in close.
