### PR TITLE
Only create staging dir if it doesn't already exist

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -326,7 +326,12 @@ public class PrestoS3FileSystem
             throw new IOException("File already exists:" + path);
         }
 
-        createDirectories(stagingDirectory.toPath());
+        if (!stagingDirectory.exists()) {
+            createDirectories(stagingDirectory.toPath());
+        }
+        if (!stagingDirectory.isDirectory()) {
+            throw new IOException("Configured staging path is not a directory: " + stagingDirectory);
+        }
         File tempFile = createTempFile(stagingDirectory.toPath(), "presto-s3-", ".tmp").toFile();
 
         String key = keyFromPath(qualifiedPath(path));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/MockAmazonS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/MockAmazonS3.java
@@ -406,21 +406,21 @@ public class MockAmazonS3
     public PutObjectResult putObject(PutObjectRequest putObjectRequest)
             throws AmazonClientException
     {
-        return null;
+        return new PutObjectResult();
     }
 
     @Override
     public PutObjectResult putObject(String bucketName, String key, File file)
             throws AmazonClientException
     {
-        return null;
+        return new PutObjectResult();
     }
 
     @Override
     public PutObjectResult putObject(String bucketName, String key, InputStream input, ObjectMetadata metadata)
             throws AmazonClientException
     {
-        return null;
+        return new PutObjectResult();
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestPrestoS3FileSystem.java
@@ -20,16 +20,22 @@ import com.amazonaws.services.s3.AmazonS3EncryptionClient;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.EncryptionMaterials;
 import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
+import com.google.common.base.StandardSystemProperty;
 import com.google.common.base.Throwables;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import javax.crypto.spec.SecretKeySpec;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import static com.facebook.presto.hive.PrestoS3FileSystem.S3_ENCRYPTION_MATERIALS_PROVIDER;
@@ -38,11 +44,13 @@ import static com.facebook.presto.hive.PrestoS3FileSystem.S3_MAX_CLIENT_RETRIES;
 import static com.facebook.presto.hive.PrestoS3FileSystem.S3_MAX_RETRY_TIME;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.testing.Assertions.assertInstanceOf;
+import static io.airlift.testing.FileUtils.deleteRecursively;
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_REQUESTED_RANGE_NOT_SATISFIABLE;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestPrestoS3FileSystem
 {
@@ -165,6 +173,87 @@ public class TestPrestoS3FileSystem
             try (FSDataInputStream inputStream = fs.open(new Path("s3n://test-bucket/test"))) {
                 inputStream.read();
             }
+        }
+    }
+
+    @Test
+    public void testCreateWithNonexistentStagingDirectory()
+        throws Exception
+    {
+        java.nio.file.Path tmpdir = Paths.get(StandardSystemProperty.JAVA_IO_TMPDIR.value());
+        java.nio.file.Path stagingParent = Files.createTempDirectory(tmpdir, "test");
+        java.nio.file.Path staging = Paths.get(stagingParent.toString(), "staging");
+        // stagingParent = /tmp/testXXX
+        // staging = /tmp/testXXX/staging
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            MockAmazonS3 s3 = new MockAmazonS3();
+            Configuration conf = new Configuration();
+            conf.set(PrestoS3FileSystem.S3_STAGING_DIRECTORY, staging.toString());
+            fs.initialize(new URI("s3n://test-bucket/"), conf);
+            fs.setS3Client(s3);
+            FSDataOutputStream stream = fs.create(new Path("s3n://test-bucket/test"));
+            stream.close();
+            assertTrue(Files.exists(staging));
+        }
+        finally {
+            deleteRecursively(stagingParent.toFile());
+        }
+    }
+
+    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = "Configured staging path is not a directory: .*")
+    public void testCreateWithStagingDirectoryFile()
+        throws Exception
+    {
+        java.nio.file.Path tmpdir = Paths.get(StandardSystemProperty.JAVA_IO_TMPDIR.value());
+        java.nio.file.Path staging = Files.createTempFile(tmpdir, "staging", null);
+        // staging = /tmp/stagingXXX.tmp
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            MockAmazonS3 s3 = new MockAmazonS3();
+            Configuration conf = new Configuration();
+            conf.set(PrestoS3FileSystem.S3_STAGING_DIRECTORY, staging.toString());
+            fs.initialize(new URI("s3n://test-bucket/"), conf);
+            fs.setS3Client(s3);
+            fs.create(new Path("s3n://test-bucket/test"));
+        }
+        finally {
+            Files.deleteIfExists(staging);
+        }
+    }
+
+    @Test
+    public void testCreateWithStagingDirectorySymlink()
+        throws Exception
+    {
+        java.nio.file.Path tmpdir = Paths.get(StandardSystemProperty.JAVA_IO_TMPDIR.value());
+        java.nio.file.Path staging = Files.createTempDirectory(tmpdir, "staging");
+        java.nio.file.Path link = Paths.get(staging + ".symlink");
+        // staging = /tmp/stagingXXX
+        // link = /tmp/stagingXXX.symlink -> /tmp/stagingXXX
+
+        try {
+            try {
+                Files.createSymbolicLink(link, staging);
+            }
+            catch (UnsupportedOperationException e) {
+                throw new SkipException("Filesystem does not support symlinks", e);
+            }
+
+            try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+                MockAmazonS3 s3 = new MockAmazonS3();
+                Configuration conf = new Configuration();
+                conf.set(PrestoS3FileSystem.S3_STAGING_DIRECTORY, link.toString());
+                fs.initialize(new URI("s3n://test-bucket/"), conf);
+                fs.setS3Client(s3);
+                FSDataOutputStream stream = fs.create(new Path("s3n://test-bucket/test"));
+                stream.close();
+                assertTrue(Files.exists(link));
+            }
+        }
+        finally {
+            deleteRecursively(link.toFile());
+            deleteRecursively(staging.toFile());
         }
     }
 


### PR DESCRIPTION
This fixes a FileAlreadyExistsException that can occur if the staging directory
is a symlink to a directory rather than an actual directory.

See https://bugs.openjdk.java.net/browse/JDK-8130464 for more information about
this exception, which was deemed "not an issue".

This fixes https://github.com/prestodb/presto/issues/5017