### PR TITLE
Add source command to CLI

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -194,7 +194,8 @@ public class Console
                         command = command.substring(0, command.length() - 1).trim();
                     }
 
-                    switch (command.toLowerCase(ENGLISH)) {
+                    command = command.toLowerCase(ENGLISH);
+                    switch (command) {
                         case "exit":
                         case "quit":
                             return;
@@ -207,6 +208,13 @@ public class Console
                             System.out.println();
                             System.out.println(getHelpText());
                             continue;
+                    }
+
+                    if (command.startsWith("source ")) {
+                        String path = command.split(" ")[1];
+                        String sql = Files.toString(new File(path), UTF_8);
+                        executeCompleteStatements(sql, queryRunner, session, tableNameCompleter, reader);
+                        continue;
                     }
                 }
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Help.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Help.java
@@ -22,6 +22,7 @@ public final class Help
         return "" +
                 "Supported commands:\n" +
                 "QUIT\n" +
+                "SOURCE <file-path>\n" +
                 "EXPLAIN [ ( option [, ...] ) ] <query>\n" +
                 "    options: FORMAT { TEXT | GRAPHVIZ }\n" +
                 "             TYPE { LOGICAL | DISTRIBUTED }\n" +

--- a/presto-docs/src/main/sphinx/sql.rst
+++ b/presto-docs/src/main/sphinx/sql.rst
@@ -31,6 +31,7 @@ This chapter describes the SQL syntax used in Presto.
     sql/show-schemas
     sql/show-session
     sql/show-tables
+    sql/source
     sql/start-transaction
     sql/use
     sql/values

--- a/presto-docs/src/main/sphinx/sql/source.rst
+++ b/presto-docs/src/main/sphinx/sql/source.rst
@@ -1,0 +1,23 @@
+======
+SOURCE
+======
+
+Synopsis
+--------
+
+.. code-block:: none
+
+    SOURCE file-path
+
+Description
+-----------
+
+Execute all complete sql statements in the given file.
+
+Examples
+--------
+
+.. code-block:: none
+
+    SOURCE /path/to/file.sql;
+


### PR DESCRIPTION
#5025

A question:
Currently It adds all queries in source file to the history, is this OK or it should add command itself? (like `source /path/to/file`)
