### PR TITLE
Apply non-TupleDomain predicates to Hive partition list

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1223,11 +1223,15 @@ public class HiveMetadata
 
         HivePartitionResult hivePartitionResult = partitionManager.getPartitions(session, metastore, tableHandle, constraint.getSummary());
 
+        List<HivePartition> partitions = hivePartitionResult.getPartitions().stream()
+                .filter(partition -> constraint.predicate().test(partition.getKeys()))
+                .collect(toList());
+
         return ImmutableList.of(new ConnectorTableLayoutResult(
                 getTableLayout(session, new HiveTableLayoutHandle(
                         handle.getClientId(),
                         ImmutableList.copyOf(hivePartitionResult.getPartitionColumns()),
-                        hivePartitionResult.getPartitions(),
+                        partitions,
                         hivePartitionResult.getEnforcedConstraint())),
                 hivePartitionResult.getUnenforcedConstraint()));
     }


### PR DESCRIPTION
When Hive connectors look up all partitions that is potentially needed, it
didn't taken advantage of the additional predicate available in Constraint to
apply the predicates that are not representable as TupleDomain.

When Hive was migrated to the current TableLayout API, this additional filter
was not added. This is most likely caused by not thinking thoroughly enough and
trying to retain whatever the code did with the old API.