### PR TITLE
Optimize aggregations over partition keys into simple metadata queries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -21,6 +21,7 @@ public class FeaturesConfig
     private boolean experimentalSyntaxEnabled;
     private boolean distributedIndexJoinsEnabled;
     private boolean distributedJoinsEnabled;
+    private boolean optimizeMetadataQueries;
 
     @LegacyConfig("analyzer.experimental-syntax-enabled")
     @Config("experimental-syntax-enabled")
@@ -57,5 +58,17 @@ public class FeaturesConfig
     public boolean isDistributedJoinsEnabled()
     {
         return distributedJoinsEnabled;
+    }
+
+    public boolean isOptimizeMetadataQueries()
+    {
+        return optimizeMetadataQueries;
+    }
+
+    @Config("optimizer.optimize-metadata-queries")
+    public FeaturesConfig setOptimizeMetadataQueries(boolean optimizeMetadataQueries)
+    {
+        this.optimizeMetadataQueries = optimizeMetadataQueries;
+        return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
@@ -66,8 +66,11 @@ public class PlanOptimizersFactory
                 new CountConstantOptimizer(),
                 new WindowFilterPushDown(), // This must run after PredicatePushDown so that it squashes any successive filter nodes
                 new PruneUnreferencedOutputs(), // Make sure to run this at the end to help clean the plan for logging/execution and not remove info that other optimizers might need at an earlier point
-                new PruneRedundantProjections(), // This MUST run after PruneUnreferencedOutputs as it may introduce new redundant projections
-                new MetadataQueryOptimizer(metadata, splitManager));
+                new PruneRedundantProjections()); // This MUST run after PruneUnreferencedOutputs as it may introduce new redundant projections
+
+        if (featuresConfig.isOptimizeMetadataQueries()) {
+            builder.add(new MetadataQueryOptimizer(metadata, splitManager));
+        }
 
         // TODO: consider adding a formal final plan sanitization optimizer that prepares the plan for transmission/execution/logging
         // TODO: figure out how to improve the set flattening optimizer so that it can run at any point

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -31,7 +31,8 @@ public class TestFeaturesConfig
         assertRecordedDefaults(ConfigAssertions.recordDefaults(FeaturesConfig.class)
                 .setExperimentalSyntaxEnabled(false)
                 .setDistributedIndexJoinsEnabled(false)
-                .setDistributedJoinsEnabled(false));
+                .setDistributedJoinsEnabled(false)
+                .setOptimizeMetadataQueries(false));
     }
 
     @Test
@@ -41,17 +42,20 @@ public class TestFeaturesConfig
                 .put("analyzer.experimental-syntax-enabled", "true")
                 .put("distributed-index-joins-enabled", "true")
                 .put("distributed-joins-enabled", "true")
+                .put("optimizer.optimize-metadata-queries", "true")
                 .build();
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("experimental-syntax-enabled", "true")
                 .put("distributed-index-joins-enabled", "true")
                 .put("distributed-joins-enabled", "true")
+                .put("optimizer.optimize-metadata-queries", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
                 .setExperimentalSyntaxEnabled(true)
                 .setDistributedIndexJoinsEnabled(true)
-                .setDistributedJoinsEnabled(true);
+                .setDistributedJoinsEnabled(true)
+                .setOptimizeMetadataQueries(true);
 
         assertFullMapping(properties, expected);
         assertDeprecatedEquivalence(FeaturesConfig.class, properties, propertiesLegacy);


### PR DESCRIPTION
This optimization rewrites aggregations that are insensitive to the
cardinality of their input (i.e., min, max, distinct aggregates) as
partition metadata queries when the input columns are only partition keys

These are a few examples of queries that benefit:

``` sql
SELECT min(key), max(key) FROM t

SELECT DISTINCT key FROM t

SELECT count(DISTINCT key) FROM t

SELECT count(DISTINCT key + 5) FROM t

SELECT count(DISTINCT key) FROM (SELECT key FROM t ORDER BY 1 LIMIT 10);
```
