### PR TITLE
Support multiple shard UUIDs in ShardPredicate

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardPredicate.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardPredicate.java
@@ -101,7 +101,7 @@ class ShardPredicate
             return Optional.empty();
         }
 
-        predicateJoiner.add(String.format("shard_uuid %s ?", operator));
+        predicateJoiner.add(format("shard_uuid %s ?", operator));
         return Optional.of(uuidBytes);
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardPredicate.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardPredicate.java
@@ -16,6 +16,7 @@ package com.facebook.presto.raptor.metadata;
 import com.facebook.presto.raptor.RaptorColumnHandle;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.Marker;
 import com.facebook.presto.spi.predicate.Range;
 import com.facebook.presto.spi.predicate.Ranges;
 import com.facebook.presto.spi.predicate.TupleDomain;
@@ -26,6 +27,7 @@ import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
@@ -34,6 +36,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.StringJoiner;
 
 import static com.facebook.presto.raptor.metadata.DatabaseShardManager.maxColumn;
@@ -42,6 +45,7 @@ import static com.facebook.presto.raptor.storage.ShardStats.truncateIndexValue;
 import static com.facebook.presto.raptor.util.Types.checkType;
 import static com.facebook.presto.raptor.util.UuidUtil.uuidStringToBytes;
 import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
+import static com.facebook.presto.spi.predicate.Marker.Bound.EXACTLY;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -85,6 +89,22 @@ class ShardPredicate
                 .toString();
     }
 
+    private static Optional<Slice> toShardPredicate(Object value, StringJoiner predicateJoiner, String operator)
+    {
+        Slice uuidText = checkType(value, Slice.class, "value");
+        Slice uuidBytes;
+        try {
+            uuidBytes = uuidStringToBytes(uuidText);
+        }
+        catch (IllegalArgumentException e) {
+            predicateJoiner.add("false");
+            return Optional.empty();
+        }
+
+        predicateJoiner.add(String.format("shard_uuid %s ?", operator));
+        return Optional.of(uuidBytes);
+    }
+
     public static ShardPredicate create(TupleDomain<RaptorColumnHandle> tupleDomain)
     {
         StringJoiner predicate = new StringJoiner(" AND ").setEmptyValue("true");
@@ -93,7 +113,7 @@ class ShardPredicate
 
         for (Entry<RaptorColumnHandle, Domain> entry : tupleDomain.getDomains().get().entrySet()) {
             Domain domain = entry.getValue();
-            if (domain.isNullAllowed() || domain.isAll()) {
+            if (domain.isAll()) {
                 continue;
             }
             RaptorColumnHandle handle = entry.getKey();
@@ -105,21 +125,42 @@ class ShardPredicate
             }
 
             if (handle.isShardUuid()) {
-                // TODO: support multiple shard UUIDs
-                if (domain.isSingleValue()) {
-                    Slice uuidText = checkType(entry.getValue().getSingleValue(), Slice.class, "value");
-                    Slice uuidBytes;
-                    try {
-                        uuidBytes = uuidStringToBytes(uuidText);
+                StringJoiner rangePredicate = new StringJoiner(" OR ").setEmptyValue("true");
+
+                for (Range range : domain.getValues().getRanges().getOrderedRanges()) {
+                    if (range.isSingleValue()) {
+                        toShardPredicate(range.getSingleValue(), rangePredicate, "=")
+                                .ifPresent(value -> {
+                                    types.add(jdbcType);
+                                    values.add(value);
+                                });
                     }
-                    catch (IllegalArgumentException e) {
-                        predicate.add("false");
-                        continue;
+                    else {
+                        Marker high = range.getHigh();
+                        if (!high.isUpperUnbounded()) {
+                            toShardPredicate(high.getValue(), rangePredicate, high.getBound() == EXACTLY ? "<=" : "<")
+                                    .ifPresent(value -> {
+                                        types.add(jdbcType);
+                                        values.add(value);
+                                    });
+                        }
+
+                        Marker low = range.getLow();
+                        if (!low.isLowerUnbounded()) {
+                            toShardPredicate(low.getValue(), rangePredicate, low.getBound() == EXACTLY ? ">=" : ">")
+                                    .ifPresent(value -> {
+                                        types.add(jdbcType);
+                                        values.add(value);
+                                    });
+                        }
                     }
-                    predicate.add("shard_uuid = ?");
-                    types.add(jdbcType);
-                    values.add(uuidBytes);
                 }
+
+                predicate.add(rangePredicate.toString());
+                continue;
+            }
+
+            if (domain.isNullAllowed()) {
                 continue;
             }
 
@@ -166,6 +207,18 @@ class ShardPredicate
         }
 
         return new ShardPredicate(predicate.toString(), types.build(), values.build());
+    }
+
+    @VisibleForTesting
+    protected List<JDBCType> getTypes()
+    {
+        return types;
+    }
+
+    @VisibleForTesting
+    protected List<Object> getValues()
+    {
+        return values;
     }
 
     public static void bindValue(PreparedStatement statement, JDBCType type, Object value, int index)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardPredicate.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardPredicate.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.metadata;
+
+import com.facebook.presto.raptor.RaptorColumnHandle;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.SortedRangeSet;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
+
+import java.sql.JDBCType;
+
+import static com.facebook.presto.raptor.RaptorColumnHandle.shardUuidColumnHandle;
+import static com.facebook.presto.raptor.util.UuidUtil.uuidStringToBytes;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.util.UUID.randomUUID;
+import static org.testng.Assert.assertEquals;
+
+public class TestShardPredicate
+{
+    @Test
+    public void testSimpleShardUuidPredicate()
+            throws Exception
+    {
+        String uuid = randomUUID().toString();
+        TupleDomain<RaptorColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                shardUuidColumnHandle("test"), Domain.singleValue(VARCHAR, utf8Slice(uuid))
+        ));
+
+        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain);
+
+        assertEquals(shardPredicate.getPredicate(), "shard_uuid = ?");
+        assertEquals(shardPredicate.getTypes(), ImmutableList.of(JDBCType.VARBINARY));
+        assertEquals(shardPredicate.getValues(), ImmutableList.of(uuidStringToBytes(utf8Slice(uuid))));
+    }
+
+    @Test
+    public void testRangeShardUuidPredicate()
+            throws Exception
+    {
+        Slice uuid0 = utf8Slice(randomUUID().toString());
+        Slice uuid1 = utf8Slice(randomUUID().toString());
+        TupleDomain<RaptorColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                shardUuidColumnHandle("test"), Domain.create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
+                        Range.equal(VARCHAR, uuid0),
+                        Range.equal(VARCHAR, uuid1)
+                )), false)
+        ));
+
+        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain);
+
+        assertEquals(shardPredicate.getPredicate(), "shard_uuid = ? OR shard_uuid = ?");
+        assertEquals(shardPredicate.getTypes(), ImmutableList.of(JDBCType.VARBINARY, JDBCType.VARBINARY));
+        assertEquals(ImmutableSet.copyOf(shardPredicate.getValues()),
+                ImmutableSet.of(uuidStringToBytes(uuid0), uuidStringToBytes(uuid1)));
+    }
+
+    @Test
+    public void testRangeMarkerShardUuidPredicate()
+            throws Exception
+    {
+        Slice uuid0 = utf8Slice(randomUUID().toString());
+        TupleDomain<RaptorColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                shardUuidColumnHandle("test"), Domain.create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
+                        Range.greaterThanOrEqual(VARCHAR, uuid0)
+                )), false)
+        ));
+
+        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain);
+
+        assertEquals(shardPredicate.getPredicate(), "shard_uuid >= ?");
+        assertEquals(shardPredicate.getTypes(), ImmutableList.of(JDBCType.VARBINARY));
+        assertEquals(shardPredicate.getValues(), ImmutableSet.of(uuidStringToBytes(uuid0)));
+    }
+}


### PR DESCRIPTION
Added predicate pushdown support for queries like 
`SELECT * FROM raptor.schema.table WHERE "$shard_uuid" in ('6360fe04-ee31-11e5-9ce9-5e5517507c66', '6361016a-ee31-11e5-9ce9-5e5517507c66')`