### PR TITLE
Add ROW definition and CAST syntax

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignature.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignature.java
@@ -198,19 +198,12 @@ public class ClientTypeSignature
     @Deprecated
     private String rowToString()
     {
-        String types = arguments.stream()
+        String fields = arguments.stream()
                 .map(ClientTypeSignatureParameter::getNamedTypeSignature)
-                .map(NamedTypeSignature::getTypeSignature)
-                .map(TypeSignature::toString)
+                .map(parameter -> format("%s %s", parameter.getName(), parameter.getTypeSignature().toString()))
                 .collect(Collectors.joining(","));
 
-        String fieldNames = arguments.stream()
-                .map(ClientTypeSignatureParameter::getNamedTypeSignature)
-                .map(NamedTypeSignature::getName)
-                .map(name -> format("'%s'", name))
-                .collect(Collectors.joining(","));
-
-        return format("row<%s>(%s)", types, fieldNames);
+        return format("row(%s)", fields);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -197,6 +197,7 @@ import static com.facebook.presto.operator.scalar.RowEqualOperator.ROW_EQUAL;
 import static com.facebook.presto.operator.scalar.RowHashCodeOperator.ROW_HASH_CODE;
 import static com.facebook.presto.operator.scalar.RowNotEqualOperator.ROW_NOT_EQUAL;
 import static com.facebook.presto.operator.scalar.RowToJsonCast.ROW_TO_JSON;
+import static com.facebook.presto.operator.scalar.RowToRowCast.ROW_TO_ROW_CAST;
 import static com.facebook.presto.operator.scalar.TryCastFunction.TRY_CAST;
 import static com.facebook.presto.operator.scalar.VarcharToVarcharCast.VARCHAR_TO_VARCHAR_CAST;
 import static com.facebook.presto.operator.window.AggregateWindowFunction.supplier;
@@ -422,7 +423,7 @@ public class FunctionRegistry
                 .functions(MAX_BY, MIN_BY, MAX_BY_N_AGGREGATION, MIN_BY_N_AGGREGATION)
                 .functions(MAX_AGGREGATION, MIN_AGGREGATION, MAX_N_AGGREGATION, MIN_N_AGGREGATION)
                 .function(COUNT_COLUMN)
-                .functions(ROW_HASH_CODE, ROW_TO_JSON, ROW_EQUAL, ROW_NOT_EQUAL)
+                .functions(ROW_HASH_CODE, ROW_TO_JSON, ROW_EQUAL, ROW_NOT_EQUAL, ROW_TO_ROW_CAST)
                 .function(CONCAT)
                 .function(DECIMAL_TO_DECIMAL_CAST)
                 .function(TRY_CAST);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToRowCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToRowCast.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.bytecode.BytecodeBlock;
+import com.facebook.presto.bytecode.ClassDefinition;
+import com.facebook.presto.bytecode.CompilerUtils;
+import com.facebook.presto.bytecode.MethodDefinition;
+import com.facebook.presto.bytecode.Parameter;
+import com.facebook.presto.bytecode.Scope;
+import com.facebook.presto.bytecode.Variable;
+import com.facebook.presto.bytecode.control.IfStatement;
+import com.facebook.presto.bytecode.expression.BytecodeExpression;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.metadata.SqlOperator;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.StandardErrorCode;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.InterleavedBlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.sql.gen.CachedInstanceBinder;
+import com.facebook.presto.sql.gen.CallSiteBinder;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.hash.Hashing;
+import com.google.common.io.BaseEncoding;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.bytecode.Access.FINAL;
+import static com.facebook.presto.bytecode.Access.PUBLIC;
+import static com.facebook.presto.bytecode.Access.STATIC;
+import static com.facebook.presto.bytecode.Access.a;
+import static com.facebook.presto.bytecode.CompilerUtils.defineClass;
+import static com.facebook.presto.bytecode.Parameter.arg;
+import static com.facebook.presto.bytecode.ParameterizedType.type;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantBoolean;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantInt;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newInstance;
+import static com.facebook.presto.metadata.OperatorType.CAST;
+import static com.facebook.presto.metadata.Signature.internalOperator;
+import static com.facebook.presto.metadata.Signature.withVariadicBound;
+import static com.facebook.presto.sql.gen.InvokeFunctionBytecodeExpression.invokeFunction;
+import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class RowToRowCast
+        extends SqlOperator
+{
+    public static final RowToRowCast ROW_TO_ROW_CAST = new RowToRowCast();
+
+    private RowToRowCast()
+    {
+        super(CAST, ImmutableList.of(withVariadicBound("F", "row"), withVariadicBound("T", "row")), ImmutableList.of(), "T", ImmutableList.of("F"));
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        checkArgument(arity == 1, "Expected arity to be 1");
+        Type fromType = boundVariables.getTypeVariable("F");
+        Type toType = boundVariables.getTypeVariable("T");
+        if (fromType.getTypeParameters().size() != toType.getTypeParameters().size()) {
+            throw new PrestoException(StandardErrorCode.INVALID_FUNCTION_ARGUMENT, "the size of fromType and toType must match");
+        }
+        Class<?> castOperatorClass = generateRowCast(fromType, toType, functionRegistry);
+        MethodHandle methodHandle = methodHandle(castOperatorClass, "castRow", ConnectorSession.class, Block.class);
+        return new ScalarFunctionImplementation(false, ImmutableList.of(false), methodHandle, isDeterministic());
+    }
+
+    private static Class<?> generateRowCast(Type fromType, Type toType, FunctionRegistry functionRegistry)
+    {
+        List<Type> toTypes = toType.getTypeParameters();
+        List<Type> fromTypes = fromType.getTypeParameters();
+
+        CallSiteBinder binder = new CallSiteBinder();
+
+        // Embed the MD5 hash code of input and output types into the generated class name instead of the raw type names,
+        // which could prevent the class name from hitting the length limitation and invalid characters.
+        byte[] md5Suffix = Hashing.md5().hashBytes((fromType + "$" + toType).getBytes()).asBytes();
+
+        ClassDefinition definition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                CompilerUtils.makeClassName(Joiner.on("$").join("RowCast", BaseEncoding.base16().encode(md5Suffix))),
+                type(Object.class));
+
+        Parameter session = arg("session", ConnectorSession.class);
+        Parameter value = arg("value", Block.class);
+
+        MethodDefinition method = definition.declareMethod(
+                a(PUBLIC, STATIC),
+                "castRow",
+                type(Block.class),
+                session,
+                value);
+
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        Variable wasNull = scope.declareVariable(boolean.class, "wasNull");
+        Variable blockBuilder = scope.createTempVariable(BlockBuilder.class);
+
+        body.append(wasNull.set(constantBoolean(false)));
+
+        CachedInstanceBinder cachedInstanceBinder = new CachedInstanceBinder(definition, binder);
+
+        // create the interleave block builder
+        body.newObject(InterleavedBlockBuilder.class)
+                .dup()
+                .append(constantType(binder, toType).invoke("getTypeParameters", List.class))
+                .append(newInstance(BlockBuilderStatus.class))
+                .append(constantInt(toTypes.size()))
+                .invokeConstructor(InterleavedBlockBuilder.class, List.class, BlockBuilderStatus.class, int.class)
+                .putVariable(blockBuilder);
+
+        // loop through to append member blocks
+        for (int i = 0; i < toTypes.size(); i++) {
+            Signature signature = internalOperator(
+                    CAST.name(),
+                    toTypes.get(i).getTypeSignature(),
+                    ImmutableList.of(fromTypes.get(i).getTypeSignature()));
+            ScalarFunctionImplementation function = functionRegistry.getScalarFunctionImplementation(signature);
+            BytecodeExpression fromElement = constantType(binder, fromTypes.get(i)).getValue(value, constantInt(i));
+            BytecodeExpression toElement = invokeFunction(scope, cachedInstanceBinder, signature.getName(), function, fromElement);
+            IfStatement ifElementNull = new IfStatement("if the element in the row type is null...");
+
+            ifElementNull.condition(value.invoke("isNull", boolean.class, constantInt(i)))
+                    .ifTrue(blockBuilder.invoke("appendNull", BlockBuilder.class).pop())
+                    .ifFalse(constantType(binder, toTypes.get(i)).writeValue(blockBuilder, toElement));
+
+            body.append(ifElementNull);
+        }
+
+        // call blockBuilder.build()
+        body.append(blockBuilder.invoke("build", Block.class))
+                .retObject();
+
+        // create constructor
+        MethodDefinition constructorDefinition = definition.declareConstructor(a(PUBLIC));
+        BytecodeBlock constructorBody = constructorDefinition.getBody();
+        Variable thisVariable = constructorDefinition.getThis();
+        constructorBody.comment("super();")
+                .append(thisVariable)
+                .invokeConstructor(Object.class);
+        cachedInstanceBinder.generateInitializations(thisVariable, constructorBody);
+        constructorBody.ret();
+
+        return defineClass(definition, Object.class, binder.getBindings(), RowToRowCast.class.getClassLoader());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TestingRowConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TestingRowConstructor.java
@@ -47,53 +47,53 @@ public final class TestingRowConstructor
     private TestingRowConstructor() {}
 
     @ScalarFunction("test_row")
-    @SqlType("row<integer,integer>('col0','col1')")
+    @SqlType("row(col0 integer,col1 integer)")
     public static Block testRowIntegerInteger(@Nullable @SqlType(StandardTypes.INTEGER) Long arg1, @Nullable @SqlType(StandardTypes.INTEGER) Long arg2)
     {
         return toStackRepresentation(ImmutableList.of(INTEGER, INTEGER), arg1, arg2);
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<integer,double>('col0','col1')")
+    @SqlType("row(col0 integer,col1 double)")
     public static Block testRowIntegerInteger(@Nullable @SqlType(StandardTypes.INTEGER) Long arg1, @Nullable @SqlType(StandardTypes.DOUBLE) Double arg2)
     {
         return toStackRepresentation(ImmutableList.of(INTEGER, DOUBLE), arg1, arg2);
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<bigint,bigint>('col0','col1')")
+    @SqlType("row(col0 bigint,col1 bigint)")
     public static Block testRowBigintBigint(@Nullable @SqlType(StandardTypes.BIGINT) Long arg1, @Nullable @SqlType(StandardTypes.BIGINT) Long arg2)
     {
         return toStackRepresentation(ImmutableList.of(BIGINT, BIGINT), arg1, arg2);
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<bigint,double>('col0','col1')")
+    @SqlType("row(col0 bigint,col1 double)")
     public static Block testRowBigintBigint(@Nullable @SqlType(StandardTypes.BIGINT) Long arg1, @Nullable @SqlType(StandardTypes.DOUBLE) Double arg2)
     {
         return toStackRepresentation(ImmutableList.of(BIGINT, DOUBLE), arg1, arg2);
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<integer,double,boolean,varchar,timestamp>('col0','col1','col2','col3','col4')")
+    @SqlType("row(col0 integer,col1 double,col2 boolean,col3 varchar,col4 timestamp)")
     public static Block testRowIntegerDoubleBooleanVarcharTimestamp(@Nullable @SqlType(StandardTypes.INTEGER) Long arg1, @Nullable @SqlType(StandardTypes.DOUBLE) Double arg2,
-                                                          @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg3, @Nullable @SqlType(StandardTypes.VARCHAR) Slice arg4,
-                                                          @Nullable @SqlType(StandardTypes.TIMESTAMP) Long arg5)
+            @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg3, @Nullable @SqlType(StandardTypes.VARCHAR) Slice arg4,
+            @Nullable @SqlType(StandardTypes.TIMESTAMP) Long arg5)
     {
         return toStackRepresentation(ImmutableList.of(INTEGER, DOUBLE, BOOLEAN, VARCHAR, TIMESTAMP), arg1, arg2, arg3, arg4, arg5);
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<HyperLogLog>('col0')")
+    @SqlType("row(col0 HyperLogLog)")
     public static Block testRowHyperLogLog(@Nullable @SqlType(StandardTypes.HYPER_LOG_LOG) Slice arg1)
     {
         return toStackRepresentation(ImmutableList.of(HYPER_LOG_LOG), arg1);
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<double,row<timestamp with time zone,timestamp with time zone>('col0','col1')>('col2','col3')")
+    @SqlType("row(col2 double,col3 row(col0 timestamp with time zone,col1 timestamp with time zone))")
     public static Block testNestedRowsWithTimestampsWithTimeZones(@Nullable @SqlType(StandardTypes.DOUBLE) Double arg1,
-                                                                  @Nullable @SqlType("row<timestamp with time zone,timestamp with time zone>('col0','col1')") Block arg2)
+            @Nullable @SqlType("row(col0 timestamp with time zone,col1 timestamp with time zone)") Block arg2)
     {
         List<Type> parameterTypes = ImmutableList.of(
                 DOUBLE,
@@ -102,44 +102,44 @@ public final class TestingRowConstructor
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<timestamp with time zone,timestamp with time zone>('col0','col1')")
+    @SqlType("row(col0 timestamp with time zone,col1 timestamp with time zone)")
     public static Block testRowTimestampsWithTimeZones(@Nullable @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) Long arg1,
-                                                                   @Nullable @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) Long arg2)
+            @Nullable @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) Long arg2)
     {
         return toStackRepresentation(ImmutableList.of(TIMESTAMP_WITH_TIME_ZONE, TIMESTAMP_WITH_TIME_ZONE), arg1, arg2);
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<double,double>('col0','col1')")
+    @SqlType("row(col0 double,col1 double)")
     public static Block testRowDoubleDouble(@Nullable @SqlType(StandardTypes.DOUBLE) Double arg1, @Nullable @SqlType(StandardTypes.DOUBLE) Double arg2)
     {
         return toStackRepresentation(ImmutableList.of(DOUBLE, DOUBLE), arg1, arg2);
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<double,varchar>('col0','col1')")
+    @SqlType("row(col0 double,col1 varchar)")
     public static Block testRowDoubleInteger(@Nullable @SqlType(StandardTypes.DOUBLE) Double arg1, @Nullable @SqlType(StandardTypes.VARCHAR) Slice arg2)
     {
         return toStackRepresentation(ImmutableList.of(DOUBLE, VARCHAR), arg1, arg2);
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<boolean,boolean>('col0','col1')")
+    @SqlType("row(col0 boolean,col1 boolean)")
     public static Block testRowIntegerInteger(@Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg1, @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg2)
     {
         return toStackRepresentation(ImmutableList.of(BOOLEAN, BOOLEAN), arg1, arg2);
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<boolean,boolean,boolean,boolean>('col0','col1','col2','col3')")
+    @SqlType("row(col0 boolean,col1 boolean,col2 boolean,col3 boolean)")
     public static Block testRowFourBooleans(@Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg1, @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg2,
-                                              @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg3, @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg4)
+            @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg3, @Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg4)
     {
         return toStackRepresentation(ImmutableList.of(BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN), arg1, arg2, arg3, arg4);
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<boolean,array(integer)>('col0','col1')")
+    @SqlType("row(col0 boolean,col1 array(integer))")
     public static Block testRowBooleanArray(@Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg1, @Nullable @SqlType("array(integer)") Block arg2)
     {
         List<Type> parameterTypes = ImmutableList.of(BOOLEAN, new ArrayType(INTEGER));
@@ -147,18 +147,18 @@ public final class TestingRowConstructor
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<boolean,array(integer),map(integer,double)>('col0','col1','col2')")
+    @SqlType("row(col0 boolean,col1 array(integer),col2 map(integer,double))")
     public static Block testRowBooleanArrayMap(@Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg1, @Nullable @SqlType("array(integer)") Block arg2,
-                                               @Nullable @SqlType("map(integer,double)") Block arg3)
+            @Nullable @SqlType("map(integer,double)") Block arg3)
     {
         List<Type> parameterTypes = ImmutableList.of(BOOLEAN, new ArrayType(INTEGER), new MapType(INTEGER, DOUBLE));
         return toStackRepresentation(parameterTypes, arg1, arg2, arg3);
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<double,array(integer),row<integer,double>('col0','col1')>('col0','col1','col2')")
+    @SqlType("row(col0 double,col1 array(integer),col2 row(col0 integer,col1 double))")
     public static Block testNestedRow(@Nullable @SqlType(StandardTypes.DOUBLE) Double arg1, @Nullable @SqlType("array(integer)") Block arg2,
-                                               @Nullable @SqlType("row<integer,double>('col0','col1')") Block arg3)
+            @Nullable @SqlType("row(col0 integer,col1 double)") Block arg3)
     {
         List<Type> parameterTypes = ImmutableList.of(
                 DOUBLE, new ArrayType(INTEGER),
@@ -167,11 +167,11 @@ public final class TestingRowConstructor
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<double,array(row<integer,double>('col0','col1')),row<integer,double>('col0','col1')>('col0','col1','col2')")
+    @SqlType("row(col0 double,col1 array(row(col0 integer,col1 double)),col2 row(col0 integer,col1 double))")
     public static Block testNestedRowWithArray(
             @Nullable @SqlType(StandardTypes.DOUBLE) Double arg1,
-            @Nullable @SqlType("array(row<integer,double>('col0','col1'))") Block arg2,
-            @Nullable @SqlType("row<integer,double>('col0','col1')") Block arg3)
+            @Nullable @SqlType("array(row(col0 integer,col1 double))") Block arg2,
+            @Nullable @SqlType("row(col0 integer,col1 double)") Block arg3)
     {
         List<Type> parameterTypes = ImmutableList.of(
                 DOUBLE,
@@ -181,14 +181,14 @@ public final class TestingRowConstructor
     }
 
     @ScalarFunction("test_row")
-    @SqlType("row<timestamp>('col0')")
+    @SqlType("row(col0 timestamp)")
     public static Block testRowIntegerInteger(@Nullable @SqlType(StandardTypes.TIMESTAMP) Long arg1)
     {
         return toStackRepresentation(ImmutableList.of(TIMESTAMP), arg1);
     }
 
     @ScalarFunction("test_non_lowercase_row")
-    @SqlType("row<integer>('Col0')")
+    @SqlType("row(Col0 integer)")
     public static Block testNonLowercaseRowInteger(@Nullable @SqlType(StandardTypes.INTEGER) Long arg1)
     {
         return toStackRepresentation(ImmutableList.of(INTEGER), arg1);
@@ -198,7 +198,7 @@ public final class TestingRowConstructor
     {
         checkArgument(parameterTypes.size() == values.length, "parameterTypes.size(" + parameterTypes.size() + ") does not equal to values.length(" + values.length + ")");
 
-        BlockBuilder blockBuilder =  new InterleavedBlockBuilder(parameterTypes, new BlockBuilderStatus(), 1024);
+        BlockBuilder blockBuilder = new InterleavedBlockBuilder(parameterTypes, new BlockBuilderStatus(), 1024);
         for (int i = 0; i < values.length; i++) {
             appendToBlockBuilder(parameterTypes.get(i), values[i], blockBuilder);
         }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestFunctionType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestFunctionType.java
@@ -27,7 +27,7 @@ public class TestFunctionType
     {
         TypeManager typeManager = new TypeRegistry();
 
-        Type function = typeManager.getType(TypeSignature.parseTypeSignature("function<row<double>('field'),bigint>"));
+        Type function = typeManager.getType(TypeSignature.parseTypeSignature("function<row(field double),bigint>"));
         assertEquals(function.getDisplayName(), "function<row(field double),bigint>");
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestSimpleRowType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestSimpleRowType.java
@@ -29,7 +29,7 @@ import static io.airlift.slice.Slices.utf8Slice;
 public class TestSimpleRowType
         extends AbstractTestType
 {
-    private static final Type TYPE = new TypeRegistry().getType(parseTypeSignature("row<bigint,varchar>('a','b')"));
+    private static final Type TYPE = new TypeRegistry().getType(parseTypeSignature("row(a bigint,b varchar)"));
 
     public TestSimpleRowType()
     {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTypeRegistry.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTypeRegistry.java
@@ -94,7 +94,7 @@ public class TestTypeRegistry
         assertFalse(TypeRegistry.canCoerce(parseTypeSignature("array(double)"), parseTypeSignature("array(bigint)")));
         assertTrue(TypeRegistry.canCoerce(parseTypeSignature("map(bigint,double)"), parseTypeSignature("map(bigint,double)")));
         assertTrue(TypeRegistry.canCoerce(parseTypeSignature("map(bigint,double)"), parseTypeSignature("map(double,double)")));
-        assertTrue(TypeRegistry.canCoerce(parseTypeSignature("row<bigint,double,varchar>('a','b','c')"), parseTypeSignature("row<bigint,double,varchar>('a','b','c')")));
+        assertTrue(TypeRegistry.canCoerce(parseTypeSignature("row(a bigint,b double,c varchar)"), parseTypeSignature("row(a bigint,b double,c varchar)")));
 
         assertTrue(TypeRegistry.canCoerce(parseTypeSignature("varchar(42)"), parseTypeSignature("varchar(42)")));
         assertTrue(TypeRegistry.canCoerce(parseTypeSignature("varchar(42)"), parseTypeSignature("varchar(44)")));
@@ -131,7 +131,7 @@ public class TestTypeRegistry
         assertCommonSuperType("array(bigint)", "array(unknown)", "array(bigint)");
         assertCommonSuperType("map(bigint,double)", "map(bigint,double)", "map(bigint,double)");
         assertCommonSuperType("map(bigint,double)", "map(double,double)", "map(double,double)");
-        assertCommonSuperType("row<bigint,double,varchar>('a','b','c')", "row<bigint,double,varchar>('a','b','c')", "row<bigint,double,varchar>('a','b','c')");
+        assertCommonSuperType("row(a bigint,b double,c varchar)", "row(a bigint,b double,c varchar)", "row(a bigint,b double,c varchar)");
 
         assertCommonSuperType("varchar(42)", "varchar(44)", "varchar(44)");
     }

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -308,6 +308,7 @@ type
     : type ARRAY
     | ARRAY '<' type '>'
     | MAP '<' type ',' type '>'
+    | ROW '(' identifier type (',' identifier type)* ')'
     | baseType ('(' typeParameter (',' typeParameter)* ')')?
     ;
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1542,6 +1542,20 @@ class AstBuilder
             return "MAP(" + getType(type.type(0)) + "," + getType(type.type(1)) + ")";
         }
 
+        if (type.ROW() != null) {
+            StringBuilder builder = new StringBuilder("(");
+            for (int i = 0; i < type.identifier().size(); i++) {
+                if (i != 0) {
+                    builder.append(",");
+                }
+                builder.append(type.identifier(i).getText())
+                        .append(" ")
+                        .append(getType(type.type(i)));
+            }
+            builder.append(")");
+            return "ROW" + builder.toString();
+        }
+
         throw new IllegalArgumentException("Unsupported type specification: " + type.getText());
     }
 

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -286,6 +286,13 @@ public class TestSqlParser
         assertCast("ARRAY<foo(42,55)>", "ARRAY(foo(42,55))");
         assertCast("varchar(42) ARRAY", "ARRAY(varchar(42))");
         assertCast("foo(42, 55) ARRAY", "ARRAY(foo(42,55))");
+
+        assertCast("ROW(m DOUBLE)", "ROW(m DOUBLE)");
+        assertCast("ROW(m DOUBLE)");
+        assertCast("ROW(x BIGINT,y DOUBLE)");
+        assertCast("ROW(x BIGINT, y DOUBLE)", "ROW(x bigint,y double)");
+        assertCast("ROW(x BIGINT, y DOUBLE, z ROW(m array<bigint>,n map<double,timestamp>))", "ROW(x BIGINT,y DOUBLE,z ROW(m array(bigint),n map(double,timestamp)))");
+        assertCast("array<ROW(x BIGINT, y TIMESTAMP)>", "ARRAY(ROW(x BIGINT,y TIMESTAMP))");
     }
 
     @Test

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -47,7 +47,7 @@ public class TestTypeSignature
         assertBindSignature("array<T1>", boundParameters, "array(double)");
         assertBindSignature("map(T1,T2)", boundParameters, "map(double,bigint)");
         assertBindSignature("map<T1,T2>", boundParameters, "map(double,bigint)");
-        assertBindSignature("row<T1,T2>('a','b')", boundParameters, "row<double,bigint>('a','b')");
+        assertBindSignature("row(a T1,b T2)", boundParameters, "row(a double,b bigint)");
         assertBindSignature("bla(T1,42,T2)", boundParameters, "bla(double,42,bigint)");
 
         assertBindSignatureFails("T1(bigint)", boundParameters, "Unbounded parameters can not have parameters");
@@ -83,33 +83,33 @@ public class TestTypeSignature
             throws Exception
     {
         assertRowSignature(
-                "row<bigint,varchar>('a','b')",
+                "row(a bigint,b varchar)",
                 rowSignature(namedParameter("a", signature("bigint")), namedParameter("b", varchar())));
         assertRowSignature(
-                "ROW<bigint,varchar>('a','b')",
+                "ROW(a bigint,b varchar)",
                 "ROW",
                 ImmutableList.of("a bigint", "b varchar"),
-                "row<bigint,varchar>('a','b')");
+                "row(a bigint,b varchar)");
         assertRowSignature(
-                "row<bigint,array(bigint),row<bigint>('a')>('a','b','c')",
+                "row(a bigint,b array(bigint),c row(a bigint))",
                 rowSignature(
                         namedParameter("a", signature("bigint")),
                         namedParameter("b", array(signature("bigint"))),
                         namedParameter("c", rowSignature(namedParameter("a", signature("bigint"))))));
         assertRowSignature(
-                "row<varchar(10),row<bigint>('a')>('a','b')",
+                "row(a varchar(10),b row(a bigint))",
                 rowSignature(
                         namedParameter("a", varchar(10)),
                         namedParameter("b", rowSignature(namedParameter("a", signature("bigint"))))));
         assertRowSignature(
-                "array(row<bigint,double>('col0','col1'))",
+                "array(row(col0 bigint,col1 double))",
                 array(rowSignature(namedParameter("col0", signature("bigint")), namedParameter("col1", signature("double")))));
         assertRowSignature(
-                "row<array(row<bigint,double>('col0','col1'))>('col0')",
+                "row(col0 array(row(col0 bigint,col1 double)))",
                 rowSignature(namedParameter("col0", array(
                         rowSignature(namedParameter("col0", signature("bigint")), namedParameter("col1", signature("double")))))));
         assertRowSignature(
-                "row<decimal(p1,s1),decimal(p2,s2)>('a','b')",
+                "row(a decimal(p1,s1),b decimal(p2,s2))",
                 ImmutableSet.of("p1", "s1", "p2", "s2"),
                 rowSignature(namedParameter("a", decimal("p1", "s1")), namedParameter("b", decimal("p2", "s2"))));
     }
@@ -211,8 +211,8 @@ public class TestTypeSignature
         assertFalse(parseTypeSignature("array(decimal(2, 1))").isCalculated());
         assertTrue(parseTypeSignature("map(decimal(p1, s1),decimal(p2, s2))", ImmutableSet.of("p1", "s1", "p2", "s2")).isCalculated());
         assertFalse(parseTypeSignature("map(decimal(2, 1),decimal(3, 1))").isCalculated());
-        assertTrue(parseTypeSignature("row<decimal(p1,s1),decimal(p2,s2)>('a','b')", ImmutableSet.of("p1", "s1", "p2", "s2")).isCalculated());
-        assertFalse(parseTypeSignature("row<decimal(2,1),decimal(3,2)>('a','b')").isCalculated());
+        assertTrue(parseTypeSignature("row(a decimal(p1,s1),b decimal(p2,s2))", ImmutableSet.of("p1", "s1", "p2", "s2")).isCalculated());
+        assertFalse(parseTypeSignature("row(a decimal(2,1),b decimal(3,2))").isCalculated());
     }
 
     private static void assertRowSignature(

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -323,6 +323,18 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testRowCast()
+            throws Exception
+    {
+        assertQuery("SELECT cast(test_row(1, 2) as row(aa bigint, bb boolean)).aa", "SELECT 1");
+        assertQuery("SELECT cast(test_row(1, 2) as row(aa bigint, bb boolean)).bb", "SELECT true");
+        assertQuery("SELECT cast(test_row(1, 2) as row(aa bigint, bb varchar)).bb", "SELECT '2'");
+        assertQuery("SELECT cast(test_row(true, array[0, 2]) as row(aa boolean, bb array(boolean))).bb[1]", "SELECT false");
+        assertQuery("SELECT cast(test_row(0.1, array[0, 2], test_row(1, 0.5)) as row(aa bigint, bb array(boolean), cc row(dd varchar, ee varchar))).cc.ee", "SELECT '0.5'");
+        assertQuery("SELECT cast(array[test_row(0.1, array[0, 2], test_row(1, 0.5))] as array<row(aa bigint, bb array(boolean), cc row(dd varchar, ee varchar))>)[1].cc.ee", "SELECT '0.5'");
+    }
+
+    @Test
     public void testDereferenceInSubquery()
             throws Exception
     {


### PR DESCRIPTION
The row type definition syntax will be like:
    ``ROW(x BIGINT, y DOUBLE)``

And the CAST for row type syntax will be like:
    ``CAST(ROW(1, 2) AS ROW(x BIGINT, y DOUBLE))``

Note that for now the field names could only contains alphanumeric
characters (there should not be special characters like `"`, `'`,
and space)