### PR TITLE
Map merge aggregation function

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -106,7 +106,6 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.slice.Slice;
 
 import javax.annotation.concurrent.ThreadSafe;
-
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -123,6 +122,7 @@ import static com.facebook.presto.operator.aggregation.ChecksumAggregation.CHECK
 import static com.facebook.presto.operator.aggregation.CountColumn.COUNT_COLUMN;
 import static com.facebook.presto.operator.aggregation.Histogram.HISTOGRAM;
 import static com.facebook.presto.operator.aggregation.MapAggregation.MAP_AGG;
+import static com.facebook.presto.operator.aggregation.MapUnionAggregation.MAP_UNION;
 import static com.facebook.presto.operator.aggregation.MaxAggregation.MAX_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.MaxBy.MAX_BY;
 import static com.facebook.presto.operator.aggregation.MaxNAggregation.MAX_N_AGGREGATION;
@@ -304,7 +304,7 @@ public class FunctionRegistry
                 .functions(MAP_EQUAL, MAP_NOT_EQUAL, MAP_HASH_CODE)
                 .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_ELEMENT_AT_FUNCTION, ARRAY_CARDINALITY, ARRAY_POSITION, ARRAY_SORT_FUNCTION, ARRAY_INTERSECT_FUNCTION, ARRAY_TO_JSON, JSON_TO_ARRAY, ARRAY_DISTINCT_FUNCTION, ARRAY_REMOVE_FUNCTION, ARRAY_SLICE_FUNCTION)
                 .functions(MAP_CONSTRUCTOR, MAP_CARDINALITY, MAP_SUBSCRIPT, MAP_TO_JSON, JSON_TO_MAP, MAP_KEYS, MAP_VALUES)
-                .functions(MAP_AGG, MULTIMAP_AGG)
+                .functions(MAP_AGG, MULTIMAP_AGG, MAP_UNION)
                 .function(HISTOGRAM)
                 .function(CHECKSUM_AGGREGATION)
                 .function(ARBITRARY_AGGREGATION)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapUnionAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapUnionAggregation.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.ExceededMemoryLimitException;
+import com.facebook.presto.byteCode.DynamicClassLoader;
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.ParametricAggregation;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.aggregation.state.KeyValuePairStateSerializer;
+import com.facebook.presto.operator.aggregation.state.KeyValuePairsState;
+import com.facebook.presto.operator.aggregation.state.KeyValuePairsStateFactory;
+import com.facebook.presto.operator.aggregation.state.KeyValuePairsStateFactory.SingleState;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.MapType;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
+import static com.facebook.presto.metadata.Signature.typeParameter;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.NULLABLE_BLOCK_INPUT_CHANNEL;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static java.lang.String.format;
+
+/**
+ * Allows compatible {@link MapType map} columns to be merged using the "{@value #NAME}" aggregate function.
+ * <p/>
+ * <pre>
+ * Example 1:
+ * select map_union(foo), map_union(bar) from (
+ *  select map(array['a', 'b'], array[1000, 2000]) as foo, cast(null as map<varchar, double>) as bar
+ *  union
+ *  select map(array['c', 'd'], array[3000, 4000]) as foo, cast(null as map<varchar, double>) as bar
+ * );
+ *
+ * Example 2:
+ * select map_union(foo), map_union(bar) from (
+ *  select cast(null as map<varchar, bigint>) as foo,
+ *         cast(null as map<bigint, double>) as bar
+ *  union
+ *  select map(array['a', 'b'], array[1000, 2000]) as foo,
+ *         map(array[33], array[3300.33]) as bar
+ *  union
+ *  select map(array['c', 'd'], array[3000, 4000]) as foo,
+ *         map(array[44, 55], array[4400.44, 5500.55]) as bar
+ *  union
+ *  select map(array['e', 'f', 'g', 'h', 'i'], array[50, 60, 70, 80, 90]) as foo,
+ *         cast(null as map<bigint, double>) as bar
+ *  union
+ *  select map(array['j', 'k', 'a', 'b', 'n', 'o', 'p'], array[200, 300, -45, -55, 600, 700, 800]) as foo,
+ *         cast(null as map<bigint, double>) as bar
+ *  union
+ *  select map(array['c', 'd'], array[90000, 120000]) as foo,
+ *         map(array[44, 55], array[1100.0, 2200.0]) as bar
+ * );
+ *
+ * Example 3:
+ * with
+ * part_a as (
+ *  select map(array['a', 'b'], array[1000, 2000]) as foo, 'homer' as first_name, 'simpson' as last_name
+ * ),
+ * part_b as (
+ *  select map(array['c', 'd'], array[3000, 4000]) as foo, 'marge' as first_name, 'simpson' as last_name
+ * ),
+ * part_c as (
+ *  select map(array['a', 'd'], array[12, 3]) as foo, 'moe' as first_name, 'szyslak' as last_name
+ * ),
+ * part_d as (
+ *  select cast(null as map<varchar, bigint>) as foo, 'bart' as first_name, 'simpson' as last_name
+ * )
+ * select last_name, map_union(foo) from (
+ *  select * from part_a
+ *  union
+ *  select * from part_b
+ *  union
+ *  select * from part_c
+ *  union
+ *  select * from part_d
+ * )
+ * group by last_name;
+ *
+ * Example 4:
+ * with
+ * part_a as (
+ *  select cast(null as map<varchar, bigint>) as foo, 'homer' as first_name, 'simpson' as last_name
+ * ),
+ * part_b as (
+ *  select cast(null as map<varchar, bigint>) as foo, 'marge' as first_name, 'simpson' as last_name
+ * ),
+ * part_c as (
+ *  select cast(null as map<varchar, bigint>) as foo, 'moe' as first_name, 'szyslak' as last_name
+ * ),
+ * part_d as (
+ *  select cast(null as map<varchar, bigint>) as foo, 'bart' as first_name, 'simpson' as last_name
+ * )
+ * select last_name, map_union(foo) from (
+ *  select * from part_a
+ *  union
+ *  select * from part_b
+ *  union
+ *  select * from part_c
+ *  union
+ *  select * from part_d
+ * )
+ * group by last_name;
+ * </pre>
+ */
+public class MapUnionAggregation
+        extends ParametricAggregation
+{
+    public static final MapUnionAggregation MAP_UNION = new MapUnionAggregation();
+    public static final String NAME = "map_union";
+    private static final MethodHandle OUTPUT_FUNCTION =
+            methodHandle(MapUnionAggregation.class, "output", KeyValuePairsState.class, BlockBuilder.class);
+    private static final MethodHandle INPUT_FUNCTION =
+            methodHandle(MapUnionAggregation.class, "input",
+                    KeyValuePairStateSerializer.class, KeyValuePairsState.class, Block.class, int.class);
+    private static final MethodHandle COMBINE_FUNCTION =
+            methodHandle(MapUnionAggregation.class, "combine", KeyValuePairsState.class, KeyValuePairsState.class);
+
+    private static final Signature SIGNATURE =
+            new Signature(NAME, ImmutableList.of(comparableTypeParameter("K"), typeParameter("V")),
+                    "map<K,V>", ImmutableList.of("map<K,V>"), false, false);
+
+    @Override
+    public Signature getSignature()
+    {
+        return SIGNATURE;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Merges 2 maps";
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager,
+                                   FunctionRegistry functionRegistry)
+    {
+        Type keyType = types.get("K");
+        Type valueType = types.get("V");
+        Signature signature = new Signature(NAME, new MapType(keyType, valueType).getTypeSignature(),
+                new MapType(keyType, valueType).getTypeSignature());
+        InternalAggregationFunction aggregation = generateAggregation(keyType, valueType);
+        return new FunctionInfo(signature, getDescription(), aggregation);
+    }
+
+    private static InternalAggregationFunction generateAggregation(Type keyType, Type valueType)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(MapUnionAggregation.class.getClassLoader());
+        Type outputType = new MapType(keyType, valueType);
+        List<Type> inputTypes = ImmutableList.of(outputType);
+        KeyValuePairStateSerializer stateSerializer = new KeyValuePairStateSerializer(keyType, valueType, false);
+        MethodHandle serializerBoundInputFn = INPUT_FUNCTION.bindTo(stateSerializer);
+        Type intermediateType = stateSerializer.getSerializedType();
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, outputType, inputTypes),
+                createInputParameterMetadata(outputType),
+                serializerBoundInputFn,
+                null,
+                null,
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION,
+                KeyValuePairsState.class,
+                stateSerializer,
+                new KeyValuePairsStateFactory(keyType, valueType),
+                outputType,
+                false);
+
+        GenericAccumulatorFactoryBinder factory =
+                new AccumulatorCompiler().generateAccumulatorFactoryBinder(metadata, classLoader);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, false, factory);
+    }
+
+    private static List<ParameterMetadata> createInputParameterMetadata(Type inputType)
+    {
+        return ImmutableList.of(new ParameterMetadata(STATE),
+                new ParameterMetadata(NULLABLE_BLOCK_INPUT_CHANNEL, inputType),
+                new ParameterMetadata(BLOCK_INDEX));
+    }
+
+    public static void input(KeyValuePairStateSerializer serializer,
+                             KeyValuePairsState toState, Block value, int position)
+    {
+        Type keyType = toState.getKeyType();
+        Type valueType = toState.getValueType();
+        SingleState fromState = new SingleState(keyType, valueType);
+        try {
+            serializer.deserialize(value, position, fromState);
+        }
+        catch (ExceededMemoryLimitException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT,
+                    format("The deserialization of %s may not exceed %s", NAME, e.getMaxMemory()));
+        }
+        if (fromState.get() != null) {
+            combine(toState, fromState);
+        }
+    }
+
+    public static void combine(KeyValuePairsState state, KeyValuePairsState otherState)
+    {
+        MapAggregation.combine(state, otherState);
+    }
+
+    public static void output(KeyValuePairsState state, BlockBuilder out)
+    {
+        MapAggregation.output(state, out);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMapUnionAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMapUnionAggregation.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.aggregation.state.KeyValuePairStateSerializer;
+import com.facebook.presto.operator.aggregation.state.KeyValuePairsStateFactory.SingleState;
+import com.facebook.presto.operator.scalar.TestingRowConstructor;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.RowType;
+import com.facebook.presto.util.StructuralTestUtil;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.aggregation;
+import static com.facebook.presto.operator.aggregation.MapUnionAggregation.NAME;
+import static com.facebook.presto.operator.aggregation.TestMapUnionAggregation.MapSerializer.serializeAsMap;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.of;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests {@link MapUnionAggregation}.
+ */
+public class TestMapUnionAggregation
+{
+    private static final MetadataManager metadata = MetadataManager.createTestMetadataManager();
+
+    @SuppressWarnings("AssertEqualsBetweenInconvertibleTypesTestNG")
+    @Test
+    public void testSimpleMapsWithDuplicates()
+            throws Exception
+    {
+        MapType mapType = new MapType(DOUBLE, VARCHAR);
+        InternalAggregationFunction aggFunc =
+                metadata.getExactFunction(
+                        new Signature(NAME,
+                                mapType.getTypeSignature().toString(), mapType.getTypeSignature().toString())
+                ).getAggregationFunction();
+
+        assertEquals(
+                ImmutableMap.of(23.0, "aaa", 33.0, "bbb", 43.0, "ccc", 53.0, "ddd", 13.0, "eee"),
+                aggregation(aggFunc, 1.0,
+                        serializeAsMap(DOUBLE, of(23.0, 33.0), VARCHAR, of("aaa", "bbb")),
+                        serializeAsMap(DOUBLE, of(43.0, 53.0, 13.0), VARCHAR, of("ccc", "ddd", "eee")))
+        );
+
+        assertEquals(
+                ImmutableMap.of(23.0, "aaa", 33.0, "bbb", 43.0, "ccc", 53.0, "ddd", 13.0, "eee"),
+                aggregation(
+                        aggFunc,
+                        1.0,
+                        serializeAsMap(DOUBLE, of(23.0, 33.0), VARCHAR, of("aaa", "bbb")),
+                        serializeAsMap(DOUBLE, of(43.0, 53.0, 13.0), VARCHAR, of("ccc", "ddd", "eee"))));
+
+        mapType = new MapType(DOUBLE, BIGINT);
+        aggFunc = metadata.getExactFunction(
+                new Signature(NAME, mapType.getTypeSignature().toString(), mapType.getTypeSignature().toString()))
+                .getAggregationFunction();
+
+        assertEquals(
+                ImmutableMap.of(1.0, 99L, 2.0, 99L, 3.0, 99L, 4.0, 44L),
+                aggregation(
+                        aggFunc,
+                        1.0,
+                        serializeAsMap(DOUBLE, of(1.0, 2.0, 3.0), BIGINT, of(99L, 99L, 99L)),
+                        serializeAsMap(DOUBLE, of(1.0, 2.0, 4.0), BIGINT, of(44L, 44L, 44L))));
+
+        mapType = new MapType(BOOLEAN, BIGINT);
+        aggFunc = metadata.getExactFunction(
+                new Signature(NAME, mapType.getTypeSignature().toString(), mapType.getTypeSignature().toString()))
+                .getAggregationFunction();
+
+        assertEquals(
+                ImmutableMap.of(false, 12L, true, 13L),
+                aggregation(
+                        aggFunc,
+                        1.0,
+                        serializeAsMap(BOOLEAN, of(false), BIGINT, of(12L)),
+                        serializeAsMap(BOOLEAN, of(true, false), BIGINT, of(13L, 33L))));
+    }
+
+    @Test
+    public void testSimpleMapsWithNulls()
+            throws Exception
+    {
+        MapType mapType = new MapType(DOUBLE, VARCHAR);
+        InternalAggregationFunction aggFunc =
+                metadata.getExactFunction(
+                        new Signature(NAME,
+                                mapType.getTypeSignature().toString(), mapType.getTypeSignature().toString())
+                ).getAggregationFunction();
+        assertEquals(
+                new HashMap<Double, String>()
+                {
+                    {
+                        put(23.0, "aaa");
+                        put(13.0, "eee");
+                        put(null, "bbb");
+                    }
+                },
+                aggregation(
+                        aggFunc,
+                        1.0,
+
+                        serializeAsMap(DOUBLE, asList(23.0, null), VARCHAR, of("aaa", "bbb")),
+                        serializeAsMap(DOUBLE, asList(null, 13.0), VARCHAR, of("ccc", "eee"))));
+
+        mapType = new MapType(VARCHAR, BIGINT);
+        aggFunc = metadata.getExactFunction(
+                new Signature(NAME, mapType.getTypeSignature().toString(), mapType.getTypeSignature().toString()))
+                .getAggregationFunction();
+        assertEquals(
+                new HashMap<String, Long>()
+                {
+                    {
+                        put("foo", 13L);
+                        put("bar", 54L);
+                        put(null, 12L);
+                    }
+                },
+                aggregation(
+                        aggFunc,
+                        1.0,
+                        serializeAsMap(VARCHAR, asList(null, "foo"), BIGINT, of(12L, 13L)),
+                        serializeAsMap(VARCHAR, asList(null, "bar", null), BIGINT, of(44L, 54L, 64L))));
+
+        mapType = new MapType(BOOLEAN, BIGINT);
+        aggFunc = metadata.getExactFunction(
+                new Signature(NAME, mapType.getTypeSignature().toString(), mapType.getTypeSignature().toString()))
+                .getAggregationFunction();
+
+        assertEquals(
+                new HashMap<Boolean, Long>()
+                {
+                    {
+                        put(true, 100L);
+                        put(false, 300L);
+                        put(null, 33L);
+                    }
+                },
+                aggregation(
+                        aggFunc,
+                        1.0,
+                        serializeAsMap(BOOLEAN, singletonList(null), BIGINT, singletonList(33L)),
+                        serializeAsMap(BOOLEAN, asList(true, null, false), BIGINT, asList(100L, 200L, 300L))));
+    }
+
+    @SuppressWarnings("AssertEqualsBetweenInconvertibleTypesTestNG")
+    @Test
+    public void testDoubleArrayMap()
+            throws Exception
+    {
+        ArrayType arrayType = new ArrayType(VARCHAR);
+        MapType mapType = new MapType(DOUBLE, arrayType);
+        InternalAggregationFunction aggFunc = metadata.getExactFunction(
+                new Signature(NAME, mapType.getTypeSignature().toString(), mapType.getTypeSignature().toString())
+        ).getAggregationFunction();
+
+        assertEquals(
+                ImmutableMap.of(
+                        1.0, of("a", "b"),
+                        2.0, of("c", "d"),
+                        3.0, of("e", "f"),
+                        4.0, of("r", "s")),
+                aggregation(
+                        aggFunc,
+                        1.0,
+                        serializeAsMap(
+                                DOUBLE, of(1.0, 2.0, 3.0),
+                                arrayType, of(of("a", "b"), of("c", "d"), of("e", "f"))),
+                        serializeAsMap(
+                                DOUBLE, of(1.0, 4.0, 3.0),
+                                arrayType, of(of("x", "y"), of("r", "s"), of("w", "z")))
+                ));
+    }
+
+    @SuppressWarnings("AssertEqualsBetweenInconvertibleTypesTestNG")
+    @Test
+    public void testDoubleMapMap()
+            throws Exception
+    {
+        MapType innerMapType = new MapType(VARCHAR, VARCHAR);
+        MapType mapType = new MapType(DOUBLE, innerMapType);
+        InternalAggregationFunction aggFunc = metadata.getExactFunction(new Signature(NAME,
+                mapType.getTypeSignature().toString(),
+                mapType.getTypeSignature().toString())).getAggregationFunction();
+
+        assertEquals(
+                ImmutableMap.of(
+                        1.0, ImmutableMap.of("a", "b"),
+                        2.0, ImmutableMap.of("c", "d"),
+                        3.0, ImmutableMap.of("e", "f")),
+                aggregation(
+                        aggFunc,
+                        1.0, serializeAsMap(
+                                DOUBLE, of(1.0, 2.0),
+                                innerMapType,
+                                of(ImmutableMap.of("a", "b"), ImmutableMap.of("c", "d"))),
+                        serializeAsMap(
+                                DOUBLE, of(3.0),
+                                innerMapType,
+                                of(ImmutableMap.of("e", "f")))
+                ));
+    }
+
+    @Test
+    public void testDoubleRowMap()
+            throws Exception
+    {
+        RowType innerRowType = new RowType(of(BIGINT, DOUBLE), Optional.of(of("f1", "f2")));
+        MapType mapType = new MapType(DOUBLE, innerRowType);
+        InternalAggregationFunction aggFunc = metadata.getExactFunction(new Signature(NAME,
+                        mapType.getTypeSignature().toString(),
+                        mapType.getTypeSignature().toString())
+        ).getAggregationFunction();
+
+        assertEquals(
+                ImmutableMap.of(
+                        1.0, of(1L, 1.0),
+                        2.0, of(2L, 2.0),
+                        3.0, of(3L, 3.0),
+                        4.0, of(4L, 4.0),
+                        5.0, of(5L, 5.0)),
+                aggregation(
+                        aggFunc,
+                        1.0,
+                        serializeAsMap(
+                                DOUBLE, of(1.0, 3.0),
+                                innerRowType, of(of(1L, 1.0), of(3L, 3.0))),
+                        serializeAsMap(
+                                DOUBLE, of(4.0, 2.0, 5.0),
+                                innerRowType, of(of(4L, 4.0), of(2L, 2.0), of(5L, 5.0)))
+                ));
+    }
+
+    @SuppressWarnings("AssertEqualsBetweenInconvertibleTypesTestNG")
+    @Test
+    public void testArrayDoubleMap()
+            throws Exception
+    {
+        ArrayType arrayType = new ArrayType(VARCHAR);
+        MapType mapType = new MapType(arrayType, DOUBLE);
+        InternalAggregationFunction aggFunc = metadata.getExactFunction(new Signature(
+                        NAME,
+                        mapType.getTypeSignature().toString(),
+                        mapType.getTypeSignature().toString())
+        ).getAggregationFunction();
+
+        assertEquals(
+                ImmutableMap.of(
+                        of("a", "b"), 1.0,
+                        of("c", "d"), 2.0,
+                        of("e", "f"), 3.0),
+                aggregation(
+                        aggFunc,
+                        1.0,
+                        serializeAsMap(
+                                arrayType, of(of("a", "b"), of("e", "f")),
+                                DOUBLE, of(1.0, 3.0)),
+                        serializeAsMap(
+                                arrayType, of(of("c", "d")),
+                                DOUBLE, of(2.0))
+                ));
+    }
+
+    abstract static class MapSerializer
+    {
+        static Page serializeAsMap(Type keyType, List<?> keys, Type valueType, List<?> values)
+        {
+            checkArgument(keys.size() == values.size(), "Length of keys and values should be the same");
+
+            //Serialize the keys and values together as a KeyValuePairs type.
+            KeyValuePairs keyValuePairs = new KeyValuePairs(keyType, valueType);
+            Block keyBlock = serializeAsListOfX(keyType, keys);
+            Block valueBlock = serializeAsListOfX(valueType, values);
+            int size = keys.size();
+            for (int i = 0; i < size; i++) {
+                keyValuePairs.add(keyBlock, valueBlock, i, i);
+            }
+
+            SingleState singleState = new SingleState(keyType, valueType);
+            singleState.set(keyValuePairs);
+
+            PageBuilder builder = new PageBuilder(of(new MapType(keyType, valueType)));
+            builder.declarePosition();
+            new KeyValuePairStateSerializer(keyType, valueType, false)
+                    .serialize(singleState, builder.getBlockBuilder(0));
+            return builder.build();
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Block serializeAsListOfX(Type type, List<?> items)
+        {
+            Block valueBlock;
+            if (type instanceof ArrayType) {
+                valueBlock = serializeAsListOfArrays((ArrayType) type, (Iterable<List<?>>) items).getBlockBuilder(0);
+            }
+            else if (type instanceof MapType) {
+                valueBlock = serializeAsListOfMaps((MapType) type, (Iterable<Map<?, ?>>) items).getBlockBuilder(0);
+            }
+            else if (type instanceof RowType) {
+                valueBlock = serializeAsListOfRows((RowType) type, (Iterable<List<?>>) items).getBlockBuilder(0);
+            }
+            else {
+                valueBlock = serializeAsListOfPrimitives(type, items);
+            }
+            return valueBlock;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Block serializeAsListOfPrimitives(Type type, Iterable<?> items)
+        {
+            if (type == BIGINT) {
+                return createLongsBlock((Iterable<Long>) items);
+            }
+            else if (type == DOUBLE) {
+                return createDoublesBlock((Iterable<Double>) items);
+            }
+            else if (type == VARCHAR) {
+                return createStringsBlock((Iterable<String>) items);
+            }
+            else if (type == BOOLEAN) {
+                return createBooleansBlock((Iterable<Boolean>) items);
+            }
+
+            throw new IllegalArgumentException("Unsupported type [" + type.getDisplayName() + "]");
+        }
+
+        private static PageBuilder serializeAsListOfArrays(ArrayType arrayType, Iterable<List<?>> items)
+        {
+            PageBuilder builder = new PageBuilder(of(arrayType));
+            for (List<?> subItems : items) {
+                builder.declarePosition();
+                arrayType.writeObject(
+                        builder.getBlockBuilder(0),
+                        StructuralTestUtil.arrayBlockOf(arrayType.getElementType(), (Object[]) subItems.toArray()));
+            }
+            return builder;
+        }
+
+        private static PageBuilder serializeAsListOfMaps(MapType mapType, Iterable<Map<?, ?>> items)
+        {
+            PageBuilder builder = new PageBuilder(of(mapType));
+            for (Map<?, ?> subItems : items) {
+                builder.declarePosition();
+                mapType.writeObject(
+                        builder.getBlockBuilder(0),
+                        StructuralTestUtil.mapBlockOf(mapType.getKeyType(), mapType.getValueType(), subItems));
+            }
+            return builder;
+        }
+
+        private static PageBuilder serializeAsListOfRows(RowType rowType, Iterable<List<?>> items)
+        {
+            PageBuilder builder = new PageBuilder(of(rowType));
+            for (List<?> subItems : items) {
+                builder.declarePosition();
+                Block block = TestingRowConstructor
+                        .toStackRepresentation(rowType.getTypeParameters(), (Object[]) subItems.toArray());
+                rowType.writeObject(builder.getBlockBuilder(0), block);
+            }
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
Hi, I'd like to submit this new aggregation function that merges/unions `map<K, V>`s. The examples below show what it can do.

This new `map_union(map<K, V>)` reuses the logic in `MapAggregation.combine(..)` by delegating to it.

```sql
Example 1:
select map_union(foo), map_union(bar) from (
 select map(array['a', 'b'], array[1000, 2000]) as foo, cast(null as map<varchar, double>) as bar
 union
 select map(array['c', 'd'], array[3000, 4000]) as foo, cast(null as map<varchar, double>) as bar
);


Example 2:
select map_union(foo), map_union(bar) from (
 select cast(null as map<varchar, bigint>) as foo,
        cast(null as map<bigint, double>) as bar
 union
 select map(array['a', 'b'], array[1000, 2000]) as foo,
        map(array[33], array[3300.33]) as bar
 union
 select map(array['c', 'd'], array[3000, 4000]) as foo,
        map(array[44, 55], array[4400.44, 5500.55]) as bar
 union
 select map(array['e', 'f', 'g', 'h', 'i'], array[50, 60, 70, 80, 90]) as foo,
        cast(null as map<bigint, double>) as bar
 union
 select map(array['j', 'k', 'a', 'b', 'n', 'o', 'p'], array[200, 300, -45, -55, 600, 700, 800]) as foo,
        cast(null as map<bigint, double>) as bar
 union
 select map(array['c', 'd'], array[90000, 120000]) as foo,
        map(array[44, 55], array[1100.0, 2200.0]) as bar
);


Example 3:
with
part_a as (
 select map(array['a', 'b'], array[1000, 2000]) as foo, 'homer' as first_name, 'simpson' as last_name
),
part_b as (
 select map(array['c', 'd'], array[3000, 4000]) as foo, 'marge' as first_name, 'simpson' as last_name
),
part_c as (
 select map(array['a', 'd'], array[12, 3]) as foo, 'moe' as first_name, 'szyslak' as last_name
),
part_d as (
 select cast(null as map<varchar, bigint>) as foo, 'bart' as first_name, 'simpson' as last_name
)
select last_name, map_union(foo) from (
 select * from part_a
 union
 select * from part_b
 union
 select * from part_c
 union
 select * from part_d
)
group by last_name;


Example 4:
with
part_a as (
 select cast(null as map<varchar, bigint>) as foo, 'homer' as first_name, 'simpson' as last_name
),
part_b as (
 select cast(null as map<varchar, bigint>) as foo, 'marge' as first_name, 'simpson' as last_name
),
part_c as (
 select cast(null as map<varchar, bigint>) as foo, 'moe' as first_name, 'szyslak' as last_name
),
part_d as (
 select cast(null as map<varchar, bigint>) as foo, 'bart' as first_name, 'simpson' as last_name
)
select last_name, map_union(foo) from (
 select * from part_a
 union
 select * from part_b
 union
 select * from part_c
 union
 select * from part_d
)
group by last_name;
```