### PR TITLE
Upgrade to hive-apache 0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
             <dependency>
                 <groupId>com.facebook.presto.hive</groupId>
                 <artifactId>hive-apache</artifactId>
-                <version>0.16</version>
+                <version>0.17</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This fixes a potential native memory leak when writing (and possibly reading) gzip'ed files