### PR TITLE
Add version() system function

### DIFF
--- a/presto-docs/src/main/sphinx/functions.rst
+++ b/presto-docs/src/main/sphinx/functions.rst
@@ -22,3 +22,4 @@ Functions and Operators
     functions/array
     functions/map
     functions/teradata
+    functions/system

--- a/presto-docs/src/main/sphinx/functions/system.rst
+++ b/presto-docs/src/main/sphinx/functions/system.rst
@@ -1,0 +1,7 @@
+==================
+System Functions
+==================
+
+.. function:: version() -> varchar
+
+    Returns the current presto version. ex) 0.126

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemFunctions.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.system;
+
+import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.metadata.PrestoNode;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.Node;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import javax.inject.Inject;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Method;
+
+import static com.facebook.presto.metadata.FunctionKind.SCALAR;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.util.Objects.requireNonNull;
+
+public final class SystemFunctions
+{
+    private final InternalNodeManager nodeManager;
+
+    @Inject
+    public SystemFunctions(InternalNodeManager nodeManager)
+    {
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+    }
+
+    private Slice getVersion()
+    {
+        Node node = nodeManager.getCurrentNode();
+        NodeVersion version = NodeVersion.UNKNOWN;
+        if (node instanceof PrestoNode) {
+            version = ((PrestoNode) node).getNodeVersion();
+        }
+        return Slices.utf8Slice(version.getVersion());
+    }
+
+    public SqlScalarFunction createVersionFunction()
+    {
+        Signature signature = new Signature("version", SCALAR, ImmutableList.of(), VARCHAR.getTypeSignature(), ImmutableList.of(), false);
+        MethodHandle methodHandle;
+        Class<?> clazz = this.getClass();
+        try {
+            Method method = clazz.getDeclaredMethod("getVersion");
+            method.setAccessible(true);
+            methodHandle = lookup().unreflect(method).bindTo(this);
+        }
+        catch (ReflectiveOperationException e) {
+            throw Throwables.propagate(e);
+        }
+
+        return SqlScalarFunction.create(signature, "Presto Version", false, methodHandle, true, false, ImmutableList.of());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemTablesModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemTablesModule.java
@@ -26,7 +26,9 @@ import com.facebook.presto.connector.system.jdbc.SuperTypeJdbcTable;
 import com.facebook.presto.connector.system.jdbc.TableJdbcTable;
 import com.facebook.presto.connector.system.jdbc.TableTypeJdbcTable;
 import com.facebook.presto.connector.system.jdbc.UdtJdbcTable;
+import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.SystemTable;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
@@ -61,15 +63,17 @@ public class SystemTablesModule
         globalTableBinder.addBinding().to(UdtJdbcTable.class).in(Scopes.SINGLETON);
 
         binder.bind(SystemConnector.class).in(Scopes.SINGLETON);
+        binder.bind(SystemFunctions.class).in(Scopes.SINGLETON);
         binder.bind(SystemTablesRegistrar.class).asEagerSingleton();
     }
 
     private static class SystemTablesRegistrar
     {
         @Inject
-        public SystemTablesRegistrar(ConnectorManager manager, SystemConnector connector)
+        public SystemTablesRegistrar(ConnectorManager manager, Metadata metadata, SystemConnector connector, SystemFunctions functions)
         {
             manager.createConnection(SystemConnector.NAME, connector);
+            metadata.addFunctions(ImmutableList.of(functions.createVersionFunction()));
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestSystemFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestSystemFunctions.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.connector.system.SystemFunctions;
+import com.facebook.presto.metadata.FunctionListBuilder;
+import com.facebook.presto.metadata.InMemoryNodeManager;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.PrestoNode;
+import com.facebook.presto.metadata.SqlFunction;
+import com.facebook.presto.spi.Node;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
+public class TestSystemFunctions
+        extends AbstractTestFunctions
+{
+    private final NodeVersion expectedVersion = new NodeVersion("1");
+
+    public TestSystemFunctions()
+    {
+        Metadata metadata = functionAssertions.getMetadata();
+        InternalNodeManager nodeManager = new InMemoryNodeManager() {
+            @Override
+            public Node getCurrentNode()
+            {
+                return new PrestoNode(super.getCurrentNode().getNodeIdentifier(), super.getCurrentNode().getHttpUri(), expectedVersion);
+            }
+        };
+
+        List<SqlFunction> functions = new FunctionListBuilder(metadata.getTypeManager())
+                .functions(new SystemFunctions(nodeManager).createVersionFunction())
+                .getFunctions();
+        metadata.getFunctionRegistry().addFunctions(functions);
+    }
+
+    @Test
+    public void testVersion()
+    {
+        assertFunction("version()", VARCHAR, expectedVersion.getVersion());
+    }
+}


### PR DESCRIPTION
We could get version information of each node by `select * from system.runtime.nodes`. Even though that we might need to have simpler way to get the version info as MySQL does.