### PR TITLE
cassandra: Add support for Cassandra 3.0 with the Cassandra 3 driver.

### DIFF
--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <cassandra.version>2.1.0</cassandra.version>
-        <datastax.version>2.1.5</datastax.version>
+        <datastax.version>3.0.0</datastax.version>
     </properties>
 
     <dependencies>
@@ -26,6 +26,22 @@
               <exclusion>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-buffer</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
               </exclusion>
             </exclusions>
         </dependency>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <cassandra.version>2.1.0</cassandra.version>
+        <cassandra.version>2.1.6</cassandra.version>
         <datastax.version>3.0.0</datastax.version>
     </properties>
 

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/BackoffRetryPolicy.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/BackoffRetryPolicy.java
@@ -13,9 +13,11 @@
  */
 package com.facebook.presto.cassandra;
 
+import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.WriteType;
+import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
 import com.datastax.driver.core.policies.RetryPolicy;
 
@@ -58,4 +60,16 @@ public class BackoffRetryPolicy
     {
         return DefaultRetryPolicy.INSTANCE.onWriteTimeout(statement, cl, writeType, requiredAcks, receivedAcks, nbRetry);
     }
+
+    @Override
+    public RetryDecision onRequestError(Statement statement, ConsistencyLevel cl, DriverException e, int nbRetry)
+    {
+        return RetryDecision.tryNextHost(cl);
+    }
+
+    @Override
+    public void init(Cluster cluster) {}
+
+    @Override
+    public void close() {}
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
@@ -105,7 +105,7 @@ public class CassandraRecordCursor
             case COUNTER:
                 return currentRow.getLong(i);
             case TIMESTAMP:
-                return currentRow.getDate(i).getTime();
+                return currentRow.getTimestamp(i).getTime();
             default:
                 throw new IllegalStateException("Cannot retrieve long for " + getCassandraType(i));
         }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
@@ -204,7 +204,7 @@ public enum CassandraType
                 case TIMEUUID:
                     return NullableValue.of(nativeType, utf8Slice(row.getUUID(i).toString()));
                 case TIMESTAMP:
-                    return NullableValue.of(nativeType, row.getDate(i).getTime());
+                    return NullableValue.of(nativeType, row.getTimestamp(i).getTime());
                 case INET:
                     return NullableValue.of(nativeType, utf8Slice(toAddrString(row.getInet(i))));
                 case VARINT:
@@ -325,7 +325,7 @@ public enum CassandraType
                 case TIMEUUID:
                     return row.getUUID(i).toString();
                 case TIMESTAMP:
-                    return Long.toString(row.getDate(i).getTime());
+                    return Long.toString(row.getTimestamp(i).getTime());
                 case INET:
                     return CassandraCqlUtils.quoteStringLiteral(toAddrString(row.getInet(i)));
                 case VARINT:

--- a/presto-cassandra/src/test/java/com/datastax/driver/core/RowUtil.java
+++ b/presto-cassandra/src/test/java/com/datastax/driver/core/RowUtil.java
@@ -28,7 +28,7 @@ public final class RowUtil
 
     public static Row createSingleStringRow(String value, int protocolVersion)
     {
-        ColumnDefinitions definitions = new ColumnDefinitions(new Definition[] {new Definition("keyspace", "table", "column", DataType.ascii())});
+        ColumnDefinitions definitions = new ColumnDefinitions(new Definition[] {new Definition("keyspace", "table", "column", DataType.ascii())}, CodecRegistry.DEFAULT_INSTANCE);
         ByteBuffer data = ByteBuffer.wrap(value.getBytes(UTF_8));
         return ArrayBackedRow.fromData(definitions, null, ProtocolVersion.fromInt(protocolVersion), ImmutableList.of(data));
     }

--- a/presto-cassandra/src/test/java/com/datastax/driver/core/TestHost.java
+++ b/presto-cassandra/src/test/java/com/datastax/driver/core/TestHost.java
@@ -20,6 +20,6 @@ public class TestHost
 {
     public TestHost(InetSocketAddress address)
     {
-        super(address, new ConvictionPolicy.DefaultConvictionPolicy.Factory(), null);
+        super(address, new ConvictionPolicy.DefaultConvictionPolicy.Factory(), Cluster.builder().addContactPoints("localhost").build().manager);
     }
 }

--- a/presto-cassandra/src/test/java/com/datastax/driver/core/TestHost.java
+++ b/presto-cassandra/src/test/java/com/datastax/driver/core/TestHost.java
@@ -20,6 +20,6 @@ public class TestHost
 {
     public TestHost(InetSocketAddress address)
     {
-        super(address, new ConvictionPolicy.Simple.Factory(), null);
+        super(address, new ConvictionPolicy.DefaultConvictionPolicy.Factory(), null);
     }
 }


### PR DESCRIPTION
This PR brings support for Cassandra 3.x to Presto. The datastax-core driver API was changed in version 3, and this PR updates presto to match the new API.

According to http://datastax.github.io/java-driver/manual/native_protocol/, the driver should also support older clusters, such as 2.1 and 2.2.

This fixes #4364