### PR TITLE
Document how to enable Kerberos on the Presto CLI/coordinator.

### DIFF
--- a/presto-docs/src/main/sphinx/develop.rst
+++ b/presto-docs/src/main/sphinx/develop.rst
@@ -11,3 +11,4 @@ This guide is intended for Presto contributors and plugin developers.
     develop/example-http
     develop/types
     develop/functions
+    develop/system-access-control

--- a/presto-docs/src/main/sphinx/develop/system-access-control.rst
+++ b/presto-docs/src/main/sphinx/develop/system-access-control.rst
@@ -1,0 +1,53 @@
+===================
+SystemAccessControl
+===================
+
+Presto separates the concept of the principal who authenticates to the
+coordinator from the username that is responsible for running queries. When
+running the Presto CLI, for example, the Presto username can be specified using
+the --user option.
+
+By default, the Presto coordinator allows any principal to run queries as any
+Presto user. In a secure environment, this is probably not desirable behavior.
+
+Implementation
+--------------
+
+This behavior can be customized by implementing the
+``SystemAccessControlFactory`` and ``SystemAccessControl`` interfaces.
+
+``SystemAccessControlFactory`` is responsible for creating a
+``SystemAccessControl`` instance. It also defines a ``SystemAccessControl``
+name which is used by the administrator in a Presto configuration.
+
+``SystemAccessControl`` implementations have two responsibilities:
+ * Verifying whether or not a given Kerberos principal is authorized to execute
+   queries as a specific user.
+ * Determining whether or not a given user can alter values for a given system
+   property.
+
+The implementation of ``SystemAccessControl`` and
+``SystemAccessControlFactory`` must be wrapped as a plugin and installed on the
+Presto cluster.
+
+.. _system-access-control-configuration:
+
+Configuration
+-------------
+
+Once a plugin that implements ``SystemAccessControl`` and
+``SystemAccessControlFactory`` has been installed on the coordinator, it is
+configured using an access-controls.properties file. All of the properties
+other than ``access-control.name`` are specific to the ``SystemAccessControl``
+plugin.
+
+.. code-block:: none
+
+  access-control.name=custom-access-control
+  custom-property1=custom-value1
+  custom-property2=custom-value2
+  ...
+
+The ``access-control.name`` property is used by Presto to find a registered
+``SystemAccessControlFactory``. The remaining properties are passed as a map to
+``SystemAccessControlFactory.create(Map<String, String> config)``.

--- a/presto-docs/src/main/sphinx/index.rst
+++ b/presto-docs/src/main/sphinx/index.rst
@@ -10,6 +10,7 @@ Presto Documentation
     installation
     admin
     connector
+    security
     functions
     language
     sql

--- a/presto-docs/src/main/sphinx/security.rst
+++ b/presto-docs/src/main/sphinx/security.rst
@@ -1,0 +1,9 @@
+********
+Security
+********
+
+.. toctree::
+    :maxdepth: 1
+
+    security/server
+    security/cli

--- a/presto-docs/src/main/sphinx/security/cli.rst
+++ b/presto-docs/src/main/sphinx/security/cli.rst
@@ -1,0 +1,124 @@
+===========================
+CLI Kerberos Authentication
+===========================
+
+The Presto :doc:`/installation/cli` can connect to a :doc:`Presto coordinator
+</security/server>` that has Kerberos authentication enabled.
+
+Environment Configuration
+-------------------------
+
+.. |subject_node| replace:: client
+.. |subject_ref| replace:: cli
+
+.. include:: kerberos-services.fragment
+.. include:: kerberos-configuration.fragment
+
+Kerberos Principals and Keytab Files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each user who connects to the Presto coordinator needs a Kerberos principal.
+You will need to create these users in Kerberos using `kadmin
+<http://web.mit.edu/kerberos/krb5-latest/doc/admin/admin_commands/kadmin_local.html>`_.
+
+Additionally, each user needs a `keytab file
+<http://web.mit.edu/kerberos/krb5-devel/doc/basic/keytab_def.html>`_. The
+keytab file can be created using :command:`kadmin` after you create the
+principal.
+
+.. code-block:: none
+
+  kadmin
+  > addprinc -randkey someuser@EXAMPLE.COM
+  > ktadd -k /home/someuser/someuser.keytab someuser@EXAMPLE.COM
+
+.. include:: ktadd-note.fragment
+
+.. include:: jce-policy.fragment
+
+Java Keystore File for TLS
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Access to the Presto coordinator should be through https when using Kerberos
+authentication. The Presto coordinator uses a :ref:`Java Keystore
+<server_java_keystore>` file for its TLS configuration. This file can be
+copied to the client machine and used for its configuration.
+
+Presto CLI execution
+--------------------
+
+In addition to the options that are required when connecting to a Presto
+coordinator that does not require Kerberos authentication, invoking the CLI
+with Kerberos support enabled requires a number of additional command line
+options. The simplest way to invoke the CLI is with a wrapper script.
+
+.. code-block:: none
+
+  #!/bin/bash
+
+  ./presto-cli-*-executable.jar \
+    --server https://presto-coordinator.example.com:7778 \
+    --enable-authentication \
+    --krb5-config-path /etc/krb5.conf \
+    --krb5-principal someuser@EXAMPLE.COM \
+    --krb5-keytab-path /home/someuser/someuser.keytab \
+    --krb5-remote-service-name presto \
+    --keystore-path /tmp/presto.jks \
+    --keystore-password password \
+    --catalog <catalog> \
+    --schema <schema>
+
+=============================== =========================================================================
+Option                          Description
+=============================== =========================================================================
+``--server``                    The address and port of the Presto coordinator.  The port must
+                                be set to the port the Presto coordinator is listening for HTTPS
+                                connections on.
+``--enable-authentication``     Enables Kerberos authentication.
+``--krb5-config-path``          Kerberos configuration file.
+``--krb5-principal``            The principal to use when authenticating to the coordinator.
+``--krb5-keytab-path``          The location of the the keytab that can be used to
+                                authenticate the principal specified by ``--krb5-principal``
+``--krb5-remote-service-name``  Presto coordinator Kerberos service name.
+``--keystore-path``             The location of the Java Keystore file that will be used
+                                to secure TLS.
+``--keystore-password``         The password for the keystore. This must match the
+                                password you specified when creating the keystore.
+=============================== =========================================================================
+
+Troubleshooting
+---------------
+
+Many of the same steps that can be used when troubleshooting the :ref:`Presto
+coordinator <coordinator-troubleshooting>` apply to troubleshooting the CLI.
+
+Additional Kerberos Debugging Information
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can enable additional Kerberos debugging information for the Presto CLI
+process by passing ``-Dsun.security.krb5.debug=true`` as a JVM argument when
+starting the CLI process. Doing so requires invoking the CLI jar through Java
+instead of running the self-executable jar directly. The self-executable jar
+file cannot pass the option to the JVM.
+
+.. code-block:: none
+
+  #!/bin/bash
+
+  java \
+    -Dsun.security.krb5.debug=true \
+    -jar presto-cli-*-executable.jar \
+    --server https://presto-coordinator.example.com:7778 \
+    --enable-authentication \
+    --krb5-config-path /etc/krb5.conf \
+    --krb5-principal someuser@EXAMPLE.COM \
+    --krb5-keytab-path /home/someuser/someuser.keytab \
+    --krb5-remote-service-name presto \
+    --keystore-path /tmp/presto.jks \
+    --keystore-password password \
+    --catalog <catalog> \
+    --schema <schema>
+
+The :ref:`additional resources <server_additional_resources>` listed in the
+documentation for setting up Kerberos authentication for the Presto coordinator
+may be of help when interpreting the Kerberos debugging messages.

--- a/presto-docs/src/main/sphinx/security/jce-policy.fragment
+++ b/presto-docs/src/main/sphinx/security/jce-policy.fragment
@@ -1,0 +1,22 @@
+Java Cryptography Extension Policy Files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Java Runtime Environment is shipped with policy files that limit the
+strengh of the cryptographic keys that can be used. Kerberos, by default, uses
+keys that are larger than those supported by the included policy files. There
+are two possible solutions to the problem:
+
+  * Update the :abbr:`JCE (Java Cryptograhy Extension)` policy files.
+  * Configure Kerberos to use reduced-strength keys.
+
+Of the two options, updating the JCE policy files is recommended. The JCE
+policy files can be downloaded from Oracle. Note that the JCE policy files vary
+based on the major version of Java you are running. Java 6 policy files will
+not work with Java 8, for example.
+
+The Java 8 policy files are available `here
+<http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html>`_.
+Instructions for installing the policy files are included in a README file in
+the zip archive. You will need administrative access to install the policy
+files if you are installing them in a system JRE.
+

--- a/presto-docs/src/main/sphinx/security/kerberos-configuration.fragment
+++ b/presto-docs/src/main/sphinx/security/kerberos-configuration.fragment
@@ -1,0 +1,24 @@
+Kerberos Configuration
+^^^^^^^^^^^^^^^^^^^^^^
+
+Kerberos needs to be configured on the |subject_node| At a minimum, there needs
+to be a ``kdc`` entry in the ``[realms]`` section of the ``/etc/krb5.conf``
+file. You may also want to include an ``admin_server`` entry and ensure that
+the |subject_node| can reach the Kerberos admin server on port 749.
+
+.. code-block:: none
+
+   [realms]
+     PRESTO.EXAMPLE.COM = {
+       kdc = kdc.example.com
+       admin_server = kdc.example.com
+     }
+
+   [domain_realm]
+     .presto.example.com = PRESTO.EXAMPLE.COM
+     presto.example.com = PRESTO.EXAMPLE.COM
+
+The complete `documentation
+<http://web.mit.edu/kerberos/krb5-latest/doc/admin/conf_files/kdc_conf.html>`_
+for ``krb5.conf`` is hosted by the MIT Kerberos Project.
+

--- a/presto-docs/src/main/sphinx/security/kerberos-configuration.fragment
+++ b/presto-docs/src/main/sphinx/security/kerberos-configuration.fragment
@@ -1,5 +1,5 @@
-Kerberos Configuration
-^^^^^^^^^^^^^^^^^^^^^^
+MIT Kerberos Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Kerberos needs to be configured on the |subject_node| At a minimum, there needs
 to be a ``kdc`` entry in the ``[realms]`` section of the ``/etc/krb5.conf``
@@ -20,5 +20,7 @@ the |subject_node| can reach the Kerberos admin server on port 749.
 
 The complete `documentation
 <http://web.mit.edu/kerberos/krb5-latest/doc/admin/conf_files/kdc_conf.html>`_
-for ``krb5.conf`` is hosted by the MIT Kerberos Project.
+for ``krb5.conf`` is hosted by the MIT Kerberos Project. If you are using a
+different implementation of the Kerberos protocol, you will need to adapt the
+configuration to your environment.
 

--- a/presto-docs/src/main/sphinx/security/kerberos-services.fragment
+++ b/presto-docs/src/main/sphinx/security/kerberos-services.fragment
@@ -1,0 +1,8 @@
+Kerberos Services
+^^^^^^^^^^^^^^^^^
+
+You will need a Kerberos :abbr:`KDC (Key Distribution Center)` running on a
+node that the |subject_node| can reach over the network. The KDC is
+responsible for authenticating principals and issuing session keys that can be
+used with Kerberos-enabled services. KDCs typically run on port 88, which is
+the IANA-assigned port for Kerberos.

--- a/presto-docs/src/main/sphinx/security/ktadd-note.fragment
+++ b/presto-docs/src/main/sphinx/security/ktadd-note.fragment
@@ -1,0 +1,6 @@
+.. note::
+
+  Running :command:`ktadd` randomizes the principal's keys. If you have just
+  created the principal, this does not matter. If the principal already exists,
+  and if existing users or services rely on being able to authenticate using a
+  password or a keytab, use the ``-norandkey`` option to :command:`ktadd`.

--- a/presto-docs/src/main/sphinx/security/server.rst
+++ b/presto-docs/src/main/sphinx/security/server.rst
@@ -1,0 +1,281 @@
+==========================================
+Presto Coordinator Kerberos Authentication
+==========================================
+
+The Presto coordinator can be configured to enable Kerberos authentication over
+HTTPS for clients, such as the :doc:`Presto CLI </security/cli>`, or the
+JDBC and ODBC drivers.
+
+.. warning::
+
+  Worker nodes cannot yet be configured to connect to the Presto coordinator
+  using HTTPS or to authenticate with Kerberos. It is the administrator's
+  responsibility to enable unauthenticated access over HTTP for worker nodes
+  and ensure unathenticated access is blocked for any node that is not a worker
+  node. For nodes that are not worker nodes, block access to the Presto
+  coordinator's HTTP port.
+
+To enable Kerberos authentication for Presto, configuration changes are made on
+the Presto coordinator. No changes are required to the worker configuration;
+the worker nodes will continue to connect to the coordinator over
+unauthenticated HTTP.
+
+Environment Configuration
+-------------------------
+
+.. |subject_node| replace:: Presto coordinator
+.. |subject_ref| replace:: server
+
+.. _server_kerberos_services:
+.. include:: kerberos-services.fragment
+
+.. _server_kerberos_configuration:
+.. include:: kerberos-configuration.fragment
+
+.. _server_kerberos_principals:
+
+Kerberos Principals and Keytab Files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Presto coordinator needs a Kerberos principal, as do users who are going to
+connect to the Presto coordinator. You will need to create these users in
+Kerberos using `kadmin
+<http://web.mit.edu/kerberos/krb5-latest/doc/admin/admin_commands/kadmin_local.html>`_.
+
+In addition, the Presto coordinator needs a `keytab file
+<http://web.mit.edu/kerberos/krb5-devel/doc/basic/keytab_def.html>`_. After you create the principal, you can create the keytab file using :command:`kadmin`
+
+.. code-block:: none
+
+  kadmin
+  > addprinc -randkey presto@EXAMPLE.COM
+  > addprinc -randkey presto/presto-coordinator.example.com@EXAMPLE.COM
+  > ktadd -k /etc/presto/presto.keytab presto@EXAMPLE.COM
+  > ktadd -k /etc/presto/presto.keytab presto/presto-coordinator.example.com@EXAMPLE.COM
+
+.. include:: ktadd-note.fragment
+
+.. include:: jce-policy.fragment
+
+.. _server_java_keystore:
+
+Java Keystore File for TLS
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using Kerberos authentication, access to the Presto coordinator should be
+through HTTPS. The Presto coordinator needs keys to secure the :abbr:`TLS
+(Transport Layer Security)` connection. These keys are generated using
+:command:`keytool` and stored in a Java Keystore file for the Presto
+coordinator.
+
+The alias in the :command:`keytool` command line should match the principal that the
+Presto coordinator will use.
+
+You'll be prompted for the first and last name. Use the Common Name that will
+be used in the certificate. In this case it should be the unqualified hostname
+of the Presto coordinator. In the example, you can see this in the prompt that
+confirms the information is correct.
+
+.. code-block:: none
+
+  keytool -genkeypair -alias presto -keyalg RSA -keystore keystore.jks
+  Enter keystore password:
+  Re-enter new password:
+  What is your first and last name?
+    [Unknown]:  presto-coordinator
+  What is the name of your organizational unit?
+    [Unknown]:
+  What is the name of your organization?
+    [Unknown]:
+  What is the name of your City or Locality?
+    [Unknown]:
+  What is the name of your State or Province?
+    [Unknown]:
+  What is the two-letter country code for this unit?
+    [Unknown]:
+  Is CN=eiger, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct?
+    [no]:  yes
+
+  Enter key password for <presto>
+          (RETURN if same as keystore password):
+
+
+.. _server_access_controller:
+
+Access Controller Implementation
+--------------------------------
+
+Presto separates the concept of the principal who authenticates to the
+coordinator from the username that is responsible for running queries. When
+running the Presto CLI, for example, the Presto username can be specified using
+the --user option.
+
+By default, the Presto coordinator allows any principal to run queries as any
+Presto user. In a secure environment, this is probably not desirable behavior.
+
+This behavior can be customized by implementing the
+``SystemAccessControlFactory`` and ``SystemAccessControl`` interfaces.
+
+``SystemAccessControlFactory`` is responsible for creating a
+``SystemAccessControl`` instance. It also defines a ``SystemAccessControl``
+name which is used by the administrator in a Presto configuration.
+
+``SystemAccessControl`` implementations have two responsibilities:
+ * Verifying whether or not a given Kerberos principal is authorized to execute
+   queries as a specific user.
+ * Determining whether or not a given user can alter values for a given system
+   property.
+
+The implementation of ``SystemAccessControl`` and
+``SystemAccessControlFactory`` must be wrapped as a plugin and installed on the
+Presto cluster.
+
+Presto Coordinator Node Configuration
+-------------------------------------
+
+You must make the above changes to the environment prior to configuring the
+Presto coordinator to use Kerberos authentication and HTTPS. After making the
+following environment changes, you can make the changes to the Presto
+configuration files.
+
+ * :ref:`server_kerberos_services`
+ * :ref:`server_kerberos_configuration`
+ * :ref:`server_kerberos_principals`
+ * :ref:`server_java_keystore`
+ * :ref:`server_access_controller`
+
+config.properties
+^^^^^^^^^^^^^^^^^
+
+Kerberos authentication is configured in the coordinator node's
+config.properties file. The entries that need to be added are listed below.
+
+.. code-block:: none
+
+  http.server.authentication.enabled=true
+
+  http.server.authentication.krb5.service-name=presto
+  http.server.authentication.krb5.keytab=/etc/presto/presto.keytab
+  http.authentication.krb5.config=/etc/krb5.conf
+
+  http-server.https.enabled=true
+  http-server.https.port=7778
+
+  http-server.https.keystore.path=/etc/presto_keystore.jks
+  http-server.https.keystore.key=keystore_password
+
+======================================================= ======================================================
+Property                                                Description
+======================================================= ======================================================
+``http.server.authentication.enabled``                  Enable authentication for the Presto coordinator.
+                                                        Must be set to ``true``.
+``http.server.authentication.krb5.service-name``        The Kerberos server name for the Presto coordinator.
+                                                        Must match the Kerberos principal.
+``http.server.authentication.krb5.keytab``              The location of the keytab that can be used to
+                                                        authenticate the Kerberos principal specified in
+                                                        ``http.server.authentication.krb5.service-name``.
+``http.authentication.krb5.config``                     The location of the Kerberos configuration file.
+``http-server.https.enabled``                           Enables HTTPS access for the Presto coordinator.
+                                                        Should be set to ``true``.
+``http-server.https.port``                              HTTPS server port.
+``http-server.https.keystore.path``                     The location of the Java Keystore file that will be
+                                                        used to secure TLS.
+``http-server.https.keystore.key``                      The password for the keystore. This must match the
+                                                        password you specified when creating the keystore.
+======================================================= ======================================================
+
+access-controls.properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once a plugin that implements ``SystemAccessControl`` and
+``SystemAccessControlFactory`` has been installed on the coordinator, it is
+configured using an access-controls.properties file. All of the properties
+other than access-control.name are specific to the ``SystemAccessControl``
+plugin.
+
+.. code-block:: none
+
+  access-control.name=custom-access-control
+  custom-property1=custom-value1
+  custom-property2=custom-value2
+  ...
+
+The ``access-control.name`` property is used by Presto to find a registered
+``SystemAccessControlFactory``. The remaining properties are passed as a map to
+``SystemAccessControlFactory.create(Map<String, String> config)``.
+
+.. _coordinator-troubleshooting:
+
+Troubleshooting
+---------------
+
+Getting Kerberos authentication working can be challenging. You can
+independently verify some of the configuration outside of Presto to help narrow
+your focus when trying to solve a problem.
+
+Kerberos Verification
+^^^^^^^^^^^^^^^^^^^^^
+
+Ensure that you can connect to the KDC from the Presto coordinator using
+:command:`telnet`.
+
+.. code-block:: none
+
+  $ telnet kdc.example.com 88
+
+Verify that the keytab file can be used to successfully obtain a ticket using
+`kinit
+<http://web.mit.edu/kerberos/krb5-1.12/doc/user/user_commands/kinit.html>`_ and
+`klist
+<http://web.mit.edu/kerberos/krb5-1.12/doc/user/user_commands/klist.html>`_
+
+.. code-block:: none
+
+  $ kinit -kt /etc/presto/presto.keytab presto@EXAMPLE.COM
+  $ klist
+
+Java Keystore File Verification
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Verify the password for a keystore file and view its contents using `keytool
+<http://docs.oracle.com/javase/8/docs/technotes/tools/windows/keytool.html>`_.
+
+.. code-block:: none
+
+  $ keytool -list -v -k /etc/presto/presto.jks
+
+Additional Kerberos Debugging Information
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can enable additional Kerberos debugging information for the Presto
+coordinator process by adding the following lines to the Presto ``jvm.config``
+file
+
+.. code-block:: none
+
+  -Dsun.security.krb5.debug=true
+  -Dlog.enable-console=true
+
+``-Dsun.security.krb5.debug=true`` enables Kerberos debugging output from the
+JRE Kerberos libraries. The debugging output goes to ``stdout``, which Presto
+redirects to the logging system. ``-Dlog.enable-console=true`` enables output
+to ``stdout`` to appear in the logs.
+
+The amount and usefulness of the information the Kerberos debugging output
+sends to the logs varies depending on where the authentication is failing.
+Exception messages and stack traces can also provide useful clues about the
+nature of the problem.
+
+.. _server_additional_resources:
+
+Additional resources
+^^^^^^^^^^^^^^^^^^^^
+
+`Common Kerberos Error Messages (A-M)
+<http://docs.oracle.com/cd/E19253-01/816-4557/trouble-6/index.html>`_
+
+`Common Kerberos Error Messages (N-Z)
+<http://docs.oracle.com/cd/E19253-01/816-4557/trouble-27/index.html>`_
+
+`MIT Kerberos Documentation: Troubleshooting
+<http://web.mit.edu/kerberos/krb5-latest/doc/admin/troubleshoot.html>`_

--- a/presto-docs/src/main/sphinx/security/server.rst
+++ b/presto-docs/src/main/sphinx/security/server.rst
@@ -184,6 +184,19 @@ Property                                                Description
                                                         password you specified when creating the keystore.
 ======================================================= ======================================================
 
+.. note::
+
+  Monitor CPU usage on the Presto coordinator after enabling HTTPS. Java will
+  choose CPU-intensive cipher suites by default. If the CPU usage is
+  unacceptably high after enabling HTTPS, you can configure JAVA to use
+  specific cipher suites by setting the ``http-server.https.included-cipher``
+  property.
+
+  ``http-server.https.included-cipher=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA256``
+
+  The Java documentation lists the `supported cipher suites
+  <http://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SupportedCipherSuites>`_.
+
 access-controls.properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-docs/src/main/sphinx/security/server.rst
+++ b/presto-docs/src/main/sphinx/security/server.rst
@@ -100,35 +100,12 @@ confirms the information is correct.
           (RETURN if same as keystore password):
 
 
-.. _server_access_controller:
+SystemAccessControl Plugin
+--------------------------
 
-Access Controller Implementation
---------------------------------
-
-Presto separates the concept of the principal who authenticates to the
-coordinator from the username that is responsible for running queries. When
-running the Presto CLI, for example, the Presto username can be specified using
-the --user option.
-
-By default, the Presto coordinator allows any principal to run queries as any
-Presto user. In a secure environment, this is probably not desirable behavior.
-
-This behavior can be customized by implementing the
-``SystemAccessControlFactory`` and ``SystemAccessControl`` interfaces.
-
-``SystemAccessControlFactory`` is responsible for creating a
-``SystemAccessControl`` instance. It also defines a ``SystemAccessControl``
-name which is used by the administrator in a Presto configuration.
-
-``SystemAccessControl`` implementations have two responsibilities:
- * Verifying whether or not a given Kerberos principal is authorized to execute
-   queries as a specific user.
- * Determining whether or not a given user can alter values for a given system
-   property.
-
-The implementation of ``SystemAccessControl`` and
-``SystemAccessControlFactory`` must be wrapped as a plugin and installed on the
-Presto cluster.
+A Presto coordinator with Kerberos enabled will probably need a
+:doc:`SystemAccessControl plugin </develop/system-access-control>` to achieve
+the desired level of security.
 
 Presto Coordinator Node Configuration
 -------------------------------------
@@ -142,13 +119,13 @@ configuration files.
  * :ref:`server_kerberos_configuration`
  * :ref:`server_kerberos_principals`
  * :ref:`server_java_keystore`
- * :ref:`server_access_controller`
+ * :doc:`SystemAccessControl Plugin </develop/system-access-control>`
 
 config.properties
 ^^^^^^^^^^^^^^^^^
 
 Kerberos authentication is configured in the coordinator node's
-config.properties file. The entries that need to be added are listed below.
+:file:`config.properties` file. The entries that need to be added are listed below.
 
 .. code-block:: none
 
@@ -200,22 +177,11 @@ Property                                                Description
 access-controls.properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once a plugin that implements ``SystemAccessControl`` and
-``SystemAccessControlFactory`` has been installed on the coordinator, it is
-configured using an access-controls.properties file. All of the properties
-other than access-control.name are specific to the ``SystemAccessControl``
-plugin.
-
-.. code-block:: none
-
-  access-control.name=custom-access-control
-  custom-property1=custom-value1
-  custom-property2=custom-value2
-  ...
-
-The ``access-control.name`` property is used by Presto to find a registered
-``SystemAccessControlFactory``. The remaining properties are passed as a map to
-``SystemAccessControlFactory.create(Map<String, String> config)``.
+At a minimum, an :file:`access-control.properties` file must contain an
+``access-control.name`` property.  All other configuration for a
+SystemAccessControl plugin is implementation dependent.  The Developer Guide
+has :ref:`general information <system-access-control-configuration>` about how
+SystemAccessControl plugins are configured.
 
 .. _coordinator-troubleshooting:
 


### PR DESCRIPTION
This adds documentation for how to set up Kerberos authentication between the Presto CLI and the Presto coordinator.