### PR TITLE
Added map_agg aggregation function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -54,6 +54,10 @@ General Aggregate Functions
 
     Returns an arbitrary non-NULL value, if one exists.
 
+.. function:: map_agg(K,V) -> map(K,V)
+
+    Returns a map created from the input key/value pairs.
+
 Approximate Aggregate Functions
 -------------------------------
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -130,6 +130,7 @@ import static com.facebook.presto.operator.aggregation.ArbitraryAggregation.ARBI
 import static com.facebook.presto.operator.aggregation.CountColumn.COUNT_COLUMN;
 import static com.facebook.presto.operator.aggregation.MaxBy.MAX_BY;
 import static com.facebook.presto.operator.aggregation.MinBy.MIN_BY;
+import static com.facebook.presto.operator.aggregation.MapAggregation.MAP_AGG;
 import static com.facebook.presto.operator.scalar.ArrayCardinalityFunction.ARRAY_CARDINALITY;
 import static com.facebook.presto.operator.scalar.ArrayConcatFunction.ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayConstructor.ARRAY_CONSTRUCTOR;
@@ -288,7 +289,7 @@ public class FunctionRegistry
                 .scalar(JsonOperators.class)
                 .functions(ARRAY_HASH_CODE, ARRAY_EQUAL, ARRAY_NOT_EQUAL, ARRAY_LESS_THAN, ARRAY_LESS_THAN_OR_EQUAL, ARRAY_GREATER_THAN, ARRAY_GREATER_THAN_OR_EQUAL)
                 .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_CARDINALITY, ARRAY_CONCAT_FUNCTION, ARRAY_TO_ELEMENT_CONCAT_FUNCTION, ELEMENT_TO_ARRAY_CONCAT_FUNCTION, ARRAY_SORT_FUNCTION, ARRAY_TO_JSON)
-                .functions(MAP_CONSTRUCTOR, MAP_CARDINALITY, MAP_SUBSCRIPT, MAP_TO_JSON, MAP_KEYS, MAP_VALUES)
+                .functions(MAP_CONSTRUCTOR, MAP_CARDINALITY, MAP_SUBSCRIPT, MAP_TO_JSON, MAP_KEYS, MAP_VALUES, MAP_AGG)
                 .function(IDENTITY_CAST)
                 .function(ARBITRARY_AGGREGATION)
                 .function(LEAST)

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
@@ -189,7 +189,7 @@ public class GroupByHash
         return false;
     }
 
-    private int putIfAbsent(int position, Page page, Block[] hashBlocks)
+    public int putIfAbsent(int position, Page page, Block[] hashBlocks)
     {
         int rawHash = hashGenerator.hashPosition(position, page);
         int hashPosition = getHashPosition(rawHash, mask);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/KeyValuePairs.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/KeyValuePairs.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.GroupByHash;
+import com.facebook.presto.server.SliceSerializer;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.RowType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import io.airlift.json.ObjectMapperProvider;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.type.TypeJsonUtils.stackRepresentationToObject;
+import static com.facebook.presto.type.TypeUtils.getValue;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Map.Entry;
+
+public class KeyValuePairs
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(KeyValuePairs.class).instanceSize();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get().registerModule(new SimpleModule().addSerializer(Slice.class, new SliceSerializer()));
+    public static final int EXPECTED_HASH_SIZE = 10_000;
+
+    private GroupByHash keysHash;
+    private PageBuilder keyPageBuilder;
+    private Type keyType;
+
+    private PageBuilder valuePageBuilder;
+    private Type valueType;
+
+    public KeyValuePairs(Type keyType, Type valueType)
+    {
+        checkNotNull(keyType, "keyType is null");
+        checkNotNull(valueType, "valueType is null");
+
+        this.keyType = keyType;
+        this.valueType = valueType;
+        keysHash = new GroupByHash(ImmutableList.of(keyType), new int[] {0}, Optional.<Integer>absent(), EXPECTED_HASH_SIZE);
+        keyPageBuilder = new PageBuilder(ImmutableList.of(this.keyType));
+        valuePageBuilder = new PageBuilder(ImmutableList.of(this.valueType));
+    }
+
+    public KeyValuePairs(Slice serialized, Type keyType, Type valueType)
+    {
+        checkNotNull(serialized, "serialized is null");
+        checkNotNull(keyType, "keyType is null");
+        checkNotNull(valueType, "valueType is null");
+
+        this.keyType = keyType;
+        this.valueType = valueType;
+        keysHash = new GroupByHash(ImmutableList.of(keyType), new int[] {0}, Optional.<Integer>absent(), 10_000);
+        keyPageBuilder = new PageBuilder(ImmutableList.of(this.keyType));
+        valuePageBuilder = new PageBuilder(ImmutableList.of(this.valueType));
+        deserialize(serialized);
+    }
+
+    //once we move to Page for the native container type for Maps we will get rid of the auto-boxing/unboxing here
+    private void deserialize(Slice serialized)
+    {
+        Map<Object, Object> map = (Map) stackRepresentationToObject(null, serialized, new MapType(keyType, valueType));
+        map.entrySet().
+                stream().
+                map(this::createBlocks).
+                forEach(blocks -> add(blocks[0], blocks[1], 0));
+    }
+
+    //once we move to Page for the native container type for Maps we will get rid of the auto-boxing/unboxing here
+    public Slice serialize()
+    {
+        Map newMap = new LinkedHashMap<>();
+        Block values = valuePageBuilder.getBlockBuilder(0).build();
+        Block keys = keyPageBuilder.getBlockBuilder(0).build();
+        IntStream.range(0, keys.getPositionCount()).
+                mapToObj(position -> new Object[] { getValue(keys, keyType, position), getValue(values, valueType, position) }).
+                forEach(x -> newMap.put(x[0], x[1]));
+        return MapType.toStackRepresentation(newMap);
+    }
+
+    public long estimatedInMemorySize()
+    {
+        return INSTANCE_SIZE + keyPageBuilder.getSizeInBytes() + valuePageBuilder.getSizeInBytes();
+    }
+
+    public void add(Block key, Block value, int position)
+    {
+        Page page = new Page(key);
+        if (!keysHash.contains(position, page)) {
+            int groupId = keysHash.putIfAbsent(position, page, new Block[] { key });
+            keysHash.appendValuesTo(groupId, keyPageBuilder, 0); //TODO outputChannelOffset??
+            if (value.isNull(position)) {
+                valuePageBuilder.getBlockBuilder(0).appendNull();
+            }
+            else {
+                valueType.appendTo(value, position, valuePageBuilder.getBlockBuilder(0)); //TODO outputChannelOffset??
+            }
+        }
+    }
+
+    private Block[] createBlocks(Entry entry)
+    {
+        return new Block[] { createBlock(entry.getKey(), keyType), createBlock(entry.getValue(), valueType) };
+    }
+
+    private Block createBlock(Object obj, Type type)
+    {
+        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
+        try {
+            if (obj == null) {
+                return blockBuilder.appendNull().build();
+            }
+            else if (type.getJavaType() == double.class) {
+                type.writeDouble(blockBuilder, ((Number) obj).doubleValue());
+            }
+            else if (type.getJavaType() == long.class) {
+                type.writeLong(blockBuilder, ((Number) obj).longValue());
+            }
+            else if (type.getJavaType() == Slice.class) {
+                //TODO is there a simpler way to handle these types?
+                if (type instanceof VarcharType) {
+                    type.writeSlice(blockBuilder, Slices.utf8Slice((String) obj));
+                }
+                else if (type instanceof ArrayType || type instanceof MapType || type instanceof RowType) {
+                    type.writeSlice(blockBuilder, Slices.utf8Slice(OBJECT_MAPPER.writeValueAsString(obj)));
+                }
+                else {
+                    type.writeSlice(blockBuilder, (Slice) obj);
+                }
+            }
+            else if (type.getJavaType() == boolean.class) {
+                type.writeBoolean(blockBuilder, (Boolean) obj);
+            }
+            else {
+                throw new IllegalArgumentException("Unsupported type: " + type.getJavaType().getSimpleName());
+            }
+        }
+        catch (IOException ioe) {
+            Throwables.propagate(ioe);
+        }
+
+        return blockBuilder.build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregation.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.byteCode.DynamicClassLoader;
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.ParametricAggregation;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.aggregation.state.KeyValuePairsStateFactory;
+import com.facebook.presto.operator.aggregation.state.KeyValuePairStateSerializer;
+import com.facebook.presto.operator.aggregation.state.KeyValuePairsState;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.MapType;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
+import static com.facebook.presto.metadata.Signature.typeParameter;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.NULLABLE_INPUT_CHANNEL;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.util.Reflection.method;
+
+public class MapAggregation
+        extends ParametricAggregation
+{
+    public static final MapAggregation MAP_AGG = new MapAggregation();
+    public static final String NAME = "map_agg";
+    private static final Method OUTPUT_FUNCTION = method(MapAggregation.class, "output", KeyValuePairsState.class, BlockBuilder.class);
+    private static final Method INPUT_FUNCTION = method(MapAggregation.class, "input", KeyValuePairsState.class, Block.class, Block.class, int.class);
+    private static final Method COMBINE_FUNCTION = method(MapAggregation.class, "combine", KeyValuePairsState.class, KeyValuePairsState.class);
+
+    private static final Signature SIGNATURE = new Signature(NAME, ImmutableList.of(comparableTypeParameter("K"), typeParameter("V")),
+                                                                   "map<K,V>", ImmutableList.of("K", "V"), false, false);
+
+    @Override
+    public Signature getSignature()
+    {
+        return SIGNATURE;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Aggregates all the rows (key/value pairs) into a single map";
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    {
+        Type keyType = types.get("K");
+        Type valueType = types.get("V");
+        Signature signature = new Signature(NAME, new MapType(keyType, valueType).getTypeSignature(), keyType.getTypeSignature(), valueType.getTypeSignature());
+        InternalAggregationFunction aggregation = generateAggregation(keyType, valueType);
+        return new FunctionInfo(signature, getDescription(), aggregation.getIntermediateType().getTypeSignature(), aggregation, false);
+    }
+
+    private static InternalAggregationFunction generateAggregation(Type keyType, Type valueType)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(MapAggregation.class.getClassLoader());
+        List<Type> inputTypes = ImmutableList.of(keyType, valueType);
+        Type outputType = new MapType(keyType, valueType);
+        KeyValuePairStateSerializer stateSerializer = new KeyValuePairStateSerializer();
+        Type intermediateType = stateSerializer.getSerializedType();
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, outputType, inputTypes),
+                createInputParameterMetadata(keyType, valueType),
+                INPUT_FUNCTION,
+                null,
+                null,
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION,
+                KeyValuePairsState.class,
+                stateSerializer,
+                new KeyValuePairsStateFactory(keyType, valueType),
+                outputType,
+                false);
+
+        GenericAccumulatorFactoryBinder factory = new AccumulatorCompiler().generateAccumulatorFactoryBinder(metadata, classLoader);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, false, factory);
+    }
+
+    private static List<ParameterMetadata> createInputParameterMetadata(Type keyType, Type valueType)
+    {
+        return ImmutableList.of(new ParameterMetadata(STATE),
+                                new ParameterMetadata(INPUT_CHANNEL, keyType),
+                                new ParameterMetadata(NULLABLE_INPUT_CHANNEL, valueType),
+                                new ParameterMetadata(BLOCK_INDEX));
+    }
+
+    public static void input(KeyValuePairsState state, Block key, Block value, int position)
+    {
+        KeyValuePairs pairs = state.get();
+        if (pairs == null) {
+            pairs = new KeyValuePairs(state.getKeyType(), state.getValueType());
+            state.set(pairs);
+        }
+
+        pairs.add(key, value, position);
+    }
+
+    public static void combine(KeyValuePairsState state, KeyValuePairsState otherState)
+    {
+        KeyValuePairs s1 = state.get();
+        KeyValuePairs s2 = otherState.get();
+
+        if (s1 != null) {
+            otherState.set(s1);
+        }
+        else {
+            state.set(s2);
+        }
+    }
+
+    public static void output(KeyValuePairsState state, BlockBuilder out)
+    {
+        final KeyValuePairs pairs = state.get();
+        if (pairs == null) {
+            out.appendNull();
+        }
+        else {
+            Slice slice = pairs.serialize();
+            out.writeBytes(slice, 0, slice.length());
+            out.closeEntry();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/KeyValuePairStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/KeyValuePairStateSerializer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.operator.aggregation.KeyValuePairs;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+
+public class KeyValuePairStateSerializer
+        implements AccumulatorStateSerializer<KeyValuePairsState>
+{
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(KeyValuePairsState state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            VARBINARY.writeSlice(out, state.get().serialize());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, KeyValuePairsState state)
+    {
+        if (!block.isNull(index)) {
+            state.set(new KeyValuePairs(VARBINARY.getSlice(block, index), state.getKeyType(), state.getValueType()));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/KeyValuePairsState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/KeyValuePairsState.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.operator.aggregation.KeyValuePairs;
+import com.facebook.presto.spi.type.Type;
+
+@AccumulatorStateMetadata(stateFactoryClass = KeyValuePairsStateFactory.class, stateSerializerClass = KeyValuePairStateSerializer.class)
+public interface KeyValuePairsState
+    extends AccumulatorState
+{
+    KeyValuePairs get();
+    void set(KeyValuePairs value);
+
+    Type getKeyType();
+    Type getValueType();
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/KeyValuePairsStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/KeyValuePairsStateFactory.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.operator.aggregation.KeyValuePairs;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.util.array.ObjectBigArray;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class KeyValuePairsStateFactory
+        implements AccumulatorStateFactory<KeyValuePairsState>
+{
+    private final Type keyType;
+    private final Type valueType;
+
+    public KeyValuePairsStateFactory(Type keyType, Type valueType)
+    {
+        this.keyType = keyType;
+        this.valueType = valueType;
+    }
+
+    @Override
+    public KeyValuePairsState createSingleState()
+    {
+        return new SingleState(keyType, valueType);
+    }
+
+    @Override
+    public Class<? extends KeyValuePairsState> getSingleStateClass()
+    {
+        return SingleState.class;
+    }
+
+    @Override
+    public KeyValuePairsState createGroupedState()
+    {
+        return new GroupedState(keyType, valueType);
+    }
+
+    @Override
+    public Class<? extends KeyValuePairsState> getGroupedStateClass()
+    {
+        return GroupedState.class;
+    }
+
+    public static class GroupedState
+            extends AbstractGroupedAccumulatorState
+            implements KeyValuePairsState
+    {
+        private final Type keyType;
+        private final Type valueType;
+        private final ObjectBigArray<KeyValuePairs> pairs = new ObjectBigArray<>();
+        private long size;
+
+        public GroupedState(Type keyType, Type valueType)
+        {
+            this.keyType = keyType;
+            this.valueType = valueType;
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            pairs.ensureCapacity(size);
+        }
+
+        @Override
+        public KeyValuePairs get()
+        {
+            return pairs.get(getGroupId());
+        }
+
+        @Override
+        public void set(KeyValuePairs value)
+        {
+            checkNotNull(value, "value is null");
+
+            KeyValuePairs previous = get();
+            if (previous != null) {
+                size -= previous.estimatedInMemorySize();
+            }
+
+            pairs.set(getGroupId(), value);
+            size += value.estimatedInMemorySize();
+        }
+
+        @Override
+        public Type getKeyType()
+        {
+            return keyType;
+        }
+
+        @Override
+        public Type getValueType()
+        {
+            return valueType;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + pairs.sizeOf();
+        }
+    }
+
+    public static class SingleState
+            implements KeyValuePairsState
+    {
+        private final Type keyType;
+        private final Type valueType;
+        private KeyValuePairs pair;
+
+        public SingleState(Type keyType, Type valueType)
+        {
+            this.keyType = keyType;
+            this.valueType = valueType;
+        }
+
+        @Override
+        public KeyValuePairs get()
+        {
+            return pair;
+        }
+
+        @Override
+        public void set(KeyValuePairs value)
+        {
+            pair = value;
+        }
+
+        @Override
+        public Type getKeyType()
+        {
+            return keyType;
+        }
+
+        @Override
+        public Type getValueType()
+        {
+            return valueType;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            if (pair == null) {
+                return 0;
+            }
+            return pair.estimatedInMemorySize();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/MapParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/MapParametricType.java
@@ -15,6 +15,7 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
@@ -34,7 +35,8 @@ public final class MapParametricType
 {
     public static final MapParametricType MAP = new MapParametricType();
     // TODO: support types that don't use == for comparison of the bits in their stack type
-    private static final Set<Type> SUPPORTED_KEY_TYPES = ImmutableSet.<Type>of(VARCHAR, VARBINARY, BIGINT, DOUBLE, BOOLEAN, DATE, TIMESTAMP);
+    @VisibleForTesting
+    public static final Set<Type> SUPPORTED_KEY_TYPES = ImmutableSet.<Type>of(VARCHAR, VARBINARY, BIGINT, DOUBLE, BOOLEAN, DATE, TIMESTAMP);
 
     private MapParametricType()
     {

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
 
 import java.util.Arrays;
 import java.util.List;
@@ -113,5 +114,28 @@ public final class TypeUtils
         }
         blocks[page.getChannelCount()] = getHashBlock(hashTypes.build(), hashBlocks);
         return new Page(blocks);
+    }
+
+    public static Object getValue(Block input, Type type, int position)
+    {
+        if (input.isNull(position)) {
+            return null;
+        }
+
+        if (type.getJavaType() == long.class) {
+            return type.getLong(input, position);
+        }
+        else if (type.getJavaType() == double.class) {
+            return type.getDouble(input, position);
+        }
+        else if (type.getJavaType() == Slice.class) {
+            return type.getObjectValue(null, input, position);
+        }
+        else if (type.getJavaType() == boolean.class) {
+            return type.getBoolean(input, position);
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported type: " + type.getJavaType().getSimpleName());
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMapAggAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMapAggAggregation.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.scalar.TestingRowConstructor;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.RowType;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.operator.aggregation.MapAggregation.NAME;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.type.ArrayType.toStackRepresentation;
+import static com.facebook.presto.type.MapParametricType.SUPPORTED_KEY_TYPES;
+import static org.testng.Assert.assertNotNull;
+
+public class TestMapAggAggregation
+{
+    private static final MetadataManager metadata = new MetadataManager();
+
+    @Test
+    public void testAllRegistered()
+    {
+        Set<Type> comparableTypes = FluentIterable.from(SUPPORTED_KEY_TYPES).filter(input -> input.isComparable()).toSet();
+
+        for (Type keyType : comparableTypes) {
+            for (Type valueType : metadata.getTypeManager().getTypes()) {
+                assertNotNull(metadata.getExactFunction(new Signature(NAME, new MapType(keyType, valueType).getTypeSignature(), keyType.getTypeSignature(), valueType.getTypeSignature())));
+            }
+        }
+    }
+
+    @Test
+    public void testDuplicateKeysValues()
+            throws Exception
+    {
+        MapType mapType = new MapType(DOUBLE, VARCHAR);
+        InternalAggregationFunction aggFunc = metadata.getExactFunction(new Signature(NAME, mapType.getTypeSignature().toString(), StandardTypes.DOUBLE, StandardTypes.VARCHAR)).getAggregationFunction();
+        assertAggregation(
+                aggFunc,
+                1.0,
+                ImmutableMap.of(1.0, "a"),
+                new Page(createDoublesBlock(1.0, 1.0, 1.0), createStringsBlock("a", "b", "c")));
+
+        mapType = new MapType(DOUBLE, BIGINT);
+        aggFunc = metadata.getExactFunction(new Signature(NAME, mapType.getTypeSignature().toString(), StandardTypes.DOUBLE, StandardTypes.BIGINT)).getAggregationFunction();
+        assertAggregation(
+                aggFunc,
+                1.0,
+                ImmutableMap.of(1.0, 99L, 2.0, 99L, 3.0, 99L),
+                new Page(createDoublesBlock(1.0, 2.0, 3.0), createLongsBlock(99L, 99L, 99L)));
+    }
+
+    @Test
+    public void testSimpleMaps()
+            throws Exception
+    {
+        MapType mapType = new MapType(DOUBLE, VARCHAR);
+        InternalAggregationFunction aggFunc = metadata.getExactFunction(new Signature(NAME, mapType.getTypeSignature().toString(), StandardTypes.DOUBLE, StandardTypes.VARCHAR)).getAggregationFunction();
+        assertAggregation(
+                aggFunc,
+                1.0,
+                ImmutableMap.of(1.0, "a", 2.0, "b", 3.0, "c"),
+                new Page(createDoublesBlock(1.0, 2.0, 3.0), createStringsBlock("a", "b", "c")));
+
+        mapType = new MapType(DOUBLE, BIGINT);
+        aggFunc = metadata.getExactFunction(new Signature(NAME, mapType.getTypeSignature().toString(), StandardTypes.DOUBLE, StandardTypes.BIGINT)).getAggregationFunction();
+        assertAggregation(
+                aggFunc,
+                1.0,
+                ImmutableMap.of(1.0, 3L, 2.0, 2L, 3.0, 1L),
+                new Page(createDoublesBlock(1.0, 2.0, 3.0), createLongsBlock(3L, 2L, 1L)));
+
+        mapType = new MapType(DOUBLE, BOOLEAN);
+        aggFunc = metadata.getExactFunction(new Signature(NAME, mapType.getTypeSignature().toString(), StandardTypes.DOUBLE, StandardTypes.BOOLEAN)).getAggregationFunction();
+        assertAggregation(
+                aggFunc,
+                1.0,
+                ImmutableMap.of(1.0, true, 2.0, false, 3.0, false),
+                new Page(createDoublesBlock(1.0, 2.0, 3.0), createBooleansBlock(true, false, false)));
+    }
+
+    @Test
+    public void testNull()
+            throws Exception
+    {
+        InternalAggregationFunction doubleDouble = metadata.getExactFunction(new Signature(NAME, new MapType(DOUBLE, DOUBLE).getTypeSignature().toString(), StandardTypes.DOUBLE, StandardTypes.DOUBLE)).getAggregationFunction();
+        assertAggregation(
+                doubleDouble,
+                1.0,
+                ImmutableMap.of(1.0, 2.0),
+                new Page(createDoublesBlock(1.0, null, null), createDoublesBlock(2.0, 3.0, 4.0)));
+
+        assertAggregation(
+                doubleDouble,
+                1.0,
+                null,
+                new Page(createDoublesBlock(null, null, null), createDoublesBlock(2.0, 3.0, 4.0)));
+
+        Map expected = new LinkedHashMap();
+        expected.put(1.0, null);
+        expected.put(2.0, null);
+        expected.put(3.0, null);
+        assertAggregation(
+                doubleDouble,
+                1.0,
+                expected,
+                new Page(createDoublesBlock(1.0, 2.0, 3.0), createDoublesBlock(null, null, null)));
+    }
+
+    @Test
+    public void testDoubleArrayMap()
+            throws Exception
+    {
+        ArrayType arrayType = new ArrayType(VARCHAR);
+        MapType mapType = new MapType(DOUBLE, arrayType);
+        InternalAggregationFunction aggFunc = metadata.getExactFunction(new Signature(NAME,
+                                                                                    mapType.getTypeSignature().toString(),
+                                                                                    StandardTypes.DOUBLE,
+                                                                                    arrayType.getTypeSignature().toString())).getAggregationFunction();
+
+        PageBuilder builder = new PageBuilder(ImmutableList.of(DOUBLE, arrayType));
+
+        DOUBLE.writeDouble(builder.getBlockBuilder(0), 1.0);
+        arrayType.writeSlice(builder.getBlockBuilder(1), toStackRepresentation(ImmutableList.of("a", "b")));
+
+        DOUBLE.writeDouble(builder.getBlockBuilder(0), 2.0);
+        arrayType.writeSlice(builder.getBlockBuilder(1), toStackRepresentation(ImmutableList.of("c", "d")));
+
+        DOUBLE.writeDouble(builder.getBlockBuilder(0), 3.0);
+        arrayType.writeSlice(builder.getBlockBuilder(1), toStackRepresentation(ImmutableList.of("e", "f")));
+
+        assertAggregation(
+                aggFunc,
+                1.0,
+                ImmutableMap.of(1.0, ImmutableList.of("a", "b"),
+                        2.0, ImmutableList.of("c", "d"),
+                        3.0, ImmutableList.of("e", "f")),
+                builder.build());
+    }
+
+    @Test
+    public void testDoubleMapMap()
+            throws Exception
+    {
+        MapType innerMapType = new MapType(VARCHAR, VARCHAR);
+        MapType mapType = new MapType(DOUBLE, innerMapType);
+        InternalAggregationFunction aggFunc = metadata.getExactFunction(new Signature(NAME,
+                mapType.getTypeSignature().toString(),
+                StandardTypes.DOUBLE,
+                innerMapType.getTypeSignature().toString())).getAggregationFunction();
+
+        PageBuilder builder = new PageBuilder(ImmutableList.of(DOUBLE, innerMapType));
+
+        DOUBLE.writeDouble(builder.getBlockBuilder(0), 1.0);
+        innerMapType.writeSlice(builder.getBlockBuilder(1), MapType.toStackRepresentation(ImmutableMap.of("a", "b")));
+
+        DOUBLE.writeDouble(builder.getBlockBuilder(0), 2.0);
+        innerMapType.writeSlice(builder.getBlockBuilder(1), MapType.toStackRepresentation(ImmutableMap.of("c", "d")));
+
+        DOUBLE.writeDouble(builder.getBlockBuilder(0), 3.0);
+        innerMapType.writeSlice(builder.getBlockBuilder(1), MapType.toStackRepresentation(ImmutableMap.of("e", "f")));
+
+        assertAggregation(
+                aggFunc,
+                1.0,
+                ImmutableMap.of(1.0, ImmutableMap.of("a", "b"),
+                        2.0, ImmutableMap.of("c", "d"),
+                        3.0, ImmutableMap.of("e", "f")),
+                builder.build());
+    }
+
+    @Test
+    public void testDoubleRowMap()
+            throws Exception
+    {
+        RowType innerRowType = new RowType(ImmutableList.of(BIGINT, DOUBLE), ImmutableList.of("f1", "f2"));
+        MapType mapType = new MapType(DOUBLE, innerRowType);
+        InternalAggregationFunction aggFunc = metadata.getExactFunction(new Signature(NAME,
+                mapType.getTypeSignature().toString(),
+                StandardTypes.DOUBLE,
+                innerRowType.getTypeSignature().toString())).getAggregationFunction();
+
+        PageBuilder builder = new PageBuilder(ImmutableList.of(DOUBLE, innerRowType));
+
+        DOUBLE.writeDouble(builder.getBlockBuilder(0), 1.0);
+        innerRowType.writeSlice(builder.getBlockBuilder(1), TestingRowConstructor.testRowBigintBigint(1L, 1.0));
+
+        DOUBLE.writeDouble(builder.getBlockBuilder(0), 2.0);
+        innerRowType.writeSlice(builder.getBlockBuilder(1), TestingRowConstructor.testRowBigintBigint(2L, 2.0));
+
+        DOUBLE.writeDouble(builder.getBlockBuilder(0), 3.0);
+        innerRowType.writeSlice(builder.getBlockBuilder(1), TestingRowConstructor.testRowBigintBigint(3L, 3.0));
+
+        assertAggregation(
+                aggFunc,
+                1.0,
+                ImmutableMap.of(1.0, ImmutableList.of(1L, 1.0),
+                        2.0, ImmutableList.of(2L, 2.0),
+                        3.0, ImmutableList.of(3L, 3.0)),
+                builder.build());
+    }
+}


### PR DESCRIPTION
This PR implements the `map_agg` function (#2014) to aggregate key/value pairs into a single map.
