### PR TITLE
Check partitioned symbol in case of constant

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PartitionFunctionBinding.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PartitionFunctionBinding.java
@@ -203,20 +203,13 @@ public class PartitionFunctionBinding
             this.constant = null;
         }
 
-        public PartitionFunctionArgumentBinding(NullableValue constant)
-        {
-            this.constant = requireNonNull(constant, "constant is null");
-            this.column = null;
-        }
-
         @JsonCreator
         public PartitionFunctionArgumentBinding(
                 @JsonProperty("column") Symbol column,
                 @JsonProperty("constant") NullableValue constant)
         {
-            this.column = column;
+            this.column = requireNonNull(column, "column is null");
             this.constant = constant;
-            checkArgument((column == null) != (constant == null), "Column or constant be set");
         }
 
         public boolean isConstant()
@@ -226,7 +219,7 @@ public class PartitionFunctionBinding
 
         public boolean isVariable()
         {
-            return column != null;
+            return constant == null;
         }
 
         @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
@@ -459,7 +459,7 @@ class ActualProperties
 
             for (int i = 0; i < partitioningArguments.size(); i++) {
                 PartitionFunctionArgumentBinding argument = partitioningArguments.get(i);
-                if (argument.isVariable() && !argument.getColumn().equals(columns.get(i))) {
+                if (!argument.getColumn().equals(columns.get(i))) {
                     return false;
                 }
             }
@@ -589,7 +589,7 @@ class ActualProperties
             // as it makes further optimizations possible.
             Optional<NullableValue> constant = constants.apply(argument.getColumn());
             if (constant.isPresent()) {
-                return Optional.of(new PartitionFunctionArgumentBinding(constant.get()));
+                return Optional.of(new PartitionFunctionArgumentBinding(argument.getColumn(), constant.get()));
             }
 
             return Optional.empty();


### PR DESCRIPTION
We found a case that distributed plan was randomly incorrectly built when child plan is bind to a constant.

At the following example, `WINDOW` function is partitioned by _name_, _address_(constant). And the `JOIN` clause _name_,_comment__ tries to check child is partitioned on them. But as the address is constant, it doesn't check symbol name. So `isPartitionedOn` returns unexpected `true`.

```
presto:sf1> set session distributed_join = false;
presto:sf1> explain (type DISTRIBUTED) with search as (select comment, name, address, phone from customer) select a.comment, b.comment, a.name, b.name from ( select * from (select *, rank() over (partition by name, address) as rank from search where address = 'hello')) as a join ( select * from ( select *, rank() over (partition by name, address) as rank from search where address='world')) as b on a.name = b.name and a.comment = b.comment;
                                                                                           Query Plan
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Fragment 0 [SINGLE]
     Output layout: [comment, comment_69, name, name_63]
     Output partitioning: SINGLE []
     - Output[comment, comment, name, name] => [comment:varchar, comment_69:varchar, name:varchar, name_63:varchar]
             comment := comment_69
             name := name_63
         - RemoteSource[1] => [comment:varchar, comment_69:varchar, name:varchar, name_63:varchar]

 Fragment 1 [HASH]
     Output layout: [comment, comment_69, name, name_63]
     Output partitioning: SINGLE []
     - Project => [name:varchar, comment:varchar, name_63:varchar, comment_69:varchar]
         - InnerJoin[("name" = "name_63") AND ("comment" = "comment_69")] => [name:varchar, comment:varchar, $hashvalue_164:bigint, comment_69:varchar, $hashvalue_169:bigint, name_63:varchar]
             - Project => [name:varchar, comment:varchar, $hashvalue_164:bigint]
                     $hashvalue_164 := "combine_hash"("combine_hash"(0, COALESCE("$operator$hash_code"("name"), 0)), COALESCE("$operator$hash_code"("comment"), 0))
                 - Window[partition by (<address>, name)] => [comment:varchar, name:varchar, address:varchar, $hashvalue_161:bigint]
                     - Project => [comment:varchar, name:varchar, address:varchar, $hashvalue_161:bigint]
                         - RemoteSource[2] => [comment:varchar, name:varchar, address:varchar, $hashvalue:bigint, $hashvalue_161:bigint]
             #### Right table must be partitioned ########
             - Project => [comment_69:varchar, $hashvalue_169:bigint, name_63:varchar]
                     $hashvalue_169 := "combine_hash"("combine_hash"(0, COALESCE("$operator$hash_code"("name_63"), 0)), COALESCE("$operator$hash_code"("comment_69"), 0))
                 - Window[partition by (<address_64>, name_63)] => [comment_69:varchar, name_63:varchar, address_64:varchar, $hashvalue_166:bigint]
                     - Project => [comment_69:varchar, name_63:varchar, address_64:varchar, $hashvalue_166:bigint]
                         - RemoteSource[3] => [comment_69:varchar, name_63:varchar, address_64:varchar, $hashvalue_165:bigint, $hashvalue_166:bigint]

 Fragment 2 [SOURCE]
     Output layout: [comment, name, address, $hashvalue_162, $hashvalue_163]
     Output partitioning: HASH [name, address]
     - Project => [name:varchar, $hashvalue_162:bigint, comment:varchar, address:varchar, $hashvalue_163:bigint]
             $hashvalue_162 := "combine_hash"("combine_hash"(0, COALESCE("$operator$hash_code"("name"), 0)), COALESCE("$operator$hash_code"("comment"), 0))
             $hashvalue_163 := "combine_hash"("combine_hash"(0, COALESCE("$operator$hash_code"("name"), 0)), COALESCE("$operator$hash_code"("address"), 0))
         - Filter[("address" = CAST('hello' AS VARCHAR))] => [name:varchar, address:varchar, comment:varchar]
             - TableScan[tpch:tpch:customer:sf1.0, originalConstraint = ("address" = 'hello')] => [name:varchar, address:varchar, comment:varchar]
                     name := tpch:name
                     address := tpch:address
                     comment := tpch:comment

 Fragment 3 [SOURCE]
     Output layout: [comment_69, name_63, address_64, $hashvalue_167, $hashvalue_168]
     Output partitioning: HASH [name_63, address_64]
     - Project => [name_63:varchar, comment_69:varchar, $hashvalue_168:bigint, address_64:varchar, $hashvalue_167:bigint]
             $hashvalue_168 := "combine_hash"("combine_hash"(0, COALESCE("$operator$hash_code"("name_63"), 0)), COALESCE("$operator$hash_code"("address_64"), 0))
             $hashvalue_167 := "combine_hash"("combine_hash"(0, COALESCE("$operator$hash_code"("name_63"), 0)), COALESCE("$operator$hash_code"("comment_69"), 0))
         - Filter[("address_64" = CAST('world' AS VARCHAR))] => [name_63:varchar, address_64:varchar, comment_69:varchar]
             - TableScan[tpch:tpch:customer:sf1.0, originalConstraint = ("address_64" = 'world')] => [name_63:varchar, address_64:varchar, comment_69:varchar]
                     name_63 := tpch:name
                     address_64 := tpch:address
                     comment_69 := tpch:comment
```