### PR TITLE
Improve HttpRemoteTask update loop

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTask.java
@@ -571,6 +571,8 @@ public class HttpRemoteTask
         {
             try (SetThreadName ignored = new SetThreadName("UpdateResponseHandler-%s", taskId)) {
                 try {
+                    currentRequest = null;
+
                     requestSucceeded(value, sources);
                 }
                 finally {
@@ -584,6 +586,8 @@ public class HttpRemoteTask
         {
             try (SetThreadName ignored = new SetThreadName("UpdateResponseHandler-%s", taskId)) {
                 try {
+                    currentRequest = null;
+
                     // on failure assume we need to update again
                     needsUpdate.set(true);
 
@@ -758,7 +762,7 @@ public class HttpRemoteTask
             }
             catch (Throwable t) {
                 // this should never happen
-                callback.failed(t);
+                callback.fatal(t);
             }
         }
 


### PR DESCRIPTION
Treat more errors a fatal
Always clear currentRequest when request is complete
