### PR TITLE
revert "Add decimal product tests in presto-hive"

### DIFF
--- a/presto-hive/src/test/sql/create-test-hive13.sql
+++ b/presto-hive/src/test/sql/create-test-hive13.sql
@@ -6,10 +6,6 @@ CREATE TABLE presto_test_types_textfile (
 , t_bigint BIGINT
 , t_float FLOAT
 , t_double DOUBLE
-, t_decimal_precision_8 DECIMAL(8,4)
-, t_decimal_precision_17 DECIMAL(17,8)
-, t_decimal_precision_18 DECIMAL(18,8)
-, t_decimal_precision_38 DECIMAL(38,16)
 , t_boolean BOOLEAN
 , t_timestamp TIMESTAMP
 , t_binary BINARY
@@ -33,10 +29,6 @@ SELECT
 , 4 + n + CASE WHEN n % 13 = 0 THEN NULL ELSE 0 END
 , 5.1 + n
 , 6.2 + n
-, CASE WHEN n % 43 = 0 THEN NULL ELSE 1000.0001BD + CAST(n AS DECIMAL) END
-, CASE WHEN n % 47 = 0 THEN NULL ELSE 100000000.00000001BD + CAST(n AS DECIMAL) END
-, CASE WHEN n % 49 = 0 THEN NULL ELSE 1000000000.00000001BD + CAST(n AS DECIMAL) END
-, CASE WHEN n % 51 = 0 THEN NULL ELSE 1000000000000000000000.0000000000000001BD + CAST(n AS DECIMAL) END
 , CASE n % 3 WHEN 0 THEN false WHEN 1 THEN true ELSE NULL END
 , CASE WHEN n % 17 = 0 THEN NULL ELSE '2011-05-06 07:08:09.1234567' END
 , CASE WHEN n % 23 = 0 THEN NULL ELSE CAST('test binary' AS BINARY) END
@@ -99,10 +91,6 @@ CREATE TABLE presto_test_types_parquet (
 , t_bigint BIGINT
 , t_float FLOAT
 , t_double DOUBLE
-, t_decimal_precision_8 DECIMAL(8,4)
-, t_decimal_precision_17 DECIMAL(17,8)
-, t_decimal_precision_18 DECIMAL(18,8)
-, t_decimal_precision_38 DECIMAL(38,16)
 , t_boolean BOOLEAN
 , t_timestamp TIMESTAMP
 , t_binary BINARY
@@ -122,10 +110,6 @@ SELECT
 , t_bigint
 , t_float
 , t_double
-, t_decimal_precision_8
-, t_decimal_precision_17
-, t_decimal_precision_18
-, t_decimal_precision_38
 , t_boolean
 , t_timestamp
 , t_binary

--- a/presto-hive/src/test/sql/create-test.sql
+++ b/presto-hive/src/test/sql/create-test.sql
@@ -157,8 +157,6 @@ SELECT
 , 5.1 + n
 , 6.2 + n
 , CASE n % 3 WHEN 0 THEN false WHEN 1 THEN true ELSE NULL END
-, 7.3 + n
-, 8.4 + n
 FROM presto_test_sequence
 LIMIT 100
 ;


### PR DESCRIPTION
This reverts commit 65dda94e4d198ef080723a48274455229caf895f. This
commit was not supposed to be merged, it was an element of a larger part
removed and edited before the merge of the DECIMAL works. This makes
the integration tests fail, due to presto-hive/src/test/sql/create-test.sql
having an 8 column table tmp_presto_test and inserting 10 columns into
it.

@martint, to make the tests pass we could just fix the create-test.sql and remove the two additional columns from the insert into, but in fact the whole commit doesn't make sense since we decided to drop it for now. 

To prevent this from happening (breaking integration tests) we're working on including them in the Travis build (currently Travis runs the units test and product tests), we should have that ready in a couple days.