### PR TITLE
Fix removal of hash symbols in HashGenerationOptimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -617,7 +617,7 @@ public class HashGenerationOptimizer
 
             // return only hash symbols that are passed through the new node
             Map<HashComputation, Symbol> hashSymbols = new HashMap<>(source.getHashSymbols());
-            hashSymbols.keySet().retainAll(result.getOutputSymbols());
+            hashSymbols.values().retainAll(result.getOutputSymbols());
 
             return new PlanWithProperties(result, hashSymbols);
         }


### PR DESCRIPTION
The key of `hashSymbols` map is of type `HashComputation` so doing a `keySet().retainAll()` on that map with a collection of type `Symbol` will not remove any symbols as types don't match (since `HashComputation` instances will be checked for equality against `Symbol` instances). This PR fixes that. /cc @dain