### PR TITLE
Exclude joda-time from aws-java-sdk

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -170,6 +170,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Their POM uses a version range which drags in the wrong version.
