### PR TITLE
Parquet fix

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ParquetHiveRecordCursor.java
@@ -334,10 +334,6 @@ class ParquetHiveRecordCursor
             }
 
             ParquetInputSplit split;
-            if (splitGroup.isEmpty()) {
-                // split is empty
-                return null;
-            }
 
             split = new ParquetInputSplit(path,
                     splitStart,


### PR DESCRIPTION
Allow parquet columns to be empty
Not returning nulls, or:
recordReader.getProgress()
will hit nullpointerexception
