### PR TITLE
Implement numeric_histogram aggregation function

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -33,6 +33,7 @@ import com.facebook.presto.operator.aggregation.LongMaxAggregation;
 import com.facebook.presto.operator.aggregation.LongMinAggregation;
 import com.facebook.presto.operator.aggregation.LongSumAggregation;
 import com.facebook.presto.operator.aggregation.MergeHyperLogLogAggregation;
+import com.facebook.presto.operator.aggregation.NumericHistogramAggregation;
 import com.facebook.presto.operator.aggregation.VarBinaryMaxAggregation;
 import com.facebook.presto.operator.aggregation.VarBinaryMinAggregation;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
@@ -231,6 +232,7 @@ public class FunctionRegistry
                 .aggregate(ApproximateCountDistinctAggregations.class)
                 .aggregate(MergeHyperLogLogAggregation.class)
                 .aggregate(ApproximateSetAggregation.class)
+                .aggregate(NumericHistogramAggregation.class)
                 .scalar(StringFunctions.class)
                 .scalar(VarbinaryFunctions.class)
                 .scalar(RegexpFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/NumericHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/NumericHistogram.java
@@ -1,0 +1,427 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.primitives.Doubles;
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.Slices;
+import it.unimi.dsi.fastutil.Arrays;
+import it.unimi.dsi.fastutil.Swapper;
+import it.unimi.dsi.fastutil.ints.AbstractIntComparator;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+public class NumericHistogram
+{
+    private static final byte FORMAT_TAG = 0;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(NumericHistogram.class).instanceSize();
+
+    private static final Comparator<Entry> COMPARATOR = new Comparator<Entry>()
+    {
+        @Override
+        public int compare(Entry first, Entry second)
+        {
+            int result = Double.compare(first.getPenalty(), second.getPenalty());
+            if (result == 0) {
+                result = Integer.compare(first.id, second.id);
+            }
+            return result;
+        }
+    };
+
+    private final int maxBuckets;
+    private final double[] values;
+    private final double[] weights;
+
+    private int nextIndex = 0;
+
+    public NumericHistogram(int maxBuckets)
+    {
+        this(maxBuckets, Math.max((int) (maxBuckets * 0.2), 1));
+    }
+
+    public NumericHistogram(int maxBuckets, int buffer)
+    {
+        checkArgument(maxBuckets >= 2, "maxBuckets must be >= 2");
+        checkArgument(buffer >= 1, "buffer must be >= 1");
+
+        this.maxBuckets = maxBuckets;
+        this.values = new double[maxBuckets + buffer];
+        this.weights = new double[maxBuckets + buffer];
+    }
+
+    public NumericHistogram(Slice serialized, int buffer)
+    {
+        checkNotNull(serialized, "serialized is null");
+        checkArgument(buffer >= 1, "buffer must be >= 1");
+
+        SliceInput input = serialized.getInput();
+
+        Preconditions.checkArgument(input.readByte() == FORMAT_TAG, "Unsupported format tag");
+
+        maxBuckets = input.readInt();
+        nextIndex = input.readInt();
+        values = new double[maxBuckets + buffer];
+        weights = new double[maxBuckets + buffer];
+
+        input.readBytes(Slices.wrappedDoubleArray(values), nextIndex * SizeOf.SIZE_OF_DOUBLE);
+        input.readBytes(Slices.wrappedDoubleArray(weights), nextIndex * SizeOf.SIZE_OF_DOUBLE);
+    }
+
+    public Slice serialize()
+    {
+        compact();
+
+        int requiredBytes = SizeOf.SIZE_OF_BYTE + // format
+                SizeOf.SIZE_OF_INT + // max buckets
+                SizeOf.SIZE_OF_INT + // entry count
+                SizeOf.SIZE_OF_DOUBLE * nextIndex + // values
+                SizeOf.SIZE_OF_DOUBLE * nextIndex; // weights
+
+        return Slices.allocate(requiredBytes)
+                .getOutput()
+                .appendByte(FORMAT_TAG)
+                .appendInt(maxBuckets)
+                .appendInt(nextIndex)
+                .appendBytes(Slices.wrappedDoubleArray(values, 0, nextIndex))
+                .appendBytes(Slices.wrappedDoubleArray(weights, 0, nextIndex))
+                .slice();
+    }
+
+    public long estimatedInMemorySize()
+    {
+        return INSTANCE_SIZE + SizeOf.sizeOf(values) + SizeOf.sizeOf(weights);
+    }
+
+    public void add(double value)
+    {
+        add(value, 1);
+    }
+
+    public void add(double value, double weight)
+    {
+        if (nextIndex == values.length) {
+            trim(maxBuckets);
+        }
+
+        values[nextIndex] = value;
+        weights[nextIndex] = weight;
+
+        nextIndex++;
+    }
+
+    public void mergeWith(NumericHistogram other)
+    {
+        int count = nextIndex + other.nextIndex;
+
+        double[] newValues = new double[count];
+        double[] newWeights = new double[count];
+
+        concat(newValues, this.values, this.nextIndex, other.values, other.nextIndex);
+        concat(newWeights, this.weights, this.nextIndex, other.weights, other.nextIndex);
+
+        sort(newValues, newWeights, count);
+
+        count = mergeSameBuckets(newValues, newWeights, count);
+
+        if (count <= maxBuckets) {
+            // copy back into this.values/this.weights
+            System.arraycopy(newValues, 0, this.values, 0, count);
+            System.arraycopy(newWeights, 0, this.weights, 0, count);
+            nextIndex = count;
+            return;
+        }
+
+        PriorityQueue<Entry> queue = initializeQueue(newValues, newWeights, count);
+        mergeEntries(queue, maxBuckets);
+        store(queue);
+    }
+
+    public Map<Double, Double> getBuckets()
+    {
+        compact();
+
+        Map<Double, Double> result = new LinkedHashMap<>();
+        for (int i = 0; i < nextIndex; i++) {
+            result.put(values[i], weights[i]);
+        }
+        return result;
+    }
+
+    @VisibleForTesting
+    public void compact()
+    {
+        trim(maxBuckets);
+    }
+
+    private void trim(int target)
+    {
+        sort(values, weights, nextIndex);
+        nextIndex = mergeSameBuckets(values, weights, nextIndex);
+
+        if (nextIndex <= target) {
+            return;
+        }
+
+        PriorityQueue<Entry> queue = initializeQueue(values, weights, nextIndex);
+        mergeEntries(queue, target);
+        store(queue);
+
+        sort(values, weights, nextIndex);
+    }
+
+    private static void mergeEntries(PriorityQueue<Entry> queue, int targetCount)
+    {
+        int count = queue.size();
+
+        while (count > targetCount) {
+            Entry current = queue.poll();
+            if (!current.isValid()) {
+                continue;
+            }
+
+            count--;
+
+            Entry right = current.getRight();
+
+            // right is guaranteed to exist because we set the penalty of the last bucket to infinity
+            // so the first current in the queue can never be the last bucket
+            checkState(right != null, "Expected right to be != null");
+            checkState(right.isValid(), "Expected right to be valid");
+
+            // merge "current" with "right"
+            double newWeight = current.getWeight() + right.getWeight();
+            double newValue = (current.getValue() * current.getWeight() + right.getValue() * right.getWeight()) / newWeight;
+
+            // mark "right" as invalid so we can skip it if it shows up as we poll from the head of the queue
+            right.invalidate();
+
+            // compute the merged entry
+            Entry merged;
+            Entry newRight = right.getRight();
+            if (newRight == null) {
+                merged = new Entry(current.id, newValue, newWeight, Double.POSITIVE_INFINITY);
+            }
+            else {
+                merged = new Entry(current.id, newValue, newWeight, computePenalty(newValue, newWeight, newRight.getValue(), newRight.getWeight()));
+                link(merged, newRight);
+            }
+            queue.add(merged);
+
+            Entry left = current.getLeft();
+            if (left != null) {
+                checkState(left.isValid(), "Expected left to be valid");
+                // replace "left" with a new entry with a penalty adjusted to account for (newValue, newWeight)
+                left.invalidate();
+
+                Entry newLeft = new Entry(left.id, left.getValue(), left.getWeight(), computePenalty(left.getValue(), left.getWeight(), newValue, newWeight));
+                link(newLeft, merged);
+                queue.add(newLeft);
+
+                if (left.getLeft() != null) {
+                    link(left.getLeft(), newLeft);
+                }
+            }
+        }
+    }
+
+    /**
+     * Dump the entries in the queue back into the bucket arrays
+     */
+    private void store(PriorityQueue<Entry> queue)
+    {
+        nextIndex = 0;
+        for (Entry entry : queue) {
+            if (entry.isValid()) {
+                values[nextIndex] = entry.getValue();
+                weights[nextIndex] = entry.getWeight();
+                nextIndex++;
+            }
+        }
+    }
+
+    /**
+     * Copy two arrays back-to-back onto the target array starting at offset 0
+     */
+    private static void concat(double[] target, double[] first, int firstLength, double[] second, int secondLength)
+    {
+        System.arraycopy(first, 0, target, 0, firstLength);
+        System.arraycopy(second, 0, target, firstLength, secondLength);
+    }
+
+    /**
+     * Simple pass that merges buckets with the same "x" value
+     * The buckets must be sorted before this method is called
+     */
+    private static int mergeSameBuckets(double[] values, double[] weights, int nextIndex)
+    {
+        int current = 0;
+        for (int i = 1; i < nextIndex; i++) {
+            if (values[current] == values[i]) {
+                weights[current] += weights[i];
+            }
+            else {
+                current++;
+                values[current] = values[i];
+                weights[current] = weights[i];
+            }
+        }
+        return current + 1;
+    }
+
+    /**
+     * Create a priority queue with an entry for each bucket, ordered by the penalty score with respect to the bucket to its right
+     * The last bucket has a penalty of infinity
+     * Entries are doubly-linked to keep track of the relative position of each bucket
+     */
+    private static PriorityQueue<Entry> initializeQueue(double[] values, double[] weights, int nextIndex)
+    {
+        PriorityQueue<Entry> queue = new PriorityQueue<>(nextIndex, COMPARATOR);
+
+        Entry previous = new Entry(0, values[0], weights[0], computePenalty(values[0], weights[0], values[1], weights[1]));
+        queue.add(previous);
+        for (int i = 1; i < nextIndex; i++) {
+            double penalty = Double.POSITIVE_INFINITY;
+            if (i < nextIndex - 1) {
+                penalty = computePenalty(values[i], weights[i], values[i + 1], weights[i + 1]);
+            }
+
+            Entry current = new Entry(i, values[i], weights[i], penalty);
+            link(previous, current);
+            queue.add(current);
+
+            previous = current;
+        }
+
+        return queue;
+    }
+
+    private static void link(Entry left, Entry right)
+    {
+        right.setLeft(left);
+        left.setRight(right);
+    }
+
+    private static void sort(final double[] values, final double[] weights, int nextIndex)
+    {
+        // sort x and y value arrays based on the x values
+        Arrays.quickSort(0, nextIndex, new AbstractIntComparator()
+        {
+            @Override
+            public int compare(int a, int b)
+            {
+                return Doubles.compare(values[a], values[b]);
+            }
+        }, new Swapper()
+        {
+            @Override
+            public void swap(int a, int b)
+            {
+                double temp = values[a];
+                values[a] = values[b];
+                values[b] = temp;
+
+                temp = weights[a];
+                weights[a] = weights[b];
+                weights[b] = temp;
+            }
+        });
+    }
+
+    private static double computePenalty(double x1, double y1, double x2, double y2)
+    {
+        double weight = y1 + y2;
+        double squaredDifference = (x1 - x2) * (x1 - x2);
+        double proportionsProduct = (y1 * y2) / ((y1 + y2) * (y1 + y2));
+        return weight * squaredDifference * proportionsProduct;
+    }
+
+    private static class Entry
+    {
+        private final double penalty;
+
+        private final int id;
+        private final double value;
+        private final double weight;
+
+        private boolean valid = true;
+        private Entry left;
+        private Entry right;
+
+        private Entry(int id, double value, double weight, double penalty)
+        {
+            this.id = id;
+            this.value = value;
+            this.weight = weight;
+            this.penalty = penalty;
+        }
+
+        public Entry getLeft()
+        {
+            return left;
+        }
+
+        public void setLeft(Entry left)
+        {
+            this.left = left;
+        }
+
+        public Entry getRight()
+        {
+            return right;
+        }
+
+        public void setRight(Entry right)
+        {
+            this.right = right;
+        }
+
+        public double getValue()
+        {
+            return value;
+        }
+
+        public double getWeight()
+        {
+            return weight;
+        }
+
+        public double getPenalty()
+        {
+            return penalty;
+        }
+
+        public boolean isValid()
+        {
+            return valid;
+        }
+
+        public void invalidate()
+        {
+            this.valid = false;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/NumericHistogramAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/NumericHistogramAggregation.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.AccumulatorState;
+import com.facebook.presto.operator.aggregation.state.AccumulatorStateMetadata;
+import com.facebook.presto.operator.aggregation.state.NumericHistogramStateSerializer;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.SqlType;
+import com.google.common.primitives.Ints;
+import io.airlift.slice.Slice;
+
+import javax.validation.constraints.NotNull;
+
+@AggregationFunction("numeric_histogram")
+public class NumericHistogramAggregation
+{
+    public static final int ENTRY_BUFFER_SIZE = 100;
+
+    private NumericHistogramAggregation()
+    {
+    }
+
+    @AccumulatorStateMetadata(stateSerializerClass = NumericHistogramStateSerializer.class, stateFactoryClass = NumericHistogramStateFactory.class)
+    public interface State
+            extends AccumulatorState
+    {
+        @NotNull
+        NumericHistogram get();
+        void set(NumericHistogram value);
+    }
+
+    @InputFunction
+    public static void add(State state, @SqlType(StandardTypes.BIGINT) long buckets, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double weight)
+    {
+        NumericHistogram histogram = state.get();
+        if (histogram == null) {
+            histogram = new NumericHistogram(Ints.checkedCast(buckets), ENTRY_BUFFER_SIZE);
+            state.set(histogram);
+        }
+
+        histogram.add(value, weight);
+    }
+
+    @InputFunction
+    public static void add(State state, @SqlType(StandardTypes.BIGINT) long buckets, @SqlType(StandardTypes.DOUBLE) double value)
+    {
+        add(state, buckets, value, 1);
+    }
+
+    @CombineFunction
+    public static void merge(State state, State other)
+    {
+        NumericHistogram input = other.get();
+        NumericHistogram previous = state.get();
+
+        if (previous == null) {
+            state.set(input);
+        }
+        else {
+            previous.mergeWith(input);
+        }
+    }
+
+    @OutputFunction("map<double,double>")
+    public static void output(State state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            Slice slice = MapType.toStackRepresentation(state.get().getBuckets());
+            out.writeBytes(slice, 0, slice.length());
+            out.closeEntry();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/NumericHistogramStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/NumericHistogramStateFactory.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.AbstractGroupedAccumulatorState;
+import com.facebook.presto.operator.aggregation.state.AccumulatorStateFactory;
+import com.facebook.presto.util.array.ObjectBigArray;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class NumericHistogramStateFactory
+        implements AccumulatorStateFactory<NumericHistogramAggregation.State>
+{
+    @Override
+    public NumericHistogramAggregation.State createSingleState()
+    {
+        return new SingleState();
+    }
+
+    @Override
+    public Class<? extends NumericHistogramAggregation.State> getSingleStateClass()
+    {
+        return SingleState.class;
+    }
+
+    @Override
+    public NumericHistogramAggregation.State createGroupedState()
+    {
+        return new GroupedState();
+    }
+
+    @Override
+    public Class<? extends NumericHistogramAggregation.State> getGroupedStateClass()
+    {
+        return GroupedState.class;
+    }
+
+    public static class GroupedState
+            extends AbstractGroupedAccumulatorState
+            implements NumericHistogramAggregation.State
+    {
+        private final ObjectBigArray<NumericHistogram> histograms = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            histograms.ensureCapacity(size);
+        }
+
+        @Override
+        public NumericHistogram get()
+        {
+            return histograms.get(getGroupId());
+        }
+
+        @Override
+        public void set(NumericHistogram value)
+        {
+            checkNotNull(value, "value is null");
+
+            NumericHistogram previous = get();
+            if (previous != null) {
+                size -= previous.estimatedInMemorySize();
+            }
+
+            histograms.set(getGroupId(), value);
+            size += value.estimatedInMemorySize();
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + histograms.sizeOf();
+        }
+    }
+
+    public static class SingleState
+            implements NumericHistogramAggregation.State
+    {
+        private NumericHistogram histogram;
+
+        @Override
+        public NumericHistogram get()
+        {
+            return histogram;
+        }
+
+        @Override
+        public void set(NumericHistogram value)
+        {
+            histogram = value;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            if (histogram == null) {
+                return 0;
+            }
+            return histogram.estimatedInMemorySize();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/NumericHistogramStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/NumericHistogramStateSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.operator.aggregation.NumericHistogram;
+import com.facebook.presto.operator.aggregation.NumericHistogramAggregation;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+
+public class NumericHistogramStateSerializer
+        implements AccumulatorStateSerializer<NumericHistogramAggregation.State>
+{
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(NumericHistogramAggregation.State state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            VARBINARY.writeSlice(out, state.get().serialize());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, NumericHistogramAggregation.State state)
+    {
+        if (!block.isNull(index)) {
+            state.set(new NumericHistogram(VARBINARY.getSlice(block, index), NumericHistogramAggregation.ENTRY_BUFFER_SIZE));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestNumericHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestNumericHistogram.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestNumericHistogram
+{
+    @Test
+    public void testBasic()
+            throws Exception
+    {
+        double[] data = {
+                2.9, 3.1, 3.4, 3.5, 3.1, 2.9, 3, 3.8, 3.6, 3.1, 3.6, 2.5, 2.8, 2.3, 3, 3,
+                3.2, 3.8, 2.6, 2.9, 3.9, 3.5, 2.2, 2.9, 3, 3.2, 3.4, 3.2, 3, 4.2, 3, 2.9,
+                4.4, 2.4, 3.9, 2.8, 3.1, 3.2, 3, 3, 3.7, 2.9, 3, 3.1, 2.5, 3.3, 2.7, 3,
+                3.1, 3, 2.8, 3, 3.5, 2.6, 3.2, 2.6, 2.9, 4, 2.8, 3.2, 2.8, 3.2, 3.4, 2.8,
+                3.7, 3.8, 2.7, 3.3, 2.5, 2.8, 2.4, 2.9, 3, 2.7, 3.8, 2.8, 3, 3, 3.5, 3.4,
+                3.4, 3.4, 3, 3.8, 2.9, 3, 3.6, 3.1, 3.4, 2.7, 2.5, 2.5, 3.2, 2.7, 2.3,
+                3.3, 2.2, 3.7, 3.5, 2.7, 2.8, 3.4, 2.9, 3.4, 3, 2.8, 2.7, 3.1, 3.5, 3.3,
+                3.2, 3.1, 3.2, 3.6, 3, 3.2, 3, 2.5, 3.1, 3, 3, 2.7, 2.7, 2.6, 3, 2.3,
+                3.3, 2.8, 3.2, 3.4, 2.8, 3, 3.1, 2, 3, 2.5, 2.4, 3.3, 2.3, 3, 2.8, 2.8,
+                2.6, 3.8, 3.2, 3.4, 2.5, 4.1, 2.2, 3.4};
+
+        NumericHistogram histogram = new NumericHistogram(4, data.length);
+
+        Set<Double> uniqueValues = new HashSet<>();
+        for (double value : data) {
+            histogram.add(value);
+
+            uniqueValues.add(value);
+            if (uniqueValues.size() == 8) {
+                histogram.compact();
+                uniqueValues.clear();
+            }
+        }
+
+        Map<Double, Double> expected = ImmutableMap.<Double, Double>builder()
+                .put(2.4571428571428564, 28.0)
+                .put(3.568571428571429, 35.0)
+                .put(3.0023809523809515, 84.0)
+                .put(4.233333333333333, 3.0)
+                .build();
+
+        assertEquals(histogram.getBuckets(), expected);
+    }
+
+    @Test
+    public void testSameValues()
+            throws Exception
+    {
+        NumericHistogram histogram = new NumericHistogram(4);
+
+        for (int i = 0; i < 100; ++i) {
+            histogram.add(1.0, 3);
+            histogram.add(2.0, 5);
+        }
+
+        Map<Double, Double> expected = ImmutableMap.<Double, Double>builder()
+                .put(1.0, 300.0)
+                .put(2.0, 500.0)
+                .build();
+
+        assertEquals(histogram.getBuckets(), expected);
+    }
+
+    @Test
+    public void testRoundtrip()
+            throws Exception
+    {
+        NumericHistogram histogram = new NumericHistogram(100, 20);
+        for (int i = 0; i < 1000; i++) {
+            histogram.add(i);
+        }
+
+        Slice serialized = histogram.serialize();
+        NumericHistogram deserialized = new NumericHistogram(serialized, 20);
+
+        assertEquals(deserialized.getBuckets(), histogram.getBuckets());
+    }
+
+    @Test
+    public void testMergeSame()
+            throws Exception
+    {
+        NumericHistogram histogram = new NumericHistogram(10, 3);
+        for (int i = 0; i < 1000; i++) {
+            histogram.add(i);
+        }
+
+        Map<Double, Double> expected = Maps.transformValues(histogram.getBuckets(), new Function<Double, Double>()
+        {
+            @Override
+            public Double apply(Double input)
+            {
+                return input * 2;
+            }
+        });
+
+        histogram.mergeWith(histogram);
+
+        assertEquals(histogram.getBuckets(), expected);
+    }
+
+    @Test
+    public void testMergeDifferent()
+            throws Exception
+    {
+        NumericHistogram histogram1 = new NumericHistogram(10, 3);
+        NumericHistogram histogram2 = new NumericHistogram(10, 3);
+        for (int i = 0; i < 1000; i++) {
+            histogram1.add(i);
+            histogram2.add(i + 1000);
+        }
+
+        NumericHistogram expected = new NumericHistogram(10, 1000);
+        for (Map.Entry<Double, Double> entry : histogram1.getBuckets().entrySet()) {
+            expected.add(entry.getKey(), entry.getValue());
+        }
+        for (Map.Entry<Double, Double> entry : histogram2.getBuckets().entrySet()) {
+            expected.add(entry.getKey(), entry.getValue());
+        }
+        expected.compact();
+
+        histogram1.mergeWith(histogram2);
+        assertEquals(histogram1.getBuckets(), expected.getBuckets());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestNumericHistogramAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestNumericHistogramAggregation.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.type.TypeRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import io.airlift.json.ObjectMapperProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.facebook.presto.spi.type.StandardTypes.BIGINT;
+import static com.facebook.presto.spi.type.StandardTypes.DOUBLE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestNumericHistogramAggregation
+{
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get();
+    private final AccumulatorFactory factory;
+    private final Page input;
+
+    public TestNumericHistogramAggregation()
+    {
+        FunctionRegistry functionRegistry = new FunctionRegistry(new TypeRegistry(), true);
+        InternalAggregationFunction function = functionRegistry.resolveFunction(QualifiedName.of("numeric_histogram"), ImmutableList.of(BIGINT, DOUBLE, DOUBLE), false).getAggregationFunction();
+        factory = function.bind(ImmutableList.of(0, 1, 2), Optional.<Integer>absent(), Optional.<Integer>absent(), 1.0);
+
+        int numberOfBuckets = 10;
+
+        PageBuilder builder = new PageBuilder(ImmutableList.of(BigintType.BIGINT, DoubleType.DOUBLE, DoubleType.DOUBLE));
+
+        for (int i = 0; i < 100; i++) {
+            builder.getBlockBuilder(0).writeLong(numberOfBuckets).closeEntry();   // buckets
+            builder.getBlockBuilder(1).writeDouble(i).closeEntry();  // value
+            builder.getBlockBuilder(2).writeDouble(1).closeEntry();  // weight
+        }
+
+        input = builder.build();
+    }
+
+    @Test
+    public void test()
+            throws Exception
+    {
+        Accumulator singleStep = factory.createAccumulator();
+        singleStep.addInput(input);
+        Block expected = singleStep.evaluateFinal();
+
+        Accumulator partialStep = factory.createAccumulator();
+        partialStep.addInput(input);
+
+        Accumulator finalStep = factory.createAccumulator();
+        finalStep.addIntermediate(partialStep.evaluateIntermediate());
+        Block actual = finalStep.evaluateFinal();
+
+        assertEquals(extractSingleValue(actual), extractSingleValue(expected));
+    }
+
+    @Test
+    public void testMerge()
+            throws Exception
+    {
+        Accumulator singleStep = factory.createAccumulator();
+        singleStep.addInput(input);
+        Block singleStepResult = singleStep.evaluateFinal();
+
+        Accumulator partialStep = factory.createAccumulator();
+        partialStep.addInput(input);
+
+        Accumulator finalStep = factory.createAccumulator();
+        Block intermediate = partialStep.evaluateIntermediate();
+
+        finalStep.addIntermediate(intermediate);
+        finalStep.addIntermediate(intermediate);
+        Block actual = finalStep.evaluateFinal();
+
+        Map<String, Double> expected = Maps.transformValues(extractSingleValue(singleStepResult), new Function<Double, Double>()
+        {
+            @Override
+            public Double apply(Double input)
+            {
+                return input * 2;
+            }
+        });
+
+        assertEquals(extractSingleValue(actual), expected);
+    }
+
+    @Test
+    public void testNull()
+            throws Exception
+    {
+        Accumulator accumulator = factory.createAccumulator();
+        Block result = accumulator.evaluateFinal();
+
+        assertTrue(result.getPositionCount() == 1);
+        assertTrue(result.isNull(0));
+    }
+
+    private static Map<String, Double> extractSingleValue(Block block)
+            throws IOException
+    {
+        String json = block.getSlice(0, 0, block.getLength(0)).toStringUtf8();
+        return OBJECT_MAPPER.readValue(json, Map.class);
+    }
+}


### PR DESCRIPTION
This is a function for computing approximate histograms based loosely on

```
Yael Ben-Haim and Elad Tom-Tov, "A streaming parallel decision tree algorithm",
J. Machine Learning Research 11 (2010), pp. 849--872.
```

It supports the following signatures:
- numeric_histogram(bigint buckets, double value, double weight) -> map<double,double>
- numeric_histogram(bigint buckets, double value) -> map<double,double>

The second variant is a shorthand for weight = 1
