### PR TITLE
Handle HiveTableProperties case where bucket count property not set

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
@@ -93,6 +93,9 @@ public class HiveTableProperties
     public static Optional<HiveBucketProperty> getBucketProperty(Map<String, Object> tableProperties)
     {
         List<String> clusteredBy = (List<String>) tableProperties.get(CLUSTERED_BY_PROPERTY);
+        if (!tableProperties.containsKey(BUCKET_COUNT_PROPERTY)) {
+            return Optional.empty();
+        }
         int bucketCount = (Integer) tableProperties.get(BUCKET_COUNT_PROPERTY);
         if ((clusteredBy.isEmpty()) && (bucketCount == 0)) {
             return Optional.empty();


### PR DESCRIPTION
Since this commit https://github.com/prestodb/presto/commit/ab2c1a779e220f0363febab992f29e6ffbd4b449 on 4/1, AbstractTestHiveClient tests are failing with NPEs.

```
testCreateTableUnsupportedType(com.facebook.presto.hive.TestHiveClient)  Time elapsed: 0.012 sec  <<< FAILURE!
java.lang.NullPointerException: null
	at com.facebook.presto.hive.HiveTableProperties.getBucketProperty(HiveTableProperties.java:96)
	at com.facebook.presto.hive.HiveMetadata.beginCreateTable(HiveMetadata.java:566)
	at com.facebook.presto.hive.HiveMetadata.beginCreateTable(HiveMetadata.java:134)
	at com.facebook.presto.hive.AbstractTestHiveClient.testCreateTableUnsupportedType(AbstractTestHiveClient.java:1445)
```

Handle the case where ```bucket_count``` table property is not set.