### PR TITLE
Log query failures at debug level

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -507,7 +507,7 @@ public class QueryStateMachine
         failureCause.compareAndSet(null, toFailure(throwable));
         boolean failed = queryState.setIf(FAILED, currentState -> !currentState.isDone());
         if (failed) {
-            log.error(throwable, "Query %s failed", queryId);
+            log.debug(throwable, "Query %s failed", queryId);
         }
         else {
             log.debug(throwable, "Failure after query %s finished", queryId);


### PR DESCRIPTION
Every query failure (including syntax or semantic errors) were
being logged at ERROR level.