### PR TITLE
Fix aggregations to check for coerced types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -162,6 +162,15 @@ public class Analysis
         return types.get(expression);
     }
 
+    public Type getTypeWithCoercions(Expression expression)
+    {
+        checkArgument(types.containsKey(expression), "Expression not analyzed: %s", expression);
+        if (coercions.containsKey(expression)) {
+            return coercions.get(expression);
+        }
+        return types.get(expression);
+    }
+
     public Type[] getRelationCoercion(Relation relation)
     {
         return relationCoercions.get(relation);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -277,7 +277,7 @@ class QueryPlanner
             }
             else {
                 Expression expression = fieldOrExpression.getExpression();
-                symbol = symbolAllocator.newSymbol(expression, analysis.getType(expression));
+                symbol = symbolAllocator.newSymbol(expression, analysis.getTypeWithCoercions(expression));
             }
 
             projections.put(symbol, subPlan.rewrite(fieldOrExpression));

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1239,6 +1239,13 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testGroupByRequireIntegerCoercion()
+            throws Exception
+    {
+        assertQuery("SELECT partkey, COUNT(DISTINCT shipdate), SUM(linenumber) FROM lineitem GROUP BY partkey");
+    }
+
+    @Test
     public void testGroupByEmptyGroupingSet()
             throws Exception
     {


### PR DESCRIPTION
The project function in QueryPlanner did not check for existing
coercions when determining the type of a symbol. Added another method
in Analysis to check for coercions.