### PR TITLE
Add sort_array function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -22,3 +22,6 @@ Array Functions
 
     Returns true iff the array ``x`` contains the element ``y``.
 
+.. function:: array_sort(x) -> array
+
+    Sorts and returns the array ``x`` iff its elements are comparable.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -126,6 +126,7 @@ import static com.facebook.presto.operator.aggregation.CountColumn.COUNT_COLUMN;
 import static com.facebook.presto.operator.aggregation.MaxBy.MAX_BY;
 import static com.facebook.presto.operator.scalar.ArrayCardinalityFunction.ARRAY_CARDINALITY;
 import static com.facebook.presto.operator.scalar.ArrayConstructor.ARRAY_CONSTRUCTOR;
+import static com.facebook.presto.operator.scalar.ArraySortFunction.ARRAY_SORT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArraySubscriptOperator.ARRAY_SUBSCRIPT;
 import static com.facebook.presto.operator.scalar.ArrayToJsonCast.ARRAY_TO_JSON;
 import static com.facebook.presto.operator.scalar.IdentityCast.IDENTITY_CAST;
@@ -263,6 +264,7 @@ public class FunctionRegistry
                 .function(ARRAY_CONSTRUCTOR)
                 .function(ARRAY_SUBSCRIPT)
                 .function(ARRAY_CARDINALITY)
+                .function(ARRAY_SORT_FUNCTION)
                 .function(MAP_CARDINALITY)
                 .function(MAP_SUBSCRIPT)
                 .function(IDENTITY_CAST)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricScalar;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.Signature.orderableTypeParameter;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.type.ArrayType.toStackRepresentation;
+import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+
+public final class ArraySortFunction
+        extends ParametricScalar
+{
+    public static final ArraySortFunction ARRAY_SORT_FUNCTION = new ArraySortFunction();
+    private static final String FUNCTION_NAME = "array_sort";
+    private static final String DESCRIPTION = "Sorts the given array in ascending order according to the natural ordering of its elements.";
+    private static final Signature SIGNATURE = new Signature(FUNCTION_NAME, ImmutableList.of(orderableTypeParameter("E")), "array<E>", ImmutableList.of("array<E>"), false, false);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(ArraySortFunction.class, "sort", Type.class, Slice.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final CollectionType COLLECTION_TYPE = OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, Object.class);
+
+    @Override
+    public Signature getSignature()
+    {
+        return SIGNATURE;
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        checkArgument(types.size() == 1, format("%s expects only one argument", FUNCTION_NAME));
+        Type type = types.get("E");
+        MethodHandle methodHandle = METHOD_HANDLE.bindTo(type);
+        Signature signature = new Signature(FUNCTION_NAME,
+                parameterizedTypeName("array", type.getTypeSignature()),
+                parameterizedTypeName("array", type.getTypeSignature()));
+        return new FunctionInfo(signature, DESCRIPTION, isHidden(), methodHandle, isDeterministic(), false, ImmutableList.of(false));
+    }
+
+    public static Slice sort(final Type type, Slice jsonArray)
+    {
+        final List<Object> elements;
+        try {
+            elements = OBJECT_MAPPER.readValue(jsonArray.getInput(), COLLECTION_TYPE);
+        }
+        catch (IOException e) {
+              return null;
+        }
+        Collections.sort(elements, new Comparator<Object>()
+        {
+            @Override
+            public int compare(Object o1, Object o2)
+            {
+                return type.compareTo(createBlock(type, o1), 0, createBlock(type, o2), 0);
+            }
+        });
+        return toStackRepresentation(elements);
+    }
+
+    private static Block createBlock(Type type, Object element)
+    {
+        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        Class<?> javaType = type.getJavaType();
+        if (javaType == boolean.class) {
+            type.writeBoolean(blockBuilder, (Boolean) element);
+        }
+        else if (javaType == long.class) {
+            type.writeLong(blockBuilder, ((Number) element).longValue());
+        }
+        else if (javaType == double.class) {
+            type.writeDouble(blockBuilder, (Double) element);
+        }
+        else if (javaType == Slice.class) {
+            type.writeSlice(blockBuilder, Slices.utf8Slice(element.toString()));
+        }
+        else {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Unexpected type %s", javaType.getName()));
+        }
+        return blockBuilder.build();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -162,4 +162,32 @@ public class TestArrayOperators
         assertFunction("ARRAY [TRUE, FALSE][2]", false);
         assertFunction("ARRAY [from_unixtime(1), from_unixtime(100)][1]", new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey()));
     }
+
+    @Test
+    public void testSort()
+            throws Exception
+    {
+        assertFunction("ARRAY_SORT(ARRAY[2, 3, 4, 1])", ImmutableList.of(1L, 2L, 3L, 4L));
+        assertFunction("ARRAY_SORT(ARRAY['z', 'f', 's', 'd', 'g'])", ImmutableList.of("d", "f", "g", "s", "z"));
+        assertFunction("ARRAY_SORT(ARRAY[TRUE, FALSE])", ImmutableList.of(false, true));
+        assertFunction("ARRAY_SORT(ARRAY[22.1, 11.1, 1.1, 44.1])", ImmutableList.of(1.1, 11.1, 22.1, 44.1));
+        assertFunction("ARRAY_SORT(ARRAY [from_unixtime(100), from_unixtime(1), from_unixtime(200)])",
+                ImmutableList.of(new SqlTimestamp(1 * 1000, TEST_SESSION.getTimeZoneKey()), new SqlTimestamp(100 * 1000, TEST_SESSION.getTimeZoneKey()), new SqlTimestamp(200 * 1000, TEST_SESSION.getTimeZoneKey())));
+
+        try {
+            assertFunction("ARRAY_SORT(ARRAY [ARRAY [1], ARRAY [2]])", null);
+            fail("ARRAY_SORT is not supported for arrays with incomparable elements");
+        }
+        catch (RuntimeException e) {
+            // Expected
+        }
+
+        try {
+            assertFunction("ARRAY_SORT(ARRAY[NULL, NULL, NULL])", null);
+            fail("ARRAY_SORT is not supported for arrays with incomparable elements");
+        }
+        catch (RuntimeException e) {
+            // Expected
+        }
+    }
 }


### PR DESCRIPTION
This PR adds Hive's `sort_array` function that sorts the given array in ascending order according to the natural ordering of its elements (only if the array elements are Comparable).
