### PR TITLE
Drop temporary table when CREATE TABLE fails in JDBC connector

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -364,6 +364,17 @@ public class BaseJdbcClient
     }
 
     @Override
+    public void rollbackCreateTable(JdbcOutputTableHandle handle)
+    {
+        dropTable(new JdbcTableHandle(
+                handle.getConnectorId(),
+                new SchemaTableName(handle.getSchemaName(), handle.getTemporaryTableName()),
+                handle.getCatalogName(),
+                handle.getSchemaName(),
+                handle.getTemporaryTableName()));
+    }
+
+    @Override
     public String buildInsertSql(JdbcOutputTableHandle handle)
     {
         String vars = Joiner.on(',').join(nCopies(handle.getColumnNames().size(), "?"));

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -56,6 +56,8 @@ public interface JdbcClient
 
     void dropTable(JdbcTableHandle jdbcTableHandle);
 
+    void rollbackCreateTable(JdbcOutputTableHandle handle);
+
     String buildInsertSql(JdbcOutputTableHandle handle);
 
     Connection getConnection(JdbcOutputTableHandle handle)

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -138,6 +138,13 @@ public class JdbcMetadata
     }
 
     @Override
+    public void rollbackCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle)
+    {
+        JdbcOutputTableHandle handle = checkType(tableHandle, JdbcOutputTableHandle.class, "tableHandle");
+        jdbcClient.rollbackCreateTable(handle);
+    }
+
+    @Override
     public void commitCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments)
     {
         JdbcOutputTableHandle handle = checkType(tableHandle, JdbcOutputTableHandle.class, "tableHandle");


### PR DESCRIPTION
Related issue: https://github.com/facebook/presto/issues/2754

Note: Exception while dropping the temporary table is ignored.