### PR TITLE
Fixed memory accounting for hash_build_concurrency

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/InMemoryJoinHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InMemoryJoinHash.java
@@ -43,7 +43,7 @@ public final class InMemoryJoinHash
     private final int[] positionLinks;
     private final long size;
 
-    public InMemoryJoinHash(LongArrayList addresses, PagesHashStrategy pagesHashStrategy)
+    public InMemoryJoinHash(LongArrayList addresses, PagesHashStrategy pagesHashStrategy, int hashBuildConcurrency)
     {
         this.addresses = requireNonNull(addresses, "addresses is null");
         this.pagesHashStrategy = requireNonNull(pagesHashStrategy, "pagesHashStrategy is null");
@@ -52,7 +52,7 @@ public final class InMemoryJoinHash
         // reserve memory for the arrays
         int hashSize = HashCommon.arraySize(addresses.size(), 0.75f);
         size = sizeOfIntArray(hashSize) + sizeOfBooleanArray(hashSize) + sizeOfIntArray(addresses.size())
-                +  sizeOf(addresses.elements()) + pagesHashStrategy.getSizeInBytes();
+                +  sizeOf(addresses.elements()) + pagesHashStrategy.getSizeInBytes() / hashBuildConcurrency;
 
         mask = hashSize - 1;
         key = new int[hashSize];

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -66,6 +66,7 @@ public class PagesIndex
     private final List<Type> types;
     private final LongArrayList valueAddresses;
     private final ObjectArrayList<Block>[] channels;
+    private final int hashBuildConcurrency;
 
     private int nextBlockToCompact;
     private int positionCount;
@@ -74,6 +75,12 @@ public class PagesIndex
 
     public PagesIndex(List<Type> types, int expectedPositions)
     {
+        this(types, expectedPositions, 1);
+    }
+
+    public PagesIndex(List<Type> types, int expectedPositions, int hashBuildConcurrency)
+    {
+        this.hashBuildConcurrency = hashBuildConcurrency;
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
         this.valueAddresses = new LongArrayList(expectedPositions);
 
@@ -360,7 +367,8 @@ public class PagesIndex
             LookupSource lookupSource = lookupSourceFactory.createLookupSource(
                     valueAddresses,
                     ImmutableList.<List<Block>>copyOf(channels),
-                    hashChannel);
+                    hashChannel,
+                    hashBuildConcurrency);
 
             return lookupSource;
         }
@@ -375,7 +383,7 @@ public class PagesIndex
                 joinChannels,
                 hashChannel);
 
-        return new InMemoryJoinHash(valueAddresses, hashStrategy);
+        return new InMemoryJoinHash(valueAddresses, hashStrategy, hashBuildConcurrency);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/ParallelHashBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ParallelHashBuilder.java
@@ -206,7 +206,7 @@ public class ParallelHashBuilder
             parallelStreamMask = partitionFutures.size() - 1;
             partitions = new PagesIndex[partitionFutures.size()];
             for (int partition = 0; partition < partitions.length; partition++) {
-                this.partitions[partition] = new PagesIndex(types, expectedPositions);
+                this.partitions[partition] = new PagesIndex(types, expectedPositions, partitions.length);
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
@@ -613,18 +613,18 @@ public class JoinCompiler
         {
             this.pagesHashStrategyFactory = pagesHashStrategyFactory;
             try {
-                constructor = lookupSourceClass.getConstructor(LongArrayList.class, PagesHashStrategy.class);
+                constructor = lookupSourceClass.getConstructor(LongArrayList.class, PagesHashStrategy.class, int.class);
             }
             catch (NoSuchMethodException e) {
                 throw Throwables.propagate(e);
             }
         }
 
-        public LookupSource createLookupSource(LongArrayList addresses, List<List<Block>> channels, Optional<Integer> hashChannel)
+        public LookupSource createLookupSource(LongArrayList addresses, List<List<Block>> channels, Optional<Integer> hashChannel, int hashBuildConcurrency)
         {
             PagesHashStrategy pagesHashStrategy = pagesHashStrategyFactory.createPagesHashStrategy(channels, hashChannel);
             try {
-                return constructor.newInstance(addresses, pagesHashStrategy);
+                return constructor.newInstance(addresses, pagesHashStrategy, hashBuildConcurrency);
             }
             catch (Exception e) {
                 throw Throwables.propagate(e);

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinProbeCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinProbeCompiler.java
@@ -109,7 +109,7 @@ public class TestJoinProbeCompiler
             hashChannel = Optional.of(1);
             channels = ImmutableList.of(channel, hashChannelBuilder.build());
         }
-        LookupSource lookupSource = lookupSourceFactoryFactory.createLookupSource(addresses, channels, hashChannel);
+        LookupSource lookupSource = lookupSourceFactoryFactory.createLookupSource(addresses, channels, hashChannel, 1);
 
         JoinProbeCompiler joinProbeCompiler = new JoinProbeCompiler();
         JoinProbeFactory probeFactory = joinProbeCompiler.internalCompileJoinProbe(types, Ints.asList(0), hashChannel);


### PR DESCRIPTION
Fixed bug that was accounting the same memory for build table multiple times when using ParallelHashBuilder (task_hash_build_concurrency > 1)