### PR TITLE
Fix broken plan when underlying view type changes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -891,8 +891,9 @@ class StatementAnalyzer
 
             analysis.addRelationCoercion(table, outputFields.stream().map(Field::getType).toArray(Type[]::new));
 
-            analysis.setOutputDescriptor(table, new RelationType(outputFields));
-            return descriptor;
+            RelationType outputType = new RelationType(outputFields);
+            analysis.setOutputDescriptor(table, outputType);
+            return outputType;
         }
 
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, name);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -593,6 +593,25 @@ public abstract class AbstractTestDistributedQueries
     }
 
     @Test
+    public void testCompatibleTypeChangeForView2()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_table_2 AS SELECT BIGINT '1' v", 1);
+        assertUpdate("CREATE VIEW test_view_2 AS SELECT * FROM test_table_2");
+
+        assertQuery("SELECT * FROM test_view_2", "VALUES 1");
+
+        // replace table with a version that's implicitly coercible to the previous one
+        assertUpdate("DROP TABLE test_table_2");
+        assertUpdate("CREATE TABLE test_table_2 AS SELECT INTEGER '1' v", 1);
+
+        assertQuery("SELECT * FROM test_view_2 WHERE v = 1", "VALUES 1");
+
+        assertUpdate("DROP VIEW test_view_2");
+        assertUpdate("DROP TABLE test_table_2");
+    }
+
+    @Test
     public void testViewMetadata()
             throws Exception
     {


### PR DESCRIPTION
The fix in 6acc22b7eecb06c39718ffce0d809a0cde4a8347 was incomplete and
did not properly return the declare type of the view. As a result,
the planner would omit necessary implicit coercions.