### PR TITLE
[record-decoder] Check size for only non-null fields

### DIFF
--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/raw/RawFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/raw/RawFieldDecoder.java
@@ -140,7 +140,10 @@ public class RawFieldDecoder
             this.columnHandle = requireNonNull(columnHandle, "columnHandle is null");
             this.fieldType = requireNonNull(fieldType, "fieldType is null");
             this.size = value.limit() - value.position();
-            checkState(size >= fieldType.getSize(), "minimum byte size is %s, found %s,", fieldType.getSize(), size);
+            // check size for non-null fields
+            if (size > 0) {
+                checkState(size >= fieldType.getSize(), "minimum byte size is %s, found %s,", fieldType.getSize(), size);
+            }
             this.value = value;
         }
 

--- a/presto-record-decoder/src/test/java/com/facebook/presto/decoder/raw/TestRawDecoder.java
+++ b/presto-record-decoder/src/test/java/com/facebook/presto/decoder/raw/TestRawDecoder.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.facebook.presto.decoder.util.DecoderTestUtil.checkIsNull;
 import static com.facebook.presto.decoder.util.DecoderTestUtil.checkValue;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -46,6 +47,19 @@ public class TestRawDecoder
             map.put(column, DEFAULT_FIELD_DECODER);
         }
         return map.build();
+    }
+
+    @Test
+    public void testEmptyRecord()
+    {
+        RawRowDecoder rowDecoder = new RawRowDecoder();
+        byte[] emptyRow = new byte[0];
+        DecoderTestColumnHandle column = new DecoderTestColumnHandle("", 0, "row1", BigintType.BIGINT, null, "LONG", null, false, false, false);
+        List<DecoderColumnHandle> columns = ImmutableList.of(column);
+        Set<FieldValueProvider> providers = new HashSet<>();
+        boolean corrupt = rowDecoder.decodeRow(emptyRow, null, providers, columns, buildMap(columns));
+        assertFalse(corrupt);
+        checkIsNull(providers, column);
     }
 
     @Test


### PR DESCRIPTION
`RawFieldDecoder.RawValueProvider` doesn't properly handle empty buffers passed to it. Although the size of the given buffer can be zero and that's already handled by the `isNull()` method (and by the other methods that return proper values for this case), the size is checked to be larger than the given type's size. Hit this when a query failed with the Kafka connector.


```Java
Query 20160415_224622_00000_gky48 failed: minimum byte size is 8, found 0,
java.lang.IllegalStateException: minimum byte size is 8, found 0,
	at com.google.common.base.Preconditions.checkState(Preconditions.java:197)
	at com.facebook.presto.decoder.raw.RawFieldDecoder$RawValueProvider.<init>(RawFieldDecoder.java:143)
	at com.facebook.presto.decoder.raw.RawFieldDecoder.decode(RawFieldDecoder.java:121)
	at com.facebook.presto.decoder.raw.RawFieldDecoder.decode(RawFieldDecoder.java:39)
	at com.facebook.presto.decoder.raw.RawRowDecoder.decodeRow(RawRowDecoder.java:55)
	at com.facebook.presto.kafka.KafkaRecordSet$KafkaRecordCursor.nextRow(KafkaRecordSet.java:221)
	at com.facebook.presto.kafka.KafkaRecordSet$KafkaRecordCursor.advanceNextPosition(KafkaRecordSet.java:175)
	at com.facebook.presto.spi.RecordPageSource.getNextPage(RecordPageSource.java:99)
	at com.facebook.presto.operator.TableScanOperator.getOutput(TableScanOperator.java:246)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:380)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:303)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:577)
	at com.facebook.presto.execution.TaskExecutor$PrioritizedSplitRunner.process(TaskExecutor.java:529)
	at com.facebook.presto.execution.TaskExecutor$Runner.run(TaskExecutor.java:665)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```