### PR TITLE
Fix special key handling in cli

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -223,7 +223,7 @@ public class Console
                             outputFormat = OutputFormat.VERTICAL;
                         }
 
-                        process(queryRunner, split.statement(), outputFormat, true);
+                        process(reader, queryRunner, split.statement(), outputFormat, true);
                     }
                     reader.getHistory().add(squeezeStatement(split.statement()) + split.terminator());
                 }
@@ -271,7 +271,7 @@ public class Console
         StatementSplitter splitter = new StatementSplitter(query);
         for (Statement split : splitter.getCompleteStatements()) {
             if (!isEmptyStatement(split.statement())) {
-                process(queryRunner, split.statement(), outputFormat, false);
+                process(null, queryRunner, split.statement(), outputFormat, false);
             }
         }
         if (!isEmptyStatement(splitter.getPartialStatement())) {
@@ -279,10 +279,10 @@ public class Console
         }
     }
 
-    private static void process(QueryRunner queryRunner, String sql, OutputFormat outputFormat, boolean interactive)
+    private static void process(LineReader reader, QueryRunner queryRunner, String sql, OutputFormat outputFormat, boolean interactive)
     {
         try (Query query = queryRunner.startQuery(sql)) {
-            query.renderOutput(System.out, outputFormat, interactive);
+            query.renderOutput(reader, System.out, outputFormat, interactive);
 
             ClientSession session = queryRunner.getSession();
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/KeyReader.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/KeyReader.java
@@ -13,10 +13,9 @@
  */
 package com.facebook.presto.cli;
 
-import java.io.FileDescriptor;
-import java.io.FileInputStream;
+import jline.internal.NonBlockingInputStream;
+
 import java.io.IOException;
-import java.io.InputStream;
 
 import static org.fusesource.jansi.internal.CLibrary.STDIN_FILENO;
 import static org.fusesource.jansi.internal.CLibrary.isatty;
@@ -26,17 +25,34 @@ public final class KeyReader
     private KeyReader() {}
 
     @SuppressWarnings("resource")
-    public static int readKey()
+    public static int peekKey(LineReader reader)
     {
         if (!hasTerminal()) {
             return -1;
         }
 
         try {
-            InputStream in = new FileInputStream(FileDescriptor.in);
-            if (in.available() > 0) {
-                return in.read();
-            }
+            return ((NonBlockingInputStream) reader.getInput()).peek(500);
+        }
+        catch (IOException e) {
+            // ignore errors reading keyboard input
+        }
+        return -1;
+    }
+
+    /**
+     * This method should be called after peekKey to consume the
+     * byte that was returned in that call
+     */
+    @SuppressWarnings("resource")
+    public static int readKey(LineReader reader)
+    {
+        if (!hasTerminal()) {
+            return -1;
+        }
+
+        try {
+            return reader.getInput().read();
         }
         catch (IOException e) {
             // ignore errors reading keyboard input

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -82,7 +82,7 @@ public class Query
         return client.isClearTransactionId();
     }
 
-    public void renderOutput(PrintStream out, OutputFormat outputFormat, boolean interactive)
+    public void renderOutput(LineReader reader, PrintStream out, OutputFormat outputFormat, boolean interactive)
     {
         Thread clientThread = Thread.currentThread();
         SignalHandler oldHandler = Signal.handle(SIGINT, signal -> {
@@ -94,7 +94,7 @@ public class Query
             clientThread.interrupt();
         });
         try {
-            renderQueryOutput(out, outputFormat, interactive);
+            renderQueryOutput(reader, out, outputFormat, interactive);
         }
         finally {
             Signal.handle(SIGINT, oldHandler);
@@ -102,14 +102,14 @@ public class Query
         }
     }
 
-    private void renderQueryOutput(PrintStream out, OutputFormat outputFormat, boolean interactive)
+    private void renderQueryOutput(LineReader reader, PrintStream out, OutputFormat outputFormat, boolean interactive)
     {
         StatusPrinter statusPrinter = null;
         @SuppressWarnings("resource")
         PrintStream errorChannel = interactive ? out : System.err;
 
         if (interactive) {
-            statusPrinter = new StatusPrinter(client, out);
+            statusPrinter = new StatusPrinter(client, reader, out);
             statusPrinter.printInitialStatusUpdates();
         }
         else {


### PR DESCRIPTION
When handling special characters in cli (such as the ones for canceling, partial canceling, and for toggling debug mode) a byte that's read from stdin is ignored. Fixes #4241.
