### PR TITLE
Cassandra connector error with Presto 0.80

### DIFF
--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -109,7 +109,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        
+        <dependency>
+            <groupId>com.github.stephenc.high-scale-lib</groupId>
+            <artifactId>high-scale-lib</artifactId>
+            <version>1.1.2</version>
+            <scope>runtime</scope>
+        </dependency>
+        
         <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>


### PR DESCRIPTION
Fixes #1895

Cassandra connector causes error when using Presto 0.80 or 0.81

```
java.lang.SecurityException: Prohibited package name: java.util.concurrent
```
