### PR TITLE
Add benchmarks for BigInt operators with overflow check

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/type/BenchmarkBigIntOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/BenchmarkBigIntOperators.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.operator.scalar.ScalarOperator;
+import com.facebook.presto.spi.type.StandardTypes;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -30,6 +32,12 @@ import org.openjdk.jmh.runner.options.VerboseMode;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongBinaryOperator;
 import java.util.function.LongUnaryOperator;
+
+import static com.facebook.presto.metadata.OperatorType.ADD;
+import static com.facebook.presto.metadata.OperatorType.DIVIDE;
+import static com.facebook.presto.metadata.OperatorType.MULTIPLY;
+import static com.facebook.presto.metadata.OperatorType.NEGATION;
+import static com.facebook.presto.metadata.OperatorType.SUBTRACT;
 
 @State(Scope.Thread)
 @Fork(2)
@@ -69,133 +77,326 @@ public class BenchmarkBigIntOperators
     @Benchmark
     public Object overflowChecksAdd()
     {
-        return execute(BigintOperators::add);
+        long result = 0;
+        result += BigintOperators.add(leftOperand0, rightOperand0);
+        result += BigintOperators.add(leftOperand1, rightOperand0);
+        result += BigintOperators.add(leftOperand2, rightOperand0);
+        result += BigintOperators.add(leftOperand3, rightOperand0);
+        result += BigintOperators.add(leftOperand4, rightOperand0);
+        result += BigintOperators.add(leftOperand0, rightOperand1);
+        result += BigintOperators.add(leftOperand1, rightOperand1);
+        result += BigintOperators.add(leftOperand2, rightOperand1);
+        result += BigintOperators.add(leftOperand3, rightOperand1);
+        result += BigintOperators.add(leftOperand4, rightOperand1);
+        result += BigintOperators.add(leftOperand0, rightOperand2);
+        result += BigintOperators.add(leftOperand1, rightOperand2);
+        result += BigintOperators.add(leftOperand2, rightOperand2);
+        result += BigintOperators.add(leftOperand3, rightOperand2);
+        result += BigintOperators.add(leftOperand4, rightOperand2);
+        result += BigintOperators.add(leftOperand0, rightOperand3);
+        result += BigintOperators.add(leftOperand1, rightOperand3);
+        result += BigintOperators.add(leftOperand2, rightOperand3);
+        result += BigintOperators.add(leftOperand3, rightOperand3);
+        result += BigintOperators.add(leftOperand4, rightOperand3);
+        result += BigintOperators.add(leftOperand0, rightOperand4);
+        result += BigintOperators.add(leftOperand1, rightOperand4);
+        result += BigintOperators.add(leftOperand2, rightOperand4);
+        result += BigintOperators.add(leftOperand3, rightOperand4);
+        result += BigintOperators.add(leftOperand4, rightOperand4);
+        return result;
     }
 
     @Benchmark
     public Object overflowChecksSubtract()
     {
-        return execute(BigintOperators::subtract);
+        long result = 0;
+        result += BigintOperators.subtract(leftOperand0, rightOperand0);
+        result += BigintOperators.subtract(leftOperand1, rightOperand0);
+        result += BigintOperators.subtract(leftOperand2, rightOperand0);
+        result += BigintOperators.subtract(leftOperand3, rightOperand0);
+        result += BigintOperators.subtract(leftOperand4, rightOperand0);
+        result += BigintOperators.subtract(leftOperand0, rightOperand1);
+        result += BigintOperators.subtract(leftOperand1, rightOperand1);
+        result += BigintOperators.subtract(leftOperand2, rightOperand1);
+        result += BigintOperators.subtract(leftOperand3, rightOperand1);
+        result += BigintOperators.subtract(leftOperand4, rightOperand1);
+        result += BigintOperators.subtract(leftOperand0, rightOperand2);
+        result += BigintOperators.subtract(leftOperand1, rightOperand2);
+        result += BigintOperators.subtract(leftOperand2, rightOperand2);
+        result += BigintOperators.subtract(leftOperand3, rightOperand2);
+        result += BigintOperators.subtract(leftOperand4, rightOperand2);
+        result += BigintOperators.subtract(leftOperand0, rightOperand3);
+        result += BigintOperators.subtract(leftOperand1, rightOperand3);
+        result += BigintOperators.subtract(leftOperand2, rightOperand3);
+        result += BigintOperators.subtract(leftOperand3, rightOperand3);
+        result += BigintOperators.subtract(leftOperand4, rightOperand3);
+        result += BigintOperators.subtract(leftOperand0, rightOperand4);
+        result += BigintOperators.subtract(leftOperand1, rightOperand4);
+        result += BigintOperators.subtract(leftOperand2, rightOperand4);
+        result += BigintOperators.subtract(leftOperand3, rightOperand4);
+        result += BigintOperators.subtract(leftOperand4, rightOperand4);
+        return result;
     }
 
     @Benchmark
     public Object overflowChecksMultiply()
     {
-        return execute(BigintOperators::multiply);
+        long result = 0;
+        result += BigintOperators.multiply(leftOperand0, rightOperand0);
+        result += BigintOperators.multiply(leftOperand1, rightOperand0);
+        result += BigintOperators.multiply(leftOperand2, rightOperand0);
+        result += BigintOperators.multiply(leftOperand3, rightOperand0);
+        result += BigintOperators.multiply(leftOperand4, rightOperand0);
+        result += BigintOperators.multiply(leftOperand0, rightOperand1);
+        result += BigintOperators.multiply(leftOperand1, rightOperand1);
+        result += BigintOperators.multiply(leftOperand2, rightOperand1);
+        result += BigintOperators.multiply(leftOperand3, rightOperand1);
+        result += BigintOperators.multiply(leftOperand4, rightOperand1);
+        result += BigintOperators.multiply(leftOperand0, rightOperand2);
+        result += BigintOperators.multiply(leftOperand1, rightOperand2);
+        result += BigintOperators.multiply(leftOperand2, rightOperand2);
+        result += BigintOperators.multiply(leftOperand3, rightOperand2);
+        result += BigintOperators.multiply(leftOperand4, rightOperand2);
+        result += BigintOperators.multiply(leftOperand0, rightOperand3);
+        result += BigintOperators.multiply(leftOperand1, rightOperand3);
+        result += BigintOperators.multiply(leftOperand2, rightOperand3);
+        result += BigintOperators.multiply(leftOperand3, rightOperand3);
+        result += BigintOperators.multiply(leftOperand4, rightOperand3);
+        result += BigintOperators.multiply(leftOperand0, rightOperand4);
+        result += BigintOperators.multiply(leftOperand1, rightOperand4);
+        result += BigintOperators.multiply(leftOperand2, rightOperand4);
+        result += BigintOperators.multiply(leftOperand3, rightOperand4);
+        result += BigintOperators.multiply(leftOperand4, rightOperand4);
+        return result;
     }
 
     @Benchmark
     public Object overflowChecksDivide()
     {
-        return execute(BigintOperators::divide);
+        long result = 0;
+        result += BigintOperators.divide(leftOperand0, rightOperand0);
+        result += BigintOperators.divide(leftOperand1, rightOperand0);
+        result += BigintOperators.divide(leftOperand2, rightOperand0);
+        result += BigintOperators.divide(leftOperand3, rightOperand0);
+        result += BigintOperators.divide(leftOperand4, rightOperand0);
+        result += BigintOperators.divide(leftOperand0, rightOperand1);
+        result += BigintOperators.divide(leftOperand1, rightOperand1);
+        result += BigintOperators.divide(leftOperand2, rightOperand1);
+        result += BigintOperators.divide(leftOperand3, rightOperand1);
+        result += BigintOperators.divide(leftOperand4, rightOperand1);
+        result += BigintOperators.divide(leftOperand0, rightOperand2);
+        result += BigintOperators.divide(leftOperand1, rightOperand2);
+        result += BigintOperators.divide(leftOperand2, rightOperand2);
+        result += BigintOperators.divide(leftOperand3, rightOperand2);
+        result += BigintOperators.divide(leftOperand4, rightOperand2);
+        result += BigintOperators.divide(leftOperand0, rightOperand3);
+        result += BigintOperators.divide(leftOperand1, rightOperand3);
+        result += BigintOperators.divide(leftOperand2, rightOperand3);
+        result += BigintOperators.divide(leftOperand3, rightOperand3);
+        result += BigintOperators.divide(leftOperand4, rightOperand3);
+        result += BigintOperators.divide(leftOperand0, rightOperand4);
+        result += BigintOperators.divide(leftOperand1, rightOperand4);
+        result += BigintOperators.divide(leftOperand2, rightOperand4);
+        result += BigintOperators.divide(leftOperand3, rightOperand4);
+        result += BigintOperators.divide(leftOperand4, rightOperand4);
+        return result;
     }
 
     @Benchmark
     public Object overflowChecksNegate()
     {
-        return executeSingleOperand(x -> BigintOperators.negate(x));
+        long result = 0;
+        result += BigintOperators.negate(leftOperand0);
+        result += BigintOperators.negate(leftOperand1);
+        result += BigintOperators.negate(leftOperand2);
+        result += BigintOperators.negate(leftOperand3);
+        result += BigintOperators.negate(leftOperand4);
+        result += BigintOperators.negate(rightOperand0);
+        result += BigintOperators.negate(rightOperand1);
+        result += BigintOperators.negate(rightOperand2);
+        result += BigintOperators.negate(rightOperand3);
+        result += BigintOperators.negate(rightOperand4);
+        return result;
     }
 
     @Benchmark
     public Object baseLineAdd()
     {
-        return execute(BenchmarkBigIntOperators::addBaseline);
+        long result = 0;
+        result += addBaseline(leftOperand0, rightOperand0);
+        result += addBaseline(leftOperand1, rightOperand0);
+        result += addBaseline(leftOperand2, rightOperand0);
+        result += addBaseline(leftOperand3, rightOperand0);
+        result += addBaseline(leftOperand4, rightOperand0);
+        result += addBaseline(leftOperand0, rightOperand1);
+        result += addBaseline(leftOperand1, rightOperand1);
+        result += addBaseline(leftOperand2, rightOperand1);
+        result += addBaseline(leftOperand3, rightOperand1);
+        result += addBaseline(leftOperand4, rightOperand1);
+        result += addBaseline(leftOperand0, rightOperand2);
+        result += addBaseline(leftOperand1, rightOperand2);
+        result += addBaseline(leftOperand2, rightOperand2);
+        result += addBaseline(leftOperand3, rightOperand2);
+        result += addBaseline(leftOperand4, rightOperand2);
+        result += addBaseline(leftOperand0, rightOperand3);
+        result += addBaseline(leftOperand1, rightOperand3);
+        result += addBaseline(leftOperand2, rightOperand3);
+        result += addBaseline(leftOperand3, rightOperand3);
+        result += addBaseline(leftOperand4, rightOperand3);
+        result += addBaseline(leftOperand0, rightOperand4);
+        result += addBaseline(leftOperand1, rightOperand4);
+        result += addBaseline(leftOperand2, rightOperand4);
+        result += addBaseline(leftOperand3, rightOperand4);
+        result += addBaseline(leftOperand4, rightOperand4);
+        return result;
     }
 
     @Benchmark
     public Object baseLineSubtract()
     {
-        return execute(BenchmarkBigIntOperators::subtractBaseline);
+        long result = 0;
+        result += subtractBaseline(leftOperand0, rightOperand0);
+        result += subtractBaseline(leftOperand1, rightOperand0);
+        result += subtractBaseline(leftOperand2, rightOperand0);
+        result += subtractBaseline(leftOperand3, rightOperand0);
+        result += subtractBaseline(leftOperand4, rightOperand0);
+        result += subtractBaseline(leftOperand0, rightOperand1);
+        result += subtractBaseline(leftOperand1, rightOperand1);
+        result += subtractBaseline(leftOperand2, rightOperand1);
+        result += subtractBaseline(leftOperand3, rightOperand1);
+        result += subtractBaseline(leftOperand4, rightOperand1);
+        result += subtractBaseline(leftOperand0, rightOperand2);
+        result += subtractBaseline(leftOperand1, rightOperand2);
+        result += subtractBaseline(leftOperand2, rightOperand2);
+        result += subtractBaseline(leftOperand3, rightOperand2);
+        result += subtractBaseline(leftOperand4, rightOperand2);
+        result += subtractBaseline(leftOperand0, rightOperand3);
+        result += subtractBaseline(leftOperand1, rightOperand3);
+        result += subtractBaseline(leftOperand2, rightOperand3);
+        result += subtractBaseline(leftOperand3, rightOperand3);
+        result += subtractBaseline(leftOperand4, rightOperand3);
+        result += subtractBaseline(leftOperand0, rightOperand4);
+        result += subtractBaseline(leftOperand1, rightOperand4);
+        result += subtractBaseline(leftOperand2, rightOperand4);
+        result += subtractBaseline(leftOperand3, rightOperand4);
+        result += subtractBaseline(leftOperand4, rightOperand4);
+        return result;
     }
 
     @Benchmark
     public Object baseLineMultiply()
     {
-        return execute(BenchmarkBigIntOperators::multiplyBaseline);
+        long result = 0;
+        result += multiplyBaseline(leftOperand0, rightOperand0);
+        result += multiplyBaseline(leftOperand1, rightOperand0);
+        result += multiplyBaseline(leftOperand2, rightOperand0);
+        result += multiplyBaseline(leftOperand3, rightOperand0);
+        result += multiplyBaseline(leftOperand4, rightOperand0);
+        result += multiplyBaseline(leftOperand0, rightOperand1);
+        result += multiplyBaseline(leftOperand1, rightOperand1);
+        result += multiplyBaseline(leftOperand2, rightOperand1);
+        result += multiplyBaseline(leftOperand3, rightOperand1);
+        result += multiplyBaseline(leftOperand4, rightOperand1);
+        result += multiplyBaseline(leftOperand0, rightOperand2);
+        result += multiplyBaseline(leftOperand1, rightOperand2);
+        result += multiplyBaseline(leftOperand2, rightOperand2);
+        result += multiplyBaseline(leftOperand3, rightOperand2);
+        result += multiplyBaseline(leftOperand4, rightOperand2);
+        result += multiplyBaseline(leftOperand0, rightOperand3);
+        result += multiplyBaseline(leftOperand1, rightOperand3);
+        result += multiplyBaseline(leftOperand2, rightOperand3);
+        result += multiplyBaseline(leftOperand3, rightOperand3);
+        result += multiplyBaseline(leftOperand4, rightOperand3);
+        result += multiplyBaseline(leftOperand0, rightOperand4);
+        result += multiplyBaseline(leftOperand1, rightOperand4);
+        result += multiplyBaseline(leftOperand2, rightOperand4);
+        result += multiplyBaseline(leftOperand3, rightOperand4);
+        result += multiplyBaseline(leftOperand4, rightOperand4);
+        return result;
     }
 
     @Benchmark
     public Object baseLineDivide()
     {
-        return execute(BenchmarkBigIntOperators::divideBaseline);
+        long result = 0;
+        result += divideBaseline(leftOperand0, rightOperand0);
+        result += divideBaseline(leftOperand1, rightOperand0);
+        result += divideBaseline(leftOperand2, rightOperand0);
+        result += divideBaseline(leftOperand3, rightOperand0);
+        result += divideBaseline(leftOperand4, rightOperand0);
+        result += divideBaseline(leftOperand0, rightOperand1);
+        result += divideBaseline(leftOperand1, rightOperand1);
+        result += divideBaseline(leftOperand2, rightOperand1);
+        result += divideBaseline(leftOperand3, rightOperand1);
+        result += divideBaseline(leftOperand4, rightOperand1);
+        result += divideBaseline(leftOperand0, rightOperand2);
+        result += divideBaseline(leftOperand1, rightOperand2);
+        result += divideBaseline(leftOperand2, rightOperand2);
+        result += divideBaseline(leftOperand3, rightOperand2);
+        result += divideBaseline(leftOperand4, rightOperand2);
+        result += divideBaseline(leftOperand0, rightOperand3);
+        result += divideBaseline(leftOperand1, rightOperand3);
+        result += divideBaseline(leftOperand2, rightOperand3);
+        result += divideBaseline(leftOperand3, rightOperand3);
+        result += divideBaseline(leftOperand4, rightOperand3);
+        result += divideBaseline(leftOperand0, rightOperand4);
+        result += divideBaseline(leftOperand1, rightOperand4);
+        result += divideBaseline(leftOperand2, rightOperand4);
+        result += divideBaseline(leftOperand3, rightOperand4);
+        result += divideBaseline(leftOperand4, rightOperand4);
+        return result;
     }
 
     @Benchmark
     public Object baseLineNegate()
     {
-        return executeSingleOperand(BenchmarkBigIntOperators::negateBaseLine);
+        long result = 0;
+        result += negateBaseLine(leftOperand0);
+        result += negateBaseLine(leftOperand1);
+        result += negateBaseLine(leftOperand2);
+        result += negateBaseLine(leftOperand3);
+        result += negateBaseLine(leftOperand4);
+        result += negateBaseLine(rightOperand0);
+        result += negateBaseLine(rightOperand1);
+        result += negateBaseLine(rightOperand2);
+        result += negateBaseLine(rightOperand3);
+        result += negateBaseLine(rightOperand4);
+        return result;
     }
 
-    private static long addBaseline(long first, long second)
+    @ScalarOperator(ADD)
+    @SqlType(StandardTypes.BIGINT)
+    private static long addBaseline(@SqlType(StandardTypes.BIGINT) long first, @SqlType(StandardTypes.BIGINT) long second)
     {
         return first + second;
     }
 
-    private static long subtractBaseline(long first, long second)
+    @ScalarOperator(SUBTRACT)
+    @SqlType(StandardTypes.BIGINT)
+    private static long subtractBaseline(@SqlType(StandardTypes.BIGINT) long first, @SqlType(StandardTypes.BIGINT) long second)
     {
         return first - second;
     }
 
-    private static long multiplyBaseline(long first, long second)
+    @ScalarOperator(MULTIPLY)
+    @SqlType(StandardTypes.BIGINT)
+    private static long multiplyBaseline(@SqlType(StandardTypes.BIGINT) long first, @SqlType(StandardTypes.BIGINT) long second)
     {
         return first * second;
     }
 
-    private static long divideBaseline(long first, long second)
+    @ScalarOperator(DIVIDE)
+    @SqlType(StandardTypes.BIGINT)
+    private static long divideBaseline(@SqlType(StandardTypes.BIGINT) long first, @SqlType(StandardTypes.BIGINT) long second)
     {
         return first / second;
     }
 
-    private static long negateBaseLine(long x)
+    @ScalarOperator(NEGATION)
+    @SqlType(StandardTypes.BIGINT)
+    private static long negateBaseLine(@SqlType(StandardTypes.BIGINT) long x)
     {
         return -x;
-    }
-
-    private Object execute(LongBinaryOperator operator)
-    {
-        long result = 0;
-        result += operator.applyAsLong(leftOperand0, rightOperand0);
-        result += operator.applyAsLong(leftOperand1, rightOperand0);
-        result += operator.applyAsLong(leftOperand2, rightOperand0);
-        result += operator.applyAsLong(leftOperand3, rightOperand0);
-        result += operator.applyAsLong(leftOperand4, rightOperand0);
-        result += operator.applyAsLong(leftOperand0, rightOperand1);
-        result += operator.applyAsLong(leftOperand1, rightOperand1);
-        result += operator.applyAsLong(leftOperand2, rightOperand1);
-        result += operator.applyAsLong(leftOperand3, rightOperand1);
-        result += operator.applyAsLong(leftOperand4, rightOperand1);
-        result += operator.applyAsLong(leftOperand0, rightOperand2);
-        result += operator.applyAsLong(leftOperand1, rightOperand2);
-        result += operator.applyAsLong(leftOperand2, rightOperand2);
-        result += operator.applyAsLong(leftOperand3, rightOperand2);
-        result += operator.applyAsLong(leftOperand4, rightOperand2);
-        result += operator.applyAsLong(leftOperand0, rightOperand3);
-        result += operator.applyAsLong(leftOperand1, rightOperand3);
-        result += operator.applyAsLong(leftOperand2, rightOperand3);
-        result += operator.applyAsLong(leftOperand3, rightOperand3);
-        result += operator.applyAsLong(leftOperand4, rightOperand3);
-        result += operator.applyAsLong(leftOperand0, rightOperand4);
-        result += operator.applyAsLong(leftOperand1, rightOperand4);
-        result += operator.applyAsLong(leftOperand2, rightOperand4);
-        result += operator.applyAsLong(leftOperand3, rightOperand4);
-        result += operator.applyAsLong(leftOperand4, rightOperand4);
-        return result;
-    }
-
-    private Object executeSingleOperand(LongUnaryOperator operator)
-    {
-        long result = 0;
-        result += operator.applyAsLong(leftOperand0);
-        result += operator.applyAsLong(leftOperand1);
-        result += operator.applyAsLong(leftOperand2);
-        result += operator.applyAsLong(leftOperand3);
-        result += operator.applyAsLong(leftOperand4);
-        result += operator.applyAsLong(rightOperand0);
-        result += operator.applyAsLong(rightOperand1);
-        result += operator.applyAsLong(rightOperand2);
-        result += operator.applyAsLong(rightOperand3);
-        result += operator.applyAsLong(rightOperand4);
-        return result;
     }
 
     public static void main(String[] args)

--- a/presto-main/src/test/java/com/facebook/presto/type/BenchmarkBigIntOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/BenchmarkBigIntOperators.java
@@ -38,14 +38,32 @@ import java.util.function.LongUnaryOperator;
 @BenchmarkMode(Mode.Throughput)
 public class BenchmarkBigIntOperators
 {
-    private long[] leftOperands;
-    private long[] rightOperands;
+    private long leftOperand0;
+    private long leftOperand1;
+    private long leftOperand2;
+    private long leftOperand3;
+    private long leftOperand4;
+
+    private long rightOperand0;
+    private long rightOperand1;
+    private long rightOperand2;
+    private long rightOperand3;
+    private long rightOperand4;
 
     @Setup
     public void setup()
     {
-        leftOperands = new long[] { 1, 20, 33, 407, 7890 };
-        rightOperands = new long[] { 123456, 9003, 809, 67, 5};
+        leftOperand0 = 1;
+        leftOperand1 = 20;
+        leftOperand2 = 33;
+        leftOperand3 = 407;
+        leftOperand4 = 7890;
+
+        rightOperand0 = 123456;
+        rightOperand1 = 9003;
+        rightOperand2 = 809;
+        rightOperand3 = 67;
+        rightOperand4 = 5;
     }
 
     @Benchmark
@@ -111,47 +129,47 @@ public class BenchmarkBigIntOperators
     private Object execute(LongBinaryOperator operator)
     {
         long result = 0;
-        result += operator.applyAsLong(leftOperands[0], rightOperands[0]);
-        result += operator.applyAsLong(leftOperands[1], rightOperands[0]);
-        result += operator.applyAsLong(leftOperands[2], rightOperands[0]);
-        result += operator.applyAsLong(leftOperands[3], rightOperands[0]);
-        result += operator.applyAsLong(leftOperands[4], rightOperands[0]);
-        result += operator.applyAsLong(leftOperands[0], rightOperands[1]);
-        result += operator.applyAsLong(leftOperands[1], rightOperands[1]);
-        result += operator.applyAsLong(leftOperands[2], rightOperands[1]);
-        result += operator.applyAsLong(leftOperands[3], rightOperands[1]);
-        result += operator.applyAsLong(leftOperands[4], rightOperands[1]);
-        result += operator.applyAsLong(leftOperands[0], rightOperands[2]);
-        result += operator.applyAsLong(leftOperands[1], rightOperands[2]);
-        result += operator.applyAsLong(leftOperands[2], rightOperands[2]);
-        result += operator.applyAsLong(leftOperands[3], rightOperands[2]);
-        result += operator.applyAsLong(leftOperands[4], rightOperands[2]);
-        result += operator.applyAsLong(leftOperands[0], rightOperands[3]);
-        result += operator.applyAsLong(leftOperands[1], rightOperands[3]);
-        result += operator.applyAsLong(leftOperands[2], rightOperands[3]);
-        result += operator.applyAsLong(leftOperands[3], rightOperands[3]);
-        result += operator.applyAsLong(leftOperands[4], rightOperands[3]);
-        result += operator.applyAsLong(leftOperands[0], rightOperands[4]);
-        result += operator.applyAsLong(leftOperands[1], rightOperands[4]);
-        result += operator.applyAsLong(leftOperands[2], rightOperands[4]);
-        result += operator.applyAsLong(leftOperands[3], rightOperands[4]);
-        result += operator.applyAsLong(leftOperands[4], rightOperands[4]);
+        result += operator.applyAsLong(leftOperand0, rightOperand0);
+        result += operator.applyAsLong(leftOperand1, rightOperand0);
+        result += operator.applyAsLong(leftOperand2, rightOperand0);
+        result += operator.applyAsLong(leftOperand3, rightOperand0);
+        result += operator.applyAsLong(leftOperand4, rightOperand0);
+        result += operator.applyAsLong(leftOperand0, rightOperand1);
+        result += operator.applyAsLong(leftOperand1, rightOperand1);
+        result += operator.applyAsLong(leftOperand2, rightOperand1);
+        result += operator.applyAsLong(leftOperand3, rightOperand1);
+        result += operator.applyAsLong(leftOperand4, rightOperand1);
+        result += operator.applyAsLong(leftOperand0, rightOperand2);
+        result += operator.applyAsLong(leftOperand1, rightOperand2);
+        result += operator.applyAsLong(leftOperand2, rightOperand2);
+        result += operator.applyAsLong(leftOperand3, rightOperand2);
+        result += operator.applyAsLong(leftOperand4, rightOperand2);
+        result += operator.applyAsLong(leftOperand0, rightOperand3);
+        result += operator.applyAsLong(leftOperand1, rightOperand3);
+        result += operator.applyAsLong(leftOperand2, rightOperand3);
+        result += operator.applyAsLong(leftOperand3, rightOperand3);
+        result += operator.applyAsLong(leftOperand4, rightOperand3);
+        result += operator.applyAsLong(leftOperand0, rightOperand4);
+        result += operator.applyAsLong(leftOperand1, rightOperand4);
+        result += operator.applyAsLong(leftOperand2, rightOperand4);
+        result += operator.applyAsLong(leftOperand3, rightOperand4);
+        result += operator.applyAsLong(leftOperand4, rightOperand4);
         return result;
     }
 
     private Object executeSingleOperand(LongUnaryOperator operator)
     {
         long result = 0;
-        result += operator.applyAsLong(leftOperands[0]);
-        result += operator.applyAsLong(leftOperands[1]);
-        result += operator.applyAsLong(leftOperands[2]);
-        result += operator.applyAsLong(leftOperands[3]);
-        result += operator.applyAsLong(leftOperands[4]);
-        result += operator.applyAsLong(rightOperands[0]);
-        result += operator.applyAsLong(rightOperands[1]);
-        result += operator.applyAsLong(rightOperands[2]);
-        result += operator.applyAsLong(rightOperands[3]);
-        result += operator.applyAsLong(rightOperands[4]);
+        result += operator.applyAsLong(leftOperand0);
+        result += operator.applyAsLong(leftOperand1);
+        result += operator.applyAsLong(leftOperand2);
+        result += operator.applyAsLong(leftOperand3);
+        result += operator.applyAsLong(leftOperand4);
+        result += operator.applyAsLong(rightOperand0);
+        result += operator.applyAsLong(rightOperand1);
+        result += operator.applyAsLong(rightOperand2);
+        result += operator.applyAsLong(rightOperand3);
+        result += operator.applyAsLong(rightOperand4);
         return result;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/type/BenchmarkBigIntOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/BenchmarkBigIntOperators.java
@@ -69,25 +69,25 @@ public class BenchmarkBigIntOperators
     @Benchmark
     public Object overflowChecksAdd()
     {
-        return execute((x, y) -> BigintOperators.add(x, y));
+        return execute(BigintOperators::add);
     }
 
     @Benchmark
     public Object overflowChecksSubtract()
     {
-        return execute((x, y) -> BigintOperators.subtract(x, y));
+        return execute(BigintOperators::subtract);
     }
 
     @Benchmark
     public Object overflowChecksMultiply()
     {
-        return execute((x, y) -> BigintOperators.multiply(x, y));
+        return execute(BigintOperators::multiply);
     }
 
     @Benchmark
     public Object overflowChecksDivide()
     {
-        return execute((x, y) -> BigintOperators.divide(x, y));
+        return execute(BigintOperators::divide);
     }
 
     @Benchmark
@@ -99,31 +99,56 @@ public class BenchmarkBigIntOperators
     @Benchmark
     public Object baseLineAdd()
     {
-        return execute((x, y) -> x + y);
+        return execute(BenchmarkBigIntOperators::addBaseline);
     }
 
     @Benchmark
     public Object baseLineSubtract()
     {
-        return execute((x, y) -> x - y);
+        return execute(BenchmarkBigIntOperators::subtractBaseline);
     }
 
     @Benchmark
     public Object baseLineMultiply()
     {
-        return execute((x, y) -> x * y);
+        return execute(BenchmarkBigIntOperators::multiplyBaseline);
     }
 
     @Benchmark
     public Object baseLineDivide()
     {
-        return execute((x, y) -> x / y);
+        return execute(BenchmarkBigIntOperators::divideBaseline);
     }
 
     @Benchmark
     public Object baseLineNegate()
     {
-        return executeSingleOperand(x -> -x);
+        return executeSingleOperand(BenchmarkBigIntOperators::negateBaseLine);
+    }
+
+    private static long addBaseline(long first, long second)
+    {
+        return first + second;
+    }
+
+    private static long subtractBaseline(long first, long second)
+    {
+        return first - second;
+    }
+
+    private static long multiplyBaseline(long first, long second)
+    {
+        return first * second;
+    }
+
+    private static long divideBaseline(long first, long second)
+    {
+        return first / second;
+    }
+
+    private static long negateBaseLine(long x)
+    {
+        return -x;
     }
 
     private Object execute(LongBinaryOperator operator)

--- a/presto-main/src/test/java/com/facebook/presto/type/BenchmarkBigIntOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/BenchmarkBigIntOperators.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongBinaryOperator;
+import java.util.function.LongUnaryOperator;
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 100, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 100, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+public class BenchmarkBigIntOperators
+{
+    private long[] leftOperands;
+    private long[] rightOperands;
+
+    @Setup
+    public void setup()
+    {
+        leftOperands = new long[] { 1, 20, 33, 407, 7890 };
+        rightOperands = new long[] { 123456, 9003, 809, 67, 5};
+    }
+
+    @Benchmark
+    public Object overflowChecksAdd()
+    {
+        return execute((x, y) -> BigintOperators.add(x, y));
+    }
+
+    @Benchmark
+    public Object overflowChecksSubtract()
+    {
+        return execute((x, y) -> BigintOperators.subtract(x, y));
+    }
+
+    @Benchmark
+    public Object overflowChecksMultiply()
+    {
+        return execute((x, y) -> BigintOperators.multiply(x, y));
+    }
+
+    @Benchmark
+    public Object overflowChecksDivide()
+    {
+        return execute((x, y) -> BigintOperators.divide(x, y));
+    }
+
+    @Benchmark
+    public Object overflowChecksNegate()
+    {
+        return executeSingleOperand(x -> BigintOperators.negate(x));
+    }
+
+    @Benchmark
+    public Object baseLineAdd()
+    {
+        return execute((x, y) -> x + y);
+    }
+
+    @Benchmark
+    public Object baseLineSubtract()
+    {
+        return execute((x, y) -> x - y);
+    }
+
+    @Benchmark
+    public Object baseLineMultiply()
+    {
+        return execute((x, y) -> x * y);
+    }
+
+    @Benchmark
+    public Object baseLineDivide()
+    {
+        return execute((x, y) -> x / y);
+    }
+
+    @Benchmark
+    public Object baseLineNegate()
+    {
+        return executeSingleOperand(x -> -x);
+    }
+
+    private Object execute(LongBinaryOperator operator)
+    {
+        long result = 0;
+        result += operator.applyAsLong(leftOperands[0], rightOperands[0]);
+        result += operator.applyAsLong(leftOperands[1], rightOperands[0]);
+        result += operator.applyAsLong(leftOperands[2], rightOperands[0]);
+        result += operator.applyAsLong(leftOperands[3], rightOperands[0]);
+        result += operator.applyAsLong(leftOperands[4], rightOperands[0]);
+        result += operator.applyAsLong(leftOperands[0], rightOperands[1]);
+        result += operator.applyAsLong(leftOperands[1], rightOperands[1]);
+        result += operator.applyAsLong(leftOperands[2], rightOperands[1]);
+        result += operator.applyAsLong(leftOperands[3], rightOperands[1]);
+        result += operator.applyAsLong(leftOperands[4], rightOperands[1]);
+        result += operator.applyAsLong(leftOperands[0], rightOperands[2]);
+        result += operator.applyAsLong(leftOperands[1], rightOperands[2]);
+        result += operator.applyAsLong(leftOperands[2], rightOperands[2]);
+        result += operator.applyAsLong(leftOperands[3], rightOperands[2]);
+        result += operator.applyAsLong(leftOperands[4], rightOperands[2]);
+        result += operator.applyAsLong(leftOperands[0], rightOperands[3]);
+        result += operator.applyAsLong(leftOperands[1], rightOperands[3]);
+        result += operator.applyAsLong(leftOperands[2], rightOperands[3]);
+        result += operator.applyAsLong(leftOperands[3], rightOperands[3]);
+        result += operator.applyAsLong(leftOperands[4], rightOperands[3]);
+        result += operator.applyAsLong(leftOperands[0], rightOperands[4]);
+        result += operator.applyAsLong(leftOperands[1], rightOperands[4]);
+        result += operator.applyAsLong(leftOperands[2], rightOperands[4]);
+        result += operator.applyAsLong(leftOperands[3], rightOperands[4]);
+        result += operator.applyAsLong(leftOperands[4], rightOperands[4]);
+        return result;
+    }
+
+    private Object executeSingleOperand(LongUnaryOperator operator)
+    {
+        long result = 0;
+        result += operator.applyAsLong(leftOperands[0]);
+        result += operator.applyAsLong(leftOperands[1]);
+        result += operator.applyAsLong(leftOperands[2]);
+        result += operator.applyAsLong(leftOperands[3]);
+        result += operator.applyAsLong(leftOperands[4]);
+        result += operator.applyAsLong(rightOperands[0]);
+        result += operator.applyAsLong(rightOperands[1]);
+        result += operator.applyAsLong(rightOperands[2]);
+        result += operator.applyAsLong(rightOperands[3]);
+        result += operator.applyAsLong(rightOperands[4]);
+        return result;
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkBigIntOperators.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/BenchmarkBigIntOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/BenchmarkBigIntOperators.java
@@ -30,8 +30,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
 import java.util.concurrent.TimeUnit;
-import java.util.function.LongBinaryOperator;
-import java.util.function.LongUnaryOperator;
 
 import static com.facebook.presto.metadata.OperatorType.ADD;
 import static com.facebook.presto.metadata.OperatorType.DIVIDE;


### PR DESCRIPTION
Due to change in BigInt operators
it is necessary to confirm no performance degradation was introduced.
New implementation was compared to a previous one.

It relates to #4523.
It's a continuation of #4577 which was partially merged.