### PR TITLE
Preserve the value of argLine for surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -610,7 +610,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration combine.children="append">
-                        <argLine>-Duser.timezone=${test.timezone} -Xmx2g -Xms2g -XX:MaxPermSize=512m</argLine>
+                        <argLine>${argLine} -Duser.timezone=${test.timezone} -Xmx2g -Xms2g -XX:MaxPermSize=512m</argLine>
                         <parallel>methods</parallel>
                         <threadCount>8</threadCount>
                         <systemPropertyVariables>


### PR DESCRIPTION
This variable is set by the JaCoCo plugin to configure the agent.
