### PR TITLE
Update existing Presto views in Hive metastore

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.147.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.147.rst
@@ -6,3 +6,5 @@ Hive Changes
 ------------
 
 * Include path in unrecoverable S3 exception messages.
+* When replacing an existing Presto view, update the view data
+  in the Hive metastore rather than dropping and recreating it.


### PR DESCRIPTION
When replacing an existing Presto view, update the view data
in the Hive metastore rather than dropping and recreating it.