### PR TITLE
Varchar(x) in JMX connector

### DIFF
--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
@@ -46,7 +46,7 @@ import static com.facebook.presto.connector.jmx.Types.checkType;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
-import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static javax.management.ObjectName.WILDCARD;
@@ -90,7 +90,7 @@ public class JmxMetadata
             MBeanInfo mbeanInfo = mbeanServer.getMBeanInfo(objectName.get());
 
             ImmutableList.Builder<JmxColumnHandle> columns = ImmutableList.builder();
-            columns.add(new JmxColumnHandle(connectorId, "node", VARCHAR));
+            columns.add(new JmxColumnHandle(connectorId, "node", createUnboundedVarcharType()));
             for (MBeanAttributeInfo attribute : mbeanInfo.getAttributes()) {
                 if (!attribute.isReadable()) {
                     continue;
@@ -200,6 +200,6 @@ public class JmxMetadata
             case "java.lang.Double":
                 return DOUBLE;
         }
-        return VARCHAR;
+        return createUnboundedVarcharType();
     }
 }

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxSplitManager.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxSplitManager.java
@@ -32,7 +32,7 @@ import java.util.List;
 import static com.facebook.presto.connector.jmx.Types.checkType;
 import static com.facebook.presto.spi.NodeState.ACTIVE;
 import static com.facebook.presto.spi.predicate.TupleDomain.fromFixedValues;
-import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -62,7 +62,7 @@ public class JmxSplitManager
         List<ConnectorSplit> splits = nodeManager.getNodes(ACTIVE)
                 .stream()
                 .filter(node -> {
-                    NullableValue value = NullableValue.of(VARCHAR, utf8Slice(node.getNodeIdentifier()));
+                    NullableValue value = NullableValue.of(createUnboundedVarcharType(), utf8Slice(node.getNodeIdentifier()));
                     return predicate.overlaps(fromFixedValues(ImmutableMap.of(nodeColumnHandle, value)));
                 })
                 .map(node -> new JmxSplit(tableHandle, ImmutableList.of(node.getHostAndPort())))

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/MetadataUtil.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/MetadataUtil.java
@@ -25,7 +25,7 @@ import io.airlift.json.ObjectMapperProvider;
 import java.util.Map;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Locale.ENGLISH;
 
@@ -51,7 +51,7 @@ public final class MetadataUtil
     {
         private final Map<String, Type> types = ImmutableMap.<String, Type>builder()
                 .put(StandardTypes.BIGINT, BIGINT)
-                .put(VARCHAR.getTypeSignature().toString(), VARCHAR) // with max value length in signature
+                .put(StandardTypes.VARCHAR, createUnboundedVarcharType()) // with max value length in signature
                 .build();
 
         public TestingTypeDeserializer()

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxColumnHandle.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxColumnHandle.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
 
 import static com.facebook.presto.connector.jmx.MetadataUtil.COLUMN_CODEC;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static org.testng.Assert.assertEquals;
 
 public class TestJmxColumnHandle
@@ -26,7 +26,7 @@ public class TestJmxColumnHandle
     @Test
     public void testJsonRoundTrip()
     {
-        JmxColumnHandle handle = new JmxColumnHandle("connectorId", "columnName", VARCHAR);
+        JmxColumnHandle handle = new JmxColumnHandle("connectorId", "columnName", createUnboundedVarcharType());
         String json = COLUMN_CODEC.toJson(handle);
         JmxColumnHandle copy = COLUMN_CODEC.fromJson(json);
         assertEquals(copy, handle);
@@ -37,14 +37,14 @@ public class TestJmxColumnHandle
     {
         EquivalenceTester.equivalenceTester()
                 .addEquivalentGroup(
-                        new JmxColumnHandle("connectorId", "columnName", VARCHAR),
-                        new JmxColumnHandle("connectorId", "columnName", VARCHAR))
+                        new JmxColumnHandle("connectorId", "columnName", createUnboundedVarcharType()),
+                        new JmxColumnHandle("connectorId", "columnName", createUnboundedVarcharType()))
                 .addEquivalentGroup(
-                        new JmxColumnHandle("connectorIdX", "columnName", VARCHAR),
-                        new JmxColumnHandle("connectorIdX", "columnName", VARCHAR))
+                        new JmxColumnHandle("connectorIdX", "columnName", createUnboundedVarcharType()),
+                        new JmxColumnHandle("connectorIdX", "columnName", createUnboundedVarcharType()))
                 .addEquivalentGroup(
-                        new JmxColumnHandle("connectorId", "columnNameX", VARCHAR),
-                        new JmxColumnHandle("connectorId", "columnNameX", VARCHAR))
+                        new JmxColumnHandle("connectorId", "columnNameX", createUnboundedVarcharType()),
+                        new JmxColumnHandle("connectorId", "columnNameX", createUnboundedVarcharType()))
                 .addEquivalentGroup(
                         new JmxColumnHandle("connectorId", "columnName", BIGINT),
                         new JmxColumnHandle("connectorId", "columnName", BIGINT))

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxMetadata.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxMetadata.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
-import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
 import static java.util.Locale.ENGLISH;
@@ -56,8 +56,8 @@ public class TestJmxMetadata
         assertEquals(handle.getObjectName(), RUNTIME_OBJECT);
 
         List<JmxColumnHandle> columns = handle.getColumns();
-        assertTrue(columns.contains(new JmxColumnHandle("test", "node", VARCHAR)));
-        assertTrue(columns.contains(new JmxColumnHandle("test", "Name", VARCHAR)));
+        assertTrue(columns.contains(new JmxColumnHandle("test", "node", createUnboundedVarcharType())));
+        assertTrue(columns.contains(new JmxColumnHandle("test", "Name", createUnboundedVarcharType())));
         assertTrue(columns.contains(new JmxColumnHandle("test", "StartTime", BigintType.BIGINT)));
     }
 }

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxSplitManager.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxSplitManager.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
-import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.String.format;
@@ -50,7 +50,7 @@ public class TestJmxSplitManager
     private final Node localNode = new TestingNode("host1");
     private final Set<Node> nodes = ImmutableSet.of(localNode, new TestingNode("host2"), new TestingNode("host3"));
 
-    private final JmxColumnHandle columnHandle = new JmxColumnHandle("test", "node", VARCHAR);
+    private final JmxColumnHandle columnHandle = new JmxColumnHandle("test", "node", createUnboundedVarcharType());
     private final JmxTableHandle tableHandle = new JmxTableHandle("test", "objectName", ImmutableList.of(columnHandle));
     private final JmxSplitManager splitManager = new JmxSplitManager("test", new TestingNodeManager());
     private final JmxMetadata metadata = new JmxMetadata("test", getPlatformMBeanServer());
@@ -62,7 +62,7 @@ public class TestJmxSplitManager
     {
         for (Node node : nodes) {
             String nodeIdentifier = node.getNodeIdentifier();
-            TupleDomain<ColumnHandle> nodeTupleDomain = TupleDomain.fromFixedValues(ImmutableMap.of(columnHandle, NullableValue.of(VARCHAR, utf8Slice(nodeIdentifier))));
+            TupleDomain<ColumnHandle> nodeTupleDomain = TupleDomain.fromFixedValues(ImmutableMap.of(columnHandle, NullableValue.of(createUnboundedVarcharType(), utf8Slice(nodeIdentifier))));
             ConnectorTableLayoutHandle layout = new JmxTableLayoutHandle(tableHandle, nodeTupleDomain);
 
             ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout);

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxTableHandle.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxTableHandle.java
@@ -21,14 +21,14 @@ import java.util.List;
 
 import static com.facebook.presto.connector.jmx.MetadataUtil.TABLE_CODEC;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static org.testng.Assert.assertEquals;
 
 public class TestJmxTableHandle
 {
     public static final List<JmxColumnHandle> COLUMNS = ImmutableList.<JmxColumnHandle>builder()
             .add(new JmxColumnHandle("connectorId", "id", BIGINT))
-            .add(new JmxColumnHandle("connectorId", "name", VARCHAR))
+            .add(new JmxColumnHandle("connectorId", "name", createUnboundedVarcharType()))
             .build();
     public static final JmxTableHandle TABLE = new JmxTableHandle("connectorId", "objectName", COLUMNS);
 


### PR DESCRIPTION
It is not possible to determine exact length for VARCHAR
columns in JMX, so the only thing can be made here is to
replace `VarcharType.VARCHAR` constant with the explicit
invocation of the `createUnboundedVarcharType`.