### PR TITLE
Skip add splits on completed remote source

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -199,6 +199,9 @@ public final class SqlStageExecution
         checkArgument(remoteSource != null, "Unknown remote source %s. Known sources are %s", exchangeLocation.getPlanFragmentId(), exchangeSources.keySet());
 
         exchangeLocations.put(remoteSource.getId(), exchangeLocation.getUri());
+        if (completeSources.contains(remoteSource.getId())) {
+            return;
+        }
         for (RemoteTask task : getAllTasks()) {
             task.addSplits(remoteSource.getId(), ImmutableList.of(createRemoteSplitFor(task.getTaskInfo().getTaskId(), exchangeLocation.getUri())));
         }


### PR DESCRIPTION
When we run a query combined `UNION` and `JOIN` with the `phased_execution` policy, it constantly causes the `IllegalStateException`. The error plan node id keeps changing but the same exception occurs. At the `all-at-once` policy, it doesn't fail.

I feel like there's race condition or an unexpected condition on the `phased_execution` 

The query works with this pull request.
```
java.lang.IllegalStateException: noMoreSplits has already been set for 192
	at com.google.common.base.Preconditions.checkState(Preconditions.java:197)
	at com.facebook.presto.server.HttpRemoteTask.addSplits(HttpRemoteTask.java:286)
	at com.facebook.presto.execution.SqlStageExecution.addExchangeLocation(SqlStageExecution.java:203)
	at com.facebook.presto.execution.scheduler.SqlQueryScheduler$StageLinkage.processScheduleResults(SqlQueryScheduler.java:435)
	at com.facebook.presto.execution.scheduler.SqlQueryScheduler.schedule(SqlQueryScheduler.java:332)
	at com.facebook.presto.execution.scheduler.SqlQueryScheduler$$Lambda$1019/1688017528.run(Unknown Source)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```