### PR TITLE
Fix leak during task cleanup

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
@@ -162,8 +162,13 @@ public class TaskInfoFetcher
     {
         TaskStatus taskStatus = getTaskInfo().getTaskStatus();
 
-        // stopped or done?
-        if (!running || isDone(getTaskInfo())) {
+        if (!running) {
+            return;
+        }
+
+        // we already have the final task info
+        if (isDone(getTaskInfo())) {
+            stop();
             return;
         }
 


### PR DESCRIPTION
There was a bug in TaskInfoFetcher that caused stop()
not getting called if the final task info had already
been fetched.