### PR TITLE
Add support for logging completed queries to a file

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -46,6 +46,8 @@ public class QueryManagerConfig
     private Duration remoteTaskMinErrorDuration = new Duration(2, TimeUnit.MINUTES);
     private int remoteTaskMaxCallbackThreads = 1000;
 
+    private String completedQueriesLogFile;
+
     public String getQueueConfigFile()
     {
         return queueConfigFile;
@@ -247,6 +249,18 @@ public class QueryManagerConfig
     public QueryManagerConfig setRemoteTaskMaxCallbackThreads(int remoteTaskMaxCallbackThreads)
     {
         this.remoteTaskMaxCallbackThreads = remoteTaskMaxCallbackThreads;
+        return this;
+    }
+
+    public String getCompletedQueriesLogFile()
+    {
+        return completedQueriesLogFile;
+    }
+
+    @Config("query.completed-queries-log-file")
+    public QueryManagerConfig setCompletedQueriesLogFile(String completedQueriesLogFile)
+    {
+        this.completedQueriesLogFile = completedQueriesLogFile;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -125,7 +125,7 @@ public class PrestoServer
 
     protected Iterable<? extends Module> getAdditionalModules()
     {
-        return ImmutableList.of();
+        return ImmutableList.of(new QueryLoggingModule());
     }
 
     private static void updateDatasources(Announcer announcer, Metadata metadata, ServerConfig serverConfig, NodeSchedulerConfig schedulerConfig)

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryEventLogger.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryEventLogger.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.event.query.QueryCompletionEvent;
+import com.facebook.presto.execution.QueryManagerConfig;
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.base.Throwables;
+import io.airlift.event.client.AbstractEventClient;
+import io.airlift.event.client.JsonEventSerializer;
+
+import javax.inject.Inject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.logging.FileHandler;
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+public class QueryEventLogger
+        extends AbstractEventClient
+{
+    private final Logger logger = Logger.getLogger("QueryEventLogger");
+
+    private final JsonFactory factory = new JsonFactory();
+    private final JsonEventSerializer serializer = new JsonEventSerializer(QueryCompletionEvent.class);
+    private final String completedQueriesLogFile;
+
+    @Inject
+    public QueryEventLogger(QueryManagerConfig queryManagerConfig)
+    {
+        this.completedQueriesLogFile = queryManagerConfig.getCompletedQueriesLogFile();
+        if (completedQueriesLogFile != null) {
+            try {
+                FileHandler fh = new FileHandler(completedQueriesLogFile);
+                fh.setFormatter(new LogFormatter());
+                logger.setUseParentHandlers(false);
+                logger.addHandler(fh);
+            }
+            catch (IOException e) {
+                throw Throwables.propagate(e);
+            }
+        }
+    }
+
+    @Override
+    protected <T> void postEvent(T event)
+            throws IOException
+    {
+        if (completedQueriesLogFile == null) {
+            //discard event
+            return;
+        }
+
+        //for now only hook into the query completion events
+        if (event instanceof QueryCompletionEvent) {
+            try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+                try (JsonGenerator generator = factory.createGenerator(buffer, JsonEncoding.UTF8)) {
+                    serializer.serialize(event, generator);
+                    logger.info(buffer.toString());
+                }
+            }
+        }
+    }
+}
+
+class LogFormatter extends Formatter
+{
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
+    @Override
+    public String format(LogRecord record)
+    {
+        StringBuilder buffer = new StringBuilder();
+        return buffer.append(record.getMessage())
+                .append(LINE_SEPARATOR).toString();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryLoggingModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryLoggingModule.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.server;
+
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.airlift.event.client.EventClient;
+import io.airlift.event.client.EventModule;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+
+public class QueryLoggingModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.install(new EventModule());
+
+        binder.bind(QueryEventLogger.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, EventClient.class).addBinding().to(Key.get(QueryEventLogger.class)).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -41,7 +41,8 @@ public class TestQueryManagerConfig
                 .setQueryManagerExecutorPoolSize(5)
                 .setRemoteTaskMaxConsecutiveErrorCount(10)
                 .setRemoteTaskMinErrorDuration(new Duration(2, TimeUnit.MINUTES))
-                .setRemoteTaskMaxCallbackThreads(1000));
+                .setRemoteTaskMaxCallbackThreads(1000)
+                .setCompletedQueriesLogFile(null));
     }
 
     @Test
@@ -63,6 +64,7 @@ public class TestQueryManagerConfig
                 .put("query.remote-task.max-consecutive-error-count", "300")
                 .put("query.remote-task.min-error-duration", "30s")
                 .put("query.remote-task.max-callback-threads", "10")
+                .put("query.completed-queries-log-file", "/tmp/presto-queries.log")
                 .build();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -80,7 +82,8 @@ public class TestQueryManagerConfig
                 .setQueryManagerExecutorPoolSize(11)
                 .setRemoteTaskMaxConsecutiveErrorCount(300)
                 .setRemoteTaskMinErrorDuration(new Duration(30, TimeUnit.SECONDS))
-                .setRemoteTaskMaxCallbackThreads(10);
+                .setRemoteTaskMaxCallbackThreads(10)
+                .setCompletedQueriesLogFile("/tmp/presto-queries.log");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This PR adds supports for logging completed queries in raw json format to a file configured with the ``query.completed-queries-log-file`` property.