### PR TITLE
Support INTERSECT

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -88,6 +88,7 @@ import com.facebook.presto.sql.tree.Relation;
 import com.facebook.presto.sql.tree.Row;
 import com.facebook.presto.sql.tree.SampledRelation;
 import com.facebook.presto.sql.tree.SelectItem;
+import com.facebook.presto.sql.tree.SetOperation;
 import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
 import com.facebook.presto.sql.tree.ShowCreate;
@@ -104,7 +105,6 @@ import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TableElement;
 import com.facebook.presto.sql.tree.TableSubquery;
-import com.facebook.presto.sql.tree.Union;
 import com.facebook.presto.sql.tree.Unnest;
 import com.facebook.presto.sql.tree.Use;
 import com.facebook.presto.sql.tree.Values;
@@ -1174,7 +1174,7 @@ class StatementAnalyzer
     }
 
     @Override
-    protected RelationType visitUnion(Union node, AnalysisContext context)
+    protected RelationType visitSetOperation(SetOperation node, AnalysisContext context)
     {
         checkState(node.getRelations().size() >= 2);
 
@@ -1187,11 +1187,12 @@ class StatementAnalyzer
         for (RelationType descriptor : descriptors) {
             int outputFieldSize = outputFieldTypes.length;
             int descFieldSize = descriptor.getVisibleFields().size();
+            String setOperationName = node.getClass().getSimpleName();
             if (outputFieldSize != descFieldSize) {
                 throw new SemanticException(MISMATCHED_SET_COLUMN_TYPES,
                         node,
-                        "union query has different number of fields: %d, %d",
-                        outputFieldSize, descFieldSize);
+                        "%s query has different number of fields: %d, %d",
+                        setOperationName, outputFieldSize, descFieldSize);
             }
             for (int i = 0; i < descriptor.getVisibleFields().size(); i++) {
                 Type descFieldType = descriptor.getFieldByIndex(i).getType();
@@ -1199,8 +1200,8 @@ class StatementAnalyzer
                 if (!commonSuperType.isPresent()) {
                     throw new SemanticException(TYPE_MISMATCH,
                             node,
-                            "column %d in union query has incompatible types: %s, %s",
-                            i, outputFieldTypes[i].getDisplayName(), descFieldType.getDisplayName());
+                            "column %d in %s query has incompatible types: %s, %s",
+                            i, outputFieldTypes[i].getDisplayName(), setOperationName, descFieldType.getDisplayName());
                 }
                 outputFieldTypes[i] = commonSuperType.get();
             }
@@ -1227,14 +1228,17 @@ class StatementAnalyzer
                 }
             }
         }
-
         return outputDescriptor;
     }
 
     @Override
     protected RelationType visitIntersect(Intersect node, AnalysisContext context)
     {
-        throw new SemanticException(NOT_SUPPORTED, node, "INTERSECT not yet implemented");
+        if (!node.isDistinct()) {
+            throw new SemanticException(NOT_SUPPORTED, node, "INTERSECT ALL not yet implemented");
+        }
+
+        return visitSetOperation(node, context);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.planner.optimizations.CountConstantOptimizer;
 import com.facebook.presto.sql.planner.optimizations.DesugaringOptimizer;
 import com.facebook.presto.sql.planner.optimizations.EmptyDeleteOptimizer;
 import com.facebook.presto.sql.planner.optimizations.HashGenerationOptimizer;
+import com.facebook.presto.sql.planner.optimizations.ImplementIntersectAsUnion;
 import com.facebook.presto.sql.planner.optimizations.ImplementSampleAsFilter;
 import com.facebook.presto.sql.planner.optimizations.IndexJoinOptimizer;
 import com.facebook.presto.sql.planner.optimizations.LimitPushDown;
@@ -71,6 +72,7 @@ public class PlanOptimizersFactory
                 new UnaliasSymbolReferences(),
                 new PruneIdentityProjections(),
                 new SetFlatteningOptimizer(),
+                new ImplementIntersectAsUnion(),
                 new LimitPushDown(), // Run the LimitPushDown after flattening set operators to make it easier to do the set flattening
                 new PredicatePushDown(metadata, sqlParser),
                 new MergeProjections(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -27,6 +27,7 @@ import com.facebook.presto.sql.analyzer.RelationType;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.IntersectNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
@@ -47,6 +48,7 @@ import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.InPredicate;
+import com.facebook.presto.sql.tree.Intersect;
 import com.facebook.presto.sql.tree.Join;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -56,6 +58,7 @@ import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.Relation;
 import com.facebook.presto.sql.tree.Row;
 import com.facebook.presto.sql.tree.SampledRelation;
+import com.facebook.presto.sql.tree.SetOperation;
 import com.facebook.presto.sql.tree.SubqueryExpression;
 import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TableSubquery;
@@ -68,6 +71,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.ListMultimap;
 import com.google.common.collect.UnmodifiableIterator;
 
 import java.util.ArrayList;
@@ -544,11 +548,34 @@ class RelationPlanner
     {
         checkArgument(!node.getRelations().isEmpty(), "No relations specified for UNION");
 
-        List<Symbol> unionOutputSymbols = null;
+        SetOperationPlan setOperationPlan = process(node);
+
+        PlanNode planNode = new UnionNode(idAllocator.getNextId(), setOperationPlan.getSources(), setOperationPlan.getSymbolMapping(), ImmutableList.copyOf(setOperationPlan.getSymbolMapping().keySet()));
+        if (node.isDistinct()) {
+            planNode = distinct(planNode);
+        }
+        return new RelationPlan(planNode, analysis.getOutputDescriptor(node), planNode.getOutputSymbols(), setOperationPlan.getOutputSampleWeight());
+    }
+
+    @Override
+    protected RelationPlan visitIntersect(Intersect node, Void context)
+    {
+        checkArgument(!node.getRelations().isEmpty(), "No relations specified for INTERSECT");
+
+        SetOperationPlan setOperationPlan = process(node);
+
+        PlanNode planNode = new IntersectNode(idAllocator.getNextId(), setOperationPlan.getSources(), setOperationPlan.getSymbolMapping(), ImmutableList.copyOf(setOperationPlan.getSymbolMapping().keySet()));
+        return new RelationPlan(planNode, analysis.getOutputDescriptor(node), planNode.getOutputSymbols(), setOperationPlan.getOutputSampleWeight());
+    }
+
+    private SetOperationPlan process(SetOperation node)
+    {
+        List<Symbol> outputs = null;
         ImmutableList.Builder<PlanNode> sources = ImmutableList.builder();
         ImmutableListMultimap.Builder<Symbol, Symbol> symbolMapping = ImmutableListMultimap.builder();
+
         List<RelationPlan> subPlans = node.getRelations().stream()
-                .map(relation -> processAndCoerceIfNecessary(relation, context))
+                .map(relation -> processAndCoerceIfNecessary(relation, null))
                 .collect(toImmutableList());
 
         boolean hasSampleWeight = false;
@@ -566,7 +593,7 @@ class RelationPlanner
             }
 
             List<Symbol> childOutputSymbols = relationPlan.getOutputSymbols();
-            if (unionOutputSymbols == null) {
+            if (outputs == null) {
                 // Use the first Relation to derive output symbol names
                 RelationType descriptor = relationPlan.getDescriptor();
                 ImmutableList.Builder<Symbol> outputSymbolBuilder = ImmutableList.builder();
@@ -575,31 +602,27 @@ class RelationPlanner
                     Symbol symbol = childOutputSymbols.get(fieldIndex);
                     outputSymbolBuilder.add(symbolAllocator.newSymbol(symbol.getName(), symbolAllocator.getTypes().get(symbol)));
                 }
-                unionOutputSymbols = outputSymbolBuilder.build();
+                outputs = outputSymbolBuilder.build();
                 outputSampleWeight = relationPlan.getSampleWeight();
             }
 
             RelationType descriptor = relationPlan.getDescriptor();
-            checkArgument(descriptor.getVisibleFieldCount() == unionOutputSymbols.size(),
+            checkArgument(descriptor.getVisibleFieldCount() == outputs.size(),
                     "Expected relation to have %s symbols but has %s symbols",
                     descriptor.getVisibleFieldCount(),
-                    unionOutputSymbols.size());
+                    outputs.size());
 
-            int unionFieldId = 0;
+            int fieldId = 0;
             for (Field field : descriptor.getVisibleFields()) {
                 int fieldIndex = descriptor.indexOf(field);
-                symbolMapping.put(unionOutputSymbols.get(unionFieldId), childOutputSymbols.get(fieldIndex));
-                unionFieldId++;
+                symbolMapping.put(outputs.get(fieldId), childOutputSymbols.get(fieldIndex));
+                fieldId++;
             }
 
             sources.add(relationPlan.getRoot());
         }
 
-        PlanNode planNode = new UnionNode(idAllocator.getNextId(), sources.build(), symbolMapping.build(), ImmutableList.copyOf(symbolMapping.build().keySet()));
-        if (node.isDistinct()) {
-            planNode = distinct(planNode);
-        }
-        return new RelationPlan(planNode, analysis.getOutputDescriptor(node), planNode.getOutputSymbols(), outputSampleWeight);
+        return new SetOperationPlan(sources.build(), symbolMapping.build(), outputSampleWeight);
     }
 
     private RelationPlan addConstantSampleWeight(RelationPlan subPlan)
@@ -711,5 +734,34 @@ class RelationPlanner
                 Optional.empty(),
                 1.0,
                 Optional.empty());
+    }
+
+    private static class SetOperationPlan
+    {
+        private final List<PlanNode> sources;
+        private final ListMultimap<Symbol, Symbol> symbolMapping;
+        private final Optional<Symbol> outputSampleWeight;
+
+        private SetOperationPlan(List<PlanNode> sources, ListMultimap<Symbol, Symbol> symbolMapping, Optional<Symbol> outputSampleWeight)
+        {
+            this.sources = sources;
+            this.symbolMapping = symbolMapping;
+            this.outputSampleWeight = outputSampleWeight;
+        }
+
+        public List<PlanNode> getSources()
+        {
+            return sources;
+        }
+
+        public ListMultimap<Symbol, Symbol> getSymbolMapping()
+        {
+            return symbolMapping;
+        }
+
+        public Optional<Symbol> getOutputSampleWeight()
+        {
+            return outputSampleWeight;
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAsUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAsUnion.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.ExpressionUtils;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.IntersectNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.UnionNode;
+import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GenericLiteral;
+import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Step;
+import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static com.facebook.presto.sql.tree.ComparisonExpression.Type.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
+import static com.google.common.collect.Iterables.concat;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Converts INTERSECT query into UNION ALL..GROUP BY...WHERE
+ * Eg:  SELECT a FROM foo INTERSECT SELECT x FROM bar
+ * <p/>
+ * =>
+ * <p/>
+ * SELECT a
+ * FROM
+ * (SELECT a,
+ * COUNT(foo_marker) AS foo_cnt,
+ * COUNT(bar_marker) AS bar_cnt
+ * FROM
+ * (
+ * SELECT a, true as foo_marker, null as bar_marker FROM foo
+ * UNION ALL
+ * SELECT x, null as foo_marker, true as bar_marker FROM bar
+ * ) T1
+ * GROUP BY a) T2
+ * WHERE foo_cnt >= 1 AND bar_cnt >= 1;
+ */
+public class ImplementIntersectAsUnion
+        implements PlanOptimizer
+{
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, Map<Symbol, Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        requireNonNull(plan, "plan is null");
+        requireNonNull(session, "session is null");
+        requireNonNull(types, "types is null");
+        requireNonNull(symbolAllocator, "symbolAllocator is null");
+        requireNonNull(idAllocator, "idAllocator is null");
+
+        return SimplePlanRewriter.rewriteWith(new Rewriter(idAllocator, symbolAllocator), plan);
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private static final String INTERSECT_MARKER = "intersect_marker";
+        private static final Signature COUNT_AGGREGATION = new Signature("count", AGGREGATE, "bigint", "boolean");
+        private final PlanNodeIdAllocator idAllocator;
+        private final SymbolAllocator symbolAllocator;
+
+        private Rewriter(PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+        {
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+            this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
+        }
+
+        @Override
+        public PlanNode visitIntersect(IntersectNode node, RewriteContext<Void> rewriteContext)
+        {
+            List<PlanNode> sources = node.getSources().stream()
+                    .map(rewriteContext::rewrite)
+                    .collect(toList());
+
+            List<Symbol> markers = allocateMarkers(sources.size());
+
+            // identity projection for all the fields in each of the sources plus marker columns
+            List<PlanNode> withMarkers = appendMarkers(markers, sources, node);
+
+            // add a union over all the rewritten sources. The outputs of the union have the same name as the
+            // original intersect node
+            List<Symbol> outputs = node.getOutputSymbols();
+            UnionNode union = union(withMarkers, ImmutableList.copyOf(concat(outputs, markers)));
+
+            // add count aggregations and filter rows where any of the counts is >= 1
+            AggregationNode aggregation = computeCounts(union, outputs, markers);
+            FilterNode filterNode = addFilter(aggregation);
+
+            return project(filterNode, outputs);
+        }
+
+        private List<Symbol> allocateMarkers(int count)
+        {
+            ImmutableList.Builder<Symbol> markers = ImmutableList.builder();
+            for (int i = 0; i < count; i++) {
+                markers.add(symbolAllocator.newSymbol(INTERSECT_MARKER, BOOLEAN));
+            }
+            return markers.build();
+        }
+
+        private List<PlanNode> appendMarkers(List<Symbol> markers, List<PlanNode> nodes, IntersectNode intersect)
+        {
+            ImmutableList.Builder<PlanNode> result = ImmutableList.builder();
+            for (int i = 0; i < nodes.size(); i++) {
+                result.add(appendMarkers(nodes.get(i), i, markers, intersect.sourceSymbolMap(i)));
+            }
+            return result.build();
+        }
+
+        private PlanNode appendMarkers(PlanNode source, int markerIndex, List<Symbol> markers, Map<Symbol, QualifiedNameReference> projections)
+        {
+            ImmutableMap.Builder<Symbol, Expression> assignments = ImmutableMap.builder();
+            // add existing intersect symbols to projection
+            for (Map.Entry<Symbol, QualifiedNameReference> entry : projections.entrySet()) {
+                Symbol symbol = symbolAllocator.newSymbol(entry.getKey().getName(), symbolAllocator.getTypes().get(entry.getKey()));
+                assignments.put(symbol, entry.getValue());
+            }
+
+            // add extra marker fields to the projection
+            for (int i = 0; i < markers.size(); ++i) {
+                Expression expression = (i == markerIndex) ? TRUE_LITERAL : new Cast(new NullLiteral(), StandardTypes.BOOLEAN);
+                assignments.put(symbolAllocator.newSymbol(markers.get(i).getName(), BOOLEAN), expression);
+            }
+
+            return new ProjectNode(idAllocator.getNextId(), source, assignments.build());
+        }
+
+        private UnionNode union(List<PlanNode> nodes, List<Symbol> outputs)
+        {
+            ImmutableListMultimap.Builder<Symbol, Symbol> outputsToInputs = ImmutableListMultimap.builder();
+            for (PlanNode source : nodes) {
+                for (int i = 0; i < source.getOutputSymbols().size(); i++) {
+                    outputsToInputs.put(outputs.get(i), source.getOutputSymbols().get(i));
+                }
+            }
+
+            return new UnionNode(idAllocator.getNextId(), nodes, outputsToInputs.build(), outputs);
+        }
+
+        private AggregationNode computeCounts(UnionNode sourceNode, List<Symbol> originalColumns, List<Symbol> markers)
+        {
+            ImmutableMap.Builder<Symbol, Signature> signatures = ImmutableMap.builder();
+            ImmutableMap.Builder<Symbol, FunctionCall> aggregations = ImmutableMap.builder();
+
+            for (Symbol marker : markers) {
+                Symbol output = symbolAllocator.newSymbol("count", BIGINT);
+                aggregations.put(output, new FunctionCall(QualifiedName.of("count"), ImmutableList.of(marker.toQualifiedNameReference())));
+                signatures.put(output, COUNT_AGGREGATION);
+            }
+
+            return new AggregationNode(idAllocator.getNextId(),
+                    sourceNode,
+                    originalColumns,
+                    aggregations.build(),
+                    signatures.build(),
+                    ImmutableMap.<Symbol, Symbol>of(),
+                    ImmutableList.of(originalColumns),
+                    Step.SINGLE,
+                    Optional.empty(),
+                    1.0,
+                    Optional.empty());
+        }
+
+        private FilterNode addFilter(AggregationNode aggregation)
+        {
+            ImmutableList<Expression> predicates = aggregation.getAggregations().keySet().stream()
+                    .map(column -> new ComparisonExpression(GREATER_THAN_OR_EQUAL, column.toQualifiedNameReference(), new GenericLiteral("BIGINT", "1")))
+                    .collect(toImmutableList());
+            return new FilterNode(idAllocator.getNextId(), aggregation, ExpressionUtils.and(predicates));
+        }
+
+        private ProjectNode project(PlanNode node, List<Symbol> columns)
+        {
+            return new ProjectNode(
+                    idAllocator.getNextId(),
+                    node,
+                    columns.stream().collect(toMap(Function.identity(), Symbol::toQualifiedNameReference)));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.IndexSourceNode;
+import com.facebook.presto.sql.planner.plan.IntersectNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
@@ -638,6 +639,12 @@ public class PruneUnreferencedOutputs
             }
 
             return new UnionNode(node.getId(), rewrittenSubPlans.build(), rewrittenSymbolMapping, ImmutableList.copyOf(rewrittenSymbolMapping.keySet()));
+        }
+
+        @Override
+        public PlanNode visitIntersect(IntersectNode node, RewriteContext<Set<Symbol>> context)
+        {
+            return new IntersectNode(node.getId(), node.getSources(), node.getSymbolMapping(), ImmutableList.copyOf(node.getSymbolMapping().keySet()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
@@ -251,6 +251,12 @@ public class ChildReplacer
     }
 
     @Override
+    public PlanNode visitIntersect(IntersectNode node, List<PlanNode> newChildren)
+    {
+        return new IntersectNode(node.getId(), newChildren, node.getSymbolMapping(), node.getOutputSymbols());
+    }
+
+    @Override
     public PlanNode visitDelete(DeleteNode node, List<PlanNode> newChildren)
     {
         return new DeleteNode(node.getId(), Iterables.getOnlyElement(newChildren), node.getTarget(), node.getRowId(), node.getOutputSymbols());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IntersectNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IntersectNode.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.sql.planner.Symbol;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ListMultimap;
 
@@ -23,11 +22,10 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 
 @Immutable
-public class UnionNode
+public class IntersectNode
         extends SetOperationNode
 {
-    @JsonCreator
-    public UnionNode(
+    public IntersectNode(
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("sources") List<PlanNode> sources,
             @JsonProperty("outputToInputs") ListMultimap<Symbol, Symbol> outputToInputs,
@@ -39,6 +37,6 @@ public class UnionNode
     @Override
     public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
     {
-        return visitor.visitUnion(this, context);
+        return visitor.visitPlan(this, context);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IntersectNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IntersectNode.java
@@ -37,6 +37,6 @@ public class IntersectNode
     @Override
     public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
     {
-        return visitor.visitPlan(this, context);
+        return visitor.visitIntersect(this, context);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNode.java
@@ -54,6 +54,7 @@ import static java.util.Objects.requireNonNull;
         @JsonSubTypes.Type(value = UnnestNode.class, name = "unnest"),
         @JsonSubTypes.Type(value = ExchangeNode.class, name = "exchange"),
         @JsonSubTypes.Type(value = UnionNode.class, name = "union"),
+        @JsonSubTypes.Type(value = IntersectNode.class, name = "intersect"),
         @JsonSubTypes.Type(value = EnforceSingleRowNode.class, name = "scalar"),
         @JsonSubTypes.Type(value = GroupIdNode.class, name = "groupid"),
         @JsonSubTypes.Type(value = ExplainAnalyzeNode.class, name = "explainAnalyze"),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanVisitor.java
@@ -135,6 +135,11 @@ public class PlanVisitor<C, R>
         return visitPlan(node, context);
     }
 
+    public R visitIntersect(IntersectNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
+
     public R visitUnnest(UnnestNode node, C context)
     {
         return visitPlan(node, context);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SetOperationNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SetOperationNode.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public abstract class SetOperationNode
+        extends PlanNode
+{
+    private final List<PlanNode> sources;
+    private final ListMultimap<Symbol, Symbol> outputToInputs;
+    private final List<Symbol> outputs;
+
+    @JsonCreator
+    protected SetOperationNode(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("sources") List<PlanNode> sources,
+            @JsonProperty("outputToInputs") ListMultimap<Symbol, Symbol> outputToInputs,
+            @JsonProperty("outputs") List<Symbol> outputs)
+    {
+        super(id);
+
+        requireNonNull(sources, "sources is null");
+        checkArgument(!sources.isEmpty(), "Must have at least one source");
+        requireNonNull(outputToInputs, "outputToInputs is null");
+        requireNonNull(outputs, "outputs is null");
+
+        this.sources = ImmutableList.copyOf(sources);
+        this.outputToInputs = ImmutableListMultimap.copyOf(outputToInputs);
+        this.outputs = ImmutableList.copyOf(outputs);
+
+        for (Collection<Symbol> inputs : this.outputToInputs.asMap().values()) {
+            checkArgument(inputs.size() == this.sources.size(), "Every source needs to map its symbols to an output %s operation symbol", this.getClass().getSimpleName());
+        }
+
+        // Make sure each source positionally corresponds to their Symbol values in the Multimap
+        for (int i = 0; i < sources.size(); i++) {
+            for (Collection<Symbol> expectedInputs : this.outputToInputs.asMap().values()) {
+                checkArgument(sources.get(i).getOutputSymbols().contains(Iterables.get(expectedInputs, i)), "Source does not provide required symbols");
+            }
+        }
+    }
+
+    @Override
+    @JsonProperty("sources")
+    public List<PlanNode> getSources()
+    {
+        return sources;
+    }
+
+    @Override
+    @JsonProperty("outputs")
+    public List<Symbol> getOutputSymbols()
+    {
+        return outputs;
+    }
+
+    @JsonProperty("outputToInputs")
+    public ListMultimap<Symbol, Symbol> getSymbolMapping()
+    {
+        return outputToInputs;
+    }
+
+    public List<Symbol> sourceOutputLayout(int sourceIndex)
+    {
+        // Make sure the sourceOutputLayout symbols are listed in the same order as the corresponding output symbols
+        return getOutputSymbols().stream()
+                .map(symbol -> outputToInputs.get(symbol).get(sourceIndex))
+                .collect(toImmutableList());
+    }
+
+    /**
+     * Returns the output to input symbol mapping for the given source channel
+     */
+    public Map<Symbol, QualifiedNameReference> sourceSymbolMap(int sourceIndex)
+    {
+        ImmutableMap.Builder<Symbol, QualifiedNameReference> builder = ImmutableMap.<Symbol, QualifiedNameReference>builder();
+        for (Map.Entry<Symbol, Collection<Symbol>> entry : outputToInputs.asMap().entrySet()) {
+            builder.put(entry.getKey(), Iterables.get(entry.getValue(), sourceIndex).toQualifiedNameReference());
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Returns the input to output symbol mapping for the given source channel.
+     * A single input symbol can map to multiple output symbols, thus requiring a Multimap.
+     */
+    public Multimap<Symbol, QualifiedNameReference> outputSymbolMap(int sourceIndex)
+    {
+        return Multimaps.transformValues(FluentIterable.from(getOutputSymbols())
+                .toMap(outputToSourceSymbolFunction(sourceIndex))
+                .asMultimap()
+                .inverse(), Symbol::toQualifiedNameReference);
+    }
+
+    private Function<Symbol, Symbol> outputToSourceSymbolFunction(final int sourceIndex)
+    {
+        return outputSymbol -> outputToInputs.get(outputSymbol).get(sourceIndex);
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -366,28 +366,11 @@ public abstract class DefaultTraversalVisitor<R, C>
     }
 
     @Override
-    protected R visitUnion(Union node, C context)
+    protected R visitSetOperation(SetOperation node, C context)
     {
         for (Relation relation : node.getRelations()) {
             process(relation, context);
         }
-        return null;
-    }
-
-    @Override
-    protected R visitIntersect(Intersect node, C context)
-    {
-        for (Relation relation : node.getRelations()) {
-            process(relation, context);
-        }
-        return null;
-    }
-
-    @Override
-    protected R visitExcept(Except node, C context)
-    {
-        process(node.getLeft(), context);
-        process(node.getRight(), context);
         return null;
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Except.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Except.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -24,7 +27,6 @@ public class Except
 {
     private final Relation left;
     private final Relation right;
-    private final boolean distinct;
 
     public Except(Relation left, Relation right, boolean distinct)
     {
@@ -38,13 +40,12 @@ public class Except
 
     private Except(Optional<NodeLocation> location, Relation left, Relation right, boolean distinct)
     {
-        super(location);
+        super(location, distinct);
         requireNonNull(left, "left is null");
         requireNonNull(right, "right is null");
 
         this.left = left;
         this.right = right;
-        this.distinct = distinct;
     }
 
     public Relation getLeft()
@@ -57,15 +58,16 @@ public class Except
         return right;
     }
 
-    public boolean isDistinct()
-    {
-        return distinct;
-    }
-
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context)
     {
         return visitor.visitExcept(this, context);
+    }
+
+    @Override
+    public List<Relation> getRelations()
+    {
+        return ImmutableList.of(left, right);
     }
 
     @Override
@@ -74,7 +76,7 @@ public class Except
         return toStringHelper(this)
                 .add("left", left)
                 .add("right", right)
-                .add("distinct", distinct)
+                .add("distinct", isDistinct())
                 .toString();
     }
 
@@ -90,12 +92,12 @@ public class Except
         Except o = (Except) obj;
         return Objects.equals(left, o.left) &&
                 Objects.equals(right, o.right) &&
-                Objects.equals(distinct, o.distinct);
+                Objects.equals(isDistinct(), o.isDistinct());
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(left, right, distinct);
+        return Objects.hash(left, right, isDistinct());
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Intersect.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Intersect.java
@@ -26,7 +26,6 @@ public class Intersect
         extends SetOperation
 {
     private final List<Relation> relations;
-    private final boolean distinct;
 
     public Intersect(List<Relation> relations, boolean distinct)
     {
@@ -40,21 +39,15 @@ public class Intersect
 
     private Intersect(Optional<NodeLocation> location, List<Relation> relations, boolean distinct)
     {
-        super(location);
+        super(location, distinct);
         requireNonNull(relations, "relations is null");
 
         this.relations = ImmutableList.copyOf(relations);
-        this.distinct = distinct;
     }
 
     public List<Relation> getRelations()
     {
         return relations;
-    }
-
-    public boolean isDistinct()
-    {
-        return distinct;
     }
 
     @Override
@@ -68,7 +61,7 @@ public class Intersect
     {
         return toStringHelper(this)
                 .add("relations", relations)
-                .add("distinct", distinct)
+                .add("distinct", isDistinct())
                 .toString();
     }
 
@@ -83,12 +76,12 @@ public class Intersect
         }
         Intersect o = (Intersect) obj;
         return Objects.equals(relations, o.relations) &&
-                Objects.equals(distinct, o.distinct);
+                Objects.equals(isDistinct(), o.isDistinct());
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(relations, distinct);
+        return Objects.hash(relations, isDistinct());
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetOperation.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetOperation.java
@@ -13,14 +13,23 @@
  */
 package com.facebook.presto.sql.tree;
 
+import java.util.List;
 import java.util.Optional;
 
 public abstract class SetOperation
         extends QueryBody
 {
-    protected SetOperation(Optional<NodeLocation> location)
+    private final boolean distinct;
+
+    protected SetOperation(Optional<NodeLocation> location, boolean distinct)
     {
         super(location);
+        this.distinct = distinct;
+    }
+
+    public boolean isDistinct()
+    {
+        return distinct;
     }
 
     @Override
@@ -28,4 +37,6 @@ public abstract class SetOperation
     {
         return visitor.visitSetOperation(this, context);
     }
+
+    public abstract List<Relation> getRelations();
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Union.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Union.java
@@ -26,7 +26,6 @@ public class Union
         extends SetOperation
 {
     private final List<Relation> relations;
-    private final boolean distinct;
 
     public Union(List<Relation> relations, boolean distinct)
     {
@@ -40,21 +39,15 @@ public class Union
 
     private Union(Optional<NodeLocation> location, List<Relation> relations, boolean distinct)
     {
-        super(location);
+        super(location, distinct);
         requireNonNull(relations, "relations is null");
 
         this.relations = ImmutableList.copyOf(relations);
-        this.distinct = distinct;
     }
 
     public List<Relation> getRelations()
     {
         return relations;
-    }
-
-    public boolean isDistinct()
-    {
-        return distinct;
     }
 
     @Override
@@ -68,7 +61,7 @@ public class Union
     {
         return toStringHelper(this)
                 .add("relations", relations)
-                .add("distinct", distinct)
+                .add("distinct", isDistinct())
                 .toString();
     }
 
@@ -83,12 +76,12 @@ public class Union
         }
         Union o = (Union) obj;
         return Objects.equals(relations, o.relations) &&
-                Objects.equals(distinct, o.distinct);
+                Objects.equals(isDistinct(), o.isDistinct());
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(relations, distinct);
+        return Objects.hash(relations, isDistinct());
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -31,6 +31,7 @@ public final class TestGroups
     public static final String QUERY_ENGINE = "qe";
     public static final String COMPARISON = "comparison";
     public static final String LOGICAL = "logical";
+    public static final String INTERSECT = "intersect";
     public static final String JSON_FUNCTIONS = "json_functions";
     public static final String URL_FUNCTIONS = "url_functions";
     public static final String ARRAY_FUNCTIONS = "array_functions";

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/intersect/intersect.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/intersect/intersect.sql
@@ -1,0 +1,29 @@
+-- database: presto; requires: com.facebook.presto.tests.ImmutableTpchTablesRequirements; tables: nation, workers; groups: intersect;
+-- delimiter: |; ignoreOrder: true;
+--! name: intersect_and_union
+SELECT n_name FROM nation WHERE n_nationkey = 17 
+INTERSECT 
+SELECT n_name FROM nation WHERE n_regionkey = 1 
+UNION 
+SELECT n_name from nation WHERE n_regionkey = 2
+--!
+INDIA|
+INDONESIA|
+CHINA|
+JAPAN|
+VIETNAM|
+PERU|
+--! name: intersect_null
+SELECT id_employee
+FROM workers
+INTERSECT
+SELECT department
+FROM workers
+--!
+null|
+9|
+4|
+7|
+2|
+5|
+8|

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1449,6 +1449,43 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testIntersect()
+            throws Exception
+    {
+        assertQuery("SELECT regionkey FROM nation WHERE nationkey < 7 INTERSECT select regionkey FROM nation WHERE nationkey > 21", "VALUES 1, 3");
+        assertQuery("SELECT regionkey FROM nation WHERE nationkey < 7 INTERSECT DISTINCT SELECT regionkey FROM nation WHERE nationkey > 21", "VALUES 1, 3");
+        assertQuery("WITH wnation AS (SELECT nationkey, regionkey FROM nation) SELECT regionkey FROM wnation WHERE nationkey < 7 INTERSECT SELECT regionkey FROM wnation WHERE nationkey > 21", "VALUES 1, 3");
+        assertQuery("SELECT num FROM (SELECT 1 as num FROM nation WHERE nationkey=10 intersect SELECT 1 FROM nation WHERE nationkey=20) T", "SELECT 1");
+        assertQuery("SELECT nationkey, nationkey / 2 FROM (SELECT nationkey FROM nation WHERE nationkey < 10 INTERSECT SELECT nationkey FROM nation WHERE nationkey > 4)T WHERE nationkey % 2 = 0", "VALUES (6,3), (8,4)");
+        assertQuery("SELECT regionkey FROM (SELECT regionkey FROM nation WHERE nationkey < 7 INTERSECT SELECT regionkey FROM nation WHERE nationkey > 21) UNION SELECT 4", "VALUES 3, 1, 4");
+        assertQuery("SELECT regionkey FROM (SELECT regionkey FROM nation WHERE nationkey < 7 UNION SELECT regionkey FROM nation WHERE nationkey > 21) INTERSECT SELECT 1", "SELECT 1");
+        assertQuery("SELECT regionkey FROM (SELECT regionkey FROM nation WHERE nationkey < 7 INTERSECT SELECT regionkey FROM nation WHERE nationkey > 21) UNION ALL SELECT 3", "VALUES 3, 1, 3");
+        assertQuery("SELECT regionkey FROM (SELECT regionkey FROM nation WHERE nationkey < 7 INTERSECT SELECT regionkey FROM nation WHERE nationkey > 21) UNION ALL SELECT 3", "VALUES 3, 1, 3");
+        assertQuery("SELECT * FROM (VALUES 1, 2) INTERSECT SELECT * FROM (VALUES 1.0, 2)", "VALUES 1.0, 2.0");
+
+        MaterializedResult emptyResult = computeActual("SELECT 100 INTERSECT (SELECT regionkey FROM nation WHERE nationkey <10)");
+        assertEquals(emptyResult.getMaterializedRows().size(), 0);
+    }
+
+    @Test
+    public void testIntersectWithAggregation()
+            throws Exception
+    {
+        assertQuery("SELECT COUNT(*) FROM nation INTERSECT SELECT COUNT(regionkey) FROM nation HAVING SUM(regionkey) IS NOT NULL", "SELECT 25");
+        assertQuery("SELECT SUM(nationkey), COUNT(name) FROM (SELECT nationkey,name FROM nation INTERSECT SELECT regionkey,name FROM nation)n", "VALUES (5, 3)");
+        assertQuery("SELECT COUNT(*) * 2 FROM nation INTERSECT (SELECT SUM(nationkey) FROM nation GROUP BY regionkey ORDER BY 1 LIMIT 2)", "SELECT 50");
+        assertQuery("SELECT COUNT(a) FROM (SELECT nationkey AS a FROM (SELECT nationkey FROM nation INTERSECT SELECT regionkey FROM nation)n1 INTERSECT SELECT regionkey FROM nation) n2", "SELECT 5");
+        assertQuery("SELECT count(*),SUM(2), regionkey FROM (SELECT nationkey, regionkey FROM nation INTERSECT SELECT regionkey, regionkey FROM nation)n GROUP BY regionkey", "VALUES (1, 2, 0), (1, 2, 1), (1, 2, 4)");
+        assertQuery("SELECT count(*) FROM (SELECT nationkey FROM nation INTERSECT SELECT 2)n1 INTERSECT SELECT regionkey FROM nation", "SELECT 1");
+    }
+
+    @Test
+    public void testIntersectAllFails()
+    {
+        assertQueryFails("SELECT * FROM (VALUES 1, 2, 3, 4) INTERSECT ALL SELECT * FROM (VALUES 3, 4)", "line 1:35: INTERSECT ALL not yet implemented");
+    }
+
+    @Test
     public void testCountAllWithComparison()
             throws Exception
     {


### PR DESCRIPTION
Implement INTERSECT sql as a query rewrite. Added a new optimization
rule for rewriting an INTERSECT query to UNION ALL. The rewrite for:

`SELECT a from foo INTERSECT SELECT x FROM bar`

is:

`
SELECT a
  FROM
  (SELECT a,
    COUNT(foo_marker) AS foo_cnt,
    COUNT(bar_marker) AS bar_cnt
        FROM
           (
            SELECT a, true as foo_marker, null as bar_marker FROM foo
            UNION ALL
            SELECT x, null as foo_marker, true as bar_marker FROM bar
           ) T1
GROUP BY a) T2
WHERE foo_cnt >= 1 AND bar_cnt >= 1;
`
This also involves related refactoring of extracting a SetOperation for
UNION, INTERSECT and EXCEPT.

Fixes #4918