### PR TITLE
Merge binary branch

### DIFF
--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -103,6 +103,10 @@
                   <groupId>io.netty</groupId>
                   <artifactId>netty</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.clearspring.analytics</groupId>
+                    <artifactId>stream</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ParquetRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ParquetRecordCursorProvider.java
@@ -98,8 +98,7 @@ public class ParquetRecordCursorProvider
         return columnHandle -> {
             HiveType hiveType = columnHandle.getHiveType();
             return !hiveType.equals(HiveType.HIVE_TIMESTAMP) &&
-                    !hiveType.equals(HiveType.HIVE_DATE) &&
-                    !hiveType.equals(HiveType.HIVE_BINARY);
+                    !hiveType.equals(HiveType.HIVE_DATE);
         };
     }
 }

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -291,6 +291,12 @@
             <artifactId>tpch</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.clearspring.analytics</groupId>
+            <artifactId>stream</artifactId>
+            <version>2.7.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -31,6 +31,7 @@ import com.facebook.presto.operator.aggregation.CovarianceAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
 import com.facebook.presto.operator.aggregation.LongSumAggregation;
 import com.facebook.presto.operator.aggregation.MergeHyperLogLogAggregation;
+import com.facebook.presto.operator.aggregation.MergeBinaryHyperLogLogAggregation;
 import com.facebook.presto.operator.aggregation.NumericHistogramAggregation;
 import com.facebook.presto.operator.aggregation.RegressionAggregation;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
@@ -304,6 +305,7 @@ public class FunctionRegistry
                 .aggregate(AverageAggregations.class)
                 .aggregate(ApproximateCountDistinctAggregations.class)
                 .aggregate(MergeHyperLogLogAggregation.class)
+                .aggregate(MergeBinaryHyperLogLogAggregation.class)
                 .aggregate(ApproximateSetAggregation.class)
                 .aggregate(NumericHistogramAggregation.class)
                 .aggregate(CovarianceAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MergeBinaryHyperLogLogAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MergeBinaryHyperLogLogAggregation.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.SliceState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+import io.airlift.slice.Slice;
+import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
+import io.airlift.slice.Slices;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+
+@AggregationFunction("merge_binary")
+public final class MergeBinaryHyperLogLogAggregation
+{
+    private MergeBinaryHyperLogLogAggregation()
+    {
+    }
+
+    @InputFunction
+    @IntermediateInputFunction
+    public static void merge(SliceState state, @SqlType(StandardTypes.VARBINARY) Slice value) throws Throwable
+    {
+        HyperLogLogPlus input = HyperLogLogPlus.Builder.build(value.getBytes());
+        HyperLogLogPlus previous = null;
+        if (state.getSlice() != null) {
+            previous = HyperLogLogPlus.Builder.build(state.getSlice().getBytes());
+        }
+
+        if (previous == null) {
+            previous = input;
+        }
+        else {
+            previous.addAll(input);
+        }
+        state.setSlice(Slices.wrappedBuffer(previous.getBytes()));
+    }
+
+    @OutputFunction(StandardTypes.BIGINT)
+    public static void output(SliceState state, BlockBuilder out) throws Throwable
+    {
+        BIGINT.writeLong(out, HyperLogLogPlus.Builder.build(state.getSlice().getBytes()).cardinality());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/SliceStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/SliceStateSerializer.java
@@ -16,12 +16,17 @@ package com.facebook.presto.operator.aggregation.state;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 
 public class SliceStateSerializer
         implements AccumulatorStateSerializer<SliceState>
 {
     private final Type type;
 
+    public SliceStateSerializer()
+    {
+        this(VARBINARY);
+    }
     public SliceStateSerializer(Type type)
     {
         this.type = type;


### PR DESCRIPTION
Added merge_binary aggregation function to take in byte arrays produced by HyperLogLogPlus objects and return the total cardinality. Allows compatibility with other programs supporting the HyperLogLogPlus library, such as Hive (https://github.com/klout/brickhouse) and Apache Spark. Provides space-efficient method of calculating and storing cardinalities by writing HyperLogLogPlus byte arrays through other programs (Hive and Spark) and then querying aggregated cardinalities in Presto. 