### PR TITLE
Migrate array_sort() to new scalar framework

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -57,6 +57,7 @@ import com.facebook.presto.operator.scalar.ArrayNotEqualOperator;
 import com.facebook.presto.operator.scalar.ArrayPositionFunction;
 import com.facebook.presto.operator.scalar.ArrayRemoveFunction;
 import com.facebook.presto.operator.scalar.ArraySliceFunction;
+import com.facebook.presto.operator.scalar.ArraySortFunction;
 import com.facebook.presto.operator.scalar.BitwiseFunctions;
 import com.facebook.presto.operator.scalar.ColorFunctions;
 import com.facebook.presto.operator.scalar.CombineHashFunction;
@@ -174,7 +175,6 @@ import static com.facebook.presto.operator.scalar.ArrayFlattenFunction.ARRAY_FLA
 import static com.facebook.presto.operator.scalar.ArrayJoin.ARRAY_JOIN;
 import static com.facebook.presto.operator.scalar.ArrayJoin.ARRAY_JOIN_WITH_NULL_REPLACEMENT;
 import static com.facebook.presto.operator.scalar.ArrayLessThanOperator.ARRAY_LESS_THAN;
-import static com.facebook.presto.operator.scalar.ArraySortFunction.ARRAY_SORT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArraySubscriptOperator.ARRAY_SUBSCRIPT;
 import static com.facebook.presto.operator.scalar.ArrayToArrayCast.ARRAY_TO_ARRAY_CAST;
 import static com.facebook.presto.operator.scalar.ArrayToElementConcatFunction.ARRAY_TO_ELEMENT_CONCAT_FUNCTION;
@@ -391,6 +391,7 @@ public class FunctionRegistry
                 .scalar(ArrayGreaterThanOperator.class)
                 .scalar(ArrayGreaterThanOrEqualOperator.class)
                 .scalar(ArrayElementAtFunction.class)
+                .scalar(ArraySortFunction.class)
                 .scalar(ArrayMinFunction.class)
                 .scalar(ArrayMaxFunction.class)
                 .scalar(ArrayDistinctFunction.class)
@@ -414,7 +415,7 @@ public class FunctionRegistry
                 .function(MAP_HASH_CODE)
                 .function(MAP_ELEMENT_AT)
                 .function(ARRAY_FLATTEN_FUNCTION)
-                .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_SORT_FUNCTION, ARRAY_TO_JSON, JSON_TO_ARRAY)
+                .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_TO_JSON, JSON_TO_ARRAY)
                 .functions(MAP_CONSTRUCTOR, MAP_SUBSCRIPT, MAP_TO_JSON, JSON_TO_MAP)
                 .functions(MAP_AGG, MULTIMAP_AGG)
                 .functions(DECIMAL_TO_VARCHAR_CAST, DECIMAL_TO_INTEGER_CAST, DECIMAL_TO_BIGINT_CAST, DECIMAL_TO_DOUBLE_CAST, DECIMAL_TO_BOOLEAN_CAST)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySort.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySort.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.FunctionListBuilder;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.PageProcessor;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.ExpressionCompiler;
+import com.facebook.presto.sql.relational.CallExpression;
+import com.facebook.presto.sql.relational.ConstantExpression;
+import com.facebook.presto.sql.relational.InputReferenceExpression;
+import com.facebook.presto.sql.relational.RowExpression;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.SqlType;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkArraySort
+{
+    private static final int POSITIONS = 100_000;
+    private static final int ARRAY_SIZE = 100;
+    private static final int NUM_TYPES = 1;
+    private static final List<Type> TYPES = ImmutableList.of(VARCHAR);
+
+    static {
+        Verify.verify(NUM_TYPES == TYPES.size());
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS * ARRAY_SIZE * NUM_TYPES)
+    public Object arraySort(BenchmarkData data)
+            throws Throwable
+    {
+        int position = 0;
+        List<Page> pages = new ArrayList<>();
+        while (position < data.getPage().getPositionCount()) {
+            position = data.getPageProcessor().process(SESSION, data.getPage(), position, data.getPage().getPositionCount(), data.getPageBuilder());
+            pages.add(data.getPageBuilder().build());
+            data.getPageBuilder().reset();
+        }
+        return pages;
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"array_sort", "old_array_sort"})
+        private String name = "array_sort";
+
+        private PageBuilder pageBuilder;
+        private Page page;
+        private PageProcessor pageProcessor;
+
+        @Setup
+        public void setup()
+        {
+            MetadataManager metadata = MetadataManager.createTestMetadataManager();
+            metadata.addFunctions(new FunctionListBuilder(metadata.getTypeManager()).scalar(BenchmarkArraySort.class).getFunctions());
+            ExpressionCompiler compiler = new ExpressionCompiler(metadata);
+            ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
+            Block[] blocks = new Block[TYPES.size()];
+            for (int i = 0; i < TYPES.size(); i++) {
+                Type elementType = TYPES.get(i);
+                ArrayType arrayType = new ArrayType(elementType);
+                Signature signature = new Signature(name, FunctionKind.SCALAR, arrayType.getTypeSignature(), arrayType.getTypeSignature());
+                projectionsBuilder.add(new CallExpression(signature, arrayType, ImmutableList.of(new InputReferenceExpression(i, arrayType))));
+                blocks[i] = createChannel(POSITIONS, ARRAY_SIZE, arrayType);
+            }
+
+            ImmutableList<RowExpression> projections = projectionsBuilder.build();
+            pageProcessor = compiler.compilePageProcessor(new ConstantExpression(true, BooleanType.BOOLEAN), projections).get();
+            pageBuilder = new PageBuilder(projections.stream().map(RowExpression::getType).collect(Collectors.toList()));
+            page = new Page(blocks);
+        }
+
+        private static Block createChannel(int positionCount, int arraySize, ArrayType arrayType)
+        {
+            BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+            for (int position = 0; position < positionCount; position++) {
+                BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+                for (int i = 0; i < arraySize; i++) {
+                    if (arrayType.getElementType().getJavaType() == long.class) {
+                        arrayType.getElementType().writeLong(entryBuilder, ThreadLocalRandom.current().nextLong());
+                    }
+                    else if (arrayType.getElementType().equals(VARCHAR)) {
+                        arrayType.getElementType().writeSlice(entryBuilder, Slices.utf8Slice("test_string"));
+                    }
+                    else {
+                        throw new UnsupportedOperationException();
+                    }
+                }
+                blockBuilder.closeEntry();
+            }
+            return blockBuilder.build();
+        }
+
+        public PageProcessor getPageProcessor()
+        {
+            return pageProcessor;
+        }
+
+        public Page getPage()
+        {
+            return page;
+        }
+
+        public PageBuilder getPageBuilder()
+        {
+            return pageBuilder;
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkArraySort().arraySort(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkArraySort.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+
+    @ScalarFunction
+    @SqlType("array(varchar)")
+    public static Block oldArraySort(@SqlType("array(varchar)") Block block)
+    {
+        List<Integer> positions = Ints.asList(new int[block.getPositionCount()]);
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            positions.set(i, i);
+        }
+
+        Collections.sort(positions, new Comparator<Integer>()
+        {
+            @Override
+            public int compare(Integer p1, Integer p2)
+            {
+                //TODO: This could be quite slow, it should use parametric equals
+                return VARCHAR.compareTo(block, p1, block, p2);
+            }
+        });
+
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount());
+
+        for (int position : positions) {
+            VARCHAR.appendTo(block, position, blockBuilder);
+        }
+
+        return blockBuilder.build();
+    }
+}


### PR DESCRIPTION
Migrate array_sort() to new scalar framework, and a benchmark to show the performance improvement:
```
Benchmark                             (name)    Mode  Cnt    Score   Error Units
BenchmarkArraySort.arraySort      array_sort    avgt   20  108.867 ± 4.888 ns/op
BenchmarkArraySort.arraySort  old_array_sort    avgt   20  120.720 ± 6.268 ns/op
```