### PR TITLE
Find the public JRE from the JDK in the preinstall script

### DIFF
--- a/presto-server-rpm/src/main/rpm/preinstall
+++ b/presto-server-rpm/src/main/rpm/preinstall
@@ -43,12 +43,12 @@ check_if_correct_java_version() {
 if ! check_if_correct_java_version "$JAVA8_HOME" && ! check_if_correct_java_version "$JAVA_HOME"; then
   java_found=false
   for candidate in \
-      /usr/lib/jvm/jdk1.8* \
+      /usr/lib/jvm/jdk1.8*/jre \
       /usr/lib/jvm/jre1.8* \
       /usr/lib/jvm/java-8-oracle* \
-      /usr/java/jdk1.8* \
+      /usr/java/jdk1.8*/jre \
       /usr/java/jre1.8* \
-      /usr/jdk64/jdk1.8* \
+      /usr/jdk64/jdk1.8*/jre \
       /usr/lib/jvm/default-java \
       /usr/java/default \
       / \


### PR DESCRIPTION
The JDK comes with two JREs: a private one in bin, lib, etc; and a public one
in jre/bin, jre/lib, etc. The presto-server-rpm preinstall script should
detect the public one rather than the private one.

Tested by installing the updated rpm on a cluster, verifying the contents of /etc/presto/env.sh, then doing an lsof -p on the presto PID and verifying that the path to the java binary:
```
[root@ediven-krb4-master ~]# lsof -p 23440 | head
COMMAND   PID   USER   FD   TYPE             DEVICE SIZE/OFF    NODE NAME
java    23440 presto  cwd    DIR              253,0     4096  783981 /var/lib/presto/data
java    23440 presto  rtd    DIR              253,0     4096       2 /
java    23440 presto  txt    REG              253,0     7734  282986 /usr/java/jdk1.8.0_71/jre/bin/java
```

Also tested with the ambari-presto-service.