### PR TITLE
Allow duplicate relations for JOIN

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/RelationType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/RelationType.java
@@ -25,11 +25,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
-import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 import static com.google.common.base.Predicates.not;
@@ -113,19 +111,6 @@ public class RelationType
     public int getAllFieldCount()
     {
         return allFields.size();
-    }
-
-    /**
-     * Returns all unique relations in this tuple.
-     * For detecting duplicate relations in a Join.
-     */
-    public Set<QualifiedName> getRelationAliases()
-    {
-        return allFields.stream()
-                .map(Field::getRelationAlias)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(toImmutableSet());
     }
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -116,7 +116,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
 
 import java.util.ArrayList;
@@ -1111,12 +1110,6 @@ class StatementAnalyzer
         RelationType left = process(node.getLeft(), context);
         leftContext.setLateralTupleDescriptor(left);
         RelationType right = process(node.getRight(), leftContext);
-
-        // todo this check should be inside of TupleDescriptor.join and then remove the public getRelationAlias method, but the exception needs the node object
-        Sets.SetView<QualifiedName> duplicateAliases = Sets.intersection(left.getRelationAliases(), right.getRelationAliases());
-        if (!duplicateAliases.isEmpty()) {
-            throw new SemanticException(DUPLICATE_RELATION, node, "Relations appear more than once: %s", duplicateAliases);
-        }
 
         RelationType output = left.joinWith(right);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -103,14 +103,6 @@ public class TestAnalyzer
     private Metadata metadata;
 
     @Test
-    public void testDuplicateRelation()
-            throws Exception
-    {
-        assertFails(DUPLICATE_RELATION, "SELECT * FROM t1 JOIN t1 USING (a)");
-        assertFails(DUPLICATE_RELATION, "SELECT * FROM t1 x JOIN t2 x USING (a)");
-    }
-
-    @Test
     public void testNonComparableGroupBy()
             throws Exception
     {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2361,6 +2361,14 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testJoinWithDuplicateRelations()
+            throws Exception
+    {
+        assertQuery("SELECT * FROM orders JOIN orders USING (orderkey)", "SELECT * FROM orders o1 JOIN orders o2 ON o1.orderkey = o2.orderkey");
+        assertQuery("SELECT * FROM lineitem x JOIN orders x USING (orderkey)", "SELECT * FROM lineitem l JOIN orders o ON l.orderkey = o.orderkey");
+    }
+
+    @Test
     public void testOrderBy()
             throws Exception
     {


### PR DESCRIPTION
Addresses #4775 and its comments.

Duplicate relations are allowed, as long as common columns are not referenced. 

After removing the duplicate check now, if common columns of duplicate relations are referenced it gives error with `column <first-referenced-common-column-name> is ambiguous`
