### PR TITLE
Support CDH Parquet name

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -180,7 +180,8 @@ public final class HiveUtil
             throws ClassNotFoundException
     {
         // CDH uses different names for Parquet
-        if ("parquet.hive.DeprecatedParquetInputFormat".equals(inputFormatName)) {
+        if ("parquet.hive.DeprecatedParquetInputFormat".equals(inputFormatName) ||
+            "parquet.hive.MapredParquetInputFormat".equals(inputFormatName)) {
             return MapredParquetInputFormat.class;
         }
 


### PR DESCRIPTION
CDH Parquet has three difference names:
parquet.hive.DeprecatedParquetInputFormat
parquet.hive.MapredParquetInputFormat
org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat

The first two are going to be deprecated.
Always resolve to the third one.
