### PR TITLE
Improve query expiration logic

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -22,13 +22,11 @@ import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.util.AsyncSemaphore;
-import com.facebook.presto.util.IterableTransformer;
 import com.facebook.presto.util.SetThreadName;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.concurrent.ThreadPoolExecutorMBean;
@@ -48,11 +46,13 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -61,9 +61,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.facebook.presto.SystemSessionProperties.isBigQueryEnabled;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_QUEUE_FULL;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Predicates.compose;
-import static com.google.common.base.Predicates.isNull;
-import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.transform;
 import static io.airlift.concurrent.Threads.threadsNamed;
@@ -85,6 +82,7 @@ public class SqlQueryManager
     private final Duration maxQueryAge;
 
     private final ConcurrentMap<QueryId, QueryExecution> queries = new ConcurrentHashMap<>();
+    private final Queue<QueryExecution> expirationQueue = new LinkedBlockingQueue<>();
 
     private final Duration clientTimeout;
 
@@ -134,19 +132,20 @@ public class SqlQueryManager
             public void run()
             {
                 try {
-                    removeExpiredQueries();
-                }
-                catch (Throwable e) {
-                    log.warn(e, "Error removing old queries");
-                }
-                try {
                     failAbandonedQueries();
                 }
                 catch (Throwable e) {
-                    log.warn(e, "Error removing old queries");
+                    log.warn(e, "Error cancelling abandoned queries");
+                }
+
+                try {
+                    removeExpiredQueries();
+                }
+                catch (Throwable e) {
+                    log.warn(e, "Error removing expired queries");
                 }
             }
-        }, 200, 200, TimeUnit.MILLISECONDS);
+        }, 1, 1, TimeUnit.SECONDS);
     }
 
     @PreDestroy
@@ -235,6 +234,7 @@ public class SqlQueryManager
 
                     stats.queryFinished(info);
                     queryMonitor.completionEvent(info);
+                    expirationQueue.add(queryExecution);
                 }
             }
         });
@@ -325,44 +325,34 @@ public class SqlQueryManager
      */
     public void removeExpiredQueries()
     {
-        List<QueryExecution> sortedQueries = IterableTransformer.on(queries.values())
-                .select(compose(not(isNull()), endTimeGetter()))
-                .orderBy(Ordering.natural().onResultOf(endTimeGetter()))
-                .list();
+        while (expirationQueue.size() > maxQueryHistory) {
+            QueryExecution query = expirationQueue.remove();
+            removeQuery(query.getQueryInfo().getQueryId());
+        }
 
-        int toRemove = Math.max(sortedQueries.size() - maxQueryHistory, 0);
         DateTime oldestAllowedQuery = DateTime.now().minus(maxQueryAge.toMillis());
+        while (expirationQueue.size() > 0) {
+            QueryExecution query = expirationQueue.peek();
+            if (query.getQueryInfo().getQueryStats().getEndTime().isAfter(oldestAllowedQuery)) {
+                return;
+            }
 
-        for (QueryExecution queryExecution : sortedQueries) {
-            try {
-                DateTime endTime = queryExecution.getQueryInfo().getQueryStats().getEndTime();
-                if ((endTime.isBefore(oldestAllowedQuery) || toRemove > 0) && isAbandoned(queryExecution)) {
-                    removeQuery(queryExecution.getQueryInfo().getQueryId());
-                    --toRemove;
-                }
-            }
-            catch (RuntimeException e) {
-                log.warn(e, "Error while inspecting age of query %s", queryExecution.getQueryInfo().getQueryId());
-            }
+            removeQuery(query.getQueryInfo().getQueryId());
+            expirationQueue.remove();
         }
     }
 
     public void failAbandonedQueries()
     {
         for (QueryExecution queryExecution : queries.values()) {
-            try {
-                QueryInfo queryInfo = queryExecution.getQueryInfo();
-                if (queryInfo.getState().isDone()) {
-                    continue;
-                }
-
-                if (isAbandoned(queryExecution)) {
-                    log.info("Failing abandoned query %s", queryExecution.getQueryInfo().getQueryId());
-                    queryExecution.fail(new AbandonedException("Query " + queryInfo.getQueryId(), queryInfo.getQueryStats().getLastHeartbeat(), DateTime.now()));
-                }
+            QueryInfo queryInfo = queryExecution.getQueryInfo();
+            if (queryInfo.getState().isDone()) {
+                continue;
             }
-            catch (RuntimeException e) {
-                log.warn(e, "Error while inspecting age of query %s", queryExecution.getQueryInfo().getQueryId());
+
+            if (isAbandoned(queryExecution)) {
+                log.info("Failing abandoned query %s", queryExecution.getQueryInfo().getQueryId());
+                queryExecution.fail(new AbandonedException("Query " + queryInfo.getQueryId(), queryInfo.getQueryStats().getLastHeartbeat(), DateTime.now()));
             }
         }
     }


### PR DESCRIPTION
Queries are placed in an expiration queue upon completion. The task
that expires old queries processes the queue in arrival order instead
of looking at every query every time, sorting them by time and processing
the oldest from the list.

Also, increase the interval for processing expired and abandoned queries to
1 second
