### PR TITLE
Fix null value handling for Parquet maps

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -1226,7 +1226,7 @@ public class ParquetHiveRecordCursor
             valueConverter.afterValue();
             // handle the case where we have a key, but the value is null
             // null keys are not supported anyway, so we can ignore that case here
-            if (builder.getPositionCount() < 2) {
+            if (builder.getPositionCount() % 2 != 0) {
                 builder.appendNull();
             }
         }


### PR DESCRIPTION
This PR fixes `null` value handling for Parquet maps. My previous fix (#4401) doesn't handle `null` map values that is between other map entries (e.g., k1, v1, k2, null, k3, v3). 

@dain @zhenxiao can you please take a look?