### PR TITLE
Add X-Presto-Connection-Property header

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -21,6 +21,7 @@ public final class PrestoHeaders
     public static final String PRESTO_SCHEMA = "X-Presto-Schema";
     public static final String PRESTO_TIME_ZONE = "X-Presto-Time-Zone";
     public static final String PRESTO_LANGUAGE = "X-Presto-Language";
+    public static final String PRESTO_CONNECTION_PROPERTY = "X-Presto-Connection-Property";
     public static final String PRESTO_SESSION = "X-Presto-Session";
     public static final String PRESTO_SET_SESSION = "X-Presto-Set-Session";
     public static final String PRESTO_CLEAR_SESSION = "X-Presto-Clear-Session";

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriver.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriver.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.jdbc;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 
 import java.io.Closeable;
 import java.net.URI;
@@ -48,6 +49,7 @@ public class PrestoDriver
     private static final String DRIVER_URL_START = "jdbc:presto:";
 
     private static final String USER_PROPERTY = "user";
+    private static final String PASSWORD_PROPERTY = "password";
 
     private final QueryExecutor queryExecutor;
 
@@ -86,7 +88,16 @@ public class PrestoDriver
             throw new SQLException(format("Username property (%s) must be set", USER_PROPERTY));
         }
 
-        return new PrestoConnection(parseDriverUrl(url), user, queryExecutor);
+        ImmutableMap.Builder<String, String> connectionProperties = ImmutableMap.builder();
+        for (String key : info.stringPropertyNames()) {
+            // Disable passing user, password properties
+            if (key.equals(USER_PROPERTY) || key.equals(PASSWORD_PROPERTY)) {
+                continue;
+            }
+            connectionProperties.put(key, info.getProperty(key));
+        }
+
+        return new PrestoConnection(parseDriverUrl(url), user, connectionProperties.build(), queryExecutor);
     }
 
     @Override

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.jdbc;
 
+import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.plugin.blackhole.BlackHolePlugin;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.tpch.TpchMetadata;
@@ -40,6 +41,7 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 
 import static io.airlift.testing.Assertions.assertInstanceOf;
@@ -1127,6 +1129,21 @@ public class TestDriver
         }
     }
 
+    @Test
+    public void testConnectionPropertiesHeader()
+            throws Exception
+    {
+        Properties props = new Properties();
+        props.setProperty("user", "test");
+        props.setProperty("token", "xxxyyyy");
+        try (PrestoConnection connection = (PrestoConnection) createConnection(props)) {
+            try (StatementClient client = connection.startQuery("SELECT 123")) {
+                List<String> connectionProperties = client.getConnectionProperties();
+                assertTrue(connectionProperties.contains("token=xxxyyyy"));
+            }
+        }
+    }
+
     @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = ".* does not exist")
     public void testBadQuery()
             throws Exception
@@ -1194,6 +1211,13 @@ public class TestDriver
     {
         String url = format("jdbc:presto://%s", server.getAddress());
         return DriverManager.getConnection(url, "test", null);
+    }
+
+    private Connection createConnection(Properties prop)
+            throws SQLException
+    {
+        String url = format("jdbc:presto://%s", server.getAddress());
+        return DriverManager.getConnection(url, prop);
     }
 
     private Connection createConnection(String catalog)

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
@@ -19,6 +19,7 @@ import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.StatementStats;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HttpHeaders;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.HttpStatus;
@@ -119,7 +120,7 @@ public class TestProgressMonitor
         HttpClient client = new TestingHttpClient(new TestingHttpClientProcessor(RESPONSES));
         QueryExecutor testQueryExecutor = QueryExecutor.create(client);
         URI uri = URI.create(format("prestotest://%s", SERVER_ADDRESS));
-        return new PrestoConnection(uri, "test", testQueryExecutor);
+        return new PrestoConnection(uri, "test", ImmutableMap.of(), testQueryExecutor);
     }
 
     private static class TestingHttpClientProcessor


### PR DESCRIPTION
This PR enables setting connection specific HTTP headers (e.g., access tokens, vendor specific information) through JDBC in `X-Presto-Connection-Property: key=value` format. This change enables us to create a proxy server to access Presto with an additional authentication filter.

- `Driver.connect(jdbcUri, Properties)` is the only API to pass these parameter through JDBC. The current presto-jdbc passes only `user` property. We would like to allow setting more parameters here.
- Currently `ClientSession.properties` is used to store the connection parameters to minimize the change.  If you are OK, I would like to split `ClientSession.properties` into `sessionProperties` and `connectionProperties` to avoid confusion.
