### PR TITLE
Add map_keys and map_values functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -18,3 +18,11 @@ Map Functions
     :noindex:
 
     Returns the cardinality (size) of the map ``x``.
+
+.. function:: map_keys(x<K,V>) -> array<K>
+
+    Returns all the keys in the map ``x``.
+
+.. function:: map_values(x<K,V>) -> array<V>
+
+    Returns all the values in the map ``x``.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -132,6 +132,8 @@ import static com.facebook.presto.operator.scalar.IdentityCast.IDENTITY_CAST;
 import static com.facebook.presto.operator.scalar.MapCardinalityFunction.MAP_CARDINALITY;
 import static com.facebook.presto.operator.scalar.MapSubscriptOperator.MAP_SUBSCRIPT;
 import static com.facebook.presto.operator.scalar.MapToJsonCast.MAP_TO_JSON;
+import static com.facebook.presto.operator.scalar.MapKeys.MAP_KEYS;
+import static com.facebook.presto.operator.scalar.MapValues.MAP_VALUES;
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -267,7 +269,9 @@ public class FunctionRegistry
                 .function(MAX_BY)
                 .function(COUNT_COLUMN)
                 .function(ARRAY_TO_JSON)
-                .function(MAP_TO_JSON);
+                .function(MAP_TO_JSON)
+                .function(MAP_KEYS)
+                .function(MAP_VALUES);
 
         if (experimentalSyntaxEnabled) {
             builder.aggregate(ApproximateAverageAggregations.class)
@@ -357,7 +361,7 @@ public class FunctionRegistry
             // verify we have one parameter of the proper type
             checkArgument(parameterTypes.size() == 1, "Expected one argument to literal function, but got %s", parameterTypes);
             Type parameterType = typeManager.getType(parameterTypes.get(0));
-            checkNotNull(parameterType, "Type %s not foudn", parameterTypes.get(0));
+            checkNotNull(parameterType, "Type %s not found", parameterTypes.get(0));
             checkArgument(parameterType.getJavaType() == type.getJavaType(),
                     "Expected type %s to use Java type %s, but Java type is %s",
                     type,

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapKeys.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapKeys.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricScalar;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.ArrayType;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.Signature.typeParameter;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
+import static com.fasterxml.jackson.core.JsonFactory.Feature.CANONICALIZE_FIELD_NAMES;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.invoke.MethodHandles.lookup;
+
+public class MapKeys extends ParametricScalar
+{
+    public static final MapKeys MAP_KEYS = new MapKeys();
+    private static final Signature SIGNATURE = new Signature("map_keys", ImmutableList.of(typeParameter("K"), typeParameter("V")), "array<K>", ImmutableList.of("map<K,V>"), false, false);
+    private static final MethodHandle METHOD_HANDLE;
+    public static final String DESCRIPTION = "Returns the keys of the given map<K,V> as an array";
+    private static final JsonFactory JSON_FACTORY = new JsonFactory()
+            .disable(CANONICALIZE_FIELD_NAMES);
+
+    static {
+        try {
+            METHOD_HANDLE = lookup().unreflect(MapKeys.class.getMethod("getKeys", Type.class, Slice.class));
+        }
+        catch (ReflectiveOperationException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public Signature getSignature()
+    {
+        return SIGNATURE;
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+    @Override
+    public String getDescription()
+    {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        checkArgument(arity == 1, "map_keys expects only one argument");
+        Type keyType = types.get("K");
+        Type valueType = types.get("V");
+        MethodHandle methodHandle = METHOD_HANDLE.bindTo(keyType);
+        return new FunctionInfo(new Signature("map_keys", parameterizedTypeName("array", keyType.getTypeSignature()), parameterizedTypeName("map", keyType.getTypeSignature(), valueType.getTypeSignature())), DESCRIPTION, false, methodHandle, true, true, ImmutableList.of(false));
+    }
+
+    public static Slice getKeys(Type keyType, Slice map)
+    {
+        List<Object> keys = new ArrayList<>();
+        try (JsonParser parser = JSON_FACTORY.createJsonParser(map.getInput())) {
+            JsonToken token = parser.nextToken();
+            while (token != null) {
+                switch (token) {
+                    case FIELD_NAME:
+                        String fieldName = parser.getCurrentName();
+                        keys.add(parseMapKeyAsType(fieldName, keyType));
+                        break;
+                    default:
+                        break;
+                }
+                token = parser.nextToken();
+            }
+        }
+        catch (IOException e) {
+            return null;
+        }
+        return ArrayType.toStackRepresentation(keys);
+    }
+
+    private static Object parseMapKeyAsType(String value, Type t)
+    {
+        if (t.equals(VARCHAR) || t.equals(VARBINARY)) {
+            return value;
+        }
+
+        if (t.equals(BIGINT) || t.equals(TIMESTAMP) || t.equals(DATE)) {
+            return Long.valueOf(value);
+        }
+
+        if (t.equals(DOUBLE)) {
+            return Double.valueOf(value);
+        }
+
+        if (t.equals(BOOLEAN)) {
+            return Boolean.valueOf(value);
+        }
+
+        throw new IllegalArgumentException("Type type " + t + " not supported as a map key");
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapValues.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapValues.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricScalar;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.ArrayType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import io.airlift.slice.Slice;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.Signature.typeParameter;
+import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.invoke.MethodHandles.lookup;
+
+public class MapValues extends ParametricScalar
+{
+    public static final MapValues MAP_VALUES = new MapValues();
+    private static final Signature SIGNATURE = new Signature("map_values", ImmutableList.of(typeParameter("K"), typeParameter("V")), "array<V>", ImmutableList.of("map<K,V>"), false, false);
+    private static final MethodHandle METHOD_HANDLE;
+    public static final String DESCRIPTION = "Returns the values of the given map<K,V> as an array";
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    static {
+        try {
+            METHOD_HANDLE = lookup().unreflect(MapValues.class.getMethod("getValues", Slice.class));
+        }
+        catch (ReflectiveOperationException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public Signature getSignature()
+    {
+        return SIGNATURE;
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+    @Override
+    public String getDescription()
+    {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        checkArgument(arity == 1, "map_values expects only one argument");
+        Type keyType = types.get("K");
+        Type valueType = types.get("V");
+        return new FunctionInfo(new Signature("map_values", parameterizedTypeName("array", valueType.getTypeSignature()), parameterizedTypeName("map", keyType.getTypeSignature(), valueType.getTypeSignature())), DESCRIPTION, false, METHOD_HANDLE, true, true, ImmutableList.of(false));
+    }
+
+    public static Slice getValues(Slice map)
+    {
+        List<Object> values = Lists.newArrayList(); //allow nulls
+        final com.fasterxml.jackson.databind.type.MapType type = mapper.getTypeFactory().constructMapType(
+                Map.class, String.class, Object.class);
+        final Map<String, Object> jsonMap;
+        try {
+            jsonMap = mapper.readValue(map.getInput(), type);
+        }
+        catch (IOException e) {
+            return null;
+        }
+        values.addAll(jsonMap.values());
+        return ArrayType.toStackRepresentation(values);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -16,8 +16,10 @@ package com.facebook.presto.type;
 import com.facebook.presto.operator.scalar.FunctionAssertions;
 import com.facebook.presto.operator.scalar.MapConstructor;
 import com.facebook.presto.spi.type.SqlTimestamp;
+import com.facebook.presto.spi.type.SqlVarbinary;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.testng.annotations.BeforeClass;
@@ -122,5 +124,34 @@ public class TestMapOperators
         assertFunction("MAP(TRUE, 2, FALSE, 4)[TRUE]", 2L);
         assertFunction("MAP('1', from_unixtime(1), '100', from_unixtime(100))['1']", new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey()));
         assertFunction("MAP(from_unixtime(1), 1.0, from_unixtime(100), 100.0)[from_unixtime(1)]", 1.0);
+    }
+
+    @Test
+    public void testMapKeys()
+            throws Exception
+    {
+        assertFunction("MAP_KEYS(MAP('1', '2', '3', '4'))",  ImmutableList.of("1", "3"));
+        assertFunction("MAP_KEYS(MAP(1.0, ARRAY[1, 2], 2.0, ARRAY[3]))", ImmutableList.of(1.0, 2.0));
+        assertFunction("MAP_KEYS(MAP('puppies', 'kittens'))", ImmutableList.of("puppies"));
+        assertFunction("MAP_KEYS(MAP(TRUE, 2))", ImmutableList.of(true));
+        assertFunction("MAP_KEYS(MAP(from_unixtime(1), 1.0))", ImmutableList.of(new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey())));
+        assertFunction("MAP_KEYS(MAP(CAST('puppies' as varbinary), 'kittens'))", ImmutableList.of(new SqlVarbinary("puppies".getBytes("utf-8"))));
+        assertFunction("MAP_KEYS(MAP(1, ARRAY[1, 2], 2, ARRAY[3]))", ImmutableList.of(1L, 2L));
+    }
+
+    @Test
+    public void testMapValues()
+            throws Exception
+    {
+        assertFunction("MAP_VALUES(MAP('1', ARRAY[TRUE, FALSE, NULL]))", ImmutableList.of(Lists.newArrayList(true, false, null)));
+        assertFunction("MAP_VALUES(MAP('1', ARRAY[ARRAY[1, 2]]))", ImmutableList.of(ImmutableList.of(ImmutableList.of(1L, 2L))));
+        assertFunction("MAP_VALUES(MAP('1', '2', '3', '4'))", ImmutableList.of("2", "4"));
+        assertFunction("MAP_VALUES(MAP(1.0, ARRAY[1, 2], 2.0, ARRAY[3]))", ImmutableList.of(ImmutableList.of(1L, 2L), ImmutableList.of(3L)));
+        assertFunction("MAP_VALUES(MAP('puppies', 'kittens'))", ImmutableList.of("kittens"));
+        assertFunction("MAP_VALUES(MAP(TRUE, 2))", ImmutableList.of(2L));
+        assertFunction("MAP_VALUES(MAP('1', NULL))", Lists.newArrayList((Object) null));
+        assertFunction("MAP_VALUES(MAP('1', TRUE))", ImmutableList.of(true));
+        assertFunction("MAP_VALUES(MAP('1', 1.0))", ImmutableList.of(1.0));
+        assertFunction("MAP_VALUES(MAP('1', ARRAY[1.0, 2.0], '2', ARRAY[3.0, 4.0]))", ImmutableList.of(ImmutableList.of(1.0, 2.0), ImmutableList.of(3.0, 4.0)));
     }
 }


### PR DESCRIPTION
This PR adds two functions that already exist in Hive: the `map_keys` and `map_values` functions. 

`map_keys(map<K,V>)` returns the list of keys of the given map as an `array<K>`

`map_values(map<K,V>)` returns the list of values of the given map as an `array<V>`
