### PR TITLE
Implement PREPARE

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -24,6 +24,8 @@ public final class PrestoHeaders
     public static final String PRESTO_SESSION = "X-Presto-Session";
     public static final String PRESTO_SET_SESSION = "X-Presto-Set-Session";
     public static final String PRESTO_CLEAR_SESSION = "X-Presto-Clear-Session";
+    public static final String PRESTO_PREPARED_STATEMENT = "X-Presto-Prepared-Statement";
+    public static final String PRESTO_ADDED_PREPARE = "X-Presto-Added-Prepare";
     public static final String PRESTO_TRANSACTION_ID = "X-Presto-Transaction-Id";
     public static final String PRESTO_STARTED_TRANSACTION_ID = "X-Presto-Started-Transaction-Id";
     public static final String PRESTO_CLEAR_TRANSACTION_ID = "X-Presto-Clear-Transaction-Id";

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -56,6 +56,7 @@ public final class Session
     private final Map<String, String> systemProperties;
     private final Map<String, Map<String, String>> catalogProperties;
     private final SessionPropertyManager sessionPropertyManager;
+    private final Map<String, String> preparedStatements;
 
     public Session(
             QueryId queryId,
@@ -72,7 +73,8 @@ public final class Session
             long startTime,
             Map<String, String> systemProperties,
             Map<String, Map<String, String>> catalogProperties,
-            SessionPropertyManager sessionPropertyManager)
+            SessionPropertyManager sessionPropertyManager,
+            Map<String, String> preparedStatements)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
@@ -88,6 +90,7 @@ public final class Session
         this.startTime = startTime;
         this.systemProperties = ImmutableMap.copyOf(requireNonNull(systemProperties, "systemProperties is null"));
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
+        this.preparedStatements = requireNonNull(preparedStatements, "preparedStatements is null");
 
         ImmutableMap.Builder<String, Map<String, String>> catalogPropertiesBuilder = ImmutableMap.<String, Map<String, String>>builder();
         catalogProperties.entrySet().stream()
@@ -189,6 +192,11 @@ public final class Session
         return systemProperties;
     }
 
+    public Map<String, String> getPreparedStatements()
+    {
+        return preparedStatements;
+    }
+
     public Session withTransactionId(TransactionId transactionId)
     {
         requireNonNull(transactionId, "transactionId is null");
@@ -218,7 +226,8 @@ public final class Session
                 startTime,
                 systemProperties,
                 catalogProperties,
-                sessionPropertyManager);
+                sessionPropertyManager,
+                preparedStatements);
     }
 
     public Session withSystemProperty(String key, String value)
@@ -244,7 +253,8 @@ public final class Session
                 startTime,
                 systemProperties,
                 catalogProperties,
-                sessionPropertyManager);
+                sessionPropertyManager,
+                preparedStatements);
     }
 
     public Session withCatalogProperty(String catalog, String key, String value)
@@ -279,7 +289,34 @@ public final class Session
                 startTime,
                 systemProperties,
                 catalogProperties,
-                sessionPropertyManager);
+                sessionPropertyManager,
+                preparedStatements);
+    }
+
+    public Session withPreparedStatement(String statementName, String query)
+    {
+        requireNonNull(statementName, "statementName is null");
+        requireNonNull(query, "query is null");
+
+        Map<String, String> preparedStatements = new HashMap<>(getPreparedStatements());
+        preparedStatements.put(statementName, query);
+        return new Session(
+                queryId,
+                transactionId,
+                clientTransactionSupport,
+                identity,
+                source,
+                catalog,
+                schema,
+                timeZoneKey,
+                locale,
+                remoteUserAddress,
+                userAgent,
+                startTime,
+                systemProperties,
+                catalogProperties,
+                sessionPropertyManager,
+                preparedStatements);
     }
 
     public ConnectorSession toConnectorSession()
@@ -343,7 +380,8 @@ public final class Session
                 userAgent,
                 startTime,
                 systemProperties,
-                catalogProperties);
+                catalogProperties,
+                preparedStatements);
     }
 
     @Override
@@ -388,6 +426,7 @@ public final class Session
         private Map<String, String> systemProperties = ImmutableMap.of();
         private final Map<String, Map<String, String>> catalogProperties = new HashMap<>();
         private final SessionPropertyManager sessionPropertyManager;
+        private Map<String, String> preparedStatements = ImmutableMap.of();
 
         private SessionBuilder(SessionPropertyManager sessionPropertyManager)
         {
@@ -489,6 +528,11 @@ public final class Session
             return this;
         }
 
+        public void setPreparedStatements(Map<String, String> preparedStatements)
+        {
+            this.preparedStatements = ImmutableMap.copyOf(preparedStatements);
+        }
+
         public Session build()
         {
             return new Session(
@@ -506,7 +550,8 @@ public final class Session
                     startTime,
                     systemProperties,
                     catalogProperties,
-                    sessionPropertyManager);
+                    sessionPropertyManager,
+                    preparedStatements);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
@@ -46,6 +46,7 @@ public final class SessionRepresentation
     private final long startTime;
     private final Map<String, String> systemProperties;
     private final Map<String, Map<String, String>> catalogProperties;
+    private final Map<String, String> preparedStatements;
 
     @JsonCreator
     public SessionRepresentation(
@@ -63,7 +64,8 @@ public final class SessionRepresentation
             @JsonProperty("userAgent") Optional<String> userAgent,
             @JsonProperty("startTime") long startTime,
             @JsonProperty("systemProperties") Map<String, String> systemProperties,
-            @JsonProperty("catalogProperties") Map<String, Map<String, String>> catalogProperties)
+            @JsonProperty("catalogProperties") Map<String, Map<String, String>> catalogProperties,
+            @JsonProperty("preparedStatements") Map<String, String> preparedStatements)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
@@ -79,6 +81,7 @@ public final class SessionRepresentation
         this.userAgent = requireNonNull(userAgent, "userAgent is null");
         this.startTime = startTime;
         this.systemProperties = ImmutableMap.copyOf(systemProperties);
+        this.preparedStatements = ImmutableMap.copyOf(preparedStatements);
 
         ImmutableMap.Builder<String, Map<String, String>> catalogPropertiesBuilder = ImmutableMap.<String, Map<String, String>>builder();
         for (Entry<String, Map<String, String>> entry : catalogProperties.entrySet()) {
@@ -177,6 +180,12 @@ public final class SessionRepresentation
         return catalogProperties;
     }
 
+    @JsonProperty
+    public Map<String, String> getPreparedStatements()
+    {
+        return preparedStatements;
+    }
+
     public Session toSession(SessionPropertyManager sessionPropertyManager)
     {
         return new Session(
@@ -194,6 +203,7 @@ public final class SessionRepresentation
                 startTime,
                 systemProperties,
                 catalogProperties,
-                sessionPropertyManager);
+                sessionPropertyManager,
+                preparedStatements);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
@@ -18,15 +18,12 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.metadata.ViewDefinition;
 import com.facebook.presto.security.AccessControl;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Analyzer;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
-import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.CreateView;
-import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.transaction.TransactionManager;
 import io.airlift.json.JsonCodec;
@@ -39,8 +36,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.metadata.ViewDefinition.ViewColumn;
-import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
-import static com.facebook.presto.sql.SqlFormatter.formatSql;
+import static com.facebook.presto.sql.SqlFormatter.getFormattedSql;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -87,7 +83,7 @@ public class CreateViewTask
 
         accessControl.checkCanCreateView(session.getRequiredTransactionId(), session.getIdentity(), name);
 
-        String sql = getFormattedSql(statement);
+        String sql = getFormattedSql(statement.getQuery(), sqlParser);
 
         Analysis analysis = analyzeStatement(statement, session, metadata);
 
@@ -107,25 +103,5 @@ public class CreateViewTask
     {
         Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.<QueryExplainer>empty(), experimentalSyntaxEnabled);
         return analyzer.analyze(statement);
-    }
-
-    private String getFormattedSql(CreateView statement)
-    {
-        Query query = statement.getQuery();
-        String sql = formatSql(query);
-
-        // verify round-trip
-        Statement parsed;
-        try {
-            parsed = sqlParser.createStatement(sql);
-        }
-        catch (ParsingException e) {
-            throw new PrestoException(INTERNAL_ERROR, "Formatted query does not parse: " + query);
-        }
-        if (!query.equals(parsed)) {
-            throw new PrestoException(INTERNAL_ERROR, "Query does not round-trip: " + query);
-        }
-
-        return sql;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
@@ -34,9 +34,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import static com.facebook.presto.execution.TaskUtils.getFormattedSql;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.metadata.ViewDefinition.ViewColumn;
-import static com.facebook.presto.sql.SqlFormatter.getFormattedSql;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;

--- a/presto-main/src/main/java/com/facebook/presto/execution/PrepareTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/PrepareTask.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.execution;
+
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Prepare;
+import com.facebook.presto.transaction.TransactionManager;
+import com.google.inject.Inject;
+
+import java.util.concurrent.CompletableFuture;
+
+import static com.facebook.presto.sql.SqlFormatter.getFormattedSql;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+public class PrepareTask
+        implements DataDefinitionTask<Prepare>
+{
+    private final SqlParser sqlParser;
+
+    @Inject
+    public PrepareTask(SqlParser sqlParser)
+    {
+        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return "PREPARE";
+    }
+
+    @Override
+    public String explain(Prepare statement)
+    {
+        return "PREPARE " + statement.getName();
+    }
+
+    @Override
+    public CompletableFuture<?> execute(Prepare prepare, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine)
+    {
+        String statementName = prepare.getName();
+        String queryString = getFormattedSql(prepare.getStatement(), sqlParser);
+        stateMachine.addPreparedStatement(statementName, queryString);
+        return completedFuture(null);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/PrepareTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/PrepareTask.java
@@ -23,7 +23,7 @@ import com.google.inject.Inject;
 
 import java.util.concurrent.CompletableFuture;
 
-import static com.facebook.presto.sql.SqlFormatter.getFormattedSql;
+import static com.facebook.presto.execution.TaskUtils.getFormattedSql;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -52,6 +52,7 @@ public class QueryInfo
     private final QueryStats queryStats;
     private final Map<String, String> setSessionProperties;
     private final Set<String> resetSessionProperties;
+    private final Map<String, String> addedPreparedStatements;
     private final Optional<TransactionId> startedTransactionId;
     private final boolean clearTransactionId;
     private final String updateType;
@@ -74,6 +75,7 @@ public class QueryInfo
             @JsonProperty("queryStats") QueryStats queryStats,
             @JsonProperty("setSessionProperties") Map<String, String> setSessionProperties,
             @JsonProperty("resetSessionProperties") Set<String> resetSessionProperties,
+            @JsonProperty("addedPreparedStatements") Map<String, String> addedPreparedStatements,
             @JsonProperty("startedTransactionId") Optional<TransactionId> startedTransactionId,
             @JsonProperty("clearTransactionId") boolean clearTransactionId,
             @JsonProperty("updateType") String updateType,
@@ -90,6 +92,7 @@ public class QueryInfo
         requireNonNull(queryStats, "queryStats is null");
         requireNonNull(setSessionProperties, "setSessionProperties is null");
         requireNonNull(resetSessionProperties, "resetSessionProperties is null");
+        requireNonNull(addedPreparedStatements, "addedPreparedStatemetns is null");
         requireNonNull(startedTransactionId, "startedTransactionId is null");
         requireNonNull(query, "query is null");
         requireNonNull(inputs, "inputs is null");
@@ -105,6 +108,7 @@ public class QueryInfo
         this.queryStats = queryStats;
         this.setSessionProperties = ImmutableMap.copyOf(setSessionProperties);
         this.resetSessionProperties = ImmutableSet.copyOf(resetSessionProperties);
+        this.addedPreparedStatements = ImmutableMap.copyOf(addedPreparedStatements);
         this.startedTransactionId = startedTransactionId;
         this.clearTransactionId = clearTransactionId;
         this.updateType = updateType;
@@ -179,6 +183,12 @@ public class QueryInfo
     public Set<String> getResetSessionProperties()
     {
         return resetSessionProperties;
+    }
+
+    @JsonProperty
+    public Map<String, String> getAddedPreparedStatements()
+    {
+        return addedPreparedStatements;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -19,6 +19,7 @@ import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.operator.BlockedReason;
 import com.facebook.presto.spi.ErrorCode;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.transaction.TransactionId;
@@ -55,6 +56,7 @@ import static com.facebook.presto.execution.QueryState.STARTING;
 import static com.facebook.presto.execution.QueryState.TERMINAL_QUERY_STATES;
 import static com.facebook.presto.execution.StageInfo.getAllStages;
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
+import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.util.Failures.toFailure;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.DataSize.Unit.BYTE;
@@ -99,6 +101,8 @@ public class QueryStateMachine
 
     private final Map<String, String> setSessionProperties = new ConcurrentHashMap<>();
     private final Set<String> resetSessionProperties = Sets.newConcurrentHashSet();
+
+    private final Map<String, String> addedPreparedStatements = new ConcurrentHashMap<>();
 
     private final AtomicReference<TransactionId> startedTransactionId = new AtomicReference<>();
     private final AtomicBoolean clearTransactionId = new AtomicBoolean();
@@ -342,6 +346,7 @@ public class QueryStateMachine
                 queryStats,
                 setSessionProperties,
                 resetSessionProperties,
+                addedPreparedStatements,
                 Optional.ofNullable(startedTransactionId.get()),
                 clearTransactionId.get(),
                 updateType.get(),
@@ -391,6 +396,25 @@ public class QueryStateMachine
     public void addResetSessionProperties(String name)
     {
         resetSessionProperties.add(requireNonNull(name, "name is null"));
+    }
+
+    public Map<String, String> getAddedPreparedStatements()
+    {
+        return addedPreparedStatements;
+    }
+
+    public void addPreparedStatement(String key, String value)
+    {
+        requireNonNull(key, "key is null");
+        requireNonNull(value, "value is null");
+
+        if (session.getPreparedStatements().containsKey(key)) {
+            throw new PrestoException(ALREADY_EXISTS, "Prepared statement already exists: " + key);
+        }
+        String previousValue = addedPreparedStatements.putIfAbsent(key, value);
+        if (previousValue != null) {
+            throw new PrestoException(ALREADY_EXISTS, "Prepared statement already exists: " + key);
+        }
     }
 
     public void setStartedTransactionId(TransactionId startedTransactionId)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -401,6 +401,7 @@ public final class SqlQueryExecution
                 queryInfo.getQueryStats(),
                 queryInfo.getSetSessionProperties(),
                 queryInfo.getResetSessionProperties(),
+                queryInfo.getAddedPreparedStatements(),
                 queryInfo.getStartedTransactionId(),
                 queryInfo.isClearTransactionId(),
                 queryInfo.getUpdateType(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.execution;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.sql.SqlFormatter;
+import com.facebook.presto.sql.parser.ParsingException;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Statement;
+
+import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
+
+public class TaskUtils
+{
+    private TaskUtils() {}
+
+    public static String getFormattedSql(Statement statement, SqlParser sqlParser)
+    {
+        String sql = SqlFormatter.formatSql(statement);
+
+        // verify round-trip
+        Statement parsed;
+        try {
+            parsed = sqlParser.createStatement(sql);
+        }
+        catch (ParsingException e) {
+            throw new PrestoException(INTERNAL_ERROR, "Formatted query does not parse: " + statement);
+        }
+        if (!statement.equals(parsed)) {
+            throw new PrestoException(INTERNAL_ERROR, "Query does not round-trip: " + statement);
+        }
+
+        return sql;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -25,6 +25,7 @@ import com.facebook.presto.execution.DropViewTask;
 import com.facebook.presto.execution.ForQueryExecution;
 import com.facebook.presto.execution.GrantTask;
 import com.facebook.presto.execution.NodeTaskMap;
+import com.facebook.presto.execution.PrepareTask;
 import com.facebook.presto.execution.QueryExecution;
 import com.facebook.presto.execution.QueryExecutionMBean;
 import com.facebook.presto.execution.QueryIdGenerator;
@@ -68,6 +69,7 @@ import com.facebook.presto.sql.tree.DropView;
 import com.facebook.presto.sql.tree.Explain;
 import com.facebook.presto.sql.tree.Grant;
 import com.facebook.presto.sql.tree.Insert;
+import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.RenameColumn;
 import com.facebook.presto.sql.tree.RenameTable;
@@ -205,6 +207,7 @@ public class CoordinatorModule
         bindDataDefinitionTask(binder, executionBinder, Rollback.class, RollbackTask.class);
         bindDataDefinitionTask(binder, executionBinder, Call.class, CallTask.class);
         bindDataDefinitionTask(binder, executionBinder, Grant.class, GrantTask.class);
+        bindDataDefinitionTask(binder, executionBinder, Prepare.class, PrepareTask.class);
 
         MapBinder<String, ExecutionPolicy> executionPolicyBinder = newMapBinder(binder, String.class, ExecutionPolicy.class);
         executionPolicyBinder.addBinding("all-at-once").to(AllAtOnceExecutionPolicy.class);

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceUtil.java
@@ -23,6 +23,8 @@ import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.TimeZoneNotSupportedException;
+import com.facebook.presto.sql.parser.ParsingException;
+import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.transaction.TransactionId;
 import com.google.common.base.Splitter;
 import com.google.common.collect.HashMultimap;
@@ -36,10 +38,13 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -48,6 +53,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CATALOG;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_LANGUAGE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SCHEMA;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SESSION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SOURCE;
@@ -138,6 +144,11 @@ final class ResourceUtil
             }
         }
 
+        Map<String, String> preparedStatements = new HashMap<>();
+        for (String preparedStatementsHeader : splitSessionHeader(servletRequest.getHeaders(PRESTO_PREPARED_STATEMENT))) {
+            parsePreparedStatementsHeader(preparedStatementsHeader, preparedStatements);
+        }
+        sessionBuilder.setPreparedStatements(preparedStatements);
         return sessionBuilder.build();
     }
 
@@ -201,6 +212,33 @@ final class ResourceUtil
         if (!expression) {
             throw badRequest(format(format, args));
         }
+    }
+
+    private static void parsePreparedStatementsHeader(String header, Map<String, String> preparedStatements)
+    {
+        List<String> nameValue = Splitter.on('=').limit(2).trimResults().splitToList(header);
+        assertRequest(nameValue.size() == 2, "Invalid %s header", PRESTO_PREPARED_STATEMENT);
+
+        String statementName;
+        String sqlString;
+        try {
+            statementName = URLDecoder.decode(nameValue.get(0), "UTF-8");
+            sqlString = URLDecoder.decode(nameValue.get(1), "UTF-8");
+        }
+        catch (UnsupportedEncodingException e) {
+            throw badRequest(e.getMessage());
+        }
+
+        // Validate statement
+        SqlParser sqlParser = new SqlParser();
+        try {
+            sqlParser.createStatement(sqlString);
+        }
+        catch (ParsingException e) {
+            throw badRequest(e.getMessage());
+        }
+
+        preparedStatements.put(statementName, sqlString);
     }
 
     private static TimeZoneKey getTimeZoneKey(String timeZoneId)

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -31,6 +31,7 @@ import com.facebook.presto.execution.DataDefinitionTask;
 import com.facebook.presto.execution.DropTableTask;
 import com.facebook.presto.execution.DropViewTask;
 import com.facebook.presto.execution.NodeTaskMap;
+import com.facebook.presto.execution.PrepareTask;
 import com.facebook.presto.execution.RenameColumnTask;
 import com.facebook.presto.execution.RenameTableTask;
 import com.facebook.presto.execution.ResetSessionTask;
@@ -111,6 +112,7 @@ import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
+import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.RenameColumn;
 import com.facebook.presto.sql.tree.RenameTable;
 import com.facebook.presto.sql.tree.ResetSession;
@@ -269,7 +271,8 @@ public class LocalQueryRunner
                 defaultSession.getStartTime(),
                 defaultSession.getSystemProperties(),
                 defaultSession.getCatalogProperties(),
-                metadata.getSessionPropertyManager());
+                metadata.getSessionPropertyManager(),
+                defaultSession.getPreparedStatements());
 
         dataDefinitionTask = ImmutableMap.<Class<? extends Statement>, DataDefinitionTask<?>>builder()
                 .put(CreateTable.class, new CreateTableTask())
@@ -280,6 +283,7 @@ public class LocalQueryRunner
                 .put(RenameTable.class, new RenameTableTask())
                 .put(ResetSession.class, new ResetSessionTask())
                 .put(SetSession.class, new SetSessionTask())
+                .put(Prepare.class, new PrepareTask(sqlParser))
                 .put(StartTransaction.class, new StartTransactionTask())
                 .put(Commit.class, new CommitTask())
                 .put(Rollback.class, new RollbackTask())

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestPrepareTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestPrepareTask.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.security.AllowAllAccessControl;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.AllColumns;
+import com.facebook.presto.sql.tree.Prepare;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.Query;
+import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.concurrent.ExecutorService;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.sql.QueryUtil.selectList;
+import static com.facebook.presto.sql.QueryUtil.simpleQuery;
+import static com.facebook.presto.sql.QueryUtil.table;
+import static com.facebook.presto.transaction.TransactionManager.createTestTransactionManager;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.testng.Assert.assertEquals;
+
+public class TestPrepareTask
+{
+    private final MetadataManager metadata = MetadataManager.createTestMetadataManager();
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stage-executor-%s"));
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testPrepare()
+    {
+        String statementName = "my_query";
+        Query query = simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("foo")));
+        String sqlString = "PREPARE my_query FROM SELECT * FROM foo";
+        QueryStateMachine stateMachine = executePrepare(statementName, query, sqlString, TEST_SESSION);
+        assertEquals(stateMachine.getAddedPreparedStatements(), ImmutableMap.of(statementName, "SELECT *\nFROM\n  foo\n"));
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testPrepareNameExists()
+    {
+        String statementName = "existing_query";
+        String query1 = "SELECT bar, baz from foo";
+        Session session = TEST_SESSION.withPreparedStatement(statementName, query1);
+
+        Query query2 = simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("foo")));
+        String sqlString = "PREPARE existing_query FROM SELECT * FROM foo";
+
+        executePrepare(statementName, query2, sqlString, session);
+    }
+
+    private QueryStateMachine executePrepare(String statementName, Query query, String sqlString, Session session)
+    {
+        TransactionManager transactionManager = createTestTransactionManager();
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), sqlString, session, URI.create("fake://uri"), false, transactionManager, executor);
+        Prepare prepare = new Prepare(statementName, query);
+        new PrepareTask(new SqlParser()).execute(prepare, transactionManager, metadata, new AllowAllAccessControl(), stateMachine);
+        return stateMachine;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/TestResourceUtil.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestResourceUtil.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.WebApplicationException;
 
 import java.util.Locale;
 
@@ -30,6 +31,7 @@ import static com.facebook.presto.SystemSessionProperties.HASH_PARTITION_COUNT;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CATALOG;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_LANGUAGE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SCHEMA;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SESSION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SOURCE;
@@ -55,6 +57,7 @@ public class TestResourceUtil
                         .put(PRESTO_TIME_ZONE, "Asia/Taipei")
                         .put(PRESTO_SESSION, QUERY_MAX_MEMORY + "=1GB")
                         .put(PRESTO_SESSION, DISTRIBUTED_JOIN + "=true," + HASH_PARTITION_COUNT + " = 43")
+                        .put(PRESTO_PREPARED_STATEMENT, "query1=select * from foo,query2=select * from bar")
                         .build(),
                 "testRemote");
 
@@ -73,5 +76,27 @@ public class TestResourceUtil
                 .put(DISTRIBUTED_JOIN, "true")
                 .put(HASH_PARTITION_COUNT, "43")
                 .build());
+        assertEquals(session.getPreparedStatements(), ImmutableMap.<String, String>builder()
+                .put("query1", "select * from foo")
+                .put("query2", "select * from bar")
+                .build());
+    }
+
+    @Test(expectedExceptions = WebApplicationException.class)
+    public void testPreparedStatementsHeaderDoesNotParse()
+            throws Exception
+    {
+        HttpServletRequest request = new MockHttpServletRequest(
+                ImmutableListMultimap.<String, String>builder()
+                        .put(PRESTO_USER, "testUser")
+                        .put(PRESTO_SOURCE, "testSource")
+                        .put(PRESTO_CATALOG, "testCatalog")
+                        .put(PRESTO_SCHEMA, "testSchema")
+                        .put(PRESTO_LANGUAGE, "zh-TW")
+                        .put(PRESTO_TIME_ZONE, "Asia/Taipei")
+                        .put(PRESTO_PREPARED_STATEMENT, "query1=abcdefg")
+                        .build(),
+                "testRemote");
+        createSessionForRequest(request, new AllowAllAccessControl(), new SessionPropertyManager(), new QueryId("test_query_id"));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.SystemSessionProperties.DISTRIBUTED_JOIN;
 import static com.facebook.presto.SystemSessionProperties.HASH_PARTITION_COUNT;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CATALOG;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SCHEMA;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SESSION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SOURCE;
@@ -97,6 +98,7 @@ public class TestServer
                 .setHeader(PRESTO_SCHEMA, "schema")
                 .addHeader(PRESTO_SESSION, QUERY_MAX_MEMORY + "=1GB")
                 .addHeader(PRESTO_SESSION, DISTRIBUTED_JOIN + "=true," + HASH_PARTITION_COUNT + " = 43")
+                .addHeader(PRESTO_PREPARED_STATEMENT, "foo=select * from bar")
                 .build();
 
         QueryResults queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
@@ -109,6 +111,11 @@ public class TestServer
                 .put(QUERY_MAX_MEMORY, "1GB")
                 .put(DISTRIBUTED_JOIN, "true")
                 .put(HASH_PARTITION_COUNT, "43")
+                .build());
+
+        // verify prepared statements
+        assertEquals(queryInfo.getSession().getPreparedStatements(), ImmutableMap.builder()
+                .put("foo", "select * from bar")
                 .build());
 
         ImmutableList.Builder<List<Object>> data = ImmutableList.builder();

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -70,6 +70,7 @@ statement
         (WHERE booleanExpression)?
         (ORDER BY sortItem (',' sortItem)*)?
         (LIMIT limit=(INTEGER_VALUE | ALL))?                           #showPartitions
+    | PREPARE identifier FROM statement                                #prepare
     ;
 
 query
@@ -578,6 +579,7 @@ READ: 'READ';
 WRITE: 'WRITE';
 ONLY: 'ONLY';
 CALL: 'CALL';
+PREPARE: 'PREPARE';
 
 NORMALIZE: 'NORMALIZE';
 NFD : 'NFD';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -13,8 +13,6 @@
  */
 package com.facebook.presto.sql;
 
-import com.facebook.presto.sql.parser.ParsingException;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.AddColumn;
 import com.facebook.presto.sql.tree.AliasedRelation;
 import com.facebook.presto.sql.tree.AllColumns;
@@ -65,7 +63,6 @@ import com.facebook.presto.sql.tree.ShowSession;
 import com.facebook.presto.sql.tree.ShowTables;
 import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.sql.tree.StartTransaction;
-import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TableSubquery;
 import com.facebook.presto.sql.tree.TransactionAccessMode;
@@ -902,24 +899,5 @@ public final class SqlFormatter
             Joiner.on(", ").appendTo(builder, columns);
             builder.append(')');
         }
-    }
-
-    public static String getFormattedSql(Statement statement, SqlParser sqlParser)
-    {
-        String sql = formatSql(statement);
-
-        // verify round-trip
-        Statement parsed;
-        try {
-            parsed = sqlParser.createStatement(sql);
-        }
-        catch (ParsingException e) {
-            throw new ParsingException("Formatted query does not parse: " + statement);
-        }
-        if (!statement.equals(parsed)) {
-            throw new ParsingException("Query does not round-trip: " + statement);
-        }
-
-        return sql;
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -81,6 +81,7 @@ import com.facebook.presto.sql.tree.NodeLocation;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullIfExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.Query;
@@ -314,6 +315,13 @@ class AstBuilder
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 visit(context.callArgument(), CallArgument.class));
+    }
+
+    @Override
+    public Node visitPrepare(SqlBaseParser.PrepareContext context)
+    {
+        String name = context.identifier().getText();
+        return new Prepare(getLocation(context), name, (Statement) visit(context.statement()));
     }
 
     // ********************** query expressions ********************

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -82,6 +82,11 @@ public abstract class AstVisitor<R, C>
         return visitNode(node, context);
     }
 
+    protected R visitPrepare(Prepare node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitQuery(Query node, C context)
     {
         return visitStatement(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Prepare.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Prepare.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class Prepare
+        extends Statement
+{
+    private final String name;
+    private final Statement statement;
+
+    public Prepare(NodeLocation location, String name, Statement statement)
+    {
+        this(Optional.of(location), name, statement);
+    }
+
+    public Prepare(String name, Statement statement)
+    {
+        this(Optional.empty(), name, statement);
+    }
+
+    private Prepare(Optional<NodeLocation> location, String name, Statement statement)
+    {
+        super(location);
+        this.name = requireNonNull(name, "name is null");
+        this.statement = requireNonNull(statement, "statement is null");
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public Statement getStatement()
+    {
+        return statement;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitPrepare(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, statement);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        Prepare o = (Prepare) obj;
+        return Objects.equals(name, o.name) &&
+                Objects.equals(statement, o.statement);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .add("statement", statement)
+                .toString();
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -63,6 +63,7 @@ import com.facebook.presto.sql.tree.NaturalJoin;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.Query;
@@ -1419,6 +1420,15 @@ public class TestSqlParser
                         new CallArgument("a", new LongLiteral("1")),
                         new CallArgument("b", new StringLiteral("go")),
                         new CallArgument(new LongLiteral("456")))));
+    }
+
+    @Test
+    public void testPrepare()
+    {
+        assertStatement("PREPARE myquery FROM select * from foo",
+                                new Prepare("myquery", simpleQuery(
+                                        selectList(new AllColumns()),
+                                        table(QualifiedName.of("foo")))));
     }
 
     private static void assertCast(String type)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4073,6 +4073,7 @@ public abstract class AbstractTestQueries
         assertExplainDdl("ALTER TABLE orders RENAME TO new_name");
         assertExplainDdl("ALTER TABLE orders RENAME COLUMN orderkey TO new_column_name");
         assertExplainDdl("SET SESSION foo = 'bar'");
+        assertExplainDdl("PREPARE my_query FROM SELECT * FROM orders", "PREPARE my_query");
         assertExplainDdl("RESET SESSION foo");
         assertExplainDdl("START TRANSACTION");
         assertExplainDdl("COMMIT");


### PR DESCRIPTION
This Pull request includes an implementation for PREPARE queries.  It is the first step for supporting prepared statements in presto.

Because Presto does not save session state, this was implemented in the same way that session variables are.  Prepared statements for a session are sent by the client via an http session header that the server parses and adds to its session.   When a prepare query is executed, it will be included in the response to the client via the X-Presto-Added-Prepare header so the client can maintain the session state.

Support for parameters is not added yet.