### PR TITLE
Add a session property to specify number of source node candidates

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -15,6 +15,7 @@ package com.facebook.presto;
 
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.TaskManagerConfig;
+import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -37,6 +38,7 @@ public final class SystemSessionProperties
     public static final String DISTRIBUTED_JOIN = "distributed_join";
     public static final String DISTRIBUTED_INDEX_JOIN = "distributed_index_join";
     public static final String HASH_PARTITION_COUNT = "hash_partition_count";
+    public static final String SOURCE_NODE_COUNT = "source_node_count";
     public static final String PREFER_STREAMING_OPERATORS = "prefer_streaming_operators";
     public static final String TASK_WRITER_COUNT = "task_writer_count";
     public static final String TASK_JOIN_CONCURRENCY = "task_join_concurrency";
@@ -63,7 +65,7 @@ public final class SystemSessionProperties
 
     public SystemSessionProperties()
     {
-        this(new QueryManagerConfig(), new TaskManagerConfig(), new MemoryManagerConfig(), new FeaturesConfig());
+        this(new QueryManagerConfig(), new TaskManagerConfig(), new MemoryManagerConfig(), new FeaturesConfig(), new NodeSchedulerConfig());
     }
 
     @Inject
@@ -71,7 +73,8 @@ public final class SystemSessionProperties
             QueryManagerConfig queryManagerConfig,
             TaskManagerConfig taskManagerConfig,
             MemoryManagerConfig memoryManagerConfig,
-            FeaturesConfig featuresConfig)
+            FeaturesConfig featuresConfig,
+            NodeSchedulerConfig nodeSchedulerConfig)
     {
         sessionProperties = ImmutableList.of(
                 stringSessionProperty(
@@ -98,6 +101,11 @@ public final class SystemSessionProperties
                         HASH_PARTITION_COUNT,
                         "Number of partitions for distributed joins and aggregations",
                         queryManagerConfig.getInitialHashPartitions(),
+                        false),
+                integerSessionProperty(
+                        SOURCE_NODE_COUNT,
+                        "Minimum number of nodes for source splits distribution",
+                        nodeSchedulerConfig.getMinCandidates(),
                         false),
                 booleanSessionProperty(
                         PREFER_STREAMING_OPERATORS,
@@ -241,6 +249,11 @@ public final class SystemSessionProperties
     public static int getHashPartitionCount(Session session)
     {
         return session.getProperty(HASH_PARTITION_COUNT, Integer.class);
+    }
+
+    public static int getSourceNodeCount(Session session)
+    {
+        return session.getProperty(SOURCE_NODE_COUNT, Integer.class);
     }
 
     public static boolean preferStreamingOperators(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -127,6 +127,11 @@ public final class SqlStageExecution
         return stateMachine.getState();
     }
 
+    public Session getSession()
+    {
+        return stateMachine.getSession();
+    }
+
     public void addStateChangeListener(StateChangeListener<StageState> stateChangeListener)
     {
         stateMachine.addStateChangeListener(stateChangeListener::stateChanged);

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/DynamicSplitPlacementPolicy.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/DynamicSplitPlacementPolicy.java
@@ -37,9 +37,9 @@ public class DynamicSplitPlacementPolicy
     }
 
     @Override
-    public Multimap<Node, Split> computeAssignments(Set<Split> splits)
+    public Multimap<Node, Split> computeAssignments(Set<Split> splits, int limit)
     {
-        return nodeSelector.computeAssignments(splits, remoteTasks.get());
+        return nodeSelector.computeAssignments(splits, remoteTasks.get(), limit);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -94,9 +94,9 @@ public class FixedSourcePartitionedScheduler
         }
 
         @Override
-        public Multimap<Node, Split> computeAssignments(Set<Split> splits)
+        public Multimap<Node, Split> computeAssignments(Set<Split> splits, int limit)
         {
-            return nodeSelector.computeAssignments(splits, remoteTasks.get(), partitioning);
+            return nodeSelector.computeAssignments(splits, remoteTasks.get(), partitioning, limit);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -165,7 +165,6 @@ public class NodeScheduler
                     includeCoordinator,
                     doubleScheduling,
                     nodeMap,
-                    minCandidates,
                     maxSplitsPerNode,
                     maxSplitsPerNodePerTaskWhenFull,
                     topologicalSplitCounters,
@@ -173,7 +172,7 @@ public class NodeScheduler
                     networkLocationCache);
         }
         else {
-            return new SimpleNodeSelector(nodeManager, nodeTaskMap, includeCoordinator, doubleScheduling, nodeMap, minCandidates, maxSplitsPerNode, maxSplitsPerNodePerTaskWhenFull);
+            return new SimpleNodeSelector(nodeManager, nodeTaskMap, includeCoordinator, doubleScheduling, nodeMap, maxSplitsPerNode, maxSplitsPerNodePerTaskWhenFull);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSelector.java
@@ -39,7 +39,7 @@ public interface NodeSelector
      * @return a multimap from node to splits only for splits for which we could identify a node to schedule on.
      * If we cannot find an assignment for a split, it is not included in the map.
      */
-    Multimap<Node, Split> computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks);
+    Multimap<Node, Split> computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, int limit);
 
     /**
      * Identifies the nodes for running the specified splits based on a precomputed fixed partitioning.
@@ -48,5 +48,5 @@ public interface NodeSelector
      * @return a multimap from node to splits only for splits for which we could identify a node with free space.
      * If we cannot find an assignment for a split, it is not included in the map.
      */
-    Multimap<Node, Split> computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, NodePartitionMap partitioning);
+    Multimap<Node, Split> computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, NodePartitionMap partitioning, int limit);
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SimpleNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SimpleNodeSelector.java
@@ -48,7 +48,6 @@ public class SimpleNodeSelector
     private final boolean includeCoordinator;
     private final boolean doubleScheduling;
     private final AtomicReference<Supplier<NodeMap>> nodeMap;
-    private final int minCandidates;
     private final int maxSplitsPerNode;
     private final int maxSplitsPerNodePerTaskWhenFull;
 
@@ -58,7 +57,6 @@ public class SimpleNodeSelector
             boolean includeCoordinator,
             boolean doubleScheduling,
             Supplier<NodeMap> nodeMap,
-            int minCandidates,
             int maxSplitsPerNode,
             int maxSplitsPerNodePerTaskWhenFull)
     {
@@ -67,7 +65,6 @@ public class SimpleNodeSelector
         this.includeCoordinator = includeCoordinator;
         this.doubleScheduling = doubleScheduling;
         this.nodeMap = new AtomicReference<>(nodeMap);
-        this.minCandidates = minCandidates;
         this.maxSplitsPerNode = maxSplitsPerNode;
         this.maxSplitsPerNodePerTaskWhenFull = maxSplitsPerNodePerTaskWhenFull;
     }
@@ -98,7 +95,7 @@ public class SimpleNodeSelector
     }
 
     @Override
-    public Multimap<Node, Split> computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks)
+    public Multimap<Node, Split> computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, int limit)
     {
         Multimap<Node, Split> assignment = HashMultimap.create();
         NodeMap nodeMap = this.nodeMap.get().get();
@@ -113,7 +110,7 @@ public class SimpleNodeSelector
                 candidateNodes = selectExactNodes(nodeMap, split.getAddresses(), includeCoordinator);
             }
             else {
-                candidateNodes = selectNodes(minCandidates, randomCandidates, doubleScheduling);
+                candidateNodes = selectNodes(limit, randomCandidates, doubleScheduling);
             }
             if (candidateNodes.isEmpty()) {
                 log.debug("No nodes available to schedule %s. Available nodes %s", split, nodeMap.getNodesByHost().keys());
@@ -148,7 +145,7 @@ public class SimpleNodeSelector
     }
 
     @Override
-    public Multimap<Node, Split> computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, NodePartitionMap partitioning)
+    public Multimap<Node, Split> computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, NodePartitionMap partitioning, int limit)
     {
         return selectDistributionNodes(nodeMap.get().get(), nodeTaskMap, maxSplitsPerNode, splits, existingTasks, partitioning);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.OutputBuffers.BROADCAST_PARTITION_ID;
+import static com.facebook.presto.SystemSessionProperties.getSourceNodeCount;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
@@ -94,7 +95,7 @@ public class SourcePartitionedScheduler
         }
 
         // assign the splits
-        Multimap<Node, Split> splitAssignment = splitPlacementPolicy.computeAssignments(pendingSplits);
+        Multimap<Node, Split> splitAssignment = splitPlacementPolicy.computeAssignments(pendingSplits, getSourceNodeCount(stage.getSession()));
         Set<RemoteTask> newTasks = assignSplits(splitAssignment);
 
         // remove assigned splits

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SplitPlacementPolicy.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SplitPlacementPolicy.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 public interface SplitPlacementPolicy
 {
-    Multimap<Node, Split> computeAssignments(Set<Split> splits);
+    Multimap<Node, Split> computeAssignments(Set<Split> splits, int limit);
 
     void lockDownNodes();
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
@@ -96,7 +96,7 @@ public class BenchmarkNodeScheduler
         Iterator<Split> splits = data.getSplits().iterator();
         Set<Split> batch = new HashSet<>();
         while (splits.hasNext() || !batch.isEmpty()) {
-            Multimap<Node, Split> assignments = data.getNodeSelector().computeAssignments(batch, remoteTasks);
+            Multimap<Node, Split> assignments = data.getNodeSelector().computeAssignments(batch, remoteTasks, data.getNodeSchedulerConfig().getMinCandidates());
             for (Node node : assignments.keySet()) {
                 MockRemoteTaskFactory.MockRemoteTask remoteTask = data.getTaskMap().get(node);
                 remoteTask.addSplits(ImmutableMultimap.<PlanNodeId, Split>builder()
@@ -174,7 +174,7 @@ public class BenchmarkNodeScheduler
             finalizerService.destroy();
         }
 
-        private NodeSchedulerConfig getNodeSchedulerConfig()
+        public NodeSchedulerConfig getNodeSchedulerConfig()
         {
             return new NodeSchedulerConfig()
                             .setMaxSplitsPerNode(MAX_SPLITS_PER_NODE)


### PR DESCRIPTION
Like `hash_partition_count`, if we're able to specify number of source node candidates, we could throttle processing of partitioned splits per query. A large scan query might get better performance by specifying large number or a low priority query could run on smaller set of worker nodes.   