### PR TITLE
Adding a parametric scalar function to flatten an array

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -137,6 +137,7 @@ import static com.facebook.presto.operator.scalar.ArrayContains.ARRAY_CONTAINS;
 import static com.facebook.presto.operator.scalar.ArrayDistinctFunction.ARRAY_DISTINCT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayElementAtFunction.ARRAY_ELEMENT_AT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayEqualOperator.ARRAY_EQUAL;
+import static com.facebook.presto.operator.scalar.ArrayFlattenFunction.ARRAY_FLATTEN_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayGreaterThanOperator.ARRAY_GREATER_THAN;
 import static com.facebook.presto.operator.scalar.ArrayGreaterThanOrEqualOperator.ARRAY_GREATER_THAN_OR_EQUAL;
 import static com.facebook.presto.operator.scalar.ArrayHashCodeOperator.ARRAY_HASH_CODE;
@@ -302,7 +303,7 @@ public class FunctionRegistry
                 .functions(ARRAY_TO_ARRAY_CAST, ARRAY_HASH_CODE, ARRAY_EQUAL, ARRAY_NOT_EQUAL, ARRAY_LESS_THAN, ARRAY_LESS_THAN_OR_EQUAL, ARRAY_GREATER_THAN, ARRAY_GREATER_THAN_OR_EQUAL)
                 .functions(ARRAY_CONCAT_FUNCTION, ARRAY_TO_ELEMENT_CONCAT_FUNCTION, ELEMENT_TO_ARRAY_CONCAT_FUNCTION)
                 .functions(MAP_EQUAL, MAP_NOT_EQUAL, MAP_HASH_CODE)
-                .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_ELEMENT_AT_FUNCTION, ARRAY_CARDINALITY, ARRAY_POSITION, ARRAY_SORT_FUNCTION, ARRAY_INTERSECT_FUNCTION, ARRAY_TO_JSON, JSON_TO_ARRAY, ARRAY_DISTINCT_FUNCTION, ARRAY_REMOVE_FUNCTION, ARRAY_SLICE_FUNCTION)
+                .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_ELEMENT_AT_FUNCTION, ARRAY_CARDINALITY, ARRAY_POSITION, ARRAY_SORT_FUNCTION, ARRAY_INTERSECT_FUNCTION, ARRAY_TO_JSON, JSON_TO_ARRAY, ARRAY_DISTINCT_FUNCTION, ARRAY_REMOVE_FUNCTION, ARRAY_SLICE_FUNCTION, ARRAY_FLATTEN_FUNCTION)
                 .functions(MAP_CONSTRUCTOR, MAP_CARDINALITY, MAP_SUBSCRIPT, MAP_TO_JSON, JSON_TO_MAP, MAP_KEYS, MAP_VALUES)
                 .functions(MAP_AGG, MULTIMAP_AGG)
                 .function(HISTOGRAM)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFlattenFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFlattenFunction.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.ParametricScalar;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.Signature.typeParameter;
+import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class ArrayFlattenFunction
+        extends ParametricScalar
+{
+    public static final ArrayFlattenFunction ARRAY_FLATTEN_FUNCTION = new ArrayFlattenFunction();
+    private static final String FUNCTION_NAME = "flatten";
+    private static final Signature SIGNATURE = new Signature(FUNCTION_NAME, ImmutableList.of(typeParameter("E")), "array<E>", ImmutableList.of("array<array<E>>"), false, false);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(ArrayFlattenFunction.class, FUNCTION_NAME, Type.class, Block.class);
+
+    @Override
+    public Signature getSignature()
+    {
+        return SIGNATURE;
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Flattens a given array";
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type elementType = types.get("E");
+        MethodHandle methodHandle = METHOD_HANDLE.bindTo(elementType);
+        TypeSignature typeSignature = parameterizedTypeName("array", types.get("E").getTypeSignature());
+        Signature signature = new Signature(FUNCTION_NAME, typeSignature, parameterizedTypeName("array", typeSignature));
+        return new FunctionInfo(signature, getDescription(), isHidden(), methodHandle, isDeterministic(), false, ImmutableList.of(false));
+    }
+
+    public static Block flatten(Type type, Block array)
+    {
+        BlockBuilder resultBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), array.getSizeInBytes());
+        for (int i = 0; i < array.getPositionCount(); ++i) {
+            Block subBlock = array.getObject(i, Block.class);
+            for (int j = 0; j < subBlock.getPositionCount(); ++j) {
+                type.appendTo(subBlock, j, resultBlockBuilder);
+            }
+        }
+        return resultBlockBuilder.build();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.type.SqlTimestamp;
 import com.facebook.presto.sql.analyzer.SemanticErrorCode;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Longs;
 import io.airlift.slice.DynamicSliceOutput;
@@ -688,6 +689,52 @@ public class TestArrayOperators
         assertFunction("ARRAY_REMOVE(ARRAY [TRUE, FALSE, TRUE], FALSE)", new ArrayType(BOOLEAN), ImmutableList.of(true, true));
         assertFunction("ARRAY_REMOVE(ARRAY [NULL, FALSE, TRUE], TRUE)", new ArrayType(BOOLEAN), asList(null, false));
         assertFunction("ARRAY_REMOVE(ARRAY [ARRAY ['foo'], ARRAY ['bar'], ARRAY ['baz']], ARRAY ['bar'])", new ArrayType(new ArrayType(VARCHAR)), ImmutableList.of(ImmutableList.of("foo"), ImmutableList.of("baz")));
+    }
+
+    @Test
+    public void testFlatten()
+    {
+        // BOOLEAN Tests
+        assertFunction("flatten(ARRAY [ARRAY [TRUE, FALSE], ARRAY [FALSE]])", new ArrayType(BOOLEAN), ImmutableList.of(true, false, false));
+        assertFunction("flatten(ARRAY [ARRAY [TRUE, FALSE], NULL])", new ArrayType(BOOLEAN), ImmutableList.of(true, false));
+        assertFunction("flatten(ARRAY [NULL, ARRAY [TRUE, FALSE]])", new ArrayType(BOOLEAN), ImmutableList.of(true, false));
+        assertFunction("flatten(ARRAY [ARRAY [TRUE], ARRAY [FALSE], ARRAY [TRUE, FALSE]])", new ArrayType(BOOLEAN), ImmutableList.of(true, false, true, false));
+        assertFunction("flatten(ARRAY [NULL, ARRAY [TRUE], NULL, ARRAY [FALSE], ARRAY [FALSE, TRUE]])", new ArrayType(BOOLEAN), ImmutableList.of(true, false, false, true));
+
+        // VARCHAR Tests
+        assertFunction("flatten(ARRAY [ARRAY ['1', '2'], ARRAY ['3']])", new ArrayType(VARCHAR), ImmutableList.of("1", "2", "3"));
+        assertFunction("flatten(ARRAY [ARRAY ['1', '2'], NULL])", new ArrayType(VARCHAR), ImmutableList.of("1", "2"));
+        assertFunction("flatten(ARRAY [NULL, ARRAY ['1', '2']])", new ArrayType(VARCHAR), ImmutableList.of("1", "2"));
+        assertFunction("flatten(ARRAY [ARRAY ['0'], ARRAY ['1'], ARRAY ['2', '3']])", new ArrayType(VARCHAR), ImmutableList.of("0", "1", "2", "3"));
+        assertFunction("flatten(ARRAY [NULL, ARRAY ['0'], NULL, ARRAY ['1'], ARRAY ['2', '3']])", new ArrayType(VARCHAR), ImmutableList.of("0", "1", "2", "3"));
+
+        // BIGINT Tests
+        assertFunction("flatten(ARRAY [ARRAY [1, 2], ARRAY [3]])", new ArrayType(BIGINT), ImmutableList.of(1L, 2L, 3L));
+        assertFunction("flatten(ARRAY [ARRAY [1, 2], NULL])", new ArrayType(BIGINT), ImmutableList.of(1L, 2L));
+        assertFunction("flatten(ARRAY [NULL, ARRAY [1, 2]])", new ArrayType(BIGINT), ImmutableList.of(1L, 2L));
+        assertFunction("flatten(ARRAY [ARRAY [0], ARRAY [1], ARRAY [2, 3]])", new ArrayType(BIGINT), ImmutableList.of(0L, 1L, 2L, 3L));
+        assertFunction("flatten(ARRAY [NULL, ARRAY [0], NULL, ARRAY [1], ARRAY [2, 3]])", new ArrayType(BIGINT), ImmutableList.of(0L, 1L, 2L, 3L));
+
+        // DOUBLE Tests
+        assertFunction("flatten(ARRAY [ARRAY [1.2, 2.2], ARRAY [3.2]])", new ArrayType(DOUBLE), ImmutableList.of(1.2, 2.2, 3.2));
+        assertFunction("flatten(ARRAY [ARRAY [1.2, 2.2], NULL])", new ArrayType(DOUBLE), ImmutableList.of(1.2, 2.2));
+        assertFunction("flatten(ARRAY [NULL, ARRAY [1.2, 2.2]])", new ArrayType(DOUBLE), ImmutableList.of(1.2, 2.2));
+        assertFunction("flatten(ARRAY [ARRAY[0.2], ARRAY [1.2], ARRAY [2.2, 3.2]])", new ArrayType(DOUBLE), ImmutableList.of(0.2, 1.2, 2.2, 3.2));
+        assertFunction("flatten(ARRAY [NULL, ARRAY [0.2], NULL, ARRAY [1.2], ARRAY [2.2, 3.2]])", new ArrayType(DOUBLE), ImmutableList.of(0.2, 1.2, 2.2, 3.2));
+
+        // ARRAY<BIGINT> tests
+        assertFunction("flatten(ARRAY [ARRAY [ARRAY [1, 2], ARRAY [3, 4]], ARRAY [ARRAY [5, 6], ARRAY [7, 8]]])", new ArrayType(new ArrayType(BIGINT)), ImmutableList.of(ImmutableList.of(1L, 2L), ImmutableList.of(3L, 4L), ImmutableList.of(5L, 6L), ImmutableList.of(7L, 8L)));
+        assertFunction("flatten(ARRAY [ARRAY [ARRAY [1, 2], ARRAY [3, 4]], NULL])", new ArrayType(new ArrayType(BIGINT)), ImmutableList.of(ImmutableList.of(1L, 2L), ImmutableList.of(3L, 4L)));
+        assertFunction("flatten(ARRAY [NULL, ARRAY [ARRAY [5, 6], ARRAY [7, 8]]])", new ArrayType(new ArrayType(BIGINT)), ImmutableList.of(ImmutableList.of(5L, 6L), ImmutableList.of(7L, 8L)));
+        assertFunction("flatten(ARRAY [ARRAY [ARRAY [1, 2], ARRAY [3, 4]], ARRAY [ARRAY [5, 6], ARRAY [7, 8]], ARRAY [ARRAY [9, 10], ARRAY [11, 12]]])", new ArrayType(new ArrayType(BIGINT)), ImmutableList.of(ImmutableList.of(1L, 2L), ImmutableList.of(3L, 4L), ImmutableList.of(5L, 6L), ImmutableList.of(7L, 8L), ImmutableList.of(9L, 10L), ImmutableList.of(11L, 12L)));
+        assertFunction("flatten(ARRAY [NULL, ARRAY [ARRAY [1, 2], ARRAY [3, 4]], ARRAY [ARRAY [5, 6], ARRAY [7, 8]], ARRAY [ARRAY [9, 10], ARRAY [11, 12]]])", new ArrayType(new ArrayType(BIGINT)), ImmutableList.of(ImmutableList.of(1L, 2L), ImmutableList.of(3L, 4L), ImmutableList.of(5L, 6L), ImmutableList.of(7L, 8L), ImmutableList.of(9L, 10L), ImmutableList.of(11L, 12L)));
+
+        // MAP<BIGINT, BIGINT> Tests
+        assertFunction("flatten(ARRAY [ARRAY [MAP (ARRAY [1, 2], ARRAY [1, 2])], ARRAY [MAP (ARRAY [3, 4], ARRAY [3, 4])]])", new ArrayType(new MapType(BIGINT, BIGINT)), ImmutableList.of(ImmutableMap.of(1L, 1L, 2L, 2L), ImmutableMap.of(3L, 3L, 4L, 4L)));
+        assertFunction("flatten(ARRAY [ARRAY [MAP (ARRAY [1, 2], ARRAY [1, 2])], NULL])", new ArrayType(new MapType(BIGINT, BIGINT)), ImmutableList.of(ImmutableMap.of(1L, 1L, 2L, 2L)));
+        assertFunction("flatten(ARRAY [NULL, ARRAY [MAP (ARRAY [3, 4], ARRAY [3, 4])]])", new ArrayType(new MapType(BIGINT, BIGINT)), ImmutableList.of(ImmutableMap.of(3L, 3L, 4L, 4L)));
+        assertFunction("flatten(ARRAY [ARRAY [MAP (ARRAY [1, 2], ARRAY [1, 2])], ARRAY [MAP (ARRAY [3, 4], ARRAY [3, 4])], ARRAY [MAP (ARRAY [5, 6], ARRAY [5, 6])]])", new ArrayType(new MapType(BIGINT, BIGINT)), ImmutableList.of(ImmutableMap.of(1L, 1L, 2L, 2L), ImmutableMap.of(3L, 3L, 4L, 4L), ImmutableMap.of(5L, 5L, 6L, 6L)));
+        assertFunction("flatten(ARRAY [NULL, ARRAY [MAP (ARRAY [1, 2], ARRAY [1, 2])], NULL, ARRAY [MAP (ARRAY [3, 4], ARRAY [3, 4])], ARRAY [MAP (ARRAY [5, 6], ARRAY [5, 6])]])", new ArrayType(new MapType(BIGINT, BIGINT)), ImmutableList.of(ImmutableMap.of(1L, 1L, 2L, 2L), ImmutableMap.of(3L, 3L, 4L, 4L), ImmutableMap.of(5L, 5L, 6L, 6L)));
     }
 
     public void assertInvalidFunction(String projection, ErrorCode errorCode)


### PR DESCRIPTION
This change adds a parametric scalar function to flatten an array. The main idea of the function is to iterate over the provided array and return an array which is a concatenation of each of its element arrays. If an element of the provided array is null, it is ignored. The change tests the added function with arrays of type VARCHAR, BIGINT and DOUBLE.