### PR TITLE
Migrate from Guava's cache to Caffeine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -737,6 +737,11 @@
                 <version>2.1.7</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>2.3.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -153,6 +153,11 @@
             <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -80,6 +80,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jline</groupId>
             <artifactId>jline</artifactId>
         </dependency>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -93,6 +93,11 @@
             <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -46,6 +46,11 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-record-decoder</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -220,6 +220,11 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.airlift</groupId>

--- a/presto-ml/pom.xml
+++ b/presto-ml/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>concurrent</artifactId>
             <scope>provided</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/presto-raptor/pom.xml
+++ b/presto-raptor/pom.xml
@@ -101,6 +101,11 @@
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardRecoveryManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardRecoveryManager.java
@@ -19,14 +19,16 @@ import com.facebook.presto.raptor.metadata.ShardMetadata;
 import com.facebook.presto.raptor.util.PrioritizedFifoExecutor;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PrestoException;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.ListenableFuture;
+
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+
 import org.weakref.jmx.Flatten;
 import org.weakref.jmx.Managed;
 
@@ -364,7 +366,7 @@ public class ShardRecoveryManager
         public MissingShardsQueue(PrioritizedFifoExecutor<MissingShardRunnable> shardRecoveryExecutor)
         {
             requireNonNull(shardRecoveryExecutor, "shardRecoveryExecutor is null");
-            this.queuedMissingShards = CacheBuilder.newBuilder().build(new CacheLoader<MissingShard, Future<?>>()
+            this.queuedMissingShards = Caffeine.newBuilder().build(new CacheLoader<MissingShard, Future<?>>()
             {
                 @Override
                 public Future<?> load(MissingShard missingShard)

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -48,6 +48,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisJedisManager.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisJedisManager.java
@@ -15,11 +15,11 @@ package com.facebook.presto.redis;
 
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.NodeManager;
-import com.google.common.base.Throwables;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.primitives.Ints;
+
 import io.airlift.log.Logger;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
@@ -28,7 +28,6 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,7 +49,7 @@ public class RedisJedisManager
             NodeManager nodeManager)
     {
         this.redisConnectorConfig = requireNonNull(redisConnectorConfig, "redisConfig is null");
-        this.jedisPoolCache = CacheBuilder.newBuilder().build(new JedisPoolCacheLoader());
+        this.jedisPoolCache = Caffeine.newBuilder().build(new JedisPoolCacheLoader());
         this.jedisPoolConfig = new JedisPoolConfig();
     }
 
@@ -75,16 +74,11 @@ public class RedisJedisManager
     public JedisPool getJedisPool(HostAddress host)
     {
         requireNonNull(host, "host is null");
-        try {
-            return jedisPoolCache.get(host);
-        }
-        catch (ExecutionException e) {
-            throw Throwables.propagate(e.getCause());
-        }
+        return jedisPoolCache.get(host);
     }
 
     private class JedisPoolCacheLoader
-            extends CacheLoader<HostAddress, JedisPool>
+            implements CacheLoader<HostAddress, JedisPool>
     {
         @Override
         public JedisPool load(HostAddress host)


### PR DESCRIPTION
[Caffeine](https://github.com/ben-manes/caffeine) is a Java 8 rewrite of Guava's cache. In addition, it has [higher performance](https://github.com/ben-manes/caffeine/wiki/Benchmarks) and a [near optimal](https://github.com/ben-manes/caffeine/wiki/Efficiency) hit rate. The [HighScalability article](http://highscalability.com/blog/2016/1/25/design-of-a-modern-cache.html) provides a nice overview of the design.

Due to providing a similar API and the full feature set, the migration was fairly simple. Alternatively the Guava adapters could have been used, but I thought that would add unnecessary noise to the code.

`TestSqlParser` appears to be flaky and sometimes failed on a clean build. While I couldn't find if this was due to a caching issue, it may be due to Caffeine delegating its maintenance work to the background executor. This is done to minimize the variability of response times by not penalizing a calling thread, but is entirely optional. For tests it can be set to synchronous, e.g. `Caffeine.executor(Runnable::run)` to have predictable behavior.

Some of the usages, like `FunctionRegistry`, are recursive and error prone. Guava only fails for recursive loads of the same key, though any recursion is frowned upon. `ConcurrentHashMap` disallows it and either live-locks (JDK8) or throws an `IllegalStateException` (JDK9) if detected. To work around this the computations are performed asynchronously through a synchronous view.

I was unable fully test due to what appeared to be unrelated failure, perhaps due to differences in the exceptions thrown. There was nothing obvious and my lack of familiarity made it hard to debug.
```
testSessionProperties(com.facebook.presto.cli.TestClientOptions)  Time elapsed: 0.006 sec  <<< FAILURE!
io.airlift.airline.ParseException: Unable to create instance com.facebook.presto.cli.Console
        at com.facebook.presto.cli.Console.<init>(Console.java:18)
```

I think this is enough for discussion, but requires someone on the Presto side to finish off.