### PR TITLE
More fixes for json parsing for non numeric numbers (nan and inf)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ArrayUnnester.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ArrayUnnester.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 
+import static com.facebook.presto.type.TypeJsonUtils.getDoubleValue;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ArrayUnnester
@@ -63,7 +64,7 @@ public class ArrayUnnester
                 elementType.writeLong(blockBuilder, jsonParser.getLongValue());
             }
             else if (elementType.getJavaType() == double.class) {
-                elementType.writeDouble(blockBuilder, jsonParser.getDoubleValue());
+                elementType.writeDouble(blockBuilder, getDoubleValue(jsonParser));
             }
             else if (elementType.getJavaType() == boolean.class) {
                 elementType.writeBoolean(blockBuilder, jsonParser.getBooleanValue());

--- a/presto-main/src/main/java/com/facebook/presto/operator/MapUnnester.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MapUnnester.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.type.TypeJsonUtils.getDoubleValue;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class MapUnnester
@@ -99,7 +100,7 @@ public class MapUnnester
                 valueType.writeLong(valueBlockBuilder, jsonParser.getLongValue());
             }
             else if (valueType.getJavaType() == double.class) {
-                valueType.writeDouble(valueBlockBuilder, jsonParser.getDoubleValue());
+                valueType.writeDouble(valueBlockBuilder, getDoubleValue(jsonParser));
             }
             else if (valueType.getJavaType() == boolean.class) {
                 valueType.writeBoolean(valueBlockBuilder, jsonParser.getBooleanValue());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonExtract.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonExtract.java
@@ -29,6 +29,7 @@ import io.airlift.slice.Slices;
 import java.io.IOException;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.type.TypeJsonUtils.getDoubleValue;
 import static com.fasterxml.jackson.core.JsonFactory.Feature.CANONICALIZE_FIELD_NAMES;
 import static com.fasterxml.jackson.core.JsonToken.END_ARRAY;
 import static com.fasterxml.jackson.core.JsonToken.END_OBJECT;
@@ -290,7 +291,7 @@ public final class JsonExtract
             if (!token.isScalarValue() || token == VALUE_NULL) {
                 return null;
             }
-            return jsonParser.getDoubleValue();
+            return getDoubleValue(jsonParser);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeJsonUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeJsonUtils.java
@@ -119,15 +119,7 @@ public final class TypeJsonUtils
             type.writeLong(blockBuilder, parser.getLongValue());
         }
         else if (type.getJavaType() == double.class) {
-            double value;
-            try {
-                value = parser.getDoubleValue();
-            }
-            catch (JsonParseException e) {
-                //handle non-numeric numbers (inf/nan)
-                value = Double.parseDouble(parser.getValueAsString());
-            }
-            type.writeDouble(blockBuilder, value);
+            type.writeDouble(blockBuilder, getDoubleValue(parser));
         }
         else if (type.getJavaType() == Slice.class) {
             type.writeSlice(blockBuilder, Slices.utf8Slice(parser.getValueAsString()));
@@ -210,5 +202,18 @@ public final class TypeJsonUtils
         else {
             throw new IllegalArgumentException("Unsupported type: " + type.getJavaType().getSimpleName());
         }
+    }
+
+    public static double getDoubleValue(JsonParser parser) throws IOException
+    {
+        double value;
+        try {
+            value = parser.getDoubleValue();
+        }
+        catch (JsonParseException e) {
+            //handle non-numeric numbers (inf/nan)
+            value = Double.parseDouble(parser.getValueAsString());
+        }
+        return value;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestUnnestOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestUnnestOperator.java
@@ -30,9 +30,13 @@ import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
 import static com.facebook.presto.operator.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.NaN;
+import static java.lang.Double.POSITIVE_INFINITY;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
 @Test(singleThreaded = true)
@@ -82,6 +86,30 @@ public class TestUnnestOperator
                 .row(2, 99, null, null)
                 .row(6, 7, 9, 10)
                 .row(6, 8, 11, 12)
+                .build();
+
+        assertOperatorEquals(operator, input, expected);
+    }
+
+    @Test
+    public void testUnnestNonNumericDoubles()
+            throws Exception
+    {
+        MetadataManager metadata = new MetadataManager();
+        Type arrayType = metadata.getType(parseTypeSignature("array<double>"));
+        Type mapType = metadata.getType(parseTypeSignature("map<bigint,double>"));
+
+        List<Page> input = rowPagesBuilder(BIGINT, arrayType, mapType)
+                .row(1, "[\"-Infinity\", \"Infinity\", \"NaN\"]", "{\"1\": \"-Infinity\", \"2\": \"Infinity\", \"3\": \"NaN\"}")
+                .build();
+
+        OperatorFactory operatorFactory = new UnnestOperator.UnnestOperatorFactory(0, ImmutableList.of(0), ImmutableList.<Type>of(BIGINT), ImmutableList.of(1, 2), ImmutableList.of(arrayType, mapType));
+        Operator operator = operatorFactory.createOperator(driverContext);
+
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, DOUBLE, BIGINT, DOUBLE)
+                .row(1, NEGATIVE_INFINITY, 1, NEGATIVE_INFINITY)
+                .row(1, POSITIVE_INFINITY, 2, POSITIVE_INFINITY)
+                .row(1, NaN, 3, NaN)
                 .build();
 
         assertOperatorEquals(operator, input, expected);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -31,6 +31,9 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.type.ArrayType.rawSlicesToStackRepresentation;
 import static com.facebook.presto.type.ArrayType.toStackRepresentation;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.NaN;
+import static java.lang.Double.POSITIVE_INFINITY;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -90,9 +93,9 @@ public class TestArrayOperators
         assertFunction("ARRAY [from_unixtime(1), from_unixtime(100)]", ImmutableList.of(
                 new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey()),
                 new SqlTimestamp(100_000, TEST_SESSION.getTimeZoneKey())));
-        assertFunction("ARRAY [sqrt(-1)]", ImmutableList.of(Double.NaN));
-        assertFunction("ARRAY [pow(infinity(), 2)]", ImmutableList.of(Double.POSITIVE_INFINITY));
-        assertFunction("ARRAY [pow(-infinity(), 1)]", ImmutableList.of(Double.NEGATIVE_INFINITY));
+        assertFunction("ARRAY [sqrt(-1)]", ImmutableList.of(NaN));
+        assertFunction("ARRAY [pow(infinity(), 2)]", ImmutableList.of(POSITIVE_INFINITY));
+        assertFunction("ARRAY [pow(-infinity(), 1)]", ImmutableList.of(NEGATIVE_INFINITY));
     }
 
     @Test
@@ -225,6 +228,9 @@ public class TestArrayOperators
         assertFunction("ARRAY ['puppies', 'kittens', NULL][3]", null);
         assertFunction("ARRAY [TRUE, FALSE][2]", false);
         assertFunction("ARRAY [from_unixtime(1), from_unixtime(100)][1]", new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey()));
+        assertFunction("ARRAY [infinity()][1]", POSITIVE_INFINITY);
+        assertFunction("ARRAY [-infinity()][1]", NEGATIVE_INFINITY);
+        assertFunction("ARRAY [sqrt(-1)][1]", NaN);
     }
 
     @Test


### PR DESCRIPTION
This PR adds more fixes for json parsing for double values, which is kind of scattered around the code base. An initial PR has already been merged for this issue (#1900).
