### PR TITLE
Support some of aggregation functions for interval types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AverageAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AverageAggregations.java
@@ -32,14 +32,28 @@ public final class AverageAggregations
     private AverageAggregations() {}
 
     @InputFunction
-    public static void input(LongAndDoubleState state, @SqlType(StandardTypes.BIGINT) long value)
+    public static void bigintInput(LongAndDoubleState state, @SqlType(StandardTypes.BIGINT) long value)
     {
         state.setLong(state.getLong() + 1);
         state.setDouble(state.getDouble() + value);
     }
 
     @InputFunction
-    public static void input(LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
+    public static void doubleInput(LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
+    {
+        state.setLong(state.getLong() + 1);
+        state.setDouble(state.getDouble() + value);
+    }
+
+    @InputFunction
+    public static void intervalDayToSecondInput(LongAndDoubleState state, @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long value)
+    {
+        state.setLong(state.getLong() + 1);
+        state.setDouble(state.getDouble() + value);
+    }
+
+    @InputFunction
+    public static void intervalYearToMonthInput(LongAndDoubleState state, @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long value)
     {
         state.setLong(state.getLong() + 1);
         state.setDouble(state.getDouble() + value);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GeometricMeanAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GeometricMeanAggregations.java
@@ -26,14 +26,28 @@ public final class GeometricMeanAggregations
     private GeometricMeanAggregations() {}
 
     @InputFunction
-    public static void input(LongAndDoubleState state, @SqlType(StandardTypes.BIGINT) long value)
+    public static void bigintInput(LongAndDoubleState state, @SqlType(StandardTypes.BIGINT) long value)
     {
         state.setLong(state.getLong() + 1);
         state.setDouble(state.getDouble() + Math.log(value));
     }
 
     @InputFunction
-    public static void input(LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
+    public static void doubleInputInput(LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
+    {
+        state.setLong(state.getLong() + 1);
+        state.setDouble(state.getDouble() + Math.log(value));
+    }
+
+    @InputFunction
+    public static void intervalDayToSecondInput(LongAndDoubleState state, @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long value)
+    {
+        state.setLong(state.getLong() + 1);
+        state.setDouble(state.getDouble() + Math.log(value));
+    }
+
+    @InputFunction
+    public static void intervalYearToMonth(LongAndDoubleState state, @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long value)
     {
         state.setLong(state.getLong() + 1);
         state.setDouble(state.getDouble() + Math.log(value));

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/VarianceAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/VarianceAggregation.java
@@ -39,6 +39,18 @@ public final class VarianceAggregation
         updateVarianceState(state, (double) value);
     }
 
+    @InputFunction
+    public static void intervalDayToSecondInput(VarianceState state, @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long value)
+    {
+        updateVarianceState(state, (double) value);
+    }
+
+    @InputFunction
+    public static void intervalYearToMonthInput(VarianceState state, @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long value)
+    {
+        updateVarianceState(state, (double) value);
+    }
+
     @CombineFunction
     public static void combine(VarianceState state, VarianceState otherState)
     {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondAverageAggregation.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+
+public class TestIntervalDayToSecondAverageAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_DAY_TIME.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double sum = 0;
+        for (int i = start; i < start + length; i++) {
+            sum += i;
+        }
+        return sum / length;
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "avg";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_DAY_TO_SECOND);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondGeometricMeanAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondGeometricMeanAggregation.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+
+public class TestIntervalDayToSecondGeometricMeanAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_DAY_TIME.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double product = 1.0d;
+        for (int i = start; i < start + length; i++) {
+            product *= i;
+        }
+        return Math.pow(product, 1.0d / length);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "geometric_mean";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_DAY_TO_SECOND);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondStdDevAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondStdDevAggregation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+
+public class TestIntervalDayToSecondStdDevAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_DAY_TIME.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length < 2) {
+            return null;
+        }
+
+        double[] values = new double[length];
+        for (int i = 0; i < length; i++) {
+            values[i] = start + i;
+        }
+
+        StandardDeviation stdDev = new StandardDeviation();
+        return stdDev.evaluate(values);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "stddev_samp";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_DAY_TO_SECOND);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondStdDevPopAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondStdDevPopAggregation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+
+public class TestIntervalDayToSecondStdDevPopAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_DAY_TIME.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double[] values = new double[length];
+        for (int i = 0; i < length; i++) {
+            values[i] = start + i;
+        }
+
+        StandardDeviation stdDev = new StandardDeviation(false);
+        return stdDev.evaluate(values);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "stddev_pop";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_DAY_TO_SECOND);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondVarianceAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondVarianceAggregation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.descriptive.moment.Variance;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+
+public class TestIntervalDayToSecondVarianceAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_DAY_TIME.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length < 2) {
+            return null;
+        }
+
+        double[] values = new double[length];
+        for (int i = 0; i < length; i++) {
+            values[i] = start + i;
+        }
+
+        Variance variance = new Variance();
+        return variance.evaluate(values);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "variance";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_DAY_TO_SECOND);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondVariancePopAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondVariancePopAggregation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.descriptive.moment.Variance;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+
+public class TestIntervalDayToSecondVariancePopAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_DAY_TIME.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double[] values = new double[length];
+        for (int i = 0; i < length; i++) {
+            values[i] = start + i;
+        }
+
+        Variance variance = new Variance(false);
+        return variance.evaluate(values);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "var_pop";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_DAY_TO_SECOND);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthAverageAggregation.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+
+public class TestIntervalYearToMonthAverageAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_YEAR_MONTH.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double sum = 0;
+        for (int i = start; i < start + length; i++) {
+            sum += i;
+        }
+        return sum / length;
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "avg";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_YEAR_TO_MONTH);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthGeometricMeanAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthGeometricMeanAggregation.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+
+public class TestIntervalYearToMonthGeometricMeanAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_YEAR_MONTH.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double product = 1.0d;
+        for (int i = start; i < start + length; i++) {
+            product *= i;
+        }
+        return Math.pow(product, 1.0d / length);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "geometric_mean";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_YEAR_TO_MONTH);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthStdDevAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthStdDevAggregation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+
+public class TestIntervalYearToMonthStdDevAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_YEAR_MONTH.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length < 2) {
+            return null;
+        }
+
+        double[] values = new double[length];
+        for (int i = 0; i < length; i++) {
+            values[i] = start + i;
+        }
+
+        StandardDeviation stdDev = new StandardDeviation();
+        return stdDev.evaluate(values);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "stddev_samp";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_YEAR_TO_MONTH);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthStdDevPopAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthStdDevPopAggregation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+
+public class TestIntervalYearToMonthStdDevPopAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_YEAR_MONTH.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double[] values = new double[length];
+        for (int i = 0; i < length; i++) {
+            values[i] = start + i;
+        }
+
+        StandardDeviation stdDev = new StandardDeviation(false);
+        return stdDev.evaluate(values);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "stddev_pop";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_YEAR_TO_MONTH);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthVarianceAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthVarianceAggregation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.descriptive.moment.Variance;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+
+public class TestIntervalYearToMonthVarianceAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_YEAR_MONTH.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length < 2) {
+            return null;
+        }
+
+        double[] values = new double[length];
+        for (int i = 0; i < length; i++) {
+            values[i] = start + i;
+        }
+
+        Variance variance = new Variance();
+        return variance.evaluate(values);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "variance";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_YEAR_TO_MONTH);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthVariancePopAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthVariancePopAggregation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.descriptive.moment.Variance;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+
+public class TestIntervalYearToMonthVariancePopAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_YEAR_MONTH.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double[] values = new double[length];
+        for (int i = 0; i < length; i++) {
+            values[i] = start + i;
+        }
+
+        Variance variance = new Variance(false);
+        return variance.evaluate(values);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "var_pop";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_YEAR_TO_MONTH);
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3897,13 +3897,19 @@ public abstract class AbstractTestQueries
         });
 
         assertTrue(functions.containsKey("avg"), "Expected function names " + functions + " to contain 'avg'");
-        assertEquals(functions.get("avg").asList().size(), 2);
+        assertEquals(functions.get("avg").asList().size(), 4);
         assertEquals(functions.get("avg").asList().get(0).getField(1), "double");
         assertEquals(functions.get("avg").asList().get(0).getField(2), "bigint");
         assertEquals(functions.get("avg").asList().get(0).getField(3), "aggregate");
         assertEquals(functions.get("avg").asList().get(1).getField(1), "double");
         assertEquals(functions.get("avg").asList().get(1).getField(2), "double");
-        assertEquals(functions.get("avg").asList().get(0).getField(3), "aggregate");
+        assertEquals(functions.get("avg").asList().get(1).getField(3), "aggregate");
+        assertEquals(functions.get("avg").asList().get(2).getField(1), "double");
+        assertEquals(functions.get("avg").asList().get(2).getField(2), "interval day to second");
+        assertEquals(functions.get("avg").asList().get(2).getField(3), "aggregate");
+        assertEquals(functions.get("avg").asList().get(3).getField(1), "double");
+        assertEquals(functions.get("avg").asList().get(3).getField(2), "interval year to month");
+        assertEquals(functions.get("avg").asList().get(3).getField(3), "aggregate");
 
         assertTrue(functions.containsKey("abs"), "Expected function names " + functions + " to contain 'abs'");
         assertEquals(functions.get("abs").asList().get(0).getField(3), "scalar");


### PR DESCRIPTION
#4417

I re-used existing aggregation implementations for all of them. 

Functions:
- variance
- stddev
- var_pop
- stddev_pop
- avg
- geometric_mean

Please note that I haven't done manual testing for all of them, other than running some queries like `select avg(INTERVAL '123-3' YEAR TO MONTH);`
