### PR TITLE
Fix null handling when reading Parquet lists

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -944,6 +944,7 @@ public class ParquetHiveRecordCursor
         private final BlockConverter elementConverter;
 
         private BlockBuilder builder;
+        private int startingPosition;
 
         public ParquetListEntryConverter(Type prestoType, String columnName, GroupType elementType)
         {
@@ -981,12 +982,17 @@ public class ParquetHiveRecordCursor
         public void start()
         {
             elementConverter.beforeValue(builder);
+            startingPosition = builder.getPositionCount();
         }
 
         @Override
         public void end()
         {
             elementConverter.afterValue();
+            //we have read nothing, this means there is a null element in this list
+            if (builder.getPositionCount() == startingPosition) {
+                builder.appendNull();
+            }
         }
 
         @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -273,6 +273,10 @@ public abstract class AbstractTestHiveFileFormats
                     getStandardMapObjectInspector(javaStringObjectInspector, javaStringObjectInspector),
                     asMap("k1", null, "k2", "v2"),
                     mapBlockOf(VARCHAR, VARCHAR, new String[] {"k1", "k2"}, new String[] {null, "v2"})))
+            .add(new TestColumn("t_array_string_starting_with_nulls", getStandardListObjectInspector(javaStringObjectInspector), Arrays.asList(null, "test"), arrayBlockOf(VARCHAR, null, "test")))
+            .add(new TestColumn("t_array_string_with_nulls_in_between", getStandardListObjectInspector(javaStringObjectInspector), Arrays.asList("test-1", null, "test-2"), arrayBlockOf(VARCHAR, "test-1", null, "test-2")))
+            .add(new TestColumn("t_array_string_ending_with_nulls", getStandardListObjectInspector(javaStringObjectInspector), Arrays.asList("test", null), arrayBlockOf(VARCHAR, "test", null)))
+            .add(new TestColumn("t_array_string_all_nulls", getStandardListObjectInspector(javaStringObjectInspector), Arrays.asList(null, null, null), arrayBlockOf(VARCHAR, null, null, null)))
             .build();
 
     private static <K, V> Map<K, V> asMap(K k1, V v1, K k2, V v2)


### PR DESCRIPTION
Currently `ParquetHiveRecordCursor` doesn't properly handle `null`s when reading lists. This PR fixes that.

@zhenxiao @dain can you please review?