### PR TITLE
add cassandra 3.0 compatibility

### DIFF
--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <cassandra.version>2.1.0</cassandra.version>
-        <datastax.version>2.1.5</datastax.version>
+        <datastax.version>3.0.0</datastax.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
support for the new system keyspace tables for schema was added in the datastax 3.0 driver.  this edit brings Cassandra 3.0 support to presto