### PR TITLE
Limit max data size per query

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -48,6 +48,7 @@ public final class SystemSessionProperties
     public static final String QUERY_MAX_RUN_TIME = "query_max_run_time";
     public static final String RESOURCE_OVERCOMMIT = "resource_overcommit";
     public static final String QUERY_MAX_CPU_TIME = "query_max_cpu_time";
+    public static final String QUERY_MAX_DATA_SIZE = "query_max_data_size";
     public static final String REDISTRIBUTE_WRITES = "redistribute_writes";
     public static final String PUSH_TABLE_WRITE_THROUGH_UNION = "push_table_write_through_union";
     public static final String EXECUTION_POLICY = "execution_policy";
@@ -166,6 +167,14 @@ public final class SystemSessionProperties
                         VARCHAR,
                         DataSize.class,
                         memoryManagerConfig.getMaxQueryMemory(),
+                        true,
+                        value -> DataSize.valueOf((String) value)),
+                new PropertyMetadata<>(
+                        QUERY_MAX_DATA_SIZE,
+                        "Maximum raw data size of a query",
+                        VARCHAR,
+                        DataSize.class,
+                        queryManagerConfig.getQueryMaxDataSize(),
                         true,
                         value -> DataSize.valueOf((String) value)),
                 booleanSessionProperty(
@@ -311,6 +320,11 @@ public final class SystemSessionProperties
     public static DataSize getQueryMaxMemory(Session session)
     {
         return session.getProperty(QUERY_MAX_MEMORY, DataSize.class);
+    }
+
+    public static DataSize getQueryMaxDataSize(Session session)
+    {
+        return session.getProperty(QUERY_MAX_DATA_SIZE, DataSize.class);
     }
 
     public static Duration getQueryMaxRunTime(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.DefunctConfig;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
@@ -22,6 +23,8 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.util.concurrent.TimeUnit;
+
+import static io.airlift.units.DataSize.Unit.TERABYTE;
 
 @DefunctConfig({"query.max-pending-splits-per-node",
                 "experimental.big-query-initial-hash-partitions",
@@ -48,6 +51,7 @@ public class QueryManagerConfig
     private String queryExecutionPolicy = "all-at-once";
     private Duration queryMaxRunTime = new Duration(100, TimeUnit.DAYS);
     private Duration queryMaxCpuTime = new Duration(1_000_000_000, TimeUnit.DAYS);
+    private DataSize maxQueryDataSize = new DataSize(100, TERABYTE);
 
     public String getQueueConfigFile()
     {
@@ -167,6 +171,19 @@ public class QueryManagerConfig
     public QueryManagerConfig setQueryManagerExecutorPoolSize(int queryManagerExecutorPoolSize)
     {
         this.queryManagerExecutorPoolSize = queryManagerExecutorPoolSize;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getQueryMaxDataSize()
+    {
+        return maxQueryDataSize;
+    }
+
+    @Config("query.max-data-size")
+    public QueryManagerConfig setQueryMaxDataSize(DataSize maxQueryDataSize)
+    {
+        this.maxQueryDataSize = maxQueryDataSize;
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -15,11 +15,14 @@ package com.facebook.presto.execution;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.configuration.testing.ConfigAssertions;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import static io.airlift.units.DataSize.Unit.TERABYTE;
 
 public class TestQueryManagerConfig
 {
@@ -41,6 +44,7 @@ public class TestQueryManagerConfig
                 .setQueryExecutionPolicy("all-at-once")
                 .setQueryMaxRunTime(new Duration(100, TimeUnit.DAYS))
                 .setQueryMaxCpuTime(new Duration(1_000_000_000, TimeUnit.DAYS))
+                .setQueryMaxDataSize(new DataSize(100, TERABYTE))
         );
     }
 
@@ -62,6 +66,7 @@ public class TestQueryManagerConfig
                 .put("query.execution-policy", "phased")
                 .put("query.max-run-time", "2h")
                 .put("query.max-cpu-time", "2d")
+                .put("query.max-data-size", "5TB")
                 .build();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -78,7 +83,8 @@ public class TestQueryManagerConfig
                 .setRemoteTaskMaxCallbackThreads(10)
                 .setQueryExecutionPolicy("phased")
                 .setQueryMaxRunTime(new Duration(2, TimeUnit.HOURS))
-                .setQueryMaxCpuTime(new Duration(2, TimeUnit.DAYS));
+                .setQueryMaxCpuTime(new Duration(2, TimeUnit.DAYS))
+                .setQueryMaxDataSize(new DataSize(5, TERABYTE));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/StandardErrorCode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/StandardErrorCode.java
@@ -72,6 +72,7 @@ public enum StandardErrorCode
     EXCEEDED_TIME_LIMIT(0x0002_0003),
     CLUSTER_OUT_OF_MEMORY(0x0002_0004),
     EXCEEDED_CPU_LIMIT(0x0002_0005),
+    EXCEEDED_DATA_SIZE_LIMIT(0x0002_0006),
 
     // Connectors can use error codes starting at EXTERNAL
     EXTERNAL(0x0100_0000);


### PR DESCRIPTION
We are seeing users submitting big queries to Presto cluster, which scans millions of splits. This PR limits the max number of splits/drivers for each query. A query will fail in case it having more drivers than the maximum number.
