### PR TITLE
SHOW CREATE VIEW statement

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.116.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.116.rst
@@ -6,3 +6,4 @@ General Changes
 ---------------
 
 * Add :func:`multimap_agg` function.
+* Add ``SHOW CREATE VIEW`` statement.

--- a/presto-docs/src/main/sphinx/sql.rst
+++ b/presto-docs/src/main/sphinx/sql.rst
@@ -27,4 +27,5 @@ This chapter describes the SQL syntax used in Presto.
     sql/show-schemas
     sql/show-session
     sql/show-tables
+    sql/show-create-view
     sql/use

--- a/presto-docs/src/main/sphinx/sql/show-create-view.rst
+++ b/presto-docs/src/main/sphinx/sql/show-create-view.rst
@@ -1,0 +1,15 @@
+================
+SHOW CREATE VIEW
+================
+
+Synopsis
+--------
+
+.. code-block:: none
+
+    SHOW CREATE VIEW table
+
+Description
+-----------
+
+Shows the ``CREATE VIEW`` statement that creates the named view.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUtil.java
@@ -119,6 +119,11 @@ public final class MetadataUtil
         return new QualifiedTableName(catalogName, schemaName, tableName);
     }
 
+    public static QualifiedName createQualifiedName(QualifiedTableName tableName)
+    {
+        return QualifiedName.of(tableName.getCatalogName(), tableName.getSchemaName(), tableName.getTableName());
+    }
+
     public static class SchemaMetadataBuilder
     {
         public static SchemaMetadataBuilder schemaMetadataBuilder()

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -61,6 +61,7 @@ import com.facebook.presto.sql.tree.ResetSession;
 import com.facebook.presto.sql.tree.SetSession;
 import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
+import com.facebook.presto.sql.tree.ShowCreateView;
 import com.facebook.presto.sql.tree.ShowFunctions;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
@@ -147,6 +148,7 @@ public class CoordinatorModule
         executionBinder.addBinding(Explain.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(ShowColumns.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(ShowPartitions.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
+        executionBinder.addBinding(ShowCreateView.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(ShowFunctions.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(ShowTables.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(ShowSchemas.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -57,6 +57,7 @@ statement
         (WHERE booleanExpression)?
         (ORDER BY sortItem (',' sortItem)*)?
         (LIMIT limit=(INTEGER_VALUE | ALL))?                           #showPartitions
+    | SHOW CREATE VIEW qualifiedName                                   #showCreateView
     ;
 
 query

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -82,6 +82,7 @@ import com.facebook.presto.sql.tree.SelectItem;
 import com.facebook.presto.sql.tree.SetSession;
 import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
+import com.facebook.presto.sql.tree.ShowCreateView;
 import com.facebook.presto.sql.tree.ShowFunctions;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
@@ -435,6 +436,12 @@ class AstBuilder
                 visitIfPresent(context.booleanExpression(), Expression.class),
                 visit(context.sortItem(), SortItem.class),
                 getTextIfPresent(context.limit));
+    }
+
+    @Override
+    public Node visitShowCreateView(SqlBaseParser.ShowCreateViewContext context)
+    {
+        return new ShowCreateView(getQualifiedName(context.qualifiedName()));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -112,6 +112,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitShowCreateView(ShowCreateView node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitShowFunctions(ShowFunctions node, C context)
     {
         return visitStatement(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QualifiedName.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QualifiedName.java
@@ -87,6 +87,7 @@ public class QualifiedName
     @Override
     public String toString()
     {
+        // TODO: We are using this method in SQLFormatter, Shouldn't we escape parts with quotes here?
         return Joiner.on('.').join(parts);
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCreateView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCreateView.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ShowCreateView
+        extends Statement
+{
+    private final QualifiedName view;
+
+    public ShowCreateView(QualifiedName view)
+    {
+        this.view = checkNotNull(view, "view is null");
+    }
+
+    public QualifiedName getView()
+    {
+        return view;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitShowCreateView(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(view);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        ShowCreateView o = (ShowCreateView) obj;
+        return Objects.equals(view, o.view);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("view", view)
+                .toString();
+    }
+}


### PR DESCRIPTION
Syntax and behaviour are exactly the same like in MySQL
For the Hive views (not created by Presto) it will throw "'view_name' is a Table" error

this commit fixes #3133