### PR TITLE
Fix NullPointerException from non-read queries

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
@@ -394,6 +394,9 @@ public class Validator
                                 timeout.toMillis() - stopwatch.elapsed(TimeUnit.MILLISECONDS),
                                 TimeUnit.MILLISECONDS, true);
                     }
+                    else {
+                        results = ImmutableList.of(ImmutableList.of(limitedStatement.getLargeUpdateCount()));
+                    }
                     prestoStatement.clearProgressMonitor();
                     QueryStats queryStats = progressMonitor.getFinalQueryStats();
                     if (queryStats == null) {


### PR DESCRIPTION
Queries that do not read (SELECT) generate null results. We would
attempt to create a multiset out of these, causing a
NullPointerException. This fixes the resultsMatch function to deal
with this case properly.