### PR TITLE
Prevent TRY expression from being merged

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
@@ -107,10 +107,14 @@ public class ExpressionOptimizer
                                 return call.getArguments().get(2).accept(this, context);
                             }
                         }
+                    case TRY:
+                        checkState(call.getArguments().size() == 1, "try call expressions must have a single argument");
+                        if (!(Iterables.getOnlyElement(call.getArguments()) instanceof CallExpression)) {
+                            return Iterables.getOnlyElement(call.getArguments());
+                        }
                     case NULL_IF:
                     case SWITCH:
                     case "WHEN":
-                    case TRY:
                     case TRY_CAST:
                     case IS_NULL:
                     case "IS_DISTINCT_FROM":

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionOptimizer.java
@@ -20,6 +20,7 @@ import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.sql.relational.CallExpression;
 import com.facebook.presto.sql.relational.ConstantExpression;
+import com.facebook.presto.sql.relational.InputReferenceExpression;
 import com.facebook.presto.sql.relational.RowExpression;
 import com.facebook.presto.sql.relational.optimizer.ExpressionOptimizer;
 import com.facebook.presto.type.TypeRegistry;
@@ -47,6 +48,20 @@ public class TestExpressionOptimizer
             expression = new CallExpression(signature, BIGINT, ImmutableList.of(expression, new ConstantExpression(1L, BIGINT)));
         }
         optimizer.optimize(expression);
+    }
+
+    @Test
+    public void testTryOptimization()
+    {
+        TypeRegistry typeManager = new TypeRegistry();
+        ExpressionOptimizer optimizer = new ExpressionOptimizer(new FunctionRegistry(typeManager, new BlockEncodingManager(typeManager), false), typeManager, TEST_SESSION);
+        Signature signature = new Signature("TRY", SCALAR, BIGINT.getTypeSignature());
+
+        RowExpression tryExpression =  new CallExpression(signature, BIGINT, ImmutableList.of(new ConstantExpression(1L, BIGINT)));
+        assertEquals(optimizer.optimize(tryExpression), new ConstantExpression(1L, BIGINT));
+
+        tryExpression =  new CallExpression(signature, BIGINT, ImmutableList.of(new InputReferenceExpression(1, BIGINT)));
+        assertEquals(optimizer.optimize(tryExpression), new InputReferenceExpression(1, BIGINT));
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4313,6 +4313,14 @@ public abstract class AbstractTestQueries
                 "SELECT SUM(CASE WHEN CAST(round(totalprice/100) AS BIGINT) BETWEEN 2 AND 36 THEN 1 ELSE 0 END) FROM orders");
     }
 
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "\\Q/ by zero\\E.*")
+    public void testTryNoMergeProjections()
+        throws Exception
+    {
+        computeActual(
+                "SELECT TRY(x) FROM (SELECT 1/y as x FROM (VALUES 1, 2, 3, 0, 4) t(y))");
+    }
+
     @Test
     public void testNoFrom()
             throws Exception


### PR DESCRIPTION
This makes situations where TRY has non-CallExpression arguments more common. Unfortunately this means more users are shown unhelpful error messages about compiler failure. Now we also optimize TRY away when input is not CallExpression to prevent this.