### PR TITLE
Don't return taskInfo when task is deleted

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
@@ -163,25 +163,17 @@ public class TaskResource
 
     @DELETE
     @Path("{taskId}")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response deleteTask(@PathParam("taskId") TaskId taskId,
+    public void deleteTask(@PathParam("taskId") TaskId taskId,
             @QueryParam("abort") @DefaultValue("true") boolean abort,
             @Context UriInfo uriInfo)
     {
         requireNonNull(taskId, "taskId is null");
 
-        TaskInfo taskInfo;
         if (abort) {
-            taskInfo = taskManager.abortTask(taskId);
+            taskManager.abortTask(taskId);
+            return;
         }
-        else {
-            taskInfo = taskManager.cancelTask(taskId);
-        }
-
-        if (shouldSummarize(uriInfo)) {
-            taskInfo = taskInfo.summarize();
-        }
-        return Response.ok(taskInfo).build();
+        taskManager.cancelTask(taskId);
     }
 
     @GET


### PR DESCRIPTION
Value returned by this call is not used and taskInfo can be quite large.