### PR TITLE
Issue with json type comparability

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/JsonType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/JsonType.java
@@ -59,14 +59,6 @@ public class JsonType
     }
 
     @Override
-    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
-    {
-        int leftLength = leftBlock.getLength(leftPosition);
-        int rightLength = rightBlock.getLength(rightPosition);
-        return leftBlock.compareTo(leftPosition, 0, leftLength, rightBlock, rightPosition, 0, rightLength);
-    }
-
-    @Override
     public Object getObjectValue(ConnectorSession session, Block block, int position)
     {
         if (block.isNull(position)) {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestJsonType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestJsonType.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import static com.facebook.presto.type.JsonType.JSON;
+
+public class TestJsonType
+        extends AbstractTestType
+{
+    //FIXME although json type is backed by Slice, getObjectValue() call returns a String
+    public TestJsonType()
+    {
+        super(JSON, String.class, createTestBlock());
+    }
+
+    public static Block createTestBlock()
+    {
+        BlockBuilder blockBuilder = JSON.createBlockBuilder(new BlockBuilderStatus());
+        Slice slice = Slices.utf8Slice("{\"x\":1, \"y\":2}");
+        JSON.writeSlice(blockBuilder, slice);
+        return blockBuilder.build();
+    }
+
+    @Override
+    protected Object getGreaterValue(Object value)
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
Although json type returns true for `isComparable()` (#1857 is still open btw) it doesn't properly implement `hash()`/`equalTo()` methods. So #1855 still fails with the 0.84 release. In addition, json type is not ordered but it implements `compareTo()`. This PR implements the `hash()`/`equalTo()` methods and removes the `compareTo()` method.
