### PR TITLE
Generate query digests to enable caching query results

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -61,6 +61,9 @@ public class ClientOptions
     @Option(name = "--execute", title = "execute", description = "Execute specified statements and exit")
     public String execute;
 
+    @Option(name = "--digest", title = "digest", description = "Use specified query digest")
+    public String digest;
+
     @Option(name = "--output-format", title = "output-format", description = "Output format for batch mode (default: CSV)")
     public OutputFormat outputFormat = OutputFormat.CSV;
 
@@ -92,7 +95,8 @@ public class ClientOptions
                 TimeZone.getDefault().getID(),
                 Locale.getDefault(),
                 toProperties(sessionProperties),
-                debug);
+                debug,
+                digest);
     }
 
     public static URI parseServer(String server)

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -112,7 +112,7 @@ public class Query
             waitForData();
         }
 
-        if ((!client.isFailed()) && (!client.isGone()) && (!client.isClosed())) {
+        if ((!client.isFailed()) && (!client.isGone()) && (!client.isClosed()) && (!client.isDigestMatched())) {
             QueryResults results = client.isValid() ? client.current() : client.finalResults();
             if (results.getUpdateType() != null) {
                 renderUpdate(out, results);
@@ -138,6 +138,9 @@ public class Query
         }
         else if (client.isFailed()) {
             renderFailure(client.finalResults(), errorChannel);
+        }
+        else if (client.isDigestMatched()) {
+            out.println("Query digest matched (query not executed): " + client.getQueryDigest());
         }
     }
 
@@ -212,6 +215,10 @@ public class Query
     {
         try (OutputHandler handler = createOutputHandler(format, createWriter(out), fieldNames)) {
             handler.processRows(client);
+        }
+
+        if (client.isDebug()) {
+            out.println("--------\nDigest: " + client.getQueryDigest());
         }
     }
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
@@ -126,6 +126,10 @@ Parallelism: 2.5
                 pluralize("node", nodes));
         out.println(querySummary);
 
+        if (client.isDebug() && !Strings.isNullOrEmpty(results.getQueryDigest())) {
+            out.println("Digest: " + results.getQueryDigest());
+        }
+
         if (client.isDebug()) {
             out.println(results.getInfoUri() + "?pretty");
         }

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
@@ -38,6 +38,7 @@ public class ClientSession
     private final Locale locale;
     private final Map<String, String> properties;
     private final boolean debug;
+    private final String digest;
 
     public static ClientSession withCatalogAndSchema(ClientSession session, String catalog, String schema)
     {
@@ -50,7 +51,8 @@ public class ClientSession
                 session.getTimeZoneId(),
                 session.getLocale(),
                 session.getProperties(),
-                session.isDebug());
+                session.isDebug(),
+                session.getDigest());
     }
 
     public static ClientSession withSessionProperties(ClientSession session, Map<String, String> sessionProperties)
@@ -67,7 +69,8 @@ public class ClientSession
                 session.getTimeZoneId(),
                 session.getLocale(),
                 properties,
-                session.isDebug());
+                session.isDebug(),
+                session.getDigest());
     }
 
     public static ClientSession withProperties(ClientSession session, Map<String, String> properties)
@@ -81,10 +84,16 @@ public class ClientSession
                 session.getTimeZoneId(),
                 session.getLocale(),
                 properties,
-                session.isDebug());
+                session.isDebug(),
+                session.getDigest());
     }
 
     public ClientSession(URI server, String user, String source, String catalog, String schema, String timeZoneId, Locale locale, Map<String, String> properties, boolean debug)
+    {
+        this(server, user, source, catalog, schema, timeZoneId, locale, properties, debug, null);
+    }
+
+    public ClientSession(URI server, String user, String source, String catalog, String schema, String timeZoneId, Locale locale, Map<String, String> properties, boolean debug, String digest)
     {
         this.server = checkNotNull(server, "server is null");
         this.user = user;
@@ -95,6 +104,7 @@ public class ClientSession
         this.timeZoneId = checkNotNull(timeZoneId, "timeZoneId is null");
         this.debug = debug;
         this.properties = ImmutableMap.copyOf(checkNotNull(properties, "properties is null"));
+        this.digest = digest;
 
         // verify the properties are valid
         CharsetEncoder charsetEncoder = US_ASCII.newEncoder();
@@ -149,6 +159,11 @@ public class ClientSession
     public boolean isDebug()
     {
         return debug;
+    }
+
+    public String getDigest()
+    {
+        return digest;
     }
 
     @Override

--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -24,6 +24,7 @@ public final class PrestoHeaders
     public static final String PRESTO_SESSION = "X-Presto-Session";
     public static final String PRESTO_SET_SESSION = "X-Presto-Set-Session";
     public static final String PRESTO_CLEAR_SESSION = "X-Presto-Clear-Session";
+    public static final String PRESTO_DIGEST = "X-Presto-Digest";
 
     public static final String PRESTO_CURRENT_STATE = "X-Presto-Current-State";
     public static final String PRESTO_MAX_WAIT = "X-Presto-Max-Wait";

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
@@ -63,9 +63,11 @@ public class QueryResults
     private final List<Column> columns;
     private final Iterable<List<Object>> data;
     private final StatementStats stats;
+    private final Boolean digestMatched;
     private final QueryError error;
     private final String updateType;
     private final Long updateCount;
+    private final String queryDigest;
 
     @JsonCreator
     public QueryResults(
@@ -76,11 +78,13 @@ public class QueryResults
             @JsonProperty("columns") List<Column> columns,
             @JsonProperty("data") List<List<Object>> data,
             @JsonProperty("stats") StatementStats stats,
+            @JsonProperty("digestMatched") Boolean digestMatched,
             @JsonProperty("error") QueryError error,
             @JsonProperty("updateType") String updateType,
-            @JsonProperty("updateCount") Long updateCount)
+            @JsonProperty("updateCount") Long updateCount,
+            @JsonProperty("queryDigest") String queryDigest)
     {
-        this(id, infoUri, partialCancelUri, nextUri, columns, fixData(columns, data), stats, error, updateType, updateCount);
+        this(id, infoUri, partialCancelUri, nextUri, columns, fixData(columns, data), stats, digestMatched, error, updateType, updateCount, queryDigest);
     }
 
     public QueryResults(
@@ -91,9 +95,11 @@ public class QueryResults
             List<Column> columns,
             Iterable<List<Object>> data,
             StatementStats stats,
+            Boolean digestMatched,
             QueryError error,
             String updateType,
-            Long updateCount)
+            Long updateCount,
+            String queryDigest)
     {
         this.id = checkNotNull(id, "id is null");
         this.infoUri = checkNotNull(infoUri, "infoUri is null");
@@ -102,9 +108,11 @@ public class QueryResults
         this.columns = (columns != null) ? ImmutableList.copyOf(columns) : null;
         this.data = (data != null) ? unmodifiableIterable(data) : null;
         this.stats = checkNotNull(stats, "stats is null");
+        this.digestMatched = digestMatched;
         this.error = error;
         this.updateType = updateType;
         this.updateCount = updateCount;
+        this.queryDigest = queryDigest;
     }
 
     @NotNull
@@ -158,6 +166,13 @@ public class QueryResults
 
     @Nullable
     @JsonProperty
+    public Boolean isDigestMatched()
+    {
+        return digestMatched;
+    }
+
+    @Nullable
+    @JsonProperty
     public QueryError getError()
     {
         return error;
@@ -177,6 +192,13 @@ public class QueryResults
         return updateCount;
     }
 
+    @Nullable
+    @JsonProperty
+    public String getQueryDigest()
+    {
+        return queryDigest;
+    }
+
     @Override
     public String toString()
     {
@@ -188,9 +210,11 @@ public class QueryResults
                 .add("columns", columns)
                 .add("hasData", data != null)
                 .add("stats", stats)
+                .add("digestMatched", digestMatched)
                 .add("error", error)
                 .add("updateType", updateType)
                 .add("updateCount", updateCount)
+                .add("queryDigest", queryDigest)
                 .toString();
     }
 

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -120,6 +120,9 @@ public class StatementClient
         if (session.getSchema() != null) {
             builder.setHeader(PrestoHeaders.PRESTO_SCHEMA, session.getSchema());
         }
+        if (session.getDigest() != null) {
+            builder.setHeader(PrestoHeaders.PRESTO_DIGEST, session.getDigest());
+        }
         builder.setHeader(PrestoHeaders.PRESTO_TIME_ZONE, session.getTimeZoneId());
         builder.setHeader(PrestoHeaders.PRESTO_LANGUAGE, session.getLocale().toLanguageTag());
         builder.setHeader(USER_AGENT, USER_AGENT_VALUE);
@@ -160,6 +163,16 @@ public class StatementClient
     public boolean isFailed()
     {
         return currentResults.get().getError() != null;
+    }
+
+    public boolean isDigestMatched()
+    {
+        return currentResults.get().isDigestMatched();
+    }
+
+    public String getQueryDigest()
+    {
+        return currentResults.get().getQueryDigest();
     }
 
     public QueryResults current()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -94,6 +94,9 @@ public class HiveClientConfig
     private DataSize orcMaxBufferSize = new DataSize(8, MEGABYTE);
     private DataSize orcStreamBufferSize = new DataSize(8, MEGABYTE);
 
+    private boolean useTableLastModifiedTimeForDigest = true;
+    private int maxNumberOfPartitionsToRetrieveForDigest = 10;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -679,6 +682,30 @@ public class HiveClientConfig
     public HiveClientConfig setAssumeCanonicalPartitionKeys(boolean assumeCanonicalPartitionKeys)
     {
         this.assumeCanonicalPartitionKeys = assumeCanonicalPartitionKeys;
+        return this;
+    }
+
+    public boolean isUseTableLastModifiedTimeForDigest()
+    {
+        return useTableLastModifiedTimeForDigest;
+    }
+
+    @Config("hive.digest.use-table-last-modified-time")
+    public HiveClientConfig setUseTableLastModifiedTimeForDigest(boolean useTableLastModifiedTimeForDigest)
+    {
+        this.useTableLastModifiedTimeForDigest = useTableLastModifiedTimeForDigest;
+        return this;
+    }
+
+    public int getMaxNumberOfPartitionsToRetrieveForDigest()
+    {
+        return maxNumberOfPartitionsToRetrieveForDigest;
+    }
+
+    @Config("hive.digest.max-partitions-to-retrieve")
+    public HiveClientConfig setMaxNumberOfPartitionsToRetrieveForDigest(int maxNumberOfPartitionsToRetrieveForDigest)
+    {
+        this.maxNumberOfPartitionsToRetrieveForDigest = maxNumberOfPartitionsToRetrieveForDigest;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveMetastore.java
@@ -53,6 +53,9 @@ public interface HiveMetastore
     Map<String, Partition> getPartitionsByNames(String databaseName, String tableName, List<String> partitionNames)
             throws NoSuchObjectException;
 
+    public Map<String, Partition> getCachedPartitionsByNames(String databaseName, String tableName, List<String> partitionNames)
+            throws NoSuchObjectException;
+
     Table getTable(String databaseName, String tableName)
             throws NoSuchObjectException;
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/InMemoryHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/InMemoryHiveMetastore.java
@@ -161,6 +161,13 @@ public class InMemoryHiveMetastore
     }
 
     @Override
+    public Map<String, Partition> getCachedPartitionsByNames(String databaseName, String tableName, List<String> partitionNames)
+            throws NoSuchObjectException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Table getTable(String databaseName, String tableName)
             throws NoSuchObjectException
     {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -323,7 +323,9 @@ public abstract class AbstractTestHiveClient
                 hiveClientConfig.getMaxInitialSplits(),
                 false,
                 false,
-                false);
+                false,
+                hiveClientConfig.isUseTableLastModifiedTimeForDigest(),
+                hiveClientConfig.getMaxNumberOfPartitionsToRetrieveForDigest());
         recordSinkProvider = new HiveRecordSinkProvider(hdfsEnvironment);
         pageSourceProvider = new HivePageSourceProvider(hiveClientConfig, hdfsEnvironment, DEFAULT_HIVE_RECORD_CURSOR_PROVIDER, DEFAULT_HIVE_DATA_STREAM_FACTORIES, TYPE_MANAGER);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -81,7 +81,9 @@ public class TestHiveClientConfig
                 .setAssumeCanonicalPartitionKeys(false)
                 .setOrcMaxMergeDistance(new DataSize(1, Unit.MEGABYTE))
                 .setOrcMaxBufferSize(new DataSize(8, Unit.MEGABYTE))
-                .setOrcStreamBufferSize(new DataSize(8, Unit.MEGABYTE)));
+                .setOrcStreamBufferSize(new DataSize(8, Unit.MEGABYTE))
+                .setMaxNumberOfPartitionsToRetrieveForDigest(10)
+                .setUseTableLastModifiedTimeForDigest(true));
     }
 
     @Test
@@ -132,6 +134,8 @@ public class TestHiveClientConfig
                 .put("hive.orc.max-merge-distance", "22kB")
                 .put("hive.orc.max-buffer-size", "44kB")
                 .put("hive.orc.stream-buffer-size", "55kB")
+                .put("hive.digest.max-partitions-to-retrieve", "50")
+                .put("hive.digest.use-table-last-modified-time", "false")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -178,7 +182,9 @@ public class TestHiveClientConfig
                 .setAssumeCanonicalPartitionKeys(true)
                 .setOrcMaxMergeDistance(new DataSize(22, Unit.KILOBYTE))
                 .setOrcMaxBufferSize(new DataSize(44, Unit.KILOBYTE))
-                .setOrcStreamBufferSize(new DataSize(55, Unit.KILOBYTE));
+                .setOrcStreamBufferSize(new DataSize(55, Unit.KILOBYTE))
+                .setMaxNumberOfPartitionsToRetrieveForDigest(50)
+                .setUseTableLastModifiedTimeForDigest(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/KafkaLoader.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/KafkaLoader.java
@@ -29,6 +29,7 @@ import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -114,7 +115,7 @@ public class KafkaLoader
         }
 
         @Override
-        public Void build(Map<String, String> setSessionProperties, Set<String> resetSessionProperties)
+        public Void build(Map<String, String> setSessionProperties, Set<String> resetSessionProperties, Optional<QueryResults> finalQueryResults)
         {
             return null;
         }

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -29,3 +29,4 @@ plugin.bundles=\
 presto.version=testversion
 experimental-syntax-enabled=true
 distributed-joins-enabled=true
+query-digest-enabled=true

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -217,7 +217,7 @@ public final class Session
         return new ConnectorSession(user, timeZoneKey, locale, startTime, catalogProperties.get(checkNotNull(catalog, "catalog is null")));
     }
 
-    public ClientSession toClientSession(URI server, boolean debug)
+    public ClientSession toClientSession(URI server, boolean debug, String digest)
     {
         ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
         properties.putAll(systemProperties);
@@ -237,7 +237,8 @@ public final class Session
                 timeZoneKey.getId(),
                 locale,
                 properties.build(),
-                debug);
+                debug,
+                digest);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryCompletionEvent.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryCompletionEvent.java
@@ -46,6 +46,7 @@ public class QueryCompletionEvent
     private final URI uri;
     private final List<String> fieldNames;
     private final String query;
+    private final String queryDigest;
 
     private final DateTime createTime;
     private final DateTime executionStartTime;
@@ -85,6 +86,7 @@ public class QueryCompletionEvent
             URI uri,
             List<String> fieldNames,
             String query,
+            String queryDigest,
             DateTime createTime,
             DateTime executionStartTime,
             DateTime endTime,
@@ -118,6 +120,7 @@ public class QueryCompletionEvent
         this.errorCode = errorCode;
         this.fieldNames = ImmutableList.copyOf(fieldNames);
         this.query = query;
+        this.queryDigest = queryDigest;
         this.createTime = createTime;
         this.executionStartTime = executionStartTime;
         this.endTime = endTime;
@@ -231,6 +234,12 @@ public class QueryCompletionEvent
     public String getQuery()
     {
         return query;
+    }
+
+    @EventField
+    public String getQueryDigest()
+    {
+        return queryDigest;
     }
 
     @EventField

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
@@ -111,6 +111,7 @@ public class QueryMonitor
                             queryInfo.getSelf(),
                             queryInfo.getFieldNames(),
                             queryInfo.getQuery(),
+                            queryInfo.getQueryDigest(),
                             queryStats.getCreateTime(),
                             queryStats.getExecutionStartTime(),
                             queryStats.getEndTime(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -141,11 +142,12 @@ public class DataDefinitionExecution<T extends Statement>
         public DataDefinitionExecution<?> createQueryExecution(
                 QueryId queryId,
                 String query,
+                Optional<String> queryDigest,
                 Session session,
                 Statement statement)
         {
             URI self = locationFactory.createQueryLocation(queryId);
-            QueryStateMachine stateMachine = new QueryStateMachine(queryId, query, session, self, executor);
+            QueryStateMachine stateMachine = new QueryStateMachine(queryId, query, queryDigest, session, self, executor);
             return createExecution(statement, session, stateMachine);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -18,6 +18,7 @@ import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import io.airlift.units.Duration;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 
 public class FailedQueryExecution
@@ -27,7 +28,7 @@ public class FailedQueryExecution
 
     public FailedQueryExecution(QueryId queryId, String query, Session session, URI self, Executor executor, Throwable cause)
     {
-        QueryStateMachine queryStateMachine = new QueryStateMachine(queryId, query, session, self, executor);
+        QueryStateMachine queryStateMachine = new QueryStateMachine(queryId, query, Optional.empty(), session, self, executor);
         queryStateMachine.fail(cause);
 
         queryInfo = queryStateMachine.getQueryInfo(null);

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -18,6 +18,8 @@ import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.sql.tree.Statement;
 import io.airlift.units.Duration;
 
+import java.util.Optional;
+
 public interface QueryExecution
 {
     QueryId getQueryId();
@@ -39,6 +41,6 @@ public interface QueryExecution
 
     interface QueryExecutionFactory<T extends QueryExecution>
     {
-        T createQueryExecution(QueryId queryId, String query, Session session, Statement statement);
+        T createQueryExecution(QueryId queryId, String query, Optional<String> queryDigest, Session session, Statement statement);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -45,6 +45,7 @@ public class QueryInfo
     private final URI self;
     private final List<String> fieldNames;
     private final String query;
+    private final String queryDigest;
     private final QueryStats queryStats;
     private final Map<String, String> setSessionProperties;
     private final Set<String> resetSessionProperties;
@@ -64,6 +65,7 @@ public class QueryInfo
             @JsonProperty("self") URI self,
             @JsonProperty("fieldNames") List<String> fieldNames,
             @JsonProperty("query") String query,
+            @JsonProperty("queryDigest") String queryDigest,
             @JsonProperty("queryStats") QueryStats queryStats,
             @JsonProperty("setSessionProperties") Map<String, String> setSessionProperties,
             @JsonProperty("resetSessionProperties") Set<String> resetSessionProperties,
@@ -91,6 +93,7 @@ public class QueryInfo
         this.self = self;
         this.fieldNames = ImmutableList.copyOf(fieldNames);
         this.query = query;
+        this.queryDigest = queryDigest;
         this.queryStats = queryStats;
         this.setSessionProperties = ImmutableMap.copyOf(setSessionProperties);
         this.resetSessionProperties = ImmutableSet.copyOf(resetSessionProperties);
@@ -142,6 +145,12 @@ public class QueryInfo
     public String getQuery()
     {
         return query;
+    }
+
+    @JsonProperty
+    public String getQueryDigest()
+    {
+        return queryDigest;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import io.airlift.units.Duration;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface QueryManager
 {
@@ -29,7 +30,7 @@ public interface QueryManager
 
     QueryInfo getQueryInfo(QueryId queryId);
 
-    QueryInfo createQuery(Session session, String query);
+    QueryInfo createQuery(Session session, String query, Optional<String> queryDigest);
 
     void cancelQuery(QueryId queryId);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryState.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryState.java
@@ -24,6 +24,10 @@ public enum QueryState
      */
     PLANNING(false),
     /**
+     * The digest generated for the query plan has matched the one provided with the query.
+     */
+    DIGEST_MATCHED(true),
+    /**
      * Query execution is being started.
      */
     STARTING(false),

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -18,6 +18,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.spi.ErrorCode;
+import com.facebook.presto.sql.planner.PlanDigest;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
@@ -38,6 +39,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
 
@@ -60,6 +62,7 @@ public class QueryStateMachine
 
     private final QueryId queryId;
     private final String query;
+    private final Optional<String> queryDigest;
     private final Session session;
     private final URI self;
 
@@ -100,10 +103,14 @@ public class QueryStateMachine
     @GuardedBy("this")
     private Set<Input> inputs = ImmutableSet.of();
 
-    public QueryStateMachine(QueryId queryId, String query, Session session, URI self, Executor executor)
+    @GuardedBy("this")
+    private Optional<PlanDigest> planDigest;
+
+    public QueryStateMachine(QueryId queryId, String query, Optional<String> queryDigest, Session session, URI self, Executor executor)
     {
         this.queryId = checkNotNull(queryId, "queryId is null");
         this.query = checkNotNull(query, "query is null");
+        this.queryDigest = checkNotNull(queryDigest, "queryDigest is null");
         this.session = checkNotNull(session, "session is null");
         this.self = checkNotNull(self, "self is null");
 
@@ -116,6 +123,8 @@ public class QueryStateMachine
                 log.debug("Query %s is %s", QueryStateMachine.this.queryId, newValue);
             }
         });
+
+        this.planDigest = Optional.empty();
     }
 
     public QueryId getQueryId()
@@ -244,6 +253,8 @@ public class QueryStateMachine
                 new DataSize(outputDataSize, BYTE).convertToMostSuccinctDataSize(),
                 outputPositions);
 
+        String digest = planDigest.map(PlanDigest::getDigestString).orElse("");
+
         return new QueryInfo(queryId,
                 session,
                 state,
@@ -251,6 +262,7 @@ public class QueryStateMachine
                 self,
                 outputFieldNames,
                 query,
+                digest,
                 queryStats,
                 setSessionProperties,
                 resetSessionProperties,
@@ -303,6 +315,16 @@ public class QueryStateMachine
         return queryState.get();
     }
 
+    public synchronized void setPlanDigest(Optional<PlanDigest> planDigest)
+    {
+        this.planDigest = planDigest;
+    }
+
+    public synchronized Optional<PlanDigest> getPlanDigest()
+    {
+        return planDigest;
+    }
+
     public synchronized boolean isDone()
     {
         return queryState.get().isDone();
@@ -321,6 +343,30 @@ public class QueryStateMachine
             queuedTime = Duration.nanosSince(createNanos).convertToMostSuccinctTimeUnit();
         }
         return true;
+    }
+
+    public synchronized boolean evaluateDigest()
+    {
+        if (!queryDigest.isPresent() || !planDigest.isPresent()) {
+            // no digest provided or generated
+            return false;
+        }
+
+        if (queryDigest.get().equals(planDigest.get().getDigestString())) {
+            // computed digest matched the one provided with the query, transitioning to a terminal state
+            boolean changed = queryState.compareAndSet(QueryState.PLANNING, QueryState.DIGEST_MATCHED);
+            if (changed) {
+                totalPlanningTime = Duration.nanosSince(createNanos);
+
+                if (endTime == null) {
+                    endTime = DateTime.now();
+                }
+            }
+
+            return changed;
+        }
+
+        return false;
     }
 
     public synchronized boolean starting()

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -230,7 +231,7 @@ public class SqlQueryManager
     }
 
     @Override
-    public QueryInfo createQuery(Session session, String query)
+    public QueryInfo createQuery(Session session, String query, Optional<String> queryDigest)
     {
         checkNotNull(query, "query is null");
         checkArgument(!query.isEmpty(), "query must not be empty string");
@@ -261,7 +262,7 @@ public class SqlQueryManager
             return execution.getQueryInfo();
         }
 
-        QueryExecution queryExecution = queryExecutionFactory.createQueryExecution(queryId, query, session, statement);
+        QueryExecution queryExecution = queryExecutionFactory.createQueryExecution(queryId, query, queryDigest, session, statement);
         queryMonitor.createdEvent(queryExecution.getQueryInfo());
 
         queryExecution.addStateChangeListener(newValue -> {

--- a/presto-main/src/main/java/com/facebook/presto/server/ExecuteResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ExecuteResource.java
@@ -40,6 +40,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CATALOG;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_DIGEST;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_LANGUAGE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SCHEMA;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SOURCE;
@@ -84,12 +85,13 @@ public class ExecuteResource
             @HeaderParam(PRESTO_SCHEMA) String schema,
             @HeaderParam(PRESTO_TIME_ZONE) String timeZoneId,
             @HeaderParam(PRESTO_LANGUAGE) String language,
+            @HeaderParam(PRESTO_DIGEST) String digest,
             @Context HttpServletRequest servletRequest)
     {
         assertRequest(!isNullOrEmpty(query), "SQL query is empty");
 
         Session session = createSessionForRequest(servletRequest);
-        ClientSession clientSession = session.toClientSession(serverUri(), false);
+        ClientSession clientSession = session.toClientSession(serverUri(), false, digest);
 
         StatementClient client = new StatementClient(httpClient, queryResultsCodec, clientSession, query);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -23,6 +23,7 @@ public class FeaturesConfig
     private boolean distributedJoinsEnabled;
     private boolean optimizeMetadataQueries;
     private boolean optimizeHashGeneration;
+    private boolean queryDigestEnabled;
 
     @LegacyConfig("analyzer.experimental-syntax-enabled")
     @Config("experimental-syntax-enabled")
@@ -82,6 +83,18 @@ public class FeaturesConfig
     public FeaturesConfig setOptimizeHashGeneration(boolean optimizeHashGeneration)
     {
         this.optimizeHashGeneration = optimizeHashGeneration;
+        return this;
+    }
+
+    public boolean isQueryDigestEnabled()
+    {
+        return queryDigestEnabled;
+    }
+
+    @Config("query-digest-enabled")
+    public FeaturesConfig setQueryDigestEnabled(boolean queryDigestEnabled)
+    {
+        this.queryDigestEnabled = queryDigestEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanDigest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.google.common.base.Charsets;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class PlanDigest
+{
+    private final Hasher hasher;
+    private HashCode hashCode;
+
+    @GuardedBy("this")
+    private boolean done;
+
+    public PlanDigest()
+    {
+        HashFunction hashFunction = Hashing.sha256();
+        this.hasher = hashFunction.newHasher();
+    }
+
+    public synchronized void update(byte[] bytes)
+    {
+        checkNotDone();
+        hasher.putBytes(bytes);
+    }
+
+    public synchronized void update(String string)
+    {
+        checkNotDone();
+        hasher.putString(string, Charsets.UTF_8);
+        hasher.putChar('|');
+    }
+
+    public synchronized void update(PlanDigest planDigest)
+    {
+        checkNotDone();
+        update(planDigest.digest());
+    }
+
+    private synchronized void checkNotDone()
+    {
+        checkState(!done, "Attempt to update a finalized digest.");
+    }
+
+    /**
+     * Returns the digest as hexadecimal string.
+     */
+    public synchronized String getDigestString()
+    {
+        if (!done) {
+            return hash().toString();
+        }
+        return hashCode.toString();
+    }
+
+    public byte[] digest()
+    {
+        return hash().asBytes();
+    }
+
+    /**
+     * Completes the hash computation on this digest object. Further update attempts will
+     * not be possible.
+     */
+    private synchronized HashCode hash()
+    {
+        if (!done) {
+            done = true;
+            hashCode = hasher.hash();
+        }
+        return hashCode;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanDigestGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanDigestGenerator.java
@@ -1,0 +1,715 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.metadata.ColumnHandle;
+import com.facebook.presto.metadata.Partition;
+import com.facebook.presto.metadata.PartitionResult;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.metadata.TypeParameter;
+import com.facebook.presto.spi.Domain;
+import com.facebook.presto.spi.Marker;
+import com.facebook.presto.spi.Range;
+import com.facebook.presto.spi.SortedRangeSet;
+import com.facebook.presto.spi.TupleDomain;
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.DistinctLimitNode;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.IndexJoinNode;
+import com.facebook.presto.sql.planner.plan.IndexSourceNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
+import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanVisitor;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.RowNumberNode;
+import com.facebook.presto.sql.planner.plan.SampleNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.facebook.presto.sql.planner.plan.SortNode;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
+import com.facebook.presto.sql.planner.plan.UnionNode;
+import com.facebook.presto.sql.planner.plan.UnnestNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FrameBound;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.SortItem;
+import com.facebook.presto.sql.tree.Window;
+import com.facebook.presto.sql.tree.WindowFrame;
+import io.airlift.slice.Slice;
+
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Computes digest for a query plan for caching.
+ */
+public class PlanDigestGenerator
+{
+    private final SplitManager splitManager;
+
+    @Inject
+    public PlanDigestGenerator(SplitManager splitManager)
+    {
+        this.splitManager = splitManager;
+    }
+
+    public PlanDigest generate(Plan plan)
+    {
+        Visitor visitor = new Visitor();
+        PlanDigest digest = plan.getRoot().accept(visitor, null);
+        return digest;
+    }
+
+    private final class Visitor
+            extends PlanVisitor<Void, PlanDigest>
+    {
+        @Override
+        public PlanDigest visitTableScan(TableScanNode node, Void context)
+        {
+            List<Partition> partitions;
+            if (node.getGeneratedPartitions().isPresent()) {
+                partitions = node.getGeneratedPartitions().get().getPartitions();
+            }
+            else {
+                PartitionResult allPartitions = splitManager.getPartitions(node.getTable(), Optional.empty());
+                partitions = allPartitions.getPartitions();
+            }
+
+            Optional<Slice> partitionDigest = splitManager.computeDigest(node.getTable(), partitions);
+
+            if (!partitionDigest.isPresent()) {
+                // connector did not generate digest for the partitions, return a random digest
+                return generateRandomDigest();
+            }
+
+            PlanDigest digest = new PlanDigest();
+            digest.update(partitionDigest.get().getBytes());
+            updateDigestWithSymbols(digest, node.getOutputSymbols());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitFilter(FilterNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null); // visit child
+
+            String predicate = node.getPredicate().toString();
+            digest.update(predicate);
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitProject(ProjectNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            // add assignments to the digest
+            Map<Symbol, Expression> assignments = node.getAssignments();
+            if (assignments != null && !assignments.isEmpty()) {
+                List<Symbol> keys = new ArrayList<>(assignments.keySet());
+                Collections.sort(keys);  // order matters for digest
+                for (Symbol symbol : keys) {
+                    Expression expression = assignments.get(symbol);
+                    digest.update(symbol.getName());
+                    digest.update(expression.toString());
+                }
+            }
+
+            // add output symbols to the digest
+            updateDigestWithSymbols(digest, node.getOutputSymbols());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitAggregation(AggregationNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            updateDigestWithSymbols(digest, node.getGroupBy());
+
+            updateDigestWithSymbolFunctionCallMap(digest, node.getAggregations());
+            updateDigestWithSymbolSignatureMap(digest, node.getFunctions());
+            updateDigestWithSymbolSymbolMap(digest, node.getMasks());
+
+            digest.update(node.getStep().name());
+
+            updateDigestWithOptionalSymbol(digest, node.getSampleWeight());
+            updateDigestWithOptionalSymbol(digest, node.getHashSymbol());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitExchange(ExchangeNode node, Void context)
+        {
+            PlanDigest digest = visitSources(node.getSources());
+
+            digest.update(node.getType().name());
+
+            updateDigestWithSymbols(digest, node.getOutputSymbols());
+            updateDigestWithSymbols(digest, node.getPartitionKeys());
+
+            updateDigestWithOptionalSymbol(digest, node.getHashSymbol());
+
+            // list of inputs for each output
+            for (List<Symbol> symbols : node.getInputs()) {
+                updateDigestWithSymbols(digest, symbols);
+            }
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitOutput(OutputNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            // add columns to the digest
+            List<String> columns = new ArrayList<>(node.getColumnNames());
+            Collections.sort(columns);
+            columns.forEach(digest::update);
+
+            // add outputs to the digest
+            updateDigestWithSymbols(digest, node.getOutputSymbols());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitLimit(LimitNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            digest.update(String.valueOf(node.getCount()));
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitDistinctLimit(DistinctLimitNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            digest.update(String.valueOf(node.getLimit()));
+
+            // add symbol for distinct
+            updateDigestWithOptionalSymbol(digest, node.getHashSymbol());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitTopN(TopNNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            digest.update(String.valueOf(node.getCount()));
+
+            // add order-by symbols
+            updateDigestWithSymbols(digest, node.getOrderBy());
+
+            // add sort order map
+            updateDigestWithOrderingsMap(digest, node.getOrderings());
+
+            digest.update(String.valueOf(node.isPartial()));
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitJoin(JoinNode node, Void context)
+        {
+            PlanNode left = node.getLeft();
+            PlanNode right = node.getRight();
+
+            // get digest from the left source, and update it with the digest
+            // from the right source.
+            PlanDigest digest = left.accept(this, null);
+            digest.update(right.accept(this, null));
+
+            // add join clauses to the digest
+            for (JoinNode.EquiJoinClause joinClause : node.getCriteria()) {
+                digest.update(joinClause.getLeft().getName());
+                digest.update(joinClause.getRight().getName());
+            }
+
+            updateDigestWithOptionalSymbol(digest, node.getLeftHashSymbol());
+            updateDigestWithOptionalSymbol(digest, node.getRightHashSymbol());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitSample(SampleNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            digest.update(String.valueOf(node.getSampleRatio()));
+            digest.update(node.getSampleType().name());
+            digest.update(String.valueOf(node.isRescaled()));
+
+            updateDigestWithOptionalSymbol(digest, node.getSampleWeightSymbol());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitValues(ValuesNode node, Void context)
+        {
+            PlanDigest digest = new PlanDigest();
+
+            updateDigestWithSymbols(digest, node.getOutputSymbols());
+
+            // add rows of expressions to the digest
+            for (List<Expression> expressions : node.getRows()) {
+                for (Expression expression : expressions) {
+                    digest.update(expression.toString());
+                }
+            }
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitIndexSource(IndexSourceNode node, Void context)
+        {
+            PlanDigest digest = new PlanDigest();
+
+            digest.update(node.getIndexHandle().getConnectorId());
+            digest.update(node.getTableHandle().getConnectorId());
+
+            List<Symbol> lookupSymbols = new ArrayList<>(node.getLookupSymbols());
+            Collections.sort(lookupSymbols);
+            updateDigestWithSymbols(digest, lookupSymbols);
+
+            updateDigestWithSymbols(digest, node.getOutputSymbols());
+
+            Map<Symbol, ColumnHandle> assignments = node.getAssignments();
+            List<Symbol> keys = new ArrayList<>(assignments.keySet());
+            Collections.sort(keys);
+            for (Symbol symbol : keys) {
+                digest.update(symbol.getName());
+                digest.update(assignments.get(symbol).getConnectorId());
+            }
+
+            TupleDomain<ColumnHandle> effectiveTupleDomain = node.getEffectiveTupleDomain();
+            Map<ColumnHandle, Domain> domains = effectiveTupleDomain.getDomains();
+            List<ColumnHandle> columnHandleList = new ArrayList<>(domains.keySet());
+            Collections.sort(columnHandleList, (k1, k2) -> k1.getConnectorId().compareTo(k2.getConnectorId()));
+            for (ColumnHandle columnHandle : columnHandleList) {
+                Domain domain = domains.get(columnHandle);
+                digest.update(columnHandle.getConnectorId());
+                updateDigestWithDomain(digest, domain);
+            }
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitSemiJoin(SemiJoinNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanNode filteringSource = node.getFilteringSource();
+
+            // get digest from the source node and update it with digest from filtering source.
+            PlanDigest digest = source.accept(this, null);
+            digest.update(filteringSource.accept(this, null));
+
+            digest.update(node.getSourceJoinSymbol().getName());
+            digest.update(node.getFilteringSourceJoinSymbol().getName());
+            digest.update(node.getSemiJoinOutput().getName());
+
+            updateDigestWithOptionalSymbol(digest, node.getSourceHashSymbol());
+            updateDigestWithOptionalSymbol(digest, node.getFilteringSourceHashSymbol());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitIndexJoin(IndexJoinNode node, Void context)
+        {
+            PlanNode probeSource = node.getProbeSource();
+            PlanNode indexSource = node.getIndexSource();
+
+            // get digest from probe source node and update it with the digest from index source
+            PlanDigest digest = probeSource.accept(this, null);
+            digest.update(indexSource.accept(this, null));
+
+            digest.update(node.getType().name());
+
+            // add join clause to the digest
+            for (IndexJoinNode.EquiJoinClause joinClause : node.getCriteria()) {
+                digest.update(joinClause.getProbe().getName());
+                digest.update(joinClause.getIndex().getName());
+            }
+
+            updateDigestWithOptionalSymbol(digest, node.getProbeHashSymbol());
+            updateDigestWithOptionalSymbol(digest, node.getIndexHashSymbol());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitSort(SortNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            updateDigestWithSymbols(digest, node.getOrderBy());
+
+            updateDigestWithOrderingsMap(digest, node.getOrderings());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitWindow(WindowNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            updateDigestWithSymbols(digest, node.getPartitionBy());
+            updateDigestWithSymbols(digest, node.getOrderBy());
+
+            updateDigestWithOrderingsMap(digest, node.getOrderings());
+
+            WindowNode.Frame frame = node.getFrame();
+            digest.update(frame.getType().name());
+            digest.update(frame.getStartType().name());
+            digest.update(frame.getEndType().name());
+            updateDigestWithOptionalSymbol(digest, frame.getStartValue());
+            updateDigestWithOptionalSymbol(digest, frame.getEndValue());
+
+            updateDigestWithSymbolFunctionCallMap(digest, node.getWindowFunctions());
+            updateDigestWithSymbolSignatureMap(digest, node.getSignatures());
+
+            updateDigestWithOptionalSymbol(digest, node.getHashSymbol());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitUnion(UnionNode node, Void context)
+        {
+            PlanDigest digest = visitSources(node.getSources());
+
+            Map<Symbol, Collection<Symbol>> outputToInputsMap = node.getSymbolMapping().asMap();
+            List<Symbol> keys = new ArrayList<>(outputToInputsMap.keySet());
+            Collections.sort(keys);
+            for (Symbol outputSymbol : keys) {
+                digest.update(outputSymbol.getName());
+                List<Symbol> inputs = new ArrayList<>(outputToInputsMap.get(outputSymbol));
+                Collections.sort(inputs);
+                for (Symbol inputSymbol : inputs) {
+                    digest.update(inputSymbol.getName());
+                }
+            }
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitUnnest(UnnestNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            updateDigestWithSymbols(digest, node.getReplicateSymbols());
+
+            Map<Symbol, List<Symbol>> unnestSymbols = node.getUnnestSymbols();
+            List<Symbol> keys = new ArrayList<>(unnestSymbols.keySet());
+            Collections.sort(keys);
+            for (Symbol symbol : keys) {
+                digest.update(symbol.getName());
+                updateDigestWithSymbols(digest, unnestSymbols.get(symbol));
+            }
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitMarkDistinct(MarkDistinctNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            digest.update(node.getMarkerSymbol().getName());
+            updateDigestWithOptionalSymbol(digest, node.getHashSymbol());
+            updateDigestWithSymbols(digest, node.getDistinctSymbols());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitRowNumber(RowNumberNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            updateDigestWithSymbols(digest, node.getPartitionBy());
+
+            if (node.getMaxRowCountPerPartition().isPresent()) {
+                digest.update(String.valueOf(node.getMaxRowCountPerPartition().get().intValue()));
+            }
+
+            digest.update(node.getRowNumberSymbol().getName());
+            updateDigestWithOptionalSymbol(digest, node.getHashSymbol());
+
+            return digest;
+        }
+
+        @Override
+        public PlanDigest visitTopNRowNumber(TopNRowNumberNode node, Void context)
+        {
+            PlanNode source = node.getSource();
+            PlanDigest digest = source.accept(this, null);
+
+            updateDigestWithSymbols(digest, node.getPartitionBy());
+            updateDigestWithSymbols(digest, node.getOrderBy());
+            updateDigestWithOrderingsMap(digest, node.getOrderings());
+
+            digest.update(node.getRowNumberSymbol().getName());
+            digest.update(String.valueOf(node.getMaxRowCountPerPartition()));
+            digest.update(String.valueOf(node.isPartial()));
+
+            updateDigestWithOptionalSymbol(digest, node.getHashSymbol());
+
+            return digest;
+        }
+
+        @Override
+        protected PlanDigest visitPlan(PlanNode node, Void context)
+        {
+            // unsupported plan node, returning a random digest
+            return generateRandomDigest();
+        }
+
+        /**
+         * Helper method to visit multiple sources
+         */
+        private PlanDigest visitSources(List<PlanNode> sources)
+        {
+            Iterator<PlanNode> itr = sources.iterator();
+            PlanDigest digest = itr.next().accept(this, null);
+            while (itr.hasNext()) {
+                digest.update(itr.next().accept(this, null));
+            }
+
+            return digest;
+        }
+
+        private void updateDigestWithSymbols(PlanDigest digest, List<Symbol> symbols)
+        {
+            if (symbols == null || symbols.isEmpty()) {
+                return;
+            }
+
+            for (Symbol symbol : symbols) {
+                digest.update(symbol.getName());
+            }
+        }
+
+        private void updateDigestWithDomain(PlanDigest digest, Domain domain)
+        {
+            SortedRangeSet sortedRangeSet = domain.getRanges();
+            digest.update(sortedRangeSet.getType().getName());
+            for (Range range : sortedRangeSet) {
+                updateDigestWithMarker(digest, range.getLow());
+                updateDigestWithMarker(digest, range.getHigh());
+            }
+
+            digest.update(String.valueOf(domain.isNullAllowed()));
+        }
+
+        private void updateDigestWithMarker(PlanDigest digest, Marker marker)
+        {
+            digest.update(marker.getType().getName());
+            digest.update(marker.getBound().name());
+        }
+
+        private void updateDigestWithSymbolSignatureMap(PlanDigest digest, Map<Symbol, Signature> symbolSignatureMap)
+        {
+            List<Symbol> keys = new ArrayList<>(symbolSignatureMap.keySet());
+            Collections.sort(keys);
+            for (Symbol symbol : keys) {
+                Signature signature = symbolSignatureMap.get(symbol);
+                digest.update(symbol.getName());
+                updateDigestWithSignature(digest, signature);
+            }
+        }
+
+        private void updateDigestWithSymbolFunctionCallMap(PlanDigest digest, Map<Symbol, FunctionCall> symbolFunctionCallMap)
+        {
+            List<Symbol> keys = new ArrayList<>(symbolFunctionCallMap.keySet());
+            Collections.sort(keys);
+            for (Symbol symbol : keys) {
+                FunctionCall functionCall = symbolFunctionCallMap.get(symbol);
+                digest.update(symbol.getName());
+                updateDigestWithFunctionCall(digest, functionCall);
+            }
+        }
+
+        private void updateDigestWithSymbolSymbolMap(PlanDigest digest, Map<Symbol, Symbol> symbolSymbolMap)
+        {
+            List<Symbol> keys = new ArrayList<>(symbolSymbolMap.keySet());
+            Collections.sort(keys);
+            for (Symbol key : keys) {
+                digest.update(key.getName());
+                digest.update(symbolSymbolMap.get(key).getName());
+            }
+        }
+
+        private void updateDigestWithSignature(PlanDigest digest, Signature signature)
+        {
+            digest.update(signature.getName());
+
+            for (TypeParameter typeParameter : signature.getTypeParameters()) {
+                digest.update(typeParameter.getName());
+                digest.update(String.valueOf(typeParameter.isComparableRequired()));
+                digest.update(String.valueOf(typeParameter.isOrderableRequired()));
+                digest.update(typeParameter.getVariadicBound());
+            }
+
+            updateDigestWithTypeSignature(digest, signature.getReturnType());
+
+            for (TypeSignature typeSignature : signature.getArgumentTypes()) {
+                updateDigestWithTypeSignature(digest, typeSignature);
+            }
+
+            digest.update(String.valueOf(signature.isVariableArity()));
+            digest.update(String.valueOf(signature.isInternal()));
+        }
+
+        private void updateDigestWithTypeSignature(PlanDigest digest, TypeSignature typeSignature)
+        {
+            digest.update(typeSignature.getBase());
+
+            for (TypeSignature typeSignatureParameter : typeSignature.getParameters()) {
+                updateDigestWithTypeSignature(digest, typeSignatureParameter);
+            }
+
+            for (Object obj : typeSignature.getLiteralParameters()) {
+                digest.update(obj.toString());
+            }
+        }
+
+        private void updateDigestWithFunctionCall(PlanDigest digest, FunctionCall functionCall)
+        {
+            for (String part : functionCall.getName().getParts()) {
+                digest.update(part);
+            }
+
+            if (functionCall.getWindow().isPresent()) {
+                updateDigestWithWindow(digest, functionCall.getWindow().get());
+            }
+
+            digest.update(String.valueOf(functionCall.isDistinct()));
+
+            for (Expression expression : functionCall.getArguments()) {
+                digest.update(expression.toString());
+            }
+        }
+
+        private void updateDigestWithWindow(PlanDigest digest, Window window)
+        {
+            for (Expression expression : window.getPartitionBy()) {
+                digest.update(expression.toString());
+            }
+
+            for (SortItem sortItem : window.getOrderBy()) {
+                digest.update(sortItem.getSortKey().toString());
+                digest.update(sortItem.getOrdering().name());
+                digest.update(sortItem.getNullOrdering().name());
+            }
+
+            if (window.getFrame().isPresent()) {
+                WindowFrame windowFrame = window.getFrame().get();
+                digest.update(windowFrame.getType().name());
+
+                updateDigestWithFrameBound(digest, windowFrame.getStart());
+                if (windowFrame.getEnd().isPresent()) {
+                    updateDigestWithFrameBound(digest, windowFrame.getEnd().get());
+                }
+
+            }
+
+        }
+
+        private void updateDigestWithFrameBound(PlanDigest digest, FrameBound frameBound)
+        {
+            digest.update(frameBound.getType().name());
+
+            if (frameBound.getValue().isPresent()) {
+                digest.update(frameBound.getValue().get().toString());
+            }
+        }
+
+        private void updateDigestWithOrderingsMap(PlanDigest digest, Map<Symbol, SortOrder> orderings)
+        {
+            List<Symbol> keys = new ArrayList<>(orderings.keySet());
+            Collections.sort(keys);
+            for (Symbol symbol : keys) {
+                SortOrder sortOder = orderings.get(symbol);
+                digest.update(symbol.getName());
+                digest.update(String.valueOf(sortOder.isAscending()));
+                digest.update(String.valueOf(sortOder.isNullsFirst()));
+            }
+        }
+
+        private void updateDigestWithOptionalSymbol(PlanDigest digest, Optional<Symbol> symbol)
+        {
+            if (symbol.isPresent()) {
+                digest.update(symbol.get().getName());
+            }
+        }
+
+        private PlanDigest generateRandomDigest()
+        {
+            PlanDigest digest = new PlanDigest();
+            byte[] buffer = new byte[128];
+            ThreadLocalRandom.current().nextBytes(buffer);
+            digest.update(buffer);
+            return digest;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -74,6 +74,8 @@ import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import com.facebook.presto.sql.planner.LogicalPlanner;
 import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.PlanDigest;
+import com.facebook.presto.sql.planner.PlanDigestGenerator;
 import com.facebook.presto.sql.planner.PlanFragmenter;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.PlanOptimizersFactory;

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -311,12 +311,12 @@ public class LocalQueryRunner
     }
 
     @Override
-    public MaterializedResult execute(Session session, @Language("SQL") String sql)
+    public MaterializedResult execute(Session session, @Language("SQL") String sql, String digest)
     {
         MaterializedOutputFactory outputFactory = new MaterializedOutputFactory();
 
         TaskContext taskContext = new TaskContext(new TaskId("query", "stage", "task"), executor, session);
-        List<Driver> drivers = createDrivers(session, sql, outputFactory, taskContext);
+        List<Driver> drivers = createDrivers(session, sql, outputFactory, taskContext, digest);
 
         boolean done = false;
         while (!done) {
@@ -333,12 +333,18 @@ public class LocalQueryRunner
         return outputFactory.getMaterializingOperator().getMaterializedResult();
     }
 
-    public List<Driver> createDrivers(@Language("SQL") String sql, OutputFactory outputFactory, TaskContext taskContext)
+    @Override
+    public MaterializedResult execute(Session session, @Language("SQL") String sql)
     {
-        return createDrivers(defaultSession, sql, outputFactory, taskContext);
+        return execute(session, sql, null);
     }
 
-    public List<Driver> createDrivers(Session session, @Language("SQL") String sql, OutputFactory outputFactory, TaskContext taskContext)
+    public List<Driver> createDrivers(@Language("SQL") String sql, OutputFactory outputFactory, TaskContext taskContext)
+    {
+        return createDrivers(defaultSession, sql, outputFactory, taskContext, null);
+    }
+
+    public List<Driver> createDrivers(Session session, @Language("SQL") String sql, OutputFactory outputFactory, TaskContext taskContext, String digest)
     {
         Statement statement = sqlParser.createStatement(sql);
 
@@ -356,6 +362,14 @@ public class LocalQueryRunner
 
         Analysis analysis = analyzer.analyze(statement);
         Plan plan = new LogicalPlanner(session, planOptimizersFactory.get(), idAllocator, metadata).plan(analysis);
+
+        PlanDigestGenerator planDigestGenerator = new PlanDigestGenerator(splitManager);
+        PlanDigest planDigest = planDigestGenerator.generate(plan);
+
+        checkState(planDigest != null, "Digest is null for query: " + sql);
+        if (digest != null) {
+            checkState(planDigest.getDigestString().equals(digest));
+        }
 
         if (printPlan) {
             System.out.println(PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata));

--- a/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
@@ -36,6 +36,8 @@ public interface QueryRunner
 
     MaterializedResult execute(Session session, @Language("SQL") String sql);
 
+    MaterializedResult execute(Session session, @Language("SQL") String sql, String digest);
+
     List<QualifiedTableName> listTables(Session session, String catalog, String schema);
 
     boolean tableExists(Session session, String table);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestResetSessionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestResetSessionTask.java
@@ -22,6 +22,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
@@ -47,7 +48,7 @@ public class TestResetSessionTask
     {
         Session session = TEST_SESSION.withSystemProperty("foo", "bar").withCatalogProperty("catalog", "baz", "blah");
 
-        QueryStateMachine stateMachine = new QueryStateMachine(new QueryId("query"), "reset foo", session, URI.create("fake://uri"), executor);
+        QueryStateMachine stateMachine = new QueryStateMachine(new QueryId("query"), "reset foo", Optional.empty(), session, URI.create("fake://uri"), executor);
         new ResetSessionTask().execute(new ResetSession(QualifiedName.of("catalog", "baz")), session, new MetadataManager(), stateMachine);
 
         Set<String> sessionProperties = stateMachine.getResetSessionProperties();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSetSessionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSetSessionTask.java
@@ -22,6 +22,7 @@ import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
@@ -44,7 +45,7 @@ public class TestSetSessionTask
     public void test()
             throws Exception
     {
-        QueryStateMachine stateMachine = new QueryStateMachine(new QueryId("query"), "set foo.bar = 'baz'", TEST_SESSION, URI.create("fake://uri"), executor);
+        QueryStateMachine stateMachine = new QueryStateMachine(new QueryId("query"), "set foo.bar = 'baz'", Optional.empty(), TEST_SESSION, URI.create("fake://uri"), executor);
         new SetSessionTask().execute(new SetSession(QualifiedName.of("foo", "bar"), "baz"), TEST_SESSION, new MetadataManager(), stateMachine);
 
         Map<String, String> sessionProperties = stateMachine.getSetSessionProperties();

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -33,7 +33,8 @@ public class TestFeaturesConfig
                 .setDistributedIndexJoinsEnabled(false)
                 .setDistributedJoinsEnabled(false)
                 .setOptimizeMetadataQueries(false)
-                .setOptimizeHashGeneration(false));
+                .setOptimizeHashGeneration(false)
+                .setQueryDigestEnabled(false));
     }
 
     @Test
@@ -45,6 +46,7 @@ public class TestFeaturesConfig
                 .put("distributed-joins-enabled", "true")
                 .put("optimizer.optimize-metadata-queries", "true")
                 .put("optimizer.optimize-hash-generation", "true")
+                .put("query-digest-enabled", "true")
                 .build();
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("experimental-syntax-enabled", "true")
@@ -52,6 +54,7 @@ public class TestFeaturesConfig
                 .put("distributed-joins-enabled", "true")
                 .put("optimizer.optimize-metadata-queries", "true")
                 .put("optimizer.optimize-hash-generation", "true")
+                .put("query-digest-enabled", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -59,7 +62,8 @@ public class TestFeaturesConfig
                 .setDistributedIndexJoinsEnabled(true)
                 .setDistributedJoinsEnabled(true)
                 .setOptimizeMetadataQueries(true)
-                .setOptimizeHashGeneration(true);
+                .setOptimizeHashGeneration(true)
+                .setQueryDigestEnabled(true);
 
         assertFullMapping(properties, expected);
         assertDeprecatedEquivalence(FeaturesConfig.class, properties, propertiesLegacy);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplitManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplitManager.java
@@ -13,7 +13,10 @@
  */
 package com.facebook.presto.spi;
 
+import io.airlift.slice.Slice;
+
 import java.util.List;
+import java.util.Optional;
 
 public interface ConnectorSplitManager
 {
@@ -25,6 +28,16 @@ public interface ConnectorSplitManager
      * this information to perform connector-specific optimizations.
      */
     ConnectorPartitionResult getPartitions(ConnectorTableHandle table, TupleDomain<ConnectorColumnHandle> tupleDomain);
+
+    /**
+     * Computes the digest for the partitions of a specific table. Digest indicates the update state of
+     * the partitions or the table. It should generate the same digest for the same set of partitions as long as
+     * those partitions would not produce a different dataset for table scan.
+     */
+    default Optional<Slice> computeDigest(ConnectorTableHandle table, List<ConnectorPartition> connectorPartitions)
+    {
+        return Optional.empty();
+    }
 
     /**
      * Gets the Splits for the specified Partitions in the indicated table.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/classloader/ClassLoaderSafeConnectorSplitManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/classloader/ClassLoaderSafeConnectorSplitManager.java
@@ -20,8 +20,10 @@ import com.facebook.presto.spi.ConnectorSplitManager;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.TupleDomain;
+import io.airlift.slice.Slice;
 
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -42,6 +44,14 @@ public final class ClassLoaderSafeConnectorSplitManager
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getPartitions(table, tupleDomain);
+        }
+    }
+
+    @Override
+    public Optional<Slice> computeDigest(ConnectorTableHandle table, List<ConnectorPartition> connectorPartitions)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.computeDigest(table, connectorPartitions);
         }
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -232,6 +232,12 @@ public class DistributedQueryRunner
     }
 
     @Override
+    public MaterializedResult execute(Session session, @Language("SQL") String sql, String digest)
+    {
+        return prestoClient.execute(session, sql, digest);
+    }
+
+    @Override
     public final void close()
     {
         try {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/ResultsSession.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/ResultsSession.java
@@ -16,11 +16,12 @@ package com.facebook.presto.tests;
 import com.facebook.presto.client.QueryResults;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public interface ResultsSession<T>
 {
     void addResults(QueryResults result);
 
-    T build(Map<String, String> setSessionProperties, Set<String> resetSessionProperties);
+    T build(Map<String, String> setSessionProperties, Set<String> resetSessionProperties, Optional<QueryResults> finalQueryResults);
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -74,6 +74,12 @@ public final class StandaloneQueryRunner
     }
 
     @Override
+    public MaterializedResult execute(Session session, @Language("SQL") String sql, String digest)
+    {
+        return prestoClient.execute(session, sql, digest);
+    }
+
+    @Override
     public void close()
     {
         Closeables.closeQuietly(prestoClient);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -30,6 +30,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -102,13 +103,17 @@ public class TestingPrestoClient
                 checkState(types.get() != null, "data received without types");
                 rows.addAll(transform(results.getData(), dataToRow(timeZoneKey, types.get())));
             }
+            else if (results.isDigestMatched()) {
+                // no columns nor data expected if query is terminated with digest matched
+                types.set(new ArrayList<>());
+            }
         }
 
         @Override
-        public MaterializedResult build(Map<String, String> setSessionProperties, Set<String> resetSessionProperties)
+        public MaterializedResult build(Map<String, String> setSessionProperties, Set<String> resetSessionProperties, Optional<QueryResults> finalQueryResults)
         {
             checkState(types.get() != null, "never received types for the query");
-            return new MaterializedResult(rows.build(), types.get(), setSessionProperties, resetSessionProperties);
+            return new MaterializedResult(rows.build(), types.get(), setSessionProperties, resetSessionProperties, finalQueryResults);
         }
     }
 

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesDigest.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesDigest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tpch.TpchPlugin;
+import io.airlift.log.Logger;
+import io.airlift.testing.Closeables;
+import io.airlift.units.Duration;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.airlift.units.Duration.nanosSince;
+import static java.util.Locale.ENGLISH;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestDistributedQueriesDigest
+        extends AbstractTestQueryFramework
+{
+    private static final Logger log = Logger.get(TestDistributedQueriesDigest.class);
+
+    protected TestDistributedQueriesDigest()
+                throws Exception
+    {
+        super(createQueryRunner());
+    }
+
+    @AfterClass
+    public void destroy()
+            throws Exception
+    {
+        Closeables.closeQuietly(queryRunner);
+    }
+
+    private static DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = Session.builder()
+                .setUser("user")
+                .setSource("test")
+                .setCatalog("tpch")
+                .setSchema(TINY_SCHEMA_NAME)
+                .setTimeZoneKey(UTC_KEY)
+                .setLocale(ENGLISH)
+                .build();
+
+        DistributedQueryRunner queryRunner = new DistributedQueryRunner(session, 2);
+
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+
+        return queryRunner;
+    }
+
+    protected void assertQuery(@Language("SQL") String sql, boolean shouldDigestMatch)
+            throws Exception
+    {
+        long start = System.nanoTime();
+        MaterializedResult results = queryRunner.execute(sql);
+        Duration executionTime = nanosSince(start);
+
+        assertTrue(results.getFinalQueryResults().isPresent());
+        QueryResults queryResults = results.getFinalQueryResults().get();
+        log.info("FINISHED in presto: %s, time: %s, digest: %s, rows: %d [sql: %s]",
+                queryResults.getStats().getState(), executionTime, queryResults.getQueryDigest(), results.getRowCount(), sql);
+
+        assertNull(queryResults.getError(), "Error in query result.");
+        assertFalse(queryResults.isDigestMatched(), "Query digest matched.");
+
+        // send the same query with the digest
+        start = System.nanoTime();
+        results = queryRunner.execute(queryRunner.getDefaultSession(), sql, queryResults.getQueryDigest());
+        executionTime = nanosSince(start);
+
+        assertTrue(results.getFinalQueryResults().isPresent());
+        queryResults = results.getFinalQueryResults().get();
+        log.info("FINISHED in presto: %s, time: %s, digest: %s, rows: %d [sql: %s]",
+                queryResults.getStats().getState(), executionTime, queryResults.getQueryDigest(), results.getRowCount(), sql);
+
+        assertNull(queryResults.getError(), "Error in query result.");
+        if (shouldDigestMatch) {
+            assertTrue(queryResults.isDigestMatched(), "Query digest not matched.");
+            assertEquals(results.getRowCount(), 0, "No rows expected in the query results but found: " + results.getRowCount());
+        }
+        else {
+            assertFalse(queryResults.isDigestMatched(), "Query digest matched.");
+        }
+    }
+
+    @Override
+    protected void assertQuery(@Language("SQL") String sql)
+            throws Exception
+    {
+        assertQuery(sql, true);
+    }
+        @Test
+    public void testQueryDigestMatched()
+            throws Exception
+    {
+        // test a sample of queries that should return the same digest every time
+        assertQuery("SELECT COUNT(true) FROM orders");
+        assertQuery("SELECT orderstatus FROM orders ORDER BY orderstatus");
+        assertQuery("SELECT * FROM orders UNION ALL SELECT * FROM orders");
+        assertQuery("SELECT COUNT(*) FROM ORDERS");
+        assertQuery("SELECT COUNT(42) FROM ORDERS");
+        assertQuery("SELECT COUNT(42 + 42) FROM ORDERS");
+        assertQuery("SELECT COUNT(null) FROM ORDERS");
+        assertQuery("SELECT *, orders.*, orderkey FROM orders");
+        assertQuery("SELECT *, orderkey NOT IN (SELECT orderkey FROM lineitem WHERE orderkey % 3 = 0) FROM orders");
+        assertQuery("SELECT sum(IF(orderstatus = 'F', totalprice, 0.0)) FROM orders");
+        assertQuery("SELECT orderkey FROM orders WHERE orderkey IN (1.5, 2.3)");
+        assertQuery("SELECT * FROM (SELECT orderkey X FROM orders)");
+        assertQuery("SELECT COUNT(DISTINCT clerk) as count, orderdate FROM orders GROUP BY orderdate ORDER BY count, orderdate");
+
+        assertQuery("" +
+                "SELECT a.custkey, b.orderkey " +
+                "FROM (SELECT * FROM orders ORDER BY orderkey LIMIT 5) a " +
+                "CROSS JOIN (SELECT * FROM lineitem ORDER BY orderkey LIMIT 5) b");
+
+        assertQuery("SELECT RANK() OVER (PARTITION BY orderdate ORDER BY COUNT(DISTINCT clerk)) rnk " +
+                "FROM orders " +
+                "GROUP BY orderdate, custkey " +
+                "ORDER BY rnk " +
+                "LIMIT 1");
+
+        assertQuery("SELECT RANK() OVER (PARTITION BY orderdate ORDER BY COUNT(DISTINCT clerk)) rnk " +
+                "FROM orders " +
+                "GROUP BY orderdate, custkey " +
+                "ORDER BY rnk " +
+                "LIMIT 1");
+
+        assertQuery("SELECT orderkey, orderstatus\n" +
+                ", row_number() OVER (ORDER BY orderkey * 2) *\n" +
+                "  row_number() OVER (ORDER BY orderkey DESC) + 100\n" +
+                "FROM (SELECT * FROM orders ORDER BY orderkey LIMIT 10) x\n" +
+                "ORDER BY orderkey LIMIT 5");
+    }
+
+    @Test
+    public void testQueryDigestNotMatched()
+            throws Exception
+    {
+        // now() should result in different digest every time
+        assertQuery("SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY now()", false);
+
+        // information_schema not in catalog, the connector should return a random digest
+        assertQuery("SELECT table_name FROM information_schema.tables WHERE table_name = 'orders' LIMIT 1", false);
+    }
+}


### PR DESCRIPTION
- Query digest is generated from an optimized plan, and returned as part of the query results. If two digests are the same, the query results when executed must be identical.
- If the generated digest matches the digest provided by X-Presto-Digest, the query state machine is terminated with DIGEST_MATCHED state, which is added to QueryState as a new terminal state.
- Connectors compute the digest for the partitions or the table. Hive connector computes the digest based on the names and the last modification timestamp of either the partitions or the table, depending on the number of partitions that it needs to fetch the metadata. 
- There are some randomizations in the plan generation for certain types of queries that result in different digests even for the same query, especially with joins.
- Query digests are logged as part of query completion event.