### PR TITLE
name of WITH query needs to be normalized to be case-insensitive

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -428,12 +428,30 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testWithCaseInsensitiveResolution()
+            throws Exception
+    {
+        // TODO: verify output
+        analyze("WITH AB AS (SELECT * FROM t1) SELECT * FROM ab");
+    }
+
+    @Test
     public void testDuplicateWithQuery()
             throws Exception
     {
         assertFails(DUPLICATE_RELATION,
                 "WITH a AS (SELECT * FROM t1)," +
                         "     a AS (SELECT * FROM t1)" +
+                        "SELECT * FROM a");
+    }
+
+    @Test
+    public void testCaseInsensitiveDuplicateWithQuery()
+            throws Exception
+    {
+        assertFails(DUPLICATE_RELATION,
+                "WITH a AS (SELECT * FROM t1)," +
+                        "     A AS (SELECT * FROM t1)" +
                         "SELECT * FROM a");
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/WithQuery.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/WithQuery.java
@@ -29,7 +29,7 @@ public class WithQuery
 
     public WithQuery(String name, Query query, List<String> columnNames)
     {
-        this.name = checkNotNull(name, "name is null");
+        this.name = QualifiedName.of(checkNotNull(name, "name is null")).getParts().get(0);
         this.query = checkNotNull(query, "query is null");
         this.columnNames = columnNames;
     }


### PR DESCRIPTION
I found that this query fails:

```
with AB as (select 1) select * from AB
```

with this error message:

```
  Query 20141119_211516_04211_iz8i5 failed: Table td-presto.sfdb.ab does not exist
```

But this query succeeds:

```
with ab as (select 1) select * from ab
```

This pull-request fixes the issue by normalizing name of WITH query so that TupleAnalyzer.visitTable can find the name using a part of QualifiedName.
