### PR TITLE
Add fetch task instance id directly from SqlTaskManager

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -162,6 +162,11 @@ public class SqlTask
         return taskStateMachine.getTaskId();
     }
 
+    public String getTaskInstanceId()
+    {
+        return taskInstanceId;
+    }
+
     public void recordHeartbeat()
     {
         lastHeartbeat.set(DateTime.now());

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -252,6 +252,14 @@ public class SqlTaskManager
     }
 
     @Override
+    public String getTaskInstanceId(TaskId taskId)
+    {
+        SqlTask sqlTask = tasks.getUnchecked(taskId);
+        sqlTask.recordHeartbeat();
+        return sqlTask.getTaskInstanceId();
+    }
+
+    @Override
     public TaskInfo updateTask(Session session, TaskId taskId, Optional<PlanFragment> fragment, List<TaskSource> sources, OutputBuffers outputBuffers)
     {
         requireNonNull(session, "session is null");

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
@@ -53,6 +53,12 @@ public interface TaskManager
      */
     CompletableFuture<TaskInfo> getTaskInfo(TaskId taskId, TaskState currentState);
 
+    /**
+     * Gets the unique instance id of a task.  This can be used to detect a task
+     * that was destroyed and recreated.
+     */
+    String getTaskInstanceId(TaskId taskId);
+
     void updateMemoryPoolAssignments(MemoryPoolAssignmentsRequest assignments);
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
@@ -210,7 +210,7 @@ public class TaskResource
         Duration waitTime = randomizeWaitTime(DEFAULT_MAX_WAIT_TIME);
         bufferResultFuture = addTimeout(
                 bufferResultFuture,
-                () -> BufferResult.emptyResults(taskManager.getTaskInfo(taskId).getTaskInstanceId(), token, false),
+                () -> BufferResult.emptyResults(taskManager.getTaskInstanceId(taskId), token, false),
                 waitTime,
                 timeoutExecutor);
 
@@ -241,7 +241,7 @@ public class TaskResource
         bindAsyncResponse(asyncResponse, responseFuture, responseExecutor)
                 .withTimeout(timeout,
                         Response.status(Status.NO_CONTENT)
-                                .header(PRESTO_TASK_INSTANCE_ID, taskManager.getTaskInfo(taskId).getTaskInstanceId())
+                                .header(PRESTO_TASK_INSTANCE_ID, taskManager.getTaskInstanceId(taskId))
                                 .header(PRESTO_PAGE_TOKEN, token)
                                 .header(PRESTO_PAGE_NEXT_TOKEN, token)
                                 .header(PRESTO_BUFFER_COMPLETE, false)


### PR DESCRIPTION
Currently when the task instance id is needed the caller asks for the
entire task info, which is very expensive to compute, and then the caller
extracts the single id field.