### PR TITLE
[WIP] Add map literal syntax

### DIFF
--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -9,6 +9,13 @@ The ``[]`` operator is used to retrieve the value corresponding to a given key f
 
     SELECT name_to_age_map['Bob'] AS bob_age
 
+Map Literals
+------------
+
+Map literal values can be constructed using a syntax similar to Python's `dictionary displays <https://docs.python.org/3.5/reference/expressions.html#dictionary-displays>`_::
+
+    SELECT {'a': 1, 'b': 2, 'c': 3} AS dict
+
 Map Functions
 -------------
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -566,16 +566,23 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitMapConstructor(MapConstructor node, StackableAstVisitorContext<AnalysisContext> context)
         {
-            ImmutableList.Builder<TypeSignature> keyTypes = ImmutableList.builder();
-            ImmutableList.Builder<TypeSignature> valueTypes = ImmutableList.builder();
+
             List<Expression> keys = node.getKeys();
-            List<Expression> values = node.getValues();
-            int numberOfPairs = keys.size();
-            for (int i = 0; i < numberOfPairs; ++i) {
-                keyTypes.add(process(keys.get(i), context).getTypeSignature());
-                valueTypes.add(process(values.get(i), context).getTypeSignature());
+            ImmutableList.Builder<TypeSignature> keyTypes = ImmutableList.builder();
+
+            for (Expression keyExpression : keys) {
+                keyTypes.add(process(keyExpression, context).getTypeSignature());
             }
+
             Type keyType = coerceToSingleType(context, "All MAP keys must be the same type", keys);
+
+            List<Expression> values = node.getValues();
+            ImmutableList.Builder<TypeSignature> valueTypes = ImmutableList.builder();
+
+            for (Expression valueExpression : values) {
+                valueTypes.add(process(valueExpression, context).getTypeSignature());
+            }
+
             Type valueType = coerceToSingleType(context, "All MAP values must be the same type", values);
             Type mapType = typeManager.getParameterizedType(MAP.getName(), ImmutableList.of(keyType.getTypeSignature(), valueType.getTypeSignature()), ImmutableList.of());
             expressionTypes.put(node, mapType);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -566,7 +566,6 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitMapConstructor(MapConstructor node, StackableAstVisitorContext<AnalysisContext> context)
         {
-
             List<Expression> keys = node.getKeys();
             ImmutableList.Builder<TypeSignature> keyTypes = ImmutableList.builder();
 

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -126,6 +126,18 @@ public class TestMapOperators
     }
 
     @Test
+    public void testLiteral()
+            throws Exception
+    {
+        assertFunction("{'a': 1}", new MapType(createVarcharType(1), INTEGER), ImmutableMap.of("a", 1));
+        assertFunction("{'a': 1, 'b': 3}", new MapType(createVarcharType(1), INTEGER), ImmutableMap.of("a", 1, "b", 3));
+        assertFunction("{'a': 2 * 3.0, 'b': 3.4 * 1.2, 'c': 2 / 2.0}",
+                new MapType(createVarcharType(1), DOUBLE), ImmutableMap.of("a", 2 * 3.0, "b", 3.4 * 1.2, "c", 2 / 2.0));
+        assertFunction("CARDINALITY({'a': 2 * 3.0, 'b': 3.4 * 1.2, 'c': 2 / 2.0})", BIGINT, 3L);
+        assertFunction("MAP_KEYS({'a': 2 * 3.0, 'b': 3.4 * 1.2, 'c': 2 / 2.0})", new ArrayType(createVarcharType(1)), ImmutableList.of("a", "b", "c"));
+    }
+
+    @Test
     public void testCardinality()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -135,6 +135,7 @@ public class TestMapOperators
                 new MapType(createVarcharType(1), DOUBLE), ImmutableMap.of("a", 2 * 3.0, "b", 3.4 * 1.2, "c", 2 / 2.0));
         assertFunction("CARDINALITY({'a': 2 * 3.0, 'b': 3.4 * 1.2, 'c': 2 / 2.0})", BIGINT, 3L);
         assertFunction("MAP_KEYS({'a': 2 * 3.0, 'b': 3.4 * 1.2, 'c': 2 / 2.0})", new ArrayType(createVarcharType(1)), ImmutableList.of("a", "b", "c"));
+        assertFunction("{}", new MapType(UNKNOWN, UNKNOWN), ImmutableMap.of());
     }
 
     @Test

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -256,6 +256,7 @@ primaryExpression
     | booleanValue                                                                   #booleanLiteral
     | STRING                                                                         #stringLiteral
     | BINARY_LITERAL                                                                 #binaryLiteral
+    | '{' (mapKey ':' mapValue (',' mapKey ':' mapValue)*)? '}'                      #mapConstructor
     | POSITION '(' valueExpression IN valueExpression ')'                            #position
     | '(' expression (',' expression)+ ')'                                           #rowConstructor
     | ROW '(' expression (',' expression)* ')'                                       #rowConstructor
@@ -281,6 +282,14 @@ primaryExpression
     | NORMALIZE '(' valueExpression (',' normalForm)? ')'                            #normalize
     | EXTRACT '(' identifier FROM valueExpression ')'                                #extract
     | '(' expression ')'                                                             #parenthesizedExpression
+    ;
+
+mapKey
+    : expression
+    ;
+
+mapValue
+    : expression
     ;
 
 timeZoneSpecifier

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -256,7 +256,7 @@ primaryExpression
     | booleanValue                                                                   #booleanLiteral
     | STRING                                                                         #stringLiteral
     | BINARY_LITERAL                                                                 #binaryLiteral
-    | '{' (mapKey ':' mapValue (',' mapKey ':' mapValue)*)? '}'                      #mapConstructor
+    | '{' (keys+=expression ':' values+=expression (',' keys+=expression ':' values+=expression)*)? '}' #mapConstructor
     | POSITION '(' valueExpression IN valueExpression ')'                            #position
     | '(' expression (',' expression)+ ')'                                           #rowConstructor
     | ROW '(' expression (',' expression)* ')'                                       #rowConstructor
@@ -282,14 +282,6 @@ primaryExpression
     | NORMALIZE '(' valueExpression (',' normalForm)? ')'                            #normalize
     | EXTRACT '(' identifier FROM valueExpression ')'                                #extract
     | '(' expression ')'                                                             #parenthesizedExpression
-    ;
-
-mapKey
-    : expression
-    ;
-
-mapValue
-    : expression
     ;
 
 timeZoneSpecifier

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -49,6 +49,7 @@ import com.facebook.presto.sql.tree.LambdaExpression;
 import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.MapConstructor;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullIfExpression;
@@ -179,6 +180,20 @@ public final class ExpressionFormatter
                 valueStrings.add(formatSql(value, unmangleNames));
             }
             return "ARRAY[" + Joiner.on(",").join(valueStrings.build()) + "]";
+        }
+
+        @Override
+        protected String visitMapConstructor(MapConstructor node, Boolean unmangleNames)
+        {
+            ImmutableList.Builder<String> mapElementStrings = ImmutableList.builder();
+            List<Expression> keys = node.getKeys();
+            List<Expression> values = node.getValues();
+            int numberOfPairs = keys.size();
+
+            for (int i = 0; i < numberOfPairs; ++i) {
+                mapElementStrings.add(format("%s: %s", formatSql(keys.get(i), unmangleNames), formatSql(values.get(i), unmangleNames)));
+            }
+            return format("{%s}", Joiner.on(",").join(mapElementStrings.build()));
         }
 
         @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -193,7 +193,7 @@ public final class ExpressionFormatter
             for (int i = 0; i < numberOfPairs; ++i) {
                 mapElementStrings.add(format("%s: %s", formatSql(keys.get(i), unmangleNames), formatSql(values.get(i), unmangleNames)));
             }
-            return format("{%s}", Joiner.on(",").join(mapElementStrings.build()));
+            return format("{%s}", Joiner.on(", ").join(mapElementStrings.build()));
         }
 
         @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -959,8 +959,8 @@ class AstBuilder
     public Node visitMapConstructor(SqlBaseParser.MapConstructorContext context)
     {
         return new MapConstructor(getLocation(context),
-                visit(context.mapKey(), Expression.class),
-                visit(context.mapValue(), Expression.class));
+                visit(context.keys, Expression.class),
+                visit(context.values, Expression.class));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -75,6 +75,7 @@ import com.facebook.presto.sql.tree.LambdaExpression;
 import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.MapConstructor;
 import com.facebook.presto.sql.tree.NaturalJoin;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NodeLocation;
@@ -952,6 +953,14 @@ class AstBuilder
     public Node visitArrayConstructor(SqlBaseParser.ArrayConstructorContext context)
     {
         return new ArrayConstructor(getLocation(context), visit(context.expression(), Expression.class));
+    }
+
+    @Override
+    public Node visitMapConstructor(SqlBaseParser.MapConstructorContext context)
+    {
+        return new MapConstructor(getLocation(context),
+                visit(context.mapKey(), Expression.class),
+                visit(context.mapValue(), Expression.class));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -342,6 +342,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitMapConstructor(MapConstructor node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitSubscriptExpression(SubscriptExpression node, C context)
     {
         return visitExpression(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -77,6 +77,20 @@ public abstract class DefaultTraversalVisitor<R, C>
     }
 
     @Override
+    protected R visitMapConstructor(MapConstructor node, C context)
+    {
+        for (Expression keyExpression : node.getKeys()) {
+            process(keyExpression, context);
+        }
+
+        for (Expression valueExpression : node.getValues()) {
+            process(valueExpression, context);
+        }
+
+        return null;
+    }
+
+    @Override
     protected R visitSubscriptExpression(SubscriptExpression node, C context)
     {
         process(node.getBase(), context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -17,7 +17,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public final class ExpressionTreeRewriter<C>
 {
@@ -151,6 +153,20 @@ public final class ExpressionTreeRewriter<C>
             }
 
             return node;
+        }
+
+        @Override
+        protected Expression visitMapConstructor(MapConstructor node, Context<C> context)
+        {
+            QualifiedName mapConstructorName = QualifiedName.of(MapConstructor.MAP_CONSTRUCTOR);
+            QualifiedName arrayConstructorName = QualifiedName.of(ArrayConstructor.ARRAY_CONSTRUCTOR);
+            List<Expression> arguments = ImmutableList.of(
+                    new FunctionCall(arrayConstructorName,
+                            node.getKeys().stream().map(key -> rewrite(key, context.get())).collect(Collectors.toList())),
+                    new FunctionCall(arrayConstructorName,
+                            node.getValues().stream().map(value -> rewrite(value, context.get())).collect(Collectors.toList()))
+            );
+            return new FunctionCall(mapConstructorName, arguments);
         }
 
         @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/MapConstructor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/MapConstructor.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class MapConstructor
+    extends Expression
+{
+    public static final String MAP_CONSTRUCTOR = "MAP";
+    private final List<Expression> keys;
+    private final List<Expression> values;
+
+    public MapConstructor(List<Expression> keys, List<Expression> values)
+    {
+        this(Optional.empty(), keys, values);
+    }
+
+    public MapConstructor(NodeLocation location, List<Expression> keys, List<Expression> values)
+    {
+        this(Optional.of(location), keys, values);
+    }
+
+    private MapConstructor(Optional<NodeLocation> location, List<Expression> keys, List<Expression> values)
+    {
+        super(location);
+        requireNonNull(keys, "keys is null");
+        requireNonNull(values, "values is null");
+        this.keys = ImmutableList.copyOf(keys);
+        this.values = ImmutableList.copyOf(values);
+    }
+
+    public List<Expression> getKeys()
+    {
+        return keys;
+    }
+
+    public List<Expression> getValues()
+    {
+        return values;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitMapConstructor(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MapConstructor that = (MapConstructor) o;
+        return Objects.equals(keys, that.keys) && Objects.equals(values, that.values);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return keys.hashCode() + values.hashCode();
+    }
+}


### PR DESCRIPTION
Work in progress implementation of a map literal syntax similar to Python's [dictionary displays](https://docs.python.org/2/reference/expressions.html#dictionary-displays). It works by rewriting `{key1: value1, ..., keyN: valueN}` to `MAP(ARRAY[key1, ..., keyN], ARRAY[value1, ..., valueN])`

Closes #5065.

Other languages:
- Python/Nim/VimScript/JavaScript/Objective-C: `{key1: value1, ..., keyN: valueN}`
- Perl/Ruby/Julia: `{key1 => value1, ..., keyN => valueN}`
- PHP `array(key1 => value1, ..., keyN => valueN)`
- Clojure: `{:key1 value1 ... :keyN valueN}`
- D/Swift: `[key1:value1, ..., keyN:valueN]`
- Go: `map[KeyType]ValueType{ key1: value1, ..., keyN: valueN }`
- [q](http://code.kx.com/wiki/Reference): [``a`b`c!1 2 3`](http://code.kx.com/wiki/Reference/BangSymbol) (not kidding)
- Scala: `Map(key1 -> value1, ..., keyN -> valueN)`
- Bash/KSH: `map=( [key1]=value1 ... [keyN]=valueN )`

Personally, I like either the Python or the Ruby syntax and those two seem to be the most prevalent.
