### PR TITLE
 Make ArrayType comparable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -133,6 +133,12 @@ import static com.facebook.presto.operator.aggregation.MaxBy.MAX_BY;
 import static com.facebook.presto.operator.scalar.ArrayCardinalityFunction.ARRAY_CARDINALITY;
 import static com.facebook.presto.operator.scalar.ArrayConstructor.ARRAY_CONSTRUCTOR;
 import static com.facebook.presto.operator.scalar.ArrayConcatFunction.ARRAY_CONCAT_FUNCTION;
+import static com.facebook.presto.operator.scalar.ArrayEqualOperator.ARRAY_EQUAL;
+import static com.facebook.presto.operator.scalar.ArrayGreaterThanOperator.ARRAY_GREATER_THAN;
+import static com.facebook.presto.operator.scalar.ArrayGreaterThanOrEqualOperator.ARRAY_GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.operator.scalar.ArrayLessThanOperator.ARRAY_LESS_THAN;
+import static com.facebook.presto.operator.scalar.ArrayLessThanOrEqualOperator.ARRAY_LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.operator.scalar.ArrayNotEqualOperator.ARRAY_NOT_EQUAL;
 import static com.facebook.presto.operator.scalar.ArrayToElementConcatFunction.ARRAY_TO_ELEMENT_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ElementToArrayConcatFunction.ELEMENT_TO_ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArraySortFunction.ARRAY_SORT_FUNCTION;
@@ -276,6 +282,12 @@ public class FunctionRegistry
                 .scalar(CombineHashFunction.class)
                 .scalar(JsonOperators.class)
                 .function(ARRAY_CONSTRUCTOR)
+                .function(ARRAY_EQUAL)
+                .function(ARRAY_GREATER_THAN)
+                .function(ARRAY_GREATER_THAN_OR_EQUAL)
+                .function(ARRAY_LESS_THAN)
+                .function(ARRAY_LESS_THAN_OR_EQUAL)
+                .function(ARRAY_NOT_EQUAL)
                 .function(ARRAY_SUBSCRIPT)
                 .function(ARRAY_CARDINALITY)
                 .function(ARRAY_CONCAT_FUNCTION)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
@@ -324,6 +324,11 @@ public final class Signature
         return new TypeParameter(name, false, false, variadicBound);
     }
 
+    public static TypeParameter comparableWithVariadicBound(String name, String variadicBound)
+    {
+        return new TypeParameter(name, true, false, variadicBound);
+    }
+
     public static TypeParameter typeParameter(String name)
     {
         return new TypeParameter(name, false, false, null);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayEqualOperator.java
@@ -1,0 +1,62 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricOperator;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.FunctionRegistry.operatorInfo;
+import static com.facebook.presto.metadata.OperatorType.EQUAL;
+import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class ArrayEqualOperator extends ParametricOperator
+{
+    public static final ArrayEqualOperator ARRAY_EQUAL = new ArrayEqualOperator();
+    private static final TypeSignature RETURN_TYPE = parseTypeSignature(StandardTypes.BOOLEAN);
+
+    private ArrayEqualOperator()
+    {
+        super(EQUAL, ImmutableList.of(comparableWithVariadicBound("T", "array"), comparableWithVariadicBound("T", "array")), StandardTypes.BOOLEAN, ImmutableList.of("T", "T"));
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        Type type = types.get("T");
+        TypeSignature typeSignature = type.getTypeSignature();
+        MethodHandle methodHandle = methodHandle(ArrayEqualOperator.class, "equals", Type.class, Slice.class, Slice.class);
+        return operatorInfo(EQUAL, RETURN_TYPE, ImmutableList.of(typeSignature, typeSignature), methodHandle.bindTo(type), false, ImmutableList.of(false, false));
+    }
+
+    public static boolean equals(Type type, Slice left, Slice right)
+    {
+        BlockBuilder leftBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        BlockBuilder rightBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        leftBlockBuilder.writeBytes(left, 0, left.length());
+        rightBlockBuilder.writeBytes(right, 0, right.length());
+        return type.equalTo(leftBlockBuilder.closeEntry().build(), 0, rightBlockBuilder.closeEntry().build(), 0);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayGreaterThanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayGreaterThanOperator.java
@@ -1,0 +1,63 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricOperator;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.FunctionRegistry.operatorInfo;
+import static com.facebook.presto.metadata.OperatorType.GREATER_THAN;
+import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class ArrayGreaterThanOperator extends ParametricOperator
+{
+    public static final ArrayGreaterThanOperator ARRAY_GREATER_THAN = new ArrayGreaterThanOperator();
+    private static final TypeSignature RETURN_TYPE = parseTypeSignature(StandardTypes.BOOLEAN);
+
+    private ArrayGreaterThanOperator()
+    {
+        super(GREATER_THAN, ImmutableList.of(comparableWithVariadicBound("T", "array"), comparableWithVariadicBound("T", "array")), StandardTypes.BOOLEAN, ImmutableList.of("T", "T"));
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        Type type = types.get("T");
+        TypeSignature typeSignature = type.getTypeSignature();
+        MethodHandle methodHandle = methodHandle(ArrayGreaterThanOperator.class, "greaterThan", Type.class, Slice.class, Slice.class);
+        return operatorInfo(GREATER_THAN, RETURN_TYPE, ImmutableList.of(typeSignature, typeSignature), methodHandle.bindTo(type), false, ImmutableList.of(false, false));
+    }
+
+    public static boolean greaterThan(Type type, Slice left, Slice right)
+    {
+        BlockBuilder leftBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        BlockBuilder rightBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        leftBlockBuilder.writeBytes(left, 0, left.length());
+        rightBlockBuilder.writeBytes(right, 0, right.length());
+        return type.compareTo(leftBlockBuilder.closeEntry().build(), 0, rightBlockBuilder.closeEntry().build(), 0) > 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayGreaterThanOrEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayGreaterThanOrEqualOperator.java
@@ -1,0 +1,63 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricOperator;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.FunctionRegistry.operatorInfo;
+import static com.facebook.presto.metadata.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class ArrayGreaterThanOrEqualOperator extends ParametricOperator
+{
+    public static final ArrayGreaterThanOrEqualOperator ARRAY_GREATER_THAN_OR_EQUAL = new ArrayGreaterThanOrEqualOperator();
+    private static final TypeSignature RETURN_TYPE = parseTypeSignature(StandardTypes.BOOLEAN);
+
+    private ArrayGreaterThanOrEqualOperator()
+    {
+        super(GREATER_THAN_OR_EQUAL, ImmutableList.of(comparableWithVariadicBound("T", "array"), comparableWithVariadicBound("T", "array")), StandardTypes.BOOLEAN, ImmutableList.of("T", "T"));
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        Type type = types.get("T");
+        TypeSignature typeSignature = type.getTypeSignature();
+        MethodHandle methodHandle = methodHandle(ArrayGreaterThanOrEqualOperator.class, "greaterThanOrEqual", Type.class, Slice.class, Slice.class);
+        return operatorInfo(GREATER_THAN_OR_EQUAL, RETURN_TYPE, ImmutableList.of(typeSignature, typeSignature), methodHandle.bindTo(type), false, ImmutableList.of(false, false));
+    }
+
+    public static boolean greaterThanOrEqual(Type type, Slice left, Slice right)
+    {
+        BlockBuilder leftBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        BlockBuilder rightBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        leftBlockBuilder.writeBytes(left, 0, left.length());
+        rightBlockBuilder.writeBytes(right, 0, right.length());
+        return type.compareTo(leftBlockBuilder.closeEntry().build(), 0, rightBlockBuilder.closeEntry().build(), 0) >= 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOperator.java
@@ -1,0 +1,63 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricOperator;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.FunctionRegistry.operatorInfo;
+import static com.facebook.presto.metadata.OperatorType.LESS_THAN;
+import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class ArrayLessThanOperator extends ParametricOperator
+{
+    public static final ArrayLessThanOperator ARRAY_LESS_THAN = new ArrayLessThanOperator();
+    private static final TypeSignature RETURN_TYPE = parseTypeSignature(StandardTypes.BOOLEAN);
+
+    private ArrayLessThanOperator()
+    {
+        super(LESS_THAN, ImmutableList.of(comparableWithVariadicBound("T", "array"), comparableWithVariadicBound("T", "array")), StandardTypes.BOOLEAN, ImmutableList.of("T", "T"));
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        Type type = types.get("T");
+        TypeSignature typeSignature = type.getTypeSignature();
+        MethodHandle methodHandle = methodHandle(ArrayLessThanOperator.class, "lessThan", Type.class, Slice.class, Slice.class);
+        return operatorInfo(LESS_THAN, RETURN_TYPE, ImmutableList.of(typeSignature, typeSignature), methodHandle.bindTo(type), false, ImmutableList.of(false, false));
+    }
+
+    public static boolean lessThan(Type type, Slice left, Slice right)
+    {
+        BlockBuilder leftBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        BlockBuilder rightBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        leftBlockBuilder.writeBytes(left, 0, left.length());
+        rightBlockBuilder.writeBytes(right, 0, right.length());
+        return type.compareTo(leftBlockBuilder.closeEntry().build(), 0, rightBlockBuilder.closeEntry().build(), 0) < 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOrEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOrEqualOperator.java
@@ -1,0 +1,63 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricOperator;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.FunctionRegistry.operatorInfo;
+import static com.facebook.presto.metadata.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class ArrayLessThanOrEqualOperator extends ParametricOperator
+{
+    public static final ArrayLessThanOrEqualOperator ARRAY_LESS_THAN_OR_EQUAL = new ArrayLessThanOrEqualOperator();
+    private static final TypeSignature RETURN_TYPE = parseTypeSignature(StandardTypes.BOOLEAN);
+
+    private ArrayLessThanOrEqualOperator()
+    {
+        super(LESS_THAN_OR_EQUAL, ImmutableList.of(comparableWithVariadicBound("T", "array"), comparableWithVariadicBound("T", "array")), StandardTypes.BOOLEAN, ImmutableList.of("T", "T"));
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        Type type = types.get("T");
+        TypeSignature typeSignature = type.getTypeSignature();
+        MethodHandle methodHandle = methodHandle(ArrayLessThanOrEqualOperator.class, "lessThanOrEqual", Type.class, Slice.class, Slice.class);
+        return operatorInfo(LESS_THAN_OR_EQUAL, RETURN_TYPE, ImmutableList.of(typeSignature, typeSignature), methodHandle.bindTo(type), false, ImmutableList.of(false, false));
+    }
+
+    public static boolean lessThanOrEqual(Type type, Slice left, Slice right)
+    {
+        BlockBuilder leftBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        BlockBuilder rightBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        leftBlockBuilder.writeBytes(left, 0, left.length());
+        rightBlockBuilder.writeBytes(right, 0, right.length());
+        return type.compareTo(leftBlockBuilder.closeEntry().build(), 0, rightBlockBuilder.closeEntry().build(), 0) <= 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayNotEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayNotEqualOperator.java
@@ -1,0 +1,63 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricOperator;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.FunctionRegistry.operatorInfo;
+import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class ArrayNotEqualOperator extends ParametricOperator
+{
+    public static final ArrayNotEqualOperator ARRAY_NOT_EQUAL = new ArrayNotEqualOperator();
+    private static final TypeSignature RETURN_TYPE = parseTypeSignature(StandardTypes.BOOLEAN);
+
+    private ArrayNotEqualOperator()
+    {
+        super(NOT_EQUAL, ImmutableList.of(comparableWithVariadicBound("T", "array"), comparableWithVariadicBound("T", "array")), StandardTypes.BOOLEAN, ImmutableList.of("T", "T"));
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        Type type = types.get("T");
+        TypeSignature typeSignature = type.getTypeSignature();
+        MethodHandle methodHandle = methodHandle(ArrayNotEqualOperator.class, "notEqual", Type.class, Slice.class, Slice.class);
+        return operatorInfo(NOT_EQUAL, RETURN_TYPE, ImmutableList.of(typeSignature, typeSignature), methodHandle.bindTo(type), false, ImmutableList.of(false, false));
+    }
+
+    public static boolean notEqual(Type type, Slice left, Slice right)
+    {
+        BlockBuilder leftBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        BlockBuilder rightBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        leftBlockBuilder.writeBytes(left, 0, left.length());
+        rightBlockBuilder.writeBytes(right, 0, right.length());
+        return !type.equalTo(leftBlockBuilder.closeEntry().build(), 0, rightBlockBuilder.closeEntry().build(), 0);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeJsonUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeJsonUtils.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.type;
 
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
@@ -21,7 +23,10 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
 import com.google.common.base.Throwables;
+import io.airlift.json.ObjectMapperProvider;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
@@ -32,13 +37,17 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.fasterxml.jackson.core.JsonFactory.Feature.CANONICALIZE_FIELD_NAMES;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
 
 public final class TypeJsonUtils
 {
     private static final JsonFactory JSON_FACTORY = new JsonFactory().disable(CANONICALIZE_FIELD_NAMES);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get();
+    private static final CollectionType COLLECTION_TYPE = OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, Object.class);
 
     private TypeJsonUtils() {}
 
@@ -142,5 +151,43 @@ public final class TypeJsonUtils
             type.writeSlice(blockBuilder, Slices.utf8Slice(jsonKey));
         }
         return type.getObjectValue(session, blockBuilder.build(), 0);
+    }
+
+    public static List<Object> getObjectList(Slice slice)
+    {
+        List<Object> array;
+        try {
+            array = OBJECT_MAPPER.readValue(slice.getInput(), COLLECTION_TYPE);
+        }
+        catch (IOException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
+        }
+        return array;
+    }
+
+    public static Block createBlock(Type type, Object element)
+    {
+        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        Class<?> javaType = type.getJavaType();
+
+        if (element == null) {
+            blockBuilder.appendNull();
+        }
+        else if (javaType == boolean.class) {
+            type.writeBoolean(blockBuilder, (Boolean) element);
+        }
+        else if (javaType == long.class) {
+            type.writeLong(blockBuilder, ((Number) element).longValue());
+        }
+        else if (javaType == double.class) {
+            type.writeDouble(blockBuilder, (Double) element);
+        }
+        else if (javaType == Slice.class) {
+            type.writeSlice(blockBuilder, Slices.utf8Slice(element.toString()));
+        }
+        else {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Unexpected type %s", javaType.getName()));
+        }
+        return blockBuilder.build();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -253,4 +253,75 @@ public class TestArrayOperators
             // Expected
         }
     }
+
+    @Test
+    public void testComparison()
+            throws Exception
+    {
+        assertFunction("ARRAY [1, 2, 3] = ARRAY [1, 2, 3]", true);
+        assertFunction("ARRAY [TRUE, FALSE] = ARRAY [TRUE, FALSE]", true);
+        assertFunction("ARRAY [1.1, 2.2, 3.3, 4.4] = ARRAY [1.1, 2.2, 3.3, 4.4]", true);
+        assertFunction("ARRAY ['puppies', 'kittens'] = ARRAY ['puppies', 'kittens']", true);
+        assertFunction("ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles'] = ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles']", true);
+        assertFunction("ARRAY [timestamp '2012-10-31 08:00 UTC'] = ARRAY [timestamp '2012-10-31 01:00 America/Los_Angeles']", true);
+
+        assertFunction("ARRAY [1, 2, 3] = ARRAY [3, 2, 1]", false);
+        assertFunction("ARRAY [TRUE, FALSE] = ARRAY [FALSE, FALSE]", false);
+        assertFunction("ARRAY [1.1, 2.2, 3.3] = ARRAY [11.1, 22.1, 1.1, 44.1]", false);
+        assertFunction("ARRAY ['puppies', 'kittens'] = ARRAY ['z', 'f', 's', 'd', 'g']", false);
+        assertFunction("ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles'] = ARRAY [TIME '04:05:06.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles']", false);
+
+        assertFunction("ARRAY [10, 20, 30] < ARRAY [10, 20, 40, 50]", true);
+        assertFunction("ARRAY [10, 20, 30] < ARRAY [10, 40]", true);
+        assertFunction("ARRAY [10, 20] < ARRAY [10, 20, 30]", true);
+        assertFunction("ARRAY [TRUE, FALSE] < ARRAY [TRUE, TRUE, TRUE]", true);
+        assertFunction("ARRAY [TRUE, FALSE, FALSE] < ARRAY [TRUE, TRUE]", true);
+        assertFunction("ARRAY [TRUE, FALSE] < ARRAY [TRUE, FALSE, FALSE]", true);
+        assertFunction("ARRAY[1.1, 2.2, 3.3, 4.4] < ARRAY[1.1, 2.2, 4.4, 4.4]", true);
+        assertFunction("ARRAY[1.1, 2.2, 3.3, 4.4] < ARRAY[1.1, 2.2, 5.5]", true);
+        assertFunction("ARRAY[1.1, 2.2] < ARRAY[1.1, 2.2, 5.5]", true);
+        assertFunction("ARRAY['puppies', 'kittens', 'lizards'] < ARRAY ['puppies', 'lizards', 'lizards']", true);
+        assertFunction("ARRAY['puppies', 'kittens', 'lizards'] < ARRAY ['puppies', 'lizards']", true);
+        assertFunction("ARRAY['puppies', 'kittens'] < ARRAY ['puppies', 'kittens', 'lizards']", true);
+        assertFunction("ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles'] < ARRAY [TIME '04:05:06.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles']", true);
+        assertFunction("ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles'] < ARRAY [TIME '04:05:06.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles']", true);
+        assertFunction("ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles'] < ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles']", true);
+
+        assertFunction("ARRAY [10, 20, 30] > ARRAY [10, 20, 20]", true);
+        assertFunction("ARRAY [10, 20, 30] > ARRAY [10, 20]", true);
+        assertFunction("ARRAY [TRUE, TRUE, TRUE] > ARRAY [TRUE, TRUE, FALSE]", true);
+        assertFunction("ARRAY [TRUE, TRUE, FALSE] > ARRAY [TRUE, TRUE]", true);
+        assertFunction("ARRAY[1.1, 2.2, 3.3, 4.4] > ARRAY[1.1, 2.2, 2.2, 4.4]", true);
+        assertFunction("ARRAY[1.1, 2.2, 3.3, 4.4] > ARRAY[1.1, 2.2, 3.3]", true);
+        assertFunction("ARRAY['puppies', 'kittens', 'lizards'] > ARRAY ['puppies', 'kittens', 'kittens']", true);
+        assertFunction("ARRAY['puppies', 'kittens', 'lizards'] > ARRAY ['puppies', 'kittens']", true);
+        assertFunction("ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles'] > ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles']", true);
+        assertFunction("ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles'] > ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:20.456 America/Los_Angeles']", true);
+
+        assertFunction("ARRAY [10, 20, 30] <= ARRAY [50]", true);
+        assertFunction("ARRAY [10, 20, 30] <= ARRAY [10, 20, 30]", true);
+        assertFunction("ARRAY [TRUE, FALSE] <= ARRAY [TRUE, FALSE, true]", true);
+        assertFunction("ARRAY [TRUE, FALSE] <= ARRAY [TRUE, FALSE]", true);
+        assertFunction("ARRAY[1.1, 2.2, 3.3, 4.4] <= ARRAY[2.2, 5.5]", true);
+        assertFunction("ARRAY[1.1, 2.2, 3.3, 4.4] <= ARRAY[1.1, 2.2, 3.3, 4.4]", true);
+        assertFunction("ARRAY['puppies', 'kittens', 'lizards'] <= ARRAY ['puppies', 'lizards']", true);
+        assertFunction("ARRAY['puppies', 'kittens'] <= ARRAY['puppies', 'kittens']", true);
+        assertFunction("ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles'] <= ARRAY [TIME '04:05:06.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles']", true);
+        assertFunction("ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles'] <= ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles']", true);
+
+        assertFunction("ARRAY [10, 20, 30] >= ARRAY [10, 20, 30]", true);
+        assertFunction("ARRAY [TRUE, FALSE, TRUE] >= ARRAY [TRUE, FALSE, TRUE]", true);
+        assertFunction("ARRAY [TRUE, FALSE, TRUE] >= ARRAY [TRUE]", true);
+        assertFunction("ARRAY[1.1, 2.2, 3.3, 4.4] >= ARRAY[1.1, 2.2]", true);
+        assertFunction("ARRAY[1.1, 2.2, 3.3, 4.4] >= ARRAY[1.1, 2.2, 3.3, 4.4]", true);
+        assertFunction("ARRAY['puppies', 'kittens', 'lizards'] >= ARRAY ['puppies', 'kittens', 'kittens']", true);
+        assertFunction("ARRAY['puppies', 'kittens'] >= ARRAY['puppies', 'kittens']", true);
+        assertFunction("ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles'] >= ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles']", true);
+
+        assertFunction("ARRAY [10, 20, 30] != ARRAY [5]", true);
+        assertFunction("ARRAY [TRUE, FALSE, TRUE] != ARRAY [TRUE]", true);
+        assertFunction("ARRAY[1.1, 2.2, 3.3, 4.4] != ARRAY[1.1, 2.2]", true);
+        assertFunction("ARRAY['puppies', 'kittens', 'lizards'] != ARRAY ['puppies', 'kittens']", true);
+        assertFunction("ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles'] != ARRAY [TIME '01:02:03.456 America/Los_Angeles', TIME '10:20:30.456 America/Los_Angeles']", true);
+   }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestBigintArrayType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestBigintArrayType.java
@@ -17,9 +17,11 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.Slice;
 
 import java.util.List;
 
+import static com.facebook.presto.type.TypeJsonUtils.getObjectList;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 
@@ -44,6 +46,8 @@ public class TestBigintArrayType
     @Override
     protected Object getGreaterValue(Object value)
     {
-        throw new UnsupportedOperationException();
+        List<Object> array = getObjectList((Slice) value);
+        array.add(1L);
+        return ArrayType.toStackRepresentation(array);
     }
 }


### PR DESCRIPTION
Following
https://github.com/facebook/presto/issues/1816

A = B if they have the same cardinality and every element in A is equal to the corresponding element in B
A < B if
for some 1 <= k <= min(cardinality(A), cardinality(B)), A[i] = B[i] for every i < k and A[k] < B[k]
or, for every 1 <= i <= cardinality(A), A[i] = B[i] and cardinality(A) < cardinality(B)
