### PR TITLE
Add dummy field to TestingSplit

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/execution/TestingSplit.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestingSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -22,6 +23,21 @@ import java.util.List;
 public class TestingSplit
         implements ConnectorSplit
 {
+    public TestingSplit()
+    {
+    }
+
+    public TestingSplit(@JsonProperty("dummy") int dummy)
+    {
+    }
+
+    // we need a dummy property because Jackson refuses to serialize/deserialize an empty object
+    @JsonProperty
+    public int getDummy()
+    {
+        return 0;
+    }
+
     @Override
     public boolean isRemotelyAccessible()
     {


### PR DESCRIPTION
This is to avoid exceptions due to Jackson refusing to serialize/deserialize an object with no fields
