### PR TITLE
Remove awareness of bucketed Hive table

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -310,6 +310,12 @@ public final class HiveWriteUtils
             throw new PrestoException(HIVE_INVALID_METADATA, format("%s does not contain a valid storage descriptor", tablePartitionDescription));
         }
 
+        // verify bucketing
+        List<String> bucketColumns = storageDescriptor.getBucketCols();
+        if (bucketColumns != null && !bucketColumns.isEmpty()) {
+            throw new PrestoException(NOT_SUPPORTED, "Writing to bucketed Hive table has been temporarily disabled");
+        }
+
         // verify sorting
         List<Order> sortColumns = storageDescriptor.getSortCols();
         if (sortColumns != null && !sortColumns.isEmpty()) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -345,7 +345,8 @@ public class TestHiveIntegrationSmokeTest
                 "WITH (partitioned_by = ARRAY['dragonfruit'])");
     }
 
-    @Test
+    // TODO: re-enable when bucketing is fixed
+    @Test(enabled = false)
     public void testCreatePartitionedBucketedTableAs()
             throws Exception
     {
@@ -408,7 +409,8 @@ public class TestHiveIntegrationSmokeTest
         assertFalse(queryRunner.tableExists(getSession(), "test_create_partitioned_bucketed_table_as"));
     }
 
-    @Test
+    // TODO: re-enable when bucketing is fixed
+    @Test(enabled = false)
     public void testInsertPartitionedBucketedTable()
             throws Exception
     {


### PR DESCRIPTION
because of known correctness issue in planning and scheduling when reading
from such table. Being aware of Hive table bucketing, Presto uses a
potentially more efficient query execution plan. But the new plan had bugs
that are only exposed when combined with the specifics of Hive.