### PR TITLE
Release data sources properly in optimized Parquet reader

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -364,8 +364,7 @@ public class ParquetHiveRecordCursor
             boolean predicatePushdownEnabled,
             TupleDomain<HiveColumnHandle> effectivePredicate)
     {
-        ParquetDataSource dataSource = buildHdfsParquetDataSource(path, configuration, start, length);
-        try {
+        try (ParquetDataSource dataSource = buildHdfsParquetDataSource(path, configuration, start, length)) {
             ParquetMetadata parquetMetadata = ParquetFileReader.readFooter(configuration, path, NO_FILTER);
             List<BlockMetaData> blocks = parquetMetadata.getBlocks();
             FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
@@ -410,11 +409,6 @@ public class ParquetHiveRecordCursor
             return realReader;
         }
         catch (Exception e) {
-            try {
-                dataSource.close();
-            }
-            catch (IOException ignored) {
-            }
             if (e instanceof PrestoException) {
                 throw (PrestoException) e;
             }


### PR DESCRIPTION
The optimized Parquet reader does not properly close the file system connections that it uses to read dictionary pages (which exhausts eventually the http client connection pool when using the AWS sdk and queries start failing etc.). This PR fixes that. Related to #4879. \cc @zhenxiao @dain 