### PR TITLE
Logical plan assertion DSL

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -144,6 +144,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.testing.TreeAssertions.assertFormattedSql;
@@ -422,11 +423,19 @@ public class LocalQueryRunner
     @Override
     public MaterializedResult execute(Session session, @Language("SQL") String sql)
     {
+        return inTransaction(session, transactionSession -> executeInternal(transactionSession, sql));
+    }
+
+    public <T> T inTransaction(Function<Session, T> transactionSessionConsumer)
+    {
+        return inTransaction(defaultSession, transactionSessionConsumer);
+    }
+
+    public <T> T inTransaction(Session session, Function<Session, T> transactionSessionConsumer)
+    {
         return transaction(transactionManager)
                 .singleStatement()
-                .execute(session, transactionSession -> {
-                    return executeInternal(transactionSession, sql);
-                });
+                .execute(session, transactionSessionConsumer);
     }
 
     private MaterializedResult executeInternal(Session session, @Language("SQL") String sql)
@@ -475,28 +484,7 @@ public class LocalQueryRunner
 
     public List<Driver> createDrivers(Session session, @Language("SQL") String sql, OutputFactory outputFactory, TaskContext taskContext)
     {
-        Statement statement = sqlParser.createStatement(sql);
-
-        assertFormattedSql(sqlParser, statement);
-
-        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
-        FeaturesConfig featuresConfig = new FeaturesConfig()
-                .setExperimentalSyntaxEnabled(true)
-                .setDistributedIndexJoinsEnabled(false)
-                .setOptimizeHashGeneration(true);
-        PlanOptimizersFactory planOptimizersFactory = new PlanOptimizersFactory(metadata, sqlParser, featuresConfig, true);
-
-        QueryExplainer queryExplainer = new QueryExplainer(
-                planOptimizersFactory.get(),
-                metadata,
-                accessControl,
-                sqlParser,
-                dataDefinitionTask,
-                featuresConfig.isExperimentalSyntaxEnabled());
-        Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.of(queryExplainer), featuresConfig.isExperimentalSyntaxEnabled());
-
-        Analysis analysis = analyzer.analyze(statement);
-        Plan plan = new LogicalPlanner(session, planOptimizersFactory.get(), idAllocator, metadata).plan(analysis);
+        Plan plan = createPlan(session, sql);
 
         if (printPlan) {
             System.out.println(PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata, session));
@@ -580,6 +568,32 @@ public class LocalQueryRunner
         }
 
         return ImmutableList.copyOf(drivers);
+    }
+
+    public Plan createPlan(Session session, @Language("SQL") String sql)
+    {
+        Statement statement = sqlParser.createStatement(sql);
+
+        assertFormattedSql(sqlParser, statement);
+
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        FeaturesConfig featuresConfig = new FeaturesConfig()
+                .setExperimentalSyntaxEnabled(true)
+                .setDistributedIndexJoinsEnabled(false)
+                .setOptimizeHashGeneration(true);
+        PlanOptimizersFactory planOptimizersFactory = new PlanOptimizersFactory(metadata, sqlParser, featuresConfig, true);
+
+        QueryExplainer queryExplainer = new QueryExplainer(
+                planOptimizersFactory.get(),
+                metadata,
+                accessControl,
+                sqlParser,
+                dataDefinitionTask,
+                featuresConfig.isExperimentalSyntaxEnabled());
+        Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.of(queryExplainer), featuresConfig.isExperimentalSyntaxEnabled());
+
+        Analysis analysis = analyzer.analyze(statement);
+        return new LogicalPlanner(session, planOptimizersFactory.get(), idAllocator, metadata).plan(analysis);
     }
 
     public OperatorFactory createTableScanOperator(int operatorId, PlanNodeId planNodeId, String tableName, String... columnNames)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.sql.planner.assertions.PlanAssert;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aliasPair;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public class TestLogicalPlanner
+{
+    private final LocalQueryRunner queryRunner;
+
+    public TestLogicalPlanner()
+    {
+        this.queryRunner = new LocalQueryRunner(testSessionBuilder()
+                .setCatalog("local")
+                .setSchema("tiny")
+                .build());
+
+        queryRunner.createCatalog(queryRunner.getDefaultSession().getCatalog().get(),
+                new TpchConnectorFactory(queryRunner.getNodeManager(), 1),
+                ImmutableMap.<String, String>of());
+    }
+
+    @Test
+    public void testPlanDsl()
+    {
+        assertPlan("SELECT orderkey FROM orders WHERE orderkey IN (1, 2, 3)",
+                node(OutputNode.class,
+                        node(FilterNode.class,
+                                tableScan("orders"))));
+
+        String simpleJoinQuery = "SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey";
+        assertPlan(simpleJoinQuery,
+                any(
+                        any(
+                                node(JoinNode.class,
+                                        any(
+                                                tableScan("orders")),
+                                        any(
+                                                any(
+                                                        tableScan("lineitem")))))));
+
+        assertPlan(simpleJoinQuery,
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(),
+                                anyTree())));
+
+        assertPlan(simpleJoinQuery, anyTree(node(TableScanNode.class)));
+
+        assertPlan("SELECT * FROM orders WHERE orderkey = (SELECT orderkey FROM lineitem ORDER BY orderkey LIMIT 1)",
+                anyTree(
+                        join(ImmutableList.of(aliasPair("X", "Y")),
+                                project(
+                                        tableScan("orders").withSymbol("orderkey", "X")),
+                                project(
+                                        node(EnforceSingleRowNode.class,
+                                                anyTree(
+                                                        tableScan("lineitem").withSymbol("orderkey", "Y")))))));
+
+        assertPlan("SELECT * FROM orders WHERE orderkey IN (SELECT orderkey FROM lineitem WHERE linenumber % 4 = 0)",
+                anyTree(
+                        filter("S",
+                                project(
+                                        semiJoin("X", "Y", "S",
+                                                anyTree(
+                                                        tableScan("orders").withSymbol("orderkey", "X")),
+                                                anyTree(
+                                                        tableScan("lineitem").withSymbol("orderkey", "Y")))))));
+
+        assertPlan("SELECT * FROM orders WHERE orderkey NOT IN (SELECT orderkey FROM lineitem WHERE linenumber < 0)",
+                anyTree(
+                        filter("NOT S",
+                                project(
+                                        semiJoin("X", "Y", "S",
+                                                anyTree(
+                                                        tableScan("orders").withSymbol("orderkey", "X")),
+                                                anyTree(
+                                                        tableScan("lineitem").withSymbol("orderkey", "Y")))))));
+    }
+
+    private void assertPlan(String sql, PlanMatchPattern pattern)
+    {
+        Plan actualPlan = queryRunner.inTransaction(transactionSession -> queryRunner.createPlan(transactionSession, sql));
+        queryRunner.inTransaction(transactionSession -> {
+            PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), actualPlan, pattern);
+            return null;
+        });
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AliasPair.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AliasPair.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import static java.util.Objects.requireNonNull;
+
+final class AliasPair
+{
+    final String left;
+    final String right;
+
+    AliasPair(String left, String right)
+    {
+        this.left = requireNonNull(left, "left is null");
+        this.right = requireNonNull(right, "right is null");
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DereferenceExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.LogicalBinaryExpression;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.NotExpression;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.QualifiedNameReference;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Expression visitor which verifies if given expression (actual) is matching other expression given as context (expected).
+ * Visitor returns true if plans match to each other.
+ * <p/>
+ * Note that actual expression is using real name references (table columns etc) while expected expression is using symbol aliases.
+ * Given symbol alias can point only to one real name reference.
+ * <p/>
+ * Example:
+ * <pre>
+ * NOT (orderkey = 3 AND custkey = 3 AND orderkey < 10)
+ * </pre>
+ * will match to:
+ * <pre>
+ * NOT (X = 3 AND Y = 3 AND X < 10)
+ * </pre>
+ * , but will not match to:
+ * <pre>
+ * NOT (X = 3 AND Y = 3 AND Z < 10)
+ * </pre>
+ * nor  to
+ * <pre>
+ * NOT (X = 3 AND X = 3 AND X < 10)
+ * </pre>
+ */
+final class ExpressionVerifier
+        extends AstVisitor<Boolean, Expression>
+{
+    private final SymbolAliases symbolAliases;
+
+    ExpressionVerifier(SymbolAliases symbolAliases)
+    {
+        this.symbolAliases = requireNonNull(symbolAliases, "symbolAliases is null");
+    }
+
+    @Override
+    protected Boolean visitNode(Node node, Expression context)
+    {
+        throw new IllegalStateException(format("Node %s is not supported", node));
+    }
+
+    @Override
+    protected Boolean visitComparisonExpression(ComparisonExpression actual, Expression expectedExpression)
+    {
+        if (expectedExpression instanceof ComparisonExpression) {
+            ComparisonExpression expected = (ComparisonExpression) expectedExpression;
+            if (actual.getType() == expected.getType()) {
+                return process(actual.getLeft(), expected.getLeft()) && process(actual.getRight(), expected.getRight());
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitLongLiteral(LongLiteral actual, Expression expectedExpression)
+    {
+        if (expectedExpression instanceof LongLiteral) {
+            LongLiteral expected = (LongLiteral) expectedExpression;
+            return actual.getValue() == expected.getValue();
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitLogicalBinaryExpression(LogicalBinaryExpression actual, Expression expectedExpression)
+    {
+        if (expectedExpression instanceof LogicalBinaryExpression) {
+            LogicalBinaryExpression expected = (LogicalBinaryExpression) expectedExpression;
+            if (actual.getType() == expected.getType()) {
+                return process(actual.getLeft(), expected.getLeft()) && process(actual.getRight(), expected.getRight());
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitNotExpression(NotExpression actual, Expression expected)
+    {
+        if (expected instanceof NotExpression) {
+            return process(actual.getValue(), ((NotExpression) expected).getValue());
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitQualifiedNameReference(QualifiedNameReference actual, Expression expected)
+    {
+        if (isReference(expected)) {
+            symbolAliases.put(asQualifiedName(expected).toString(), Symbol.fromQualifiedName(asQualifiedName(actual)));
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitDereferenceExpression(DereferenceExpression actual, Expression expected)
+    {
+        if (isReference(expected)) {
+            symbolAliases.put(asQualifiedName(expected).toString(), Symbol.fromQualifiedName(asQualifiedName(actual)));
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isReference(Expression expression)
+    {
+        return expression instanceof DereferenceExpression || expression instanceof QualifiedNameReference;
+    }
+
+    private QualifiedName asQualifiedName(Expression expression)
+    {
+        if (expression instanceof DereferenceExpression) {
+            return DereferenceExpression.getQualifiedName((DereferenceExpression) expression);
+        }
+        else if (expression instanceof QualifiedNameReference) {
+            return ((QualifiedNameReference) expression).getName();
+        }
+        else {
+            throw new IllegalArgumentException("Expression is not a DereferenceExpression or QualifiedNameReference");
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/FilterMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/FilterMatcher.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.base.MoreObjects;
+
+import static java.util.Objects.requireNonNull;
+
+final class FilterMatcher
+        implements Matcher
+{
+    private final Expression predicate;
+
+    FilterMatcher(Expression predicate)
+    {
+        this.predicate = requireNonNull(predicate, "predicate is null");
+    }
+
+    @Override
+    public boolean matches(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        if (node instanceof FilterNode) {
+            FilterNode filterNode = (FilterNode) node;
+            if (new ExpressionVerifier(symbolAliases).process(filterNode.getPredicate(), predicate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.base.MoreObjects;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+final class JoinMatcher
+        implements Matcher
+{
+    private final List<AliasPair> equiCriteria;
+
+    JoinMatcher(List<AliasPair> equiCriteria)
+    {
+        this.equiCriteria = requireNonNull(equiCriteria, "equiCriteria is null");
+    }
+
+    @Override
+    public boolean matches(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        if (node instanceof JoinNode) {
+            JoinNode joinNode = (JoinNode) node;
+            if (joinNode.getCriteria().size() == equiCriteria.size()) {
+                int i = 0;
+                for (JoinNode.EquiJoinClause equiJoinClause : joinNode.getCriteria()) {
+                    AliasPair expectedEquiClause = equiCriteria.get(i++);
+                    symbolAliases.put(expectedEquiClause.left, equiJoinClause.getLeft());
+                    symbolAliases.put(expectedEquiClause.right, equiJoinClause.getRight());
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("equiCriteria", equiCriteria)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/Matcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/Matcher.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+public interface Matcher
+{
+    boolean matches(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases);
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.Plan;
+
+import static com.facebook.presto.sql.planner.PlanPrinter.textLogicalPlan;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertTrue;
+
+public final class PlanAssert
+{
+    private PlanAssert() {}
+
+    public static void assertPlan(Session session, Metadata metadata, Plan actual, PlanMatchPattern pattern)
+    {
+        requireNonNull(actual, "root is null");
+
+        boolean matches = actual.getRoot().accept(new PlanMatchingVisitor(session, metadata), new PlanMatchingContext(pattern));
+        if (!matches) {
+            String logicalPlan = textLogicalPlan(actual.getRoot(), actual.getTypes(), metadata, session);
+            assertTrue(matches, format("Plan does not match:\n %s\n, to pattern:\n%s", logicalPlan, pattern));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.nCopies;
+import static java.util.Objects.requireNonNull;
+
+public final class PlanMatchPattern
+{
+    private final List<Matcher> matchers = new ArrayList<>();
+
+    private final List<PlanMatchPattern> sourcePatterns;
+    private boolean anyTree;
+
+    public static PlanMatchPattern node(Class<? extends PlanNode> nodeClass, PlanMatchPattern... sources)
+    {
+        return any(sources).with(new PlanNodeMatcher(nodeClass));
+    }
+
+    public static PlanMatchPattern any(PlanMatchPattern... sources)
+    {
+        return new PlanMatchPattern(ImmutableList.copyOf(sources));
+    }
+
+    /**
+     * Matches to any tree of nodes with children matching to given source matchers.
+     * anyNodeTree(tableScanNode("nation")) - will match to any plan which all leafs contain
+     * any node containing table scan from nation table.
+     */
+    public static PlanMatchPattern anyTree(PlanMatchPattern... sources)
+    {
+        return any(sources).matchToAnyNodeTree();
+    }
+
+    public static PlanMatchPattern tableScan(String expectedTableName)
+    {
+        return any().with(new TableScanMatcher(expectedTableName));
+    }
+
+    public static PlanMatchPattern project(PlanMatchPattern... sources)
+    {
+        return node(ProjectNode.class, sources);
+    }
+
+    public static PlanMatchPattern semiJoin(String sourceSymbolAlias, String filteringSymbolAlias, String outputAlias, PlanMatchPattern... sources)
+    {
+        return any(sources).with(new SemiJoinMatcher(sourceSymbolAlias, filteringSymbolAlias, outputAlias));
+    }
+
+    public static PlanMatchPattern join(List<AliasPair> expectedEquiCriteria, PlanMatchPattern... sources)
+    {
+        return any(sources).with(new JoinMatcher(expectedEquiCriteria));
+    }
+
+    public static AliasPair aliasPair(String left, String right)
+    {
+        return new AliasPair(left, right);
+    }
+
+    public static PlanMatchPattern filter(String predicate, PlanMatchPattern... sources)
+    {
+        Expression expectedPredicate = new SqlParser().createExpression(predicate);
+        return any(sources).with(new FilterMatcher(expectedPredicate));
+    }
+
+    public PlanMatchPattern(List<PlanMatchPattern> sourcePatterns)
+    {
+        requireNonNull(sourcePatterns, "sourcePatterns are null");
+
+        this.sourcePatterns = ImmutableList.copyOf(sourcePatterns);
+    }
+
+    List<PlanMatchingState> matches(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        ImmutableList.Builder<PlanMatchingState> states = ImmutableList.builder();
+        if (anyTree) {
+            int sourcesCount = node.getSources().size();
+            if (sourcesCount > 1) {
+                states.add(new PlanMatchingState(nCopies(sourcesCount, this), symbolAliases));
+            }
+            else {
+                states.add(new PlanMatchingState(ImmutableList.of(this), symbolAliases));
+            }
+        }
+        if (node.getSources().size() == sourcePatterns.size() && matchers.stream().allMatch(it -> it.matches(node, session, metadata, symbolAliases))) {
+            states.add(new PlanMatchingState(sourcePatterns, symbolAliases));
+        }
+        return states.build();
+    }
+
+    public PlanMatchPattern withSymbol(String pattern, String alias)
+    {
+        return with(new SymbolMatcher(pattern, alias));
+    }
+
+    public PlanMatchPattern with(Matcher matcher)
+    {
+        matchers.add(matcher);
+        return this;
+    }
+
+    public PlanMatchPattern matchToAnyNodeTree()
+    {
+        anyTree = true;
+        return this;
+    }
+
+    public boolean isTerminated()
+    {
+        return sourcePatterns.isEmpty();
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        toString(builder, 0);
+        return builder.toString();
+    }
+
+    private void toString(StringBuilder builder, int indent)
+    {
+        builder.append(indentString(indent));
+        if (anyTree) {
+            builder.append("anyTree ");
+        }
+        builder.append("PlanMatchPattern {\n");
+
+        for (Matcher matcher : matchers) {
+            builder.append(indentString(indent + 1)).append(matcher.toString()).append("\n");
+        }
+
+        for (PlanMatchPattern pattern : sourcePatterns) {
+            pattern.toString(builder, indent + 1);
+        }
+
+        builder.append(indentString(indent)).append("}\n");
+    }
+
+    private String indentString(int indent)
+    {
+        return Strings.repeat("    ", indent);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchingContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchingContext.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import static java.util.Objects.requireNonNull;
+
+final class PlanMatchingContext
+{
+    private final SymbolAliases symbolAliases;
+    private final PlanMatchPattern pattern;
+
+    PlanMatchingContext(PlanMatchPattern pattern)
+    {
+        this(new SymbolAliases(), pattern);
+    }
+
+    PlanMatchingContext(SymbolAliases symbolAliases, PlanMatchPattern pattern)
+    {
+        requireNonNull(symbolAliases, "symbolAliases is null");
+        requireNonNull(pattern, "pattern is null");
+        this.symbolAliases = new SymbolAliases(symbolAliases);
+        this.pattern = pattern;
+    }
+
+    PlanMatchPattern getPattern()
+    {
+        return pattern;
+    }
+
+    SymbolAliases getSymbolAliases()
+    {
+        return symbolAliases;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchingState.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchingState.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+final class PlanMatchingState
+{
+    private final List<PlanMatchPattern> patterns;
+    private final SymbolAliases symbolAliases;
+
+    PlanMatchingState(List<PlanMatchPattern> patterns, SymbolAliases symbolAliases)
+    {
+        requireNonNull(symbolAliases, "symbolAliases is null");
+        requireNonNull(patterns, "matchers is null");
+        this.symbolAliases = new SymbolAliases(symbolAliases);
+        this.patterns = ImmutableList.copyOf(patterns);
+    }
+
+    boolean isTerminated()
+    {
+        return patterns.isEmpty() || patterns.stream().allMatch(PlanMatchPattern::isTerminated);
+    }
+
+    PlanMatchingContext createContext(int matcherId)
+    {
+        checkArgument(matcherId < patterns.size(), "mactcherId out of scope");
+        return new PlanMatchingContext(symbolAliases, patterns.get(matcherId));
+    }
+
+    List<PlanMatchPattern> getPatterns()
+    {
+        return patterns;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchingVisitor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchingVisitor.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanVisitor;
+
+import java.util.List;
+
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+final class PlanMatchingVisitor
+        extends PlanVisitor<PlanMatchingContext, Boolean>
+{
+    private final Metadata metadata;
+    private final Session session;
+
+    PlanMatchingVisitor(Session session, Metadata metadata)
+    {
+        this.session = requireNonNull(session, "session is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    protected Boolean visitPlan(PlanNode node, PlanMatchingContext context)
+    {
+        List<PlanMatchingState> states = context.getPattern().matches(node, session, metadata, context.getSymbolAliases());
+
+        if (states.isEmpty()) {
+            return false;
+        }
+
+        if (node.getSources().isEmpty()) {
+            return !filterTerminated(states).isEmpty();
+        }
+
+        for (PlanMatchingState state : states) {
+            checkState(node.getSources().size() == state.getPatterns().size(), "Matchers count does not match count of sources");
+            int i = 0;
+            boolean sourcesMatch = true;
+            for (PlanNode source : node.getSources()) {
+                sourcesMatch = sourcesMatch && source.accept(this, state.createContext(i++));
+            }
+            if (sourcesMatch) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<PlanMatchingState> filterTerminated(List<PlanMatchingState> states)
+    {
+        return states.stream()
+                .filter(PlanMatchingState::isTerminated)
+                .collect(toImmutableList());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanNodeMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanNodeMatcher.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.base.MoreObjects;
+
+import static java.util.Objects.requireNonNull;
+
+final class PlanNodeMatcher
+        implements Matcher
+{
+    private final Class<? extends PlanNode> nodeClass;
+
+    public PlanNodeMatcher(Class<? extends PlanNode> nodeClass)
+    {
+        this.nodeClass = requireNonNull(nodeClass, "nodeClass is null");
+    }
+
+    @Override
+    public boolean matches(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        return node.getClass().equals(nodeClass);
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("nodeClass", nodeClass)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SemiJoinMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SemiJoinMatcher.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.google.common.base.MoreObjects;
+
+import static java.util.Objects.requireNonNull;
+
+final class SemiJoinMatcher
+        implements Matcher
+{
+    private final String sourceSymbolAlias;
+    private final String filteringSymbolAlias;
+    private final String outputAlias;
+
+    SemiJoinMatcher(String sourceSymbolAlias, String filteringSymbolAlias, String outputAlias)
+    {
+        this.sourceSymbolAlias = requireNonNull(sourceSymbolAlias, "sourceSymbolAlias is null");
+        this.filteringSymbolAlias = requireNonNull(filteringSymbolAlias, "filteringSymbolAlias is null");
+        this.outputAlias = requireNonNull(outputAlias, "outputAlias is null");
+    }
+
+    @Override
+    public boolean matches(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        if (node instanceof SemiJoinNode) {
+            SemiJoinNode semiJoinNode = (SemiJoinNode) node;
+            symbolAliases.put(sourceSymbolAlias, semiJoinNode.getSourceJoinSymbol());
+            symbolAliases.put(filteringSymbolAlias, semiJoinNode.getFilteringSourceJoinSymbol());
+            symbolAliases.put(outputAlias, semiJoinNode.getSemiJoinOutput());
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("filteringSymbolAlias", filteringSymbolAlias)
+                .add("sourceSymbolAlias", sourceSymbolAlias)
+                .add("outputAlias", outputAlias)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolAliases.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolAliases.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+final class SymbolAliases
+{
+    private final Multimap<String, Symbol> map;
+
+    SymbolAliases()
+    {
+        this.map = ArrayListMultimap.create();
+    }
+
+    SymbolAliases(SymbolAliases symbolAliases)
+    {
+        requireNonNull(symbolAliases, "symbolAliases are null");
+        this.map = ArrayListMultimap.create(symbolAliases.map);
+    }
+
+    public void put(String alias, Symbol symbol)
+    {
+        alias = alias.toLowerCase();
+        if (map.containsKey(alias)) {
+            checkState(map.get(alias).contains(symbol), "Alias %s points to different symbols %s and %s", alias, symbol, map.get(alias));
+        }
+        else {
+            checkState(!map.values().contains(symbol), "Symbol %s is already pointed by different alias than %s, check mapping %s", symbol, alias, map);
+            map.put(alias, symbol);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolMatcher.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.base.MoreObjects;
+
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkState;
+
+final class SymbolMatcher
+        implements Matcher
+{
+    private final Pattern pattern;
+    private final String alias;
+
+    SymbolMatcher(String pattern, String alias)
+    {
+        this.pattern = Pattern.compile(pattern);
+        this.alias = alias;
+    }
+
+    @Override
+    public boolean matches(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        Symbol symbol = null;
+        for (Symbol outputSymbol : node.getOutputSymbols()) {
+            if (pattern.matcher(outputSymbol.getName()).find()) {
+                checkState(symbol == null, "%s symbol was found multiple times in %s", pattern, node.getOutputSymbols());
+                symbol = outputSymbol;
+            }
+        }
+        if (symbol != null) {
+            symbolAliases.put(alias, symbol);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("alias", alias)
+                .add("pattern", pattern)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TableScanMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TableScanMatcher.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.TableMetadata;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.google.common.base.MoreObjects;
+
+import static java.util.Objects.requireNonNull;
+
+final class TableScanMatcher
+        implements Matcher
+{
+    private final String expectedTableName;
+
+    TableScanMatcher(String expectedTableName)
+    {
+        this.expectedTableName = requireNonNull(expectedTableName, "expectedTableName is null");
+    }
+
+    @Override
+    public boolean matches(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        if (node instanceof TableScanNode) {
+            TableScanNode tableScanNode = (TableScanNode) node;
+            TableMetadata tableMetadata = metadata.getTableMetadata(session, tableScanNode.getTable());
+            String actualTableName = tableMetadata.getTable().getTableName();
+            if (expectedTableName.equalsIgnoreCase(actualTableName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("expectedTableName", expectedTableName)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TestExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TestExpressionVerifier.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Expression;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+public class TestExpressionVerifier
+{
+    private final SqlParser parser = new SqlParser();
+
+    @Test
+    public void test()
+    {
+        Expression actual = expression("NOT(orderkey = 3 AND custkey = 3 AND orderkey < 10)");
+
+        ExpressionVerifier verifier = new ExpressionVerifier(new SymbolAliases());
+
+        assertTrue(verifier.process(actual, expression("NOT(X = 3 AND Y = 3 AND X < 10)")));
+        assertThrows(() -> verifier.process(actual, expression("NOT(X = 3 AND Y = 3 AND Z < 10)")));
+        assertThrows(() -> verifier.process(actual, expression("NOT(X = 3 AND X = 3 AND X < 10)")));
+    }
+
+    private Expression expression(String sql)
+    {
+        return parser.createExpression(sql);
+    }
+
+    private static void assertThrows(Runnable runnable)
+    {
+        try {
+            runnable.run();
+            throw new AssertionError("Method din't throw an exception as it was expected");
+        }
+        catch (Exception expected) {
+        }
+    }
+}


### PR DESCRIPTION
Currently in Presto SQL support is tested by executing end-to-end number
of different SQL queries. However, knowing that given SQL query is
passing and returns good results may be not enough. SQL query may have a
number of different equivalent (returning the same data set) logical
plan representations with different cost estimates. In order to test if
logical planner generates proper logical plan we need to verify that
plan.

Simple plan verification (explain string or plan node objects comparison)
has following flaws:
 - high maintenance cost
 - verbose tests

To overcome this problems, this pull request proposes plan assertion
framework, which uses set of abstract plan rules.