### PR TITLE
Exclude test from incompatible connectors

### DIFF
--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -80,6 +80,13 @@ public class TestCassandraDistributed
     }
 
     @Override
+    public void testCompatibleTypeChangeForView2()
+            throws Exception
+    {
+        // Cassandra connector currently does not support views
+    }
+
+    @Override
     public void testViewMetadata()
             throws Exception
     {

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaDistributed.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaDistributed.java
@@ -91,6 +91,13 @@ public class TestKafkaDistributed
     }
 
     @Override
+    public void testCompatibleTypeChangeForView2()
+            throws Exception
+    {
+        // Kafka connector currently does not support views
+    }
+
+    @Override
     public void testViewMetadata()
             throws Exception
     {

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributed.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributed.java
@@ -86,6 +86,13 @@ public class TestRedisDistributed
     }
 
     @Override
+    public void testCompatibleTypeChangeForView2()
+            throws Exception
+    {
+        // Redis connector currently does not support views
+    }
+
+    @Override
     public void testViewMetadata()
     {
     }

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributedHash.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributedHash.java
@@ -86,6 +86,13 @@ public class TestRedisDistributedHash
     }
 
     @Override
+    public void testCompatibleTypeChangeForView2()
+            throws Exception
+    {
+        // Redis connector currently does not support views
+    }
+
+    @Override
     public void testViewMetadata()
     {
     }


### PR DESCRIPTION
testCompatibleTypeChangeForView2 is not compatible with Redis, Kafka,
and Cassandra connectors.