### PR TITLE
Add event handler and support for pluggable query event processors

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/EventProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/EventProcessor.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.event;
+
+import com.facebook.presto.event.query.QueryCompletionEvent;
+import com.facebook.presto.event.query.QueryCreatedEvent;
+import com.facebook.presto.event.query.QueryEvent;
+import com.facebook.presto.event.query.QueryEventHandler;
+import com.facebook.presto.event.query.SplitCompletionEvent;
+import com.google.inject.Inject;
+import io.airlift.event.client.AbstractEventClient;
+import io.airlift.event.client.EventType;
+import io.airlift.log.Logger;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Class that listens for airlift events and sends presto events to handlers
+ */
+public class EventProcessor extends AbstractEventClient
+{
+    private static final String QUERY_CREATED = "QueryCreated";
+    private static final String QUERY_COMPLETION = "QueryCompletion";
+    private static final String SPLIT_COMPLETION = "SplitCompletion";
+    private static final Logger log = Logger.get(EventProcessor.class);
+
+    private Set<QueryEventHandler<QueryCreatedEvent>> queryCreatedEventHandlers;
+    private Set<QueryEventHandler<QueryCompletionEvent>> queryCompletionEventHandlers;
+    private Set<QueryEventHandler<SplitCompletionEvent>> splitCompletionEventHandlers;
+
+    @Inject
+    public EventProcessor(
+            Set<QueryEventHandler<QueryCreatedEvent>> queryCreatedEventHandlers,
+            Set<QueryEventHandler<QueryCompletionEvent>> queryCompletionEventHandlers,
+            Set<QueryEventHandler<SplitCompletionEvent>> splitCompletionEventHandlers)
+    {
+        this.queryCreatedEventHandlers = queryCreatedEventHandlers;
+        this.queryCompletionEventHandlers = queryCompletionEventHandlers;
+        this.splitCompletionEventHandlers = splitCompletionEventHandlers;
+    }
+
+    @Override
+    protected <T> void postEvent(T event)
+            throws IOException
+    {
+        EventType eventTypeAnnotation = event.getClass().getAnnotation(EventType.class);
+        if (eventTypeAnnotation == null) {
+            return;
+        }
+
+        String type = eventTypeAnnotation.value();
+
+        switch (type) {
+            case QUERY_CREATED:
+                handle(queryCreatedEventHandlers, type, (QueryCreatedEvent) event);
+                break;
+            case QUERY_COMPLETION:
+                handle(queryCompletionEventHandlers, type, (QueryCompletionEvent) event);
+                break;
+            case SPLIT_COMPLETION:
+                handle(splitCompletionEventHandlers, type, (SplitCompletionEvent) event);
+                break;
+            default:
+                log.warn("Unrecognized event found: " + type);
+        }
+    }
+
+    private <E extends QueryEvent> void handle(Set<QueryEventHandler<E>> handlers, String type, E event)
+    {
+        for (QueryEventHandler<E> handler : handlers) {
+            try {
+                handler.handle(event);
+            }
+            catch (Throwable e) {
+                log.error(e, String.format(
+                        "Exception processing %s event for query %s", type, event.getQueryId()));
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryCompletionEvent.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryCompletionEvent.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 @Immutable
 @EventType("QueryCompletion")
-public class QueryCompletionEvent
+public class QueryCompletionEvent implements QueryEvent
 {
     private final QueryId queryId;
     private final String transactionId;

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryCreatedEvent.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryCreatedEvent.java
@@ -24,7 +24,7 @@ import java.net.URI;
 
 @Immutable
 @EventType("QueryCreated")
-public class QueryCreatedEvent
+public class QueryCreatedEvent implements QueryEvent
 {
     private final QueryId queryId;
     private final String transactionId;

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryEvent.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryEvent.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.event.query;
+
+public interface QueryEvent
+{
+    String getQueryId();
+}

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryEventHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryEventHandler.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.event.query;
+
+public interface QueryEventHandler<T extends QueryEvent>
+{
+    void handle(T event);
+}

--- a/presto-main/src/main/java/com/facebook/presto/event/query/SplitCompletionEvent.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/SplitCompletionEvent.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 
 @Immutable
 @EventType("SplitCompletion")
-public class SplitCompletionEvent
+public class SplitCompletionEvent implements QueryEvent
 {
     private final QueryId queryId;
     private final StageId stageId;


### PR DESCRIPTION
Add an event processor that sends typed presto query events to registered handlers. This allows easy extension of event logic like logging. See https://github.com/twitter-forks/presto/pull/37 and https://github.com/twitter-forks/presto/pull/37/files#diff-c20dbfd6a40fef96c66cf1654e16b9fd for an example.

If this approach seems like the direction we want to go, I'll add a unit test.