### PR TITLE
Array concat function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -11,6 +11,14 @@ The ``[]`` operator is used to access an element of an array, and is indexed sta
 
     SELECT my_array[1] AS first_element
 
+Concatenation Operator: ||
+--------------------------
+The ``||`` operator can be used to concatenate an array with an array or an element of the same type::
+
+    SELECT ARRAY [1] || ARRAY [2]; => [1, 2]
+    SELECT ARRAY [1] || 2; => [1, 2]
+    SELECT 2 || ARRAY [1]; => [2, 1]
+
 Array Functions
 ---------------
 
@@ -25,3 +33,9 @@ Array Functions
 .. function:: array_sort(x) -> array
 
     Sorts and returns the array ``x``. The elements of ``x`` must be orderable.
+
+.. function:: concat(x, y) -> array
+    :noindex:
+
+    Concatenates given arrays ``x`` and ``y``. The element types of ``x`` and ``y`` must be the same.
+    This function provides the same functionality as the concatenation operator (``||``).

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -130,6 +130,9 @@ import static com.facebook.presto.operator.aggregation.CountColumn.COUNT_COLUMN;
 import static com.facebook.presto.operator.aggregation.MaxBy.MAX_BY;
 import static com.facebook.presto.operator.scalar.ArrayCardinalityFunction.ARRAY_CARDINALITY;
 import static com.facebook.presto.operator.scalar.ArrayConstructor.ARRAY_CONSTRUCTOR;
+import static com.facebook.presto.operator.scalar.ArrayConcatFunction.ARRAY_CONCAT_FUNCTION;
+import static com.facebook.presto.operator.scalar.ArrayToElementConcatFunction.ARRAY_TO_ELEMENT_CONCAT_FUNCTION;
+import static com.facebook.presto.operator.scalar.ElementToArrayConcatFunction.ELEMENT_TO_ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArraySortFunction.ARRAY_SORT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArraySubscriptOperator.ARRAY_SUBSCRIPT;
 import static com.facebook.presto.operator.scalar.ArrayToJsonCast.ARRAY_TO_JSON;
@@ -271,6 +274,9 @@ public class FunctionRegistry
                 .function(ARRAY_CONSTRUCTOR)
                 .function(ARRAY_SUBSCRIPT)
                 .function(ARRAY_CARDINALITY)
+                .function(ARRAY_CONCAT_FUNCTION)
+                .function(ARRAY_TO_ELEMENT_CONCAT_FUNCTION)
+                .function(ELEMENT_TO_ARRAY_CONCAT_FUNCTION)
                 .function(ARRAY_SORT_FUNCTION)
                 .function(MAP_CARDINALITY)
                 .function(MAP_SUBSCRIPT)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatFunction.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricScalar;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.Signature.typeParameter;
+import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class ArrayConcatFunction
+        extends ParametricScalar
+{
+    public static final ArrayConcatFunction ARRAY_CONCAT_FUNCTION = new ArrayConcatFunction();
+    private static final String FUNCTION_NAME = "concat";
+    private static final Signature SIGNATURE = new Signature(FUNCTION_NAME, ImmutableList.of(typeParameter("E")), "array<E>", ImmutableList.of("array<E>", "array<E>"), false, false);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(ArrayConcatUtils.class, FUNCTION_NAME, Slice.class, Slice.class);
+
+    @Override
+    public Signature getSignature()
+    {
+        return SIGNATURE;
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Concatenates given arrays";
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        TypeSignature typeSignature = parameterizedTypeName("array", types.get("E").getTypeSignature());
+        Signature signature = new Signature(FUNCTION_NAME, typeSignature, typeSignature, typeSignature); // return type & arg types are the same
+        return new FunctionInfo(signature, getDescription(), isHidden(), METHOD_HANDLE, isDeterministic(), false, ImmutableList.of(false, false));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatUtils.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.server.SliceSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.google.common.base.Throwables;
+import io.airlift.json.ObjectMapperProvider;
+import io.airlift.slice.Slice;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.type.ArrayType.toStackRepresentation;
+
+public class ArrayConcatUtils
+{
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get().registerModule(new SimpleModule().addSerializer(Slice.class, new SliceSerializer()));
+    private static final CollectionType COLLECTION_TYPE = OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, Object.class);
+
+    private ArrayConcatUtils() {}
+
+    public static Slice concat(Slice left, Slice right)
+    {
+        List<Object> leftArray = readArray(left);
+        List<Object> rightArray = readArray(right);
+        List<Object> result = new ArrayList<>(leftArray.size() + rightArray.size()); // allow nulls
+        result.addAll(leftArray);
+        result.addAll(rightArray);
+        return toStackRepresentation(result);
+    }
+
+    private static Slice concatElement(Slice in, Object value, boolean append)
+    {
+        List<Object> array = readArray(in);
+        List<Object> result = new ArrayList<>(array.size() + 1); // allow nulls
+        if (append) {
+            result.addAll(array);
+            result.add(value);
+        }
+        else {
+            result.add(value);
+            result.addAll(array);
+        }
+        return toStackRepresentation(result);
+    }
+
+    public static Slice appendElement(Slice in, Object value)
+    {
+        return concatElement(in, value, true);
+    }
+
+    public static Slice appendElement(Slice in, long value)
+    {
+        return appendElement(in, Long.valueOf(value));
+    }
+
+    public static Slice appendElement(Slice in, boolean value)
+    {
+        return appendElement(in, Boolean.valueOf(value));
+    }
+
+    public static Slice appendElement(Slice in, double value)
+    {
+        return appendElement(in, Double.valueOf(value));
+    }
+
+    public static Slice appendElement(Slice in, Slice value)
+    {
+        return concatElement(in, value, true);
+    }
+
+    public static Slice prependElement(Slice value, Slice in)
+    {
+        return concatElement(in, value, false);
+    }
+
+    public static Slice prependElement(Object value, Slice in)
+    {
+        return concatElement(in, value, false);
+    }
+
+    public static Slice prependElement(long value, Slice in)
+    {
+        return prependElement(Long.valueOf(value), in);
+    }
+
+    public static Slice prependElement(boolean value, Slice in)
+    {
+        return prependElement(Boolean.valueOf(value), in);
+    }
+
+    public static Slice prependElement(double value, Slice in)
+    {
+        return prependElement(Double.valueOf(value), in);
+    }
+
+    private static List<Object> readArray(Slice json)
+    {
+        try {
+            return OBJECT_MAPPER.readValue(json.getInput(), COLLECTION_TYPE);
+        }
+        catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToElementConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToElementConcatFunction.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricScalar;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.Signature.typeParameter;
+import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class ArrayToElementConcatFunction
+        extends ParametricScalar
+{
+    public static final ArrayToElementConcatFunction ARRAY_TO_ELEMENT_CONCAT_FUNCTION = new ArrayToElementConcatFunction();
+    private static final String FUNCTION_NAME = "concat";
+    private static final Signature SIGNATURE = new Signature(FUNCTION_NAME, ImmutableList.of(typeParameter("E")), "array<E>", ImmutableList.of("array<E>", "E"), false, false);
+
+    @Override
+    public Signature getSignature()
+    {
+        return SIGNATURE;
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Concatenates an array to an element";
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        Type type = types.get("E");
+        MethodHandle methodHandle = methodHandle(ArrayConcatUtils.class, "appendElement", Slice.class, type.getJavaType());
+        TypeSignature typeSignature = type.getTypeSignature();
+        TypeSignature returnType = parameterizedTypeName("array", typeSignature);
+        Signature signature = new Signature(FUNCTION_NAME, returnType, returnType, typeSignature);
+        return new FunctionInfo(signature, getDescription(), isHidden(), methodHandle, isDeterministic(), false, ImmutableList.of(false, false));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ElementToArrayConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ElementToArrayConcatFunction.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricScalar;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.Signature.typeParameter;
+import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class ElementToArrayConcatFunction
+        extends ParametricScalar
+{
+    public static final ElementToArrayConcatFunction ELEMENT_TO_ARRAY_CONCAT_FUNCTION = new ElementToArrayConcatFunction();
+    private static final String FUNCTION_NAME = "concat";
+    private static final Signature SIGNATURE = new Signature(FUNCTION_NAME, ImmutableList.of(typeParameter("E")), "array<E>", ImmutableList.of("E", "array<E>"), false, false);
+
+    @Override
+    public Signature getSignature()
+    {
+        return SIGNATURE;
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Concatenates an element to an array";
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        Type type = types.get("E");
+        MethodHandle methodHandle = methodHandle(ArrayConcatUtils.class, "prependElement", type.getJavaType(), Slice.class);
+        TypeSignature typeSignature = type.getTypeSignature();
+        TypeSignature returnType = parameterizedTypeName("array", typeSignature);
+        Signature signature = new Signature(FUNCTION_NAME, returnType, typeSignature, returnType);
+        return new FunctionInfo(signature, getDescription(), isHidden(), methodHandle, isDeterministic(), false, ImmutableList.of(false, false));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -13,7 +13,9 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.metadata.FunctionListBuilder;
 import com.facebook.presto.operator.scalar.FunctionAssertions;
+import com.facebook.presto.operator.scalar.TestingRowConstructor;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.SqlTimestamp;
 import com.facebook.presto.sql.analyzer.SemanticErrorCode;
@@ -40,6 +42,7 @@ public class TestArrayOperators
     public void setUp()
     {
         functionAssertions = new FunctionAssertions();
+        functionAssertions.getMetadata().getFunctionRegistry().addFunctions(new FunctionListBuilder(functionAssertions.getMetadata().getTypeManager()).scalar(TestingRowConstructor.class).getFunctions());
     }
 
     private void assertFunction(String projection, Object expected)
@@ -86,6 +89,63 @@ public class TestArrayOperators
         assertFunction("ARRAY [from_unixtime(1), from_unixtime(100)]", ImmutableList.of(
                 new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey()),
                 new SqlTimestamp(100_000, TEST_SESSION.getTimeZoneKey())));
+    }
+
+    @Test
+    public void testArrayToArrayConcat()
+            throws Exception
+    {
+        assertFunction("ARRAY [1, NULL] || ARRAY [3]", Lists.newArrayList(1L, null, 3L));
+        assertFunction("ARRAY [1, 2] || ARRAY[3, 4]", ImmutableList.of(1L, 2L, 3L, 4L));
+        assertFunction("ARRAY [NULL] || ARRAY[NULL]", Lists.newArrayList(null, null));
+        assertFunction("ARRAY ['puppies'] || ARRAY ['kittens']", ImmutableList.of("puppies", "kittens"));
+        assertFunction("ARRAY [TRUE] || ARRAY [FALSE]", ImmutableList.of(true, false));
+        assertFunction("concat(ARRAY [1] , ARRAY[2,3])", ImmutableList.of(1L, 2L, 3L));
+        assertFunction("ARRAY [from_unixtime(1)] || ARRAY[from_unixtime(100)]", ImmutableList.of(
+                new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey()),
+                new SqlTimestamp(100_000, TEST_SESSION.getTimeZoneKey())));
+        assertFunction("ARRAY [ARRAY[ARRAY[1]]] || ARRAY [ARRAY[ARRAY[2]]]", ImmutableList.of(ImmutableList.of(ImmutableList.of(1L)), ImmutableList.of(ImmutableList.of(2L))));
+        assertFunction("ARRAY [] || ARRAY []", ImmutableList.of());
+        assertFunction("ARRAY [TRUE] || ARRAY [FALSE] || ARRAY [TRUE]", ImmutableList.of(true, false, true));
+        assertFunction("ARRAY [1] || ARRAY [2] || ARRAY [3] || ARRAY [4]", ImmutableList.of(1L, 2L, 3L, 4L));
+
+        try {
+            assertFunction("ARRAY [ARRAY[1]] || ARRAY[ARRAY[true], ARRAY[false]]", null);
+            fail("arrays must be of the same type");
+        }
+        catch (RuntimeException e) {
+            // Expected
+        }
+
+        try {
+            assertFunction("ARRAY [ARRAY[1]] || ARRAY[NULL]", null);
+            fail("arrays must be of the same type");
+        }
+        catch (RuntimeException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testElementArrayConcat()
+            throws Exception
+    {
+        assertFunction("CAST (ARRAY [DATE '2001-08-22'] || DATE '2001-08-23' AS JSON)", "[\"2001-08-22\",\"2001-08-23\"]");
+        assertFunction("CAST (DATE '2001-08-23' || ARRAY [DATE '2001-08-22'] AS JSON)", "[\"2001-08-23\",\"2001-08-22\"]");
+        assertFunction("1 || ARRAY [2]", Lists.newArrayList(1L, 2L));
+        assertFunction("ARRAY [2] || 1", Lists.newArrayList(2L, 1L));
+        assertFunction("TRUE || ARRAY [FALSE]", Lists.newArrayList(true, false));
+        assertFunction("ARRAY [FALSE] || TRUE", Lists.newArrayList(false, true));
+        assertFunction("1.0 || ARRAY [2.0]", Lists.newArrayList(1.0, 2.0));
+        assertFunction("ARRAY [2.0] || 1.0", Lists.newArrayList(2.0, 1.0));
+        assertFunction("'puppies' || ARRAY ['kittens']", Lists.newArrayList("puppies", "kittens"));
+        assertFunction("ARRAY ['kittens'] || 'puppies'", Lists.newArrayList("kittens", "puppies"));
+        assertFunction("ARRAY [from_unixtime(1)] || from_unixtime(100)", ImmutableList.of(
+                new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey()),
+                new SqlTimestamp(100_000, TEST_SESSION.getTimeZoneKey())));
+        assertFunction("from_unixtime(100) || ARRAY [from_unixtime(1)]", ImmutableList.of(
+                new SqlTimestamp(100_000, TEST_SESSION.getTimeZoneKey()),
+                new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey())));
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractType.java
@@ -157,7 +157,7 @@ public abstract class AbstractType
             return false;
         }
 
-        return true;
+        return this.getTypeSignature().equals(((AbstractType) o).getTypeSignature());
     }
 
     @Override


### PR DESCRIPTION
This PR implements an array concat function that supports array-to-array, element-to-array, and array-to-element concatenation. 

```
select ARRAY [1,2] || ARRAY[3];
select 1 || ARRAY [2,3];
select ARRAY [1,2] || 3;
   _col0
-----------
 [1, 2, 3]
(1 row)
```
