### PR TITLE
Fix hashcode operator for varbinary

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/VarbinaryOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarbinaryOperators.java
@@ -16,6 +16,7 @@ package com.facebook.presto.type;
 import com.facebook.presto.operator.scalar.ScalarOperator;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 
 import static com.facebook.presto.metadata.OperatorType.BETWEEN;
 import static com.facebook.presto.metadata.OperatorType.EQUAL;
@@ -85,6 +86,9 @@ public final class VarbinaryOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.VARBINARY) Slice value)
     {
-        return value.hashCode();
+        // This needs to match the hash function for VARBINARY blocks
+        // (i.e. AstractVariableWidthBlock.hash(...))
+        // TODO: we need to get rid of hash from Block and rely on HASH_CODE operators only
+        return XxHash64.hash(value);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
@@ -13,7 +13,12 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.SqlVarbinary;
+import com.facebook.presto.type.VarbinaryOperators;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
 import java.util.Base64;
@@ -25,6 +30,7 @@ import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.google.common.io.BaseEncoding.base16;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
 
 public class TestVarbinaryFunctions
         extends AbstractTestFunctions
@@ -161,6 +167,20 @@ public class TestVarbinaryFunctions
     {
         assertFunction("sha512(CAST('' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("CF83E1357EEFB8BDF1542850D66D8007D620E4050B5715DC83F4A921D36CE9CE47D0D13C5D85F2B0FF8318D2877EEC2F63B931BD47417A81A538327AF927DA3E"));
         assertFunction("sha512(CAST('hashme' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("8A4B59FB9188D09B989FF596AC9CEFBF2ED91DED8DCD9498E8BF2236814A92B23BE6867E7FC340880E514F8FDF97E1F147EA4B0FD6C2DA3557D0CF1C0B58A204"));
+    }
+
+    @Test
+    public void testHashCode()
+            throws Exception
+    {
+        Slice data = Slices.wrappedBuffer(ALL_BYTES);
+
+        Block block = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1, ALL_BYTES.length)
+                .writeBytes(data, 0, data.length())
+                .closeEntry()
+                .build();
+
+        assertEquals(VarbinaryOperators.hashCode(data), VARBINARY.hash(block, 0));
     }
 
     private static String encodeBase64(byte[] value)


### PR DESCRIPTION
Due to legacy reasons, we have code for computing the hash code
of a type in two places: hash_code operator and block.

The update to 64-bit hashes missed a change to varbinary's
HASH_CODE operator, so the operator and the block produced
different hashes for the same data.

Eventually, we should converge to having just the hash_code
operator implementations and get rid of the block methods.