### PR TITLE
Add a Developers section w/ style guidelines to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ We recommend you use IntelliJ as your IDE. The code style template for the proje
 * Use Guava's `Splitter` for parsing strings.
 * When appropriate, use the Java 8 stream API. However, note that the stream implementation does not perform well so avoid using it in inner loops or otherwise performance sensitive sections.
 * Categorize errors when throwing exceptions. For example, PrestoException takes an error code as an argument, `PrestoException(HIVE_TOO_MANY_OPEN_PARTITIONS)`. This categorization lets you generate reports so you can monitor the frequency of various failures.
-* Ensure that all files have the appropriate license; you can generate the license by running `mvn license:format`.
-* Consider using String formatting (printf style formatting using the Java `Formatter class`): `String.format("Session property %s is invalid: %s", name, value)`. Sometimes, if you only need to append something, consider using the `+` operator.
+* Ensure that all files have the appropriate license header; you can generate the license by running `mvn license:format`.
+* Consider using String formatting (printf style formatting using the Java `Formatter` class): `format("Session property %s is invalid: %s", name, value)` (note that `format()` should always be statically imported). Sometimes, if you only need to append something, consider using the `+` operator.
 * Avoid using the ternary operator.
-* Use the `Assertions` class from Airlift where possible. Those assertion methods are preferred because they give better error messages than the TestNG equivalents. Over time we may move over to more fluent assertions like AssertJ or Fest.
+* Use an assertion from Airlift's `Assertions` class if there is one that covers your case rather than writing the assertion by hand. Over time we may move over to more fluent assertions like AssertJ or Fest.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,16 @@ Run a query to see the nodes in the cluster:
 In the sample configuration, the Hive connector is mounted in the `hive` catalog, so you can run the following queries to show the tables in the Hive database `default`:
 
     SHOW TABLES FROM hive.default;
+
+## Developers
+
+We recommend you use IntelliJ as your IDE. The code style template for the project can be found in the [codestyle](https://github.com/airlift/codestyle) repository along with our general programming and Java guidelines. In addition to those you should also adhere to the following:
+
+* Alphabetize sections in the documentation source files (both in table of contents files and other regular documentation files). In general, alphabetize methods/variables/sections if such ordering already exists in the surrounding code.
+* Use Guava's `Splitter` for parsing strings.
+* When appropriate, use the Java 8 stream API. However, note that the stream implementation does not perform well so avoid using it in inner loops or otherwise performance sensitive sections.
+* Categorize errors when throwing exceptions. For example, PrestoException takes an error code as an argument, `PrestoException(HIVE_TOO_MANY_OPEN_PARTITIONS)`. This categorization lets you generate reports so you can monitor the frequency of various failures.
+* Ensure that all files have the appropriate license; you can generate the license by running `mvn license:format`.
+* Consider using String formatting (printf style formatting using the Java `Formatter class`): `String.format("Session property %s is invalid: %s", name, value)`. Sometimes, if you only need to append something, consider using the `+` operator.
+* Avoid using the ternary operator.
+* Use the `Assertions` class from Airlift where possible. Those assertion methods are preferred because they give better error messages than the TestNG equivalents. Over time we may move over to more fluent assertions like AssertJ or Fest.


### PR DESCRIPTION
This is the second half of the style guidelines discussed during the Boston Presto meetup (the other half is here https://github.com/airlift/codestyle/pull/3). I split the guidelines into two sections: one that is more general (to be merged in codestyle) and another section that is more specific to the Presto codebase (this PR).