### PR TITLE
Handle negative indices in the array subscript operator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySubscriptOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySubscriptOperator.java
@@ -152,7 +152,7 @@ public class ArraySubscriptOperator
     @SuppressWarnings("unchecked")
     private static <T> T subscript(Slice array, long index, ExtractorType type)
     {
-        if (index == 0) {
+        if (index <= 0) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Index out of bounds");
         }
         JsonExtractor<?> extractor = CACHE.getUnchecked(new CacheKey(index, type));


### PR DESCRIPTION
Array subscript operator currently doesn't handle negative indices and fail with a json path error message. This PR handles the negative subscript case to fail with an index out of bounds message.

```
presto:default> select array[1,2,3][-1];
Query 20141224_205003_00008_dkhgr failed: com.facebook.presto.spi.PrestoException: Invalid JSON path: '$[-2]'
Caused by: com.facebook.presto.spi.PrestoException: Invalid JSON path: '$[-2]'
        at com.facebook.presto.operator.scalar.JsonPathTokenizer.invalidJsonPath(JsonPathTokenizer.java:163)
        at com.facebook.presto.operator.scalar.JsonPathTokenizer.matchUnquotedSubscript(JsonPathTokenizer.java:102)
        at com.facebook.presto.operator.scalar.JsonPathTokenizer.computeNext(JsonPathTokenizer.java:56)
        at com.facebook.presto.operator.scalar.JsonPathTokenizer.computeNext(JsonPathTokenizer.java:24)
        at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:143)
        at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:138)
        at com.google.common.collect.ImmutableList.copyOf(ImmutableList.java:268)
        at com.facebook.presto.operator.scalar.JsonExtract.generateExtractor(JsonExtract.java:154)
        at com.facebook.presto.operator.scalar.ArraySubscriptOperator$1.load(ArraySubscriptOperator.java:88)
        at com.facebook.presto.operator.scalar.ArraySubscriptOperator$1.load(ArraySubscriptOperator.java:83)
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3527)
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2319)
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2282)
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2197)
        ... 63 more
```
