### PR TITLE
Fix excessive garbage creation

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcCorruptionException.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcCorruptionException.java
@@ -13,8 +13,6 @@
  */
 package com.facebook.presto.orc;
 
-import org.jetbrains.annotations.Contract;
-
 import java.io.IOException;
 
 import static java.lang.String.format;
@@ -22,13 +20,9 @@ import static java.lang.String.format;
 public class OrcCorruptionException
         extends IOException
 {
-    @Contract("false, _, _ -> fail")
-    public static void verifyFormat(boolean test, String messageFormat, Object... args)
-            throws OrcCorruptionException
+    public OrcCorruptionException(String message)
     {
-        if (!test) {
-            throw new OrcCorruptionException(messageFormat, args);
-        }
+        super(message);
     }
 
     public OrcCorruptionException(String messageFormat, Object... args)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/json/BooleanJsonReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/json/BooleanJsonReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.json;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -24,7 +25,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -55,7 +55,9 @@ public class BooleanJsonReader
             return;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         generator.writeBoolean(dataStream.nextBit());
     }
@@ -68,7 +70,9 @@ public class BooleanJsonReader
             return null;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         return String.valueOf(dataStream.nextBit());
     }
@@ -86,7 +90,9 @@ public class BooleanJsonReader
             return;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         // skip non-null values
         dataStream.skip(skipSize);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/json/ByteJsonReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/json/ByteJsonReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.json;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -25,7 +26,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -56,7 +56,9 @@ public class ByteJsonReader
             return;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         generator.writeNumber(dataStream.next());
     }
@@ -69,7 +71,9 @@ public class ByteJsonReader
             return null;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         return String.valueOf(dataStream.next());
     }
@@ -87,7 +91,9 @@ public class ByteJsonReader
             return;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         // skip non-null values
         dataStream.skip(skipSize);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/json/DateJsonReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/json/DateJsonReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.json;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -26,7 +27,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -59,7 +59,9 @@ public class DateJsonReader
             return;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         long millis = dataStream.next() * MILLIS_IN_DAY;
         generator.writeNumber(millis);
@@ -73,7 +75,9 @@ public class DateJsonReader
             return null;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         long millis = dataStream.next() * MILLIS_IN_DAY;
         return String.valueOf(millis);
@@ -92,7 +96,9 @@ public class DateJsonReader
             return;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         // skip non-null values
         dataStream.skip(skipSize);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/json/DoubleJsonReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/json/DoubleJsonReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.json;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -25,7 +26,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -56,7 +56,9 @@ public class DoubleJsonReader
             return;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         double value = dataStream.next();
         generator.writeNumber(value);
@@ -70,7 +72,9 @@ public class DoubleJsonReader
             return null;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         double value = dataStream.next();
         return String.valueOf(value);
@@ -89,7 +93,9 @@ public class DoubleJsonReader
             return;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         // skip non-null values
         dataStream.skip(skipSize);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/json/FloatJsonReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/json/FloatJsonReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.json;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -25,7 +26,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -56,7 +56,9 @@ public class FloatJsonReader
             return;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         // write value as a double to avoid strange rounding errors
         double value = dataStream.next();
@@ -71,7 +73,9 @@ public class FloatJsonReader
             return null;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         // write value as a double to avoid strange rounding errors
         double value = dataStream.next();
@@ -91,7 +95,9 @@ public class FloatJsonReader
             return;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
 
         // skip non-null values
         dataStream.skip(skipSize);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/json/ListJsonReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/json/ListJsonReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.json;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -27,7 +28,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.json.JsonReaders.createJsonReader;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
@@ -65,7 +65,9 @@ public class ListJsonReader
             return;
         }
 
-        verifyFormat(lengthStream != null, "Value is not null but length stream is not present");
+        if (lengthStream == null) {
+            throw new OrcCorruptionException("Value is not null but length stream is not present");
+        }
 
         long length = lengthStream.next();
         generator.writeStartArray();
@@ -88,7 +90,9 @@ public class ListJsonReader
             return;
         }
 
-        verifyFormat(lengthStream != null, "Value is not null but length stream is not present");
+        if (lengthStream == null) {
+            throw new OrcCorruptionException("Value is not null but length stream is not present");
+        }
 
         long elementSkipSize = lengthStream.sum(skipSize);
         elementReader.skip(Ints.checkedCast(elementSkipSize));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/json/LongDictionaryJsonReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/json/LongDictionaryJsonReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.json;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -26,7 +27,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.IN_DICTIONARY;
@@ -80,7 +80,9 @@ public class LongDictionaryJsonReader
     private long nextValue()
             throws IOException
     {
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
         long value = dataStream.next();
         if (inDictionaryStream == null || inDictionaryStream.nextBit()) {
             value = dictionary[((int) value)];
@@ -102,7 +104,9 @@ public class LongDictionaryJsonReader
             inDictionaryStream.skip(skipSize);
         }
         if (skipSize > 0) {
-            verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+            if (dataStream == null) {
+                throw new OrcCorruptionException("Value is not null but data stream is not present");
+            }
             dataStream.skip(skipSize);
         }
     }
@@ -118,7 +122,9 @@ public class LongDictionaryJsonReader
             }
 
             LongStream dictionaryStream = dictionaryStreamSources.getStreamSource(streamDescriptor, DICTIONARY_DATA, LongStream.class).openStream();
-            verifyFormat(dictionaryStream != null, "Dictionary is not empty but data stream is not present");
+            if (dictionaryStream == null) {
+                throw new OrcCorruptionException("Dictionary is not empty but data stream is not present");
+            }
             dictionaryStream.nextLongVector(dictionarySize, dictionary);
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/json/LongDirectJsonReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/json/LongDirectJsonReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.json;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -25,7 +26,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -55,7 +55,9 @@ public class LongDirectJsonReader
             return;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
         generator.writeNumber(dataStream.next());
     }
 
@@ -67,7 +69,9 @@ public class LongDirectJsonReader
             return null;
         }
 
-        verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Value is not null but data stream is not present");
+        }
         return String.valueOf(dataStream.next());
     }
 
@@ -82,7 +86,9 @@ public class LongDirectJsonReader
 
         // skip non-null values
         if (skipSize > 0) {
-            verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+            if (dataStream == null) {
+                throw new OrcCorruptionException("Value is not null but data stream is not present");
+            }
             dataStream.skip(skipSize);
         }
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/json/MapJsonReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/json/MapJsonReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.json;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -27,7 +28,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.json.JsonReaders.createJsonMapKeyReader;
 import static com.facebook.presto.orc.json.JsonReaders.createJsonReader;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
@@ -67,7 +67,9 @@ public class MapJsonReader
             return;
         }
 
-        verifyFormat(lengthStream != null, "Value is not null but length stream is not present");
+        if (lengthStream == null) {
+            throw new OrcCorruptionException("Value is not null but length stream is not present");
+        }
 
         long length = lengthStream.next();
         generator.writeStartObject();
@@ -97,7 +99,9 @@ public class MapJsonReader
             return;
         }
 
-        verifyFormat(lengthStream != null, "Value is not null but length stream is not present");
+        if (lengthStream == null) {
+            throw new OrcCorruptionException("Value is not null but length stream is not present");
+        }
 
         // skip non-null values
         long elementSkipSize = lengthStream.sum(skipSize);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/json/SliceDirectJsonReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/json/SliceDirectJsonReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.json;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -29,7 +30,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
@@ -101,7 +101,9 @@ public class SliceDirectJsonReader
     private int bufferNextValue()
             throws IOException
     {
-        verifyFormat(lengthStream != null, "Value is not null but length stream is not present");
+        if (lengthStream == null) {
+            throw new OrcCorruptionException("Value is not null but length stream is not present");
+        }
 
         int length = Ints.checkedCast(lengthStream.next());
         if (data.length < length) {
@@ -109,7 +111,9 @@ public class SliceDirectJsonReader
         }
 
         if (length > 0) {
-            verifyFormat(dataStream != null, "Length is not zero but data stream is not present");
+            if (dataStream == null) {
+                throw new OrcCorruptionException("Length is not zero but data stream is not present");
+            }
             dataStream.next(length, data);
         }
         return length;
@@ -128,7 +132,9 @@ public class SliceDirectJsonReader
             return;
         }
 
-        verifyFormat(lengthStream != null, "Value is not null but length stream is not present");
+        if (lengthStream == null) {
+            throw new OrcCorruptionException("Value is not null but length stream is not present");
+        }
 
         // skip non-null length
         long dataSkipSize = lengthStream.sum(skipSize);
@@ -137,7 +143,9 @@ public class SliceDirectJsonReader
             return;
         }
 
-        verifyFormat(dataStream != null, "Length is not zero but data stream is not present");
+        if (dataStream == null) {
+            throw new OrcCorruptionException("Length is not zero but data stream is not present");
+        }
 
         // skip data bytes
         dataStream.skip(Ints.checkedCast(dataSkipSize));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/json/TimestampJsonReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/json/TimestampJsonReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.json;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -27,7 +28,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.SECONDARY;
@@ -66,8 +66,12 @@ public class TimestampJsonReader
             return;
         }
 
-        verifyFormat(secondsStream != null, "Value is not null but seconds stream is not present");
-        verifyFormat(nanosStream != null, "Value is not null but nanos stream is not present");
+        if (secondsStream == null) {
+            throw new OrcCorruptionException("Value is not null but seconds stream is not present");
+        }
+        if (nanosStream == null) {
+            throw new OrcCorruptionException("Value is not null but nanos stream is not present");
+        }
 
         long timestamp = decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds);
         generator.writeNumber(timestamp);
@@ -81,8 +85,12 @@ public class TimestampJsonReader
             return null;
         }
 
-        verifyFormat(secondsStream != null, "Value is not null but seconds stream is not present");
-        verifyFormat(nanosStream != null, "Value is not null but nanos stream is not present");
+        if (secondsStream == null) {
+            throw new OrcCorruptionException("Value is not null but seconds stream is not present");
+        }
+        if (nanosStream == null) {
+            throw new OrcCorruptionException("Value is not null but nanos stream is not present");
+        }
 
         long timestamp = decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds);
         return String.valueOf(timestamp);
@@ -101,8 +109,12 @@ public class TimestampJsonReader
             return;
         }
 
-        verifyFormat(secondsStream != null, "Value is not null but seconds stream is not present");
-        verifyFormat(nanosStream != null, "Value is not null but nanos stream is not present");
+        if (secondsStream == null) {
+            throw new OrcCorruptionException("Value is not null but seconds stream is not present");
+        }
+        if (nanosStream == null) {
+            throw new OrcCorruptionException("Value is not null but nanos stream is not present");
+        }
 
         // skip non-null values
         secondsStream.skip(skipSize);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc.reader;
 
 import com.facebook.presto.orc.LongVector;
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -28,7 +29,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingStreamSource.missingStreamSource;
@@ -82,21 +82,27 @@ public class ByteStreamReader
                 readOffset = presentStream.countBitsSet(readOffset);
             }
             if (readOffset > 0) {
-                verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+                if (dataStream == null) {
+                    throw new OrcCorruptionException("Value is not null but data stream is not present");
+                }
                 dataStream.skip(readOffset);
             }
         }
 
         LongVector byteVector = (LongVector) vector;
         if (presentStream == null) {
-            verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+            if (dataStream == null) {
+                throw new OrcCorruptionException("Value is not null but data stream is not present");
+            }
             Arrays.fill(byteVector.isNull, false);
             dataStream.nextVector(nextBatchSize, byteVector.vector);
         }
         else {
             int nullValues = presentStream.getUnsetBits(nextBatchSize, byteVector.isNull);
             if (nullValues != nextBatchSize) {
-                verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+                if (dataStream == null) {
+                    throw new OrcCorruptionException("Value is not null but data stream is not present");
+                }
                 dataStream.nextVector(nextBatchSize, byteVector.vector, byteVector.isNull);
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc.reader;
 
 import com.facebook.presto.orc.DoubleVector;
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -28,7 +29,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingStreamSource.missingStreamSource;
@@ -82,21 +82,27 @@ public class DoubleStreamReader
                 readOffset = presentStream.countBitsSet(readOffset);
             }
             if (readOffset > 0) {
-                verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+                if (dataStream == null) {
+                    throw new OrcCorruptionException("Value is not null but data stream is not present");
+                }
                 dataStream.skip(readOffset);
             }
         }
 
         DoubleVector doubleVector = (DoubleVector) vector;
         if (presentStream == null) {
-            verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+            if (dataStream == null) {
+                throw new OrcCorruptionException("Value is not null but data stream is not present");
+            }
             Arrays.fill(doubleVector.isNull, false);
             dataStream.nextVector(nextBatchSize, doubleVector.vector);
         }
         else {
             int nullValues = presentStream.getUnsetBits(nextBatchSize, doubleVector.isNull);
             if (nullValues != nextBatchSize) {
-                verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+                if (dataStream == null) {
+                    throw new OrcCorruptionException("Value is not null but data stream is not present");
+                }
                 dataStream.nextVector(nextBatchSize, doubleVector.vector, doubleVector.isNull);
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectStreamReader.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc.reader;
 
 import com.facebook.presto.orc.LongVector;
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
@@ -28,7 +29,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingStreamSource.missingStreamSource;
@@ -82,21 +82,27 @@ public class LongDirectStreamReader
                 readOffset = presentStream.countBitsSet(readOffset);
             }
             if (readOffset > 0) {
-                verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+                if (dataStream == null) {
+                    throw new OrcCorruptionException("Value is not null but data stream is not present");
+                }
                 dataStream.skip(readOffset);
             }
         }
 
         LongVector longVector = (LongVector) vector;
         if (presentStream == null) {
-            verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+            if (dataStream == null) {
+                throw new OrcCorruptionException("Value is not null but data stream is not present");
+            }
             Arrays.fill(longVector.isNull, false);
             dataStream.nextLongVector(nextBatchSize, longVector.vector);
         }
         else {
             int nullValues = presentStream.getUnsetBits(nextBatchSize, longVector.isNull);
             if (nullValues != nextBatchSize) {
-                verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+                if (dataStream == null) {
+                    throw new OrcCorruptionException("Value is not null but data stream is not present");
+                }
                 dataStream.nextLongVector(nextBatchSize, longVector.vector, longVector.isNull);
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.SliceVector;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.Vector;
@@ -32,7 +33,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
@@ -94,10 +94,14 @@ public class SliceDirectStreamReader
                 readOffset = presentStream.countBitsSet(readOffset);
             }
             if (readOffset > 0) {
-                verifyFormat(lengthStream != null, "Value is not null but length stream is not present");
+                if (lengthStream == null) {
+                    throw new OrcCorruptionException("Value is not null but length stream is not present");
+                }
                 long dataSkipSize = lengthStream.sum(readOffset);
                 if (dataSkipSize > 0) {
-                    verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+                    if (dataStream == null) {
+                        throw new OrcCorruptionException("Value is not null but data stream is not present");
+                    }
                     dataStream.skip(Ints.checkedCast(dataSkipSize));
                 }
             }
@@ -105,13 +109,17 @@ public class SliceDirectStreamReader
 
         SliceVector sliceVector = (SliceVector) vector;
         if (presentStream == null) {
-            verifyFormat(lengthStream != null, "Value is not null but length stream is not present");
+            if (lengthStream == null) {
+                throw new OrcCorruptionException("Value is not null but length stream is not present");
+            }
             lengthStream.nextIntVector(nextBatchSize, lengthVector);
         }
         else {
             int nullValues = presentStream.getUnsetBits(nextBatchSize, isNullVector);
             if (nullValues != nextBatchSize) {
-                verifyFormat(lengthStream != null, "Value is not null but length stream is not present");
+                if (lengthStream == null) {
+                    throw new OrcCorruptionException("Value is not null but length stream is not present");
+                }
                 lengthStream.nextIntVector(nextBatchSize, lengthVector, isNullVector);
             }
         }
@@ -125,7 +133,9 @@ public class SliceDirectStreamReader
 
         byte[] data = new byte[0];
         if (totalLength > 0) {
-            verifyFormat(dataStream != null, "Value is not null but data stream is not present");
+            if (dataStream == null) {
+                throw new OrcCorruptionException("Value is not null but data stream is not present");
+            }
             data = dataStream.next(totalLength);
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampStreamReader.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc.reader;
 
 import com.facebook.presto.orc.LongVector;
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.Vector;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
@@ -31,7 +32,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.SECONDARY;
@@ -97,8 +97,12 @@ public class TimestampStreamReader
                 readOffset = presentStream.countBitsSet(readOffset);
             }
             if (readOffset > 0) {
-                verifyFormat(secondsStream != null, "Value is not null but seconds stream is not present");
-                verifyFormat(nanosStream != null, "Value is not null but nanos stream is not present");
+                if (secondsStream == null) {
+                    throw new OrcCorruptionException("Value is not null but seconds stream is not present");
+                }
+                if (nanosStream == null) {
+                    throw new OrcCorruptionException("Value is not null but nanos stream is not present");
+                }
 
                 secondsStream.skip(readOffset);
                 nanosStream.skip(readOffset);
@@ -107,8 +111,12 @@ public class TimestampStreamReader
 
         LongVector longVector = (LongVector) vector;
         if (presentStream == null) {
-            verifyFormat(secondsStream != null, "Value is not null but seconds stream is not present");
-            verifyFormat(nanosStream != null, "Value is not null but nanos stream is not present");
+            if (secondsStream == null) {
+                throw new OrcCorruptionException("Value is not null but seconds stream is not present");
+            }
+            if (nanosStream == null) {
+                throw new OrcCorruptionException("Value is not null but nanos stream is not present");
+            }
 
             Arrays.fill(longVector.isNull, false);
             secondsStream.nextLongVector(nextBatchSize, longVector.vector);
@@ -117,8 +125,12 @@ public class TimestampStreamReader
         else {
             int nullValues = presentStream.getUnsetBits(nextBatchSize, longVector.isNull);
             if (nullValues != nextBatchSize) {
-                verifyFormat(secondsStream != null, "Value is not null but seconds stream is not present");
-                verifyFormat(nanosStream != null, "Value is not null but nanos stream is not present");
+                if (secondsStream == null) {
+                    throw new OrcCorruptionException("Value is not null but seconds stream is not present");
+                }
+                if (nanosStream == null) {
+                    throw new OrcCorruptionException("Value is not null but nanos stream is not present");
+                }
 
                 secondsStream.nextLongVector(nextBatchSize, longVector.vector, longVector.isNull);
                 nanosStream.nextLongVector(nextBatchSize, nanosVector, longVector.isNull);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongDecode.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongDecode.java
@@ -13,12 +13,12 @@
  */
 package com.facebook.presto.orc.stream;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.INT;
 import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.LONG;
 import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.SHORT;
@@ -134,7 +134,9 @@ public final class LongDecode
         long b;
         do {
             b = inputStream.read();
-            verifyFormat(b != -1, "EOF while reading unsigned vint");
+            if (b == -1) {
+                throw new OrcCorruptionException("EOF while reading unsigned vint");
+            }
             result |= (b & 0b0111_1111) << offset;
             offset += 7;
         } while ((b & 0b1000_0000) != 0);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcInputStream.java
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.facebook.presto.orc.checkpoint.InputStreamCheckpoint.createInputStreamCheckpoint;
 import static com.facebook.presto.orc.checkpoint.InputStreamCheckpoint.decodeCompressedBlockOffset;
 import static com.facebook.presto.orc.checkpoint.InputStreamCheckpoint.decodeDecompressedOffset;
@@ -148,7 +147,9 @@ public final class OrcInputStream
         int decompressedOffset = decodeDecompressedOffset(checkpoint);
         boolean discardedBuffer;
         if (compressedBlockOffset != currentCompressedBlockOffset) {
-            verifyFormat(compressionKind != UNCOMPRESSED, "Reset stream has a compressed block offset but stream is not compressed");
+            if (compressionKind == UNCOMPRESSED) {
+                throw new OrcCorruptionException("Reset stream has a compressed block offset but stream is not compressed");
+            }
             compressedSliceInput.setPosition(compressedBlockOffset);
             current = EMPTY_SLICE.getInput();
             discardedBuffer = true;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcStreamUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcStreamUtils.java
@@ -13,10 +13,11 @@
  */
 package com.facebook.presto.orc.stream;
 
+import com.facebook.presto.orc.OrcCorruptionException;
+
 import java.io.IOException;
 import java.io.InputStream;
 
-import static com.facebook.presto.orc.OrcCorruptionException.verifyFormat;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -33,7 +34,9 @@ final class OrcStreamUtils
     {
         while (length > 0) {
             long result = input.skip(length);
-            verifyFormat(result >= 0, "Unexpected end of stream");
+            if (result < 0) {
+                throw new OrcCorruptionException("Unexpected end of stream");
+            }
             length -= result;
         }
     }
@@ -43,7 +46,9 @@ final class OrcStreamUtils
     {
         while (offset < length) {
             int result = input.read(buffer, offset, length - offset);
-            verifyFormat(result >= 0, "Unexpected end of stream");
+            if (result < 0) {
+                throw new OrcCorruptionException("Unexpected end of stream");
+            }
             offset += result;
         }
     }


### PR DESCRIPTION
The ORC decoder was generating a large amount of garbage because it was
invoking a varargs function in the inner decoding loop. This reduces
object creation by about 80% on the workers
