### PR TITLE
Fix product tests resource processing

### DIFF
--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -83,8 +83,18 @@
     <build>
         <resources>
             <resource>
-                <directory>${project.basedir}/src/main/resources</directory>
+                <directory>src/main/resources</directory>
                 <filtering>true</filtering>
+                <includes>
+                    <include>presto.env</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>presto.env</exclude>
+                </excludes>
             </resource>
         </resources>
         <plugins>

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestTablePartitioningSelect.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestTablePartitioningSelect.java
@@ -28,7 +28,6 @@ import java.sql.SQLException;
 import java.util.Optional;
 
 import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
-import static com.facebook.presto.tests.TestGroups.QUARANTINE;
 import static com.teradata.tempto.Requirements.allOf;
 import static com.teradata.tempto.assertions.QueryAssert.Row.row;
 import static com.teradata.tempto.assertions.QueryAssert.assertThat;
@@ -87,7 +86,7 @@ public class TestTablePartitioningSelect
         );
     }
 
-    @Test(groups = {HIVE_CONNECTOR, QUARANTINE})
+    @Test(groups = {HIVE_CONNECTOR})
     public void testSelectPartitionedHiveTableDifferentFormats()
             throws SQLException
     {


### PR DESCRIPTION
Apply maven resource pluging filtering only to `presto.env` file
instead of to all the presto-product-tests resources.

Maven resource filtering is used to replace properties
placeholders e.g. `${project.version}` in the module resource files.
In our case we use this feature to substitute the actual presto version
in `presto.env` file which is used for running product tests on travis.
The problem is that the `presto-product-tests` module contains
many binary files with the test tables data. Resource plugin with filtering
enabled always tries to parse resources as text files and writes
the parsed result to the target even if no placeholders has been replaced.
This operation breaks the binary files.