### PR TITLE
Make Row type comparable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
@@ -159,6 +159,14 @@ public class FunctionListBuilder
         return this;
     }
 
+    public FunctionListBuilder functions(ParametricFunction ... parametricFunctions)
+    {
+        for (ParametricFunction parametricFunction : parametricFunctions) {
+            function(parametricFunction);
+        }
+        return this;
+    }
+
     public FunctionListBuilder function(ParametricFunction parametricFunction)
     {
         checkNotNull(parametricFunction, "parametricFunction is null");

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -144,6 +144,8 @@ import static com.facebook.presto.operator.scalar.MapSubscriptOperator.MAP_SUBSC
 import static com.facebook.presto.operator.scalar.MapToJsonCast.MAP_TO_JSON;
 import static com.facebook.presto.operator.scalar.MapKeys.MAP_KEYS;
 import static com.facebook.presto.operator.scalar.MapValues.MAP_VALUES;
+import static com.facebook.presto.operator.scalar.RowEqualOperator.ROW_EQUAL;
+import static com.facebook.presto.operator.scalar.RowNotEqualOperator.ROW_NOT_EQUAL;
 import static com.facebook.presto.operator.scalar.RowToJsonCast.ROW_TO_JSON;
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -275,23 +277,12 @@ public class FunctionRegistry
                 .scalar(ArrayFunctions.class)
                 .scalar(CombineHashFunction.class)
                 .scalar(JsonOperators.class)
-                .function(ARRAY_CONSTRUCTOR)
-                .function(ARRAY_SUBSCRIPT)
-                .function(ARRAY_CARDINALITY)
-                .function(ARRAY_CONCAT_FUNCTION)
-                .function(ARRAY_TO_ELEMENT_CONCAT_FUNCTION)
-                .function(ELEMENT_TO_ARRAY_CONCAT_FUNCTION)
-                .function(ARRAY_SORT_FUNCTION)
-                .function(MAP_CARDINALITY)
-                .function(MAP_SUBSCRIPT)
+                .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_CARDINALITY, ARRAY_CONCAT_FUNCTION, ARRAY_TO_ELEMENT_CONCAT_FUNCTION, ELEMENT_TO_ARRAY_CONCAT_FUNCTION, ARRAY_SORT_FUNCTION, ARRAY_TO_JSON)
+                .functions(MAP_CARDINALITY, MAP_SUBSCRIPT, MAP_TO_JSON, MAP_KEYS, MAP_VALUES)
                 .function(IDENTITY_CAST)
                 .function(MAX_BY)
                 .function(COUNT_COLUMN)
-                .function(ARRAY_TO_JSON)
-                .function(MAP_TO_JSON)
-                .function(MAP_KEYS)
-                .function(MAP_VALUES)
-                .function(ROW_TO_JSON);
+                .functions(ROW_TO_JSON, ROW_EQUAL, ROW_NOT_EQUAL);
 
         if (experimentalSyntaxEnabled) {
             builder.aggregate(ApproximateAverageAggregations.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
@@ -324,6 +324,11 @@ public final class Signature
         return new TypeParameter(name, false, false, variadicBound);
     }
 
+    public static TypeParameter comparableWithVariadicBound(String name, String variadicBound)
+    {
+        return new TypeParameter(name, true, false, variadicBound);
+    }
+
     public static TypeParameter typeParameter(String name)
     {
         return new TypeParameter(name, false, false, null);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
@@ -17,9 +17,6 @@ import com.facebook.presto.metadata.FunctionInfo;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,7 +24,6 @@ import com.fasterxml.jackson.databind.type.CollectionType;
 import com.google.common.collect.ImmutableList;
 import io.airlift.json.ObjectMapperProvider;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandle;
@@ -39,6 +35,7 @@ import java.util.Map;
 import static com.facebook.presto.metadata.Signature.orderableTypeParameter;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.type.ArrayType.toStackRepresentation;
+import static com.facebook.presto.type.TypeUtils.createBlock;
 import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -108,27 +105,5 @@ public final class ArraySortFunction
             }
         });
         return toStackRepresentation(elements);
-    }
-
-    private static Block createBlock(Type type, Object element)
-    {
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
-        Class<?> javaType = type.getJavaType();
-        if (javaType == boolean.class) {
-            type.writeBoolean(blockBuilder, (Boolean) element);
-        }
-        else if (javaType == long.class) {
-            type.writeLong(blockBuilder, ((Number) element).longValue());
-        }
-        else if (javaType == double.class) {
-            type.writeDouble(blockBuilder, (Double) element);
-        }
-        else if (javaType == Slice.class) {
-            type.writeSlice(blockBuilder, Slices.utf8Slice(element.toString()));
-        }
-        else {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Unexpected type %s", javaType.getName()));
-        }
-        return blockBuilder.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowEqualOperator.java
@@ -1,0 +1,69 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricOperator;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.FunctionRegistry.operatorInfo;
+import static com.facebook.presto.metadata.OperatorType.EQUAL;
+import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class RowEqualOperator extends ParametricOperator
+{
+    public static final RowEqualOperator ROW_EQUAL = new RowEqualOperator();
+    private static final TypeSignature RETURN_TYPE = parseTypeSignature(StandardTypes.BOOLEAN);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(RowEqualOperator.class, "equals", Type.class, Slice.class, Slice.class);
+
+    private RowEqualOperator()
+    {
+        super(EQUAL, ImmutableList.of(comparableWithVariadicBound("T", "row"), comparableWithVariadicBound("T", "row")), StandardTypes.BOOLEAN, ImmutableList.of("T", "T"));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "The EQUAL operator for the row type";
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        Type type = types.get("T");
+        TypeSignature typeSignature = type.getTypeSignature();
+        return operatorInfo(EQUAL, RETURN_TYPE, ImmutableList.of(typeSignature, typeSignature), METHOD_HANDLE.bindTo(type), false, ImmutableList.of(false, false));
+    }
+
+    public static boolean equals(Type rowType, Slice leftRow, Slice rightRow)
+    {
+        BlockBuilder leftBlockBuilder = rowType.createBlockBuilder(new BlockBuilderStatus());
+        BlockBuilder rightBlockBuilder = rowType.createBlockBuilder(new BlockBuilderStatus());
+        leftBlockBuilder.writeBytes(leftRow, 0, leftRow.length());
+        rightBlockBuilder.writeBytes(rightRow, 0, rightRow.length());
+        return rowType.equalTo(leftBlockBuilder.closeEntry().build(), 0, rightBlockBuilder.closeEntry().build(), 0);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowNotEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowNotEqualOperator.java
@@ -1,0 +1,63 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricOperator;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.FunctionRegistry.operatorInfo;
+import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class RowNotEqualOperator extends ParametricOperator
+{
+    public static final RowNotEqualOperator ROW_NOT_EQUAL = new RowNotEqualOperator();
+    private static final TypeSignature RETURN_TYPE = parseTypeSignature(StandardTypes.BOOLEAN);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(RowNotEqualOperator.class, "notEqual", Type.class, Slice.class, Slice.class);
+
+    private RowNotEqualOperator()
+    {
+        super(NOT_EQUAL, ImmutableList.of(comparableWithVariadicBound("T", "row"), comparableWithVariadicBound("T", "row")), StandardTypes.BOOLEAN, ImmutableList.of("T", "T"));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "The NOT_EQUAL operator for the row type";
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        Type type = types.get("T");
+        TypeSignature typeSignature = type.getTypeSignature();
+        return operatorInfo(NOT_EQUAL, RETURN_TYPE, ImmutableList.of(typeSignature, typeSignature), METHOD_HANDLE.bindTo(type), false, ImmutableList.of(false, false));
+    }
+
+    public static boolean notEqual(Type rowType, Slice leftRow, Slice rightRow)
+    {
+        return !RowEqualOperator.equals(rowType, leftRow, rightRow);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TestingRowConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TestingRowConstructor.java
@@ -49,6 +49,38 @@ public final class TestingRowConstructor
     }
 
     @ScalarFunction("test_row")
+    @SqlType("row<bigint,double,boolean,varchar,timestamp>('col0','col1','col2','col3','col4')")
+    public static Slice testRowBigintDoubleBooleanVarcharTimestamp(@Nullable @SqlType(StandardTypes.BIGINT) Long arg1, @Nullable @SqlType(StandardTypes.DOUBLE) Double arg2,
+                                                          @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg3, @Nullable @SqlType(StandardTypes.VARCHAR) Slice arg4,
+                                                          @Nullable @SqlType(StandardTypes.TIMESTAMP) Long arg5)
+    {
+        return toStackRepresentation(arg1, arg2, arg3, arg4, arg5);
+    }
+
+    @ScalarFunction("test_row")
+    @SqlType("row<HyperLogLog>('col0')")
+    public static Slice testRowHyperLogLog(@Nullable @SqlType(StandardTypes.HYPER_LOG_LOG) Slice arg1)
+    {
+        return toStackRepresentation(arg1);
+    }
+
+    @ScalarFunction("test_row")
+    @SqlType("row<double,row<timestamp with time zone,timestamp with time zone>('col0','col1')>('col2','col3')")
+    public static Slice testNestedRowsWithTimestampsWithTimeZones(@Nullable @SqlType(StandardTypes.DOUBLE) Double arg1,
+                                                                  @Nullable @SqlType("row<timestamp with time zone,timestamp with time zone>") Slice arg2)
+    {
+        return toStackRepresentation(arg1, arg2);
+    }
+
+    @ScalarFunction("test_row")
+    @SqlType("row<timestamp with time zone,timestamp with time zone>('col0','col1')")
+    public static Slice testRowTimestampsWithTimeZones(@Nullable @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) Long arg1,
+                                                                   @Nullable @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) Long arg2)
+    {
+        return toStackRepresentation(arg1, arg2);
+    }
+
+    @ScalarFunction("test_row")
     @SqlType("row<double,double>('col0','col1')")
     public static Slice testRowBigintBigint(@Nullable @SqlType(StandardTypes.DOUBLE) Double arg1, @Nullable @SqlType(StandardTypes.DOUBLE) Double arg2)
     {
@@ -67,6 +99,37 @@ public final class TestingRowConstructor
     public static Slice testRowBigintBigint(@Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg1, @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg2)
     {
         return toStackRepresentation(arg1, arg2);
+    }
+
+    @ScalarFunction("test_row")
+    @SqlType("row<boolean,boolean,boolean,boolean>('col0','col1','col2','col3')")
+    public static Slice testRowFourBooleans(@Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg1, @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg2,
+                                              @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg3, @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg4)
+    {
+        return toStackRepresentation(arg1, arg2, arg3, arg4);
+    }
+
+    @ScalarFunction("test_row")
+    @SqlType("row<boolean,array<bigint>>('col0','col1')")
+    public static Slice testRowBooleanArray(@Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg1, @Nullable @SqlType("array<bigint>") Slice arg2)
+    {
+        return toStackRepresentation(arg1, arg2);
+    }
+
+    @ScalarFunction("test_row")
+    @SqlType("row<boolean,array<bigint>,map<bigint,double>>('col0','col1','col2')")
+    public static Slice testRowBooleanArrayMap(@Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg1, @Nullable @SqlType("array<bigint>") Slice arg2,
+                                               @Nullable @SqlType("map<bigint,double>") Slice arg3)
+    {
+        return toStackRepresentation(arg1, arg2, arg3);
+    }
+
+    @ScalarFunction("test_row")
+    @SqlType("row<double,array<bigint>,row<bigint,double>>('col0','col1','col2')")
+    public static Slice testNestedRow(@Nullable @SqlType(StandardTypes.DOUBLE) Double arg1, @Nullable @SqlType("array<bigint>") Slice arg2,
+                                               @Nullable @SqlType("row<bigint,double>") Slice arg3)
+    {
+        return toStackRepresentation(arg1, arg2, arg3);
     }
 
     @ScalarFunction("test_row")

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -15,13 +15,16 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.metadata.FunctionListBuilder;
 import com.facebook.presto.operator.scalar.FunctionAssertions;
+import com.facebook.presto.operator.scalar.MapConstructor;
 import com.facebook.presto.operator.scalar.TestingRowConstructor;
 import com.facebook.presto.spi.type.SqlTimestamp;
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.metadata.FunctionRegistry.mangleFieldAccessor;
+import static org.testng.Assert.fail;
 
 public class TestRowOperators
 {
@@ -32,6 +35,7 @@ public class TestRowOperators
     {
         functionAssertions = new FunctionAssertions();
         functionAssertions.getMetadata().getFunctionRegistry().addFunctions(new FunctionListBuilder(functionAssertions.getMetadata().getTypeManager()).scalar(TestingRowConstructor.class).getFunctions());
+        functionAssertions.getMetadata().getFunctionRegistry().addFunctions(ImmutableList.of(new MapConstructor(2, new TypeRegistry())));
     }
     private void assertFunction(String projection, Object expected)
     {
@@ -59,5 +63,51 @@ public class TestRowOperators
         String mangledName2 = mangleFieldAccessor("col1");
         assertFunction('"' + mangledName1 + "\"(test_row(1, 2))", 1);
         assertFunction('"' + mangledName2 + "\"(test_row(1, 'kittens'))", "kittens");
+    }
+
+    @Test
+    public void testRowEquality()
+            throws Exception
+    {
+        assertFunction("test_row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10') = " +
+                "test_row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10')", true);
+        assertFunction("test_row(1.0, test_row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10')) =" +
+                "test_row(1.0, test_row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10'))", true);
+        assertFunction("test_row(1.0, 'kittens') = test_row(1.0, 'kittens')", true);
+        assertFunction("test_row(1, 2.0) = test_row(1, 2.0)", true);
+        assertFunction("test_row(TRUE, FALSE, TRUE, FALSE) = test_row(TRUE, FALSE, TRUE, FALSE)", true);
+        assertFunction("test_row(TRUE, FALSE, TRUE, FALSE) = test_row(TRUE, TRUE, TRUE, FALSE)", false);
+        assertFunction("test_row(1, 2.0, TRUE, 'kittens', from_unixtime(1)) = test_row(1, 2.0, TRUE, 'kittens', from_unixtime(1))", true);
+
+        assertFunction("test_row(1.0, test_row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10')) !=" +
+                "test_row(1.0, test_row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:11'))", true);
+        assertFunction("test_row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10') != " +
+                "test_row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:11')", true);
+        assertFunction("test_row(1.0, 'kittens') != test_row(1.0, 'kittens')", false);
+        assertFunction("test_row(1, 2.0) != test_row(1, 2.0)", false);
+        assertFunction("test_row(TRUE, FALSE, TRUE, FALSE) != test_row(TRUE, FALSE, TRUE, FALSE)", false);
+        assertFunction("test_row(TRUE, FALSE, TRUE, FALSE) != test_row(TRUE, TRUE, TRUE, FALSE)", true);
+        assertFunction("test_row(1, 2.0, TRUE, 'kittens', from_unixtime(1)) != test_row(1, 2.0, TRUE, 'puppies', from_unixtime(1))", true);
+
+        try {
+            assertFunction("test_row(cast(cast ('' as varbinary) as hyperloglog)) = test_row(cast(cast ('' as varbinary) as hyperloglog))", true);
+            fail("hyperloglog is not comparable");
+        }
+        catch (RuntimeException e) {
+            //Expected
+        }
+
+        //TODO uncomment these tests when ARRAY type is comparable
+//        assertFunction("test_row(TRUE, ARRAY [1]) = test_row(TRUE, ARRAY [1])", true);
+//        assertFunction("test_row(TRUE, ARRAY [1]) = test_row(TRUE, ARRAY [1,2])", false);
+//        assertFunction("test_row(TRUE, ARRAY [1], MAP(1, 2.0, 3, 4.0)) = test_row(TRUE, ARRAY [1,2], MAP(1, 2.0, 3, 4.0))", false);
+//        assertFunction("test_row(TRUE, ARRAY [1,2], MAP(1, 2.0, 3, 4.0)) = test_row(TRUE, ARRAY [1,2], MAP(1, 2.0, 3, 4.0))", true);
+//        assertFunction("test_row(1.0, ARRAY [1,2,3], test_row(2,2.0)) = test_row(1.0, ARRAY [1,2,3], test_row(2,2.0))", true);
+
+//        assertFunction("test_row(TRUE, ARRAY [1]) != test_row(TRUE, ARRAY [1])", false);
+//        assertFunction("test_row(TRUE, ARRAY [1]) != test_row(TRUE, ARRAY [1,2])", true);
+//        assertFunction("test_row(TRUE, ARRAY [1], MAP(1, 2.0, 3, 4.0)) != test_row(TRUE, ARRAY [1,2], MAP(1, 2.0, 3, 4.0))", true);
+//        assertFunction("test_row(TRUE, ARRAY [1,2], MAP(1, 2.0, 3, 4.0)) != test_row(TRUE, ARRAY [1,2], MAP(1, 2.0, 3, 4.0))", false);
+//        assertFunction("test_row(1.0, ARRAY [1,2,3], test_row(2,2.0)) != test_row(1.0, ARRAY [1,2,3], test_row(1,2.0))", true);
     }
 }


### PR DESCRIPTION
This PR addresses #1957 to make `row` type comparable and implements the `EQUAL` and `NOT_EQUAL` operators for the `row` type.
