### PR TITLE
Pass FunctionRegistry to specialize

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionInfo.java
@@ -180,7 +180,7 @@ public final class FunctionInfo
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         return this;
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -343,7 +343,7 @@ public class FunctionRegistry
             Map<String, Type> boundTypeParameters = function.getSignature().bindTypeParameters(resolvedTypes, false, typeManager);
             if (boundTypeParameters != null) {
                 checkArgument(match == null, "Ambiguous call to %s with parameters %s", name, parameterTypes);
-                match = function.specialize(boundTypeParameters, resolvedTypes.size(), typeManager);
+                match = function.specialize(boundTypeParameters, resolvedTypes.size(), typeManager, this);
             }
         }
 
@@ -356,7 +356,7 @@ public class FunctionRegistry
             Map<String, Type> boundTypeParameters = function.getSignature().bindTypeParameters(resolvedTypes, true, typeManager);
             if (boundTypeParameters != null) {
                 // TODO: This should also check for ambiguities
-                return function.specialize(boundTypeParameters, resolvedTypes.size(), typeManager);
+                return function.specialize(boundTypeParameters, resolvedTypes.size(), typeManager, this);
             }
         }
 
@@ -412,7 +412,7 @@ public class FunctionRegistry
                     Map<String, Type> boundTypeParameters = function.getSignature().bindTypeParameters(resolvedTypes, false, typeManager);
                     if (boundTypeParameters != null) {
                         checkArgument(match == null, "Ambiguous call to %s with parameters %s", name, parameterTypes);
-                        match = function.specialize(boundTypeParameters, resolvedTypes.size(), typeManager);
+                        match = function.specialize(boundTypeParameters, resolvedTypes.size(), typeManager, this);
                     }
                 }
 
@@ -434,7 +434,7 @@ public class FunctionRegistry
             List<Type> argumentTypes = resolveTypes(signature.getArgumentTypes(), typeManager);
             Map<String, Type> boundTypeParameters = operator.getSignature().bindTypeParameters(returnType, argumentTypes, false, typeManager);
             if (boundTypeParameters != null) {
-                return operator.specialize(boundTypeParameters, signature.getArgumentTypes().size(), typeManager);
+                return operator.specialize(boundTypeParameters, signature.getArgumentTypes().size(), typeManager, this);
             }
         }
         return null;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/ParametricFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/ParametricFunction.java
@@ -39,5 +39,5 @@ public interface ParametricFunction
     String getDescription();
 
     // TODO: This should really return an object with just the MethodHandle/InternalAggregation...etc. However, due to the magic literal hack this is not possible
-    FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager);
+    FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregation.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.byteCode.DynamicClassLoader;
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricAggregation;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.aggregation.state.ArbitraryAggregationState;
@@ -61,7 +62,7 @@ public class ArbitraryAggregation
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type valueType = types.get("T");
         Signature signature = new Signature(NAME, valueType.getTypeSignature(), valueType.getTypeSignature());

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountColumn.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountColumn.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.byteCode.DynamicClassLoader;
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricAggregation;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.aggregation.state.AccumulatorStateFactory;
@@ -63,7 +64,7 @@ public class CountColumn
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("T");
         Signature signature = new Signature(NAME, parseTypeSignature(StandardTypes.BIGINT), type.getTypeSignature());

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MaxBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MaxBy.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.byteCode.DynamicClassLoader;
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricAggregation;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.aggregation.state.MaxOrMinByState;
@@ -62,7 +63,7 @@ public class MaxBy
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type keyType = types.get("K");
         Type valueType = types.get("V");

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MinBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MinBy.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.byteCode.DynamicClassLoader;
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricAggregation;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.aggregation.state.MaxOrMinByState;
@@ -62,7 +63,7 @@ public class MinBy
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type keyType = types.get("K");
         Type valueType = types.get("V");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayCardinalityFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayCardinalityFunction.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.type.StandardTypes;
@@ -63,7 +64,7 @@ public final class ArrayCardinalityFunction
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         checkArgument(types.size() == 1, "Cardinality expects only one argument");
         Type type = types.get("E");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatFunction.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.type.Type;
@@ -62,7 +63,7 @@ public class ArrayConcatFunction
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         TypeSignature typeSignature = parameterizedTypeName("array", types.get("E").getTypeSignature());
         Signature signature = new Signature(FUNCTION_NAME, typeSignature, typeSignature, typeSignature); // return type & arg types are the same

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
@@ -20,6 +20,7 @@ import com.facebook.presto.byteCode.DynamicClassLoader;
 import com.facebook.presto.byteCode.NamedParameterDefinition;
 import com.facebook.presto.byteCode.Variable;
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.type.Type;
@@ -94,7 +95,7 @@ public final class ArrayConstructor
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         // Check to see if we're creating an empty, un-specialized array
         if (types.isEmpty()) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayEqualOperator.java
@@ -13,6 +13,7 @@ package com.facebook.presto.operator.scalar;
  * limitations under the License.
  */
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -45,7 +46,7 @@ public class ArrayEqualOperator
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("T");
         type = typeManager.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(type.getTypeSignature()), ImmutableList.of());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayGreaterThanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayGreaterThanOperator.java
@@ -14,6 +14,7 @@ package com.facebook.presto.operator.scalar;
  */
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -46,7 +47,7 @@ public class ArrayGreaterThanOperator
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("T");
         type = typeManager.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(type.getTypeSignature()), ImmutableList.of());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayGreaterThanOrEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayGreaterThanOrEqualOperator.java
@@ -14,6 +14,7 @@ package com.facebook.presto.operator.scalar;
  */
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -46,7 +47,7 @@ public class ArrayGreaterThanOrEqualOperator
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("T");
         type = typeManager.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(type.getTypeSignature()), ImmutableList.of());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayHashCodeOperator.java
@@ -13,6 +13,7 @@ package com.facebook.presto.operator.scalar;
  * limitations under the License.
  */
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -45,7 +46,7 @@ public class ArrayHashCodeOperator
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("T");
         type = typeManager.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(type.getTypeSignature()), ImmutableList.of());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOperator.java
@@ -14,6 +14,7 @@ package com.facebook.presto.operator.scalar;
  */
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -46,7 +47,7 @@ public class ArrayLessThanOperator
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("T");
         type = typeManager.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(type.getTypeSignature()), ImmutableList.of());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOrEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOrEqualOperator.java
@@ -14,6 +14,7 @@ package com.facebook.presto.operator.scalar;
  */
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -46,7 +47,7 @@ public class ArrayLessThanOrEqualOperator
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("T");
         type = typeManager.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(type.getTypeSignature()), ImmutableList.of());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayNotEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayNotEqualOperator.java
@@ -14,6 +14,7 @@ package com.facebook.presto.operator.scalar;
  */
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -46,7 +47,7 @@ public class ArrayNotEqualOperator
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("T");
         type = typeManager.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(type.getTypeSignature()), ImmutableList.of());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.PrestoException;
@@ -76,7 +77,7 @@ public final class ArraySortFunction
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         checkArgument(types.size() == 1, format("%s expects only one argument", FUNCTION_NAME));
         Type type = types.get("E");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySubscriptOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySubscriptOperator.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.PrestoException;
@@ -83,7 +84,7 @@ public class ArraySubscriptOperator
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         checkArgument(types.size() == 1, "Expected one type, got %s", types);
         Type elementType = types.get("E");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToElementConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToElementConcatFunction.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.type.Type;
@@ -61,7 +62,7 @@ public class ArrayToElementConcatFunction
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("E");
         MethodHandle methodHandle = methodHandle(ArrayConcatUtils.class, "appendElement", Slice.class, type.getJavaType());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToJsonCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToJsonCast.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.OperatorType;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.server.SliceSerializer;
@@ -53,7 +54,7 @@ public class ArrayToJsonCast
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         checkArgument(arity == 1, "Expected arity to be 1");
         Type type = types.get("T");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ElementToArrayConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ElementToArrayConcatFunction.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.type.Type;
@@ -61,7 +62,7 @@ public class ElementToArrayConcatFunction
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("E");
         MethodHandle methodHandle = methodHandle(ArrayConcatUtils.class, "prependElement", type.getJavaType(), Slice.class);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/Greatest.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/Greatest.java
@@ -21,6 +21,7 @@ import com.facebook.presto.byteCode.NamedParameterDefinition;
 import com.facebook.presto.byteCode.Variable;
 import com.facebook.presto.byteCode.control.IfStatement;
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.PrestoException;
@@ -93,7 +94,7 @@ public final class Greatest
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("E");
         checkArgument(type.isOrderable(), "Type must be orderable");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/IdentityCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/IdentityCast.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.OperatorType;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.spi.type.Type;
@@ -39,7 +40,7 @@ public class IdentityCast
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         checkArgument(types.size() == 1, "Expected only one type");
         Type type = types.get("T");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/Least.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/Least.java
@@ -21,6 +21,7 @@ import com.facebook.presto.byteCode.NamedParameterDefinition;
 import com.facebook.presto.byteCode.Variable;
 import com.facebook.presto.byteCode.control.IfStatement;
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.PrestoException;
@@ -93,7 +94,7 @@ public final class Least
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("E");
         checkArgument(type.isOrderable(), "Type must be orderable");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapCardinalityFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapCardinalityFunction.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.type.StandardTypes;
@@ -64,7 +65,7 @@ public final class MapCardinalityFunction
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         checkArgument(arity == 1, "Cardinality expects only one argument");
         Type keyType = types.get("K");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.TypeParameter;
@@ -76,7 +77,7 @@ public final class MapConstructor
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type keyType = types.get("K");
         Type valueType = types.get("V");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapKeys.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapKeys.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.PrestoException;
@@ -80,7 +81,7 @@ public class MapKeys
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         checkArgument(arity == 1, "map_keys expects only one argument");
         Type keyType = types.get("K");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.type.Type;
@@ -69,7 +70,7 @@ public class MapSubscriptOperator
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type keyType = types.get("K");
         Type valueType = types.get("V");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToJsonCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToJsonCast.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.OperatorType;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.server.SliceSerializer;
@@ -58,7 +59,7 @@ public class MapToJsonCast
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         checkArgument(arity == 1, "Expected arity to be 1");
         Type keyType = types.get("K");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapValues.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapValues.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.server.SliceSerializer;
@@ -72,7 +73,7 @@ public class MapValues
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         checkArgument(arity == 1, "map_values expects only one argument");
         Type keyType = types.get("K");

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowEqualOperator.java
@@ -14,6 +14,7 @@ package com.facebook.presto.operator.scalar;
  */
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -46,7 +47,7 @@ public class RowEqualOperator
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("T");
         TypeSignature typeSignature = type.getTypeSignature();

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowFieldAccessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowFieldAccessor.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.type.Type;
@@ -123,7 +124,7 @@ public class RowFieldAccessor
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         checkNotNull(methodHandle, "methodHandle is null");
         return new FunctionInfo(signature, getDescription(), isHidden(), methodHandle, isDeterministic(), true, ImmutableList.of(false));

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowHashCodeOperator.java
@@ -14,6 +14,7 @@ package com.facebook.presto.operator.scalar;
  */
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -46,7 +47,7 @@ public class RowHashCodeOperator
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("T");
         TypeSignature typeSignature = type.getTypeSignature();

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowNotEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowNotEqualOperator.java
@@ -14,6 +14,7 @@ package com.facebook.presto.operator.scalar;
  */
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
@@ -44,7 +45,7 @@ public class RowNotEqualOperator
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = types.get("T");
         TypeSignature typeSignature = type.getTypeSignature();

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToJsonCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToJsonCast.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.OperatorType;
 import com.facebook.presto.metadata.ParametricOperator;
 import com.facebook.presto.server.SliceSerializer;
@@ -58,7 +59,7 @@ public class RowToJsonCast
     }
 
     @Override
-    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager)
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         checkArgument(arity == 1, "Expected arity to be 1");
         Type type = types.get("T");


### PR DESCRIPTION
This is needed for functions that need to rely on other type-specific functions
(e.g., map comparison, which requires a specific comparator based on the key type)
