### PR TITLE
Remove left partition directories after insert into hive table

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -188,11 +188,6 @@ public class HiveMetadata
         return metastore;
     }
 
-    public HivePartitionManager getPartitionManager()
-    {
-        return partitionManager;
-    }
-
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -759,8 +759,8 @@ public class HiveMetadata
                                 hdfsEnvironment,
                                 table.get().getDbName(),
                                 table.get().getTableName(),
-                                new Path(partitionUpdate.getWritePath()),
-                                new Path(partitionUpdate.getTargetPath()));
+                                partitionUpdate.getWritePath(),
+                                partitionUpdate.getTargetPath());
                     }
                     // add new partition
                     Partition partition = buildPartitionObject(table.get(), partitionUpdate);
@@ -772,8 +772,8 @@ public class HiveMetadata
                 else {
                     // move data to final location
                     if (!partitionUpdate.getWritePath().equals(partitionUpdate.getTargetPath())) {
-                        Path writeDir = new Path(partitionUpdate.getWritePath());
-                        Path targetDir = new Path(partitionUpdate.getTargetPath());
+                        Path writeDir = partitionUpdate.getWritePath();
+                        Path targetDir =partitionUpdate.getTargetPath();
 
                         FileSystem fileSystem;
                         try {
@@ -822,13 +822,13 @@ public class HiveMetadata
 
         if (respectTableFormat) {
             partition.setSd(table.getSd().deepCopy());
-            partition.getSd().setLocation(partitionUpdate.getTargetPath());
+            partition.getSd().setLocation(partitionUpdate.getTargetPath().toString());
         }
         else {
             partition.setSd(makeStorageDescriptor(
                     table.getTableName(),
                     defaultStorageFormat,
-                    new Path(partitionUpdate.getTargetPath()),
+                    partitionUpdate.getTargetPath(),
                     table.getSd().getCols(),
                     HiveBucketProperty.fromStorageDescriptor(table.getSd(), table.getTableName())));
         }
@@ -905,8 +905,8 @@ public class HiveMetadata
     private void rollbackPartitionUpdates(String user, List<PartitionUpdate> partitionUpdates, String actionName)
     {
         for (PartitionUpdate partitionUpdate : partitionUpdates) {
-            String targetPath = partitionUpdate.getTargetPath();
-            String writePath = partitionUpdate.getWritePath();
+            Path targetPath = partitionUpdate.getTargetPath();
+            Path writePath = partitionUpdate.getWritePath();
 
             // delete temp data if we used a temp dir
             if (!writePath.equals(targetPath)) {
@@ -946,8 +946,15 @@ public class HiveMetadata
      */
     public boolean deleteIfExists(String user, String location)
     {
-        Path path = new Path(location);
+        return deleteIfExists(user, new Path(location));
+    }
 
+    /**
+     * Attempts to remove the file or empty directory.
+     * @return true if the location no longer exists
+     */
+    private boolean deleteIfExists(String user, Path path)
+    {
         FileSystem fileSystem;
         try {
             fileSystem = hdfsEnvironment.getFileSystem(user, path);
@@ -988,12 +995,11 @@ public class HiveMetadata
      * Attempt to remove the {@code fileNames} files within {@code location}.
      * @return the files that could not be removed
      */
-    private List<String> deleteFilesFrom(String user, String location, List<String> fileNames)
+    private List<String> deleteFilesFrom(String user, Path location, List<String> fileNames)
     {
-        Path directory = new Path(location);
         FileSystem fileSystem;
         try {
-            fileSystem = hdfsEnvironment.getFileSystem(user, directory);
+            fileSystem = hdfsEnvironment.getFileSystem(user, location);
         }
         catch (IOException e) {
             return fileNames;
@@ -1001,7 +1007,7 @@ public class HiveMetadata
 
         ImmutableList.Builder<String> notDeletedFiles = ImmutableList.builder();
         for (String fileName : fileNames) {
-            Path file = new Path(directory, fileName);
+            Path file = new Path(location, fileName);
             if (!deleteIfExists(fileSystem, file)) {
                 notDeletedFiles.add(file.toString());
             }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PartitionUpdate.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PartitionUpdate.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimaps;
+import org.apache.hadoop.fs.Path;
 
 import java.util.Collection;
 import java.util.List;
@@ -30,8 +31,8 @@ public class PartitionUpdate
 {
     private final String name;
     private final boolean isNew;
-    private final String writePath;
-    private final String targetPath;
+    private final Path writePath;
+    private final Path targetPath;
     private final List<String> fileNames;
 
     public PartitionUpdate(
@@ -40,6 +41,15 @@ public class PartitionUpdate
             @JsonProperty("writePath") String writePath,
             @JsonProperty("targetPath") String targetPath,
             @JsonProperty("fileNames") List<String> fileNames)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.isNew = isNew;
+        this.writePath = new Path(requireNonNull(writePath, "writePath is null"));
+        this.targetPath = new Path(requireNonNull(targetPath, "targetPath is null"));
+        this.fileNames = ImmutableList.copyOf(requireNonNull(fileNames, "fileNames is null"));
+    }
+
+    public PartitionUpdate(String name, boolean isNew, Path writePath, Path targetPath, List<String> fileNames)
     {
         this.name = requireNonNull(name, "name is null");
         this.isNew = isNew;
@@ -60,14 +70,12 @@ public class PartitionUpdate
         return isNew;
     }
 
-    @JsonProperty
-    public String getWritePath()
+    public Path getWritePath()
     {
         return writePath;
     }
 
-    @JsonProperty
-    public String getTargetPath()
+    public Path getTargetPath()
     {
         return targetPath;
     }
@@ -76,6 +84,18 @@ public class PartitionUpdate
     public List<String> getFileNames()
     {
         return fileNames;
+    }
+
+    @JsonProperty("targetPath")
+    public String getJsonSerializableTargetPath()
+    {
+        return targetPath.toString();
+    }
+
+    @JsonProperty("writePath")
+    public String getJsonSerializableWritePath()
+    {
+        return writePath.toString();
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -2005,6 +2005,7 @@ public abstract class AbstractTestHiveClient
     }
 
     private void insertData(ConnectorTableHandle tableHandle, MaterializedResult data, ConnectorSession session)
+            throws Exception
     {
         ConnectorMetadata metadata = newMetadata();
         ConnectorTransactionHandle transaction = newTransaction();
@@ -2018,6 +2019,12 @@ public abstract class AbstractTestHiveClient
 
         // commit the insert
         metadata.finishInsert(session, insertTableHandle, fragments);
+
+        // check that temporary files are removed
+        HiveInsertTableHandle hiveInsertTableHandle = (HiveInsertTableHandle) insertTableHandle;
+        Path writePath = new Path(getLocationService(hiveInsertTableHandle.getSchemaName()).writePathRoot(hiveInsertTableHandle.getLocationHandle()).get().toString());
+        FileSystem fileSystem = hdfsEnvironment.getFileSystem("user", writePath);
+        assertFalse(fileSystem.exists(writePath));
     }
 
     private void doMetadataDelete(HiveStorageFormat storageFormat, SchemaTableName tableName)


### PR DESCRIPTION
Remove left partition directories after insert into hive table

When a table was partitioned by multiple columns (let say N), then N-1
levels of partition directories were left in temporary directory.
Also global insert temporary directory was also not cleaned.

Fixes: #3731
