### PR TITLE
Fix `hive.orc.stream-buffer-size` property usage.

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -59,7 +59,7 @@ public final class HiveSessionProperties
                 dataSizeSessionProperty(
                         ORC_STREAM_BUFFER_SIZE,
                         "ORC: Size of buffer for streaming reads",
-                        config.getOrcMaxBufferSize(),
+                        config.getOrcStreamBufferSize(),
                         false),
                 booleanSessionProperty(
                         PARQUET_OPTIMIZED_READER_ENABLED,


### PR DESCRIPTION
The property was unused but it seems like it was intended to be used
as default of `orc_stream_buffer_size` session property in the same
manner as the `hive.orc.max-buffer-size` is used as default for
`orc_max_buffer_size`.

This looks like typo in 1376164ce3de09c555d9e370bbacf5cf293fe9a5.