### PR TITLE
Add width bucket implementation for array bin specification

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -191,3 +191,9 @@ Floating Point Functions
 
     Returns the bin number of ``x`` in an equi-width histogram with the
     specified ``bound1`` and ``bound2`` bounds and ``n`` number of buckets.
+
+.. function:: width_bucket(x, bins) -> bigint
+
+    Returns the bin number of ``x`` according to the bins specified by the
+    array ``bins``. The ``bins`` parameter must be an array of doubles and is
+    assumed to be in sorted ascending order.


### PR DESCRIPTION
Adds `width_bucket(double operand, array<double> bins)` implementation. This is a follow up to https://github.com/prestodb/presto/pull/4791