### PR TITLE
Add split_to_map function to string operations

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -96,6 +96,13 @@ String Functions
     Field indexes start with ``1``. If the index is larger than than
     the number of fields, then null is returned.
 
+.. function:: split_to_map(string, entryDelimiter, keyValueDelimiter) -> map<varchar, varchar>
+
+    Splits ``string`` by ``entryDelimiter`` and ``keyValueDelimiter`` and returns a map.
+    ``entryDelimiter`` splits ``string`` into key-value pairs. ``keyValueDelimiter`` splits
+    each pair into key and value. If key-value pairs are not found from ``string``,
+    then an empty map is returned.
+
 .. function:: strpos(string, substring) -> bigint
 
     Returns the starting position of the first instance of ``substring`` in

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -367,6 +367,7 @@ public final class StringFunctions
     {
         checkCondition(entryDelimiter.length() > 0, INVALID_FUNCTION_ARGUMENT, "The entryDelimiter may not be the empty string");
         checkCondition(keyValueDelimiter.length() > 0, INVALID_FUNCTION_ARGUMENT, "The keyValueDelimiter may not be the empty string");
+        checkCondition(!(entryDelimiter.equals(keyValueDelimiter)), INVALID_FUNCTION_ARGUMENT, "The entryDelimiter and keyValueDelimiter must not be the same");
 
         final Map<Slice, Slice> map = new TreeMap<>();
         int index = 0;

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -390,9 +390,13 @@ public final class StringFunctions
                 Slice key = keyValuePair.slice(0, keyValueDelimiterIndex);
                 Slice value = keyValuePair.slice(offset, keyValuePair.length() - offset);
 
+                if (value.indexOf(keyValueDelimiter) >= 0) {
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Key-value delimiter must appear exactly once in each entry: " + keyValuePair.toString());
+                }
                 if (map.containsKey(key)) {
                     throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Duplicate keys are not allowed: " + key.toString());
                 }
+
                 map.put(key, value);
             }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -247,7 +247,6 @@ public class TestStringFunctions
     public void testSplitToMap()
     {
         assertFunction("SPLIT_TO_MAP('', ',', '=')", new MapType(VARCHAR, VARCHAR), ImmutableMap.of());
-        assertFunction("SPLIT_TO_MAP('a=123,b=.4,c=', ' ', ' ')", new MapType(VARCHAR, VARCHAR), ImmutableMap.of());
 
         assertFunction("SPLIT_TO_MAP('a=123,b=.4,c=', ' ', '=')",
                 new MapType(VARCHAR, VARCHAR),
@@ -317,6 +316,10 @@ public class TestStringFunctions
         assertFunction("SPLIT_TO_MAP('\u4EA0\u4EFF\u4EFF\u4EA1\u4E00\u4EB0\u4EFF\u4EB1\u4EFF\u4EB2\u4E00\u4EC0\u4EFF\u4EC1\u4EFF', '\u4E00', '\u4EFF')",
                 new MapType(VARCHAR, VARCHAR),
                 ImmutableMap.of("\u4EA0", "\u4EFF\u4EA1", "\u4EB0", "\u4EB1\u4EFF\u4EB2", "\u4EC0", "\u4EC1\u4EFF"));
+
+        // Entry delimiter and key-value delimiter must not be the same.
+        assertInvalidFunction("SPLIT_TO_MAP('a=123,b=.4,c=', '=', '=')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("SPLIT_TO_MAP('\u4EA0\u4EA1\u4EA2\u4EA3\u4EA4\u4EA5', '\u4EFF', '\u4EFF')", INVALID_FUNCTION_ARGUMENT);
 
         // Duplicate keys are not allowed to exist.
         assertInvalidFunction("SPLIT_TO_MAP('a=123,a=.4,a=', ',', '=')", INVALID_FUNCTION_ARGUMENT);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -248,10 +248,6 @@ public class TestStringFunctions
     {
         assertFunction("SPLIT_TO_MAP('', ',', '=')", new MapType(VARCHAR, VARCHAR), ImmutableMap.of());
 
-        assertFunction("SPLIT_TO_MAP('a=123,b=.4,c=', ' ', '=')",
-                new MapType(VARCHAR, VARCHAR),
-                ImmutableMap.of("a", "123,b=.4,c="));
-
         assertFunction("SPLIT_TO_MAP('a=123,', ',', '=')",
                 new MapType(VARCHAR, VARCHAR),
                 ImmutableMap.of("a", "123"));
@@ -275,10 +271,6 @@ public class TestStringFunctions
         assertFunction("SPLIT_TO_MAP('a=123,b=.4,notSplittableByKeyValueDelimiter', ',', '=')",
                 new MapType(VARCHAR, VARCHAR),
                 ImmutableMap.of("a", "123", "b", ".4"));
-
-        assertFunction("SPLIT_TO_MAP('key==value,key2=va=lue2,key3=value3=', ',', '=')",
-                new MapType(VARCHAR, VARCHAR),
-                ImmutableMap.of("key", "=value", "key2", "va=lue2", "key3", "value3="));
 
         // Test SPLIT_TO_MAP for non-ASCII
         assertFunction("SPLIT_TO_MAP('\u4EA0\u4EA1\u4EA2\u4EA3\u4EA4\u4EA5', '\u4E00', '\u4EFF')",
@@ -312,11 +304,6 @@ public class TestStringFunctions
                 new MapType(VARCHAR, VARCHAR),
                 ImmutableMap.of("\u4EA0", "\u4EA1", "\u4EB0", "\u4EB1"));
 
-        // If split words contain multiple keyValueDelimiters, then the first occurrence of the delimiter is the point to split words.
-        assertFunction("SPLIT_TO_MAP('\u4EA0\u4EFF\u4EFF\u4EA1\u4E00\u4EB0\u4EFF\u4EB1\u4EFF\u4EB2\u4E00\u4EC0\u4EFF\u4EC1\u4EFF', '\u4E00', '\u4EFF')",
-                new MapType(VARCHAR, VARCHAR),
-                ImmutableMap.of("\u4EA0", "\u4EFF\u4EA1", "\u4EB0", "\u4EB1\u4EFF\u4EB2", "\u4EC0", "\u4EC1\u4EFF"));
-
         // Entry delimiter and key-value delimiter must not be the same.
         assertInvalidFunction("SPLIT_TO_MAP('a=123,b=.4,c=', '=', '=')", INVALID_FUNCTION_ARGUMENT);
         assertInvalidFunction("SPLIT_TO_MAP('\u4EA0\u4EA1\u4EA2\u4EA3\u4EA4\u4EA5', '\u4EFF', '\u4EFF')", INVALID_FUNCTION_ARGUMENT);
@@ -324,6 +311,14 @@ public class TestStringFunctions
         // Duplicate keys are not allowed to exist.
         assertInvalidFunction("SPLIT_TO_MAP('a=123,a=.4,a=', ',', '=')", INVALID_FUNCTION_ARGUMENT);
         assertInvalidFunction("SPLIT_TO_MAP('\u4EA0\u4EFF\u4EA1\u4E00\u4EA0\u4EFF\u4EB1\u4E00\u4EA0\u4EFF', '\u4E00', '\u4EFF')", INVALID_FUNCTION_ARGUMENT);
+
+        // Key-value delimiter must appear exactly once in each entry.
+        assertInvalidFunction("SPLIT_TO_MAP('key==value', ',', '=')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("SPLIT_TO_MAP('\u4EA0\u4EFF\u4EFF\u4EA1\u4EA1', '\u4E00', '\u4EFF')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("SPLIT_TO_MAP('key=va=lue', ',', '=')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("SPLIT_TO_MAP('\u4EA0\u4EFF\u4EA1\u4EFF\u4EA1', '\u4E00', '\u4EFF')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("SPLIT_TO_MAP('key=value=', ',', '=')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("SPLIT_TO_MAP('\u4EA0\u4EFF\u4EA1\u4EA1\u4EFF', '\u4E00', '\u4EFF')", INVALID_FUNCTION_ARGUMENT);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -277,10 +277,6 @@ public class TestStringFunctions
                 new MapType(VARCHAR, VARCHAR),
                 ImmutableMap.of("a", "123", "b", ".4"));
 
-        assertFunction("SPLIT_TO_MAP('a=123,a=.4,a=', ',', '=')",
-                new MapType(VARCHAR, VARCHAR),
-                ImmutableMap.of("a", ""));
-
         assertFunction("SPLIT_TO_MAP('key==value,key2=va=lue2,key3=value3=', ',', '=')",
                 new MapType(VARCHAR, VARCHAR),
                 ImmutableMap.of("key", "=value", "key2", "va=lue2", "key3", "value3="));
@@ -317,15 +313,14 @@ public class TestStringFunctions
                 new MapType(VARCHAR, VARCHAR),
                 ImmutableMap.of("\u4EA0", "\u4EA1", "\u4EB0", "\u4EB1"));
 
-        // If there are same keys, the last corresponding key and value pair is honored.
-        assertFunction("SPLIT_TO_MAP('\u4EA0\u4EFF\u4EA1\u4E00\u4EA0\u4EFF\u4EB1\u4E00\u4EA0\u4EFF', '\u4E00', '\u4EFF')",
-                new MapType(VARCHAR, VARCHAR),
-                ImmutableMap.of("\u4EA0", ""));
-
         // If split words contain multiple keyValueDelimiters, then the first occurrence of the delimiter is the point to split words.
         assertFunction("SPLIT_TO_MAP('\u4EA0\u4EFF\u4EFF\u4EA1\u4E00\u4EB0\u4EFF\u4EB1\u4EFF\u4EB2\u4E00\u4EC0\u4EFF\u4EC1\u4EFF', '\u4E00', '\u4EFF')",
                 new MapType(VARCHAR, VARCHAR),
                 ImmutableMap.of("\u4EA0", "\u4EFF\u4EA1", "\u4EB0", "\u4EB1\u4EFF\u4EB2", "\u4EC0", "\u4EC1\u4EFF"));
+
+        // Duplicate keys are not allowed to exist.
+        assertInvalidFunction("SPLIT_TO_MAP('a=123,a=.4,a=', ',', '=')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("SPLIT_TO_MAP('\u4EA0\u4EFF\u4EA1\u4E00\u4EA0\u4EFF\u4EB1\u4E00\u4EA0\u4EFF', '\u4E00', '\u4EFF')", INVALID_FUNCTION_ARGUMENT);
     }
 
     @Test


### PR DESCRIPTION
ref. issue #2544 
This commit adds a function which is expected to work almost the same as hive's str_to_map() function that generates a map based on input string and two delimiters.

Additionally, we might need to discuss a proper function name.