### PR TITLE
Fix dictionary fallback detection.

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/ParquetPredicateUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/ParquetPredicateUtils.java
@@ -21,6 +21,7 @@ import com.facebook.presto.hive.parquet.predicate.TupleDomainParquetPredicate.Co
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
@@ -46,11 +47,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static parquet.column.Encoding.BIT_PACKED;
+import static parquet.column.Encoding.PLAIN_DICTIONARY;
+import static parquet.column.Encoding.RLE;
+
 public final class ParquetPredicateUtils
 {
-    // definition level, repetition level, value
-    private static final int PARQUET_DATA_TRIPLE = 3;
-
     private ParquetPredicateUtils()
     {
     }
@@ -188,14 +190,37 @@ public final class ParquetPredicateUtils
                 .anyMatch(columnName::equals);
     }
 
-    private static boolean isOnlyDictionaryEncodingPages(Set<Encoding> encodings)
+    @VisibleForTesting
+    @SuppressWarnings("deprecation")
+    static boolean isOnlyDictionaryEncodingPages(Set<Encoding> encodings)
     {
-        // more than 1 encodings for values
-        if (encodings.size() > PARQUET_DATA_TRIPLE) {
+        // TODO: update to use EncodingStats in ColumnChunkMetaData when available
+        if (encodings.contains(PLAIN_DICTIONARY)) {
+            // PLAIN_DICTIONARY was present, which means at least one page was
+            // dictionary-encoded and 1.0 encodings are used
+            int expectedEncodings = 1; // for PLAIN_DICTIONARY
+
+            // RLE and BIT_PACKED are only used for repetition or definition levels
+            if (encodings.contains(RLE)) {
+                expectedEncodings += 1;
+            }
+
+            if (encodings.contains(BIT_PACKED)) {
+                expectedEncodings += 1;
+            }
+
+            if (encodings.size() > expectedEncodings) {
+                return false; // no encodings other than dictionary or rep/def levels
+            }
+
+            return true;
+        }
+        else {
+            // if PLAIN_DICTIONARY wasn't present, then either the column is not
+            // dictionary-encoded, or the 2.0 encoding, RLE_DICTIONARY, was used.
+            // for 2.0, this cannot determine whether a page fell back without
+            // page encoding stats
             return false;
         }
-        // definition level, repetition level never have dictionary encoding
-        // TODO: add PageEncodingStats in ColumnChunkMetaData
-        return encodings.stream().anyMatch(Encoding::usesDictionary);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.predicate;
+
+import parquet.column.Encoding;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.isOnlyDictionaryEncodingPages;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestParquetPredicateUtils
+{
+    @Test
+    public void testDictionaryEncodingCasesV1()
+    {
+        Set<Encoding> required = new HashSet<>();
+        required.add(Encoding.BIT_PACKED); // max rl = 0, max dl = 0
+        Set<Encoding> optional = new HashSet<>();
+        optional.add(Encoding.BIT_PACKED); // max rl = 0
+        optional.add(Encoding.RLE);        // max dl = 1
+        Set<Encoding> repeated = new HashSet<>();
+        repeated.add(Encoding.RLE);        // max rl = 1, dl = 1
+
+        Set<Encoding> plain = new HashSet<>();
+        plain.add(Encoding.PLAIN);               // no dictionary pages
+        Set<Encoding> fallback = new HashSet<>();
+        fallback.add(Encoding.PLAIN_DICTIONARY); // some dictionary-encoded data pages
+        fallback.add(Encoding.PLAIN);            // some non-dictionary data pages
+        Set<Encoding> dictionary = new HashSet<>();
+        dictionary.add(Encoding.PLAIN_DICTIONARY); // both dictionary and data pages use PLAIN_DICTIONARY
+
+        assertFalse(isOnlyDictionaryEncodingPages(union(required, plain)), "required plain");
+        assertFalse(isOnlyDictionaryEncodingPages(union(optional, plain)), "optional plain");
+        assertFalse(isOnlyDictionaryEncodingPages(union(repeated, plain)), "repeated plain");
+        assertFalse(isOnlyDictionaryEncodingPages(union(required, fallback)), "required fallback");
+        assertFalse(isOnlyDictionaryEncodingPages(union(optional, fallback)), "optional fallback");
+        assertFalse(isOnlyDictionaryEncodingPages(union(repeated, fallback)), "repeated fallback");
+        assertTrue(isOnlyDictionaryEncodingPages(union(required, dictionary)), "required dictionary");
+        assertTrue(isOnlyDictionaryEncodingPages(union(optional, dictionary)), "optional dictionary");
+        assertTrue(isOnlyDictionaryEncodingPages(union(repeated, dictionary)), "repeated dictionary");
+    }
+
+    private <T> Set<T> union(Set<T> s1, Set<T> s2)
+    {
+        Set<T> r = new HashSet<>();
+        r.addAll(s1);
+        r.addAll(s2);
+        return r;
+    }
+}


### PR DESCRIPTION
This commit updates the dictionary-encoding fallback detection for Parquet so that it will no longer skip row groups that appear not to match a query based on the dictionary, but have non-dictionary data pages that do match.

This fixes #4778.