### PR TITLE
Add support for filtering tasks table by stage id

### DIFF
--- a/presto-main/src/main/resources/webapp/query.html
+++ b/presto-main/src/main/resources/webapp/query.html
@@ -547,7 +547,7 @@ function precisionRound(n) {
 }
 
 function renderTable(id, data) {
-    var body = d3.select('#' + id).append("tbody");
+    var body = d3.select('#' + id).append("tbody").attr("class", "filterable");
 
     var rows = body.selectAll("tr")
             .data(data)
@@ -568,6 +568,31 @@ function renderTable(id, data) {
                     return d["sortableString"];
                 }
             });
+}
+
+var currentFilterStageId = null;
+
+function filterTaskTable(stageIdToFilter) {
+    if (currentFilterStageId != null && currentFilterStageId == stageIdToFilter) {
+        resetTaskTableFilter();
+        currentFilterStageId = null;
+        return;
+    }
+    else {
+        currentFilterStageId = stageIdToFilter;
+    }
+
+    $('.filterable tr').hide();
+    $('.filterable tr').filter(function () {
+        var taskId = $(this).find('td.sorted').text();
+        var stageTaskId = removeQueryId(taskId);
+        var currentStageId = stageTaskId.split('.')[0];
+        return currentStageId == stageIdToFilter;
+    }).show();
+}
+
+function resetTaskTableFilter() {
+    $('.filterable tr').show();
 }
 
 function renderStagesTree(source) {
@@ -638,7 +663,10 @@ function renderStagesTree(source) {
                 .attr("r", 1e-6)
                 .style("fill", function (d) {
                     return d._children ? "lightsteelblue" : "#fff";
-                });
+                })
+                .on("click", function (d) {
+                    return filterTaskTable(removeQueryId(d.stageId))
+                 });
 
         nodeEnter.append("svg:text")
                 .attr("x", function (d) {


### PR DESCRIPTION
If a query has a lot of tasks and a large number of stages, it may be hard to identify the tasks that belong to a particular stage (although sorting the tasks table definitely helps). This PR adds additional support for easy navigation of the tasks table. In particular it adds support for filtering the tasks table when the user clicks on a stage in the query details page. Another click on the same stage resets the filter.

Before:

![image](https://cloud.githubusercontent.com/assets/1223839/13538772/45eb028e-e201-11e5-80c7-54a4d7b9b7b2.png)

After the user clicks stage 7 in the "Stages" tree:

![image](https://cloud.githubusercontent.com/assets/1223839/13538783/562104dc-e201-11e5-88bb-58962d602456.png)
