### PR TITLE
Columnar block identity projection should be loaded

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageProcessorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageProcessorCompiler.java
@@ -314,7 +314,9 @@ public class PageProcessorCompiler
             // if nothing is filtered out, copy the entire block, else project it
             body.append(new IfStatement()
                     .condition(equal(cardinality, positionCount))
-                    .ifTrue(outputBlock.set(inputs.get(0)))
+                    .ifTrue(new BytecodeBlock()
+                            .append(inputs.get(0).invoke("assureLoaded", void.class))
+                            .append(outputBlock.set(inputs.get(0))))
                     .ifFalse(projectBlock));
         }
         else if (isConstantExpression(projection)) {


### PR DESCRIPTION
For a lazy block to be processed through columnar processing, it should be loaded before transferring to upper driver.