### PR TITLE
Fix joins to check for coerced types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -661,7 +661,7 @@ class RelationPlanner
 
         ImmutableMap.Builder<Symbol, Expression> newTranslations = ImmutableMap.builder();
         for (Expression expression : expressions) {
-            Symbol symbol = symbolAllocator.newSymbol(expression, analysis.getType(expression));
+            Symbol symbol = symbolAllocator.newSymbol(expression, analysis.getTypeWithCoercions(expression));
 
             // TODO: CHECK IF THE REWRITE OF A SEMI JOINED EXPRESSION WILL WORK!!!!!!!
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1198,6 +1198,13 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testJoinCoercionOnEqualityComparison()
+            throws Exception
+    {
+        assertQuery("SELECT o.clerk, avg(o.shippriority), COUNT(l.linenumber) FROM orders o LEFT OUTER JOIN lineitem l ON o.orderkey=l.orderkey AND o.shippriority=1 GROUP BY o.clerk");
+    }
+
+    @Test
     public void testGroupByNoAggregations()
             throws Exception
     {


### PR DESCRIPTION
Can't find a test that breaks, unfortunately. The plans produced were wrong but most queries will still actually work.