### PR TITLE
#2135 : Fix to add bufferIds for the tasks created during waitForFreeNod...

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -682,7 +682,8 @@ public class SqlStageExecution
             // waiting for the "noMoreBuffers" call
             nodeSelector.lockDownNodes();
             for (Node node : Sets.difference(new HashSet<>(nodeSelector.allNodes()), localNodeTaskMap.keySet())) {
-                scheduleTask(nextTaskId.getAndIncrement(), node);
+                RemoteTask task = scheduleTask(nextTaskId.getAndIncrement(), node);
+                addStageNode(task.getTaskInfo().getTaskId());
             }
             // tell sub stages there will be no more output buffers
             setNoMoreStageNodes();


### PR DESCRIPTION
PR for fix for #2135 Inconsistent results with joins when parent stage does not get slot in any nodes to assign splits
