### PR TITLE
Switch to Docker based Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+sudo: false
 before_install: free -m
 script: mvn test -P travis -Dair.check.skip-dependency=true
 env:


### PR DESCRIPTION
This should give us 4GB of memory instead of 3GB and also more CPU
resources
