### PR TITLE
Fix json parsing for non numeric numbers (nan and inf)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/TypeJsonUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeJsonUtils.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.google.common.base.Throwables;
@@ -109,7 +110,15 @@ public final class TypeJsonUtils
             type.writeLong(blockBuilder, parser.getLongValue());
         }
         else if (type.getJavaType() == double.class) {
-            type.writeDouble(blockBuilder, parser.getDoubleValue());
+            double value;
+            try {
+                value = parser.getDoubleValue();
+            }
+            catch (JsonParseException e) {
+                //handle non-numeric numbers (inf/nan)
+                value = Double.parseDouble(parser.getValueAsString());
+            }
+            type.writeDouble(blockBuilder, value);
         }
         else if (type.getJavaType() == Slice.class) {
             type.writeSlice(blockBuilder, Slices.utf8Slice(parser.getValueAsString()));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -86,6 +86,9 @@ public class TestArrayOperators
         assertFunction("ARRAY [from_unixtime(1), from_unixtime(100)]", ImmutableList.of(
                 new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey()),
                 new SqlTimestamp(100_000, TEST_SESSION.getTimeZoneKey())));
+        assertFunction("ARRAY [sqrt(-1)]", ImmutableList.of(Double.NaN));
+        assertFunction("ARRAY [pow(infinity(), 2)]", ImmutableList.of(Double.POSITIVE_INFINITY));
+        assertFunction("ARRAY [pow(-infinity(), 1)]", ImmutableList.of(Double.NEGATIVE_INFINITY));
     }
 
     @Test


### PR DESCRIPTION
This PR fixes #1893 by disabling `QUOTE_NON_NUMERIC_NUMBERS` for arrays' json generators and enabling `ALLOW_NON_NUMERIC_NUMBERS` for arrays' json parsers. Although this is documented to result in non-conformant json output I guess it is still OK as the json representations of collections are used internally (see http://wiki.fasterxml.com/JacksonFeaturesGenerator)
