### PR TITLE
Add support for non-equi outer joins (v1)

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
@@ -26,6 +26,7 @@ import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.testing.NullOutputOperator.NullOutputOperatorFactory;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
 
 import java.util.List;
@@ -73,7 +74,7 @@ public class HashBuildAndJoinBenchmark
         }
 
         // hash build
-        HashBuilderOperatorFactory hashBuilder = new HashBuilderOperatorFactory(2, new PlanNodeId("test"), source.getTypes(), Ints.asList(0), hashChannel, 1_500_000);
+        HashBuilderOperatorFactory hashBuilder = new HashBuilderOperatorFactory(2, new PlanNodeId("test"), source.getTypes(), ImmutableMap.of(), Ints.asList(0), hashChannel, Optional.empty(), 1_500_000);
         driversBuilder.add(hashBuilder);
         DriverFactory hashBuildDriverFactory = new DriverFactory(true, false, driversBuilder.build());
         Driver hashBuildDriver = hashBuildDriverFactory.createDriver(taskContext.addPipelineContext(true, false).addDriverContext());
@@ -89,7 +90,7 @@ public class HashBuildAndJoinBenchmark
             hashChannel = Optional.of(2);
         }
 
-        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceSupplier(), source.getTypes(), Ints.asList(0), hashChannel);
+        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceSupplier(), source.getTypes(), Ints.asList(0), hashChannel, Optional.empty());
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test"), joinOperator.getTypes()));
         DriverFactory joinDriverFactory = new DriverFactory(true, true, joinDriversBuilder.build());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
@@ -21,6 +21,7 @@ import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
 
 import java.util.List;
@@ -40,7 +41,7 @@ public class HashBuildBenchmark
     protected List<Driver> createDrivers(TaskContext taskContext)
     {
         OperatorFactory ordersTableScan = createTableScanOperator(0, new PlanNodeId("test"), "orders", "orderkey", "totalprice");
-        HashBuilderOperatorFactory hashBuilder = new HashBuilderOperatorFactory(1, new PlanNodeId("test"), ordersTableScan.getTypes(), Ints.asList(0), Optional.empty(), 1_500_000);
+        HashBuilderOperatorFactory hashBuilder = new HashBuilderOperatorFactory(1, new PlanNodeId("test"), ordersTableScan.getTypes(), ImmutableMap.of(), Ints.asList(0), Optional.empty(), Optional.empty(), 1_500_000);
 
         DriverFactory driverFactory = new DriverFactory(true, true, ordersTableScan, hashBuilder);
         Driver driver = driverFactory.createDriver(taskContext.addPipelineContext(true, true).addDriverContext());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
@@ -25,6 +25,7 @@ import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.testing.NullOutputOperator.NullOutputOperatorFactory;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
 
 import java.util.List;
@@ -52,7 +53,7 @@ public class HashJoinBenchmark
     {
         if (lookupSourceSupplier == null) {
             OperatorFactory ordersTableScan = createTableScanOperator(0, new PlanNodeId("test"), "orders", "orderkey", "totalprice");
-            HashBuilderOperatorFactory hashBuilder = new HashBuilderOperatorFactory(1, new PlanNodeId("test"), ordersTableScan.getTypes(), Ints.asList(0), Optional.empty(), 1_500_000);
+            HashBuilderOperatorFactory hashBuilder = new HashBuilderOperatorFactory(1, new PlanNodeId("test"), ordersTableScan.getTypes(), ImmutableMap.of(), Ints.asList(0), Optional.empty(), Optional.empty(), 1_500_000);
 
             DriverContext driverContext = taskContext.addPipelineContext(false, false).addDriverContext();
             Driver driver = new DriverFactory(false, false, ordersTableScan, hashBuilder).createDriver(driverContext);
@@ -64,7 +65,7 @@ public class HashJoinBenchmark
 
         OperatorFactory lineItemTableScan = createTableScanOperator(0, new PlanNodeId("test"), "lineitem", "orderkey", "quantity");
 
-        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(1, new PlanNodeId("test"), lookupSourceSupplier, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty());
+        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(1, new PlanNodeId("test"), lookupSourceSupplier, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty(), Optional.empty());
 
         NullOutputOperatorFactory output = new NullOutputOperatorFactory(2, new PlanNodeId("test"), joinOperator.getTypes());
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -62,7 +62,7 @@ public class HashBuilderOperator
                     requireNonNull(types, "types is null"),
                     requireNonNull(layout, "layout is null"));
 
-            Preconditions.checkArgument(!hashChannels.isEmpty(), "hashChannels is empty");
+            Preconditions.checkArgument(!hashChannels.isEmpty() || filterFunction.isPresent(), "hashChannels is empty and filterFunction is not set");
             this.hashChannels = ImmutableList.copyOf(requireNonNull(hashChannels, "hashChannels is null"));
             this.hashChannel = requireNonNull(hashChannel, "hashChannel is null");
             this.filterFunction = requireNonNull(filterFunction, "filterFunction is null");
@@ -130,7 +130,7 @@ public class HashBuilderOperator
 
         this.lookupSourceSupplier = requireNonNull(lookupSourceSupplier, "hashSupplier is null");
 
-        Preconditions.checkArgument(!hashChannels.isEmpty(), "hashChannels is empty");
+        Preconditions.checkArgument(!hashChannels.isEmpty() || filterFunction.isPresent(), "hashChannels is empty and filterFunction is not set");
         this.hashChannels = ImmutableList.copyOf(requireNonNull(hashChannels, "hashChannels is null"));
         this.hashChannel = requireNonNull(hashChannel, "hashChannel is null");
         this.filterFunction = requireNonNull(filterFunction, "filterFunction is null");

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinFilterFunction.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.Block;
+
+public interface JoinFilterFunction extends FilterFunction
+{
+    boolean filter(int leftPosition, Block[] leftBlocks, int rightPosition,  Block[] rightBlocks);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinProbe.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 
 public interface JoinProbe
@@ -24,4 +25,8 @@ public interface JoinProbe
     long getCurrentJoinPosition();
 
     void appendTo(PageBuilder pageBuilder);
+
+    int getPosition();
+
+    Page getPage();
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -202,7 +202,7 @@ public class LookupJoinOperator
             lookupSource.appendTo(joinPosition, pageBuilder, probe.getChannelCount());
 
             // get next join position for this row
-            joinPosition = lookupSource.getNextJoinPosition(joinPosition);
+            joinPosition = lookupSource.getNextJoinPosition(joinPosition, probe.getPosition(), probe.getPage());
             if (pageBuilder.isFull()) {
                 return false;
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
@@ -50,9 +50,7 @@ public class LookupJoinOperatorFactory
         this.lookupSourceSupplier = lookupSourceSupplier;
         this.probeTypes = probeTypes;
         this.joinType = joinType;
-
         this.joinProbeFactory = joinProbeFactory;
-
         this.types = ImmutableList.<Type>builder()
                 .addAll(probeTypes)
                 .addAll(lookupSourceSupplier.getTypes())

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinProbeCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.sql.tree.Expression;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,23 +36,23 @@ public class LookupJoinOperators
 
     private static final JoinProbeCompiler JOIN_PROBE_COMPILER = new JoinProbeCompiler();
 
-    public static OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceSupplier lookupSourceSupplier, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public static OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceSupplier lookupSourceSupplier, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<Expression> filterFunction)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceSupplier, probeTypes, probeJoinChannel, probeHashChannel, JoinType.INNER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceSupplier, probeTypes, probeJoinChannel, probeHashChannel, JoinType.INNER, filterFunction.isPresent());
     }
 
-    public static OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceSupplier lookupSourceSupplier, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public static OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceSupplier lookupSourceSupplier, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<Expression> filterFunction)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceSupplier, probeTypes, probeJoinChannel, probeHashChannel, JoinType.PROBE_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceSupplier, probeTypes, probeJoinChannel, probeHashChannel, JoinType.PROBE_OUTER, filterFunction.isPresent());
     }
 
-    public static OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceSupplier lookupSourceSupplier, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public static OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceSupplier lookupSourceSupplier, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<Expression> filterFunction)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceSupplier, probeTypes, probeJoinChannel, probeHashChannel, JoinType.LOOKUP_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceSupplier, probeTypes, probeJoinChannel, probeHashChannel, JoinType.LOOKUP_OUTER, filterFunction.isPresent());
     }
 
-    public static OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceSupplier lookupSourceSupplier, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public static OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceSupplier lookupSourceSupplier, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<Expression> filterFunction)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceSupplier, probeTypes, probeJoinChannel, probeHashChannel, JoinType.FULL_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceSupplier, probeTypes, probeJoinChannel, probeHashChannel, JoinType.FULL_OUTER, filterFunction.isPresent());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupOuterOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupOuterOperator.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -28,6 +29,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -248,6 +250,12 @@ public class LookupOuterOperator
         }
 
         @Override
+        public Map<Symbol, Integer> getLayout()
+        {
+            return lookupSourceSupplier.getLayout();
+        }
+
+        @Override
         public ListenableFuture<LookupSource> getLookupSource(OperatorContext operatorContext)
         {
             // wrapper lookup source to track used positions
@@ -346,9 +354,9 @@ public class LookupOuterOperator
         }
 
         @Override
-        public long getJoinPosition(int position, Page page)
+        public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage)
         {
-            return lookupSource.getJoinPosition(position, page);
+            return lookupSource.getJoinPosition(position, hashChannelsPage, allChannelsPage);
         }
 
         @Override
@@ -358,15 +366,15 @@ public class LookupOuterOperator
         }
 
         @Override
-        public long getNextJoinPosition(long currentPosition)
+        public long getNextJoinPosition(long currentJoinPosition, int probePosition, Page allProbeChannelsPage)
         {
-            return lookupSource.getNextJoinPosition(currentPosition);
+            return lookupSource.getNextJoinPosition(currentJoinPosition, probePosition, allProbeChannelsPage);
         }
 
         @Override
-        public long getJoinPosition(int position, Page page, int rawHash)
+        public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage, int rawHash)
         {
-            return lookupSource.getJoinPosition(position, page, rawHash);
+            return lookupSource.getJoinPosition(position, hashChannelsPage, allChannelsPage, rawHash);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
@@ -27,11 +27,11 @@ public interface LookupSource
 
     int getJoinPositionCount();
 
-    long getJoinPosition(int position, Page page, int rawHash);
+    long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage, int rawHash);
 
-    long getJoinPosition(int position, Page page);
+    long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage);
 
-    long getNextJoinPosition(long currentPosition);
+    long getNextJoinPosition(long currentJoinPosition, int probePosition, Page allProbeChannelsPage);
 
     void appendTo(long position, PageBuilder pageBuilder, int outputChannelOffset);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceSupplier.java
@@ -14,13 +14,17 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
+import java.util.Map;
 
 public interface LookupSourceSupplier
 {
     List<Type> getTypes();
+
+    Map<Symbol, Integer> getLayout();
 
     ListenableFuture<LookupSource> getLookupSource(OperatorContext operatorContext);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesHashStrategy.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
 
+import java.util.Optional;
+
 public interface PagesHashStrategy
 {
     /**
@@ -57,6 +59,7 @@ public interface PagesHashStrategy
      * Compares the hashed columns in this PagesHashStrategy to the values in the specified blocks.  The
      * values are compared positionally, so {@code rightBlocks} must have the same number of entries as
      * the hashed columns and each entry is expected to be the same type.
+     * {@code rightBlocks} is used if join uses filter function and must contain all columns from probe side of join.
      */
     @Deprecated
     boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Block... rightBlocks);
@@ -72,4 +75,14 @@ public interface PagesHashStrategy
      * Compares the hashed columns in this PagesHashStrategy at the specified positions.
      */
     boolean positionEqualsPosition(int leftBlockIndex, int leftPosition, int rightBlockIndex, int rightPosition);
+
+    /**
+     * Returns filter function assigned to this PagesHashStrategy.
+     */
+    Optional<JoinFilterFunction> getFilterFunction();
+
+    /**
+     * Checks result of filter function for given row.
+     */
+    boolean checkFilterFunction(int leftBlockIndex, int leftPosition, int rightPosition, Block[] allRightBlocks);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/ParallelLookupSourceSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ParallelLookupSourceSupplier.java
@@ -14,12 +14,15 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
@@ -30,14 +33,16 @@ public final class ParallelLookupSourceSupplier
         implements LookupSourceSupplier
 {
     private final List<Type> types;
+    private final Map<Symbol, Integer> layout;
     private final List<Type> hashChannelTypes;
     private final ListenableFuture<LookupSource> lookupSourceFuture;
     private final List<? extends ListenableFuture<SharedLookupSource>> partitions;
     private final AtomicInteger referenceCount = new AtomicInteger(1);
 
-    public ParallelLookupSourceSupplier(List<Type> types, List<Integer> hashChannels, List<? extends ListenableFuture<SharedLookupSource>> partitions)
+    public ParallelLookupSourceSupplier(List<Type> types, Map<Symbol, Integer> layout, List<Integer> hashChannels, List<? extends ListenableFuture<SharedLookupSource>> partitions)
     {
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        this.layout = ImmutableMap.copyOf(requireNonNull(layout, "layout is null"));
         this.partitions = requireNonNull(partitions, "partitions is null");
 
         hashChannelTypes = hashChannels.stream()
@@ -54,6 +59,12 @@ public final class ParallelLookupSourceSupplier
     public List<Type> getTypes()
     {
         return types;
+    }
+
+    @Override
+    public Map<Symbol, Integer> getLayout()
+    {
+        return layout;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
@@ -63,17 +63,17 @@ public class PartitionedLookupSource
     }
 
     @Override
-    public long getJoinPosition(int position, Page page)
+    public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage)
     {
-        return getJoinPosition(position, page, hashGenerator.hashPosition(position, page));
+        return getJoinPosition(position, hashChannelsPage, allChannelsPage, hashGenerator.hashPosition(position, hashChannelsPage));
     }
 
     @Override
-    public long getJoinPosition(int position, Page page, int rawHash)
+    public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage, int rawHash)
     {
         int partition = murmurHash3(rawHash) & partitionMask;
         LookupSource lookupSource = lookupSources[partition];
-        long joinPosition = lookupSource.getJoinPosition(position, page, rawHash);
+        long joinPosition = lookupSource.getJoinPosition(position, hashChannelsPage, allChannelsPage, rawHash);
         if (joinPosition < 0) {
             return joinPosition;
         }
@@ -81,12 +81,12 @@ public class PartitionedLookupSource
     }
 
     @Override
-    public long getNextJoinPosition(long partitionedJoinPosition)
+    public long getNextJoinPosition(long currentJoinPosition, int probePosition, Page allProbeChannelsPage)
     {
-        int partition = (int) (partitionedJoinPosition & partitionMask);
-        long joinPosition = partitionedJoinPosition >>> lookupSources.length;
+        int partition = (int) (currentJoinPosition & partitionMask);
+        long joinPosition = currentJoinPosition >>> lookupSources.length;
         LookupSource lookupSource = lookupSources[partition];
-        long nextJoinPosition = lookupSource.getNextJoinPosition(joinPosition);
+        long nextJoinPosition = lookupSource.getNextJoinPosition(joinPosition, probePosition, allProbeChannelsPage);
         if (nextJoinPosition < 0) {
             return nextJoinPosition;
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/SettableLookupSourceSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SettableLookupSourceSupplier.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -22,6 +24,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -32,18 +35,26 @@ public final class SettableLookupSourceSupplier
         implements LookupSourceSupplier
 {
     private final List<Type> types;
+    private final ImmutableMap<Symbol, Integer> layout;
     private final SettableFuture<SharedLookupSource> lookupSourceFuture = SettableFuture.create();
     private final AtomicInteger referenceCount = new AtomicInteger(1);
 
-    public SettableLookupSourceSupplier(List<Type> types)
+    public SettableLookupSourceSupplier(List<Type> types, Map<Symbol, Integer> layout)
     {
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        this.layout = ImmutableMap.copyOf(requireNonNull(layout, "layout is null"));
     }
 
     @Override
     public List<Type> getTypes()
     {
         return types;
+    }
+
+    @Override
+    public Map<Symbol, Integer> getLayout()
+    {
+        return layout;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/SharedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SharedLookupSource.java
@@ -56,21 +56,21 @@ public final class SharedLookupSource
     }
 
     @Override
-    public long getJoinPosition(int position, Page page, int rawHash)
+    public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage, int rawHash)
     {
-        return lookupSource.getJoinPosition(position, page, rawHash);
+        return lookupSource.getJoinPosition(position, hashChannelsPage, allChannelsPage, rawHash);
     }
 
     @Override
-    public long getJoinPosition(int position, Page page)
+    public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage)
     {
-        return lookupSource.getJoinPosition(position, page);
+        return lookupSource.getJoinPosition(position, hashChannelsPage, allChannelsPage);
     }
 
     @Override
-    public long getNextJoinPosition(long currentPosition)
+    public long getNextJoinPosition(long currentJoinPosition, int probePosition, Page allProbeChannelsPage)
     {
-        return lookupSource.getNextJoinPosition(currentPosition);
+        return lookupSource.getNextJoinPosition(currentJoinPosition, probePosition, allProbeChannelsPage);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimpleJoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimpleJoinProbe.java
@@ -74,7 +74,7 @@ public class SimpleJoinProbe
             probeBlocks[i] = blocks[probeJoinChannels.get(i)];
         }
         this.page = page;
-        this.probePage = new Page(probeBlocks);
+        this.probePage = new Page(page.getPositionCount(), probeBlocks);
         this.probeHashBlock = hashChannel.isPresent() ? Optional.of(page.getBlock(hashChannel.get())) : Optional.empty();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimpleJoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimpleJoinProbe.java
@@ -52,6 +52,7 @@ public class SimpleJoinProbe
     private final int positionCount;
     private final Block[] blocks;
     private final Block[] probeBlocks;
+    private final Page page;
     private final Page probePage;
     private final Optional<Block> probeHashBlock;
 
@@ -72,6 +73,7 @@ public class SimpleJoinProbe
         for (int i = 0; i < probeJoinChannels.size(); i++) {
             probeBlocks[i] = blocks[probeJoinChannels.get(i)];
         }
+        this.page = page;
         this.probePage = new Page(probeBlocks);
         this.probeHashBlock = hashChannel.isPresent() ? Optional.of(page.getBlock(hashChannel.get())) : Optional.empty();
     }
@@ -107,9 +109,9 @@ public class SimpleJoinProbe
         }
         if (probeHashBlock.isPresent()) {
             int rawHash = (int) BIGINT.getLong(probeHashBlock.get(), position);
-            return lookupSource.getJoinPosition(position, probePage, rawHash);
+            return lookupSource.getJoinPosition(position, probePage, page, rawHash);
         }
-        return lookupSource.getJoinPosition(position, probePage);
+        return lookupSource.getJoinPosition(position, probePage, page);
     }
 
     private boolean currentRowContainsNull()
@@ -120,5 +122,17 @@ public class SimpleJoinProbe
             }
         }
         return false;
+    }
+
+    @Override
+    public int getPosition()
+    {
+        return position;
+    }
+
+    @Override
+    public Page getPage()
+    {
+        return page;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
@@ -32,6 +32,7 @@ import static java.util.Objects.requireNonNull;
 public class SimplePagesHashStrategy
         implements PagesHashStrategy
 {
+    private static final Block[] EMPTY_BLOCK_ARRAY = new Block[0];
     private final List<Type> types;
     private final List<List<Block>> channels;
     private final List<Block[]> channelArrays;

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
@@ -20,11 +20,13 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.type.TypeUtils;
 import com.google.common.collect.ImmutableList;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class SimplePagesHashStrategy
@@ -32,13 +34,18 @@ public class SimplePagesHashStrategy
 {
     private final List<Type> types;
     private final List<List<Block>> channels;
+    private final List<Block[]> channelArrays;
     private final List<Integer> hashChannels;
     private final List<Block> precomputedHashChannel;
+    private final Optional<JoinFilterFunction> filterFunction;
 
-    public SimplePagesHashStrategy(List<Type> types, List<List<Block>> channels, List<Integer> hashChannels, Optional<Integer> precomputedHashChannel)
+    public SimplePagesHashStrategy(List<Type> types, List<List<Block>> channels, List<Integer> hashChannels, Optional<Integer> precomputedHashChannel, Optional<JoinFilterFunction> filterFunction)
     {
+        this.filterFunction = filterFunction;
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
         this.channels = ImmutableList.copyOf(requireNonNull(channels, "channels is null"));
+        channelArrays = buildChannelArrays(channels);
+
         checkArgument(types.size() == channels.size(), "Expected types and channels to be the same length");
         this.hashChannels = ImmutableList.copyOf(requireNonNull(hashChannels, "hashChannels is null"));
         if (precomputedHashChannel.isPresent()) {
@@ -47,6 +54,24 @@ public class SimplePagesHashStrategy
         else {
             this.precomputedHashChannel = null;
         }
+    }
+
+    private List<Block[]> buildChannelArrays(List<List<Block>> channels)
+    {
+        if (channels.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        int pagesCount = channels.get(0).size();
+        List<Block[]> channelArrays = new ArrayList<>();
+        for (int i = 0; i < pagesCount; ++i) {
+            Block[] blocks = new Block[channels.size()];
+            for (int j = 0; j < channels.size(); ++j) {
+                blocks[j] = channels.get(j).get(i);
+            }
+            channelArrays.add(blocks);
+        }
+        return channelArrays;
     }
 
     @Override
@@ -107,6 +132,7 @@ public class SimplePagesHashStrategy
     @Override
     public boolean rowEqualsRow(int leftPosition, Block[] leftBlocks, int rightPosition, Block[] rightBlocks)
     {
+        checkState(!filterFunction.isPresent(), "filterFunction not supported for rowEqualsRow");
         for (int i = 0; i < hashChannels.size(); i++) {
             int hashChannel = hashChannels.get(i);
             Type type = types.get(hashChannel);
@@ -120,13 +146,13 @@ public class SimplePagesHashStrategy
     }
 
     @Override
-    public boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Block... rightBlocks)
+    public boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Block[] rightHashBlocks)
     {
         for (int i = 0; i < hashChannels.size(); i++) {
             int hashChannel = hashChannels.get(i);
             Type type = types.get(hashChannel);
             Block leftBlock = channels.get(hashChannel).get(leftBlockIndex);
-            Block rightBlock = rightBlocks[i];
+            Block rightBlock = rightHashBlocks[i];
             if (!TypeUtils.positionEqualsPosition(type, leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
@@ -135,13 +161,13 @@ public class SimplePagesHashStrategy
     }
 
     @Override
-    public boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Page page, int[] rightChannels)
+    public boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Page page, int[] rightHashChannels)
     {
         for (int i = 0; i < hashChannels.size(); i++) {
             int hashChannel = hashChannels.get(i);
             Type type = types.get(hashChannel);
             Block leftBlock = channels.get(hashChannel).get(leftBlockIndex);
-            Block rightBlock = page.getBlock(rightChannels[i]);
+            Block rightBlock = page.getBlock(rightHashChannels[i]);
             if (!TypeUtils.positionEqualsPosition(type, leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
@@ -161,7 +187,18 @@ public class SimplePagesHashStrategy
                 return false;
             }
         }
-
         return true;
+    }
+
+    @Override
+    public Optional<JoinFilterFunction> getFilterFunction()
+    {
+        return filterFunction;
+    }
+
+    @Override
+    public boolean checkFilterFunction(int leftBlockIndex, int leftPosition, int rightPosition, Block[] allRightBlocks)
+    {
+        return filterFunction.get().filter(leftPosition, channelArrays.get(leftBlockIndex), rightPosition, allRightBlocks);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/TwoChannelJoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TwoChannelJoinProbe.java
@@ -63,6 +63,7 @@ public class TwoChannelJoinProbe
     private final Block probeBlockA;
     private final Block probeBlockB;
     private final Block[] probeBlocks;
+    private final Page page;
     private final Page probePage;
     private int position = -1;
 
@@ -79,6 +80,7 @@ public class TwoChannelJoinProbe
         this.probeBlocks = new Block[2];
         probeBlocks[0] = probeBlockA;
         probeBlocks[1] = probeBlockB;
+        this.page = page;
         this.probePage = new Page(probeBlocks);
     }
 
@@ -108,7 +110,7 @@ public class TwoChannelJoinProbe
         if (currentRowContainsNull()) {
             return -1;
         }
-        return lookupSource.getJoinPosition(position, probePage);
+        return lookupSource.getJoinPosition(position, probePage, page);
     }
 
     private boolean currentRowContainsNull()
@@ -120,5 +122,17 @@ public class TwoChannelJoinProbe
             return true;
         }
         return false;
+    }
+
+    @Override
+    public int getPosition()
+    {
+        return position;
+    }
+
+    @Override
+    public Page getPage()
+    {
+        return page;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
@@ -388,19 +388,19 @@ public class IndexLoader
         }
 
         @Override
-        public long getJoinPosition(int position, Page page, int rawHash)
+        public long getJoinPosition(int position, Page page, Page allChannelsPage, int rawHash)
         {
             return IndexSnapshot.UNLOADED_INDEX_KEY;
         }
 
         @Override
-        public long getJoinPosition(int position, Page page)
+        public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage)
         {
             return IndexSnapshot.UNLOADED_INDEX_KEY;
         }
 
         @Override
-        public long getNextJoinPosition(long currentPosition)
+        public long getNextJoinPosition(long currentJoinPosition, int probePosition, Page allProbeChannelsPage)
         {
             return IndexSnapshot.UNLOADED_INDEX_KEY;
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSource.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.index;
 
+import com.facebook.presto.operator.FilterFunction;
 import com.facebook.presto.operator.LookupSource;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
@@ -30,6 +31,7 @@ public class IndexLookupSource
 {
     private final IndexLoader indexLoader;
     private IndexedData indexedData;
+    private FilterFunction filterFunction;
 
     public IndexLookupSource(IndexLoader indexLoader)
     {
@@ -56,21 +58,21 @@ public class IndexLookupSource
     }
 
     @Override
-    public long getJoinPosition(int position, Page page, int rawHash)
+    public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage, int rawHash)
     {
         // TODO update to take advantage of precomputed hash
-        return getJoinPosition(position, page);
+        return getJoinPosition(position, hashChannelsPage, allChannelsPage);
     }
 
     @Override
-    public long getJoinPosition(int position, Page page)
+    public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage)
     {
-        Block[] blocks = page.getBlocks();
-        long joinPosition = indexedData.getJoinPosition(position, page);
+        Block[] blocks = hashChannelsPage.getBlocks();
+        long joinPosition = indexedData.getJoinPosition(position, hashChannelsPage);
         if (joinPosition == UNLOADED_INDEX_KEY) {
             indexedData.close(); // Close out the old indexedData
             indexedData = indexLoader.getIndexedDataForKeys(position, blocks);
-            joinPosition = indexedData.getJoinPosition(position, page);
+            joinPosition = indexedData.getJoinPosition(position, hashChannelsPage);
             checkState(joinPosition != UNLOADED_INDEX_KEY);
         }
         // INVARIANT: position is -1 or a valid position greater than or equal to zero
@@ -78,9 +80,9 @@ public class IndexLookupSource
     }
 
     @Override
-    public long getNextJoinPosition(long currentPosition)
+    public long getNextJoinPosition(long currentJoinPosition, int probePosition, Page allProbeChannelsPage)
     {
-        long nextPosition = indexedData.getNextJoinPosition(currentPosition);
+        long nextPosition = indexedData.getNextJoinPosition(currentJoinPosition);
         checkState(nextPosition != UNLOADED_INDEX_KEY);
         // INVARIANT: currentPosition is -1 or a valid currentPosition greater than or equal to zero
         return nextPosition;

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceSupplier.java
@@ -17,12 +17,15 @@ import com.facebook.presto.operator.LookupSource;
 import com.facebook.presto.operator.LookupSourceSupplier;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -33,6 +36,7 @@ public class IndexLookupSourceSupplier
         implements LookupSourceSupplier
 {
     private final List<Type> outputTypes;
+    private final Map<Symbol, Integer> layout;
     private final Supplier<IndexLoader> indexLoaderSupplier;
 
     public IndexLookupSourceSupplier(
@@ -40,12 +44,14 @@ public class IndexLookupSourceSupplier
             List<Integer> keyOutputChannels,
             Optional<Integer> keyOutputHashChannel,
             List<Type> outputTypes,
+            Map<Symbol, Integer> layout,
             IndexBuildDriverFactoryProvider indexBuildDriverFactoryProvider,
             DataSize maxIndexMemorySize,
             IndexJoinLookupStats stats,
             boolean shareIndexLoading)
     {
         this.outputTypes = ImmutableList.copyOf(requireNonNull(outputTypes, "outputTypes is null"));
+        this.layout = ImmutableMap.copyOf(requireNonNull(layout, "layout is null"));
 
         if (shareIndexLoading) {
             IndexLoader shared = new IndexLoader(lookupSourceInputChannels, keyOutputChannels, keyOutputHashChannel, outputTypes, indexBuildDriverFactoryProvider, 10_000, maxIndexMemorySize, stats);
@@ -60,6 +66,12 @@ public class IndexLookupSourceSupplier
     public List<Type> getTypes()
     {
         return outputTypes;
+    }
+
+    @Override
+    public Map<Symbol, Integer> getLayout()
+    {
+        return layout;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSnapshot.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSnapshot.java
@@ -37,9 +37,9 @@ public class IndexSnapshot
     @Override
     public long getJoinPosition(int position, Page page)
     {
-        long joinPosition = values.getJoinPosition(position, page);
+        long joinPosition = values.getJoinPosition(position, page, page);
         if (joinPosition < 0) {
-            if (missingKeys.getJoinPosition(position, page) < 0) {
+            if (missingKeys.getJoinPosition(position, page, page) < 0) {
                 return UNLOADED_INDEX_KEY;
             }
             else {
@@ -52,7 +52,7 @@ public class IndexSnapshot
     @Override
     public long getNextJoinPosition(long currentPosition)
     {
-        return values.getNextJoinPosition(currentPosition);
+        return values.getNextJoinPosition(currentPosition, -1, null);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSnapshotBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSnapshotBuilder.java
@@ -118,7 +118,7 @@ public class IndexSnapshotBuilder
         }
         pages.clear();
 
-        LookupSource lookupSource = outputPagesIndex.createLookupSource(keyOutputChannels, keyOutputHashChannel);
+        LookupSource lookupSource = outputPagesIndex.createLookupSource(keyOutputChannels, keyOutputHashChannel, Optional.empty());
 
         // Build a page containing the keys that produced no output rows, so in future requests can skip these keys
         PageBuilder missingKeysPageBuilder = new PageBuilder(missingKeysIndex.getTypes());
@@ -127,7 +127,7 @@ public class IndexSnapshotBuilder
             Block[] blocks = indexKeysRecordCursor.getBlocks();
             Page page = indexKeysRecordCursor.getPage();
             int position = indexKeysRecordCursor.getPosition();
-            if (lookupSource.getJoinPosition(position, page) < 0) {
+            if (lookupSource.getJoinPosition(position, page, page) < 0) {
                 missingKeysPageBuilder.declarePosition();
                 for (int i = 0; i < blocks.length; i++) {
                     Block block = blocks[i];

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1199,6 +1199,24 @@ class StatementAnalyzer
 
             for (Expression conjunct : ExpressionUtils.extractConjuncts((Expression) optimizedExpression)) {
                 conjunct = ExpressionUtils.normalize(conjunct);
+
+                // in case of outer join we look for case when conjunct can be resolved using only inner side symbols.
+                // In such case it will be pushed to filter node on inner side of join by RelationPlanner
+                if (node.getType() == Join.Type.RIGHT) {
+                    Set<QualifiedName> names = DependencyExtractor.extractNames(conjunct, analyzer.getColumnReferences());
+                    if (names.stream().allMatch(left.canResolvePredicate())) {
+                        analyzeExpression(conjunct, left, context);
+                        continue;
+                    }
+                }
+                if (node.getType() == Join.Type.LEFT) {
+                    Set<QualifiedName> names = DependencyExtractor.extractNames(conjunct, analyzer.getColumnReferences());
+                    if (names.stream().allMatch(right.canResolvePredicate())) {
+                        analyzeExpression(conjunct, right, context);
+                        continue;
+                    }
+                }
+
                 if (conjunct instanceof ComparisonExpression) {
                     Expression conjunctFirst = ((ComparisonExpression) conjunct).getLeft();
                     Expression conjunctSecond = ((ComparisonExpression) conjunct).getRight();

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1217,7 +1217,8 @@ class StatementAnalyzer
                     }
                 }
 
-                if (conjunct instanceof ComparisonExpression) {
+                if (conjunct instanceof ComparisonExpression
+                        && (((ComparisonExpression) conjunct).getType() == EQUAL || node.getType() == Join.Type.INNER)) {
                     Expression conjunctFirst = ((ComparisonExpression) conjunct).getLeft();
                     Expression conjunctSecond = ((ComparisonExpression) conjunct).getRight();
                     Set<QualifiedName> firstDependencies = DependencyExtractor.extractNames(conjunctFirst, analyzer.getColumnReferences());

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
@@ -28,6 +28,7 @@ import com.facebook.presto.bytecode.control.IfStatement;
 import com.facebook.presto.bytecode.expression.BytecodeExpression;
 import com.facebook.presto.bytecode.instruction.LabelNode;
 import com.facebook.presto.operator.InMemoryJoinHash;
+import com.facebook.presto.operator.JoinFilterFunction;
 import com.facebook.presto.operator.LookupSource;
 import com.facebook.presto.operator.PagesHashStrategy;
 import com.facebook.presto.spi.Page;
@@ -65,6 +66,7 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.consta
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantLong;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantNull;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantTrue;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.invokeStatic;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.notEqual;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static java.util.Objects.requireNonNull;
@@ -162,6 +164,7 @@ public class JoinCompiler
         generatePositionEqualsRowMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
         generatePositionEqualsRowWithPageMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
         generatePositionEqualsPositionMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
+        generateGetFilterFunctionMethod(classDefinition);
 
         return defineClass(classDefinition, PagesHashStrategy.class, callSiteBinder.getBindings(), getClass().getClassLoader());
     }
@@ -579,6 +582,18 @@ public class JoinCompiler
                 .getBody()
                 .push(true)
                 .retInt();
+    }
+
+    private void generateGetFilterFunctionMethod(ClassDefinition classDefinition)
+    {
+        MethodDefinition getFilterFunctionMethod = classDefinition.declareMethod(
+                a(PUBLIC),
+                "getFilterFunction",
+                type(Optional.class, JoinFilterFunction.class));
+
+        getFilterFunctionMethod.getBody()
+                .append(invokeStatic(Optional.class, "empty", Optional.class))
+                .ret(Optional.class);
     }
 
     private static BytecodeNode typeEquals(

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
@@ -32,6 +32,7 @@ import com.facebook.presto.operator.LookupJoinOperators.JoinType;
 import com.facebook.presto.operator.LookupSource;
 import com.facebook.presto.operator.LookupSourceSupplier;
 import com.facebook.presto.operator.OperatorFactory;
+import com.facebook.presto.operator.SimpleJoinProbe;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
@@ -77,7 +78,7 @@ public class JoinProbeCompiler
                 public HashJoinOperatorFactoryFactory load(JoinOperatorCacheKey key)
                         throws Exception
                 {
-                    return internalCompileJoinOperatorFactory(key.getTypes(), key.getProbeChannels(), key.getProbeHashChannel());
+                    return internalCompileJoinOperatorFactory(key.getTypes(), key.getProbeChannels(), key.getProbeHashChannel(), key.isFilterFunctionPresent());
                 }
             });
 
@@ -87,10 +88,11 @@ public class JoinProbeCompiler
             List<? extends Type> probeTypes,
             List<Integer> probeJoinChannel,
             Optional<Integer> probeHashChannel,
-            JoinType joinType)
+            JoinType joinType,
+            boolean filterFunctionPresent)
     {
         try {
-            HashJoinOperatorFactoryFactory operatorFactoryFactory = joinProbeFactories.get(new JoinOperatorCacheKey(probeTypes, probeJoinChannel, probeHashChannel, joinType));
+            HashJoinOperatorFactoryFactory operatorFactoryFactory = joinProbeFactories.get(new JoinOperatorCacheKey(probeTypes, probeJoinChannel, probeHashChannel, joinType, filterFunctionPresent));
             return operatorFactoryFactory.createHashJoinOperatorFactory(operatorId, planNodeId, lookupSourceSupplier, probeTypes, probeJoinChannel, joinType);
         }
         catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
@@ -98,7 +100,7 @@ public class JoinProbeCompiler
         }
     }
 
-    public HashJoinOperatorFactoryFactory internalCompileJoinOperatorFactory(List<Type> types, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public HashJoinOperatorFactoryFactory internalCompileJoinOperatorFactory(List<Type> types, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, boolean filterFunctionPresent)
     {
         Class<? extends JoinProbe> joinProbeClass = compileJoinProbe(types, probeJoinChannel, probeHashChannel);
 
@@ -123,13 +125,19 @@ public class JoinProbeCompiler
                 .retObject();
 
         DynamicClassLoader classLoader = new DynamicClassLoader(joinProbeClass.getClassLoader());
-        Class<? extends JoinProbeFactory> joinProbeFactoryClass = defineClass(classDefinition, JoinProbeFactory.class, classLoader);
+
         JoinProbeFactory joinProbeFactory;
-        try {
-            joinProbeFactory = joinProbeFactoryClass.newInstance();
+        if (filterFunctionPresent) {
+            joinProbeFactory = new SimpleJoinProbe.SimpleJoinProbeFactory(types, probeJoinChannel, probeHashChannel);
         }
-        catch (Exception e) {
-            throw Throwables.propagate(e);
+        else {
+            Class<? extends JoinProbeFactory> joinProbeFactoryClass = defineClass(classDefinition, JoinProbeFactory.class, classLoader);
+            try {
+                joinProbeFactory = joinProbeFactoryClass.newInstance();
+            }
+            catch (Exception e) {
+                throw Throwables.propagate(e);
+            }
         }
 
         Class<? extends OperatorFactory> operatorFactoryClass = IsolatedClass.isolateClass(
@@ -181,6 +189,8 @@ public class JoinProbeCompiler
         generateAdvanceNextPosition(classDefinition, positionField, positionCountField);
         generateGetCurrentJoinPosition(classDefinition, callSiteBinder, lookupSourceField, probePageField, probeHashChannel, probeHashBlockField, positionField);
         generateCurrentRowContainsNull(classDefinition, probeBlockFields, positionField);
+        generateGetPosition(classDefinition);
+        generateGetPage(classDefinition);
 
         return defineClass(classDefinition, JoinProbe.class, callSiteBinder.getBindings(), getClass().getClassLoader());
     }
@@ -354,12 +364,13 @@ public class JoinProbeCompiler
                         .ifTrue(constantLong(-1).ret()));
 
         BytecodeExpression position = thisVariable.getField(positionField);
-        BytecodeExpression page = thisVariable.getField(probePageField);
+        BytecodeExpression hashChannelsPage = thisVariable.getField(probePageField);
         BytecodeExpression probeHashBlock = thisVariable.getField(probeHashBlockField);
         if (probeHashChannel.isPresent()) {
             body.append(thisVariable.getField(lookupSourceField).invoke("getJoinPosition", long.class,
                     position,
-                    page,
+                    hashChannelsPage,
+                    hashChannelsPage, // todo: we do not use allChannelsPage in compiled operators for now.
                     constantType(callSiteBinder, BigintType.BIGINT).invoke("getLong",
                             long.class,
                             probeHashBlock,
@@ -368,7 +379,8 @@ public class JoinProbeCompiler
                     .retLong();
         }
         else {
-            body.append(thisVariable.getField(lookupSourceField).invoke("getJoinPosition", long.class, position, page)).retLong();
+            // todo: we do not use allChannelsPage in compiled operators for now.
+            body.append(thisVariable.getField(lookupSourceField).invoke("getJoinPosition", long.class, position, hashChannelsPage, hashChannelsPage)).retLong();
         }
     }
 
@@ -393,6 +405,28 @@ public class JoinProbeCompiler
         method.getBody()
                 .push(false)
                 .retInt();
+    }
+
+    private void generateGetPosition(ClassDefinition classDefinition)
+    {
+        // dummy implementation for now
+        // compiled class is used only in usecase case when result of this method is ignored.
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC),
+                "getPosition",
+                type(int.class));
+        method.getBody().push(-1).retInt();
+    }
+
+    private void generateGetPage(ClassDefinition classDefinition)
+    {
+        // dummy implementation for now
+        // compiled class is used only in usecase case when result of this method is ignored.
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC),
+                "getPage",
+                type(Page.class));
+        method.getBody().pushNull().ret(Page.class);
     }
 
     public static class ReflectionJoinProbeFactory
@@ -428,16 +462,19 @@ public class JoinProbeCompiler
         private final List<Integer> probeChannels;
         private final JoinType joinType;
         private final Optional<Integer> probeHashChannel;
+        private final boolean filterFunctionPresent;
 
         private JoinOperatorCacheKey(List<? extends Type> types,
                 List<Integer> probeChannels,
                 Optional<Integer> probeHashChannel,
-                JoinType joinType)
+                JoinType joinType,
+                boolean filterFunctionPresent)
         {
             this.probeHashChannel = probeHashChannel;
             this.types = ImmutableList.copyOf(types);
             this.probeChannels = ImmutableList.copyOf(probeChannels);
             this.joinType = joinType;
+            this.filterFunctionPresent = filterFunctionPresent;
         }
 
         private List<Type> getTypes()
@@ -455,10 +492,15 @@ public class JoinProbeCompiler
             return probeHashChannel;
         }
 
+        private boolean isFilterFunctionPresent()
+        {
+            return filterFunctionPresent;
+        }
+
         @Override
         public int hashCode()
         {
-            return Objects.hash(types, probeChannels, joinType);
+            return Objects.hash(types, probeChannels, joinType, filterFunctionPresent);
         }
 
         @Override
@@ -474,7 +516,8 @@ public class JoinProbeCompiler
             return Objects.equals(this.types, other.types) &&
                     Objects.equals(this.probeChannels, other.probeChannels) &&
                     Objects.equals(this.probeHashChannel, other.probeHashChannel) &&
-                    Objects.equals(this.joinType, other.joinType);
+                    Objects.equals(this.joinType, other.joinType) &&
+                    Objects.equals(this.filterFunctionPresent, other.filterFunctionPresent);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -222,7 +222,13 @@ public class ExpressionInterpreter
     public Object evaluate(int position, Block... inputs)
     {
         checkState(!optimize, "evaluate(int, Block...) not allowed for optimizer");
-        return visitor.process(expression, new PagePositionContext(position, inputs));
+        return visitor.process(expression, new SinglePagePositionContext(position, inputs));
+    }
+
+    public Object evaluate(int leftPosition, Block[] leftBlocks, int rightPosition, Block[] rightBlocks)
+    {
+        checkState(!optimize, "evaluate(int, Block[], int, Block[]) not allowed for optimizer");
+        return visitor.process(expression, new TwoPagesPositionContext(leftPosition, leftBlocks, rightPosition, rightBlocks));
     }
 
     public Object optimize(SymbolResolver inputs)
@@ -279,7 +285,7 @@ public class ExpressionInterpreter
             int channel = node.getChannel();
             if (context instanceof PagePositionContext) {
                 PagePositionContext pagePositionContext = (PagePositionContext) context;
-                int position = pagePositionContext.getPosition();
+                int position = pagePositionContext.getPosition(channel);
                 Block block = pagePositionContext.getBlock(channel);
 
                 if (block.isNull(position)) {
@@ -1050,12 +1056,20 @@ public class ExpressionInterpreter
         }
     }
 
-    private static class PagePositionContext
+    private interface PagePositionContext
+    {
+        public Block getBlock(int channel);
+
+        public int getPosition(int channel);
+    }
+
+    private static class SinglePagePositionContext
+            implements PagePositionContext
     {
         private final int position;
         private final Block[] blocks;
 
-        private PagePositionContext(int position, Block[] blocks)
+        private SinglePagePositionContext(int position, Block[] blocks)
         {
             this.position = position;
             this.blocks = blocks;
@@ -1066,9 +1080,48 @@ public class ExpressionInterpreter
             return blocks[channel];
         }
 
-        public int getPosition()
+        public int getPosition(int channel)
         {
             return position;
+        }
+    }
+
+    private static class TwoPagesPositionContext
+            implements PagePositionContext
+    {
+        private final int leftPosition;
+        private final int rightPosition;
+        private final Block[] leftBlocks;
+        private final Block[] rightBlocks;
+
+        private TwoPagesPositionContext(int leftPosition, Block[] leftBlocks, int rightPosition, Block[] rightBlocks)
+        {
+            this.leftPosition = leftPosition;
+            this.rightPosition = rightPosition;
+            this.leftBlocks = leftBlocks;
+            this.rightBlocks = rightBlocks;
+        }
+
+        @Override
+        public Block getBlock(int channel)
+        {
+            if (channel < leftBlocks.length) {
+                return leftBlocks[channel];
+            }
+            else {
+                return rightBlocks[channel - leftBlocks.length];
+            }
+        }
+
+        @Override
+        public int getPosition(int channel)
+        {
+            if (channel < leftBlocks.length) {
+                return leftPosition;
+            }
+            else {
+                return rightPosition;
+            }
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/InterpretedFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/InterpretedFilterFunction.java
@@ -15,7 +15,7 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.operator.FilterFunction;
+import com.facebook.presto.operator.JoinFilterFunction;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
@@ -33,7 +33,7 @@ import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionT
 import static java.lang.Boolean.TRUE;
 
 public class InterpretedFilterFunction
-        implements FilterFunction
+        implements JoinFilterFunction
 {
     private final ExpressionInterpreter evaluator;
     private final Set<Integer> inputChannels;
@@ -60,6 +60,12 @@ public class InterpretedFilterFunction
         InputReferenceExtractor inputReferenceExtractor = new InputReferenceExtractor();
         inputReferenceExtractor.process(rewritten, null);
         this.inputChannels = ImmutableSet.copyOf(inputReferenceExtractor.getInputChannels());
+    }
+
+    @Override
+    public boolean filter(int leftPosition, Block[] leftBlocks, int rightPosition, Block[] rightBlocks)
+    {
+        return evaluator.evaluate(leftPosition, leftBlocks, rightPosition, rightBlocks) == TRUE;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -40,6 +40,7 @@ import com.facebook.presto.operator.HashBuilderOperator.HashBuilderOperatorFacto
 import com.facebook.presto.operator.HashPartitionMaskOperator.HashPartitionMaskOperatorFactory;
 import com.facebook.presto.operator.HashSemiJoinOperator.HashSemiJoinOperatorFactory;
 import com.facebook.presto.operator.InMemoryExchange;
+import com.facebook.presto.operator.JoinFilterFunction;
 import com.facebook.presto.operator.JoinOperatorFactory;
 import com.facebook.presto.operator.LimitOperator.LimitOperatorFactory;
 import com.facebook.presto.operator.LocalPlannerAware;
@@ -1458,6 +1459,7 @@ public class LocalExecutionPlanner
                     indexOutputChannels,
                     indexHashChannel,
                     indexSource.getTypes(),
+                    indexSource.getLayout(),
                     indexBuildDriverFactoryProvider,
                     maxIndexMemorySize,
                     indexJoinLookupStats,
@@ -1477,10 +1479,10 @@ public class LocalExecutionPlanner
             OperatorFactory lookupJoinOperatorFactory;
             switch (node.getType()) {
                 case INNER:
-                    lookupJoinOperatorFactory = LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceSupplier, probeSource.getTypes(), probeChannels, probeHashChannel);
+                    lookupJoinOperatorFactory = LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceSupplier, probeSource.getTypes(), probeChannels, probeHashChannel, Optional.empty());
                     break;
                 case SOURCE_OUTER:
-                    lookupJoinOperatorFactory = LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceSupplier, probeSource.getTypes(), probeChannels, probeHashChannel);
+                    lookupJoinOperatorFactory = LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceSupplier, probeSource.getTypes(), probeChannels, probeHashChannel, Optional.empty());
                     break;
                 default:
                     throw new AssertionError("Unknown type: " + node.getType());
@@ -1492,7 +1494,7 @@ public class LocalExecutionPlanner
         public PhysicalOperation visitJoin(JoinNode node, LocalExecutionPlanContext context)
         {
             List<JoinNode.EquiJoinClause> clauses = node.getCriteria();
-            if (clauses.isEmpty()) {
+            if (clauses.isEmpty() && !node.getFilter().isPresent()) {
                 return createNestedLoopJoin(node, context);
             }
 
@@ -1554,9 +1556,6 @@ public class LocalExecutionPlanner
                 Optional<Symbol> buildHashSymbol,
                 LocalExecutionPlanContext context)
         {
-            // Plan build
-            LookupSourceSupplier lookupSourceSupplier = createLookupJoinSource(node, buildNode, buildSymbols, buildHashSymbol, context);
-
             // Plan probe and introduce a projection to put all fields from the probe side into a single channel if necessary
             PhysicalOperation probeSource;
             LocalExecutionPlanContext parallelParentContext = null;
@@ -1578,6 +1577,10 @@ public class LocalExecutionPlanner
             else {
                 probeSource = probeNode.accept(this, context);
             }
+
+            // Plan build
+            LookupSourceSupplier lookupSourceSupplier = createLookupJoinSource(node, buildNode, buildSymbols, buildHashSymbol, probeSource.getLayout(), context);
+
             OperatorFactory operator = createLookupJoin(node, probeSource, probeSymbols, probeHashSymbol, lookupSourceSupplier, context);
 
             ImmutableMap.Builder<Symbol, Integer> outputMappings = ImmutableMap.builder();
@@ -1606,12 +1609,17 @@ public class LocalExecutionPlanner
                 PlanNode buildNode,
                 List<Symbol> buildSymbols,
                 Optional<Symbol> buildHashSymbol,
-                LocalExecutionPlanContext context)
+                Map<Symbol, Integer> probleLayout, LocalExecutionPlanContext context)
         {
             LocalExecutionPlanContext buildContext = context.createSubContext();
             PhysicalOperation buildSource = buildNode.accept(this, buildContext);
             List<Integer> buildChannels = ImmutableList.copyOf(getChannelsForSymbols(buildSymbols, buildSource.getLayout()));
             Optional<Integer> buildHashChannel = buildHashSymbol.map(channelGetter(buildSource));
+
+            Optional<JoinFilterFunction> filterFunction = node.getFilter().map(filter -> {
+                Map<Symbol, Integer> joinSourcesLayout = createJoinSourcesLayout(buildSource.getLayout(), probleLayout);
+                return new InterpretedFilterFunction(filter, context.getTypes(), joinSourcesLayout, metadata, sqlParser, context.getSession());
+            });
 
             LookupSourceSupplier lookupSourceSupplier;
             int hashBuildConcurrency = getTaskHashBuildConcurrency(session);
@@ -1620,8 +1628,10 @@ public class LocalExecutionPlanner
                         buildContext.getNextOperatorId(),
                         node.getId(),
                         buildSource.getTypes(),
+                        buildSource.getLayout(),
                         buildChannels,
                         buildHashChannel,
+                        filterFunction,
                         10_000);
 
                 context.addDriverFactory(new DriverFactory(
@@ -1640,9 +1650,10 @@ public class LocalExecutionPlanner
 
                 ParallelHashBuilder parallelHashBuilder = new ParallelHashBuilder(
                         buildSource.getTypes(),
+                        buildSource.getLayout(),
                         buildChannels,
                         buildHashChannel,
-                        10_000,
+                        filterFunction, 10_000,
                         parallelBuildCount);
 
                 context.addDriverFactory(new DriverFactory(
@@ -1683,16 +1694,26 @@ public class LocalExecutionPlanner
 
             switch (node.getType()) {
                 case INNER:
-                    return LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), lookupSourceSupplier, probeTypes, probeJoinChannels, probeHashChannel);
+                    return LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), lookupSourceSupplier, probeTypes, probeJoinChannels, probeHashChannel, node.getFilter());
                 case LEFT:
-                    return LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceSupplier, probeTypes, probeJoinChannels, probeHashChannel);
+                    return LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceSupplier, probeTypes, probeJoinChannels, probeHashChannel, node.getFilter());
                 case RIGHT:
-                    return LookupJoinOperators.lookupOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceSupplier, probeTypes, probeJoinChannels, probeHashChannel);
+                    return LookupJoinOperators.lookupOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceSupplier, probeTypes, probeJoinChannels, probeHashChannel, node.getFilter());
                 case FULL:
-                    return LookupJoinOperators.fullOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceSupplier, probeTypes, probeJoinChannels, probeHashChannel);
+                    return LookupJoinOperators.fullOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceSupplier, probeTypes, probeJoinChannels, probeHashChannel, node.getFilter());
                 default:
                     throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
             }
+        }
+
+        private Map<Symbol, Integer> createJoinSourcesLayout(Map<Symbol, Integer> lookupSourceLayout, Map<Symbol, Integer> probeSourceLayout)
+        {
+            Builder<Symbol, Integer> joinSourcesLayout = ImmutableMap.builder();
+            joinSourcesLayout.putAll(lookupSourceLayout);
+            for (Map.Entry<Symbol, Integer> probeLayoutEntry : probeSourceLayout.entrySet()) {
+                joinSourcesLayout.put(probeLayoutEntry.getKey(), probeLayoutEntry.getValue() + lookupSourceLayout.size());
+            }
+            return joinSourcesLayout.build();
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -749,6 +749,7 @@ class QueryPlanner
                             enforceSingleRowNode,
                             ImmutableList.of(),
                             Optional.empty(),
+                            Optional.empty(),
                             Optional.empty()),
                     builder.getSampleWeight());
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -49,6 +49,7 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.Join;
+import com.facebook.presto.sql.tree.JoinUsing;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
@@ -83,6 +84,8 @@ import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.planner.ExpressionInterpreter.evaluateConstantExpression;
 import static com.facebook.presto.sql.tree.Join.Type.INNER;
+import static com.facebook.presto.sql.tree.Join.Type.LEFT;
+import static com.facebook.presto.sql.tree.Join.Type.RIGHT;
 import static com.facebook.presto.type.TypeRegistry.isTypeOnlyCoercion;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.Types.checkType;
@@ -227,6 +230,8 @@ class RelationPlanner
         ImmutableList.Builder<JoinNode.EquiJoinClause> equiClauses = ImmutableList.builder();
         List<Expression> complexJoinExpressions = new ArrayList<>();
         List<Expression> postInnerJoinConditions = new ArrayList<>();
+        List<Expression> preLeftConditions = new ArrayList<>();
+        List<Expression> preRightConditions = new ArrayList<>();
         if (node.getType() != Join.Type.CROSS && node.getType() != Join.Type.IMPLICIT) {
             Expression criteria = analysis.getJoinCriteria(node);
 
@@ -239,8 +244,27 @@ class RelationPlanner
 
             for (Expression conjunct : ExpressionUtils.extractConjuncts(criteria)) {
                 conjunct = ExpressionUtils.normalize(conjunct);
+
+                // We skip this section for joins using "USING" clause as generated criteria uses non qualified column names.
+                // Criteria expression looks like "a = a" which then seem to be resolvable by any side of join.
+                if ((node.getType() == LEFT || node.getType() == RIGHT) && (!(node.getCriteria().get() instanceof JoinUsing))) {
+                    Set<QualifiedName> dependencies = DependencyExtractor.extractNames(conjunct, analysis.getColumnReferences());
+                    if (node.getType() == LEFT) {
+                        if (dependencies.stream().allMatch(right.canResolvePredicate())) {
+                            preRightConditions.add(rightPlanBuilder.rewrite(conjunct));
+                            continue;
+                        }
+                    }
+                    else if (node.getType() == RIGHT) {
+                        if (dependencies.stream().allMatch(left.canResolvePredicate())) {
+                            preLeftConditions.add(leftPlanBuilder.rewrite(conjunct));
+                            continue;
+                        }
+                    }
+                }
+
                 if (!isEqualComparisonExpression(conjunct) && node.getType() != INNER) {
-                    throw new SemanticException(NOT_SUPPORTED, node, "Non-equi joins only supported for inner join: %s", conjunct);
+                    throw new SemanticException(NOT_SUPPORTED, node, "Non-equi joins only supported for inner join or must relate to inner side of outer join: %s", conjunct);
                 }
 
                 if (conjunct instanceof ComparisonExpression) {
@@ -299,8 +323,8 @@ class RelationPlanner
 
         PlanNode root = new JoinNode(idAllocator.getNextId(),
                 JoinNode.Type.typeConvert(node.getType()),
-                leftPlanBuilder.getRoot(),
-                rightPlanBuilder.getRoot(),
+                wrapWithFilterIfNeeded(leftPlanBuilder.getRoot(), preLeftConditions),
+                wrapWithFilterIfNeeded(rightPlanBuilder.getRoot(), preRightConditions),
                 equiClauses.build(),
                 Optional.empty(),
                 Optional.empty());
@@ -343,11 +367,19 @@ class RelationPlanner
             postInnerJoinCriteria = new BooleanLiteral("TRUE");
         }
 
-        if (node.getType() == INNER) {
-            root = new FilterNode(idAllocator.getNextId(), root, postInnerJoinCriteria);
-        }
+        root = new FilterNode(idAllocator.getNextId(), root, postInnerJoinCriteria);
 
         return new RelationPlan(root, outputDescriptor, outputSymbols, sampleWeight);
+    }
+
+    private PlanNode wrapWithFilterIfNeeded(PlanNode planNode, List<Expression> filterConditions)
+    {
+        if (!filterConditions.isEmpty()) {
+            return new FilterNode(idAllocator.getNextId(), planNode, ExpressionUtils.and(filterConditions));
+        }
+        else {
+            return planNode;
+        }
     }
 
     private boolean isEqualComparisonExpression(Expression conjunct)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -264,7 +264,7 @@ class RelationPlanner
                 }
 
                 if (!isEqualComparisonExpression(conjunct) && node.getType() != INNER) {
-                    throw new SemanticException(NOT_SUPPORTED, node, "Non-equi joins only supported for inner join or must relate to inner side of outer join: %s", conjunct);
+                    throw new SemanticException(NOT_SUPPORTED, node, "Unsupported conjunct in join condition: %s", conjunct);
                 }
 
                 if (conjunct instanceof ComparisonExpression) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -873,6 +873,7 @@ public class AddExchanges
                     left.getNode(),
                     right.getNode(),
                     node.getCriteria(),
+                    node.getFilter(),
                     node.getLeftHashSymbol(),
                     node.getRightHashSymbol());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -286,6 +286,7 @@ public class HashGenerationOptimizer
                                 left.getNode(),
                                 right.getNode(),
                                 node.getCriteria(),
+                                node.getFilter(),
                                 Optional.empty(),
                                 Optional.empty()),
                         allHashSymbols);
@@ -319,6 +320,7 @@ public class HashGenerationOptimizer
                             left.getNode(),
                             right.getNode(),
                             node.getCriteria(),
+                            node.getFilter(),
                             Optional.of(leftHashSymbol),
                             Optional.of(rightHashSymbol)),
                     allHashSymbols);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -168,7 +168,7 @@ public class IndexJoinOptimizer
             }
 
             if (leftRewritten != node.getLeft() || rightRewritten != node.getRight()) {
-                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
             }
             return node;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -336,7 +336,7 @@ public class PredicatePushDown
                     rightSource != node.getRight() ||
                     !expressionEquivalence.areExpressionsEquivalent(session, newJoinPredicate, joinPredicate, types)) {
                 if (newJoinPredicate.equals(BooleanLiteral.TRUE_LITERAL)) {
-                    output = new JoinNode(node.getId(), INNER, leftSource, rightSource, ImmutableList.of(), Optional.<Symbol>empty(), Optional.<Symbol>empty());
+                    output = new JoinNode(node.getId(), INNER, leftSource, rightSource, ImmutableList.of(), node.getFilter(), Optional.<Symbol>empty(), Optional.<Symbol>empty());
                 }
                 else {
                     // Create identity projections for all existing symbols
@@ -373,7 +373,7 @@ public class PredicatePushDown
                     leftSource = new ProjectNode(idAllocator.getNextId(), leftSource, leftProjections.build());
                     rightSource = new ProjectNode(idAllocator.getNextId(), rightSource, rightProjections.build());
 
-                    output = new JoinNode(node.getId(), node.getType(), leftSource, rightSource, builder.build(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+                    output = new JoinNode(node.getId(), node.getType(), leftSource, rightSource, builder.build(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
                 }
             }
             if (!postJoinPredicate.equals(BooleanLiteral.TRUE_LITERAL)) {
@@ -635,11 +635,11 @@ public class PredicatePushDown
                     return node;
                 }
                 if (canConvertToLeftJoin && canConvertToRightJoin) {
-                    return new JoinNode(node.getId(), INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+                    return new JoinNode(node.getId(), INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
                 }
                 else {
                     return new JoinNode(node.getId(), canConvertToLeftJoin ? LEFT : RIGHT,
-                            node.getLeft(), node.getRight(), node.getCriteria(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+                            node.getLeft(), node.getRight(), node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
                 }
             }
 
@@ -647,7 +647,7 @@ public class PredicatePushDown
                     node.getType() == JoinNode.Type.RIGHT && !canConvertOuterToInner(node.getLeft().getOutputSymbols(), inheritedPredicate)) {
                 return node;
             }
-            return new JoinNode(node.getId(), JoinNode.Type.INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+            return new JoinNode(node.getId(), JoinNode.Type.INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
         }
 
         private boolean canConvertOuterToInner(List<Symbol> innerSymbolsForOuterJoin, Expression inheritedPredicate)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -64,6 +64,7 @@ import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -174,11 +175,20 @@ public class PruneUnreferencedOutputs
         @Override
         public PlanNode visitJoin(JoinNode node, RewriteContext<Set<Symbol>> context)
         {
+            Set<Symbol> expectedFilterInputs = new HashSet<>();
+            if (node.getFilter().isPresent()) {
+                expectedFilterInputs = ImmutableSet.<Symbol>builder()
+                        .addAll(DependencyExtractor.extractUnique(node.getFilter().get()))
+                        .addAll(context.get())
+                        .build();
+            }
+
             ImmutableSet.Builder<Symbol> leftInputsBuilder = ImmutableSet.builder();
             leftInputsBuilder.addAll(context.get()).addAll(Iterables.transform(node.getCriteria(), JoinNode.EquiJoinClause::getLeft));
             if (node.getLeftHashSymbol().isPresent()) {
                 leftInputsBuilder.add(node.getLeftHashSymbol().get());
             }
+            leftInputsBuilder.addAll(expectedFilterInputs);
             Set<Symbol> leftInputs = leftInputsBuilder.build();
 
             ImmutableSet.Builder<Symbol> rightInputsBuilder = ImmutableSet.builder();
@@ -186,13 +196,13 @@ public class PruneUnreferencedOutputs
             if (node.getRightHashSymbol().isPresent()) {
                 rightInputsBuilder.add(node.getRightHashSymbol().get());
             }
-
+            rightInputsBuilder.addAll(expectedFilterInputs);
             Set<Symbol> rightInputs = rightInputsBuilder.build();
 
             PlanNode left = context.rewrite(node.getLeft(), leftInputs);
             PlanNode right = context.rewrite(node.getRight(), rightInputs);
 
-            return new JoinNode(node.getId(), node.getType(), left, right, node.getCriteria(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+            return new JoinNode(node.getId(), node.getType(), left, right, node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -447,7 +447,7 @@ public class UnaliasSymbolReferences
             PlanNode left = context.rewrite(node.getLeft());
             PlanNode right = context.rewrite(node.getRight());
 
-            return new JoinNode(node.getId(), node.getType(), left, right, canonicalizeJoinCriteria(node.getCriteria()), canonicalize(node.getLeftHashSymbol()), canonicalize(node.getRightHashSymbol()));
+            return new JoinNode(node.getId(), node.getType(), left, right, canonicalizeJoinCriteria(node.getCriteria()), node.getFilter().map(this::canonicalize), canonicalize(node.getLeftHashSymbol()), canonicalize(node.getRightHashSymbol()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
@@ -147,7 +147,7 @@ public class ChildReplacer
     public PlanNode visitJoin(JoinNode node, List<PlanNode> newChildren)
     {
         checkArgument(newChildren.size() == 2, "expected newChildren to contain 2 nodes");
-        return new JoinNode(node.getId(), node.getType(), newChildren.get(0), newChildren.get(1), node.getCriteria(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+        return new JoinNode(node.getId(), node.getType(), newChildren.get(0), newChildren.get(1), node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Join;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -34,6 +35,7 @@ public class JoinNode
     private final PlanNode left;
     private final PlanNode right;
     private final List<EquiJoinClause> criteria;
+    private final Optional<Expression> filter;
     private final Optional<Symbol> leftHashSymbol;
     private final Optional<Symbol> rightHashSymbol;
 
@@ -43,6 +45,7 @@ public class JoinNode
             @JsonProperty("left") PlanNode left,
             @JsonProperty("right") PlanNode right,
             @JsonProperty("criteria") List<EquiJoinClause> criteria,
+            @JsonProperty("filter") Optional<Expression> filter,
             @JsonProperty("leftHashSymbol") Optional<Symbol> leftHashSymbol,
             @JsonProperty("rightHashSymbol") Optional<Symbol> rightHashSymbol)
     {
@@ -51,6 +54,7 @@ public class JoinNode
         requireNonNull(left, "left is null");
         requireNonNull(right, "right is null");
         requireNonNull(criteria, "criteria is null");
+        requireNonNull(filter, "filter is null");
         requireNonNull(leftHashSymbol, "leftHashSymbol is null");
         requireNonNull(rightHashSymbol, "rightHashSymbol is null");
 
@@ -58,6 +62,7 @@ public class JoinNode
         this.left = left;
         this.right = right;
         this.criteria = ImmutableList.copyOf(criteria);
+        this.filter = filter;
         this.leftHashSymbol = leftHashSymbol;
         this.rightHashSymbol = rightHashSymbol;
     }
@@ -123,6 +128,12 @@ public class JoinNode
     public List<EquiJoinClause> getCriteria()
     {
         return criteria;
+    }
+
+    @JsonProperty("filter")
+    public Optional<Expression> getFilter()
+    {
+        return filter;
     }
 
     @JsonProperty("leftHashSymbol")

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -28,6 +28,7 @@ import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.UnionNode;
+import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -192,6 +193,7 @@ public class TestPhasedExecutionSchedule
                 tableScan,
                 new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of()),
                 ImmutableList.of(),
+                Optional.<Expression>empty(),
                 Optional.<Symbol>empty(),
                 Optional.<Symbol>empty());
 
@@ -206,6 +208,7 @@ public class TestPhasedExecutionSchedule
                 new RemoteSourceNode(new PlanNodeId("probe_id"), probeFragment.getId(), ImmutableList.of()),
                 new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of()),
                 ImmutableList.of(),
+                Optional.empty(),
                 Optional.<Symbol>empty(),
                 Optional.<Symbol>empty());
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -432,6 +432,7 @@ public class TestSourcePartitionedScheduler
                                 null),
                         new RemoteSourceNode(new PlanNodeId("remote_id"), new PlanFragmentId("plan_fragment_id"), ImmutableList.of()),
                         ImmutableList.of(),
+                        Optional.empty(),
                         Optional.<Symbol>empty(),
                         Optional.<Symbol>empty()),
                 ImmutableMap.<Symbol, Type>of(symbol, VARCHAR),

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.TestingTaskContext;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
 import io.airlift.units.DataSize;
 import org.testng.annotations.AfterClass;
@@ -31,6 +32,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
@@ -98,7 +100,9 @@ public class TestHashJoinOperator
                 lookupSourceSupplier,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty()
+        );
 
         Operator joinOperator = joinOperatorFactory.createOperator(taskContext.addPipelineContext(true, true).addDriverContext());
 
@@ -149,7 +153,9 @@ public class TestHashJoinOperator
                 lookupSourceSupplier,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty()
+        );
         Operator joinOperator = joinOperatorFactory.createOperator(taskContext.addPipelineContext(true, true).addDriverContext());
 
         // expected
@@ -192,7 +198,9 @@ public class TestHashJoinOperator
                 lookupSourceSupplier,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty()
+        );
         Operator joinOperator = joinOperatorFactory.createOperator(taskContext.addPipelineContext(true, true).addDriverContext());
 
         // expected
@@ -236,7 +244,9 @@ public class TestHashJoinOperator
                 lookupSourceSupplier,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty()
+        );
         Operator joinOperator = joinOperatorFactory.createOperator(taskContext.addPipelineContext(true, true).addDriverContext());
 
         // expected
@@ -273,7 +283,8 @@ public class TestHashJoinOperator
                 lookupSourceSupplier,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
         Operator joinOperator = joinOperatorFactory.createOperator(taskContext.addPipelineContext(true, true).addDriverContext());
 
         // expected
@@ -329,7 +340,8 @@ public class TestHashJoinOperator
                 lookupSourceSupplier,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
         Operator joinOperator = joinOperatorFactory.createOperator(taskContext.addPipelineContext(true, true).addDriverContext());
 
         // expected
@@ -374,7 +386,8 @@ public class TestHashJoinOperator
                 lookupSourceSupplier,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
         Operator joinOperator = joinOperatorFactory.createOperator(taskContext.addPipelineContext(true, true).addDriverContext());
 
         // expected
@@ -418,7 +431,8 @@ public class TestHashJoinOperator
                 lookupSourceSupplier,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
         Operator joinOperator = joinOperatorFactory.createOperator(taskContext.addPipelineContext(true, true).addDriverContext());
 
         // expected
@@ -463,8 +477,9 @@ public class TestHashJoinOperator
 
     private static LookupSourceSupplier buildHash(boolean parallelBuild, TaskContext taskContext, List<Integer> hashChannels, RowPagesBuilder buildPages)
     {
+        // todo add tests for filter function
         if (parallelBuild) {
-            ParallelHashBuilder parallelHashBuilder = new ParallelHashBuilder(buildPages.getTypes(), hashChannels, buildPages.getHashChannel(), 100, PARTITION_COUNT);
+            ParallelHashBuilder parallelHashBuilder = new ParallelHashBuilder(buildPages.getTypes(), ImmutableMap.of(), hashChannels, buildPages.getHashChannel(), Optional.empty(), 100, PARTITION_COUNT);
 
             // collect input data
             DriverContext collectDriverContext = taskContext.addPipelineContext(true, true).addDriverContext();
@@ -497,7 +512,7 @@ public class TestHashJoinOperator
             DriverContext driverContext = taskContext.addPipelineContext(true, true).addDriverContext();
 
             ValuesOperatorFactory valuesOperatorFactory = new ValuesOperatorFactory(0, new PlanNodeId("test"), buildPages.getTypes(), buildPages.build());
-            HashBuilderOperatorFactory hashBuilderOperatorFactory = new HashBuilderOperatorFactory(1, new PlanNodeId("test"), buildPages.getTypes(), hashChannels, buildPages.getHashChannel(), 100);
+            HashBuilderOperatorFactory hashBuilderOperatorFactory = new HashBuilderOperatorFactory(1, new PlanNodeId("test"), buildPages.getTypes(), ImmutableMap.of(), hashChannels, buildPages.getHashChannel(), Optional.empty(), 100);
 
             Driver driver = new Driver(driverContext,
                     valuesOperatorFactory.createOperator(driverContext),

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
@@ -100,7 +100,7 @@ public class TestJoinCompiler
                     Block rightBlock = channel.get(rightBlockIndex);
                     for (int rightBlockPosition = 0; rightBlockPosition < rightBlock.getPositionCount(); rightBlockPosition++) {
                         boolean expected = positionEqualsPosition(VARCHAR, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
-                        assertEquals(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightBlockPosition, rightBlock), expected);
+                        assertEquals(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightBlockPosition, new Block[] {rightBlock}), expected);
                         assertEquals(hashStrategy.rowEqualsRow(leftBlockPosition, new Block[] {leftBlock}, rightBlockPosition, new Block[] {rightBlock}), expected);
                         assertEquals(hashStrategy.positionEqualsPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition), expected);
                     }
@@ -111,7 +111,7 @@ public class TestJoinCompiler
                     Block rightBlock = channel.get(rightBlockIndex);
                     for (int rightBlockPosition = 0; rightBlockPosition < rightBlock.getPositionCount(); rightBlockPosition++) {
                         boolean expected = positionEqualsPosition(VARCHAR, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
-                        assertEquals(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightBlockPosition, rightBlock), expected);
+                        assertEquals(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightBlockPosition, new Block[] {rightBlock}), expected);
                         assertEquals(hashStrategy.rowEqualsRow(leftBlockPosition, new Block[] {leftBlock}, rightBlockPosition, new Block[] {rightBlock}), expected);
                         assertEquals(hashStrategy.positionEqualsPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition), expected);
                     }
@@ -175,7 +175,8 @@ public class TestJoinCompiler
 
         PagesHashStrategyFactory pagesHashStrategyFactory = joinCompiler.compilePagesHashStrategyFactory(types, joinChannels);
         PagesHashStrategy hashStrategy = pagesHashStrategyFactory.createPagesHashStrategy(channels, hashChannel);
-        PagesHashStrategy expectedHashStrategy = new SimplePagesHashStrategy(types, channels, joinChannels, hashChannel);
+        // todo add tests for filter function
+        PagesHashStrategy expectedHashStrategy = new SimplePagesHashStrategy(types, channels, joinChannels, hashChannel, Optional.empty());
 
         // verify channel count
         assertEquals(hashStrategy.getChannelCount(), types.size());

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinProbeCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinProbeCompiler.java
@@ -130,7 +130,7 @@ public class TestJoinProbeCompiler
             pageBuilder.declarePosition();
             joinProbe.appendTo(pageBuilder);
 
-            assertEquals(joinProbe.getCurrentJoinPosition(), lookupSource.getJoinPosition(position, page));
+            assertEquals(joinProbe.getCurrentJoinPosition(), lookupSource.getJoinPosition(position, page, page));
         }
         assertFalse(joinProbe.advanceNextPosition());
         assertPageEquals(types, pageBuilder.build(), page);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -429,6 +429,7 @@ public class TestEffectivePredicateExtractor
                                 lessThan(FE, number(100)))),
                 criteria,
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
@@ -486,6 +487,7 @@ public class TestEffectivePredicateExtractor
                                 lessThan(FE, number(100)))),
                 criteria,
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
@@ -536,6 +538,7 @@ public class TestEffectivePredicateExtractor
                                 lessThan(CE, number(10)))),
                 filter(rightScan, FALSE_LITERAL),
                 criteria,
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 
@@ -591,6 +594,7 @@ public class TestEffectivePredicateExtractor
                                 lessThan(FE, number(100)))),
                 criteria,
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
@@ -641,6 +645,7 @@ public class TestEffectivePredicateExtractor
                                 equals(DE, EE),
                                 lessThan(FE, number(100)))),
                 criteria,
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1804,18 +1804,62 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND NULL");
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Non-equi.*")
-    public void testNonEqualityLeftJoin()
+    @Test
+    public void testSupportedNonEqualityLeftJoin()
             throws Exception
     {
-        assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 2");
+        assertQuery("SELECT COUNT(*) FROM " +
+                "      (SELECT * FROM lineitem ORDER BY orderkey,linenumber LIMIT 5) l " +
+                "         LEFT OUTER JOIN " +
+                "      (SELECT * FROM orders ORDER BY orderkey LIMIT 5) o " +
+                "         ON " +
+                "      o.custkey != 1000");
+        assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000");
+        assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000.0");
+        assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > orders.shippriority");
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Non-equi.*")
-    public void testNonEqualityRightJoin()
+    @Test
+    public void testUnsupportedNonEqualityLeftJoin()
             throws Exception
     {
-        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 2");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > lineitem.quantity", ".*Non-equi.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5", ".*Non-equi.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.quantity > 5", ".*Non-equi.*");
+    }
+
+    @Test
+    public void testUnsupportedNonEqualityFullJoin()
+            throws Exception
+    {
+        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5", ".*Non-equi.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000", ".*Non-equi.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.quantity > 5", ".*Non-equi.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON orders.custkey > 1000", ".*Non-equi.*");
+    }
+
+    @Test
+    public void testSupportedNonEqualityRightJoin()
+            throws Exception
+    {
+        assertQuery("SELECT COUNT(*) FROM " +
+                "      (SELECT * FROM lineitem ORDER BY orderkey,linenumber LIMIT 5) l " +
+                "         RIGHT OUTER JOIN " +
+                "      (SELECT * FROM orders ORDER BY orderkey LIMIT 5) o " +
+                "         ON " +
+                "      l.quantity != 5");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5.0");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > lineitem.suppkey");
+    }
+
+    @Test
+    public void testUnsupportedNonEqualityRightJoin()
+            throws Exception
+    {
+        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > orders.shippriority", ".*Non-equi.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.shippriority > 5", ".*Non-equi.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON orders.shippriority > 5", ".*Non-equi.*");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1805,7 +1805,7 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testSupportedNonEqualityLeftJoin()
+    public void testNonEqualityLeftJoin()
             throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM " +
@@ -1852,7 +1852,54 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testSupportedNonEqualityFullJoin()
+    public void testNonEqualityRightJoin()
+            throws Exception
+    {
+        assertQuery("SELECT COUNT(*) FROM " +
+                "      (SELECT * FROM lineitem ORDER BY orderkey,linenumber LIMIT 5) l " +
+                "         RIGHT OUTER JOIN " +
+                "      (SELECT * FROM orders ORDER BY orderkey LIMIT 5) o " +
+                "         ON " +
+                "      l.quantity != 5 WHERE l.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5 WHERE lineitem.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5.0 WHERE lineitem.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > lineitem.suppkey WHERE lineitem.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity*1000 > orders.totalprice WHERE lineitem.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.totalprice > 1000 WHERE lineitem.orderkey IS NULL");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > d",
+                "VALUES (1, 2, 1, 1), (NULL, NULL, 1, 2)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b < d",
+                "VALUES (1, 1, 1, 2), (NULL, NULL, 1, 1)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > 2",
+                "VALUES (NULL, NULL, 1, 1), (NULL, NULL, 1, 2)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 2",
+                "VALUES (NULL, NULL, 1, 1), (NULL, NULL, 1, 2)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > 0",
+                "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 0",
+                "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) RIGHT OUTER JOIN (VALUES 10, 11) t2(b) ON a > 1",
+                "VALUES (2, 11), (2, 10)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) RIGHT OUTER JOIN (VALUES 10, 11) t2(b) ON b > 10",
+                "VALUES (NULL, 10), (1, 11), (2, 11)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) RIGHT OUTER JOIN (VALUES 10, 11) t2(b) ON a > b",
+                "VALUES (NULL, 10), (NULL, 11)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) RIGHT OUTER JOIN (VALUES 10, 11) t2(b) ON a < b",
+                "VALUES (1, 10), (1, 11), (2, 10), (2, 11)");
+    }
+
+    @Test
+    public void testNonEqualityFullJoin()
             throws Exception
     {
         assertQuery(
@@ -1863,7 +1910,7 @@ public abstract class AbstractTestQueries
                         "SELECT lineitem.orderkey AS o1, orders.orderkey AS o2 FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5 " +
                         "    WHERE lineitem.orderkey IS NULL) " +
                         " WHERE o1 IS NULL OR o2 IS NULL"
-                );
+        );
         assertQuery(
                 "SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000 WHERE lineitem.orderkey IS NULL OR orders.orderkey IS NULL",
                 "SELECT COUNT(*) FROM " +
@@ -1911,53 +1958,6 @@ public abstract class AbstractTestQueries
                 "VALUES (NULL, 10), (NULL, 11), (1, NULL), (2, NULL)");
         assertQuery(
                 "SELECT * FROM (VALUES 1, 2) t1(a) FULL OUTER JOIN (VALUES 10, 11) t2(b) ON a < b",
-                "VALUES (1, 10), (1, 11), (2, 10), (2, 11)");
-    }
-
-    @Test
-    public void testSupportedNonEqualityRightJoin()
-            throws Exception
-    {
-        assertQuery("SELECT COUNT(*) FROM " +
-                "      (SELECT * FROM lineitem ORDER BY orderkey,linenumber LIMIT 5) l " +
-                "         RIGHT OUTER JOIN " +
-                "      (SELECT * FROM orders ORDER BY orderkey LIMIT 5) o " +
-                "         ON " +
-                "      l.quantity != 5 WHERE l.orderkey IS NULL");
-        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5 WHERE lineitem.orderkey IS NULL");
-        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5.0 WHERE lineitem.orderkey IS NULL");
-        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > lineitem.suppkey WHERE lineitem.orderkey IS NULL");
-        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity*1000 > orders.totalprice WHERE lineitem.orderkey IS NULL");
-        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.totalprice > 1000 WHERE lineitem.orderkey IS NULL");
-        assertQuery(
-                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > d",
-                "VALUES (1, 2, 1, 1), (NULL, NULL, 1, 2)");
-        assertQuery(
-                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b < d",
-                "VALUES (1, 1, 1, 2), (NULL, NULL, 1, 1)");
-        assertQuery(
-                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > 2",
-                "VALUES (NULL, NULL, 1, 1), (NULL, NULL, 1, 2)");
-        assertQuery(
-                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 2",
-                "VALUES (NULL, NULL, 1, 1), (NULL, NULL, 1, 2)");
-        assertQuery(
-                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > 0",
-                "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
-        assertQuery(
-                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 0",
-                "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
-        assertQuery(
-                "SELECT * FROM (VALUES 1, 2) t1(a) RIGHT OUTER JOIN (VALUES 10, 11) t2(b) ON a > 1",
-                "VALUES (2, 11), (2, 10)");
-        assertQuery(
-                "SELECT * FROM (VALUES 1, 2) t1(a) RIGHT OUTER JOIN (VALUES 10, 11) t2(b) ON b > 10",
-                "VALUES (NULL, 10), (1, 11), (2, 11)");
-        assertQuery(
-                "SELECT * FROM (VALUES 1, 2) t1(a) RIGHT OUTER JOIN (VALUES 10, 11) t2(b) ON a > b",
-                "VALUES (NULL, 10), (NULL, 11)");
-        assertQuery(
-                "SELECT * FROM (VALUES 1, 2) t1(a) RIGHT OUTER JOIN (VALUES 10, 11) t2(b) ON a < b",
                 "VALUES (1, 10), (1, 11), (2, 10), (2, 11)");
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1802,6 +1802,12 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND NOT (orders.comment LIKE lineitem.comment)");
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity + length(orders.comment) > 7");
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND NULL");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) JOIN (VALUES 10, 11) t2(b) ON a > 1",
+                "VALUES (2, 11), (2, 10)");
+        assertQuery(
+                "SELECT COUNT(*) FROM (VALUES 1, 2) t1(a) JOIN (VALUES 10, 11) t2(b) ON a > 2",
+                "VALUES (0)");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1823,19 +1823,19 @@ public abstract class AbstractTestQueries
     public void testUnsupportedNonEqualityLeftJoin()
             throws Exception
     {
-        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > lineitem.quantity", ".*Non-equi.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5", ".*Non-equi.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.quantity > 5", ".*Non-equi.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > lineitem.quantity", ".*Unsupported conjunct.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5", ".*Unsupported conjunct.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.quantity > 5", ".*Unsupported conjunct.*");
     }
 
     @Test
     public void testUnsupportedNonEqualityFullJoin()
             throws Exception
     {
-        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5", ".*Non-equi.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000", ".*Non-equi.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.quantity > 5", ".*Non-equi.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON orders.custkey > 1000", ".*Non-equi.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5", ".*Unsupported conjunct.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000", ".*Unsupported conjunct.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.quantity > 5", ".*Unsupported conjunct.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON orders.custkey > 1000", ".*Unsupported conjunct.*");
     }
 
     @Test
@@ -1857,9 +1857,9 @@ public abstract class AbstractTestQueries
     public void testUnsupportedNonEqualityRightJoin()
             throws Exception
     {
-        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > orders.shippriority", ".*Non-equi.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.shippriority > 5", ".*Non-equi.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON orders.shippriority > 5", ".*Non-equi.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > orders.shippriority", ".*Unsupported conjunct.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.shippriority > 5", ".*Unsupported conjunct.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON orders.shippriority > 5", ".*Unsupported conjunct.*");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1837,13 +1837,18 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 0",
                 "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
-    }
-
-    @Test
-    public void testUnsupportedNonEqualityLeftJoin()
-            throws Exception
-    {
-        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.quantity > 5", ".*hashChannels is empty.*");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) LEFT OUTER JOIN (VALUES 10, 11) t2(b) ON a > 1",
+                "VALUES (1, NULL), (2, 11), (2, 10)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) LEFT OUTER JOIN (VALUES 10, 11) t2(b) ON b > 10",
+                "VALUES (1, 11), (2, 11)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) LEFT OUTER JOIN (VALUES 10, 11) t2(b) ON a > b",
+                "VALUES (1, NULL), (2, NULL)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) LEFT OUTER JOIN (VALUES 10, 11) t2(b) ON a < b",
+                "VALUES (1, 10), (1, 11), (2, 10), (2, 11)");
     }
 
     @Test
@@ -1895,14 +1900,18 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) FULL OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 0",
                 "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
-    }
-
-    @Test
-    public void testUnsupportedNonEqualityFullJoin()
-            throws Exception
-    {
-        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON orders.custkey > 1000", ".*hashChannels is empty.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.quantity > 5", ".*hashChannels is empty.*");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) FULL OUTER JOIN (VALUES 10, 11) t2(b) ON a > 1",
+                "VALUES (2, 11), (2, 10), (1, NULL)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) FULL OUTER JOIN (VALUES 10, 11) t2(b) ON b > 10",
+                "VALUES (NULL, 10), (1, 11), (2, 11)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) FULL OUTER JOIN (VALUES 10, 11) t2(b) ON a > b",
+                "VALUES (NULL, 10), (NULL, 11), (1, NULL), (2, NULL)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) FULL OUTER JOIN (VALUES 10, 11) t2(b) ON a < b",
+                "VALUES (1, 10), (1, 11), (2, 10), (2, 11)");
     }
 
     @Test
@@ -1938,13 +1947,18 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 0",
                 "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
-    }
-
-    @Test
-    public void testUnsupportedNonEqualityRightJoin()
-            throws Exception
-    {
-        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON orders.shippriority > 5", ".*hashChannels is empty.*");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) RIGHT OUTER JOIN (VALUES 10, 11) t2(b) ON a > 1",
+                "VALUES (2, 11), (2, 10)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) RIGHT OUTER JOIN (VALUES 10, 11) t2(b) ON b > 10",
+                "VALUES (NULL, 10), (1, 11), (2, 11)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) RIGHT OUTER JOIN (VALUES 10, 11) t2(b) ON a > b",
+                "VALUES (NULL, 10), (NULL, 11)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) RIGHT OUTER JOIN (VALUES 10, 11) t2(b) ON a < b",
+                "VALUES (1, 10), (1, 11), (2, 10), (2, 11)");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1813,29 +1813,96 @@ public abstract class AbstractTestQueries
                 "         LEFT OUTER JOIN " +
                 "      (SELECT * FROM orders ORDER BY orderkey LIMIT 5) o " +
                 "         ON " +
-                "      o.custkey != 1000");
-        assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000");
-        assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000.0");
-        assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > orders.shippriority");
+                "      o.custkey != 1000 WHERE o.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000 WHERE orders.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000.0 WHERE orders.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > orders.totalprice WHERE orders.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > lineitem.quantity WHERE orders.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5 WHERE orders.orderkey IS NULL");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > d",
+                "VALUES (1, 2, 1, 1), (1, 1, NULL, NULL)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b < d",
+                "VALUES (1, 1, 1, 2), (1, 2, NULL, NULL)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > 2",
+                "VALUES (1, 1, NULL,  NULL), (1, 2, NULL, NULL)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 2",
+                "VALUES (1, 1, NULL, NULL), (1, 2, NULL, NULL)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > 0",
+                "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 0",
+                "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
     }
 
     @Test
     public void testUnsupportedNonEqualityLeftJoin()
             throws Exception
     {
-        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > lineitem.quantity", ".*Unsupported conjunct.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5", ".*Unsupported conjunct.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.quantity > 5", ".*Unsupported conjunct.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.quantity > 5", ".*hashChannels is empty.*");
+    }
+
+    @Test
+    public void testSupportedNonEqualityFullJoin()
+            throws Exception
+    {
+        assertQuery(
+                "SELECT COUNT(*) FROM lineitem FULL JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5 WHERE lineitem.orderkey IS NULL OR orders.orderkey IS NULL",
+                "SELECT COUNT(*) FROM " +
+                        "(SELECT lineitem.orderkey AS o1, orders.orderkey AS o2 FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5 " +
+                        "    UNION ALL " +
+                        "SELECT lineitem.orderkey AS o1, orders.orderkey AS o2 FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5 " +
+                        "    WHERE lineitem.orderkey IS NULL) " +
+                        " WHERE o1 IS NULL OR o2 IS NULL"
+                );
+        assertQuery(
+                "SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000 WHERE lineitem.orderkey IS NULL OR orders.orderkey IS NULL",
+                "SELECT COUNT(*) FROM " +
+                        "(SELECT lineitem.orderkey AS o1, orders.orderkey AS o2 FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000 " +
+                        "    UNION ALL " +
+                        "SELECT lineitem.orderkey AS o1, orders.orderkey AS o2 FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000 " +
+                        "    WHERE lineitem.orderkey IS NULL) " +
+                        " WHERE o1 IS NULL OR o2 IS NULL"
+        );
+        assertQuery(
+                "SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > lineitem.quantity WHERE lineitem.orderkey IS NULL OR orders.orderkey IS NULL",
+                "SELECT COUNT(*) FROM " +
+                        "(SELECT lineitem.orderkey AS o1, orders.orderkey AS o2 FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > lineitem.quantity " +
+                        "    UNION ALL " +
+                        "SELECT lineitem.orderkey AS o1, orders.orderkey AS o2 FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > lineitem.quantity " +
+                        "    WHERE lineitem.orderkey IS NULL) " +
+                        " WHERE o1 IS NULL OR o2 IS NULL"
+        );
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) FULL OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > d",
+                "VALUES (1, 2, 1, 1), (NULL, NULL, 1, 2), (1, 1, NULL, NULL)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) FULL OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b < d",
+                "VALUES (1, 1, 1, 2), (NULL, NULL, 1, 1), (1, 2, NULL, NULL)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) FULL OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > 2",
+                "VALUES (NULL, NULL, 1, 1), (NULL, NULL, 1, 2), (1, 1, NULL, NULL), (1, 2, NULL, NULL)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) FULL OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 2",
+                "VALUES (NULL, NULL, 1, 1), (NULL, NULL, 1, 2), (1, 1, NULL, NULL), (1, 2, NULL, NULL)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) FULL OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > 0",
+                "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) FULL OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 0",
+                "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
     }
 
     @Test
     public void testUnsupportedNonEqualityFullJoin()
             throws Exception
     {
-        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5", ".*Unsupported conjunct.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey > 1000", ".*Unsupported conjunct.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.quantity > 5", ".*Unsupported conjunct.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON orders.custkey > 1000", ".*Unsupported conjunct.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON orders.custkey > 1000", ".*hashChannels is empty.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem FULL OUTER JOIN orders ON lineitem.quantity > 5", ".*hashChannels is empty.*");
     }
 
     @Test
@@ -1847,19 +1914,37 @@ public abstract class AbstractTestQueries
                 "         RIGHT OUTER JOIN " +
                 "      (SELECT * FROM orders ORDER BY orderkey LIMIT 5) o " +
                 "         ON " +
-                "      l.quantity != 5");
-        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5");
-        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5.0");
-        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > lineitem.suppkey");
+                "      l.quantity != 5 WHERE l.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5 WHERE lineitem.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5.0 WHERE lineitem.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > lineitem.suppkey WHERE lineitem.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity*1000 > orders.totalprice WHERE lineitem.orderkey IS NULL");
+        assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.totalprice > 1000 WHERE lineitem.orderkey IS NULL");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > d",
+                "VALUES (1, 2, 1, 1), (NULL, NULL, 1, 2)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b < d",
+                "VALUES (1, 1, 1, 2), (NULL, NULL, 1, 1)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > 2",
+                "VALUES (NULL, NULL, 1, 1), (NULL, NULL, 1, 2)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 2",
+                "VALUES (NULL, NULL, 1, 1), (NULL, NULL, 1, 2)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND b > 0",
+                "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) RIGHT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND d > 0",
+                "VALUES (1, 1, 1, 1), (1, 1, 1, 2), (1, 2, 1, 1), (1, 2, 1, 2)");
     }
 
     @Test
     public void testUnsupportedNonEqualityRightJoin()
             throws Exception
     {
-        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > orders.shippriority", ".*Unsupported conjunct.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.shippriority > 5", ".*Unsupported conjunct.*");
-        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON orders.shippriority > 5", ".*Unsupported conjunct.*");
+        assertQueryFails("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON orders.shippriority > 5", ".*hashChannels is empty.*");
     }
 
     @Test


### PR DESCRIPTION
Add support for non-equi conjuncts in join condition for outer joins.
Supported case is when conjunct is resolvable as a whole using symbols
of inner join table. In such case conjunct is pushed down as filter to
inner source relation.