### PR TITLE
Fix ArrayIndexOutOfBoundsException when parsing Hive timestamp column

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursor.java
@@ -399,7 +399,7 @@ class ColumnarBinaryHiveRecordCursor<K>
         else if (hiveTypes[column].equals(HIVE_TIMESTAMP)) {
             checkState(length >= 1, "Timestamp should be at least 1 byte");
             long seconds = TimestampWritable.getSeconds(bytes, start);
-            long nanos = TimestampWritable.getNanos(bytes, start + SIZE_OF_INT);
+            long nanos = (bytes[start] >> 7) != 0 ? TimestampWritable.getNanos(bytes, start + SIZE_OF_INT) : 0;
             longs[column] = (seconds * 1000) + (nanos / 1_000_000);
         }
         else if (hiveTypes[column].equals(HIVE_BYTE)) {


### PR DESCRIPTION
When parsing hive timestamp column, `TimestampWritable.getNanos` would cause problem (such as `ArrayIndexOutOfBoundsException`) if the nanos field is not available in byte array. `TimestampWritable` has detection logic to prevent this problem. So this PR uses `TimestampWritable` to parse the bytes of hive timestamp data. Since `TimestampWritable.set()` directly uses given byte data without copying it, the modifying should not add too much cost.
