### PR TITLE
Update to floatingdecimal 0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>floatingdecimal</artifactId>
-                <version>0.1</version>
+                <version>0.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This version prints a better error message when attempting to use it with Java 8
