### PR TITLE
Support MySQL sub-table

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
@@ -13,7 +13,10 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import java.util.concurrent.TimeUnit;
+
 import io.airlift.configuration.Config;
+import io.airlift.units.Duration;
 
 import javax.validation.constraints.NotNull;
 
@@ -22,6 +25,12 @@ public class BaseJdbcConfig
     private String connectionUrl;
     private String connectionUser;
     private String connectionPassword;
+    public static final String DEFAULT_VALUE = "NA";
+    private Duration jdbcReloadSubtableInterval = new Duration(5, TimeUnit.MINUTES);
+    private String jdbcSubTableConnectionDB = DEFAULT_VALUE;
+    private String jdbcSubTableConnectionTable = DEFAULT_VALUE;
+    private boolean jdbcSubTableAllocator = false;
+    private boolean jdbcSubTableEnable = false;
 
     @NotNull
     public String getConnectionUrl()
@@ -57,6 +66,66 @@ public class BaseJdbcConfig
     public BaseJdbcConfig setConnectionPassword(String connectionPassword)
     {
         this.connectionPassword = connectionPassword;
+        return this;
+    }
+
+    public Duration getJdbcReloadSubtableInterval()
+    {
+        return jdbcReloadSubtableInterval;
+    }
+
+    @Config("jdbc-reload-subtable-interval")
+    public BaseJdbcConfig setJdbcReloadSubtableInterval(Duration jdbcReloadSubtableInterval)
+    {
+        this.jdbcReloadSubtableInterval = jdbcReloadSubtableInterval;
+        return this;
+    }
+
+    public String getJdbcSubTableConnectionDB()
+    {
+        return jdbcSubTableConnectionDB;
+    }
+
+    @Config("jdbc-sub-table-connection-db")
+    public BaseJdbcConfig setJdbcSubTableConnectionDB(String jdbcSubTableConnectionDB)
+    {
+        this.jdbcSubTableConnectionDB = jdbcSubTableConnectionDB;
+        return this;
+    }
+
+    public String getJdbcSubTableConnectionTable()
+    {
+        return jdbcSubTableConnectionTable;
+    }
+
+    @Config("jdbc-sub-table-connection-table")
+    public BaseJdbcConfig setJdbcSubTableConnectionTable(String jdbcSubTableConnectionTable)
+    {
+        this.jdbcSubTableConnectionTable = jdbcSubTableConnectionTable;
+        return this;
+    }
+
+    public boolean getJdbcSubTableAllocator()
+    {
+        return jdbcSubTableAllocator;
+    }
+
+    @Config("jdbc-sub-table-allocator-enable")
+    public BaseJdbcConfig setJdbcSubTableAllocator(boolean allocator)
+    {
+        this.jdbcSubTableAllocator = allocator;
+        return this;
+    }
+
+    public boolean getJdbcSubTableEnable()
+    {
+        return jdbcSubTableEnable;
+    }
+
+    @Config("jdbc-sub-table-enable")
+    public BaseJdbcConfig setJdbcSubTableEnable(boolean jdbcSubTableEnable)
+    {
+        this.jdbcSubTableEnable = jdbcSubTableEnable;
         return this;
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplit.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplit.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.TupleDomain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nullable;
@@ -39,16 +38,19 @@ public class JdbcSplit
     private final String connectionUrl;
     private final Map<String, String> connectionProperties;
     private final TupleDomain<ConnectorColumnHandle> tupleDomain;
+    private final List<HostAddress> addresses;
+    private final boolean remotelyAccessible;
 
     @JsonCreator
-    public JdbcSplit(
-            @JsonProperty("connectorId") String connectorId,
+    public JdbcSplit(@JsonProperty("connectorId") String connectorId,
             @JsonProperty("catalogName") @Nullable String catalogName,
             @JsonProperty("schemaName") @Nullable String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("connectionUrl") String connectionUrl,
             @JsonProperty("connectionProperties") Map<String, String> connectionProperties,
-            @JsonProperty("tupleDomain") TupleDomain<ConnectorColumnHandle> tupleDomain)
+            @JsonProperty("tupleDomain") TupleDomain<ConnectorColumnHandle> tupleDomain,
+            @JsonProperty("addresses") List<HostAddress> addresses,
+            @JsonProperty("remotelyAccessible") boolean remotelyAccessible)
     {
         this.connectorId = checkNotNull(connectorId, "connector id is null");
         this.catalogName = catalogName;
@@ -57,6 +59,8 @@ public class JdbcSplit
         this.connectionUrl = checkNotNull(connectionUrl, "connectionUrl is null");
         this.connectionProperties = ImmutableMap.copyOf(checkNotNull(connectionProperties, "connectionProperties is null"));
         this.tupleDomain = checkNotNull(tupleDomain, "tupleDomain is null");
+        this.remotelyAccessible = remotelyAccessible;
+        this.addresses = checkNotNull(addresses, "host addresses is null");
     }
 
     @JsonProperty
@@ -103,16 +107,18 @@ public class JdbcSplit
         return tupleDomain;
     }
 
+    @JsonProperty
     @Override
     public boolean isRemotelyAccessible()
     {
-        return true;
+        return remotelyAccessible;
     }
 
+    @JsonProperty
     @Override
     public List<HostAddress> getAddresses()
     {
-        return ImmutableList.of();
+        return addresses;
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/MySqlSubTableConfig.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/MySqlSubTableConfig.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+public class MySqlSubTableConfig
+{
+    private String catalogname;
+    private String schemaname;
+    private String tablename;
+    private String id;
+    private String basecatalog;
+    private String baseschema;
+    private String basetable;
+    private String connectionURL;
+    private String host;
+    private String remotelyaccessible;
+    public static final String COLUMN_NAME = "connectionurl,catalogname,schemaname,tablename,basecatalog,baseschema,basetable,host,remotelyaccessible,id";
+
+    public String getCatalogname()
+    {
+        return catalogname;
+    }
+
+    public void setCatalogname(String catalog)
+    {
+        this.catalogname = catalog;
+    }
+
+    public String getSchemaname()
+    {
+        return schemaname;
+    }
+
+    public void setSchemaname(String schema)
+    {
+        this.schemaname = schema;
+    }
+
+    public String getTablename()
+    {
+        return tablename;
+    }
+
+    public void setTablename(String table)
+    {
+        this.tablename = table;
+    }
+
+    public String getId()
+    {
+        return id;
+    }
+
+    public void setId(String id)
+    {
+        this.id = id;
+    }
+
+    public String getBasecatalog()
+    {
+        return basecatalog;
+    }
+
+    public void setBasecatalog(String basecatalog)
+    {
+        this.basecatalog = basecatalog;
+    }
+
+    public String getBaseschema()
+    {
+        return baseschema;
+    }
+
+    public void setBaseschema(String baseschema)
+    {
+        this.baseschema = baseschema;
+    }
+
+    public String getBasetable()
+    {
+        return basetable;
+    }
+
+    public void setBasetable(String basetable)
+    {
+        this.basetable = basetable;
+    }
+
+    public String getConnectionURL()
+    {
+        return connectionURL;
+    }
+
+    public void setConnectionURL(String connectionURL)
+    {
+        this.connectionURL = connectionURL;
+    }
+
+    public String getHost()
+    {
+        return host;
+    }
+
+    public void setHost(String host)
+    {
+        this.host = host;
+    }
+
+    public boolean getRemotelyaccessible()
+    {
+        if (remotelyaccessible == null || "".equals(remotelyaccessible)) {
+            return true;
+        }
+        else if ("Y".equals(remotelyaccessible)
+                || "y".equals(remotelyaccessible)) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+    public void setRemotelyaccessible(String remotelyaccessible)
+    {
+        this.remotelyaccessible = remotelyaccessible;
+    }
+}

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcHandleResolver.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcHandleResolver.java
@@ -13,10 +13,15 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import java.util.List;
+
 import com.facebook.presto.spi.ConnectorColumnHandle;
+import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TupleDomain;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.plugin.jdbc.TestingDatabase.CONNECTOR_ID;
@@ -49,6 +54,7 @@ public class TestJdbcHandleResolver
 
     private static JdbcSplit createSplit(String connectorId)
     {
-        return new JdbcSplit(connectorId, "catalog", "schema", "table", "connectionUrl", ImmutableMap.<String, String>of(), TupleDomain.<ConnectorColumnHandle>all());
+        List<HostAddress> addresss = ImmutableList.of();
+        return new JdbcSplit(connectorId, "catalog", "schema", "table", "connectionUrl", ImmutableMap.<String, String>of(), TupleDomain.<ConnectorColumnHandle>all(), addresss, true);
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcSplit.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcSplit.java
@@ -13,11 +13,16 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import java.util.List;
+
 import com.facebook.presto.spi.ConnectorColumnHandle;
+import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.TupleDomain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
 import io.airlift.json.JsonCodec;
+
 import org.testng.annotations.Test;
 
 import static io.airlift.json.JsonCodec.jsonCodec;
@@ -25,7 +30,8 @@ import static org.testng.Assert.assertEquals;
 
 public class TestJdbcSplit
 {
-    private final JdbcSplit split = new JdbcSplit("connectorId", "catalog", "schemaName", "tableName", "connectionUrl", ImmutableMap.<String, String>of(), TupleDomain.<ConnectorColumnHandle>all());
+    private List<HostAddress> addresss = ImmutableList.of();
+    private final JdbcSplit split = new JdbcSplit("connectorId", "catalog", "schemaName", "tableName", "connectionUrl", ImmutableMap.<String, String>of(), TupleDomain.<ConnectorColumnHandle>all(), addresss, true);
 
     @Test
     public void testAddresses()
@@ -34,7 +40,7 @@ public class TestJdbcSplit
         assertEquals(split.getAddresses(), ImmutableList.of());
         assertEquals(split.isRemotelyAccessible(), true);
 
-        JdbcSplit jdbcSplit = new JdbcSplit("connectorId", "catalog", "schemaName", "tableName", "connectionUrl", ImmutableMap.<String, String>of(), TupleDomain.<ConnectorColumnHandle>all());
+        JdbcSplit jdbcSplit = new JdbcSplit("connectorId", "catalog", "schemaName", "tableName", "connectionUrl", ImmutableMap.<String, String>of(), TupleDomain.<ConnectorColumnHandle>all(), addresss, true);
         assertEquals(jdbcSplit.getAddresses(), ImmutableList.of());
     }
 


### PR DESCRIPTION
 Need to depend on sub-table info. 
   The create table sql is : 
    CREATE TABLE table_route ( 
         id int(11) NOT NULL AUTO_INCREMENT, 
         catalogname varchar(50) DEFAULT NULL, 
         schemaname varchar(50) DEFAULT NULL, 
         tablename varchar(50) DEFAULT NULL, 
         basecatalog varchar(50) DEFAULT NULL, 
         baseschema varchar(50) DEFAULT NULL, 
         basetable varchar(50) DEFAULT NULL, 
         host varchar(100) DEFAULT NULL, 
         remotelyaccessible varchar(5) DEFAULT NULL, 
         connectionurl varchar(100) DEFAULT NULL, 
         PRIMARY KEY (id) 
    )

e.g. 
INSERT INTO table_route VALUES (1,'','employees','dept_emp','presto','employees','dept_emp','slave1:8190','N','jdbc:mysql://slave1:3306/');

Add some session properties in the BaseJdbcConfig.
   In the mysql connection properties follow like this:
   connector.name=mysql
   connection-url=jdbc:mysql://192.168.178.37:3306
   connection-user=root
   connection-password=root
   jdbc-reload-subtable-interval=5m
   jdbc-sub-table-connection-db=presto
   jdbc-sub-table-connection-table=table_route
   jdbc-sub-table-allocator-enable=true
   jdbc-sub-table-enable=true

The jdbc-sub-table-allocator-enable property set to false in workers
