### PR TITLE
Implement json equality operators

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -43,6 +43,7 @@ import com.facebook.presto.operator.scalar.CombineHashFunction;
 import com.facebook.presto.operator.scalar.DateTimeFunctions;
 import com.facebook.presto.operator.scalar.HyperLogLogFunctions;
 import com.facebook.presto.operator.scalar.JsonFunctions;
+import com.facebook.presto.operator.scalar.JsonOperators;
 import com.facebook.presto.operator.scalar.MathFunctions;
 import com.facebook.presto.operator.scalar.RegexpFunctions;
 import com.facebook.presto.operator.scalar.StringFunctions;
@@ -273,6 +274,7 @@ public class FunctionRegistry
                 .scalar(LikeFunctions.class)
                 .scalar(ArrayFunctions.class)
                 .scalar(CombineHashFunction.class)
+                .scalar(JsonOperators.class)
                 .function(ARRAY_CONSTRUCTOR)
                 .function(ARRAY_SUBSCRIPT)
                 .function(ARRAY_CARDINALITY)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
@@ -62,13 +62,6 @@ public final class JsonFunctions
     }
 
     @ScalarOperator(OperatorType.CAST)
-    @SqlType(StandardTypes.JSON)
-    public static Slice castToJson(@SqlType(StandardTypes.VARCHAR) Slice slice)
-    {
-        return slice;
-    }
-
-    @ScalarOperator(OperatorType.CAST)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice castToVarchar(@SqlType(StandardTypes.JSON) Slice slice)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonOperators.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.metadata.OperatorType.EQUAL;
+import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.type.JsonType.JSON;
+
+public class JsonOperators
+{
+    private JsonOperators()
+    {
+    }
+
+    @ScalarOperator(EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean equals(@SqlType(StandardTypes.JSON) Slice leftJson, @SqlType(StandardTypes.JSON) Slice rightJson)
+    {
+        BlockBuilder leftBlockBuilder = JSON.createBlockBuilder(new BlockBuilderStatus());
+        BlockBuilder rightBlockBuilder = JSON.createBlockBuilder(new BlockBuilderStatus());
+        leftBlockBuilder.writeBytes(leftJson, 0, leftJson.length());
+        rightBlockBuilder.writeBytes(rightJson, 0, rightJson.length());
+        return JSON.equalTo(leftBlockBuilder.closeEntry().build(), 0, rightBlockBuilder.closeEntry().build(), 0);
+    }
+
+    @ScalarOperator(NOT_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean notEqual(@SqlType(StandardTypes.JSON) Slice leftJson, @SqlType(StandardTypes.JSON) Slice rightJson)
+    {
+        return !equals(leftJson, rightJson);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
@@ -13,10 +13,17 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.metadata.OperatorType;
 import com.facebook.presto.operator.scalar.ScalarOperator;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.StandardTypes;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airlift.json.ObjectMapperProvider;
+import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+
+import java.io.IOException;
 
 import static com.facebook.presto.metadata.OperatorType.BETWEEN;
 import static com.facebook.presto.metadata.OperatorType.CAST;
@@ -28,11 +35,14 @@ import static com.facebook.presto.metadata.OperatorType.LESS_THAN;
 import static com.facebook.presto.metadata.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class VarcharOperators
 {
+    private static final ObjectMapper SORTED_MAPPER = new ObjectMapperProvider().get().configure(ORDER_MAP_ENTRIES_BY_KEYS, true);
+
     private VarcharOperators()
     {
     }
@@ -156,6 +166,16 @@ public final class VarcharOperators
     public static Slice castToBinary(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
         return slice;
+    }
+
+    @ScalarOperator(OperatorType.CAST)
+    @SqlType(StandardTypes.JSON)
+    public static Slice castToJson(@SqlType(StandardTypes.VARCHAR) Slice slice) throws IOException
+    {
+        byte[] in = slice.getBytes();
+        SliceOutput dynamicSliceOutput = new DynamicSliceOutput(in.length);
+        SORTED_MAPPER.writeValue(dynamicSliceOutput, SORTED_MAPPER.readValue(in, Object.class));
+        return dynamicSliceOutput.slice();
     }
 
     @ScalarOperator(HASH_CODE)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonFunctions.java
@@ -237,6 +237,28 @@ public class TestJsonFunctions
         assertFunction(format("JSON_SIZE(CAST('%s' AS JSON), null)", "[1,2,3]"), null);
     }
 
+    @Test
+    public void testJsonEquality()
+    {
+        assertFunction("CAST('[1,2,3]' AS JSON) = CAST('[1,2,3]' AS JSON)", true);
+        assertFunction("CAST('{\"a\":1, \"b\":2}' AS JSON) = CAST('{\"b\":2, \"a\":1}' AS JSON)", true);
+        assertFunction("CAST('null' AS JSON) = CAST('null' AS JSON)", true);
+        assertFunction("CAST('true' AS JSON) = CAST('true' AS JSON)", true);
+        assertFunction("CAST('{\"x\":\"y\"}' AS JSON) = CAST('{\"x\":\"y\"}' AS JSON)", true);
+        assertFunction("CAST('[1,2,3]' AS JSON) = CAST('[2,3,1]' AS JSON)", false);
+        assertFunction("CAST('{\"p_1\": 1, \"p_2\":\"v_2\", \"p_3\":null, \"p_4\":true, \"p_5\": {\"p_1\":1}}' AS JSON) = " +
+                "CAST('{\"p_2\":\"v_2\", \"p_4\":true, \"p_1\": 1, \"p_3\":null, \"p_5\": {\"p_1\":1}}' AS JSON)", true);
+
+        assertFunction("CAST('[1,2,3]' AS JSON) != CAST('[1,2,3]' AS JSON)", false);
+        assertFunction("CAST('{\"a\":1, \"b\":2}' AS JSON) != CAST('{\"b\":2, \"a\":1}' AS JSON)", false);
+        assertFunction("CAST('null' AS JSON) != CAST('null' AS JSON)", false);
+        assertFunction("CAST('true' AS JSON) != CAST('true' AS JSON)", false);
+        assertFunction("CAST('{\"x\":\"y\"}' AS JSON) != CAST('{\"x\":\"y\"}' AS JSON)", false);
+        assertFunction("CAST('[1,2,3]' AS JSON) != CAST('[2,3,1]' AS JSON)", true);
+        assertFunction("CAST('{\"p_1\": 1, \"p_2\":\"v_2\", \"p_3\":null, \"p_4\":true, \"p_5\": {\"p_1\":1}}' AS JSON) != " +
+                "CAST('{\"p_2\":\"v_2\", \"p_4\":true, \"p_1\": 1, \"p_3\":null, \"p_5\": {\"p_1\":1}}' AS JSON)", false);
+    }
+
     private void assertFunction(String projection, Object expected)
     {
         functionAssertions.assertFunction(projection, expected);


### PR DESCRIPTION
This PR implements the equality operators for the json type and updates the current `equalTo()` implementation to use the Jackson library instead of just checking the equality of the backing slices. The reason is that the equality implementation of the Jackson library seems to be closer (not sure whether it implements the spec completely) to the IETF spec (see http://tools.ietf.org/html/draft-zyp-json-schema-04#section-3.6) than just checking the equality of the backing slices. For example, the below test fails with the current implementation while it is OK according to the spec && the new implementation:

```
assertFunction("CAST('{\"a\":1, \"b\":2}' AS JSON) = CAST('{\"b\":2, \"a\":1}' AS JSON)", true);
```

I guess with this PR #1857 is now addressed.
