### PR TITLE
Configurable cassandra LoadBalancingPolicy and NoHostAvailable retry …

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
@@ -62,6 +62,15 @@ public class CassandraClientConfig
     private Duration clientConnectTimeout = new Duration(SocketOptions.DEFAULT_CONNECT_TIMEOUT_MILLIS, MILLISECONDS);
     private Integer clientSoLinger;
     private RetryPolicyType retryPolicy = RetryPolicyType.DEFAULT;
+    private boolean useDCAware;
+    private String dcAwareLocalDC;
+    private int dcAwareUsedHostsPerRemoteDc;
+    private boolean dcAwareAllowRemoteDCsForLocalConsistencyLevel;
+    private boolean useTokenAware;
+    private boolean tokenAwareShuffleReplicas;
+    private boolean useWhiteList;
+    private List<String> whiteListAddresses = ImmutableList.of();
+    private int noHostAvailableRetryCount = 1;
 
     @Min(0)
     public int getLimitForPartitionKeySelect()
@@ -350,6 +359,122 @@ public class CassandraClientConfig
     public CassandraClientConfig setRetryPolicy(RetryPolicyType retryPolicy)
     {
         this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    public boolean getUseDCAware()
+    {
+        return this.useDCAware;
+    }
+
+    @Config("cassandra.load-policy.use-dc-aware")
+    public CassandraClientConfig setUseDCAware(boolean useDCAware)
+    {
+        this.useDCAware = useDCAware;
+        return this;
+    }
+
+    public String getDcAwareLocalDC()
+    {
+        return dcAwareLocalDC;
+    }
+
+    @Config("cassandra.load-policy.dc-aware.local-dc")
+    public CassandraClientConfig setDcAwareLocalDC(String dcAwareLocalDC)
+    {
+        this.dcAwareLocalDC = dcAwareLocalDC;
+        return this;
+    }
+
+    @Min(0)
+    public Integer getDcAwareUsedHostsPerRemoteDc()
+    {
+        return dcAwareUsedHostsPerRemoteDc;
+    }
+
+    @Config("cassandra.load-policy.dc-aware.used-hosts-per-remote-dc")
+    public CassandraClientConfig setDcAwareUsedHostsPerRemoteDc(Integer dcAwareUsedHostsPerRemoteDc)
+    {
+        this.dcAwareUsedHostsPerRemoteDc = dcAwareUsedHostsPerRemoteDc;
+        return this;
+    }
+
+    public boolean getDcAwareAllowRemoteDCsForLocalConsistencyLevel()
+    {
+        return this.dcAwareAllowRemoteDCsForLocalConsistencyLevel;
+    }
+
+    @Config("cassandra.load-policy.dc-aware.allow-remote-dc-for-local-consistency-level")
+    public CassandraClientConfig setDcAwareAllowRemoteDCsForLocalConsistencyLevel(boolean dcAwareAllowRemoteDCsForLocalConsistencyLevel)
+    {
+        this.dcAwareAllowRemoteDCsForLocalConsistencyLevel = dcAwareAllowRemoteDCsForLocalConsistencyLevel;
+        return this;
+    }
+
+    public boolean getUseTokenAware()
+    {
+        return this.useTokenAware;
+    }
+
+    @Config("cassandra.load-policy.use-token-aware")
+    public CassandraClientConfig setUseTokenAware(boolean useTokenAware)
+    {
+        this.useTokenAware = useTokenAware;
+        return this;
+    }
+
+    public boolean getTokenAwareShuffleReplicas()
+    {
+        return this.tokenAwareShuffleReplicas;
+    }
+
+    @Config("cassandra.load-policy.token-aware.shuffle-replicas")
+    public CassandraClientConfig setTokenAwareShuffleReplicas(boolean tokenAwareShuffleReplicas)
+    {
+        this.tokenAwareShuffleReplicas = tokenAwareShuffleReplicas;
+        return this;
+    }
+
+    public boolean getUseWhiteList()
+    {
+        return this.useWhiteList;
+    }
+
+    @Config("cassandra.load-policy.use-white-list")
+    public CassandraClientConfig setUseWhiteList(boolean useWhiteList)
+    {
+        this.useWhiteList = useWhiteList;
+        return this;
+    }
+
+    public List<String> getWhiteListAddresses()
+    {
+        return whiteListAddresses;
+    }
+
+    @Config("cassandra.load-policy.white-list.addresses")
+    public CassandraClientConfig setWhiteListAddresses(String commaSeparatedList)
+    {
+        this.whiteListAddresses = SPLITTER.splitToList(commaSeparatedList);
+        return this;
+    }
+
+    public CassandraClientConfig setWhiteListAddresses(String... whiteListAddresses)
+    {
+        this.whiteListAddresses = Arrays.asList(whiteListAddresses);
+        return this;
+    }
+
+    @Min(1)
+    public int getNoHostAvailableRetryCount()
+    {
+        return noHostAvailableRetryCount;
+    }
+
+    @Config("cassandra.no-host-available-retry-count")
+    public CassandraClientConfig setNoHostAvailableRetryCount(int noHostAvailableRetryCount)
+    {
+        this.noHostAvailableRetryCount = noHostAvailableRetryCount;
         return this;
     }
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
@@ -16,7 +16,12 @@ package com.facebook.presto.cassandra;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.SocketOptions;
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.ExponentialReconnectionPolicy;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy;
+import com.datastax.driver.core.policies.WhiteListPolicy;
 import com.google.common.primitives.Ints;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -26,6 +31,8 @@ import io.airlift.json.JsonCodec;
 
 import javax.inject.Singleton;
 
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
@@ -102,6 +109,29 @@ public class CassandraClientModule
         clusterBuilder.withReconnectionPolicy(new ExponentialReconnectionPolicy(500, 10000));
         clusterBuilder.withRetryPolicy(config.getRetryPolicy().getPolicy());
 
+        LoadBalancingPolicy loadPolicy = new RoundRobinPolicy();
+        if (config.getUseDCAware()) {
+            checkNotNull(config.getDcAwareLocalDC(), "DCAwarePolicy localDC is null");
+            if (config.getDcAwareUsedHostsPerRemoteDc() > 0) {
+                loadPolicy = new DCAwareRoundRobinPolicy(config.getDcAwareLocalDC(), config.getDcAwareUsedHostsPerRemoteDc(), config.getDcAwareAllowRemoteDCsForLocalConsistencyLevel());
+            }
+            else {
+                loadPolicy = new DCAwareRoundRobinPolicy(config.getDcAwareLocalDC());
+            }
+        }
+        if (config.getUseTokenAware()) {
+            loadPolicy = new TokenAwarePolicy(loadPolicy, config.getTokenAwareShuffleReplicas());
+        }
+        if (config.getUseWhiteList()) {
+            checkArgument(!config.getWhiteListAddresses().isEmpty(), "empty WhiteListAddresses");
+            List<InetSocketAddress> whiteList = new ArrayList<>();
+            for (String point : config.getWhiteListAddresses()) {
+                whiteList.add(new InetSocketAddress(point, config.getNativeProtocolPort()));
+            }
+            loadPolicy = new WhiteListPolicy(loadPolicy, whiteList);
+        }
+        clusterBuilder.withLoadBalancingPolicy(loadPolicy);
+
         SocketOptions socketOptions = new SocketOptions();
         socketOptions.setReadTimeoutMillis(Ints.checkedCast(config.getClientReadTimeout().toMillis()));
         socketOptions.setConnectTimeoutMillis(Ints.checkedCast(config.getClientConnectTimeout().toMillis()));
@@ -124,6 +154,7 @@ public class CassandraClientModule
                 clusterBuilder,
                 config.getFetchSizeForPartitionKeySelect(),
                 config.getLimitForPartitionKeySelect(),
-                extraColumnMetadataCodec);
+                extraColumnMetadataCodec,
+                config.getNoHostAvailableRetryCount());
     }
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
@@ -71,6 +71,7 @@ public class CassandraSession
     private final int fetchSizeForPartitionKeySelect;
     private final int limitForPartitionKeySelect;
     private final JsonCodec<List<ExtraColumnMetadata>> extraColumnMetadataCodec;
+    private final int noHostAvailableRetryCount;
 
     private LoadingCache<String, Session> sessionBySchema;
 
@@ -78,12 +79,14 @@ public class CassandraSession
             final Builder clusterBuilder,
             int fetchSizeForPartitionKeySelect,
             int limitForPartitionKeySelect,
-            JsonCodec<List<ExtraColumnMetadata>> extraColumnMetadataCodec)
+            JsonCodec<List<ExtraColumnMetadata>> extraColumnMetadataCodec,
+            int noHostAvailableRetryCount)
     {
         this.connectorId = connectorId;
         this.fetchSizeForPartitionKeySelect = fetchSizeForPartitionKeySelect;
         this.limitForPartitionKeySelect = limitForPartitionKeySelect;
         this.extraColumnMetadataCodec = extraColumnMetadataCodec;
+        this.noHostAvailableRetryCount = noHostAvailableRetryCount;
 
         sessionBySchema = CacheBuilder.newBuilder()
                 .build(new CacheLoader<String, Session>()
@@ -431,7 +434,7 @@ public class CassandraSession
     public <T> T executeWithSession(String schemaName, SessionCallable<T> sessionCallable)
     {
         NoHostAvailableException lastException = null;
-        for (int i = 0; i < 2; i++) {
+        for (int i = 0; i <= noHostAvailableRetryCount; i++) {
             Session session = getSession(schemaName);
             try {
                 return sessionCallable.executeWithSession(session);

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/MockCassandraSession.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/MockCassandraSession.java
@@ -49,7 +49,8 @@ public class MockCassandraSession
                 null,
                 config.getFetchSizeForPartitionKeySelect(),
                 config.getLimitForPartitionKeySelect(),
-                listJsonCodec(ExtraColumnMetadata.class));
+                listJsonCodec(ExtraColumnMetadata.class),
+                config.getNoHostAvailableRetryCount());
     }
 
     public void setThrowException(boolean throwException)

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraClientConfig.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraClientConfig.java
@@ -52,7 +52,16 @@ public class TestCassandraClientConfig
                 .setClientReadTimeout(new Duration(SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS, MILLISECONDS))
                 .setClientConnectTimeout(new Duration(SocketOptions.DEFAULT_CONNECT_TIMEOUT_MILLIS, MILLISECONDS))
                 .setClientSoLinger(null)
-                .setRetryPolicy(RetryPolicyType.DEFAULT));
+                .setRetryPolicy(RetryPolicyType.DEFAULT)
+                .setUseDCAware(false)
+                .setDcAwareLocalDC(null)
+                .setDcAwareUsedHostsPerRemoteDc(0)
+                .setDcAwareAllowRemoteDCsForLocalConsistencyLevel(false)
+                .setUseTokenAware(false)
+                .setTokenAwareShuffleReplicas(false)
+                .setUseWhiteList(false)
+                .setWhiteListAddresses("")
+                .setNoHostAvailableRetryCount(1));
     }
 
     @Test
@@ -81,6 +90,15 @@ public class TestCassandraClientConfig
                 .put("cassandra.client.connect-timeout", "22ms")
                 .put("cassandra.client.so-linger", "33")
                 .put("cassandra.retry-policy", "BACKOFF")
+                .put("cassandra.load-policy.use-dc-aware", "true")
+                .put("cassandra.load-policy.dc-aware.local-dc", "dc1")
+                .put("cassandra.load-policy.dc-aware.used-hosts-per-remote-dc", "1")
+                .put("cassandra.load-policy.dc-aware.allow-remote-dc-for-local-consistency-level", "true")
+                .put("cassandra.load-policy.use-token-aware", "true")
+                .put("cassandra.load-policy.token-aware.shuffle-replicas", "true")
+                .put("cassandra.load-policy.use-white-list", "true")
+                .put("cassandra.load-policy.white-list.addresses", "host1")
+                .put("cassandra.no-host-available-retry-count", "10")
                 .build();
 
         CassandraClientConfig expected = new CassandraClientConfig()
@@ -105,8 +123,17 @@ public class TestCassandraClientConfig
                 .setClientReadTimeout(new Duration(11, MILLISECONDS))
                 .setClientConnectTimeout(new Duration(22, MILLISECONDS))
                 .setClientSoLinger(33)
-                .setRetryPolicy(RetryPolicyType.BACKOFF);
+                .setRetryPolicy(RetryPolicyType.BACKOFF)
+                .setUseDCAware(true)
+                .setDcAwareLocalDC("dc1")
+                .setDcAwareUsedHostsPerRemoteDc(1)
+                .setDcAwareAllowRemoteDCsForLocalConsistencyLevel(true)
+                .setUseTokenAware(true)
+                .setTokenAwareShuffleReplicas(true)
+                .setUseWhiteList(true)
+                .setWhiteListAddresses("host1")
+                .setNoHostAvailableRetryCount(10);
 
-        ConfigAssertions.assertFullMapping(properties, expected);
+            ConfigAssertions.assertFullMapping(properties, expected);
     }
 }

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -86,53 +86,76 @@ Property Name                                      Description
 
 The following advanced configuration properties are available:
 
-================================================== ======================================================================
-Property Name                                      Description
-================================================== ======================================================================
-``cassandra.fetch-size``                           Number of rows fetched at a time in a Cassandra query.
+============================================================================== ======================================================================
+Property Name                                                                  Description
+============================================================================== ======================================================================
+``cassandra.fetch-size``                                                       Number of rows fetched at a time in a Cassandra query.
 
-``cassandra.fetch-size-for-partition-key-select``  Number of rows fetched at a time in a Cassandra query that
-                                                   selects partition keys.
+``cassandra.fetch-size-for-partition-key-select``                              Number of rows fetched at a time in a Cassandra query that
+                                                                               selects partition keys.
 
-``cassandra.partition-size-for-batch-select``      Number of partitions batched together into a single select for a
-                                                   single partion key column table.
+``cassandra.partition-size-for-batch-select``                                  Number of partitions batched together into a single select for a
+                                                                               single partion key column table.
 
-``cassandra.split-size``                           Number of keys per split when querying Cassandra.
+``cassandra.split-size``                                                       Number of keys per split when querying Cassandra.
 
-``cassandra.partitioner``                          Partitioner to use for hashing and data distribution. This
-                                                   property defaults to ``Murmur3Partitioner``. The other supported
-                                                   values are ``RandomPartitioner`` and ``ByteOrderedPartitioner``.
+``cassandra.partitioner``                                                      Partitioner to use for hashing and data distribution. This
+                                                                               property defaults to ``Murmur3Partitioner``. The other supported
+                                                                               values are ``RandomPartitioner`` and ``ByteOrderedPartitioner``.
 
-``cassandra.thrift-connection-factory-class``      Allows for the specification of a custom implementation of
-                                                   ``org.apache.cassandra.thrift.ITransportFactory`` to be used to
-                                                   connect to Cassandra using the Thrift protocol.
+``cassandra.thrift-connection-factory-class``                                  Allows for the specification of a custom implementation of
+                                                                               ``org.apache.cassandra.thrift.ITransportFactory`` to be used to
+                                                                               connect to Cassandra using the Thrift protocol.
 
-``cassandra.transport-factory-options``            Allows for the specification of arbitrary options to be passed to
-                                                   the Thrift connection factory.
+``cassandra.transport-factory-options``                                        Allows for the specification of arbitrary options to be passed to
+                                                                               the Thrift connection factory.
 
-``cassandra.client.read-timeout``                  Maximum time the Cassandra driver will wait for an
-                                                   answer to a query from one Cassandra node. Note that the underlying
-                                                   Cassandra driver may retry a query against more than one node in
-                                                   the event of a read timeout. Increasing this may help with queries
-                                                   that use an index.
+``cassandra.client.read-timeout``                                              Maximum time the Cassandra driver will wait for an
+                                                                               answer to a query from one Cassandra node. Note that the underlying
+                                                                               Cassandra driver may retry a query against more than one node in
+                                                                               the event of a read timeout. Increasing this may help with queries
+                                                                               that use an index.
 
-``cassandra.client.connect-timeout``               Maximum time the Cassandra driver will wait to establish
-                                                   a connection to a Cassandra node. Increasing this may help with
-                                                   heavily loaded Cassandra clusters.
+``cassandra.client.connect-timeout``                                           Maximum time the Cassandra driver will wait to establish
+                                                                               a connection to a Cassandra node. Increasing this may help with
+                                                                               heavily loaded Cassandra clusters.
 
-``cassandra.client.so-linger``                     Number of seconds to linger on close if unsent data is queued.
-                                                   If set to zero, the socket will be closed immediately.
-                                                   When this option is non-zero, a socket will linger that many
-                                                   seconds for an acknowledgement that all data was written to a
-                                                   peer. This option can be used to avoid consuming sockets on a
-                                                   Cassandra server by immediately closing connections when they
-                                                   are no longer needed.
+``cassandra.client.so-linger``                                                 Number of seconds to linger on close if unsent data is queued.
+                                                                               If set to zero, the socket will be closed immediately.
+                                                                               When this option is non-zero, a socket will linger that many
+                                                                               seconds for an acknowledgement that all data was written to a
+                                                                               peer. This option can be used to avoid consuming sockets on a
+                                                                               Cassandra server by immediately closing connections when they
+                                                                               are no longer needed.
 
-``cassandra.retry-policy``                         Policy used to retry failed requests to Cassandra. This property
-                                                   defaults to ``DEFAULT``. Using ``BACKOFF`` may help when
-                                                   queries fail with *"not enough replicas"*. The other possible
-                                                   values are ``DOWNGRADING_CONSISTENCY`` and ``FALLTHROUGH``.
-================================================== ======================================================================
+``cassandra.retry-policy``                                                     Policy used to retry failed requests to Cassandra. This property
+                                                                               defaults to ``DEFAULT``. Using ``BACKOFF`` may help when
+                                                                               queries fail with *"not enough replicas"*. The other possible
+                                                                               values are ``DOWNGRADING_CONSISTENCY`` and ``FALLTHROUGH``.
+
+``cassandra.load-policy.use-dc-aware``                                         Set to ``true`` to use ``DCAwareRoundRobinPolicy``
+                                                                               (defaults to ``false``).
+
+``cassandra.load-policy.dc-aware.local-dc``                                    The name of the local datacenter for ``DCAwareRoundRobinPolicy``.
+
+``cassandra.load-policy.dc-aware.used-hosts-per-remote-dc``                    Uses the provided number of host per remote datacenter
+                                                                               as failover for the local hosts for ``DCAwareRoundRobinPolicy``.
+
+``cassandra.load-policy.dc-aware.allow-remote-dc-for-local-consistency-level`` Set to ``true`` to allow to use hosts of
+                                                                               remote datacenter for local consistency level.
+
+``cassandra.load-policy.use-token-aware``                                      Set to ``true`` to use ``TokenAwarePolicy`` (defaults to ``false``).
+
+``cassandra.load-policy.shuffle-replicas``                                     Set to ``true`` to use ``TokenAwarePolicy`` with shuffling of replicas
+                                                                               (defaults to ``false``).
+
+``cassandra.load-policy.use-white-list``                                       Set to ``true`` to use ``WhiteListPolicy`` (defaults to ``false``).
+
+``cassandra.load-policy.white-list.addresses``                                 Comma-separated list of hosts for ``WhiteListPolicy``.
+
+``cassandra.no-host-available-retry-count``                                    Retry count for NoHostAvailableException (defaults to ``1``).
+
+============================================================================== ======================================================================
 
 Querying Cassandra Tables
 -------------------------


### PR DESCRIPTION
…count.
New cassandra config parameters:
cassandra.load-policy.use-dc-aware
cassandra.load-policy.dc-aware.local-dc
cassandra.load-policy.dc-aware.used-hosts-per-remote-dc
cassandra.load-policy.dc-aware.allow-remote-dc-for-local-consistency-level

cassandra.load-policy.use-token-aware
cassandra.load-policy.token-aware.shuffle-replicas

cassandra.load-policy.use-white-list
cassandra.load-policy.white-list.addresses

cassandra.no-host-available-retry-count