### PR TITLE
Table writers need to be closeable

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 
 import javax.inject.Inject;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -153,6 +154,12 @@ public class JdbcMetadata
     }
 
     @Override
+    public void closeCreateTable(ConnectorOutputTableHandle tableHandle)
+            throws IOException
+    {
+    }
+
+    @Override
     public void renameTable(ConnectorTableHandle tableHandle, SchemaTableName newTableName)
     {
         throw new UnsupportedOperationException();
@@ -166,6 +173,13 @@ public class JdbcMetadata
 
     @Override
     public void commitInsert(ConnectorInsertTableHandle insertHandle, Collection<String> fragments)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void closeInsert(ConnectorInsertTableHandle insertHandle)
+            throws IOException
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.json.JsonCodec;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -301,6 +302,12 @@ public class CassandraMetadata
     }
 
     @Override
+    public void closeCreateTable(ConnectorOutputTableHandle tableHandle)
+            throws IOException
+    {
+    }
+
+    @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         throw new UnsupportedOperationException();
@@ -308,6 +315,13 @@ public class CassandraMetadata
 
     @Override
     public void commitInsert(ConnectorInsertTableHandle insertHandle, Collection<String> fragments)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void closeInsert(ConnectorInsertTableHandle insertHandle)
+            throws IOException
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordSink.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordSink.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.RecordSink;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
@@ -130,6 +131,12 @@ public class CassandraRecordSink implements RecordSink
     {
         checkState(field == -1, "record not finished");
         return "";
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
     }
 
     private void append(Object value)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
@@ -744,6 +744,12 @@ public class HiveClient
     }
 
     @Override
+    public void closeCreateTable(ConnectorOutputTableHandle tableHandle)
+            throws IOException
+    {
+    }
+
+    @Override
     public RecordSink getRecordSink(ConnectorOutputTableHandle tableHandle)
     {
         HiveOutputTableHandle handle = checkType(tableHandle, HiveOutputTableHandle.class, "tableHandle");
@@ -936,6 +942,12 @@ public class HiveClient
 
     @Override
     public void commitInsert(ConnectorInsertTableHandle insertHandle, Collection<String> fragments)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void closeInsert(ConnectorInsertTableHandle insertHandle)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveRecordSink.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveRecordSink.java
@@ -196,14 +196,14 @@ public class HiveRecordSink
     {
         checkState(field == -1, "record not finished");
 
-        try {
-            recordWriter.close(false);
-        }
-        catch (IOException e) {
-            throw Throwables.propagate(e);
-        }
-
         return ""; // the committer can list the directory
+    }
+
+    @Override
+    public void close()
+                throws IOException
+    {
+        recordWriter.close(false);
     }
 
     private void append(Object value)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -23,6 +23,7 @@ import com.google.common.base.Optional;
 
 import javax.validation.constraints.NotNull;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -134,6 +135,11 @@ public interface Metadata
     void commitCreateTable(OutputTableHandle tableHandle, Collection<String> fragments);
 
     /**
+     * Release table creation resources
+     */
+    void closeCreateTable(OutputTableHandle tableHandle) throws IOException;
+
+    /**
      * Begin insert query
      */
     InsertTableHandle beginInsert(Session session, TableHandle tableHandle);
@@ -142,6 +148,11 @@ public interface Metadata
      * Commit insert query
      */
     void commitInsert(InsertTableHandle tableHandle, Collection<String> fragments);
+
+    /**
+     * Release insert resources
+     */
+    void closeInsert(InsertTableHandle tableHandle) throws IOException;
 
     /**
      * Gets all the loaded catalogs

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -48,6 +48,7 @@ import io.airlift.json.ObjectMapperProvider;
 
 import javax.inject.Inject;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -357,6 +358,13 @@ public class MetadataManager
     }
 
     @Override
+    public void closeCreateTable(OutputTableHandle tableHandle)
+            throws IOException
+    {
+        lookupConnectorFor(tableHandle).closeCreateTable(tableHandle.getConnectorHandle());
+    }
+
+    @Override
     public InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
     {
         // assume connectorId and catalog are the same
@@ -369,6 +377,13 @@ public class MetadataManager
     public void commitInsert(InsertTableHandle tableHandle, Collection<String> fragments)
     {
         lookupConnectorFor(tableHandle).commitInsert(tableHandle.getConnectorHandle(), fragments);
+    }
+
+    @Override
+    public void closeInsert(InsertTableHandle tableHandle)
+            throws IOException
+    {
+        lookupConnectorFor(tableHandle).closeInsert(tableHandle.getConnectorHandle());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableCommitOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableCommitOperator.java
@@ -17,9 +17,12 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
@@ -103,6 +106,13 @@ public class TableCommitOperator
         if (state == State.RUNNING) {
             state = State.FINISHING;
         }
+
+        try {
+            tableCommitter.close();
+        }
+        catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
     }
 
     @Override
@@ -153,7 +163,12 @@ public class TableCommitOperator
     }
 
     public interface TableCommitter
+            extends Closeable
     {
         void commitTable(Collection<String> fragments);
+
+        @Override
+        void close()
+                throws IOException;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
@@ -20,12 +20,14 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
+import java.io.IOException;
 import java.util.List;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -132,6 +134,12 @@ public class TableWriterOperator
     {
         if (state == State.RUNNING) {
             state = State.FINISHING;
+        }
+        try {
+            recordSink.close();
+        }
+        catch (IOException e) {
+            throw Throwables.propagate(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -138,6 +138,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -1531,6 +1532,21 @@ public class LocalExecutionPlanner
                 }
                 else if (target instanceof InsertHandle) {
                     metadata.commitInsert(((InsertHandle) target).getHandle(), fragments);
+                }
+                else {
+                    throw new AssertionError("Unhandled target type: " + target.getClass().getName());
+                }
+            }
+
+            @Override
+            public void close()
+                    throws IOException
+            {
+                if (target instanceof CreateHandle) {
+                    metadata.closeCreateTable(((CreateHandle) target).getHandle());
+                }
+                else if (target instanceof InsertHandle) {
+                    metadata.closeInsert(((InsertHandle) target).getHandle());
                 }
                 else {
                     throw new AssertionError("Unhandled target type: " + target.getClass().getName());

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestingMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestingMetadata.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -178,6 +179,13 @@ public class TestingMetadata
     }
 
     @Override
+    public void closeCreateTable(ConnectorOutputTableHandle tableHandle)
+            throws IOException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         throw new UnsupportedOperationException();
@@ -185,6 +193,13 @@ public class TestingMetadata
 
     @Override
     public void commitInsert(ConnectorInsertTableHandle insertHandle, Collection<String> fragments)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void closeInsert(ConnectorInsertTableHandle insertHandle)
+            throws IOException
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
@@ -53,6 +53,7 @@ import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -339,6 +340,12 @@ public class RaptorMetadata
     }
 
     @Override
+    public void closeCreateTable(ConnectorOutputTableHandle outputTableHandle)
+            throws IOException
+    {
+    }
+
+    @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         long tableId = checkType(tableHandle, RaptorTableHandle.class, "tableHandle").getTableId();
@@ -363,6 +370,12 @@ public class RaptorMetadata
         Optional<String> externalBatchId = Optional.fromNullable(handle.getExternalBatchId());
 
         shardManager.commitTable(tableId, parseFragments(fragments), externalBatchId);
+    }
+
+    @Override
+    public void closeInsert(ConnectorInsertTableHandle insertHandle)
+            throws IOException
+    {
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorRecordSink.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorRecordSink.java
@@ -23,6 +23,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -149,6 +150,12 @@ public class RaptorRecordSink
         storageManager.commit(outputHandle);
 
         return Joiner.on(':').join(nodeId, outputHandle.getShardUuid());
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
     }
 
     private Type currentType()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorMetadata.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -100,6 +101,11 @@ public interface ConnectorMetadata
     void commitCreateTable(ConnectorOutputTableHandle tableHandle, Collection<String> fragments);
 
     /**
+     * Release table creation resources
+     */
+    void closeCreateTable(ConnectorOutputTableHandle tableHandle) throws IOException;
+
+    /**
      * Begin insert query
      */
     ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle);
@@ -108,6 +114,11 @@ public interface ConnectorMetadata
      * Commit insert query
      */
     void commitInsert(ConnectorInsertTableHandle insertHandle, Collection<String> fragments);
+
+    /**
+     * Release insert resources
+     */
+    void closeInsert(ConnectorInsertTableHandle insertHandle) throws IOException;
 
     /**
      * Create the specified view. The data for the view is opaque to the connector.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ReadOnlyConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ReadOnlyConnectorMetadata.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +61,13 @@ public abstract class ReadOnlyConnectorMetadata
     }
 
     @Override
+    public final void closeCreateTable(ConnectorOutputTableHandle tableHandle)
+            throws IOException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public final ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         throw new UnsupportedOperationException();
@@ -67,6 +75,13 @@ public abstract class ReadOnlyConnectorMetadata
 
     @Override
     public final void commitInsert(ConnectorInsertTableHandle insertHandle, Collection<String> fragments)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final void closeInsert(ConnectorInsertTableHandle insertHandles)
+            throws IOException
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/RecordSink.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/RecordSink.java
@@ -13,7 +13,11 @@
  */
 package com.facebook.presto.spi;
 
+import java.io.Closeable;
+import java.io.IOException;
+
 public interface RecordSink
+        extends Closeable
 {
     /**
      *
@@ -34,4 +38,11 @@ public interface RecordSink
     void appendString(byte[] value);
 
     String commit();
+
+    /**
+     * Cleanup resources. Presto will always call this method.
+     */
+    @Override
+    void close()
+            throws IOException;
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -155,6 +156,15 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public void closeCreateTable(ConnectorOutputTableHandle tableHandle)
+            throws IOException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.closeCreateTable(tableHandle);
+        }
+    }
+
+    @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
@@ -167,6 +177,15 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             delegate.commitInsert(insertHandle, fragments);
+        }
+    }
+
+    @Override
+    public void closeInsert(ConnectorInsertTableHandle insertHandle)
+            throws IOException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.closeInsert(insertHandle);
         }
     }
 


### PR DESCRIPTION
Current table write operators, `CREATE TABLE tbl AS` and `INSERT INTO` support `commit` when they sucessfully finish their operations. But when they fails during writes or are cancelled by user, `commit` is not called. So there's no point of releasing resources and rolling back operations.

Like as other adapters of operators, it would be nice if adapters are closeable and `close` is called at operators' `finish` whether they success or not. Adapters could safely close resources and rollback if commit is not invoked.
