### PR TITLE
Minor cleanup of Least

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/Signatures.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/Signatures.java
@@ -112,11 +112,6 @@ public final class Signatures
         return internalFunction(ARRAY_CONSTRUCTOR, returnType, argumentTypes);
     }
 
-    public static Signature leastSignature(TypeSignature returnType, List<TypeSignature> argumentTypes)
-    {
-        return internalFunction("LEAST", returnType, argumentTypes);
-    }
-
     public static Signature comparisonExpressionSignature(ComparisonExpression.Type expressionType, Type leftType, Type rightType)
     {
         for (OperatorType operatorType : OperatorType.values()) {


### PR DESCRIPTION
Remove custom method in Signatures to create a specialized signature for least.
That's not necessary outside of the Least class and it's an implementation detail.
