### PR TITLE
Remove supported type check in HiveType factories

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -62,7 +62,9 @@ import static com.facebook.presto.hive.HiveUtil.checkCondition;
 import static com.facebook.presto.hive.HiveUtil.getInputFormat;
 import static com.facebook.presto.hive.HiveUtil.isSplittable;
 import static com.facebook.presto.hive.UnpartitionedPartition.isUnpartitioned;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
 
 public class BackgroundHiveSplitLoader
         implements HiveSplitLoader
@@ -494,6 +496,9 @@ public class BackgroundHiveSplitLoader
         for (int i = 0; i < keys.size(); i++) {
             String name = keys.get(i).getName();
             HiveType hiveType = HiveType.valueOf(keys.get(i).getType());
+            if (!hiveType.isSupportedType()) {
+                throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type %s found in partition keys of table %s.%s", hiveType, table.getDbName(), table.getTableName()));
+            }
             String value = values.get(i);
             checkCondition(value != null, HIVE_INVALID_PARTITION_VALUE, "partition key value cannot be null for field: %s", name);
             partitionKeys.add(new HivePartitionKey(name, hiveType, value));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -678,13 +678,16 @@ public class HiveMetadata
 
         checkTableIsWritable(table.get());
 
-        List<HiveColumnHandle> handles = hiveColumnHandles(connectorId, table.get());
-
-        for (HiveColumnHandle hiveColumnHandle : handles) {
-            if (!isWritableType(hiveColumnHandle.getHiveType())) {
-                throw new PrestoException(NOT_SUPPORTED, format("Inserting into Hive table with column type %s not supported", hiveColumnHandle.getHiveType()));
+        for (FieldSchema fieldSchema : table.get().getSd().getCols()) {
+            HiveType hiveType = HiveType.valueOf(fieldSchema.getType());
+            if (!isWritableType(hiveType)) {
+                throw new PrestoException(
+                        NOT_SUPPORTED,
+                        format("Inserting into Hive table %s.%s with column type %s not supported", table.get().getDbName(), table.get().getTableName(), hiveType));
             }
         }
+
+        List<HiveColumnHandle> handles = hiveColumnHandles(connectorId, table.get());
 
         HiveStorageFormat tableStorageFormat = extractHiveStorageFormat(table.get());
         HiveInsertTableHandle result = new HiveInsertTableHandle(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveType.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveType.java
@@ -153,6 +153,11 @@ public final class HiveType
         return hiveTypeName;
     }
 
+    public boolean isSupportedType()
+    {
+        return isSupportedType(getTypeInfo());
+    }
+
     public static boolean isSupportedType(TypeInfo typeInfo)
     {
         switch (typeInfo.getCategory()) {
@@ -190,12 +195,9 @@ public final class HiveType
     }
 
     @Nonnull
-    public static HiveType toHiveType(TypeInfo typeInfo)
+    private static HiveType toHiveType(TypeInfo typeInfo)
     {
         requireNonNull(typeInfo, "typeInfo is null");
-        if (!isSupportedType(typeInfo)) {
-            throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type: %s", typeInfo));
-        }
         return new HiveType(typeInfo);
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
-import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
@@ -87,7 +86,6 @@ import static com.facebook.presto.hive.HiveType.HIVE_LONG;
 import static com.facebook.presto.hive.HiveType.HIVE_SHORT;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.HiveType.HIVE_TIMESTAMP;
-import static com.facebook.presto.hive.HiveType.toHiveType;
 import static com.facebook.presto.hive.RetryDriver.retry;
 import static com.facebook.presto.hive.util.Types.checkType;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -121,7 +119,6 @@ import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_LIB;
 import static org.apache.hadoop.hive.serde2.ColumnProjectionUtils.READ_ALL_COLUMNS;
 import static org.apache.hadoop.hive.serde2.ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
-import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils.getTypeInfoFromTypeString;
 
 public final class HiveUtil
 {
@@ -639,9 +636,8 @@ public final class HiveUtil
         int hiveColumnIndex = 0;
         for (FieldSchema field : table.getSd().getCols()) {
             // ignore unsupported types rather than failing
-            TypeInfo typeInfo = getTypeInfoFromTypeString(field.getType());
-            if (HiveType.isSupportedType(typeInfo)) {
-                HiveType hiveType = toHiveType(typeInfo);
+            HiveType hiveType = HiveType.valueOf(field.getType());
+            if (hiveType.isSupportedType()) {
                 columns.add(new HiveColumnHandle(connectorId, field.getName(), hiveType, hiveType.getTypeSignature(), hiveColumnIndex, false));
             }
             hiveColumnIndex++;
@@ -657,7 +653,10 @@ public final class HiveUtil
         List<FieldSchema> partitionKeys = table.getPartitionKeys();
         for (FieldSchema field : partitionKeys) {
             HiveType hiveType = HiveType.valueOf(field.getType());
-            columns.add(new HiveColumnHandle(connectorId, field.getName(), hiveType, HiveType.valueOf(field.getType()).getTypeSignature(), -1, true));
+            if (!hiveType.isSupportedType()) {
+                throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type %s found in partition keys of table %s.%s", hiveType, table.getDbName(), table.getTableName()));
+            }
+            columns.add(new HiveColumnHandle(connectorId, field.getName(), hiveType, hiveType.getTypeSignature(), -1, true));
         }
 
         return columns.build();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -89,6 +89,7 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.testng.TestException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -1919,7 +1920,11 @@ public abstract class AbstractTestHiveClient
             fail("expected failure");
         }
         catch (PrestoException e) {
-            assertEquals(e.getMessage(), "Inserting into Hive table with column type smallint not supported");
+            String expected = "Inserting into Hive table .* with column type smallint not supported";
+            if (!e.getMessage().matches(expected)) {
+                throw new TestException("The exception was thrown with the wrong message:" +
+                        " expected \"" + expected + "\"" + " but got \"" + e.getMessage() + "\"", e);
+            }
         }
     }
 


### PR DESCRIPTION
* Add supported type check where necessary after surveying callers
* Improve supported type check in HiveMetadata to catch unsupported type
  (Originally, only supported type that can't be written is caught.
  Unsupported types are caught downstream by HiveRecordWriter.)
* Improve error message to provide user more context on unsupported type
* Pre-requisite for upcoming refactoring of metastore classes