### PR TITLE
Ignore case when matching row field

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -523,7 +523,7 @@ public class FunctionRegistry
         checkState(rowType.getTypeSignature().getBase().equals(StandardTypes.ROW), "rowType is not a ROW type");
         SqlFunction match = null;
         for (SqlFunction function : RowParametricType.ROW.createFunctions(rowType)) {
-            if (!function.getSignature().getName().equals(field)) {
+            if (!function.getSignature().getName().equalsIgnoreCase(field)) {
                 continue;
             }
             checkArgument(match == null, "Ambiguous field %s in type %s", field, rowType.getDisplayName());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TestingRowConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TestingRowConstructor.java
@@ -172,6 +172,13 @@ public final class TestingRowConstructor
         return toStackRepresentation(ImmutableList.of(TIMESTAMP), arg1);
     }
 
+    @ScalarFunction("test_non_lowercase_row")
+    @SqlType("row<bigint>('Col0')")
+    public static Block testNonLowercaseRowBigint(@Nullable @SqlType(StandardTypes.BIGINT) Long arg1)
+    {
+        return toStackRepresentation(ImmutableList.of(BIGINT), arg1);
+    }
+
     public static Block toStackRepresentation(List<Type> parameterTypes, Object... values)
     {
         checkArgument(parameterTypes.size() == values.length, "parameterTypes.size(" + parameterTypes.size() + ") does not equal to values.length(" + values.length + ")");

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -315,7 +315,7 @@ public class ExpressionAnalyzer
 
             Type rowFieldType = null;
             for (RowField rowField : rowType.getFields()) {
-                if (rowField.getName().equals(Optional.of(node.getFieldName()))) {
+                if (node.getFieldName().equalsIgnoreCase(rowField.getName().orElse(null))) {
                     rowFieldType = rowField.getType();
                     break;
                 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3901,6 +3901,13 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testCaseInsensitiveRowFieldReference()
+            throws Exception
+    {
+        assertQuery("SELECT a.Col0 FROM (VALUES ROW (test_non_lowercase_row(1))) AS t (a)", "SELECT 1");
+    }
+
+    @Test
     public void testSubqueryBody()
             throws Exception
     {


### PR DESCRIPTION
When query a Hive table like

select msg.ID from t;

fails to find the field.
Here, msg is a struct. ID is a field in msg.

Tried to create a test case, but not got one yet.