### PR TITLE
Add max split size session parameters

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -59,6 +59,8 @@ import static com.facebook.presto.hadoop.HadoopFileStatus.isFile;
 import static com.facebook.presto.hive.HiveBucketing.HiveBucket;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_PARTITION_VALUE;
+import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
+import static com.facebook.presto.hive.HiveSessionProperties.getMaxSplitSize;
 import static com.facebook.presto.hive.HiveUtil.checkCondition;
 import static com.facebook.presto.hive.HiveUtil.getInputFormat;
 import static com.facebook.presto.hive.HiveUtil.isSplittable;
@@ -107,27 +109,25 @@ public class BackgroundHiveSplitLoader
             Table table,
             Iterable<HivePartitionMetadata> partitions,
             Optional<HiveBucket> bucket,
-            DataSize maxSplitSize,
             ConnectorSession session,
             HdfsEnvironment hdfsEnvironment,
             NamenodeStats namenodeStats,
             DirectoryLister directoryLister,
             Executor executor,
             int maxPartitionBatchSize,
-            DataSize maxInitialSplitSize,
             int maxInitialSplits,
             boolean recursiveDirWalkerEnabled)
     {
         this.connectorId = connectorId;
         this.table = table;
         this.bucket = bucket;
-        this.maxSplitSize = maxSplitSize;
+        this.maxSplitSize = getMaxSplitSize(session);
         this.maxPartitionBatchSize = maxPartitionBatchSize;
         this.session = session;
         this.hdfsEnvironment = hdfsEnvironment;
         this.namenodeStats = namenodeStats;
         this.directoryLister = directoryLister;
-        this.maxInitialSplitSize = maxInitialSplitSize;
+        this.maxInitialSplitSize = getMaxInitialSplitSize(session);
         this.remainingInitialSplits = new AtomicInteger(maxInitialSplits);
         this.recursiveDirWalkerEnabled = recursiveDirWalkerEnabled;
         this.executor = executor;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -34,6 +34,8 @@ public final class HiveSessionProperties
     private static final String ORC_STREAM_BUFFER_SIZE = "orc_stream_buffer_size";
     private static final String PARQUET_PREDICATE_PUSHDOWN_ENABLED = "parquet_predicate_pushdown_enabled";
     private static final String PARQUET_OPTIMIZED_READER_ENABLED = "parquet_optimized_reader_enabled";
+    private static final String MAX_SPLIT_SIZE = "max_split_size";
+    private static final String MAX_INITIAL_SPLIT_SIZE = "max_initial_split_size";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -70,7 +72,17 @@ public final class HiveSessionProperties
                         PARQUET_PREDICATE_PUSHDOWN_ENABLED,
                         "Experimental: Parquet: Enable predicate pushdown for Parquet",
                         config.isParquetPredicatePushdownEnabled(),
-                        false));
+                        false),
+                dataSizeSessionProperty(
+                        MAX_SPLIT_SIZE,
+                        "Max split size",
+                        config.getMaxSplitSize(),
+                        true),
+                dataSizeSessionProperty(
+                        MAX_INITIAL_SPLIT_SIZE,
+                        "Max initial split size",
+                        config.getMaxInitialSplitSize(),
+                        true));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -106,6 +118,16 @@ public final class HiveSessionProperties
     public static boolean isParquetPredicatePushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(PARQUET_PREDICATE_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static DataSize getMaxSplitSize(ConnectorSession session)
+    {
+        return session.getProperty(MAX_SPLIT_SIZE, DataSize.class);
+    }
+
+    public static DataSize getMaxInitialSplitSize(ConnectorSession session)
+    {
+        return session.getProperty(MAX_INITIAL_SPLIT_SIZE, DataSize.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -30,7 +30,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import io.airlift.concurrent.BoundedExecutor;
-import io.airlift.units.DataSize;
 import org.apache.hadoop.hive.metastore.ProtectMode;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -79,8 +78,6 @@ public class HiveSplitManager
     private final int maxOutstandingSplits;
     private final int minPartitionBatchSize;
     private final int maxPartitionBatchSize;
-    private final DataSize maxSplitSize;
-    private final DataSize maxInitialSplitSize;
     private final int maxInitialSplits;
     private final boolean recursiveDfsWalkerEnabled;
 
@@ -103,8 +100,6 @@ public class HiveSplitManager
                 hiveClientConfig.getMaxOutstandingSplits(),
                 hiveClientConfig.getMinPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionBatchSize(),
-                hiveClientConfig.getMaxSplitSize(),
-                hiveClientConfig.getMaxInitialSplitSize(),
                 hiveClientConfig.getMaxInitialSplits(),
                 hiveClientConfig.getRecursiveDirWalkerEnabled()
         );
@@ -120,8 +115,6 @@ public class HiveSplitManager
             int maxOutstandingSplits,
             int minPartitionBatchSize,
             int maxPartitionBatchSize,
-            DataSize maxSplitSize,
-            DataSize maxInitialSplitSize,
             int maxInitialSplits,
             boolean recursiveDfsWalkerEnabled)
     {
@@ -135,8 +128,6 @@ public class HiveSplitManager
         this.maxOutstandingSplits = maxOutstandingSplits;
         this.minPartitionBatchSize = minPartitionBatchSize;
         this.maxPartitionBatchSize = maxPartitionBatchSize;
-        this.maxSplitSize = requireNonNull(maxSplitSize, "maxSplitSize is null");
-        this.maxInitialSplitSize = requireNonNull(maxInitialSplitSize, "maxInitialSplitSize is null");
         this.maxInitialSplits = maxInitialSplits;
         this.recursiveDfsWalkerEnabled = recursiveDfsWalkerEnabled;
     }
@@ -169,14 +160,12 @@ public class HiveSplitManager
                 table.get(),
                 hivePartitions,
                 bucket,
-                maxSplitSize,
                 session,
                 hdfsEnvironment,
                 namenodeStats,
                 directoryLister,
                 executor,
                 maxPartitionBatchSize,
-                maxInitialSplitSize,
                 maxInitialSplits,
                 recursiveDfsWalkerEnabled);
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -469,8 +469,6 @@ public abstract class AbstractTestHiveClient
                 maxOutstandingSplits,
                 hiveClientConfig.getMinPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionBatchSize(),
-                hiveClientConfig.getMaxSplitSize(),
-                hiveClientConfig.getMaxInitialSplitSize(),
                 hiveClientConfig.getMaxInitialSplits(),
                 false
         );


### PR DESCRIPTION
This PR adds support for specifying max split size and max initial split size session parameters (which are hidden from the user), and also adds a fix that prevents hidden session parameters from being displayed with `show session`. 

The reason we needed these session parameters is for fine tuning the performance of some of our queries that process highly compressed parquet files. For those queries the cluster-wide split size settings were suboptimal so we ended up tuning the split size per query (as we didn't want to change the write path).