### PR TITLE
Changes to the new Parquet reader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -775,6 +775,26 @@
                 <version>2.1.7</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.anarres.lzo</groupId>
+                <artifactId>lzo-hadoop</artifactId>
+                <version>1.0.4</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -251,6 +251,23 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.anarres.lzo</groupId>
+            <artifactId>lzo-hadoop</artifactId>
+            <version>1.0.4</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- for benchmark -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -254,18 +254,7 @@
         <dependency>
             <groupId>org.anarres.lzo</groupId>
             <artifactId>lzo-hadoop</artifactId>
-            <version>1.0.4</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>jsr305</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- for benchmark -->

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCompressionUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCompressionUtils.java
@@ -75,8 +75,10 @@ public final class ParquetCompressionUtils
         byte[] buffer = new byte[uncompressedSize];
         try (InputStream gzipInputStream = new GZIPInputStream(input.getInput(), GZIP_BUFFER_SIZE)) {
             int bytesRead;
-            while ((bytesRead = gzipInputStream.read(buffer)) != -1) {
-                sliceOutput.write(buffer, 0, bytesRead);
+            if (uncompressedSize != 0) {
+                while ((bytesRead = gzipInputStream.read(buffer)) != -1) {
+                    sliceOutput.write(buffer, 0, bytesRead);
+                }
             }
             return sliceOutput.getUnderlyingSlice();
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCompressionUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCompressionUtils.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.hive.parquet;
 
-import io.airlift.compress.Decompressor;
 import io.airlift.compress.snappy.SnappyDecompressor;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
@@ -30,6 +29,8 @@ import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public final class ParquetCompressionUtils
 {
+    private static final int GZIP_BUFFER_SIZE = 8 * 1024;
+
     private ParquetCompressionUtils() {}
 
     public static Slice decompress(CompressionCodecName codec, Slice input, int uncompressedSize)
@@ -71,7 +72,7 @@ public final class ParquetCompressionUtils
     {
         DynamicSliceOutput sliceOutput = new DynamicSliceOutput(uncompressedSize);
         byte[] buffer = new byte[uncompressedSize];
-        try (InputStream gzipInputStream = new GZIPInputStream(input.getInput())) {
+        try (InputStream gzipInputStream = new GZIPInputStream(input.getInput(), GZIP_BUFFER_SIZE)) {
             int bytesRead;
             while ((bytesRead = gzipInputStream.read(buffer)) != -1) {
                 sliceOutput.write(buffer, 0, bytesRead);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCompressionUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCompressionUtils.java
@@ -82,7 +82,6 @@ public final class ParquetCompressionUtils
             }
             return sliceOutput.getUnderlyingSlice();
         }
-
     }
 
     private static Slice decompressLZO(Slice input, int uncompressedSize)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCompressionUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCompressionUtils.java
@@ -16,11 +16,10 @@ package com.facebook.presto.hive.parquet;
 import io.airlift.compress.Decompressor;
 import io.airlift.compress.lzo.LzoDecompressor;
 import io.airlift.compress.snappy.SnappyDecompressor;
+import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import parquet.hadoop.metadata.CompressionCodecName;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.GZIPInputStream;
@@ -70,14 +69,14 @@ public final class ParquetCompressionUtils
     private static Slice decompressGzip(Slice input, int uncompressedSize)
             throws IOException
     {
-        ByteArrayOutputStream uncompressedStream = new ByteArrayOutputStream();
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(uncompressedSize);
         byte[] buffer = new byte[uncompressedSize];
-        try (InputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(input.getBytes()))) {
+        try (InputStream gzipInputStream = new GZIPInputStream(input.getInput())) {
             int bytesRead;
             while ((bytesRead = gzipInputStream.read(buffer)) != -1) {
-                uncompressedStream.write(buffer, 0, bytesRead);
+                sliceOutput.write(buffer, 0, bytesRead);
             }
-            return wrappedBuffer(uncompressedStream.toByteArray());
+            return sliceOutput.getUnderlyingSlice();
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCompressionUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCompressionUtils.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.hive.parquet;
 
+import io.airlift.compress.Decompressor;
+import io.airlift.compress.lzo.LzoDecompressor;
 import io.airlift.compress.snappy.SnappyDecompressor;
 import io.airlift.slice.Slice;
 import parquet.hadoop.metadata.CompressionCodecName;
@@ -45,23 +47,22 @@ public final class ParquetCompressionUtils
             case GZIP:
                 return decompressGzip(input, uncompressedSize);
             case SNAPPY:
-                return decompressSnappy(input, uncompressedSize);
+                return decompress(new SnappyDecompressor(), input, uncompressedSize);
+            case LZO:
+                return decompress(new LzoDecompressor(), input, uncompressedSize);
             case UNCOMPRESSED:
                 return input;
             default:
-                // TODO add LZO support using pure java aircompressor
                 throw new ParquetCorruptionException("Codec not supported in Parquet: " + codec);
         }
     }
 
-    private static Slice decompressSnappy(Slice input, int uncompressedSize)
+    private static Slice decompress(Decompressor decompressor, Slice input, int uncompressedSize)
     {
         byte[] inArray = (byte[]) input.getBase();
         int inOffset = (int) (input.getAddress() - ARRAY_BYTE_BASE_OFFSET);
         int inLength = input.length();
-
         byte[] buffer = new byte[uncompressedSize];
-        SnappyDecompressor decompressor = new SnappyDecompressor();
         decompressor.decompress(inArray, inOffset, inLength, buffer, 0, uncompressedSize);
         return wrappedBuffer(buffer);
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetDictionaryPage.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetDictionaryPage.java
@@ -30,13 +30,16 @@ public class ParquetDictionaryPage
 
     public ParquetDictionaryPage(Slice slice, int dictionarySize, ParquetEncoding encoding)
     {
-        this(slice, slice.length(), dictionarySize, encoding);
+        this(requireNonNull(slice, "slice is null"),
+                slice.length(),
+                dictionarySize,
+                requireNonNull(encoding, "encoding is null"));
     }
 
     public ParquetDictionaryPage(Slice slice, int uncompressedSize, int dictionarySize, ParquetEncoding encoding)
     {
-        super(slice.length(), uncompressedSize);
-        this.slice = requireNonNull(slice, "slice is null");
+        super(requireNonNull(slice, "slice is null").length(), uncompressedSize);
+        this.slice = slice;
         this.dictionarySize = dictionarySize;
         this.encoding = requireNonNull(encoding, "encoding is null");
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -126,16 +126,14 @@ class ParquetPageSource
         this.requestedSchema = requestedSchema;
         this.totalBytes = totalBytes;
 
-        Map<String, HivePartitionKey> partitionKeysByName = uniqueIndex(requireNonNull(partitionKeys, "partitionKeys is null"), HivePartitionKey::getName);
-
-        int size = requireNonNull(columns, "columns is null").size();
-
+        int size = columns.size();
         this.constantBlocks = new Block[size];
         this.hiveColumnIndexes = new int[size];
 
+        Map<String, HivePartitionKey> partitionKeysByName = uniqueIndex(partitionKeys, HivePartitionKey::getName);
         ImmutableList.Builder<String> namesBuilder = ImmutableList.builder();
         ImmutableList.Builder<Type> typesBuilder = ImmutableList.builder();
-        for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+        for (int columnIndex = 0; columnIndex < size; columnIndex++) {
             HiveColumnHandle column = columns.get(columnIndex);
 
             String name = column.getName();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -191,11 +191,8 @@ public class ParquetPageSourceFactory
             }
 
             ParquetReader parquetReader = new ParquetReader(
-                    fileMetaData.getSchema(),
-                    fileMetaData.getKeyValueMetaData(),
                     requestedSchema,
                     blocks,
-                    configuration,
                     dataSource);
 
             return new ParquetPageSource(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/dictionary/ParquetDictionaryReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/dictionary/ParquetDictionaryReader.java
@@ -48,74 +48,49 @@ public class ParquetDictionaryReader
     @Override
     public int readValueDictionaryId()
     {
-        try {
-            return decoder.readInt();
-        }
-        catch (IOException e) {
-            throw new ParquetDecodingException(e);
-        }
+        return readInt();
     }
 
     @Override
     public Binary readBytes()
     {
-        try {
-            return dictionary.decodeToBinary(decoder.readInt());
-        }
-        catch (IOException e) {
-            throw new ParquetDecodingException(e);
-        }
+        return dictionary.decodeToBinary(readInt());
     }
 
     @Override
     public float readFloat()
     {
-        try {
-            return dictionary.decodeToFloat(decoder.readInt());
-        }
-        catch (IOException e) {
-            throw new ParquetDecodingException(e);
-        }
+        return dictionary.decodeToFloat(readInt());
     }
 
     @Override
     public double readDouble()
     {
-        try {
-            return dictionary.decodeToDouble(decoder.readInt());
-        }
-        catch (IOException e) {
-            throw new ParquetDecodingException(e);
-        }
+        return dictionary.decodeToDouble(readInt());
     }
 
     @Override
     public int readInteger()
     {
-        try {
-            return dictionary.decodeToInt(decoder.readInt());
-        }
-        catch (IOException e) {
-            throw new ParquetDecodingException(e);
-        }
+        return dictionary.decodeToInt(readInt());
     }
 
     @Override
     public long readLong()
     {
-        try {
-            return dictionary.decodeToLong(decoder.readInt());
-        }
-        catch (IOException e) {
-            throw new ParquetDecodingException(e);
-        }
+        return dictionary.decodeToLong(readInt());
     }
 
     @Override
     public void skip()
     {
+        readInt();
+    }
+
+    private int readInt()
+    {
         try {
-            decoder.readInt();
+            return decoder.readInt();
         }
         catch (IOException e) {
             throw new ParquetDecodingException(e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
@@ -25,6 +25,8 @@ import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.spi.type.Varchars.truncateToLength;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static io.airlift.slice.Slices.wrappedBuffer;
 
 public class ParquetBinaryColumnReader
         extends ParquetColumnReader
@@ -47,10 +49,10 @@ public class ParquetBinaryColumnReader
                 Binary binary = valuesReader.readBytes();
                 Slice value;
                 if (binary.length() == 0) {
-                    value = Slices.EMPTY_SLICE;
+                    value = EMPTY_SLICE;
                 }
                 else {
-                    value = Slices.wrappedBuffer(binary.getBytes());
+                    value = wrappedBuffer(binary.getBytes());
                 }
                 if (isVarcharType(type)) {
                     value = truncateToLength(value, type);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
@@ -17,7 +17,6 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import parquet.column.ColumnDescriptor;
 import parquet.io.api.Binary;
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetColumnChunkDescriptor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetColumnChunkDescriptor.java
@@ -20,18 +20,15 @@ public class ParquetColumnChunkDescriptor
 {
     private final ColumnDescriptor columnDescriptor;
     private final ColumnChunkMetaData columnChunkMetaData;
-    private final long fileOffset;
     private final int size;
 
     public ParquetColumnChunkDescriptor(
             ColumnDescriptor columnDescriptor,
             ColumnChunkMetaData columnChunkMetaData,
-            long fileOffset,
             int size)
     {
         this.columnDescriptor = columnDescriptor;
         this.columnChunkMetaData = columnChunkMetaData;
-        this.fileOffset = fileOffset;
         this.size = size;
     }
 
@@ -48,10 +45,5 @@ public class ParquetColumnChunkDescriptor
     public ColumnChunkMetaData getColumnChunkMetaData()
     {
         return columnChunkMetaData;
-    }
-
-    public long getFileOffset()
-    {
-        return fileOffset;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetColumnReader.java
@@ -233,7 +233,7 @@ public abstract class ParquetColumnReader
             int offset = rlReader.getNextOffset();
             dlReader.initFromPage(pageValueCount, bytes, offset);
             offset = dlReader.getNextOffset();
-            return initDataReader(page.getValueEncoding(), bytes, offset, page.getValueCount());
+            return initDataReader(page.getValueEncoding(), bytes, offset);
         }
         catch (IOException e) {
             throw new ParquetDecodingException("Error reading parquet page " + page + " in column " + columnDescriptor, e);
@@ -244,7 +244,7 @@ public abstract class ParquetColumnReader
     {
         repetitionReader = buildLevelRLEReader(columnDescriptor.getMaxRepetitionLevel(), page.getRepetitionLevels());
         definitionReader = buildLevelRLEReader(columnDescriptor.getMaxDefinitionLevel(), page.getDefinitionLevels());
-        return initDataReader(page.getDataEncoding(), page.getSlice().getBytes(), 0, page.getValueCount());
+        return initDataReader(page.getDataEncoding(), page.getSlice().getBytes(), 0);
     }
 
     private ParquetLevelReader buildLevelRLEReader(int maxLevel, Slice slice)
@@ -255,7 +255,7 @@ public abstract class ParquetColumnReader
         return new ParquetLevelRLEReader(new RunLengthBitPackingHybridDecoder(BytesUtils.getWidthFromMaxInt(maxLevel), new ByteArrayInputStream(slice.getBytes())));
     }
 
-    private ValuesReader initDataReader(ParquetEncoding dataEncoding, byte[] bytes, int offset, int valueCount)
+    private ValuesReader initDataReader(ParquetEncoding dataEncoding, byte[] bytes, int offset)
     {
         ValuesReader valuesReader;
         if (dataEncoding.usesDictionary()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetPageReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetPageReader.java
@@ -17,6 +17,7 @@ import com.facebook.presto.hive.parquet.ParquetDataPage;
 import com.facebook.presto.hive.parquet.ParquetDataPageV1;
 import com.facebook.presto.hive.parquet.ParquetDataPageV2;
 import com.facebook.presto.hive.parquet.ParquetDictionaryPage;
+import parquet.Ints;
 import parquet.hadoop.metadata.CompressionCodecName;
 
 import java.io.IOException;
@@ -74,6 +75,10 @@ class ParquetPageReader
                 if (!dataPageV2.isCompressed()) {
                     return dataPageV2;
                 }
+                int uncompressedSize = Ints.checkedCast(
+                        dataPageV2.getUncompressedSize()
+                                - dataPageV2.getDefinitionLevels().length()
+                                - dataPageV2.getRepetitionLevels().length());
                 return new ParquetDataPageV2(
                         dataPageV2.getRowCount(),
                         dataPageV2.getNullCount(),
@@ -81,7 +86,7 @@ class ParquetPageReader
                         dataPageV2.getRepetitionLevels(),
                         dataPageV2.getDefinitionLevels(),
                         dataPageV2.getDataEncoding(),
-                        decompress(codec, dataPageV2.getSlice(), dataPageV2.getUncompressedSize()),
+                        decompress(codec, dataPageV2.getSlice(), uncompressedSize),
                         dataPageV2.getUncompressedSize(),
                         dataPageV2.getStatistics(),
                         false);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
@@ -115,10 +115,9 @@ public class ParquetReader
         }
         currentBlockMetadata = blocks.get(currentBlock);
         currentBlock = currentBlock + 1;
-        long rowCount = currentBlockMetadata.getRowCount();
 
         nextRowInGroup = 0L;
-        currentGroupRowCount = rowCount;
+        currentGroupRowCount = currentBlockMetadata.getRowCount();
         columnReadersMap.clear();
         initializeColumnReaders();
         return true;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
@@ -149,7 +149,7 @@ public class ParquetReader
                 return metadata;
             }
         }
-        throw new ParquetCorruptionException("Malformed Parquet file. Could not find column metadata %s", columnDescriptor);
+        throw new ParquetCorruptionException("Metadata is missing for column: %s", columnDescriptor);
     }
 
     private void initializeColumnReaders()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
@@ -19,7 +19,6 @@ import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.primitives.Ints;
-import org.apache.hadoop.conf.Configuration;
 import parquet.column.ColumnDescriptor;
 import parquet.hadoop.metadata.BlockMetaData;
 import parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -41,8 +40,6 @@ public class ParquetReader
 {
     public static final int MAX_VECTOR_LENGTH = 1024;
 
-    private final MessageType fileSchema;
-    private final Map<String, String> extraMetadata;
     private final MessageType requestedSchema;
     private final List<BlockMetaData> blocks;
     private final ParquetDataSource dataSource;
@@ -55,16 +52,11 @@ public class ParquetReader
     private long nextRowInGroup;
     private Map<ColumnDescriptor, ParquetColumnReader> columnReadersMap = new HashMap<>();
 
-    public ParquetReader(MessageType fileSchema,
-            Map<String, String> extraMetadata,
-            MessageType requestedSchema,
+    public ParquetReader(MessageType requestedSchema,
             List<BlockMetaData> blocks,
-            Configuration configuration,
             ParquetDataSource dataSource)
             throws IOException
     {
-        this.fileSchema = fileSchema;
-        this.extraMetadata = extraMetadata;
         this.requestedSchema = requestedSchema;
         this.blocks = blocks;
         this.dataSource = dataSource;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
@@ -148,7 +148,7 @@ public class ParquetReader
             int totalSize = Ints.checkedCast(metadata.getTotalSize());
             byte[] buffer = new byte[totalSize];
             dataSource.readFully(startingPosition, buffer);
-            ParquetColumnChunkDescriptor descriptor = new ParquetColumnChunkDescriptor(columnDescriptor, metadata, startingPosition, totalSize);
+            ParquetColumnChunkDescriptor descriptor = new ParquetColumnChunkDescriptor(columnDescriptor, metadata, totalSize);
             ParquetColumnChunk columnChunk = new ParquetColumnChunk(descriptor, buffer, 0);
             columnReader.setPageReader(columnChunk.readAllPages());
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
@@ -87,11 +87,6 @@ public class ParquetReader
         return currentPosition;
     }
 
-    public long getFileRowCount()
-    {
-        return fileRowCount;
-    }
-
     public int nextBatch()
             throws IOException, InterruptedException
     {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -64,6 +64,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
 import static parquet.hadoop.metadata.CompressionCodecName.GZIP;
+import static parquet.hadoop.metadata.CompressionCodecName.LZO;
 import static parquet.hadoop.metadata.CompressionCodecName.SNAPPY;
 import static parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
 
@@ -86,7 +87,7 @@ public class ParquetTester
     public static ParquetTester fullParquetTester()
     {
         ParquetTester parquetTester = new ParquetTester();
-        parquetTester.compressions = ImmutableSet.of(GZIP, UNCOMPRESSED, SNAPPY);
+        parquetTester.compressions = ImmutableSet.of(GZIP, UNCOMPRESSED, SNAPPY, LZO);
         parquetTester.versions = ImmutableSet.copyOf(WriterVersion.values());
         return parquetTester;
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -172,10 +172,7 @@ public class ParquetTester
         ParquetDataSource dataSource = new HdfsParquetDataSource(path, size, inputStream);
 
         ParquetReader parquetReader = new ParquetReader(fileSchema,
-                                                        fileMetaData.getKeyValueMetaData(),
-                                                        fileSchema,
                                                         parquetMetadata.getBlocks(),
-                                                        jobConf,
                                                         dataSource);
         assertEquals(parquetReader.getPosition(), 0);
 


### PR DESCRIPTION
This PR makes the following changes to the new Parquet reader:
- Add LZO decompression support
- Get rid of unnecessary array copies in GZIP decompression
- Fix data page v2 handling (uncompressed size calculation)
- Simplify dictionary reader
- Remove unused field/method/args

/cc @zhenxiao @dain 

I will squash before merge.