### PR TITLE
Cassandra: Don't use Count(*) to estimate partition columns in Cassandra >=2.2 (Fixes #4014)

### DIFF
--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <cassandra.version>2.1.0</cassandra.version>
-        <datastax.version>2.1.5</datastax.version>
+        <datastax.version>3.0.0</datastax.version>
     </properties>
 
     <dependencies>
@@ -26,6 +26,22 @@
               <exclusion>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-buffer</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
               </exclusion>
             </exclusions>
         </dependency>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <cassandra.version>2.1.0</cassandra.version>
+        <cassandra.version>2.1.6</cassandra.version>
         <datastax.version>3.0.0</datastax.version>
     </properties>
 

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/BackoffRetryPolicy.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/BackoffRetryPolicy.java
@@ -13,9 +13,11 @@
  */
 package com.facebook.presto.cassandra;
 
+import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.WriteType;
+import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
 import com.datastax.driver.core.policies.RetryPolicy;
 
@@ -58,4 +60,16 @@ public class BackoffRetryPolicy
     {
         return DefaultRetryPolicy.INSTANCE.onWriteTimeout(statement, cl, writeType, requiredAcks, receivedAcks, nbRetry);
     }
+
+    @Override
+    public RetryDecision onRequestError(Statement statement, ConsistencyLevel cl, DriverException e, int nbRetry)
+    {
+        return RetryDecision.tryNextHost(cl);
+    }
+
+    @Override
+    public void init(Cluster cluster) {}
+
+    @Override
+    public void close() {}
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
@@ -105,7 +105,7 @@ public class CassandraRecordCursor
             case COUNTER:
                 return currentRow.getLong(i);
             case TIMESTAMP:
-                return currentRow.getDate(i).getTime();
+                return currentRow.getTimestamp(i).getTime();
             default:
                 throw new IllegalStateException("Cannot retrieve long for " + getCassandraType(i));
         }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
@@ -24,6 +24,7 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.VersionNumber;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.querybuilder.Clause;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
@@ -396,6 +397,18 @@ public class CassandraSession
         partitionKeys.setFetchSize(fetchSizeForPartitionKeySelect);
 
         if (!fullPartitionKey) {
+            Set<Host> clusterHosts = getSession(schemaName).getCluster().getMetadata().getAllHosts();
+            if (!clusterHosts.isEmpty()) {
+                VersionNumber v = clusterHosts.iterator().next().getCassandraVersion();
+                // Cassandra 2.2 changes the functionality of COUNT(*) to be
+                // more like SQL standard. COUNT(*) can no longer
+                // be used to see if a table has <limitForPartitionKeySelect partitions.
+                // See CASSANDRA-8216
+                if (v.getMajor() >= 3 || (v.getMajor() == 2 && v.getMinor() >= 2)) {
+                    return null;
+                }
+            }
+
             addWhereClause(partitionKeys.where(), partitionKeyColumns, new ArrayList<>());
             ResultSetFuture partitionKeyFuture = executeWithSession(schemaName, new SessionCallable<ResultSetFuture>() {
                 @Override

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
@@ -204,7 +204,7 @@ public enum CassandraType
                 case TIMEUUID:
                     return NullableValue.of(nativeType, utf8Slice(row.getUUID(i).toString()));
                 case TIMESTAMP:
-                    return NullableValue.of(nativeType, row.getDate(i).getTime());
+                    return NullableValue.of(nativeType, row.getTimestamp(i).getTime());
                 case INET:
                     return NullableValue.of(nativeType, utf8Slice(toAddrString(row.getInet(i))));
                 case VARINT:
@@ -325,7 +325,7 @@ public enum CassandraType
                 case TIMEUUID:
                     return row.getUUID(i).toString();
                 case TIMESTAMP:
-                    return Long.toString(row.getDate(i).getTime());
+                    return Long.toString(row.getTimestamp(i).getTime());
                 case INET:
                     return CassandraCqlUtils.quoteStringLiteral(toAddrString(row.getInet(i)));
                 case VARINT:

--- a/presto-cassandra/src/test/java/com/datastax/driver/core/RowUtil.java
+++ b/presto-cassandra/src/test/java/com/datastax/driver/core/RowUtil.java
@@ -28,7 +28,7 @@ public final class RowUtil
 
     public static Row createSingleStringRow(String value, int protocolVersion)
     {
-        ColumnDefinitions definitions = new ColumnDefinitions(new Definition[] {new Definition("keyspace", "table", "column", DataType.ascii())});
+        ColumnDefinitions definitions = new ColumnDefinitions(new Definition[] {new Definition("keyspace", "table", "column", DataType.ascii())}, CodecRegistry.DEFAULT_INSTANCE);
         ByteBuffer data = ByteBuffer.wrap(value.getBytes(UTF_8));
         return ArrayBackedRow.fromData(definitions, null, ProtocolVersion.fromInt(protocolVersion), ImmutableList.of(data));
     }

--- a/presto-cassandra/src/test/java/com/datastax/driver/core/TestHost.java
+++ b/presto-cassandra/src/test/java/com/datastax/driver/core/TestHost.java
@@ -20,6 +20,6 @@ public class TestHost
 {
     public TestHost(InetSocketAddress address)
     {
-        super(address, new ConvictionPolicy.DefaultConvictionPolicy.Factory(), null);
+        super(address, new ConvictionPolicy.DefaultConvictionPolicy.Factory(), Cluster.builder().addContactPoints("localhost").build().manager);
     }
 }

--- a/presto-cassandra/src/test/java/com/datastax/driver/core/TestHost.java
+++ b/presto-cassandra/src/test/java/com/datastax/driver/core/TestHost.java
@@ -20,6 +20,6 @@ public class TestHost
 {
     public TestHost(InetSocketAddress address)
     {
-        super(address, new ConvictionPolicy.Simple.Factory(), null);
+        super(address, new ConvictionPolicy.DefaultConvictionPolicy.Factory(), null);
     }
 }


### PR DESCRIPTION
The changes are primarily in 1bf48e6, as this PR depends on #4525.

Previously, the Cassandra connection would do an `SELECT * FROM x WHERE pk IN (a,b)` is the number of partition keys were less than 200. In Cassandra < 2.2, the query `SELECT COUNT(*) FROM x LIMIT 200` would return at most 200 if there were more than 200 rows. 

In Cassandra 2.2 ([CASSANDRA-8216](https://issues.apache.org/jira/browse/CASSANDRA-8216)) this behavior was changed, and now COUNT(*) accurately returns all the rows in the table. Not only is this slow, but the logic in the code also assumed that if the number of rows returned was anything but 200 it would only query (up to) 200 partitions (Which is what caused #4014). 

This PR simply disables this optimization for Cassandra 2.2+. In the future, For table scans Presto should also move away from the thrift API and move towards the `size_estimates` which should reduce needs to optimizations like this. 