### PR TITLE
Fix streaming for JDBC-based connectors

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -251,6 +251,7 @@ public class BaseJdbcClient
             throws SQLException
     {
         return new QueryBuilder(identifierQuote).buildSql(
+                this,
                 getConnection(split),
                 split.getCatalogName(),
                 split.getSchemaName(),
@@ -372,10 +373,10 @@ public class BaseJdbcClient
     }
 
     @Override
-    public Statement getStatement(Connection connection)
+    public PreparedStatement getPreparedStatement(Connection connection, String sql)
             throws SQLException
     {
-        return connection.createStatement();
+        return connection.prepareStatement(sql);
     }
 
     protected ResultSet getTables(Connection connection, String schemaName, String tableName)

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -23,7 +23,6 @@ import javax.annotation.Nullable;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -58,6 +57,6 @@ public interface JdbcClient
     Connection getConnection(JdbcOutputTableHandle handle)
             throws SQLException;
 
-    Statement getStatement(Connection connection)
+    PreparedStatement getPreparedStatement(Connection connection, String sql)
             throws SQLException;
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
@@ -69,7 +69,7 @@ public class QueryBuilder
         this.quote = requireNonNull(quote, "quote is null");
     }
 
-    public PreparedStatement buildSql(Connection connection, String catalog, String schema, String table, List<JdbcColumnHandle> columns, TupleDomain<ColumnHandle> tupleDomain)
+    public PreparedStatement buildSql(JdbcClient client, Connection connection, String catalog, String schema, String table, List<JdbcColumnHandle> columns, TupleDomain<ColumnHandle> tupleDomain)
             throws SQLException
     {
         StringBuilder sql = new StringBuilder();
@@ -102,7 +102,7 @@ public class QueryBuilder
                     .append(Joiner.on(" AND ").join(clauses));
         }
 
-        PreparedStatement statement = connection.prepareStatement(sql.toString());
+        PreparedStatement statement = client.getPreparedStatement(connection, sql.toString());
 
         for (int i = 0; i < accumulator.size(); i++) {
             TypeAndValue typeAndValue = accumulator.get(i);

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -24,9 +24,6 @@ import com.facebook.presto.spi.type.DoubleType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.skife.jdbi.v2.DBI;
-import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.IDBI;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -43,17 +40,23 @@ import static org.testng.Assert.assertEquals;
 @Test(singleThreaded = true)
 public class TestJdbcQueryBuilder
 {
-    private IDBI dbi;
-    private Handle dummyHandle;
+    private TestingDatabase database;
+    private String catalogName;
+    private JdbcClient jdbcClient;
+
+    // private IDBI dbi;
+    // private Handle dummyHandle;
     private List<JdbcColumnHandle> cols = new ArrayList<>();
 
     @BeforeMethod
     public void setup()
             throws SQLException
     {
-        dbi = new DBI("jdbc:h2:mem:test" + System.nanoTime());
-        dummyHandle = dbi.open();
-        Connection connection = dummyHandle.getConnection();
+        database = new TestingDatabase();
+        catalogName = database.getConnection().getCatalog();
+        jdbcClient = database.getJdbcClient();
+
+        Connection connection = database.getConnection();
         PreparedStatement preparedStatement = connection.prepareStatement("create table \"test_table\" (" + "" +
                 "\"col_0\" BIGINT, " +
                 "\"col_1\" DOUBLE, " +
@@ -78,8 +81,9 @@ public class TestJdbcQueryBuilder
 
     @AfterMethod
     public void teardown()
+            throws Exception
     {
-        dummyHandle.close();
+        database.close();
     }
 
     @Test
@@ -109,9 +113,9 @@ public class TestJdbcQueryBuilder
                         ImmutableList.of(Range.equal(BooleanType.BOOLEAN, true))),
                         false)
         ));
-        Connection connection = dummyHandle.getConnection();
+        Connection connection = database.getConnection();
 
-        PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(connection, "", "", "test_table", cols, tupleDomain);
+        PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, connection, "", "", "test_table", cols, tupleDomain);
 
         ResultSet res = preparedStatement.executeQuery();
 
@@ -130,9 +134,9 @@ public class TestJdbcQueryBuilder
                 cols.get(0), Domain.all(BigintType.BIGINT),
                 cols.get(1), Domain.onlyNull(DoubleType.DOUBLE)
         ));
-        Connection connection = dummyHandle.getConnection();
+        Connection connection = database.getConnection();
 
-        PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(connection, "", "", "test_table", cols, tupleDomain);
+        PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, connection, "", "", "test_table", cols, tupleDomain);
 
         ResultSet res = preparedStatement.executeQuery();
         assertEquals(res.next(), false);

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -26,9 +26,9 @@ import javax.inject.Inject;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Set;
 
 import static java.util.Locale.ENGLISH;
@@ -73,14 +73,14 @@ public class MySqlClient
     }
 
     @Override
-    public Statement getStatement(Connection connection)
+    public PreparedStatement getPreparedStatement(Connection connection, String sql)
             throws SQLException
     {
-        Statement statement = connection.createStatement();
-        if (statement.isWrapperFor(com.mysql.jdbc.Statement.class)) {
-            statement.unwrap(com.mysql.jdbc.Statement.class).enableStreamingResults();
+        PreparedStatement preparedStatement = connection.prepareStatement(sql);
+        if (preparedStatement.isWrapperFor(com.mysql.jdbc.PreparedStatement.class)) {
+            preparedStatement.unwrap(com.mysql.jdbc.PreparedStatement.class).enableStreamingResults();
         }
-        return statement;
+        return preparedStatement;
     }
 
     @Override

--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
@@ -24,8 +24,8 @@ import org.postgresql.Driver;
 import javax.inject.Inject;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Collection;
 
 public class PostgreSqlClient
@@ -57,12 +57,12 @@ public class PostgreSqlClient
     }
 
     @Override
-    public Statement getStatement(Connection connection)
+    public PreparedStatement getPreparedStatement(Connection connection, String sql)
             throws SQLException
     {
         connection.setAutoCommit(false);
-        Statement statement = connection.createStatement();
-        statement.setFetchSize(1000);
-        return statement;
+        PreparedStatement preparedStatement = connection.prepareStatement(sql);
+        preparedStatement.setFetchSize(1000);
+        return preparedStatement;
     }
 }


### PR DESCRIPTION
Pull request #4651 broke MySQL(and presumably PostgreSQL) streaming outputs because the JdbcClient implementations can't control the creation of PreparedStatements.

I've added a getPreparedStatement method and implemented it for both PostgresSQL and MySQL. The original getStatement, which was unused since #4651, has been removed.

BR.