### PR TITLE
Add truncated histogram aggregation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -195,6 +195,24 @@ Approximate Aggregate Functions
     for all ``value``\ s. This function is equivalent to the variant of
     :func:`numeric_histogram` that takes a ``weight``, with a per-item weight of ``1``.
 
+.. function:: truncated_histogram(buckets, value) -> map<[same as value], bigint>
+
+    Computes a truncated histogram with up to ``buckets`` number of buckets
+    for all ``value``\ s. The algorithm periodically truncates the histogram
+    to ``buckets`` entries and overflows the truncated entries by setting the
+    lowest retained entries to a constant, rounding up.
+    The resulting histogram's counts are an upper bound on the true count.
+    Furthermore, the error is less than the minimum count retained in the histogram.
+
+    The algorithm is based loosely on:
+
+    .. code-block:: none
+
+        Ahmed Metwally, Divyakant Agrawal, and Amr El Abbadi,
+        "Efficient Computation of Frequent and Top-*k* Elements in Data Streams",
+        https://icmi.cs.ucsb.edu/research/tech_reports/reports/2005-23.pdf
+
+
 Statistical Aggregate Functions
 -------------------------------
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -140,6 +140,7 @@ import static com.facebook.presto.operator.aggregation.MinBy.MIN_BY;
 import static com.facebook.presto.operator.aggregation.MinByNAggregationFunction.MIN_BY_N_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.MinNAggregationFunction.MIN_N_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.MultimapAggregationFunction.MULTIMAP_AGG;
+import static com.facebook.presto.operator.aggregation.TruncatedHistogram.TRUNCATED_HISTOGRAM;
 import static com.facebook.presto.operator.scalar.ArrayCardinalityFunction.ARRAY_CARDINALITY;
 import static com.facebook.presto.operator.scalar.ArrayConcatFunction.ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayConstructor.ARRAY_CONSTRUCTOR;
@@ -349,6 +350,7 @@ public class FunctionRegistry
                 .functions(MAP_CONSTRUCTOR, MAP_CARDINALITY, MAP_SUBSCRIPT, MAP_TO_JSON, JSON_TO_MAP, MAP_KEYS, MAP_VALUES)
                 .functions(MAP_AGG, MULTIMAP_AGG)
                 .function(HISTOGRAM)
+                .function(TRUNCATED_HISTOGRAM)
                 .function(CHECKSUM_AGGREGATION)
                 .function(ARBITRARY_AGGREGATION)
                 .function(ARRAY_AGGREGATION)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TruncatedHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TruncatedHistogram.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.ExceededMemoryLimitException;
+import com.facebook.presto.byteCode.DynamicClassLoader;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.state.AccumulatorStateSerializer;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.MapType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static java.lang.String.format;
+
+public class TruncatedHistogram
+        extends SqlAggregationFunction
+{
+    public static final TruncatedHistogram TRUNCATED_HISTOGRAM = new TruncatedHistogram();
+    public static final String NAME = "truncated_histogram";
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(TruncatedHistogram.class, "output", TruncatedHistogramState.class, BlockBuilder.class);
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(TruncatedHistogram.class, "input", Type.class, TruncatedHistogramState.class, long.class, Block.class, int.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(TruncatedHistogram.class, "combine", TruncatedHistogramState.class, TruncatedHistogramState.class);
+
+    public static final int EXPECTED_SIZE_FOR_HASHING = 10;
+
+    public TruncatedHistogram()
+    {
+        super(NAME, ImmutableList.of(comparableTypeParameter("K")), "map<K,bigint>", ImmutableList.of(StandardTypes.BIGINT, "K"));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Count the number of times each value occurs, mixing up counts for infrequent values after max buckets";
+    }
+
+    @Override
+    public InternalAggregationFunction specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type keyType = types.get("K");
+        Type valueType = BigintType.BIGINT;
+        return generateAggregation(keyType, valueType);
+    }
+
+    private static InternalAggregationFunction generateAggregation(Type keyType, Type valueType)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(TruncatedHistogram.class.getClassLoader());
+        List<Type> inputTypes = ImmutableList.of(BIGINT, keyType);
+        Type outputType = new MapType(keyType, valueType);
+        AccumulatorStateSerializer<TruncatedHistogramState> stateSerializer = new TruncatedHistogramState.Serializer(keyType);
+        Type intermediateType = stateSerializer.getSerializedType();
+        MethodHandle inputFunction = INPUT_FUNCTION.bindTo(keyType);
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, outputType, inputTypes),
+                createInputParameterMetadata(keyType),
+                inputFunction,
+                null,
+                null,
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION,
+                TruncatedHistogramState.class,
+                stateSerializer,
+                new TruncatedHistogramState.Factory(),
+                outputType,
+                false);
+
+        GenericAccumulatorFactoryBinder factory = new AccumulatorCompiler().generateAccumulatorFactoryBinder(metadata, classLoader);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, false, factory);
+    }
+
+    private static List<ParameterMetadata> createInputParameterMetadata(Type keyType)
+    {
+        return ImmutableList.of(new ParameterMetadata(STATE),
+                new ParameterMetadata(INPUT_CHANNEL, BIGINT),
+                new ParameterMetadata(BLOCK_INPUT_CHANNEL, keyType),
+                new ParameterMetadata(BLOCK_INDEX));
+    }
+
+    public static void input(Type type, TruncatedHistogramState state, long buckets, Block key, int position)
+    {
+        TypedTruncatedHistogram typedHistogram = state.get();
+        if (typedHistogram == null) {
+            checkCondition(buckets >= 2, INVALID_FUNCTION_ARGUMENT, "truncated_histogram bucket count must be greater than one");
+            typedHistogram = new TypedTruncatedHistogram(type, EXPECTED_SIZE_FOR_HASHING, Ints.checkedCast(buckets));
+            state.set(typedHistogram);
+        }
+
+        try {
+            typedHistogram.add(position, key, 1L);
+        }
+        catch (ExceededMemoryLimitException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("The result of histogram may not exceed %s", e.getMaxMemory()));
+        }
+    }
+
+    public static void combine(TruncatedHistogramState state, TruncatedHistogramState otherState)
+    {
+        if (state.get() != null && otherState.get() != null) {
+            TypedTruncatedHistogram typedHistogram = state.get();
+            try {
+                typedHistogram.addAll(otherState.get());
+            }
+            catch (ExceededMemoryLimitException e) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("The result of histogram may not exceed %s", e.getMaxMemory()));
+            }
+        }
+        else if (state.get() == null) {
+            state.set(otherState.get());
+        }
+    }
+
+    public static void output(TruncatedHistogramState state, BlockBuilder out)
+    {
+        TypedTruncatedHistogram typedHistogram = state.get();
+        if (typedHistogram == null) {
+            out.appendNull();
+        }
+        else {
+            typedHistogram.writeMapTo(out);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TruncatedHistogramState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TruncatedHistogramState.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.AbstractGroupedAccumulatorState;
+import com.facebook.presto.operator.aggregation.state.AccumulatorState;
+import com.facebook.presto.operator.aggregation.state.AccumulatorStateFactory;
+import com.facebook.presto.operator.aggregation.state.AccumulatorStateMetadata;
+import com.facebook.presto.operator.aggregation.state.AccumulatorStateSerializer;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.RowType;
+import com.facebook.presto.util.array.ObjectBigArray;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static java.util.Objects.requireNonNull;
+
+@AccumulatorStateMetadata(stateSerializerClass = TruncatedHistogramState.Serializer.class, stateFactoryClass = TruncatedHistogramState.Factory.class)
+public interface TruncatedHistogramState
+        extends AccumulatorState
+{
+    void set(TypedTruncatedHistogram histogram);
+
+    TypedTruncatedHistogram get();
+
+    void addMemoryUsage(long memory);
+
+    class Factory
+            implements AccumulatorStateFactory<TruncatedHistogramState>
+    {
+        @Override
+        public TruncatedHistogramState createSingleState()
+        {
+            return new Factory.SingleTruncatedHistogramState();
+        }
+
+        @Override
+        public Class<? extends TruncatedHistogramState> getSingleStateClass()
+        {
+            return Factory.SingleTruncatedHistogramState.class;
+        }
+
+        @Override
+        public TruncatedHistogramState createGroupedState()
+        {
+            return new Factory.GroupedTruncatedHistogramState();
+        }
+
+        @Override
+        public Class<? extends TruncatedHistogramState> getGroupedStateClass()
+        {
+            return Factory.GroupedTruncatedHistogramState.class;
+        }
+
+        public static class GroupedTruncatedHistogramState
+                extends AbstractGroupedAccumulatorState
+                implements TruncatedHistogramState
+        {
+            private final ObjectBigArray<TypedTruncatedHistogram> typedHistogram = new ObjectBigArray<>();
+            private long size;
+
+            @Override
+            public void ensureCapacity(long size)
+            {
+                typedHistogram.ensureCapacity(size);
+            }
+
+            @Override
+            public TypedTruncatedHistogram get()
+            {
+                return typedHistogram.get(getGroupId());
+            }
+
+            @Override
+            public void set(TypedTruncatedHistogram value)
+            {
+                requireNonNull(value, "value is null");
+
+                TypedTruncatedHistogram previous = get();
+                if (previous != null) {
+                    size -= previous.getEstimatedSize();
+                }
+
+                typedHistogram.set(getGroupId(), value);
+                size += value.getEstimatedSize();
+            }
+
+            @Override
+            public void addMemoryUsage(long memory)
+            {
+                size += memory;
+            }
+
+            @Override
+            public long getEstimatedSize()
+            {
+                return size + typedHistogram.sizeOf();
+            }
+        }
+
+        public static class SingleTruncatedHistogramState
+                implements TruncatedHistogramState
+        {
+            private TypedTruncatedHistogram typedHistogram;
+
+            @Override
+            public TypedTruncatedHistogram get()
+            {
+                return typedHistogram;
+            }
+
+            @Override
+            public void set(TypedTruncatedHistogram value)
+            {
+                typedHistogram = value;
+            }
+
+            @Override
+            public void addMemoryUsage(long memory)
+            {
+            }
+
+            @Override
+            public long getEstimatedSize()
+            {
+                if (typedHistogram == null) {
+                    return 0;
+                }
+                return typedHistogram.getEstimatedSize();
+            }
+        }
+    }
+
+    class Serializer
+            implements AccumulatorStateSerializer<TruncatedHistogramState>
+    {
+        private final Type type;
+
+        public Serializer(Type type)
+        {
+            this.type = type;
+        }
+
+        @Override
+        public Type getSerializedType()
+        {
+            return new RowType(ImmutableList.of(BIGINT, new MapType(type, BIGINT)), Optional.empty());
+        }
+
+        @Override
+        public void serialize(TruncatedHistogramState state, BlockBuilder out)
+        {
+            if (state.get() == null) {
+                out.appendNull();
+            }
+            else {
+                state.get().serialize(out);
+            }
+        }
+
+        @Override
+        public void deserialize(Block block, int index, TruncatedHistogramState state)
+        {
+            if (block.isNull(index)) {
+                state.set(null);
+            }
+            else {
+                Block subBlock = (Block) getSerializedType().getObject(block, index);
+                state.set(TypedTruncatedHistogram.deserialize(type, subBlock));
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedTruncatedHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedTruncatedHistogram.java
@@ -1,0 +1,318 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.MapType;
+import com.facebook.presto.util.array.IntBigArray;
+import com.facebook.presto.util.array.LongBigArray;
+import com.google.common.primitives.Ints;
+import io.airlift.units.DataSize;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalLimit;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.type.TypeUtils.expectedValueSize;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static it.unimi.dsi.fastutil.HashCommon.arraySize;
+import static it.unimi.dsi.fastutil.HashCommon.murmurHash3;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A histogram that periodically truncates infrequent items and overflows their counters onto other items.
+ */
+public class TypedTruncatedHistogram
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(TypedTruncatedHistogram.class).instanceSize();
+
+    private static final float FILL_RATIO = 0.75f;
+    private static final float COMPACT_RATIO = 0.5f;
+    private static final long FOUR_MEGABYTES = new DataSize(4, MEGABYTE).toBytes();
+
+    private int maxFill;
+    private int mask;
+    private final int compactLimit;
+
+    private final Type type;
+
+    private BlockBuilder values;
+    private IntBigArray hashPositions;
+    private final LongBigArray counts;
+
+    public TypedTruncatedHistogram(Type type, int expectedSize, int compactLimit)
+    {
+        this.type = type;
+        this.compactLimit = compactLimit;
+
+        checkArgument(expectedSize > 0, "expectedSize must be greater than zero");
+
+        int hashSize = arraySize(expectedSize, FILL_RATIO);
+
+        maxFill = calculateMaxFill(hashSize);
+        mask = hashSize - 1;
+        values = this.type.createBlockBuilder(new BlockBuilderStatus(), hashSize, expectedValueSize(type, hashSize));
+        hashPositions = new IntBigArray(-1);
+        hashPositions.ensureCapacity(hashSize);
+        counts = new LongBigArray();
+        counts.ensureCapacity(hashSize);
+    }
+
+    public long getEstimatedSize()
+    {
+        return INSTANCE_SIZE +
+                values.getRetainedSizeInBytes() +
+                counts.sizeOf() +
+                hashPositions.sizeOf();
+    }
+
+    private Block getValues()
+    {
+        return values.build();
+    }
+
+    private LongBigArray getCounts()
+    {
+        return counts;
+    }
+
+    public void addAll(TypedTruncatedHistogram other)
+    {
+        Block otherValues = other.getValues();
+        LongBigArray otherCounts = other.getCounts();
+        for (int i = 0; i < otherValues.getPositionCount(); i++) {
+            long count = otherCounts.get(i);
+            if (count > 0) {
+                add(i, otherValues, count);
+            }
+        }
+    }
+
+    public void add(int position, Block block, long count)
+    {
+        int hashPosition = getHashPosition(com.facebook.presto.type.TypeUtils.hashPosition(type, block, position), mask);
+
+        // look for an empty slot or a slot containing this key
+        while (true) {
+            if (hashPositions.get(hashPosition) == -1) {
+                break;
+            }
+
+            if (type.equalTo(block, position, values, hashPositions.get(hashPosition))) {
+                counts.add(hashPositions.get(hashPosition), count);
+                return;
+            }
+
+            // increment position and mask to handle wrap around
+            hashPosition = (hashPosition + 1) & mask;
+        }
+
+        addNewGroup(hashPosition, position, block, count);
+    }
+
+    private void addNewGroup(int hashPosition, int position, Block block, long count)
+    {
+        hashPositions.set(hashPosition, values.getPositionCount());
+        counts.set(values.getPositionCount(), count);
+        type.appendTo(block, position, values);
+
+        compactIfNeeded();
+
+        rehashIfNeeded();
+
+        if (getEstimatedSize() > FOUR_MEGABYTES) {
+            throw exceededLocalLimit(new DataSize(4, MEGABYTE));
+        }
+    }
+
+    private void rehashIfNeeded()
+    {
+        // increase capacity, if necessary
+        if (values.getPositionCount() >= maxFill) {
+            int size = maxFill * 2;
+            int hashSize = arraySize(size + 1, FILL_RATIO);
+            mask = hashSize - 1;
+            rehash();
+        }
+    }
+
+    private void rehash()
+    {
+        int hashSize = mask + 1;
+        IntBigArray newHashPositions = new IntBigArray(-1);
+        newHashPositions.ensureCapacity(hashSize);
+
+        for (int i = 0; i < values.getPositionCount(); i++) {
+            // find an empty slot for the address
+            int hashPosition = getHashPosition(com.facebook.presto.type.TypeUtils.hashPosition(type, values, i), mask);
+            while (newHashPositions.get(hashPosition) != -1) {
+                hashPosition = (hashPosition + 1) & mask;
+            }
+
+            // record the mapping
+            newHashPositions.set(hashPosition, i);
+        }
+
+        maxFill = calculateMaxFill(hashSize);
+        hashPositions = newHashPositions;
+
+        this.counts.ensureCapacity(maxFill);
+    }
+
+    /**
+     * Call {@link #compact()} if over {@link #COMPACT_RATIO} of the value/count pairs exceeds {@link #compactLimit}.
+     */
+    private void compactIfNeeded()
+    {
+        if (values.getPositionCount() * COMPACT_RATIO > compactLimit) {
+            compact();
+        }
+    }
+
+    /**
+     * Ensure there are no more than {@link #compactLimit} value/counts pairs.
+     * This works by evicting the smallest counts and overflowing the counts to the smallest retained counts, increasing
+     * them all to the same value (rounding up).
+     * The end result is that the estimated counts are an upper bound to the true counts.
+     * In addition, the over-estimation is less than the minimum retained count.
+     * This is because every overflow increases the minimum retained count by the most.
+     */
+    private void compact()
+    {
+        if (values.getPositionCount() <= compactLimit) {
+            return;
+        }
+
+        int truncatedNum = values.getPositionCount() - compactLimit;
+        assert 0 < truncatedNum;
+        assert truncatedNum < values.getPositionCount();
+
+        int hashSize = mask + 1;
+        BlockBuilder newValues = type.createBlockBuilder(new BlockBuilderStatus(), hashSize, expectedValueSize(type, hashSize));
+
+        // Sort the counts so we know which counts to truncate.
+        long[] countsSorted = new long[values.getPositionCount()];
+        for (int i = 0; i < values.getPositionCount(); i++) {
+            countsSorted[i] = counts.get(i);
+        }
+        Arrays.sort(countsSorted);
+
+        // Redistribute truncated counts approximately to the overflowed counts:
+        // If countsCopy = [1, 1, 2, 3, 10, 15, 20] and we need to truncate the 2 counts [1, 1]...
+        long truncatedSum = 0;
+        // Number equal to max truncated. 2 in this case. Used to break ties.
+        long maxTruncated = countsSorted[truncatedNum - 1];
+        int maxTruncatedCount = 0;
+        for (int i = 0; i < truncatedNum; ++i) {
+            truncatedSum += countsSorted[i];
+            if (countsSorted[i] == maxTruncated) {
+                ++maxTruncatedCount;
+            }
+        }
+
+        // Overflow [1, 1] into the start of [2, 3, 10, 15, 20] by increasing the smallest prefix of the array to a
+        // constant, maintaining sorted order.
+        // For the example, overflow until the 10, producing [4, 4, 10, 15, 20].
+        // This is where overflowSum = sum([1, 1, 2, 3]) <= sum([4, 4]) <= 10 * 2.
+        int overflowUntil = truncatedNum;
+        long overflowSum = truncatedSum;
+        while (overflowUntil < countsSorted.length &&
+                countsSorted[overflowUntil] * (overflowUntil - truncatedNum) < overflowSum) {
+            overflowSum += countsSorted[overflowUntil++];
+        }
+        int overflowNum = overflowUntil - truncatedNum;
+        long overflowConstant = overflowNum == 0 ? 0 : (overflowSum + (overflowNum - 1)) / overflowNum;
+
+        // Copy the value/count pairs over, skipping truncated counts and "overflowing" other counts.
+        for (int oldPosition = 0; oldPosition < values.getPositionCount(); ++oldPosition) {
+            long oldCount = counts.get(oldPosition);
+
+            // Skip the truncated values
+            if (oldCount < maxTruncated
+                    // If there's a tie, break it by first-come-first-serve
+                    || (oldCount == maxTruncated && maxTruncatedCount-- > 0)) {
+                continue;
+            }
+
+            final int newPosition = newValues.getPositionCount();
+            assert newPosition <= oldPosition;
+            counts.set(newPosition, Math.max(overflowConstant, oldCount));
+            values.writePositionTo(oldPosition, newValues);
+            newValues.closeEntry();
+        }
+
+        values = newValues;
+        assert values.getPositionCount() == compactLimit;
+
+        rehash();
+    }
+
+    private static int getHashPosition(long rawHash, int mask)
+    {
+        return ((int) murmurHash3(rawHash)) & mask;
+    }
+
+    private static int calculateMaxFill(int hashSize)
+    {
+        checkArgument(hashSize > 0, "hashSize must greater than 0");
+        int maxFill = (int) Math.ceil(hashSize * FILL_RATIO);
+        if (maxFill == hashSize) {
+            maxFill--;
+        }
+        checkArgument(hashSize > maxFill, "hashSize must be larger than maxFill");
+        return maxFill;
+    }
+
+    public void writeMapTo(BlockBuilder out)
+    {
+        compact();
+
+        Block valuesBlock = values.build();
+        BlockBuilder blockBuilder = out.beginBlockEntry();
+        for (int i = 0; i < valuesBlock.getPositionCount(); i++) {
+            type.appendTo(valuesBlock, i, blockBuilder);
+            BIGINT.writeLong(blockBuilder, counts.get(i));
+        }
+        out.closeEntry();
+    }
+
+    public void serialize(BlockBuilder out)
+    {
+        BlockBuilder blockBuilder = out.beginBlockEntry();
+
+        BIGINT.writeLong(blockBuilder, compactLimit);
+        writeMapTo(blockBuilder);
+
+        out.closeEntry();
+    }
+
+    public static TypedTruncatedHistogram deserialize(Type type, Block block)
+    {
+        requireNonNull(block, "block is null");
+        int compactLimit = Ints.checkedCast(BIGINT.getLong(block, 0));
+        final TypedTruncatedHistogram histogram = new TypedTruncatedHistogram(type, TruncatedHistogram.EXPECTED_SIZE_FOR_HASHING, compactLimit);
+
+        Block mapBlock = new MapType(type, BIGINT).getObject(block, 1);
+        for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
+            histogram.add(i, mapBlock, BIGINT.getLong(mapBlock, i + 1));
+        }
+
+        return histogram;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTruncatedHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTruncatedHistogram.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.SqlTimestampWithTimeZone;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.TimeZoneKey;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.RowType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringArraysBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.operator.aggregation.TruncatedHistogram.NAME;
+import static com.facebook.presto.operator.scalar.TestingRowConstructor.testRowBigintBigint;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TimeZoneKey.getTimeZoneKey;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.util.DateTimeZoneIndex.getDateTimeZone;
+import static com.facebook.presto.util.StructuralTestUtil.mapBlockOf;
+
+public class TestTruncatedHistogram
+{
+    private static final MetadataManager metadata = MetadataManager.createTestMetadataManager();
+    private static final TimeZoneKey TIME_ZONE_KEY = getTimeZoneKey("UTC");
+    private static final DateTimeZone DATE_TIME_ZONE = getDateTimeZone(TIME_ZONE_KEY);
+
+    @Test
+    public void testSimpleHistograms()
+            throws Exception
+    {
+        MapType mapType = new MapType(VARCHAR, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, StandardTypes.VARCHAR));
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                ImmutableMap.of("a", 1L, "b", 1L, "c", 1L),
+                createRLEBlock(251, 3),
+                createStringsBlock("a", "b", "c"));
+
+        mapType = new MapType(BIGINT, BIGINT);
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, StandardTypes.BIGINT));
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                ImmutableMap.of(100L, 1L, 200L, 1L, 300L, 1L),
+                createRLEBlock(251, 3),
+                createLongsBlock(100L, 200L, 300L));
+
+        mapType = new MapType(DOUBLE, BIGINT);
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, StandardTypes.DOUBLE));
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                ImmutableMap.of(0.1, 1L, 0.3, 1L, 0.2, 1L),
+                createRLEBlock(251, 3),
+                createDoublesBlock(0.1, 0.3, 0.2));
+
+        mapType = new MapType(BOOLEAN, BIGINT);
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, StandardTypes.BOOLEAN));
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                ImmutableMap.of(true, 1L, false, 1L),
+                createRLEBlock(251, 2),
+                createBooleansBlock(true, false));
+    }
+
+    @Test
+    public void testDuplicateKeysValues()
+            throws Exception
+    {
+        MapType mapType = new MapType(VARCHAR, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, StandardTypes.VARCHAR));
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                ImmutableMap.of("a", 2L, "b", 1L),
+                createRLEBlock(251, 3),
+                createStringsBlock("a", "b", "a"));
+
+        mapType = new MapType(TIMESTAMP_WITH_TIME_ZONE, BIGINT);
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, StandardTypes.TIMESTAMP_WITH_TIME_ZONE));
+        long timestampWithTimeZone1 = packDateTimeWithZone(new DateTime(1970, 1, 1, 0, 0, 0, 0, DATE_TIME_ZONE).getMillis(), TIME_ZONE_KEY);
+        long timestampWithTimeZone2 = packDateTimeWithZone(new DateTime(2015, 1, 1, 0, 0, 0, 0, DATE_TIME_ZONE).getMillis(), TIME_ZONE_KEY);
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                ImmutableMap.of(new SqlTimestampWithTimeZone(timestampWithTimeZone1), 2L, new SqlTimestampWithTimeZone(timestampWithTimeZone2), 1L),
+                createRLEBlock(251, 3),
+                createLongsBlock(timestampWithTimeZone1, timestampWithTimeZone1, timestampWithTimeZone2));
+    }
+
+    @Test
+    public void testWithNulls()
+            throws Exception
+    {
+        MapType mapType = new MapType(BIGINT, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, StandardTypes.BIGINT));
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                ImmutableMap.of(1L, 1L, 2L, 1L),
+                createRLEBlock(251, 3),
+                createLongsBlock(2L, null, 1L));
+
+        mapType = new MapType(BIGINT, BIGINT);
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, StandardTypes.BIGINT));
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                null,
+                createRLEBlock(251, 1),
+                createLongsBlock((Long) null));
+        //noinspection RedundantArrayCreation
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                null,
+                createRLEBlock(251, 0),
+                createLongsBlock(new Long[0]));
+    }
+
+    @Test
+    public void testArrayHistograms()
+            throws Exception
+    {
+        ArrayType arrayType = new ArrayType(VARCHAR);
+        MapType mapType = new MapType(arrayType, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, arrayType.getTypeSignature().toString()));
+
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                ImmutableMap.of(ImmutableList.of("a", "b", "c"), 1L, ImmutableList.of("d", "e", "f"), 1L, ImmutableList.of("c", "b", "a"), 1L),
+                createRLEBlock(251, 3),
+                createStringArraysBlock(ImmutableList.of(ImmutableList.of("a", "b", "c"), ImmutableList.of("d", "e", "f"), ImmutableList.of("c", "b", "a"))));
+    }
+
+    @Test
+    public void testMapHistograms()
+            throws Exception
+    {
+        MapType innerMapType = new MapType(VARCHAR, VARCHAR);
+        MapType mapType = new MapType(innerMapType, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, innerMapType.getTypeSignature().toString()));
+
+        BlockBuilder builder = innerMapType.createBlockBuilder(new BlockBuilderStatus(), 3);
+        innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("a", "b")));
+        innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("c", "d")));
+        innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("e", "f")));
+
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                ImmutableMap.of(ImmutableMap.of("a", "b"), 1L, ImmutableMap.of("c", "d"), 1L, ImmutableMap.of("e", "f"), 1L),
+                createRLEBlock(251, 3),
+                builder.build());
+    }
+
+    @Test
+    public void testRowHistograms()
+            throws Exception
+    {
+        RowType innerRowType = new RowType(ImmutableList.of(BIGINT, DOUBLE), Optional.of(ImmutableList.of("f1", "f2")));
+        MapType mapType = new MapType(innerRowType, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, innerRowType.getTypeSignature().toString()));
+
+        BlockBuilder builder = innerRowType.createBlockBuilder(new BlockBuilderStatus(), 3);
+        innerRowType.writeObject(builder, testRowBigintBigint(1L, 1.0));
+        innerRowType.writeObject(builder, testRowBigintBigint(2L, 2.0));
+        innerRowType.writeObject(builder, testRowBigintBigint(3L, 3.0));
+
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                ImmutableMap.of(ImmutableList.of(1L, 1.0), 1L, ImmutableList.of(2L, 2.0), 1L, ImmutableList.of(3L, 3.0), 1L),
+                createRLEBlock(251, 3),
+                builder.build());
+    }
+
+    @Test
+    public void testLargerHistograms()
+            throws Exception
+    {
+        MapType mapType = new MapType(VARCHAR, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, StandardTypes.VARCHAR));
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                // the d=1 and e=2 buckets are truncated and overflow onto the b=10 and c=12 buckets
+                // This result means a appeared at least 13 times and b and c appeared at least once each.
+                ImmutableMap.of("a", 25L, "b", 13L, "c", 13L),
+                createRLEBlock(3, 25 + 10 + 12 + 1 + 2),
+                createStringsBlock("a", "b", "c", "d", "e", "e", "c", "a", "a", "a", "b", "a", "a", "a", "a", "b", "a", "a", "a", "a", "b", "a", "a", "a", "a", "b", "a", "a", "a", "a", "b", "a", "c", "c", "b", "a", "c", "c", "b", "a", "c", "c", "b", "a", "c", "c", "b", "a", "c", "c"));
+    }
+
+    @Test
+    public void testHighCardinality()
+            throws Exception
+    {
+        MapType mapType = new MapType(VARCHAR, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT, StandardTypes.VARCHAR));
+        assertAggregation(
+                aggregationFunction,
+                1.0,
+                // The 6 cdefgh overflow onto the 2 ab buckets, resulting in 9+ of each of a and b
+                // Due to extra compactions, the result is actually 10 each
+                // Note that this result merely means that:
+                // - a and b appeared 1-10 times
+                // - there are up to 20 values.
+                // - nothing appeared more than 10 times
+                ImmutableMap.of("a", 10L, "b", 10L),
+                createRLEBlock(2, 6 * (2 + 1)),
+                // c [ab] d [ab] e [ab] f [ab] g [ab] h [ab]
+                createStringsBlock("c", "a", "b", "d", "a", "b", "e", "a", "b", "f", "a", "b", "g", "a", "b", "h", "a", "b"));
+    }
+}


### PR DESCRIPTION
This PR adds a truncated histogram aggregation that computes an approximate histogram of values. It's a hybrid of `histogram` and `numeric_histogram`.

The truncated histogram aggregation can be used to get an upper and lower bound for how many times each value appears in a column, for up to `buckets` values:
- For less than `buckets` distinct values, it'll return the same result as `histogram(value)`.
- For skewed distributions, you can get tight bounds for most permutations of the distribution.
- For unskewed distributions, the bounds will be very loose. (for example, `SELECT truncated_histogram(251, user_id) FROM users`).
- I think, if any value appears more than `1 / buckets` of the time, it will be reported.

In addition, just like `histogram`, if the memory usage exceeds 4 MB, the query will fail. However, this generally happens only when the bucket count is set too high. I've also decreased the hash table load factor from 90% to 75% because it gives me 1.8x throughput (rows/cpu sec) in my tests.

Original issue: https://github.com/facebook/presto/issues/4094
Copied from: https://github.com/facebook/presto/pull/4119/

Text from issue:

> I'm looking for an efficient way to get an (approximate) histogram of the frequent values for each column of a table. These columns are generally high-cardinality, but often skewed. Currently, I'm running a sequence of queries like:
> 
> ```
> SELECT col_x, count(*) AS c
>     FROM my_table
>     GROUP BY col_x
>     ORDER BY c DESC
>     LIMIT 250;
> ```
> 
> This is pretty slow when there are a lot of columns. I've tried running the queries together (using UNION ALL) and such, but it doesn't seem to avoid scanning the table multiple times. I'm looking for a faster way to approximate this result. I've looked at `TABLESAMPLE SYSTEM`, but it seems to omit data in a predictable way because of how my tables are laid out.
> 
> I've noticed there is the `histogram(value)` and `numeric_histogram(bucket_limit, value)` aggregations. Are there any plans for an approximate variant of my SQL query?
> 
> If not, would a patch be welcome? I'm thinking the signature would be:
> `truncated_histogram(bucket_limit, value)`. The algorithm would be a variant of Space-Saving [1], which computes frequent elements in constant space and linear time in input size. It returns tight error bounds for skewed data. In the limit, as `bucket_limit => infinity`, it degrades to `histogram`.
> The implementation would be similar to that of `numeric_histogram`: Periodically, the smallest counters are merged.
> 
> [1] Ahmed Metwally, Divyakant Agrawal, and Amr El Abbadi,
>         "Efficient Computation of Frequent and Top-_k_ Elements in Data Streams",
>         https://icmi.cs.ucsb.edu/research/tech_reports/reports/2005-23.pdf
