### PR TITLE
Add beginSelect notification for Connector SPI

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -226,7 +226,7 @@ public class DataDefinitionExecution<T extends Statement>
             DataDefinitionTask<Statement> task = getTask(statement);
             checkArgument(task != null, "no task for statement: %s", statement.getClass().getSimpleName());
 
-            QueryStateMachine stateMachine = QueryStateMachine.begin(queryId, query, session, self, task.isTransactionControl(), transactionManager, executor);
+            QueryStateMachine stateMachine = QueryStateMachine.begin(queryId, query, session, self, task.isTransactionControl(), transactionManager, metadata, executor);
             stateMachine.setUpdateType(task.getName());
             return new DataDefinitionExecution<>(task, statement, transactionManager, metadata, accessControl, stateMachine);
         }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -140,7 +140,7 @@ public final class SqlQueryExecution
             requireNonNull(query, "query is null");
             requireNonNull(session, "session is null");
             requireNonNull(self, "self is null");
-            this.stateMachine = QueryStateMachine.begin(queryId, query, session, self, false, transactionManager, queryExecutor);
+            this.stateMachine = QueryStateMachine.begin(queryId, query, session, self, false, transactionManager, metadata, queryExecutor);
 
             // when the query finishes cache the final query info, and clear the reference to the output stage
             stateMachine.addStateChangeListener(state -> {
@@ -157,6 +157,11 @@ public final class SqlQueryExecution
 
             this.remoteTaskFactory = new MemoryTrackingRemoteTaskFactory(requireNonNull(remoteTaskFactory, "remoteTaskFactory is null"), stateMachine);
         }
+    }
+
+    public Metadata getMetadata()
+    {
+        return metadata;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -54,6 +54,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.facebook.presto.execution.QueryState.FINISHED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.spi.StandardErrorCode.ABANDONED_QUERY;
 import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TIME_LIMIT;
@@ -268,7 +269,7 @@ public class SqlQueryManager
     }
 
     @Override
-    public QueryInfo createQuery(Session session, String query)
+    public QueryInfo createQuery(final Session session, String query)
     {
         requireNonNull(query, "query is null");
         checkArgument(!query.isEmpty(), "query must not be empty string");
@@ -318,6 +319,11 @@ public class SqlQueryManager
         queryMonitor.createdEvent(queryInfo);
 
         queryExecution.addStateChangeListener(newValue -> {
+            if (newValue.equals(FINISHED)) {
+                if (queryExecution instanceof SqlQueryExecution) {
+                    ((SqlQueryExecution) queryExecution).getMetadata().finishSelect(session);
+                }
+            }
             if (newValue.isDone()) {
                 try {
                     QueryInfo info = queryExecution.getQueryInfo();

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -54,7 +54,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.facebook.presto.execution.QueryState.FINISHED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.spi.StandardErrorCode.ABANDONED_QUERY;
 import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TIME_LIMIT;
@@ -269,7 +268,7 @@ public class SqlQueryManager
     }
 
     @Override
-    public QueryInfo createQuery(final Session session, String query)
+    public QueryInfo createQuery(Session session, String query)
     {
         requireNonNull(query, "query is null");
         checkArgument(!query.isEmpty(), "query must not be empty string");
@@ -319,7 +318,7 @@ public class SqlQueryManager
         queryMonitor.createdEvent(queryInfo);
 
         queryExecution.addStateChangeListener(newValue -> {
-            if (newValue.equals(FINISHED)) {
+            if (newValue.isDone()) {
                 if (queryExecution instanceof SqlQueryExecution) {
                     ((SqlQueryExecution) queryExecution).getMetadata().finishSelect(session);
                 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -195,7 +195,7 @@ public interface Metadata
     /**
      * Notify connector about starting select query execution
      */
-    void beginSelect(Session session, TableHandle tableHandle, Optional<TableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles);
+    void beginSelect(Session session, TableHandle tableHandle, TableLayoutHandle layoutHandle, Collection<ColumnHandle> columnHandles);
 
     /**
      * Notify connector about finishing execution of select query.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -192,6 +192,8 @@ public interface Metadata
      */
     void finishDelete(Session session, TableHandle tableHandle, Collection<Slice> fragments);
 
+    void beginSelect(Session session, TableHandle tableHandle, Optional<TableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles);
+
     /**
      * Gets all the loaded catalogs
      *

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -192,7 +192,16 @@ public interface Metadata
      */
     void finishDelete(Session session, TableHandle tableHandle, Collection<Slice> fragments);
 
-    void beginSelect(Session session, TableHandle tableHandle, Optional<TableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles);
+    /**
+     * Notify connector about starting select query execution
+     * @return {@link TableHandle} of affected table. If null, no {@link #finishSelect(Session)} will be called.
+     */
+    TableHandle beginSelect(Session session, TableHandle tableHandle, Optional<TableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles);
+
+    /**
+     * Notify connector about finishing execution of select query.
+     */
+    void finishSelect(Session session);
 
     /**
      * Gets all the loaded catalogs

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -194,9 +194,8 @@ public interface Metadata
 
     /**
      * Notify connector about starting select query execution
-     * @return {@link TableHandle} of affected table. If null, no {@link #finishSelect(Session)} will be called.
      */
-    TableHandle beginSelect(Session session, TableHandle tableHandle, Optional<TableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles);
+    void beginSelect(Session session, TableHandle tableHandle, Optional<TableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles);
 
     /**
      * Notify connector about finishing execution of select query.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -621,10 +621,10 @@ public class MetadataManager
             if (tables == null) {
                 return;
             }
-            for (TableHandle th : tables) {
-                ConnectorEntry entry = lookupConnectorFor(th);
+            for (TableHandle table : tables) {
+                ConnectorEntry entry = lookupConnectorFor(table);
                 ConnectorMetadata metadata = entry.getMetadata(session);
-                metadata.finishSelect(session.toConnectorSession(entry.getCatalog()), th.getConnectorHandle());
+                metadata.finishSelect(session.toConnectorSession(entry.getCatalog()), table.getConnectorHandle());
             }
         }
         finally {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -591,13 +591,13 @@ public class MetadataManager
     }
 
     @Override
-    public void beginSelect(Session session, TableHandle tableHandle, Optional<TableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles)
+    public void beginSelect(Session session, TableHandle tableHandle, TableLayoutHandle layoutHandle, Collection<ColumnHandle> columnHandles)
     {
         ConnectorEntry entry = lookupConnectorFor(tableHandle);
         ConnectorMetadata metadata = entry.getMetadata(session);
         ConnectorTableHandle connectorHandle = metadata.beginSelect(session.toConnectorSession(entry.getCatalog()),
                 tableHandle.getConnectorHandle(),
-                layoutHandle.map(handle -> handle.getConnectorHandle()),
+                layoutHandle.getConnectorHandle(),
                 columnHandles);
         if (connectorHandle == null) {
             return;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.execution.QueryId;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
@@ -109,6 +110,7 @@ public class MetadataManager
     private final ConcurrentMap<String, ConnectorEntry> systemTablesByCatalog = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ConnectorEntry> connectorsByCatalog = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ConnectorEntry> connectorsById = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, List<TableHandle>> tablesToNotifyByQueryId = new ConcurrentHashMap<>();
     private final FunctionRegistry functions;
     private final ProcedureRegistry procedures;
     private final TypeManager typeManager;
@@ -590,11 +592,44 @@ public class MetadataManager
     }
 
     @Override
-    public void beginSelect(Session session, TableHandle tableHandle, Optional<TableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles)
+    public TableHandle beginSelect(Session session, TableHandle tableHandle, Optional<TableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles)
     {
         ConnectorEntry entry = lookupConnectorFor(tableHandle);
         ConnectorMetadata metadata = entry.getMetadata(session);
-        metadata.beginSelect(session.toConnectorSession(entry.getCatalog()), tableHandle.getConnectorHandle(), convertToConnectorTableLayoutHandle(layoutHandle), columnHandles);
+        ConnectorTableHandle connectorHandle = metadata.beginSelect(session.toConnectorSession(entry.getCatalog()), tableHandle.getConnectorHandle(), convertToConnectorTableLayoutHandle(layoutHandle), columnHandles);
+        if (connectorHandle == null) {
+            return null;
+        }
+        TableHandle th = new TableHandle(tableHandle.getConnectorId(), connectorHandle);
+        registerTableForQueryId(session.getQueryId(), th);
+        return th;
+    }
+
+    private void registerTableForQueryId(QueryId queryId, TableHandle tableHandle)
+    {
+        tablesToNotifyByQueryId.putIfAbsent(queryId.getId(), new ArrayList<>());
+        List<TableHandle> tables = tablesToNotifyByQueryId.get(queryId.getId());
+        tables.add(tableHandle);
+    }
+
+    @Override
+    public void finishSelect(Session session)
+    {
+        String queryId = session.getQueryId().getId();
+        try {
+            List<TableHandle> tables = tablesToNotifyByQueryId.get(queryId);
+            if (tables == null) {
+                return;
+            }
+            for (TableHandle th : tables) {
+                ConnectorEntry entry = lookupConnectorFor(th);
+                ConnectorMetadata metadata = entry.getMetadata(session);
+                metadata.finishSelect(session.toConnectorSession(entry.getCatalog()), th.getConnectorHandle());
+            }
+        }
+        finally {
+            tablesToNotifyByQueryId.remove(queryId);
+        }
     }
 
     private static Optional<ConnectorTableLayoutHandle> convertToConnectorTableLayoutHandle(

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorResolvedIndex;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutResult;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.ConnectorViewDefinition;
@@ -586,6 +587,24 @@ public class MetadataManager
         ConnectorEntry entry = lookupConnectorFor(tableHandle);
         ConnectorMetadata metadata = entry.getMetadata(session);
         metadata.finishDelete(session.toConnectorSession(entry.getCatalog()), tableHandle.getConnectorHandle(), fragments);
+    }
+
+    @Override
+    public void beginSelect(Session session, TableHandle tableHandle, Optional<TableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles)
+    {
+        ConnectorEntry entry = lookupConnectorFor(tableHandle);
+        ConnectorMetadata metadata = entry.getMetadata(session);
+        metadata.beginSelect(session.toConnectorSession(entry.getCatalog()), tableHandle.getConnectorHandle(), convertToConnectorTableLayoutHandle(layoutHandle), columnHandles);
+    }
+
+    private static Optional<ConnectorTableLayoutHandle> convertToConnectorTableLayoutHandle(
+            Optional<TableLayoutHandle> tableLayoutHandle)
+    {
+        if (!tableLayoutHandle.isPresent()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(tableLayoutHandle.get().getConnectorHandle());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
+import com.facebook.presto.sql.planner.optimizations.BeginSelectTable;
 import com.facebook.presto.sql.planner.optimizations.BeginTableWrite;
 import com.facebook.presto.sql.planner.optimizations.CanonicalizeExpressions;
 import com.facebook.presto.sql.planner.optimizations.CountConstantOptimizer;
@@ -123,6 +124,7 @@ public class PlanOptimizersFactory
 
         builder.add(new MetadataDeleteOptimizer(metadata));
         builder.add(new BeginTableWrite(metadata)); // HACK! see comments in BeginTableWrite
+        builder.add(new BeginSelectTable(metadata)); // HACK! like above
 
         // TODO: consider adding a formal final plan sanitization optimizer that prepares the plan for transmission/execution/logging
         // TODO: figure out how to improve the set flattening optimizer so that it can run at any point

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginSelectTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginSelectTable.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class BeginSelectTable
+        implements PlanOptimizer
+{
+    private final Metadata metadata;
+
+    public BeginSelectTable(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, Map<Symbol, Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        return SimplePlanRewriter.rewriteWith(new Rewriter(session), plan, new Context());
+    }
+
+    private class Rewriter
+            extends SimplePlanRewriter<Context>
+    {
+        private final Session session;
+
+        public Rewriter(Session session)
+        {
+            this.session = requireNonNull(session, "session is null");
+        }
+
+        @Override
+        public PlanNode visitOutput(OutputNode node, RewriteContext<Context> context)
+        {
+            node.getSource().accept(this, context);
+            context.get().getNodes().stream().forEach((n) -> metadata.beginSelect(session, n.getTable(), n.getLayout(), n.getAssignments().values()));
+            return node;
+        }
+
+        @Override
+        public PlanNode visitTableScan(TableScanNode node, RewriteContext<Context> context)
+        {
+            context.get().registerTableScan(node);
+            node.getSources().stream().forEach((n) -> n.accept(this, context));
+            return node;
+        }
+    }
+
+    private static class Context
+    {
+        private ImmutableSet.Builder<TableScanNode> nodesBuilder = ImmutableSet.builder();
+
+        public void registerTableScan(TableScanNode node)
+        {
+            nodesBuilder.add(node);
+        }
+
+        public Set<TableScanNode> getNodes()
+        {
+            return nodesBuilder.build();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginSelectTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginSelectTable.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class BeginSelectTable
@@ -61,7 +62,8 @@ public class BeginSelectTable
         {
             node.getSource().accept(this, context);
             for (TableScanNode scanNode : context.get().getNodes()) {
-                metadata.beginSelect(session, scanNode.getTable(), scanNode.getLayout(), scanNode.getAssignments().values());
+                checkState(scanNode.getLayout().isPresent(), "Layout is not present"); // since BeginSelectTable has to be last rewriter, a layout should exist here already
+                metadata.beginSelect(session, scanNode.getTable(), scanNode.getLayout().get(), scanNode.getAssignments().values());
             }
             return node;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginSelectTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginSelectTable.java
@@ -60,7 +60,9 @@ public class BeginSelectTable
         public PlanNode visitOutput(OutputNode node, RewriteContext<Context> context)
         {
             node.getSource().accept(this, context);
-            context.get().getNodes().stream().forEach((n) -> metadata.beginSelect(session, n.getTable(), n.getLayout(), n.getAssignments().values()));
+            for (TableScanNode scanNode : context.get().getNodes()) {
+                metadata.beginSelect(session, scanNode.getTable(), scanNode.getLayout(), scanNode.getAssignments().values());
+            }
             return node;
         }
 
@@ -68,7 +70,9 @@ public class BeginSelectTable
         public PlanNode visitTableScan(TableScanNode node, RewriteContext<Context> context)
         {
             context.get().registerTableScan(node);
-            node.getSources().stream().forEach((n) -> n.accept(this, context));
+            for (PlanNode sourceNode : node.getSources()) {
+                sourceNode.accept(this, context);
+            }
             return node;
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCommitTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCommitTask.java
@@ -63,7 +63,7 @@ public class TestCommitTask
         Session session = sessionBuilder()
                 .setTransactionId(transactionManager.beginTransaction(false))
                 .build();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "COMMIT", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "COMMIT", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
         assertTrue(stateMachine.getSession().getTransactionId().isPresent());
         assertEquals(transactionManager.getAllTransactionInfos().size(), 1);
 
@@ -82,7 +82,7 @@ public class TestCommitTask
 
         Session session = sessionBuilder()
                 .build();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "COMMIT", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "COMMIT", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
 
         try {
             try {
@@ -111,7 +111,7 @@ public class TestCommitTask
         Session session = sessionBuilder()
                 .setTransactionId(TransactionId.create()) // Use a random transaction ID that is unknown to the system
                 .build();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "COMMIT", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "COMMIT", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
 
         try {
             try {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestDeallocateTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestDeallocateTask.java
@@ -72,7 +72,8 @@ public class TestDeallocateTask
     private Set<String> executeDeallocate(String statementName, String sqlString, Session session)
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), sqlString, session, URI.create("fake://uri"), false, transactionManager, executor);
+        MetadataManager metadataManager = createTestMetadataManager();
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), sqlString, session, URI.create("fake://uri"), false, transactionManager, metadataManager, executor);
         Deallocate deallocate = new Deallocate(statementName);
         new DeallocateTask().execute(deallocate, transactionManager, metadata, new AllowAllAccessControl(), stateMachine);
         return stateMachine.getDeallocatedPreparedStatements();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestPrepareTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestPrepareTask.java
@@ -75,7 +75,8 @@ public class TestPrepareTask
     private Map<String, String> executePrepare(String statementName, Query query, String sqlString, Session session)
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), sqlString, session, URI.create("fake://uri"), false, transactionManager, executor);
+        MetadataManager metadataManager = createTestMetadataManager();
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), sqlString, session, URI.create("fake://uri"), false, transactionManager, metadataManager, executor);
         Prepare prepare = new Prepare(statementName, query);
         new PrepareTask(new SqlParser()).execute(prepare, transactionManager, metadata, new AllowAllAccessControl(), stateMachine);
         return stateMachine.getAddedPreparedStatements();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.memory.MemoryPoolId;
 import com.facebook.presto.memory.VersionedMemoryPoolId;
+import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableList;
@@ -43,6 +44,7 @@ import static com.facebook.presto.execution.QueryState.PLANNING;
 import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.execution.QueryState.STARTING;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.USER_CANCELED;
 import static com.facebook.presto.transaction.TransactionManager.createTestTransactionManager;
@@ -360,7 +362,8 @@ public class TestQueryStateMachine
     private QueryStateMachine createQueryStateMachine()
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(QUERY_ID, QUERY, TEST_SESSION, LOCATION, false, transactionManager, executor);
+        Metadata metadata = createTestMetadataManager();
+        QueryStateMachine stateMachine = QueryStateMachine.begin(QUERY_ID, QUERY, TEST_SESSION, LOCATION, false, transactionManager, metadata, executor);
         stateMachine.setInputs(INPUTS);
         stateMachine.setOutputFieldNames(OUTPUT_FIELD_NAMES);
         stateMachine.setUpdateType(UPDATE_TYPE);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestResetSessionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestResetSessionTask.java
@@ -68,7 +68,7 @@ public class TestResetSessionTask
         Session session = TEST_SESSION.withSystemProperty("foo", "bar").withCatalogProperty("catalog", "baz", "blah");
 
         TransactionManager transactionManager = createTestTransactionManager();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "reset foo", session, URI.create("fake://uri"), false, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "reset foo", session, URI.create("fake://uri"), false, transactionManager, metadata, executor);
         new ResetSessionTask().execute(new ResetSession(QualifiedName.of("catalog", "baz")), transactionManager, metadata, new AllowAllAccessControl(), stateMachine).join();
 
         Set<String> sessionProperties = stateMachine.getResetSessionProperties();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestRollbackTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestRollbackTask.java
@@ -62,7 +62,7 @@ public class TestRollbackTask
         Session session = sessionBuilder()
                 .setTransactionId(transactionManager.beginTransaction(false))
                 .build();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "ROLLBACK", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "ROLLBACK", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
         assertTrue(stateMachine.getSession().getTransactionId().isPresent());
         assertEquals(transactionManager.getAllTransactionInfos().size(), 1);
 
@@ -81,7 +81,7 @@ public class TestRollbackTask
 
         Session session = sessionBuilder()
                 .build();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "ROLLBACK", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "ROLLBACK", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
 
         try {
             try {
@@ -110,7 +110,7 @@ public class TestRollbackTask
         Session session = sessionBuilder()
                 .setTransactionId(TransactionId.create()) // Use a random transaction ID that is unknown to the system
                 .build();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "ROLLBACK", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "ROLLBACK", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
 
         new RollbackTask().execute(new Rollback(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine).join();
         assertTrue(stateMachine.getQueryInfoWithoutDetails().isClearTransactionId()); // Still issue clear signal

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSetSessionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSetSessionTask.java
@@ -78,7 +78,7 @@ public class TestSetSessionTask
             throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "set foo.bar = 'baz'", TEST_SESSION, URI.create("fake://uri"), false, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "set foo.bar = 'baz'", TEST_SESSION, URI.create("fake://uri"), false, transactionManager, metadata, executor);
         new SetSessionTask().execute(new SetSession(QualifiedName.of("foo", "bar"), expression), transactionManager, metadata, new AllowAllAccessControl(), stateMachine).join();
 
         Map<String, String> sessionProperties = stateMachine.getSetSessionProperties();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStartTransactionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStartTransactionTask.java
@@ -73,7 +73,7 @@ public class TestStartTransactionTask
     {
         Session session = sessionBuilder().build();
         TransactionManager transactionManager = createTestTransactionManager();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
         try {
@@ -104,7 +104,7 @@ public class TestStartTransactionTask
                 .setTransactionId(TransactionId.create())
                 .setClientTransactionSupport()
                 .build();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
 
         try {
             try {
@@ -132,7 +132,7 @@ public class TestStartTransactionTask
                 .setClientTransactionSupport()
                 .build();
         TransactionManager transactionManager = createTestTransactionManager();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
         new StartTransactionTask().execute(new StartTransaction(ImmutableList.of()), transactionManager, metadata, new AllowAllAccessControl(), stateMachine).join();
@@ -152,7 +152,7 @@ public class TestStartTransactionTask
                 .setClientTransactionSupport()
                 .build();
         TransactionManager transactionManager = createTestTransactionManager();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
         new StartTransactionTask().execute(new StartTransaction(ImmutableList.of(new Isolation(Isolation.Level.SERIALIZABLE), new TransactionAccessMode(true))), transactionManager, metadata, new AllowAllAccessControl(), stateMachine).join();
@@ -174,7 +174,7 @@ public class TestStartTransactionTask
                 .setClientTransactionSupport()
                 .build();
         TransactionManager transactionManager = createTestTransactionManager();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
         try {
@@ -203,7 +203,7 @@ public class TestStartTransactionTask
                 .setClientTransactionSupport()
                 .build();
         TransactionManager transactionManager = createTestTransactionManager();
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
         try {
@@ -237,7 +237,7 @@ public class TestStartTransactionTask
                         .setIdleCheckInterval(new Duration(10, TimeUnit.MILLISECONDS)),
                 scheduledExecutor,
                 executor);
-        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, executor);
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, metadata, executor);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
         new StartTransactionTask().execute(new StartTransaction(ImmutableList.of()), transactionManager, metadata, new AllowAllAccessControl(), stateMachine).join();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -267,7 +267,7 @@ public interface ConnectorMetadata
      *
      * @return serializable {@link ConnectorTableHandle}. This handle will be brought back in {@link #finishSelect(ConnectorSession, ConnectorTableHandle)} if null returned, no finishSelect will be called.
      */
-    default ConnectorTableHandle beginSelect(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles)
+    default ConnectorTableHandle beginSelect(ConnectorSession session, ConnectorTableHandle tableHandle, ConnectorTableLayoutHandle layoutHandle, Collection<ColumnHandle> columnHandles)
     {
         return null;
     }
@@ -275,7 +275,7 @@ public interface ConnectorMetadata
     /**
      * Notifies when select query finishes processing
      *
-     * @param tableHandle returned by {@link #beginSelect(ConnectorSession, ConnectorTableHandle, Optional, Collection)} method
+     * @param tableHandle returned by {@link #beginSelect(ConnectorSession, ConnectorTableHandle, ConnectorTableLayoutHandle, Collection)} method
      */
     default void finishSelect(ConnectorSession session, ConnectorTableHandle tableHandle) {}
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -252,9 +252,6 @@ public interface ConnectorMetadata
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support deletes");
     }
 
-    default void beginSelect(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles)
-    {}
-
     /**
      * Finish delete query
      *
@@ -263,6 +260,25 @@ public interface ConnectorMetadata
     default void finishDelete(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<Slice> fragments)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support deletes");
+    }
+
+    /**
+     * Notifies when select query starts
+     *
+     * @return serializable {@link ConnectorTableHandle}. This handle will be brought back in {@link #finishSelect(ConnectorSession, ConnectorTableHandle)} if null returned, no finishSelect will be called.
+     */
+    default ConnectorTableHandle beginSelect(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles)
+    {
+        return null;
+    }
+
+    /**
+     * Notifies when select query finishes processing
+     *
+     * @param tableHandle returned by {@link #beginSelect(ConnectorSession, ConnectorTableHandle, Optional, Collection)} method
+     */
+    default void finishSelect(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -277,9 +277,7 @@ public interface ConnectorMetadata
      *
      * @param tableHandle returned by {@link #beginSelect(ConnectorSession, ConnectorTableHandle, Optional, Collection)} method
      */
-    default void finishSelect(ConnectorSession session, ConnectorTableHandle tableHandle)
-    {
-    }
+    default void finishSelect(ConnectorSession session, ConnectorTableHandle tableHandle) {}
 
     /**
      * Create the specified view. The data for the view is opaque to the connector.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -252,6 +252,9 @@ public interface ConnectorMetadata
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support deletes");
     }
 
+    default void beginSelect(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles)
+    {}
+
     /**
      * Finish delete query
      *

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -227,7 +227,7 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public ConnectorTableHandle beginSelect(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles)
+    public ConnectorTableHandle beginSelect(ConnectorSession session, ConnectorTableHandle tableHandle, ConnectorTableLayoutHandle layoutHandle, Collection<ColumnHandle> columnHandles)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.beginSelect(session, tableHandle, layoutHandle, columnHandles);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -227,6 +227,22 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public ConnectorTableHandle beginSelect(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> layoutHandle, Collection<ColumnHandle> columnHandles)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.beginSelect(session, tableHandle, layoutHandle, columnHandles);
+        }
+    }
+
+    @Override
+    public void finishSelect(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.finishSelect(session, tableHandle);
+        }
+    }
+
+    @Override
     public void createView(ConnectorSession session, SchemaTableName viewName, String viewData, boolean replace)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
This is just a proof of concept.
I pushed it to start a discussion about possible approaches to the issue of not having post-rewrites final query shape in coordinator.
Current implementation is based on the same hack (in `BeginTableWriter`) which is used for example to implement `ConnectorMetadata.beginInsert`.

When we figure out a better place to have this notification propagated, we should rewrite all from this family (`beginInsert`, `beginCreateTable` etc.).
Maybe this will have to wait until new optimizer shows up?