### PR TITLE
Add unit test for query cancellation via JDBC driver

### DIFF
--- a/presto-blackhole/pom.xml
+++ b/presto-blackhole/pom.xml
@@ -41,6 +41,16 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleConnector.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleConnector.java
@@ -26,13 +26,17 @@ import com.facebook.presto.spi.transaction.IsolationLevel;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.Duration;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 import static com.facebook.presto.spi.session.PropertyMetadata.integerSessionProperty;
 import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Locale.ENGLISH;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 
 public class BlackHoleConnector
@@ -43,6 +47,7 @@ public class BlackHoleConnector
     public static final String ROWS_PER_PAGE_PROPERTY = "rows_per_page";
     public static final String FIELD_LENGTH_PROPERTY = "field_length";
     public static final String DISTRIBUTED_ON = "distributed_on";
+    public static final String PAGE_PROCESSING_DELAY = "page_processing_delay";
 
     private final BlackHoleMetadata metadata;
     private final BlackHoleSplitManager splitManager;
@@ -50,13 +55,16 @@ public class BlackHoleConnector
     private final BlackHolePageSinkProvider pageSinkProvider;
     private final BlackHoleNodePartitioningProvider partitioningProvider;
     private final TypeManager typeManager;
+    private final ExecutorService executorService;
 
-    public BlackHoleConnector(BlackHoleMetadata metadata,
+    public BlackHoleConnector(
+            BlackHoleMetadata metadata,
             BlackHoleSplitManager splitManager,
             BlackHolePageSourceProvider pageSourceProvider,
             BlackHolePageSinkProvider pageSinkProvider,
             BlackHoleNodePartitioningProvider partitioningProvider,
-            TypeManager typeManager)
+            TypeManager typeManager,
+            ExecutorService executorService)
     {
         this.metadata = metadata;
         this.splitManager = splitManager;
@@ -64,6 +72,7 @@ public class BlackHoleConnector
         this.pageSinkProvider = pageSinkProvider;
         this.partitioningProvider = partitioningProvider;
         this.typeManager = typeManager;
+        this.executorService = executorService;
     }
 
     @Override
@@ -137,12 +146,27 @@ public class BlackHoleConnector
                         value -> ImmutableList.copyOf(((List<String>) value).stream()
                                 .map(name -> name.toLowerCase(ENGLISH))
                                 .collect(toList())),
-                        List.class::cast));
+                        List.class::cast),
+                new PropertyMetadata<>(
+                        PAGE_PROCESSING_DELAY,
+                        "Sleep duration before processing each page",
+                        VARCHAR,
+                        Duration.class,
+                        new Duration(0, SECONDS),
+                        false,
+                        value -> Duration.valueOf((String) value),
+                        Duration::toString));
     }
 
     @Override
     public ConnectorNodePartitioningProvider getNodePartitioningProvider()
     {
         return partitioningProvider;
+    }
+
+    @Override
+    public void shutdown()
+    {
+        executorService.shutdownNow();
     }
 }

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleInsertTableHandle.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleInsertTableHandle.java
@@ -15,10 +15,26 @@
 package com.facebook.presto.plugin.blackhole;
 
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.units.Duration;
 
-// HACK: this class is an enum to make this class to be auto serializable
-public enum BlackHoleInsertTableHandle
+import static java.util.Objects.requireNonNull;
+
+public final class BlackHoleInsertTableHandle
         implements ConnectorInsertTableHandle
 {
-    BLACK_HOLE_INSERT_TABLE_HANDLE
+    private final Duration pageProcessingDelay;
+
+    @JsonCreator
+    public BlackHoleInsertTableHandle(@JsonProperty("pageProcessingDelay") Duration pageProcessingDelay)
+    {
+        this.pageProcessingDelay = requireNonNull(pageProcessingDelay, "pageProcessingDelay is null");
+    }
+
+    @JsonProperty
+    public Duration getPageProcessingDelay()
+    {
+        return pageProcessingDelay;
+    }
 }

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleOutputTableHandle.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleOutputTableHandle.java
@@ -17,21 +17,34 @@ package com.facebook.presto.plugin.blackhole;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.units.Duration;
+
+import static java.util.Objects.requireNonNull;
 
 public final class BlackHoleOutputTableHandle
         implements ConnectorOutputTableHandle
 {
     private final BlackHoleTableHandle table;
+    private final Duration pageProcessingDelay;
 
     @JsonCreator
-    public BlackHoleOutputTableHandle(@JsonProperty("table") BlackHoleTableHandle table)
+    public BlackHoleOutputTableHandle(
+            @JsonProperty("table") BlackHoleTableHandle table,
+            @JsonProperty("pageProcessingDelay") Duration pageProcessingDelay)
     {
-        this.table = table;
+        this.table = requireNonNull(table, "table is null");
+        this.pageProcessingDelay = requireNonNull(pageProcessingDelay, "pageProcessingDelay is null");
     }
 
     @JsonProperty
     public BlackHoleTableHandle getTable()
     {
         return table;
+    }
+
+    @JsonProperty
+    public Duration getPageProcessingDelay()
+    {
+        return pageProcessingDelay;
     }
 }

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHolePageSink.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHolePageSink.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.plugin.blackhole;
+
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import io.airlift.slice.Slice;
+import io.airlift.units.Duration;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+import static io.airlift.concurrent.MoreFutures.toCompletableFuture;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+class BlackHolePageSink
+        implements ConnectorPageSink
+{
+    private final ListeningScheduledExecutorService executorService;
+    private final long pageProcessingDelayMillis;
+
+    public BlackHolePageSink(ListeningScheduledExecutorService executorService, Duration pageProcessingDelay)
+    {
+        this.executorService = requireNonNull(executorService, "executorService is null");
+        this.pageProcessingDelayMillis = requireNonNull(pageProcessingDelay, "pageProcessingDelay is null").toMillis();
+    }
+
+    @Override
+    public CompletableFuture<?> appendPage(Page page, Block sampleWeightBlock)
+    {
+        if (pageProcessingDelayMillis > 0) {
+            return toCompletableFuture(executorService.schedule(() -> null, pageProcessingDelayMillis, MILLISECONDS));
+        }
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public Collection<Slice> finish()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public void abort() {}
+}

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHolePageSourceProvider.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHolePageSourceProvider.java
@@ -18,7 +18,6 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
-import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
@@ -75,9 +74,11 @@ public final class BlackHolePageSourceProvider
         }
         List<Type> types = builder.build();
 
-        return new FixedPageSource(Iterables.limit(
+        Iterable<Page> pages = Iterables.limit(
                 Iterables.cycle(generateZeroPage(types, blackHoleSplit.getRowsPerPage(), blackHoleSplit.getFieldsLength())),
-                blackHoleSplit.getPagesCount()));
+                blackHoleSplit.getPagesCount()
+        );
+        return new DelayPageSource(pages, blackHoleSplit.getPageProcessingDelay());
     }
 
     private Page generateZeroPage(List<Type> types, int rowsCount, int fieldLength)

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleSplit.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleSplit.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.HostAddress;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.Duration;
 
 import java.util.List;
 import java.util.Objects;
@@ -30,16 +31,19 @@ public final class BlackHoleSplit
     private final int pagesCount;
     private final int rowsPerPage;
     private final int fieldsLength;
+    private final Duration pageProcessingDelay;
 
     @JsonCreator
     public BlackHoleSplit(
             @JsonProperty("pagesCount") int pagesCount,
             @JsonProperty("rowsPerPage") int rowsPerPage,
-            @JsonProperty("fieldsLength") int fieldsLength)
+            @JsonProperty("fieldsLength") int fieldsLength,
+            @JsonProperty("pageProcessingDelay") Duration pageProcessingDelay)
     {
         this.rowsPerPage = requireNonNull(rowsPerPage, "rowsPerPage is null");
         this.pagesCount = requireNonNull(pagesCount, "pagesCount is null");
         this.fieldsLength = requireNonNull(fieldsLength, "fieldsLength is null");
+        this.pageProcessingDelay = requireNonNull(pageProcessingDelay, "pageProcessingDelay is null");
     }
 
     @JsonProperty
@@ -58,6 +62,12 @@ public final class BlackHoleSplit
     public int getFieldsLength()
     {
         return fieldsLength;
+    }
+
+    @JsonProperty
+    public Duration getPageProcessingDelay()
+    {
+        return pageProcessingDelay;
     }
 
     @Override

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleSplitManager.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleSplitManager.java
@@ -42,7 +42,8 @@ public final class BlackHoleSplitManager
                     new BlackHoleSplit(
                             layout.getPagesPerSplit(),
                             layout.getRowsPerPage(),
-                            layout.getFieldsLength()));
+                            layout.getFieldsLength(),
+                            layout.getPageProcessingDelay()));
         }
         return new FixedSplitSource(builder.build());
     }

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleTableHandle.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleTableHandle.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.units.Duration;
 
 import java.util.List;
 import java.util.Objects;
@@ -35,13 +36,15 @@ public final class BlackHoleTableHandle
     private final int pagesPerSplit;
     private final int rowsPerPage;
     private final int fieldsLength;
+    private final Duration pageProcessingDelay;
 
     public BlackHoleTableHandle(
             ConnectorTableMetadata tableMetadata,
             int splitCount,
             int pagesPerSplit,
             int rowsPerPage,
-            int fieldsLength)
+            int fieldsLength,
+            Duration pageProcessingDelay)
     {
         this(tableMetadata.getTable().getSchemaName(),
                 tableMetadata.getTable().getTableName(),
@@ -51,7 +54,8 @@ public final class BlackHoleTableHandle
                 splitCount,
                 pagesPerSplit,
                 rowsPerPage,
-                fieldsLength);
+                fieldsLength,
+                pageProcessingDelay);
     }
 
     @JsonCreator
@@ -62,7 +66,8 @@ public final class BlackHoleTableHandle
             @JsonProperty("splitCount") int splitCount,
             @JsonProperty("pagesPerSplit") int pagesPerSplit,
             @JsonProperty("rowsPerPage") int rowsPerPage,
-            @JsonProperty("fieldsLength") int fieldsLength)
+            @JsonProperty("fieldsLength") int fieldsLength,
+            @JsonProperty("pageProcessingDelay") Duration pageProcessingDelay)
     {
         this.schemaName = schemaName;
         this.tableName = tableName;
@@ -71,6 +76,7 @@ public final class BlackHoleTableHandle
         this.pagesPerSplit = pagesPerSplit;
         this.rowsPerPage = rowsPerPage;
         this.fieldsLength = fieldsLength;
+        this.pageProcessingDelay = pageProcessingDelay;
     }
 
     @JsonProperty
@@ -113,6 +119,12 @@ public final class BlackHoleTableHandle
     public int getFieldsLength()
     {
         return fieldsLength;
+    }
+
+    @JsonProperty
+    public Duration getPageProcessingDelay()
+    {
+        return pageProcessingDelay;
     }
 
     public ConnectorTableMetadata toTableMetadata()

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleTableLayoutHandle.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleTableLayoutHandle.java
@@ -17,6 +17,7 @@ package com.facebook.presto.plugin.blackhole;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.units.Duration;
 
 import java.util.Objects;
 
@@ -27,18 +28,21 @@ public final class BlackHoleTableLayoutHandle
     private final int pagesPerSplit;
     private final int rowsPerPage;
     private final int fieldsLength;
+    private final Duration pageProcessingDelay;
 
     @JsonCreator
     public BlackHoleTableLayoutHandle(
             @JsonProperty("splitCount") int splitCount,
             @JsonProperty("pagesPerSplit") int pagesPerSplit,
             @JsonProperty("rowsPerPage") int rowsPerPage,
-            @JsonProperty("fieldsLength") int fieldsLength)
+            @JsonProperty("fieldsLength") int fieldsLength,
+            @JsonProperty("pageProcessingDelay") Duration pageProcessingDelay)
     {
         this.splitCount = splitCount;
         this.pagesPerSplit = pagesPerSplit;
         this.rowsPerPage = rowsPerPage;
         this.fieldsLength = fieldsLength;
+        this.pageProcessingDelay = pageProcessingDelay;
     }
 
     @JsonProperty
@@ -63,6 +67,12 @@ public final class BlackHoleTableLayoutHandle
     public int getFieldsLength()
     {
         return fieldsLength;
+    }
+
+    @JsonProperty
+    public Duration getPageProcessingDelay()
+    {
+        return pageProcessingDelay;
     }
 
     @Override

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/DelayPageSource.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/DelayPageSource.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.plugin.blackhole;
+
+import com.facebook.presto.spi.FixedPageSource;
+import com.facebook.presto.spi.Page;
+import com.google.common.base.Throwables;
+import io.airlift.units.Duration;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+class DelayPageSource
+        extends FixedPageSource
+{
+    private final long pageProcessingDelayInMillis;
+
+    public DelayPageSource(Iterable<Page> pages, Duration pageProcessingDelay)
+    {
+        super(pages);
+        this.pageProcessingDelayInMillis = requireNonNull(pageProcessingDelay, "pageProcessingDelay is null").toMillis();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        if (isFinished()) {
+            return null;
+        }
+
+        if (pageProcessingDelayInMillis > 0) {
+            try {
+                MILLISECONDS.sleep(pageProcessingDelayInMillis);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw Throwables.propagate(e);
+            }
+        }
+
+        return super.getNextPage();
+    }
+}

--- a/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleMetadata.java
+++ b/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleMetadata.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -36,7 +38,8 @@ public class TestBlackHoleMetadata
             BlackHoleConnector.SPLIT_COUNT_PROPERTY, 0,
             BlackHoleConnector.PAGES_PER_SPLIT_PROPERTY, 0,
             BlackHoleConnector.ROWS_PER_PAGE_PROPERTY, 0,
-            BlackHoleConnector.FIELD_LENGTH_PROPERTY, 16);
+            BlackHoleConnector.FIELD_LENGTH_PROPERTY, 16,
+            BlackHoleConnector.PAGE_PROCESSING_DELAY, new Duration(0, SECONDS));
 
     @Test
     public void tableIsCreatedAfterCommits()

--- a/presto-docs/src/main/sphinx/connector/blackhole.rst
+++ b/presto-docs/src/main/sphinx/connector/blackhole.rst
@@ -2,9 +2,11 @@
 Black Hole Connector
 ====================
 
-The Black Hole connector works like the ``/dev/null`` device on Unix-like
+Primarily Black Hole connector is designed for high performance testing of
+other components. It works like the ``/dev/null`` device on Unix-like
 operating systems for data writing and like ``/dev/null`` or ``/dev/zero``
-for data reading. Metadata for any tables created via this connector
+for data reading. However, it also has some other features that allow testing Presto
+in a more controlled manner. Metadata for any tables created via this connector
 is kept in memory on the coordinator and discarded when Presto restarts.
 Created tables are by default always empty, and any data written to them
 will be ignored and data reads will return no rows.
@@ -79,3 +81,19 @@ table property (default value is equal to 16)::
       rows_per_page = 2000,
       field_length = 100
     );
+
+The consuming and producing rate can be slowed down
+using the ``page_processing_delay`` table property.
+Setting this property to ``5s`` will lead to a 5 second
+delay before consuming or producing a new page::
+
+    CREATE TABLE blackhole.test.delay (
+      dummy bigint
+    )
+    WITH (
+      split_count = 1,
+      pages_per_split = 1,
+      rows_per_page = 1,
+      page_processing_delay = '5s'
+    );
+

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -138,6 +138,12 @@
             <artifactId>log-manager</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
With the "page_processing_delay" property of the blackhole tables we can make Presto wait for some fixed amount of time before return the row. It helps us to test cancellation. So, instead of running query on some huge TPCH table we can just run query which sleep without consuming CPU. Although making ResultSet responsive to interrupt seems to be hacky from the JDBC point of view, we are using this trick in our code, so, it is better to have this part of functionality tested. 