### PR TITLE
Fix using qualified table name with views

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -857,6 +857,14 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testQualifiedViewColumnResolution()
+            throws Exception
+    {
+        // it should be possible to qualify the column reference with the view name
+        analyze("SELECT v1.a FROM v1");
+    }
+
+    @Test
     public void testUse()
             throws Exception
     {

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/CreateDropViewTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/CreateDropViewTests.java
@@ -44,6 +44,16 @@ public class CreateDropViewTests
     }
 
     @Test(groups = CREATE_DROP_VIEW)
+    public void querySimpleViewQualified()
+            throws IOException
+    {
+        executeWith(createViewAs("SELECT * FROM nation"), view -> {
+            assertThat(query(format("SELECT %s.n_regionkey FROM %s", view.getName(), view.getName())))
+                    .hasRowsCount(25);
+        });
+    }
+
+    @Test(groups = CREATE_DROP_VIEW)
     public void createViewWithAggregate()
             throws IOException
     {


### PR DESCRIPTION
Without this patch, I can't qualify column references from views.

```
create table tbl (a bigint);
create view tbl_view as select * from tbl;
-- fails
select tbl_view.a from tbl_view;
-- works
select a from tbl_view;
```

With this patch, both work.