### PR TITLE
Fix scheduling for information_schema tables

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplitManager.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.connector.informationSchema;
 
-import com.facebook.presto.connector.system.SystemTablesManager;
 import com.facebook.presto.spi.ConnectorColumnHandle;
 import com.facebook.presto.spi.ConnectorPartition;
 import com.facebook.presto.spi.ConnectorPartitionResult;
@@ -70,7 +69,7 @@ public class InformationSchemaSplitManager
     {
         checkNotNull(partitions, "partitions is null");
         if (partitions.isEmpty()) {
-            return new FixedSplitSource(SystemTablesManager.CONNECTOR_ID, ImmutableList.<ConnectorSplit>of());
+            return new FixedSplitSource(null, ImmutableList.<ConnectorSplit>of());
         }
 
         ConnectorPartition partition = Iterables.getOnlyElement(partitions);
@@ -86,7 +85,7 @@ public class InformationSchemaSplitManager
 
         ConnectorSplit split = new InformationSchemaSplit(informationSchemaPartition.getTable(), filters.build(), localAddress);
 
-        return new FixedSplitSource(SystemTablesManager.CONNECTOR_ID, ImmutableList.of(split));
+        return new FixedSplitSource(null, ImmutableList.of(split));
     }
 
     public static class InformationSchemaPartition

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -56,7 +56,7 @@ public final class TaskTestUtils
     {
     }
 
-    public static final ScheduledSplit SPLIT = new ScheduledSplit(0, new Split("test", new TestingSplit()));
+    public static final ScheduledSplit SPLIT = new ScheduledSplit(0, new Split("test", TestingSplit.createLocalSplit()));
 
     public static final PlanNodeId TABLE_SCAN_NODE_ID = new PlanNodeId("tableScan");
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestingSplit.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestingSplit.java
@@ -23,12 +23,26 @@ import java.util.List;
 public class TestingSplit
         implements ConnectorSplit
 {
-    public TestingSplit()
+    private static HostAddress localHost = HostAddress.fromString("127.0.0.1");
+
+    public static TestingSplit createLocalSplit()
     {
+        return new TestingSplit(ImmutableList.of(localHost));
+    }
+
+    public static TestingSplit createEmptySplit()
+    {
+        return new TestingSplit(ImmutableList.<HostAddress>of());
     }
 
     public TestingSplit(@JsonProperty("dummy") int dummy)
     {
+        this.addresses = ImmutableList.of(localHost);
+    }
+
+    public TestingSplit(List<HostAddress> addresses)
+    {
+        this.addresses = addresses;
     }
 
     // we need a dummy property because Jackson refuses to serialize/deserialize an empty object
@@ -47,7 +61,7 @@ public class TestingSplit
     @Override
     public List<HostAddress> getAddresses()
     {
-        return ImmutableList.of(HostAddress.fromString("127.0.0.1"));
+        return addresses;
     }
 
     @Override
@@ -55,4 +69,6 @@ public class TestingSplit
     {
         return this;
     }
+
+    private List<HostAddress> addresses;
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -73,7 +73,7 @@ public class TestScanFilterAndProjectOperator
                 ImmutableList.<Type>of(VARCHAR));
 
         SourceOperator operator = factory.createOperator(driverContext);
-        operator.addSplit(new Split("test", new TestingSplit()));
+        operator.addSplit(new Split("test", TestingSplit.createLocalSplit()));
         operator.noMoreSplits();
 
         MaterializedResult expected = toMaterializedResult(driverContext.getSession(), ImmutableList.<Type>of(VARCHAR), ImmutableList.of(input));
@@ -106,7 +106,7 @@ public class TestScanFilterAndProjectOperator
                 ImmutableList.<Type>of(VARCHAR));
 
         SourceOperator operator = factory.createOperator(driverContext);
-        operator.addSplit(new Split("test", new TestingSplit()));
+        operator.addSplit(new Split("test", TestingSplit.createLocalSplit()));
         operator.noMoreSplits();
 
         MaterializedResult expected = toMaterializedResult(driverContext.getSession(), ImmutableList.<Type>of(VARCHAR), ImmutableList.of(input));


### PR DESCRIPTION
fix #1823: In distributed env, the queries on information schema tables must be performed on the coordinator despite of the configuration said 'no jobs on coordinator', since the coordinator is the only one that has the cache.
