### PR TITLE
Fix could not fetch data from Kafka

### DIFF
--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaRecordSet.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaRecordSet.java
@@ -312,7 +312,7 @@ public class KafkaRecordSet
 
                 // TODO - this should look at the actual node this is running on and prefer
                 // that copy if running locally. - look into NodeInfo
-                SimpleConsumer consumer = consumerManager.getConsumer(split.getNodes().get(0));
+                SimpleConsumer consumer = consumerManager.getConsumer(split.getLeader());
 
                 FetchResponse fetchResponse = consumer.fetch(req);
                 if (fetchResponse.hasError()) {


### PR DESCRIPTION
fix #2704 

The error is caused by split.getNodes().get(0) in KafkaRecordSet.
This IP should be partition's leader, and the error code '6' occurs when it is not partition's leader.