### PR TITLE
Fix TRY compilation when part of a sub-expression

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeExpressionVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeExpressionVisitor.java
@@ -17,14 +17,12 @@ import com.facebook.presto.bytecode.BytecodeBlock;
 import com.facebook.presto.bytecode.BytecodeNode;
 import com.facebook.presto.bytecode.MethodDefinition;
 import com.facebook.presto.bytecode.Scope;
-import com.facebook.presto.bytecode.Variable;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.sql.relational.CallExpression;
 import com.facebook.presto.sql.relational.ConstantExpression;
 import com.facebook.presto.sql.relational.InputReferenceExpression;
 import com.facebook.presto.sql.relational.RowExpressionVisitor;
 
-import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantTrue;
@@ -51,7 +49,6 @@ public class BytecodeExpressionVisitor
     private final CachedInstanceBinder cachedInstanceBinder;
     private final RowExpressionVisitor<Scope, BytecodeNode> fieldReferenceCompiler;
     private final FunctionRegistry registry;
-    private final List<? extends Variable> expressionInputs;
     private final Map<CallExpression, MethodDefinition> tryExpressionsMap;
 
     public BytecodeExpressionVisitor(
@@ -59,14 +56,12 @@ public class BytecodeExpressionVisitor
             CachedInstanceBinder cachedInstanceBinder,
             RowExpressionVisitor<Scope, BytecodeNode> fieldReferenceCompiler,
             FunctionRegistry registry,
-            List<? extends Variable> expressionInputs,
             Map<CallExpression, MethodDefinition> tryExpressionsMap)
     {
         this.callSiteBinder = callSiteBinder;
         this.cachedInstanceBinder = cachedInstanceBinder;
         this.fieldReferenceCompiler = fieldReferenceCompiler;
         this.registry = registry;
-        this.expressionInputs = expressionInputs;
         this.tryExpressionsMap = tryExpressionsMap;
     }
 
@@ -92,7 +87,7 @@ public class BytecodeExpressionVisitor
                     generator = new SwitchCodeGenerator();
                     break;
                 case TRY:
-                    generator = new TryCodeGenerator(tryExpressionsMap, expressionInputs);
+                    generator = new TryCodeGenerator(tryExpressionsMap);
                     break;
                 // functions that take null as input
                 case IS_NULL:

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CursorProcessorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CursorProcessorCompiler.java
@@ -204,7 +204,6 @@ public class CursorProcessorCompiler
                     cachedInstanceBinder,
                     fieldReferenceCompiler(cursor, wasNull),
                     metadata.getFunctionRegistry(),
-                    inputParameters,
                     tryMethodMap.build());
 
             MethodDefinition tryMethod = defineTryMethod(
@@ -241,7 +240,6 @@ public class CursorProcessorCompiler
                 cachedInstanceBinder,
                 fieldReferenceCompiler(cursor, wasNullVariable),
                 metadata.getFunctionRegistry(),
-                ImmutableList.of(session, cursor, wasNullVariable),
                 tryMethodMap);
 
         LabelNode end = new LabelNode("end");
@@ -282,7 +280,6 @@ public class CursorProcessorCompiler
                 cachedInstanceBinder,
                 fieldReferenceCompiler(cursor, wasNullVariable),
                 metadata.getFunctionRegistry(),
-                ImmutableList.of(session, cursor, wasNullVariable),
                 tryMethodMap);
 
         body.getVariable(output)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4306,6 +4306,11 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT COUNT(TRY(to_base(100, CAST(round(totalprice/100) AS BIGINT)))) FROM orders",
                 "SELECT SUM(CASE WHEN CAST(round(totalprice/100) AS BIGINT) BETWEEN 2 AND 36 THEN 1 ELSE 0 END) FROM orders");
+
+        // as part of a complex expression
+        assertQuery(
+                "SELECT COUNT(CAST(orderkey AS VARCHAR) || TRY(to_base(100, CAST(round(totalprice/100) AS BIGINT)))) FROM orders",
+                "SELECT SUM(CASE WHEN CAST(round(totalprice/100) AS BIGINT) BETWEEN 2 AND 36 THEN 1 ELSE 0 END) FROM orders");
     }
 
     @Test


### PR DESCRIPTION
TRY method calls expect only the subset of parameters required to
evaluate the inner expression. Howver, due to the way the parameter
list was constructed, method calls would instead be passed a superset
of parameters when the TRY call was a sub-expression. This caused
compilation to fail.

Fixes #4901 