### PR TITLE
Fix cli hex rendering in non-interactive/batch mode

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/AlignedTablePrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/AlignedTablePrinter.java
@@ -147,11 +147,8 @@ public class AlignedTablePrinter
 
     private static String formatHexDump(byte[] bytes, int bytesPerLine)
     {
-        // hex dump: "616263"
-        String hexDump = base16().lowerCase().encode(bytes);
-
         // hex pairs: ["61", "62", "63"]
-        Iterable<String> hexPairs = HEX_SPLITTER.split(hexDump);
+        Iterable<String> hexPairs = createHexPairs(bytes);
 
         // hex lines: [["61", "62", "63], [...]]
         Iterable<List<String>> hexLines = partition(hexPairs, bytesPerLine);
@@ -161,6 +158,21 @@ public class AlignedTablePrinter
 
         // joined: "61 62 63\n..."
         return HEX_LINE_JOINER.join(lines);
+    }
+
+    static String formatHexDump(byte[] bytes)
+    {
+        Iterable<String> hexPairs = createHexPairs(bytes);
+        return HEX_BYTE_JOINER.join(hexPairs);
+    }
+
+    private static Iterable<String> createHexPairs(byte[] bytes)
+    {
+        // hex dump: "616263"
+        String hexDump = base16().lowerCase().encode(bytes);
+
+        // hex pairs: ["61", "62", "63"]
+        return HEX_SPLITTER.split(hexDump);
     }
 
     private static String center(String s, int maxWidth, int padding)

--- a/presto-cli/src/main/java/com/facebook/presto/cli/CsvPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/CsvPrinter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
 
+import static com.facebook.presto.cli.AlignedTablePrinter.formatHexDump;
 import static java.util.Objects.requireNonNull;
 
 public class CsvPrinter
@@ -76,8 +77,21 @@ public class CsvPrinter
         String[] array = new String[values.size()];
         for (int i = 0; i < values.size(); i++) {
             Object value = values.get(i);
-            array[i] = (value == null) ? "" : value.toString();
+            array[i] = formatValue(value);
         }
         return array;
+    }
+
+    private static String formatValue(Object o)
+    {
+        if (o == null) {
+            return "";
+        }
+
+        if (o instanceof byte[]) {
+            return formatHexDump((byte[]) o);
+        }
+
+        return o.toString();
     }
 }

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestCsvPrinter.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestCsvPrinter.java
@@ -16,6 +16,7 @@ package com.facebook.presto.cli;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.List;
 
@@ -86,6 +87,22 @@ public class TestCsvPrinter
         String expected = "" +
                 "\"hello\",\"world\",\"123\"\n" +
                 "\"a\",\"\",\"4.5\"\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    @Test
+    public void testCsvVarbinaryPrinting()
+            throws IOException
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, false);
+
+        printer.printRows(rows(row("hello".getBytes(), null, 123)), true);
+        printer.finish();
+
+        String expected = "\"68 65 6c 6c 6f\",\"\",\"123\"\n";
 
         assertEquals(writer.getBuffer().toString(), expected);
     }


### PR DESCRIPTION
In non-interactive/batch mode `CsvPrinter` renders `byte[]`s incorrectly. This PR fixes that.

Currently
``presto --execute "select cast('12345678910111213141516171819' as varbinary)"`` returns ``"[B@3e08ff24"``

With this fix it returns
``"31 32 33 34 35 36 37 38 39 31 30 31 31 31 32 31 33 31 34 31 35 31 36 31 37 31 38 31 39"``

