### PR TITLE
Add queries that fail before starting to expiration queue

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -375,6 +375,7 @@ public class SqlQueryManager
         queryMonitor.createdEvent(execution.getQueryInfo());
         queryMonitor.completionEvent(execution.getQueryInfo());
         stats.queryFinished(execution.getQueryInfo());
+        expirationQueue.add(execution);
 
         return execution.getQueryInfo();
     }


### PR DESCRIPTION
This was a bug introduced in https://github.com/facebook/presto/pull/1917
