### PR TITLE
Map JDBC's Types.OTHER to VARCHAR in base-jdbc connector

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -427,6 +427,7 @@ public class BaseJdbcClient
             case Types.NVARCHAR:
             case Types.LONGVARCHAR:
             case Types.LONGNVARCHAR:
+            case Types.OTHER:
                 return VARCHAR;
             case Types.BINARY:
             case Types.VARBINARY:

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -27,6 +27,7 @@ import java.sql.Statement;
 
 import static com.facebook.presto.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
 import static io.airlift.testing.Closeables.closeAllRuntimeException;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -67,7 +68,7 @@ public class TestPostgreSqlDistributedQueries
         assertFalse(queryRunner.tableExists(getSession(), "test_drop"));
     }
 
-    @Test
+	@Test
     public void testViews()
             throws Exception
     {
@@ -76,6 +77,24 @@ public class TestPostgreSqlDistributedQueries
         assertQuery("SELECT orderkey FROM test_view", "SELECT orderkey FROM orders");
 
         execute("DROP VIEW IF EXISTS tpch.test_view");
+    }
+    
+    @Test
+    public void testSelectNativeDataTypeColumn()
+        throws Exception
+    {
+        execute("CREATE TABLE tpch.test_other_data_type (_foo UUID)");
+        assertTrue(queryRunner.tableExists(getSession(), "test_other_data_type"));
+
+        execute("INSERT INTO tpch.test_other_data_type VALUES ('00000000-0000-0000-0000-000000000000')");
+        assertEquals(
+            queryRunner
+                .execute(getSession(), "SELECT _foo from test_other_data_type")
+                .getRowCount(),
+            1);
+
+        execute("DROP TABLE IF EXISTS tpch.test_other_data_type");
+        assertFalse(queryRunner.tableExists(getSession(), "test_other_data_type"));
     }
 
     private void execute(String sql)

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -68,7 +68,7 @@ public class TestPostgreSqlDistributedQueries
         assertFalse(queryRunner.tableExists(getSession(), "test_drop"));
     }
 
-	@Test
+    @Test
     public void testViews()
             throws Exception
     {
@@ -78,10 +78,10 @@ public class TestPostgreSqlDistributedQueries
 
         execute("DROP VIEW IF EXISTS tpch.test_view");
     }
-    
+
     @Test
     public void testSelectNativeDataTypeColumn()
-        throws Exception
+            throws Exception
     {
         execute("CREATE TABLE tpch.test_other_data_type (_foo UUID)");
         assertTrue(queryRunner.tableExists(getSession(), "test_other_data_type"));


### PR DESCRIPTION
instead of discarding unknown column types, try to convert it to an UTF_8 String.
it will produce a readable result if the value being returned is a byte[](handled for *free* by io.airlift.slice)

Refs #4082
