### PR TITLE
Updated jol version to 0.2 to resolve the slow startup problem due to heavy GC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,7 +435,7 @@
             <dependency>
                 <groupId>org.openjdk.jol</groupId>
                 <artifactId>jol-core</artifactId>
-                <version>0.1</version>
+                <version>0.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR fixes #1902. Jol 0.2 has been just released to maven central: http://mail.openjdk.java.net/pipermail/jol-dev/2014-November/000037.html
