### PR TITLE
Set X-Presto-User header when reading nextUri

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -87,6 +87,7 @@ public class StatementClient
     private final AtomicBoolean valid = new AtomicBoolean(true);
     private final String timeZoneId;
     private final long requestTimeoutNanos;
+    private final String user;
 
     public StatementClient(HttpClient httpClient, JsonCodec<QueryResults> queryResultsCodec, ClientSession session, String query)
     {
@@ -101,6 +102,7 @@ public class StatementClient
         this.timeZoneId = session.getTimeZoneId();
         this.query = query;
         this.requestTimeoutNanos = session.getClientRequestTimeout().roundTo(NANOSECONDS);
+        this.user = session.getUser();
 
         Request request = buildQueryRequest(session, query);
         JsonResponse<QueryResults> response = httpClient.execute(request, responseHandler);
@@ -112,15 +114,11 @@ public class StatementClient
         processResponse(response);
     }
 
-    private static Request buildQueryRequest(ClientSession session, String query)
+    private Request buildQueryRequest(ClientSession session, String query)
     {
-        Request.Builder builder = preparePost()
-                .setUri(uriBuilderFrom(session.getServer()).replacePath("/v1/statement").build())
+        Request.Builder builder = prepareRequest(preparePost(), uriBuilderFrom(session.getServer()).replacePath("/v1/statement").build())
                 .setBodyGenerator(createStaticBodyGenerator(query, UTF_8));
 
-        if (session.getUser() != null) {
-            builder.setHeader(PrestoHeaders.PRESTO_USER, session.getUser());
-        }
         if (session.getSource() != null) {
             builder.setHeader(PrestoHeaders.PRESTO_SOURCE, session.getSource());
         }
@@ -132,7 +130,6 @@ public class StatementClient
         }
         builder.setHeader(PrestoHeaders.PRESTO_TIME_ZONE, session.getTimeZoneId());
         builder.setHeader(PrestoHeaders.PRESTO_LANGUAGE, session.getLocale().toLanguageTag());
-        builder.setHeader(USER_AGENT, USER_AGENT_VALUE);
 
         Map<String, String> property = session.getProperties();
         for (Entry<String, String> entry : property.entrySet()) {
@@ -216,6 +213,15 @@ public class StatementClient
         return valid.get() && (!isGone()) && (!isClosed());
     }
 
+    private Request.Builder prepareRequest(Request.Builder builder, URI nextUri)
+    {
+        builder.setHeader(PrestoHeaders.PRESTO_USER, user);
+        builder.setHeader(USER_AGENT, USER_AGENT_VALUE)
+                .setUri(nextUri);
+
+        return builder;
+    }
+
     public boolean advance()
     {
         URI nextUri = current().getNextUri();
@@ -224,10 +230,7 @@ public class StatementClient
             return false;
         }
 
-        Request request = prepareGet()
-                .setHeader(USER_AGENT, USER_AGENT_VALUE)
-                .setUri(nextUri)
-                .build();
+        Request request = prepareRequest(prepareGet(), nextUri).build();
 
         Exception cause = null;
         long start = System.nanoTime();
@@ -319,10 +322,7 @@ public class StatementClient
             return false;
         }
 
-        Request request = prepareDelete()
-                .setHeader(USER_AGENT, USER_AGENT_VALUE)
-                .setUri(uri)
-                .build();
+        Request request = prepareRequest(prepareDelete(), uri).build();
 
         HttpResponseFuture<StatusResponse> response = httpClient.executeAsync(request, createStatusResponseHandler());
         try {
@@ -347,10 +347,7 @@ public class StatementClient
         if (!closed.getAndSet(true)) {
             URI uri = currentResults.get().getNextUri();
             if (uri != null) {
-                Request request = prepareDelete()
-                        .setHeader(USER_AGENT, USER_AGENT_VALUE)
-                        .setUri(uri)
-                        .build();
+                Request request = prepareRequest(prepareDelete(), uri).build();
                 httpClient.executeAsync(request, createStatusResponseHandler());
             }
         }


### PR DESCRIPTION
Even when reading a query result, we would like to check who is accessing the nextUri. This PR sets X-Presto-User header while reading next statement result. For example, some service access token can be set here to authenticate each request.

This would be an easier alternative for #4928. 