### PR TITLE
Modify presto to use 64bit hashes returned from types.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
@@ -191,7 +191,7 @@ public class BigintGroupByHash
         }
 
         long value = BIGINT.getLong(block, position);
-        int hashPosition = getHashPosition(value, mask);
+        long hashPosition = getHashPosition(value, mask);
 
         // look for an empty slot or a slot containing this key
         while (true) {
@@ -227,7 +227,7 @@ public class BigintGroupByHash
         }
 
         long value = BIGINT.getLong(block, position);
-        int hashPosition = getHashPosition(value, mask);
+        long hashPosition = getHashPosition(value, mask);
 
         // look for an empty slot or a slot containing this key
         while (true) {
@@ -247,7 +247,7 @@ public class BigintGroupByHash
         return addNewGroup(hashPosition, value);
     }
 
-    private int addNewGroup(int hashPosition, long value)
+    private int addNewGroup(long hashPosition, long value)
     {
         // record group id in hash
         int groupId = nextGroupId++;
@@ -284,7 +284,7 @@ public class BigintGroupByHash
             long value = valuesByGroupId.get(groupId);
 
             // find an empty slot for the address
-            int hashPosition = getHashPosition(value, newMask);
+            long hashPosition = getHashPosition(value, newMask);
             while (newGroupIds.get(hashPosition) != -1) {
                 hashPosition = (hashPosition + 1) & newMask;
             }
@@ -303,9 +303,9 @@ public class BigintGroupByHash
         this.valuesByGroupId.ensureCapacity(maxFill);
     }
 
-    private static int getHashPosition(long rawHash, int mask)
+    private static long getHashPosition(long rawHash, int mask)
     {
-        return ((int) murmurHash3(rawHash)) & mask;
+        return murmurHash3(rawHash) & mask;
     }
 
     private static int calculateMaxFill(int hashSize)

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -147,7 +147,7 @@ public class GroupByIdBlock
     }
 
     @Override
-    public int hash(int position, int offset, int length)
+    public long hash(int position, int offset, int length)
     {
         return block.hash(position, offset, length);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashGenerator.java
@@ -19,16 +19,17 @@ import static com.google.common.base.Preconditions.checkState;
 
 public interface HashGenerator
 {
-    int hashPosition(int position, Page page);
+    long hashPosition(int position, Page page);
 
     default int getPartition(int partitionCount, int position, Page page)
     {
-        int rawHash = hashPosition(position, page);
+        long rawHash = hashPosition(position, page);
 
         // clear the sign bit
-        rawHash &= 0x7fff_ffffL;
+        rawHash &= 0x7fff_ffff_ffff_ffffL;
 
-        int partition = rawHash % partitionCount;
+        int partition = (int) (rawHash % partitionCount);
+
         checkState(partition >= 0 && partition < partitionCount);
         return partition;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashPartitionMaskOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashPartitionMaskOperator.java
@@ -199,10 +199,10 @@ public class HashPartitionMaskOperator
             maskBuilders[i] = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), page.getPositionCount());
         }
         for (int position = 0; position < page.getPositionCount(); position++) {
-            int rawHash = hashGenerator.hashPosition(position, page);
+            long rawHash = hashGenerator.hashPosition(position, page);
             // mix the bits so we don't use the same hash used to distribute between stages
-            rawHash = (int) XxHash64.hash(Integer.reverse(rawHash));
-            rawHash &= Integer.MAX_VALUE;
+            rawHash = XxHash64.hash(Long.reverse(rawHash));
+            rawHash &= Long.MAX_VALUE;
 
             boolean active = (rawHash % partitionCount == partition);
             BOOLEAN.writeBoolean(activePositions, active);

--- a/presto-main/src/main/java/com/facebook/presto/operator/InMemoryJoinHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InMemoryJoinHash.java
@@ -63,7 +63,7 @@ public final class InMemoryJoinHash
 
         // index pages
         for (int position = 0; position < addresses.size(); position++) {
-            int pos = getHashPosition(hashPosition(position), mask);
+            int pos = (int) getHashPosition(hashPosition(position), mask);
 
             // look for an empty slot or a slot containing this key
             while (key[pos] != -1) {
@@ -109,9 +109,9 @@ public final class InMemoryJoinHash
     }
 
     @Override
-    public long getJoinPosition(int position, Page page, int rawHash)
+    public long getJoinPosition(int position, Page page, long rawHash)
     {
-        int pos = getHashPosition(rawHash, mask);
+        int pos = (int) getHashPosition(rawHash, mask);
 
         while (key[pos] != -1) {
             if (positionEqualsCurrentRow(key[pos], position, page.getBlocks())) {
@@ -144,7 +144,7 @@ public final class InMemoryJoinHash
     {
     }
 
-    private int hashPosition(int position)
+    private long hashPosition(int position)
     {
         long pageAddress = addresses.getLong(position);
         int blockIndex = decodeSliceIndex(pageAddress);
@@ -175,8 +175,8 @@ public final class InMemoryJoinHash
         return pagesHashStrategy.positionEqualsPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition);
     }
 
-    private static int getHashPosition(int rawHash, int mask)
+    private static long getHashPosition(long rawHash, long mask)
     {
-        return ((int) XxHash64.hash(rawHash)) & mask;
+        return (XxHash64.hash(rawHash)) & mask;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/InterpretedHashGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InterpretedHashGenerator.java
@@ -41,13 +41,13 @@ public class InterpretedHashGenerator
     }
 
     @Override
-    public int hashPosition(int position, Page page)
+    public long hashPosition(int position, Page page)
     {
         Block[] blocks = page.getBlocks();
-        int result = HashGenerationOptimizer.INITIAL_HASH_VALUE;
+        long result = HashGenerationOptimizer.INITIAL_HASH_VALUE;
         for (int i = 0; i < hashChannels.length; i++) {
             Type type = hashChannelTypes.get(i);
-            result = (int) CombineHashFunction.getHash(result, TypeUtils.hashPosition(type, blocks[hashChannels[i]], position));
+            result = CombineHashFunction.getHash(result, TypeUtils.hashPosition(type, blocks[hashChannels[i]], position));
         }
         return result;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupOuterOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupOuterOperator.java
@@ -364,7 +364,7 @@ public class LookupOuterOperator
         }
 
         @Override
-        public long getJoinPosition(int position, Page page, int rawHash)
+        public long getJoinPosition(int position, Page page, long rawHash)
         {
             return lookupSource.getJoinPosition(position, page, rawHash);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
@@ -27,7 +27,7 @@ public interface LookupSource
 
     int getJoinPositionCount();
 
-    long getJoinPosition(int position, Page page, int rawHash);
+    long getJoinPosition(int position, Page page, long rawHash);
 
     long getJoinPosition(int position, Page page);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -233,8 +233,8 @@ public class MultiChannelGroupByHash
     @Override
     public boolean contains(int position, Page page, int[] hashChannels)
     {
-        int rawHash = hashStrategy.hashRow(position, page.getBlocks());
-        int hashPosition = getHashPosition(rawHash, mask);
+        long rawHash = hashStrategy.hashRow(position, page.getBlocks());
+        int hashPosition = (int) getHashPosition(rawHash, mask);
 
         // look for a slot containing this key
         while (groupAddressByHash[hashPosition] != -1) {
@@ -252,13 +252,13 @@ public class MultiChannelGroupByHash
     @Override
     public int putIfAbsent(int position, Page page)
     {
-        int rawHash = hashGenerator.hashPosition(position, page);
+        long rawHash = hashGenerator.hashPosition(position, page);
         return putIfAbsent(position, page, rawHash);
     }
 
-    private int putIfAbsent(int position, Page page, int rawHash)
+    private int putIfAbsent(int position, Page page, long rawHash)
     {
-        int hashPosition = getHashPosition(rawHash, mask);
+        int hashPosition = (int) getHashPosition(rawHash, mask);
 
         // look for an empty slot or a slot containing this key
         int groupId = -1;
@@ -280,7 +280,7 @@ public class MultiChannelGroupByHash
         return groupId;
     }
 
-    private int addNewGroup(int hashPosition, int position, Page page, int rawHash)
+    private int addNewGroup(int hashPosition, int position, Page page, long rawHash)
     {
         // add the row to the open page
         for (int i = 0; i < channels.length; i++) {
@@ -352,9 +352,9 @@ public class MultiChannelGroupByHash
             // get the address for this slot
             long address = groupAddressByHash[oldIndex];
 
-            int rawHash = hashPosition(address);
+            long rawHash = hashPosition(address);
             // find an empty slot for the address
-            int pos = getHashPosition(rawHash, newMask);
+            int pos = (int) getHashPosition(rawHash, newMask);
             while (newKey[pos] != -1) {
                 pos = (pos + 1) & newMask;
             }
@@ -374,7 +374,7 @@ public class MultiChannelGroupByHash
         groupAddressByGroupId.ensureCapacity(maxFill);
     }
 
-    private int hashPosition(long sliceAddress)
+    private long hashPosition(long sliceAddress)
     {
         int sliceIndex = decodeSliceIndex(sliceAddress);
         int position = decodePosition(sliceAddress);
@@ -384,9 +384,9 @@ public class MultiChannelGroupByHash
         return hashStrategy.hashPosition(sliceIndex, position);
     }
 
-    private int getRawHash(int sliceIndex, int position)
+    private long getRawHash(int sliceIndex, int position)
     {
-        return (int) channelBuilders.get(precomputedHashChannel.get()).get(sliceIndex).getLong(position, 0);
+        return channelBuilders.get(precomputedHashChannel.get()).get(sliceIndex).getLong(position, 0);
     }
 
     private boolean positionEqualsCurrentRow(long address, int hashPosition, int position, Page page, byte rawHash, int[] hashChannels)
@@ -397,7 +397,7 @@ public class MultiChannelGroupByHash
         return hashStrategy.positionEqualsRow(decodeSliceIndex(address), decodePosition(address), position, page, hashChannels);
     }
 
-    private static int getHashPosition(int rawHash, int mask)
+    private static long getHashPosition(long rawHash, int mask)
     {
         return murmurHash3(rawHash) & mask;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesHashStrategy.java
@@ -38,13 +38,13 @@ public interface PagesHashStrategy
     /**
      * Calculates the hash code the hashed columns in this PagesHashStrategy at the specified position.
      */
-    int hashPosition(int blockIndex, int position);
+    long hashPosition(int blockIndex, int position);
 
     /**
      * Calculates the hash code at {@code position} in {@code blocks}. Blocks must have the same number of
      * entries as the hashed columns and each entry is expected to be the same type.
      */
-    int hashRow(int position, Block... blocks);
+    long hashRow(int position, Block... blocks);
 
     /**
      * Compares the values in the specified blocks.  The values are compared positionally, so {@code leftBlocks}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ParallelHashBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ParallelHashBuilder.java
@@ -257,8 +257,8 @@ public class ParallelHashBuilder
             // build a block containing the partition id of each position
             BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), page.getPositionCount());
             for (int position = 0; position < page.getPositionCount(); position++) {
-                int rawHash = hashGenerator.hashPosition(position, page);
-                int partition = murmurHash3(rawHash) & parallelStreamMask;
+                long rawHash = hashGenerator.hashPosition(position, page);
+                int partition = (int) (murmurHash3(rawHash) & parallelStreamMask);
                 BIGINT.writeLong(blockBuilder, partition);
             }
             Block partitionIds = blockBuilder.build();

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
@@ -69,9 +69,9 @@ public class PartitionedLookupSource
     }
 
     @Override
-    public long getJoinPosition(int position, Page page, int rawHash)
+    public long getJoinPosition(int position, Page page, long rawHash)
     {
-        int partition = murmurHash3(rawHash) & partitionMask;
+        int partition = (int) murmurHash3(rawHash) & partitionMask;
         LookupSource lookupSource = lookupSources[partition];
         long joinPosition = lookupSource.getJoinPosition(position, page, rawHash);
         if (joinPosition < 0) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/PrecomputedHashGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PrecomputedHashGenerator.java
@@ -28,9 +28,9 @@ public class PrecomputedHashGenerator
     }
 
     @Override
-    public int hashPosition(int position, Page page)
+    public long hashPosition(int position, Page page)
     {
-        return (int) BigintType.BIGINT.getLong(page.getBlock(hashChannel), position);
+        return BigintType.BIGINT.getLong(page.getBlock(hashChannel), position);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/SharedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SharedLookupSource.java
@@ -56,7 +56,7 @@ public final class SharedLookupSource
     }
 
     @Override
-    public long getJoinPosition(int position, Page page, int rawHash)
+    public long getJoinPosition(int position, Page page, long rawHash)
     {
         return lookupSource.getJoinPosition(position, page, rawHash);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimpleJoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimpleJoinProbe.java
@@ -106,7 +106,7 @@ public class SimpleJoinProbe
             return -1;
         }
         if (probeHashBlock.isPresent()) {
-            int rawHash = (int) BIGINT.getLong(probeHashBlock.get(), position);
+            long rawHash = BIGINT.getLong(probeHashBlock.get(), position);
             return lookupSource.getJoinPosition(position, probePage, rawHash);
         }
         return lookupSource.getJoinPosition(position, probePage);

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
@@ -77,12 +77,12 @@ public class SimplePagesHashStrategy
     }
 
     @Override
-    public int hashPosition(int blockIndex, int position)
+    public long hashPosition(int blockIndex, int position)
     {
         if (precomputedHashChannel != null) {
-            return (int) BIGINT.getLong(precomputedHashChannel.get(blockIndex), position);
+            return BIGINT.getLong(precomputedHashChannel.get(blockIndex), position);
         }
-        int result = 0;
+        long result = 0;
         for (int hashChannel : hashChannels) {
             Type type = types.get(hashChannel);
             Block block = channels.get(hashChannel).get(blockIndex);
@@ -92,9 +92,9 @@ public class SimplePagesHashStrategy
     }
 
     @Override
-    public int hashRow(int position, Block... blocks)
+    public long hashRow(int position, Block... blocks)
     {
-        int result = 0;
+        long result = 0;
         for (int i = 0; i < hashChannels.size(); i++) {
             int hashChannel = hashChannels.get(i);
             Type type = types.get(hashChannel);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
@@ -90,7 +90,7 @@ public class TypedSet
             containsNullElement = true;
         }
         else {
-            int hashPosition = getHashPositionOfElement(block, position);
+            long hashPosition = getHashPositionOfElement(block, position);
             if (blockPositionByHash.get(hashPosition) == EMPTY_SLOT) {
                 addNewElement(hashPosition, block, position);
             }
@@ -110,9 +110,9 @@ public class TypedSet
     /**
      * Get slot position of element at {@code position} of {@code block}
      */
-    private int getHashPositionOfElement(Block block, int position)
+    private long getHashPositionOfElement(Block block, int position)
     {
-        int hashPosition = getMaskedHash(hashPosition(elementType, block, position));
+        long hashPosition = getMaskedHash(hashPosition(elementType, block, position));
         while (true) {
             int blockPosition = blockPositionByHash.get(hashPosition);
             // Doesn't have this element
@@ -128,7 +128,7 @@ public class TypedSet
         }
     }
 
-    private void addNewElement(int hashPosition, Block block, int position)
+    private void addNewElement(long hashPosition, Block block, int position)
     {
         elementType.appendTo(block, position, elementBlock);
         if (elementBlock.getSizeInBytes() > FOUR_MEGABYTES) {
@@ -171,7 +171,7 @@ public class TypedSet
         return maxFill;
     }
 
-    private int getMaskedHash(int rawHash)
+    private long getMaskedHash(long rawHash)
     {
         return rawHash & hashMask;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
@@ -388,7 +388,7 @@ public class IndexLoader
         }
 
         @Override
-        public long getJoinPosition(int position, Page page, int rawHash)
+        public long getJoinPosition(int position, Page page, long rawHash)
         {
             return IndexSnapshot.UNLOADED_INDEX_KEY;
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSource.java
@@ -56,7 +56,7 @@ public class IndexLookupSource
     }
 
     @Override
-    public long getJoinPosition(int position, Page page, int rawHash)
+    public long getJoinPosition(int position, Page page, long rawHash)
     {
         // TODO update to take advantage of precomputed hash
         return getJoinPosition(position, page);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/CombineHashFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/CombineHashFunction.java
@@ -24,7 +24,6 @@ public final class CombineHashFunction
     @SqlType(StandardTypes.BIGINT)
     public static long getHash(@SqlType(StandardTypes.BIGINT) long previousHashValue, @SqlType(StandardTypes.BIGINT) long value)
     {
-        // Hash values are required to be ints
-        return (int) (31 * previousHashValue + value);
+        return (31 * previousHashValue + value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/InCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/InCodeGenerator.java
@@ -54,6 +54,7 @@ import static com.facebook.presto.sql.gen.BytecodeUtils.ifWasNullPopAndGoto;
 import static com.facebook.presto.sql.gen.BytecodeUtils.invoke;
 import static com.facebook.presto.sql.gen.BytecodeUtils.loadConstant;
 import static com.facebook.presto.util.FastutilSetHelper.toFastutilHashSet;
+import static com.facebook.presto.util.Types.longHashToIntegerHash;
 import static java.util.Objects.requireNonNull;
 
 public class InCodeGenerator
@@ -143,7 +144,7 @@ public class InCodeGenerator
                         break;
                     case HASH_SWITCH:
                         try {
-                            int hashCode = Ints.checkedCast((Long) hashCodeFunction.invoke(object));
+                            int hashCode = Ints.checkedCast(longHashToIntegerHash((Long) hashCodeFunction.invoke(object)));
                             hashBucketsBuilder.put(hashCode, testBytecode);
                         }
                         catch (Throwable throwable) {
@@ -210,7 +211,13 @@ public class InCodeGenerator
                         .comment("lookupSwitch(hashCode(<stackValue>))")
                         .dup(javaType)
                         .append(invoke(hashCodeBinding, hashCodeSignature))
+                        //.invokeStatic(Types.class, "longHashToIntegerHash", int.class, long.class)
+                        .dup(long.class)
+                        .push(32)
+                        .unsignedLongRightShift()
+                        .longBitXor()
                         .longToInt()
+                        //end of .invokeStatic equivalent
                         .append(switchBuilder.build())
                         .append(switchCaseBlocks);
                 break;

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/InCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/InCodeGenerator.java
@@ -54,7 +54,6 @@ import static com.facebook.presto.sql.gen.BytecodeUtils.ifWasNullPopAndGoto;
 import static com.facebook.presto.sql.gen.BytecodeUtils.invoke;
 import static com.facebook.presto.sql.gen.BytecodeUtils.loadConstant;
 import static com.facebook.presto.util.FastutilSetHelper.toFastutilHashSet;
-import static com.facebook.presto.util.Types.longHashToIntegerHash;
 import static java.util.Objects.requireNonNull;
 
 public class InCodeGenerator
@@ -144,7 +143,7 @@ public class InCodeGenerator
                         break;
                     case HASH_SWITCH:
                         try {
-                            int hashCode = Ints.checkedCast(longHashToIntegerHash((Long) hashCodeFunction.invoke(object)));
+                            int hashCode = Ints.checkedCast(Long.hashCode((Long) hashCodeFunction.invoke(object)));
                             hashBucketsBuilder.put(hashCode, testBytecode);
                         }
                         catch (Throwable throwable) {
@@ -211,13 +210,7 @@ public class InCodeGenerator
                         .comment("lookupSwitch(hashCode(<stackValue>))")
                         .dup(javaType)
                         .append(invoke(hashCodeBinding, hashCodeSignature))
-                        //.invokeStatic(Types.class, "longHashToIntegerHash", int.class, long.class)
-                        .dup(long.class)
-                        .push(32)
-                        .unsignedLongRightShift()
-                        .longBitXor()
-                        .longToInt()
-                        //end of .invokeStatic equivalent
+                        .invokeStatic(Long.class, "hashCode", int.class, long.class)
                         .append(switchBuilder.build())
                         .append(switchCaseBlocks);
                 break;

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
@@ -304,7 +304,7 @@ public class JoinCompiler
         MethodDefinition hashPositionMethod = classDefinition.declareMethod(
                 a(PUBLIC),
                 "hashPosition",
-                type(int.class),
+                type(long.class),
                 blockIndex,
                 blockPosition);
 
@@ -320,7 +320,6 @@ public class JoinCompiler
                         long.class,
                         hashChannel.invoke("get", Object.class, blockIndex).cast(Block.class),
                         blockPosition)
-                        .cast(int.class)
                         .ret()
         );
 
@@ -328,8 +327,8 @@ public class JoinCompiler
                 .getBody()
                 .append(ifStatement);
 
-        Variable resultVariable = hashPositionMethod.getScope().declareVariable(int.class, "result");
-        hashPositionMethod.getBody().push(0).putVariable(resultVariable);
+        Variable resultVariable = hashPositionMethod.getScope().declareVariable(long.class, "result");
+        hashPositionMethod.getBody().push(0L).putVariable(resultVariable);
 
         for (int index = 0; index < joinChannelTypes.size(); index++) {
             BytecodeExpression type = constantType(callSiteBinder, joinChannelTypes.get(index));
@@ -343,27 +342,27 @@ public class JoinCompiler
             hashPositionMethod
                     .getBody()
                     .getVariable(resultVariable)
-                    .push(31)
-                    .append(OpCode.IMUL)
+                    .push(31L)
+                    .append(OpCode.LMUL)
                     .append(typeHashCode(type, block, blockPosition))
-                    .append(OpCode.IADD)
+                    .append(OpCode.LADD)
                     .putVariable(resultVariable);
         }
 
         hashPositionMethod
                 .getBody()
                 .getVariable(resultVariable)
-                .retInt();
+                .retLong();
     }
 
     private static void generateHashRowMethod(ClassDefinition classDefinition, CallSiteBinder callSiteBinder, List<Type> joinChannelTypes)
     {
         Parameter position = arg("position", int.class);
         Parameter blocks = arg("blocks", Block[].class);
-        MethodDefinition hashRowMethod = classDefinition.declareMethod(a(PUBLIC), "hashRow", type(int.class), position, blocks);
+        MethodDefinition hashRowMethod = classDefinition.declareMethod(a(PUBLIC), "hashRow", type(long.class), position, blocks);
 
-        Variable resultVariable = hashRowMethod.getScope().declareVariable(int.class, "result");
-        hashRowMethod.getBody().push(0).putVariable(resultVariable);
+        Variable resultVariable = hashRowMethod.getScope().declareVariable(long.class, "result");
+        hashRowMethod.getBody().push(0L).putVariable(resultVariable);
 
         for (int index = 0; index < joinChannelTypes.size(); index++) {
             BytecodeExpression type = constantType(callSiteBinder, joinChannelTypes.get(index));
@@ -374,25 +373,25 @@ public class JoinCompiler
             hashRowMethod
                     .getBody()
                     .getVariable(resultVariable)
-                    .push(31)
-                    .append(OpCode.IMUL)
+                    .push(31L)
+                    .append(OpCode.LMUL)
                     .append(typeHashCode(type, block, position))
-                    .append(OpCode.IADD)
+                    .append(OpCode.LADD)
                     .putVariable(resultVariable);
         }
 
         hashRowMethod
                 .getBody()
                 .getVariable(resultVariable)
-                .retInt();
+                .retLong();
     }
 
     private static BytecodeNode typeHashCode(BytecodeExpression type, BytecodeExpression blockRef, BytecodeExpression blockPosition)
     {
         return new IfStatement()
             .condition(blockRef.invoke("isNull", boolean.class, blockPosition))
-            .ifTrue(constantInt(0))
-            .ifFalse(type.invoke("hash", int.class, blockRef, blockPosition));
+            .ifTrue(constantLong(0L))
+            .ifFalse(type.invoke("hash", long.class, blockRef, blockPosition));
     }
 
     private static void generateRowEqualsRowMethod(

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
@@ -363,8 +363,7 @@ public class JoinProbeCompiler
                     constantType(callSiteBinder, BigintType.BIGINT).invoke("getLong",
                             long.class,
                             probeHashBlock,
-                            position)
-                            .cast(int.class)))
+                            position)))
                     .retLong();
         }
         else {

--- a/presto-main/src/main/java/com/facebook/presto/type/ArrayType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ArrayType.java
@@ -84,7 +84,7 @@ public class ArrayType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         Block array = getObject(block, position);
         int hash = 0;

--- a/presto-main/src/main/java/com/facebook/presto/type/BigintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/BigintOperators.java
@@ -207,6 +207,6 @@ public final class BigintOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.BIGINT) long value)
     {
-        return (int) (value ^ (value >>> 32));
+        return value;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/ColorType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ColorType.java
@@ -66,7 +66,7 @@ public class ColorType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         return block.getInt(position, 0);
     }

--- a/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
@@ -187,7 +187,6 @@ public final class DoubleOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.DOUBLE) double value)
     {
-        long bits = doubleToLongBits(value);
-        return (int) (bits ^ (bits >>> 32));
+        return doubleToLongBits(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/JsonType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/JsonType.java
@@ -51,7 +51,7 @@ public class JsonType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         return block.hash(position, 0, block.getLength(position));
     }

--- a/presto-main/src/main/java/com/facebook/presto/type/MapType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/MapType.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import static com.facebook.presto.type.TypeUtils.checkElementNotNull;
 import static com.facebook.presto.type.TypeUtils.hashPosition;
 import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
+import static com.facebook.presto.util.Types.longHashToIntegerHash;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class MapType
@@ -82,7 +83,7 @@ public class MapType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         Block mapBlock = getObject(block, position);
         int result = 0;
@@ -152,7 +153,7 @@ public class MapType
         @Override
         public int hashCode()
         {
-            return type.hash(block, position);
+            return longHashToIntegerHash(type.hash(block, position));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/type/MapType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/MapType.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import static com.facebook.presto.type.TypeUtils.checkElementNotNull;
 import static com.facebook.presto.type.TypeUtils.hashPosition;
 import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
-import static com.facebook.presto.util.Types.longHashToIntegerHash;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class MapType
@@ -153,7 +152,7 @@ public class MapType
         @Override
         public int hashCode()
         {
-            return longHashToIntegerHash(type.hash(block, position));
+            return Long.hashCode(type.hash(block, position));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/type/RowType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RowType.java
@@ -198,10 +198,10 @@ public class RowType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         Block arrayBlock = block.getObject(position, Block.class);
-        int result = 1;
+        long result = 1;
         for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
             checkElementNotNull(arrayBlock.isNull(i));
             Type elementType = fields.get(i).getType();

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
@@ -62,7 +62,7 @@ public final class TypeUtils
         return defaultSize;
     }
 
-    public static int hashPosition(Type type, Block block, int position)
+    public static long hashPosition(Type type, Block block, int position)
     {
         if (block.isNull(position)) {
             return NULL_HASH_CODE;
@@ -131,7 +131,7 @@ public final class TypeUtils
         return new TypeSignature(base, parameters.build());
     }
 
-    public static int getHashPosition(List<? extends Type> hashTypes, Block[] hashBlocks, int position)
+    public static long getHashPosition(List<? extends Type> hashTypes, Block[] hashBlocks, int position)
     {
         int[] hashChannels = new int[hashBlocks.length];
         for (int i = 0; i < hashBlocks.length; i++) {

--- a/presto-main/src/main/java/com/facebook/presto/type/UnknownType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/UnknownType.java
@@ -45,7 +45,7 @@ public final class UnknownType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         // Check that the position is valid
         checkArgument(block.isNull(position), "Expected NULL value for UnknownType");

--- a/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
@@ -17,6 +17,7 @@ import com.facebook.presto.operator.scalar.ScalarOperator;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 
 import static com.facebook.presto.metadata.OperatorType.BETWEEN;
 import static com.facebook.presto.metadata.OperatorType.CAST;
@@ -186,6 +187,6 @@ public final class VarcharOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType("varchar(x)") Slice value)
     {
-        return value.hashCode();
+        return XxHash64.hash(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import static com.facebook.presto.metadata.OperatorType.EQUAL;
 import static com.facebook.presto.metadata.OperatorType.HASH_CODE;
 import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
-import static com.facebook.presto.util.Types.longHashToIntegerHash;
 
 public final class FastutilSetHelper
 {
@@ -101,7 +100,7 @@ public final class FastutilSetHelper
         public int hashCode(long value)
         {
             try {
-                return longHashToIntegerHash((long) hashCodeHandle.invokeExact(value));
+                return Long.hashCode((long) hashCodeHandle.invokeExact(value));
             }
             catch (Throwable t) {
                 Throwables.propagateIfInstanceOf(t, Error.class);
@@ -140,7 +139,7 @@ public final class FastutilSetHelper
         public int hashCode(double value)
         {
             try {
-                return longHashToIntegerHash((long) hashCodeHandle.invokeExact(value));
+                return Long.hashCode((long) hashCodeHandle.invokeExact(value));
             }
             catch (Throwable t) {
                 Throwables.propagateIfInstanceOf(t, Error.class);
@@ -183,7 +182,7 @@ public final class FastutilSetHelper
         public int hashCode(Object value)
         {
             try {
-                return Ints.checkedCast(longHashToIntegerHash((long) hashCodeHandle.invokeExact(value)));
+                return Ints.checkedCast(Long.hashCode((long) hashCodeHandle.invokeExact(value)));
             }
             catch (Throwable t) {
                 Throwables.propagateIfInstanceOf(t, Error.class);

--- a/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import static com.facebook.presto.metadata.OperatorType.EQUAL;
 import static com.facebook.presto.metadata.OperatorType.HASH_CODE;
 import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
+import static com.facebook.presto.util.Types.longHashToIntegerHash;
 
 public final class FastutilSetHelper
 {
@@ -100,7 +101,7 @@ public final class FastutilSetHelper
         public int hashCode(long value)
         {
             try {
-                return Ints.checkedCast((long) hashCodeHandle.invokeExact(value));
+                return longHashToIntegerHash((long) hashCodeHandle.invokeExact(value));
             }
             catch (Throwable t) {
                 Throwables.propagateIfInstanceOf(t, Error.class);
@@ -139,7 +140,7 @@ public final class FastutilSetHelper
         public int hashCode(double value)
         {
             try {
-                return Ints.checkedCast((long) hashCodeHandle.invokeExact(value));
+                return longHashToIntegerHash((long) hashCodeHandle.invokeExact(value));
             }
             catch (Throwable t) {
                 Throwables.propagateIfInstanceOf(t, Error.class);
@@ -182,7 +183,7 @@ public final class FastutilSetHelper
         public int hashCode(Object value)
         {
             try {
-                return Ints.checkedCast((long) hashCodeHandle.invokeExact(value));
+                return Ints.checkedCast(longHashToIntegerHash((long) hashCodeHandle.invokeExact(value)));
             }
             catch (Throwable t) {
                 Throwables.propagateIfInstanceOf(t, Error.class);

--- a/presto-main/src/main/java/com/facebook/presto/util/Types.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/Types.java
@@ -32,4 +32,15 @@ public final class Types
                 value.getClass().getName());
         return target.cast(value);
     }
+
+    /**
+     * Uses 64 bit hash and compact its entropy in 32 bits.
+     * @deprecated This function should only be used for keeping backward compatibility with external libraries using 32 hashes.
+     * @param hash - the 64bit (long) hash
+     * @return 32bit (int) hash created based on long hash
+     */
+    public static int longHashToIntegerHash(long hash)
+    {
+        return (int) ((hash >>> 32) ^ hash);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/util/Types.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/Types.java
@@ -32,15 +32,4 @@ public final class Types
                 value.getClass().getName());
         return target.cast(value);
     }
-
-    /**
-     * Uses 64 bit hash and compact its entropy in 32 bits.
-     * @deprecated This function should only be used for keeping backward compatibility with external libraries using 32 hashes.
-     * @param hash - the 64bit (long) hash
-     * @return 32bit (int) hash created based on long hash
-     */
-    public static int longHashToIntegerHash(long hash)
-    {
-        return (int) ((hash >>> 32) ^ hash);
-    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -146,7 +146,6 @@ public abstract class AbstractTestBlock
 
             for (int offset = 0; offset < length - 3; offset++) {
                 assertEquals(block.getSlice(position, offset, 3), expectedSliceValue.slice(offset, 3));
-                assertEquals(block.hash(position, offset, 3), expectedSliceValue.hashCode(offset, 3));
                 assertTrue(block.bytesEqual(position, offset, expectedSliceValue, offset, 3));
                 // if your tests fail here, please change your test to not use this value
                 assertFalse(block.bytesEqual(position, offset, Slices.utf8Slice("XXX"), 0, 3));

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashPartitionMaskOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashPartitionMaskOperator.java
@@ -94,10 +94,10 @@ public class TestHashPartitionMaskOperator
 
             MaterializedResult.Builder expected = resultBuilder(TEST_SESSION, BIGINT, BOOLEAN);
             for (int i = 0; i < ROW_COUNT; i++) {
-                int rawHash = (int) BigintOperators.hashCode(i);
+                long rawHash = BigintOperators.hashCode(i);
                 // mix the bits so we don't use the same hash used to distribute between stages
-                rawHash = (int) XxHash64.hash(Integer.reverse(rawHash));
-                rawHash &= Integer.MAX_VALUE;
+                rawHash = XxHash64.hash(Long.reverse(rawHash));
+                rawHash &= Long.MAX_VALUE;
 
                 boolean active = (rawHash % PARTITION_COUNT == partition);
                 expected.row((long) i, active);
@@ -138,10 +138,10 @@ public class TestHashPartitionMaskOperator
 
             MaterializedResult.Builder expected = resultBuilder(TEST_SESSION, BIGINT, BOOLEAN, BOOLEAN, BOOLEAN);
             for (int i = 0; i < ROW_COUNT; i++) {
-                int rawHash = (int) BigintOperators.hashCode(i);
+                long rawHash = BigintOperators.hashCode(i);
                 // mix the bits so we don't use the same hash used to distribute between stages
-                rawHash = (int) XxHash64.hash(Integer.reverse(rawHash));
-                rawHash &= Integer.MAX_VALUE;
+                rawHash = XxHash64.hash(Long.reverse(rawHash));
+                rawHash &= Long.MAX_VALUE;
 
                 boolean active = (rawHash % PARTITION_COUNT == partition);
                 boolean maskValue = i % 2 == 0;

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMinMaxByAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMinMaxByAggregation.java
@@ -288,7 +288,7 @@ public class TestMinMaxByAggregation
         }
 
         @Override
-        public int hash(Block block, int position)
+        public long hash(Block block, int position)
         {
             long value = block.getLong(position, 0);
             return (int) (value ^ (value >>> 32));

--- a/presto-main/src/test/java/com/facebook/presto/type/AbstractTestType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/AbstractTestType.java
@@ -116,7 +116,7 @@ public abstract class AbstractTestType
 
     protected void assertPositionEquals(Block block, int position, Object expectedStackValue, Object expectedObjectValue)
     {
-        int hash = 0;
+        long hash = 0;
         if (type.isComparable()) {
             hash = hashPosition(type, block, position);
         }
@@ -131,7 +131,7 @@ public abstract class AbstractTestType
         assertPositionValue(blockBuilder.build(), 0, expectedStackValue, hash, expectedObjectValue);
     }
 
-    private void assertPositionValue(Block block, int position, Object expectedStackValue, int expectedHash, Object expectedObjectValue)
+    private void assertPositionValue(Block block, int position, Object expectedStackValue, long expectedHash, Object expectedObjectValue)
     {
         Object objectValue = type.getObjectValue(SESSION, block, position);
         assertEquals(objectValue, expectedObjectValue);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -212,7 +212,7 @@ public abstract class AbstractArrayBlock
     }
 
     @Override
-    public int hash(int position, int offset, int length)
+    public long hash(int position, int offset, int length)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayElementBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayElementBlock.java
@@ -135,7 +135,7 @@ public abstract class AbstractArrayElementBlock
     }
 
     @Override
-    public int hash(int position, int offset, int length)
+    public long hash(int position, int offset, int length)
     {
         checkReadablePosition(position);
         return getBlock().hash(position + start, offset, length);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.airlift.slice.XxHash64;
 
 public abstract class AbstractFixedWidthBlock
         implements Block
@@ -113,13 +114,14 @@ public abstract class AbstractFixedWidthBlock
     }
 
     @Override
-    public int hash(int position, int offset, int length)
+    public long hash(int position, int offset, int length)
     {
         checkReadablePosition(position);
         if (isNull(position)) {
             return 0;
         }
-        return getRawSlice().hashCode(valueOffset(position) + offset, length);
+
+        return XxHash64.hash(getRawSlice(), valueOffset(position) + offset, length);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractInterleavedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractInterleavedBlock.java
@@ -163,7 +163,7 @@ public abstract class AbstractInterleavedBlock
     }
 
     @Override
-    public int hash(int position, int offset, int length)
+    public long hash(int position, int offset, int length)
     {
         int blockIndex = position % columns;
         int positionInBlock = position / columns;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.airlift.slice.XxHash64;
 
 public abstract class AbstractVariableWidthBlock
         implements Block
@@ -99,10 +100,10 @@ public abstract class AbstractVariableWidthBlock
     }
 
     @Override
-    public int hash(int position, int offset, int length)
+    public long hash(int position, int offset, int length)
     {
         checkReadablePosition(position);
-        return getRawSlice(position).hashCode(getPositionOffset(position) + offset, length);
+        return XxHash64.hash(getRawSlice(position), getPositionOffset(position) + offset, length);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -101,7 +101,7 @@ public interface Block
      * Calculates the hash code the byte sequences at {@code offset} in the
      * value at {@code position}.
      */
-    int hash(int position, int offset, int length);
+    long hash(int position, int offset, int length);
 
     /**
      * Compares the byte sequences at {@code offset} in the value at {@code position}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -184,7 +184,7 @@ public class DictionaryBlock
     }
 
     @Override
-    public int hash(int position, int offset, int length)
+    public long hash(int position, int offset, int length)
     {
         return dictionary.hash(getIndex(position), offset, length);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
@@ -43,7 +43,7 @@ public class FixedWidthBlock
 
         this.slice = Objects.requireNonNull(slice, "slice is null");
         if (slice.length() < fixedSize * positionCount) {
-            throw new IllegalArgumentException("slice length is less than positionCount * fixedSize");
+            throw new IllegalArgumentException("slice length is less n positionCount * fixedSize");
         }
 
         if (valueIsNull.length() < positionCount) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -151,7 +151,7 @@ public class LazyBlock
     }
 
     @Override
-    public int hash(int position, int offset, int length)
+    public long hash(int position, int offset, int length)
     {
         assureLoaded();
         return block.hash(position, offset, length);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -193,7 +193,7 @@ public class RunLengthEncodedBlock
     }
 
     @Override
-    public int hash(int position, int offset, int length)
+    public long hash(int position, int offset, int length)
     {
         return value.hash(0, offset, length);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/EquatableValueSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/EquatableValueSet.java
@@ -337,7 +337,7 @@ public class EquatableValueSet
         @Override
         public int hashCode()
         {
-            return type.hash(block, 0);
+            return (int) type.hash(block, 0);
         }
 
         @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/Marker.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/Marker.java
@@ -260,7 +260,7 @@ public final class Marker
     {
         int hash = Objects.hash(type, bound);
         if (valueBlock.isPresent()) {
-            hash = hash * 31 + type.hash(valueBlock.get(), 0);
+            hash = hash * 31 + (int) type.hash(valueBlock.get(), 0);
         }
         return hash;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/NullableValue.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/NullableValue.java
@@ -91,7 +91,7 @@ public final class NullableValue
     {
         int hash = Objects.hash(type);
         if (value != null) {
-            hash = hash * 31 + type.hash(Utils.nativeValueToBlock(type, value), 0);
+            hash = hash * 31 + (int) type.hash(Utils.nativeValueToBlock(type, value), 0);
         }
         return hash;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractType.java
@@ -70,7 +70,7 @@ public abstract class AbstractType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         throw new UnsupportedOperationException(getTypeSignature() + " type is not comparable");
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BigintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BigintType.java
@@ -61,10 +61,9 @@ public final class BigintType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
-        long value = block.getLong(position, 0);
-        return (int) (value ^ (value >>> 32));
+        return block.getLong(position, 0);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
@@ -61,7 +61,7 @@ public final class BooleanType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         boolean value = block.getByte(position, 0) != 0;
         return value ? 1231 : 1237;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DateType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DateType.java
@@ -70,7 +70,7 @@ public final class DateType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         return block.getInt(position, 0);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
@@ -60,10 +60,9 @@ public final class DoubleType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
-        long value = block.getLong(position, 0);
-        return (int) (value ^ (value >>> 32));
+        return block.getLong(position, 0);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/IntegerType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/IntegerType.java
@@ -63,7 +63,7 @@ public final class IntegerType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         return block.getInt(position, 0);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/IntervalDayTimeType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/IntervalDayTimeType.java
@@ -60,7 +60,7 @@ public final class IntervalDayTimeType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         long value = block.getLong(position, 0);
         return (int) (value ^ (value >>> 32));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/IntervalYearMonthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/IntervalYearMonthType.java
@@ -60,7 +60,7 @@ public final class IntervalYearMonthType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         long value = block.getLong(position, 0);
         return (int) (value ^ (value >>> 32));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
@@ -51,7 +51,7 @@ final class LongDecimalType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         return block.hash(position, 0, getFixedSize());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -51,7 +51,7 @@ final class ShortDecimalType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         return Long.hashCode(block.getLong(position, 0));
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeType.java
@@ -65,7 +65,7 @@ public final class TimeType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         long value = block.getLong(position, 0);
         return (int) (value ^ (value >>> 32));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeWithTimeZoneType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeWithTimeZoneType.java
@@ -62,7 +62,7 @@ public final class TimeWithTimeZoneType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         long value = unpackMillisUtc(block.getLong(position, 0));
         return (int) (value ^ (value >>> 32));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampType.java
@@ -65,7 +65,7 @@ public final class TimestampType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         long value = block.getLong(position, 0);
         return (int) (value ^ (value >>> 32));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampWithTimeZoneType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampWithTimeZoneType.java
@@ -62,7 +62,7 @@ public final class TimestampWithTimeZoneType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         long value = unpackMillisUtc(block.getLong(position, 0));
         return (int) (value ^ (value >>> 32));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/Type.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/Type.java
@@ -149,7 +149,7 @@ public interface Type
      * Calculates the hash code of the value at the specified position in the
      * specified block.
      */
-    int hash(Block block, int position);
+    long hash(Block block, int position);
 
     /**
      * Compare the values in the specified block at the specified positions equal.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/VarbinaryType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/VarbinaryType.java
@@ -64,7 +64,7 @@ public final class VarbinaryType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         return block.hash(position, 0, block.getLength(position));
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/VarcharType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/VarcharType.java
@@ -89,7 +89,7 @@ public final class VarcharType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         return block.hash(position, 0, block.getLength(position));
     }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingIdType.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingIdType.java
@@ -56,7 +56,7 @@ public class TestingIdType
     }
 
     @Override
-    public int hash(Block block, int position)
+    public long hash(Block block, int position)
     {
         long value = block.getLong(position, 0);
         return (int) (value ^ (value >>> 32));


### PR DESCRIPTION
This implementation of issue: https://github.com/prestodb/presto/issues/4133
Here are results of benchmarks pointed inside the issue:
Before changes: https://gist.github.com/fiedukow/81ae0e1b31f4e086d3befa75aa7c091f
After changes: https://gist.github.com/fiedukow/03739319f2f10d0fcf2467c53671457f

It seems that this has positive impact on performance for large group by hashing.

Note that due to nature of some parts of code and external dependencies (eg. airlift) 32 bit hashes are still required in some places. There is longHashToShortHash function introduce to cover conversion without changing local presto code back to 32 bits hashes.

@cberner 