### PR TITLE
Spilling to disk for aggregation

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashAggregationBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashAggregationBenchmark.java
@@ -51,7 +51,8 @@ public class HashAggregationBenchmark
     {
         OperatorFactory tableScanOperator = createTableScanOperator(0, new PlanNodeId("test"), "orders", "orderstatus", "totalprice");
         List<Type> types = ImmutableList.of(tableScanOperator.getTypes().get(0));
-        HashAggregationOperatorFactory aggregationOperator = new HashAggregationOperatorFactory(1,
+        HashAggregationOperatorFactory aggregationOperator = new HashAggregationOperatorFactory(
+                1,
                 new PlanNodeId("test"),
                 types,
                 Ints.asList(0),

--- a/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
@@ -189,6 +189,12 @@ public class BigintGroupByHash
         return putIfAbsent(position, block);
     }
 
+    @Override
+    public int compare(int leftGroupId, int rightGroupId)
+    {
+        return Long.compare(valuesByGroupId.get(leftGroupId), valuesByGroupId.get(rightGroupId));
+    }
+
     private int putIfAbsent(int position, Block block)
     {
         if (block.isNull(position)) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
@@ -64,4 +64,6 @@ public interface GroupByHash
     boolean contains(int position, Page page, int[] hashChannels);
 
     int putIfAbsent(int position, Page page);
+
+    int compare(int leftGroupId, int rightGroupId);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -196,7 +196,7 @@ public class HashAggregationOperator
     @Override
     public boolean needsInput()
     {
-        return !finishing && outputIterator == null && (aggregationBuilder == null || !aggregationBuilder.isFull());
+        return !finishing && outputIterator == null && (aggregationBuilder == null || !aggregationBuilder.checkFullAndUpdateMemory());
     }
 
     @Override
@@ -217,7 +217,7 @@ public class HashAggregationOperator
             // assume initial aggregationBuilder is not full
         }
         else {
-            checkState(!aggregationBuilder.isFull(), "Aggregation buffer is full");
+            checkState(!aggregationBuilder.checkFullAndUpdateMemory(), "Aggregation buffer is full");
         }
         aggregationBuilder.processPage(page);
     }
@@ -235,7 +235,7 @@ public class HashAggregationOperator
             }
 
             // only flush if we are finishing or the aggregation builder is full
-            if (!finishing && !aggregationBuilder.isFull()) {
+            if (!finishing && !aggregationBuilder.checkFullAndUpdateMemory()) {
                 return null;
             }
 
@@ -309,7 +309,7 @@ public class HashAggregationOperator
             }
         }
 
-        public boolean isFull()
+        public boolean checkFullAndUpdateMemory()
         {
             long memorySize = groupByHash.getEstimatedSize();
             for (Aggregator aggregator : aggregators) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -13,40 +13,26 @@
  */
 package com.facebook.presto.operator;
 
-import com.facebook.presto.memory.LocalMemoryContext;
 import com.facebook.presto.operator.aggregation.AccumulatorFactory;
-import com.facebook.presto.operator.aggregation.GroupedAccumulator;
+import com.facebook.presto.operator.aggregation.builder.HashAggregationBuilder;
+import com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder;
+import com.facebook.presto.operator.aggregation.builder.SpillableHashAggregationBuilder;
 import com.facebook.presto.spi.Page;
-import com.facebook.presto.spi.PageBuilder;
-import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.spiller.Spiller;
 import com.facebook.presto.spi.spiller.SpillerFactory;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
-import com.google.common.base.Throwables;
-import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
-import com.google.common.primitives.Ints;
-import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
 
-import java.io.Closeable;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.IntStream;
 
-import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder.toTypes;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
@@ -199,7 +185,7 @@ public class HashAggregationOperator
 
     private final List<Type> types;
 
-    private GroupByHashAggregationBuilder aggregationBuilder;
+    private HashAggregationBuilder hashAggregationBuilder;
     private Iterator<Page> outputIterator;
     private boolean finishing;
 
@@ -253,13 +239,13 @@ public class HashAggregationOperator
     @Override
     public boolean isFinished()
     {
-        return finishing && aggregationBuilder == null && (outputIterator == null || !outputIterator.hasNext());
+        return finishing && hashAggregationBuilder == null && (outputIterator == null || !outputIterator.hasNext());
     }
 
     @Override
     public boolean needsInput()
     {
-        return !finishing && outputIterator == null && (aggregationBuilder == null || !aggregationBuilder.checkFullAndUpdateMemory());
+        return !finishing && outputIterator == null && (hashAggregationBuilder == null || !hashAggregationBuilder.checkFullAndUpdateMemory());
     }
 
     @Override
@@ -267,26 +253,38 @@ public class HashAggregationOperator
     {
         checkState(!finishing, "Operator is already finishing");
         requireNonNull(page, "page is null");
-        if (aggregationBuilder == null) {
-            aggregationBuilder = new GroupByHashAggregationBuilder(
-                    accumulatorFactories,
-                    step,
-                    expectedGroups,
-                    groupByTypes,
-                    groupByChannels,
-                    hashChannel,
-                    operatorContext,
-                    maxEntriesBeforeSpill,
-                    memoryLimitBeforeSpill,
-                    spillerFactory);
+        if (hashAggregationBuilder == null) {
+            if (step.isOutputPartial() || (maxEntriesBeforeSpill == 0 && memoryLimitBeforeSpill.toBytes() == 0)) {
+                hashAggregationBuilder = new InMemoryHashAggregationBuilder(
+                        accumulatorFactories,
+                        step,
+                        expectedGroups,
+                        groupByTypes,
+                        groupByChannels,
+                        hashChannel,
+                        operatorContext);
+            }
+            else {
+                hashAggregationBuilder = new SpillableHashAggregationBuilder(
+                        accumulatorFactories,
+                        step,
+                        expectedGroups,
+                        groupByTypes,
+                        groupByChannels,
+                        hashChannel,
+                        operatorContext,
+                        maxEntriesBeforeSpill,
+                        memoryLimitBeforeSpill,
+                        spillerFactory);
+            }
 
-            closer.register(aggregationBuilder);
+            closer.register(hashAggregationBuilder);
             // assume initial aggregationBuilder is not full
         }
         else {
-            checkState(!aggregationBuilder.checkFullAndUpdateMemory(), "Aggregation buffer is full");
+            checkState(!hashAggregationBuilder.checkFullAndUpdateMemory(), "Aggregation buffer is full");
         }
-        aggregationBuilder.processPage(page);
+        hashAggregationBuilder.processPage(page);
     }
 
     @Override
@@ -297,16 +295,16 @@ public class HashAggregationOperator
             outputIterator = null;
 
             // no data
-            if (aggregationBuilder == null) {
+            if (hashAggregationBuilder == null) {
                 return null;
             }
 
-            if (!finishing && (aggregationBuilder.isSpillInProgress() || !aggregationBuilder.checkFullAndUpdateMemory())) {
+            if (!finishing && (hashAggregationBuilder.isBusy() || !hashAggregationBuilder.checkFullAndUpdateMemory())) {
                 return null;
             }
 
-            outputIterator = aggregationBuilder.buildResult();
-            aggregationBuilder = null;
+            outputIterator = hashAggregationBuilder.buildResult();
+            hashAggregationBuilder = null;
 
             if (!outputIterator.hasNext()) {
                 // current output iterator is done
@@ -323,445 +321,5 @@ public class HashAggregationOperator
             throws IOException
     {
         closer.close();
-    }
-
-    private static List<Type> toTypes(List<? extends Type> groupByType, Step step, List<AccumulatorFactory> factories, Optional<Integer> hashChannel)
-    {
-        ImmutableList.Builder<Type> types = ImmutableList.builder();
-        types.addAll(groupByType);
-        if (hashChannel.isPresent()) {
-            types.add(BIGINT);
-        }
-        for (AccumulatorFactory factory : factories) {
-            types.add(new Aggregator(factory, step).getType());
-        }
-        return types.build();
-    }
-
-    private static class GroupByHashAggregationBuilder implements Closeable
-    {
-        private static final Logger log = Logger.get(GroupByHashAggregationBuilder.class);
-        private static final int MAX_GROUPS_COUNT_DURING_MERGE = 1_000_000;
-
-        private GroupByHash groupByHash;
-        private List<Aggregator> aggregators;
-        private final int expectedGroups;
-        private final List<Type> groupByTypes;
-        private List<Integer> groupByChannels;
-        private Optional<Integer> hashChannel;
-        private final OperatorContext operatorContext;
-        private final LocalMemoryContext systemMemoryContext;
-        private final boolean partial;
-        private final List<AccumulatorFactory> accumulatorFactories;
-        private Step step;
-        private final Optional<SpillerFactory> spillerFactory;
-        private final long maxEntriesBeforeSpill;
-        private final long memorySizeBeforeSpill;
-        private Optional<Spiller> spiller = Optional.empty();
-        private CompletableFuture<?> spillInProgress = CompletableFuture.completedFuture(null);
-
-        private GroupByHashAggregationBuilder(
-                List<AccumulatorFactory> accumulatorFactories,
-                Step step,
-                int expectedGroups,
-                List<Type> groupByTypes,
-                List<Integer> groupByChannels,
-                Optional<Integer> hashChannel,
-                OperatorContext operatorContext,
-                long maxEntriesBeforeSpill,
-                DataSize memoryLimitBeforeSpill,
-                Optional<SpillerFactory> spillerFactory)
-        {
-            this.accumulatorFactories = accumulatorFactories;
-            this.step = step;
-            this.expectedGroups = expectedGroups;
-            this.groupByTypes = groupByTypes;
-            this.groupByChannels = groupByChannels;
-            this.hashChannel = hashChannel;
-            this.operatorContext = operatorContext;
-            this.partial = step.isOutputPartial();
-            this.maxEntriesBeforeSpill = maxEntriesBeforeSpill;
-            this.memorySizeBeforeSpill = memoryLimitBeforeSpill.toBytes();
-            this.spillerFactory = spillerFactory;
-            this.systemMemoryContext = operatorContext.getSystemMemoryContext().newLocalMemoryContext();
-
-            rebuildAggregators();
-        }
-
-        public void processPage(Page page)
-        {
-            checkState(!isSpillInProgress(), "Previous spill hasn't yet finished");
-
-            if (aggregators.isEmpty()) {
-                groupByHash.addPage(page);
-                return;
-            }
-
-            GroupByIdBlock groupIds = groupByHash.getGroupIds(page);
-
-            for (Aggregator aggregator : aggregators) {
-                aggregator.processPage(groupIds, page);
-            }
-        }
-
-        public boolean checkFullAndUpdateMemory()
-        {
-            if (isSpillInProgress()) {
-                return true;
-            }
-
-            long memorySize = getSizeInMemory();
-            if (partial) {
-                return !operatorContext.trySetMemoryReservation(memorySize);
-            }
-            else {
-                if (isSpillingEnabled()) {
-                    systemMemoryContext.setBytes(memorySize);
-
-                    if (shouldSpill(memorySize)) {
-                        spillToDisk();
-                    }
-                }
-                else {
-                    operatorContext.setMemoryReservation(memorySize);
-                }
-                return false;
-            }
-        }
-
-        private boolean shouldSpill(long memorySize)
-        {
-            return (maxEntriesBeforeSpill > 0 && groupByHash.getGroupCount() > maxEntriesBeforeSpill)
-                    || (memorySizeBeforeSpill > 0 && memorySize > memorySizeBeforeSpill);
-        }
-
-        private boolean isSpillingEnabled()
-        {
-            return maxEntriesBeforeSpill > 0 || memorySizeBeforeSpill > 0;
-        }
-
-        public Iterator<Page> buildResult()
-        {
-            checkState(!isSpillInProgress(), "Previous spill hasn't yet finished");
-
-            if (!spiller.isPresent()) {
-                return buildResultFromMemory();
-            }
-
-            try {
-                // TODO: don't spill here to disk, instead merge disk content with memory content
-                spillToDisk().get();
-                return mergeFromDisk();
-            }
-            catch (InterruptedException | ExecutionException e) {
-                Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
-            }
-        }
-
-        @Override
-        public void close()
-                throws IOException
-        {
-            if (spiller.isPresent()) {
-                spiller.get().close();
-                spiller = Optional.empty();
-            }
-        }
-
-        private CompletableFuture<?> spillToDisk()
-        {
-            for (Aggregator aggregator : aggregators) {
-                aggregator.setOutputPartial();
-            }
-
-            if (!spiller.isPresent()) {
-                spiller = Optional.of(spillerFactory.get().create(buildTypes()));
-            }
-
-            // start spilling process with current content of the aggregators and groupByHash...
-            spillInProgress = spiller.get().spill(buildResultFromMemory(sortedGroupIds(), buildTypes(), groupByHash, aggregators));
-            // ... and immediately create new aggregators and groupByHash so effectively memory ownership
-            // over groupByHash and aggregators is transferred from this thread to spilling thread
-            rebuildAggregators();
-
-            return spillInProgress;
-        }
-
-        private Iterator<Page> mergeFromDisk()
-        {
-            checkState(spiller.isPresent());
-
-            convertToMerge();
-            rebuildAggregatorsForMerge();
-
-            MergeSort mergeSort = new MergeSort(groupByTypes, buildIntermediateTypes());
-            Iterator<Page> mergedSpilledPages = mergeSort.merge(spiller.get().getSpills());
-
-            return buildResultFromMerge(mergedSpilledPages);
-        }
-
-        private Iterator<Page> buildResultFromMerge(Iterator<Page> mergedPages)
-        {
-            return new Iterator<Page>() {
-                private Iterator<Page> resultPages = Collections.emptyIterator();
-
-                @Override
-                public boolean hasNext()
-                {
-                    return mergedPages.hasNext() || resultPages.hasNext();
-                }
-
-                @Override
-                public Page next()
-                {
-                    if (!resultPages.hasNext()) {
-                        rebuildAggregatorsForMerge();
-                        long memorySize = 0; // ensure that at least one merged page will be processed
-
-                        while (mergedPages.hasNext() && !shouldSpill(memorySize)) {
-                            processPage(mergedPages.next());
-                            memorySize = getSizeInMemory();
-                            systemMemoryContext.setBytes(memorySize);
-                        }
-                        resultPages = buildResultFromMemory();
-                    }
-
-                    return resultPages.next();
-                }
-            };
-        }
-
-        private Iterator<Page> buildResultFromMemory()
-        {
-            return buildResultFromMemory(
-                    consecutiveGroupIds(),
-                    buildTypes(),
-                    groupByHash,
-                    aggregators);
-        }
-
-        private static Iterator<Page> buildResultFromMemory(
-                Iterator<Integer> groupIds,
-                List<Type> types,
-                GroupByHash groupByHash,
-                List<Aggregator> aggregators)
-        {
-            final PageBuilder pageBuilder = new PageBuilder(types);
-            return new AbstractIterator<Page>()
-            {
-                @Override
-                protected Page computeNext()
-                {
-                    if (!groupIds.hasNext()) {
-                        return endOfData();
-                    }
-
-                    pageBuilder.reset();
-
-                    List<Type> types = groupByHash.getTypes();
-                    while (!pageBuilder.isFull() && groupIds.hasNext()) {
-                        int groupId = groupIds.next();
-
-                        groupByHash.appendValuesTo(groupId, pageBuilder, 0);
-
-                        pageBuilder.declarePosition();
-                        for (int i = 0; i < aggregators.size(); i++) {
-                            Aggregator aggregator = aggregators.get(i);
-                            BlockBuilder output = pageBuilder.getBlockBuilder(types.size() + i);
-                            aggregator.evaluate(groupId, output);
-                        }
-                    }
-
-                    return pageBuilder.build();
-                }
-            };
-        }
-
-        private void rebuildAggregators()
-        {
-            groupByHash = createGroupByHash();
-            aggregators = createAggregators();
-        }
-
-        private void rebuildAggregatorsForMerge()
-        {
-            groupByHash = createGroupByHash();
-            aggregators = createAggregatorsForMerge(groupByHash.getTypes().size());
-        }
-
-        private GroupByHash createGroupByHash()
-        {
-            return GroupByHash.createGroupByHash(operatorContext.getSession(), groupByTypes, Ints.toArray(groupByChannels), hashChannel, expectedGroups);
-        }
-
-        private List<Aggregator> createAggregators()
-        {
-            // wrapper each function with an aggregator
-            ImmutableList.Builder<Aggregator> builder = ImmutableList.builder();
-
-            requireNonNull(accumulatorFactories, "accumulatorFactories is null");
-            for (int i = 0; i < accumulatorFactories.size(); i++) {
-                AccumulatorFactory accumulatorFactory = accumulatorFactories.get(i);
-                builder.add(new Aggregator(accumulatorFactory, step));
-            }
-            return builder.build();
-        }
-
-        private List<Aggregator> createAggregatorsForMerge(int numberOfColumnsInKey)
-        {
-            // wrapper each function with an aggregator
-            ImmutableList.Builder<Aggregator> builder = ImmutableList.builder();
-
-            requireNonNull(accumulatorFactories, "accumulatorFactories is null");
-            for (int i = 0; i < accumulatorFactories.size(); i++) {
-                AccumulatorFactory accumulatorFactory = accumulatorFactories.get(i);
-                builder.add(new Aggregator(accumulatorFactory, step, numberOfColumnsInKey + i));
-            }
-            return builder.build();
-        }
-
-        private void convertToMerge()
-        {
-            step = Step.partialInput(step);
-            ImmutableList.Builder<Integer> groupByPartialChannels = ImmutableList.builder();
-            for (int i = 0; i < groupByTypes.size(); i++) {
-                groupByPartialChannels.add(i);
-            }
-            if (hashChannel.isPresent()) {
-                hashChannel = Optional.of(groupByTypes.size());
-            }
-
-            groupByChannels = groupByPartialChannels.build();
-        }
-
-        private List<Type> buildIntermediateTypes()
-        {
-            ArrayList<Type> types = new ArrayList<>(groupByHash.getTypes());
-            for (Aggregator aggregator : aggregators) {
-                types.add(aggregator.getIntermediateType());
-            }
-            return types;
-        }
-
-        private List<Type> buildTypes()
-        {
-            ArrayList<Type> types = new ArrayList<>(groupByHash.getTypes());
-            for (Aggregator aggregator : aggregators) {
-                types.add(aggregator.getType());
-            }
-            return types;
-        }
-
-        private long getSizeInMemory()
-        {
-            long sizeInMemory = groupByHash.getEstimatedSize();
-            for (Aggregator aggregator : aggregators) {
-                sizeInMemory += aggregator.getEstimatedSize();
-            }
-            sizeInMemory -= operatorContext.getOperatorPreAllocatedMemory().toBytes();
-            if (sizeInMemory < 0) {
-                sizeInMemory = 0;
-            }
-            return sizeInMemory;
-        }
-
-        private Iterator<Integer> consecutiveGroupIds()
-        {
-            return IntStream.range(0, groupByHash.getGroupCount()).iterator();
-        }
-
-        private Iterator<Integer> sortedGroupIds()
-        {
-            List<Integer> groupIds = Lists.newArrayList(consecutiveGroupIds());
-            groupIds.sort(groupByHash::compare);
-            return groupIds.iterator();
-        }
-
-        public boolean isSpillInProgress()
-        {
-            return !spillInProgress.isDone();
-        }
-    }
-
-    private static class Aggregator
-    {
-        private final GroupedAccumulator aggregation;
-        private Step step;
-        private final int intermediateChannel;
-
-        private Aggregator(AccumulatorFactory accumulatorFactory, Step step)
-        {
-            if (step.isInputRaw()) {
-                intermediateChannel = -1;
-                aggregation = accumulatorFactory.createGroupedAccumulator();
-            }
-            else {
-                checkArgument(accumulatorFactory.getInputChannels().size() == 1, "expected 1 input channel for intermediate aggregation");
-                intermediateChannel = accumulatorFactory.getInputChannels().get(0);
-                aggregation = accumulatorFactory.createGroupedIntermediateAccumulator();
-            }
-            this.step = step;
-        }
-
-        public Aggregator(AccumulatorFactory accumulatorFactory, Step step, int intermediateChannel)
-        {
-            if (step.isInputRaw()) {
-                this.intermediateChannel = -1;
-                aggregation = accumulatorFactory.createGroupedAccumulator();
-            }
-            else {
-                //TODO: re-enable this check somehow?
-                //checkArgument(accumulatorFactory.getInputChannels().size() == 1, "expected 1 input channel for intermediate aggregation");
-                this.intermediateChannel = intermediateChannel;
-                aggregation = accumulatorFactory.createGroupedIntermediateAccumulator();
-            }
-            this.step = step;
-        }
-
-        public long getEstimatedSize()
-        {
-            return aggregation.getEstimatedSize();
-        }
-
-        public Type getIntermediateType()
-        {
-            return aggregation.getIntermediateType();
-        }
-
-        public Type getType()
-        {
-            if (step.isOutputPartial()) {
-                return aggregation.getIntermediateType();
-            }
-            else {
-                return aggregation.getFinalType();
-            }
-        }
-
-        public void processPage(GroupByIdBlock groupIds, Page page)
-        {
-            if (step.isInputRaw()) {
-                aggregation.addInput(groupIds, page);
-            }
-            else {
-                aggregation.addIntermediate(groupIds, page.getBlock(intermediateChannel));
-            }
-        }
-
-        public void evaluate(int groupId, BlockBuilder output)
-        {
-            if (step.isOutputPartial()) {
-                aggregation.evaluateIntermediate(groupId, output);
-            }
-            else {
-                aggregation.evaluateFinal(groupId, output);
-            }
-        }
-
-        public void setOutputPartial()
-        {
-            step = Step.partialOutput(step);
-        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -13,29 +13,42 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.memory.LocalMemoryContext;
 import com.facebook.presto.operator.aggregation.AccumulatorFactory;
 import com.facebook.presto.operator.aggregation.GroupedAccumulator;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.spiller.Spiller;
+import com.facebook.presto.spi.spiller.SpillerFactory;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.io.Closer;
 import com.google.common.primitives.Ints;
+import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
 
-import static com.facebook.presto.operator.GroupByHash.createGroupByHash;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
 
 public class HashAggregationOperator
@@ -51,11 +64,14 @@ public class HashAggregationOperator
         private final Step step;
         private final List<AccumulatorFactory> accumulatorFactories;
         private final Optional<Integer> hashChannel;
-
         private final int expectedGroups;
         private final List<Type> types;
-        private boolean closed;
         private final long maxPartialMemory;
+        private final long maxEntriesBeforeSpill;
+        private final DataSize memoryLimitBeforeSpill;
+        private final Optional<SpillerFactory> spillerFactory;
+
+        private boolean closed;
 
         public HashAggregationOperatorFactory(
                 int operatorId,
@@ -68,6 +84,34 @@ public class HashAggregationOperator
                 int expectedGroups,
                 DataSize maxPartialMemory)
         {
+            this(operatorId,
+                    planNodeId,
+                    groupByTypes,
+                    groupByChannels,
+                    step,
+                    accumulatorFactories,
+                    hashChannel,
+                    expectedGroups,
+                    maxPartialMemory,
+                    0,
+                    new DataSize(0, MEGABYTE),
+                    Optional.empty());
+        }
+
+        public HashAggregationOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                List<? extends Type> groupByTypes,
+                List<Integer> groupByChannels,
+                Step step,
+                List<AccumulatorFactory> accumulatorFactories,
+                Optional<Integer> hashChannel,
+                int expectedGroups,
+                DataSize maxPartialMemory,
+                long maxEntriesBeforeSpill,
+                DataSize memoryLimitBeforeSpill,
+                Optional<SpillerFactory> spillerFactory)
+        {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.hashChannel = requireNonNull(hashChannel, "hashChannel is null");
@@ -77,6 +121,9 @@ public class HashAggregationOperator
             this.accumulatorFactories = ImmutableList.copyOf(accumulatorFactories);
             this.expectedGroups = expectedGroups;
             this.maxPartialMemory = requireNonNull(maxPartialMemory, "maxPartialMemory is null").toBytes();
+            this.maxEntriesBeforeSpill = maxEntriesBeforeSpill;
+            this.memoryLimitBeforeSpill = requireNonNull(memoryLimitBeforeSpill, "memoryLimitBeforeSpill is null");
+            this.spillerFactory = requireNonNull(spillerFactory, "spillerFactory is null");
 
             this.types = toTypes(groupByTypes, step, accumulatorFactories, hashChannel);
         }
@@ -106,7 +153,10 @@ public class HashAggregationOperator
                     step,
                     accumulatorFactories,
                     hashChannel,
-                    expectedGroups);
+                    expectedGroups,
+                    maxEntriesBeforeSpill,
+                    memoryLimitBeforeSpill,
+                    spillerFactory);
             return hashAggregationOperator;
         }
 
@@ -128,7 +178,10 @@ public class HashAggregationOperator
                     accumulatorFactories,
                     hashChannel,
                     expectedGroups,
-                    new DataSize(maxPartialMemory, Unit.BYTE));
+                    new DataSize(maxPartialMemory, Unit.BYTE),
+                    maxEntriesBeforeSpill,
+                    memoryLimitBeforeSpill,
+                    spillerFactory);
         }
     }
 
@@ -139,6 +192,10 @@ public class HashAggregationOperator
     private final List<AccumulatorFactory> accumulatorFactories;
     private final Optional<Integer> hashChannel;
     private final int expectedGroups;
+    private final Optional<SpillerFactory> spillerFactory;
+    private final long maxEntriesBeforeSpill;
+    private final DataSize memoryLimitBeforeSpill;
+    private final Closer closer = Closer.create();
 
     private final List<Type> types;
 
@@ -153,7 +210,10 @@ public class HashAggregationOperator
             Step step,
             List<AccumulatorFactory> accumulatorFactories,
             Optional<Integer> hashChannel,
-            int expectedGroups)
+            int expectedGroups,
+            long maxEntriesBeforeSpill,
+            DataSize memoryLimitBeforeSpill,
+            Optional<SpillerFactory> spillerFactory)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         requireNonNull(step, "step is null");
@@ -167,6 +227,9 @@ public class HashAggregationOperator
         this.step = step;
         this.expectedGroups = expectedGroups;
         this.types = toTypes(groupByTypes, step, accumulatorFactories, hashChannel);
+        this.spillerFactory = requireNonNull(spillerFactory, "spillerFactory is null");
+        this.maxEntriesBeforeSpill = maxEntriesBeforeSpill;
+        this.memoryLimitBeforeSpill = requireNonNull(memoryLimitBeforeSpill, "memoryLimitBeforeSpill is null");
     }
 
     @Override
@@ -212,8 +275,12 @@ public class HashAggregationOperator
                     groupByTypes,
                     groupByChannels,
                     hashChannel,
-                    operatorContext);
+                    operatorContext,
+                    maxEntriesBeforeSpill,
+                    memoryLimitBeforeSpill,
+                    spillerFactory);
 
+            closer.register(aggregationBuilder);
             // assume initial aggregationBuilder is not full
         }
         else {
@@ -234,12 +301,11 @@ public class HashAggregationOperator
                 return null;
             }
 
-            // only flush if we are finishing or the aggregation builder is full
-            if (!finishing && !aggregationBuilder.checkFullAndUpdateMemory()) {
+            if (!finishing && (aggregationBuilder.isSpillInProgress() || !aggregationBuilder.checkFullAndUpdateMemory())) {
                 return null;
             }
 
-            outputIterator = aggregationBuilder.build();
+            outputIterator = aggregationBuilder.buildResult();
             aggregationBuilder = null;
 
             if (!outputIterator.hasNext()) {
@@ -250,6 +316,13 @@ public class HashAggregationOperator
         }
 
         return outputIterator.next();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        closer.close();
     }
 
     private static List<Type> toTypes(List<? extends Type> groupByType, Step step, List<AccumulatorFactory> factories, Optional<Integer> hashChannel)
@@ -265,12 +338,27 @@ public class HashAggregationOperator
         return types.build();
     }
 
-    private static class GroupByHashAggregationBuilder
+    private static class GroupByHashAggregationBuilder implements Closeable
     {
-        private final GroupByHash groupByHash;
-        private final List<Aggregator> aggregators;
+        private static final Logger log = Logger.get(GroupByHashAggregationBuilder.class);
+        private static final int MAX_GROUPS_COUNT_DURING_MERGE = 1_000_000;
+
+        private GroupByHash groupByHash;
+        private List<Aggregator> aggregators;
+        private final int expectedGroups;
+        private final List<Type> groupByTypes;
+        private List<Integer> groupByChannels;
+        private Optional<Integer> hashChannel;
         private final OperatorContext operatorContext;
+        private final LocalMemoryContext systemMemoryContext;
         private final boolean partial;
+        private final List<AccumulatorFactory> accumulatorFactories;
+        private Step step;
+        private final Optional<SpillerFactory> spillerFactory;
+        private final long maxEntriesBeforeSpill;
+        private final long memorySizeBeforeSpill;
+        private Optional<Spiller> spiller = Optional.empty();
+        private CompletableFuture<?> spillInProgress = CompletableFuture.completedFuture(null);
 
         private GroupByHashAggregationBuilder(
                 List<AccumulatorFactory> accumulatorFactories,
@@ -279,24 +367,31 @@ public class HashAggregationOperator
                 List<Type> groupByTypes,
                 List<Integer> groupByChannels,
                 Optional<Integer> hashChannel,
-                OperatorContext operatorContext)
+                OperatorContext operatorContext,
+                long maxEntriesBeforeSpill,
+                DataSize memoryLimitBeforeSpill,
+                Optional<SpillerFactory> spillerFactory)
         {
-            this.groupByHash = createGroupByHash(operatorContext.getSession(), groupByTypes, Ints.toArray(groupByChannels), hashChannel, expectedGroups);
+            this.accumulatorFactories = accumulatorFactories;
+            this.step = step;
+            this.expectedGroups = expectedGroups;
+            this.groupByTypes = groupByTypes;
+            this.groupByChannels = groupByChannels;
+            this.hashChannel = hashChannel;
             this.operatorContext = operatorContext;
             this.partial = step.isOutputPartial();
+            this.maxEntriesBeforeSpill = maxEntriesBeforeSpill;
+            this.memorySizeBeforeSpill = memoryLimitBeforeSpill.toBytes();
+            this.spillerFactory = spillerFactory;
+            this.systemMemoryContext = operatorContext.getSystemMemoryContext().newLocalMemoryContext();
 
-            // wrapper each function with an aggregator
-            ImmutableList.Builder<Aggregator> builder = ImmutableList.builder();
-            requireNonNull(accumulatorFactories, "accumulatorFactories is null");
-            for (int i = 0; i < accumulatorFactories.size(); i++) {
-                AccumulatorFactory accumulatorFactory = accumulatorFactories.get(i);
-                builder.add(new Aggregator(accumulatorFactory, step));
-            }
-            aggregators = builder.build();
+            rebuildAggregators();
         }
 
-        private void processPage(Page page)
+        public void processPage(Page page)
         {
+            checkState(!isSpillInProgress(), "Previous spill hasn't yet finished");
+
             if (aggregators.isEmpty()) {
                 groupByHash.addPage(page);
                 return;
@@ -311,47 +406,163 @@ public class HashAggregationOperator
 
         public boolean checkFullAndUpdateMemory()
         {
-            long memorySize = groupByHash.getEstimatedSize();
-            for (Aggregator aggregator : aggregators) {
-                memorySize += aggregator.getEstimatedSize();
+            if (isSpillInProgress()) {
+                return true;
             }
-            memorySize -= operatorContext.getOperatorPreAllocatedMemory().toBytes();
-            if (memorySize < 0) {
-                memorySize = 0;
-            }
+
+            long memorySize = getSizeInMemory();
             if (partial) {
                 return !operatorContext.trySetMemoryReservation(memorySize);
             }
             else {
-                operatorContext.setMemoryReservation(memorySize);
+                if (isSpillingEnabled()) {
+                    systemMemoryContext.setBytes(memorySize);
+
+                    if (shouldSpill(memorySize)) {
+                        spillToDisk();
+                    }
+                }
+                else {
+                    operatorContext.setMemoryReservation(memorySize);
+                }
                 return false;
             }
         }
 
-        public Iterator<Page> build()
+        private boolean shouldSpill(long memorySize)
         {
-            List<Type> types = new ArrayList<>(groupByHash.getTypes());
-            for (Aggregator aggregator : aggregators) {
-                types.add(aggregator.getType());
+            return (maxEntriesBeforeSpill > 0 && groupByHash.getGroupCount() > maxEntriesBeforeSpill)
+                    || (memorySizeBeforeSpill > 0 && memorySize > memorySizeBeforeSpill);
+        }
+
+        private boolean isSpillingEnabled()
+        {
+            return maxEntriesBeforeSpill > 0 || memorySizeBeforeSpill > 0;
+        }
+
+        public Iterator<Page> buildResult()
+        {
+            checkState(!isSpillInProgress(), "Previous spill hasn't yet finished");
+
+            if (!spiller.isPresent()) {
+                return buildResultFromMemory();
             }
 
+            try {
+                // TODO: don't spill here to disk, instead merge disk content with memory content
+                spillToDisk().get();
+                return mergeFromDisk();
+            }
+            catch (InterruptedException | ExecutionException e) {
+                Thread.currentThread().interrupt();
+                throw Throwables.propagate(e);
+            }
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            if (spiller.isPresent()) {
+                spiller.get().close();
+                spiller = Optional.empty();
+            }
+        }
+
+        private CompletableFuture<?> spillToDisk()
+        {
+            for (Aggregator aggregator : aggregators) {
+                aggregator.setOutputPartial();
+            }
+
+            if (!spiller.isPresent()) {
+                spiller = Optional.of(spillerFactory.get().create(buildTypes()));
+            }
+
+            // start spilling process with current content of the aggregators and groupByHash...
+            spillInProgress = spiller.get().spill(buildResultFromMemory(sortedGroupIds(), buildTypes(), groupByHash, aggregators));
+            // ... and immediately create new aggregators and groupByHash so effectively memory ownership
+            // over groupByHash and aggregators is transferred from this thread to spilling thread
+            rebuildAggregators();
+
+            return spillInProgress;
+        }
+
+        private Iterator<Page> mergeFromDisk()
+        {
+            checkState(spiller.isPresent());
+
+            convertToMerge();
+            rebuildAggregatorsForMerge();
+
+            MergeSort mergeSort = new MergeSort(groupByTypes, buildIntermediateTypes());
+            Iterator<Page> mergedSpilledPages = mergeSort.merge(spiller.get().getSpills());
+
+            return buildResultFromMerge(mergedSpilledPages);
+        }
+
+        private Iterator<Page> buildResultFromMerge(Iterator<Page> mergedPages)
+        {
+            return new Iterator<Page>() {
+                private Iterator<Page> resultPages = Collections.emptyIterator();
+
+                @Override
+                public boolean hasNext()
+                {
+                    return mergedPages.hasNext() || resultPages.hasNext();
+                }
+
+                @Override
+                public Page next()
+                {
+                    if (!resultPages.hasNext()) {
+                        rebuildAggregatorsForMerge();
+                        long memorySize = 0; // ensure that at least one merged page will be processed
+
+                        while (mergedPages.hasNext() && !shouldSpill(memorySize)) {
+                            processPage(mergedPages.next());
+                            memorySize = getSizeInMemory();
+                            systemMemoryContext.setBytes(memorySize);
+                        }
+                        resultPages = buildResultFromMemory();
+                    }
+
+                    return resultPages.next();
+                }
+            };
+        }
+
+        private Iterator<Page> buildResultFromMemory()
+        {
+            return buildResultFromMemory(
+                    consecutiveGroupIds(),
+                    buildTypes(),
+                    groupByHash,
+                    aggregators);
+        }
+
+        private static Iterator<Page> buildResultFromMemory(
+                Iterator<Integer> groupIds,
+                List<Type> types,
+                GroupByHash groupByHash,
+                List<Aggregator> aggregators)
+        {
             final PageBuilder pageBuilder = new PageBuilder(types);
             return new AbstractIterator<Page>()
             {
-                private final int groupCount = groupByHash.getGroupCount();
-                private int groupId;
-
                 @Override
                 protected Page computeNext()
                 {
-                    if (groupId >= groupCount) {
+                    if (!groupIds.hasNext()) {
                         return endOfData();
                     }
 
                     pageBuilder.reset();
 
                     List<Type> types = groupByHash.getTypes();
-                    while (!pageBuilder.isFull() && groupId < groupCount) {
+                    while (!pageBuilder.isFull() && groupIds.hasNext()) {
+                        int groupId = groupIds.next();
+
                         groupByHash.appendValuesTo(groupId, pageBuilder, 0);
 
                         pageBuilder.declarePosition();
@@ -360,20 +571,123 @@ public class HashAggregationOperator
                             BlockBuilder output = pageBuilder.getBlockBuilder(types.size() + i);
                             aggregator.evaluate(groupId, output);
                         }
-
-                        groupId++;
                     }
 
                     return pageBuilder.build();
                 }
             };
         }
+
+        private void rebuildAggregators()
+        {
+            groupByHash = createGroupByHash();
+            aggregators = createAggregators();
+        }
+
+        private void rebuildAggregatorsForMerge()
+        {
+            groupByHash = createGroupByHash();
+            aggregators = createAggregatorsForMerge(groupByHash.getTypes().size());
+        }
+
+        private GroupByHash createGroupByHash()
+        {
+            return GroupByHash.createGroupByHash(operatorContext.getSession(), groupByTypes, Ints.toArray(groupByChannels), hashChannel, expectedGroups);
+        }
+
+        private List<Aggregator> createAggregators()
+        {
+            // wrapper each function with an aggregator
+            ImmutableList.Builder<Aggregator> builder = ImmutableList.builder();
+
+            requireNonNull(accumulatorFactories, "accumulatorFactories is null");
+            for (int i = 0; i < accumulatorFactories.size(); i++) {
+                AccumulatorFactory accumulatorFactory = accumulatorFactories.get(i);
+                builder.add(new Aggregator(accumulatorFactory, step));
+            }
+            return builder.build();
+        }
+
+        private List<Aggregator> createAggregatorsForMerge(int numberOfColumnsInKey)
+        {
+            // wrapper each function with an aggregator
+            ImmutableList.Builder<Aggregator> builder = ImmutableList.builder();
+
+            requireNonNull(accumulatorFactories, "accumulatorFactories is null");
+            for (int i = 0; i < accumulatorFactories.size(); i++) {
+                AccumulatorFactory accumulatorFactory = accumulatorFactories.get(i);
+                builder.add(new Aggregator(accumulatorFactory, step, numberOfColumnsInKey + i));
+            }
+            return builder.build();
+        }
+
+        private void convertToMerge()
+        {
+            step = Step.partialInput(step);
+            ImmutableList.Builder<Integer> groupByPartialChannels = ImmutableList.builder();
+            for (int i = 0; i < groupByTypes.size(); i++) {
+                groupByPartialChannels.add(i);
+            }
+            if (hashChannel.isPresent()) {
+                hashChannel = Optional.of(groupByTypes.size());
+            }
+
+            groupByChannels = groupByPartialChannels.build();
+        }
+
+        private List<Type> buildIntermediateTypes()
+        {
+            ArrayList<Type> types = new ArrayList<>(groupByHash.getTypes());
+            for (Aggregator aggregator : aggregators) {
+                types.add(aggregator.getIntermediateType());
+            }
+            return types;
+        }
+
+        private List<Type> buildTypes()
+        {
+            ArrayList<Type> types = new ArrayList<>(groupByHash.getTypes());
+            for (Aggregator aggregator : aggregators) {
+                types.add(aggregator.getType());
+            }
+            return types;
+        }
+
+        private long getSizeInMemory()
+        {
+            long sizeInMemory = groupByHash.getEstimatedSize();
+            for (Aggregator aggregator : aggregators) {
+                sizeInMemory += aggregator.getEstimatedSize();
+            }
+            sizeInMemory -= operatorContext.getOperatorPreAllocatedMemory().toBytes();
+            if (sizeInMemory < 0) {
+                sizeInMemory = 0;
+            }
+            return sizeInMemory;
+        }
+
+        private Iterator<Integer> consecutiveGroupIds()
+        {
+            return IntStream.range(0, groupByHash.getGroupCount()).iterator();
+        }
+
+        private Iterator<Integer> sortedGroupIds()
+        {
+            List<Integer> groupIds = Lists.newArrayList(consecutiveGroupIds());
+            groupIds.sort(groupByHash::compare);
+            return groupIds.iterator();
+        }
+
+        public boolean isSpillInProgress()
+        {
+            return !spillInProgress.isDone();
+        }
     }
 
     private static class Aggregator
     {
         private final GroupedAccumulator aggregation;
-        private final Step step;
+        private Step step;
         private final int intermediateChannel;
 
         private Aggregator(AccumulatorFactory accumulatorFactory, Step step)
@@ -390,9 +704,29 @@ public class HashAggregationOperator
             this.step = step;
         }
 
+        public Aggregator(AccumulatorFactory accumulatorFactory, Step step, int intermediateChannel)
+        {
+            if (step.isInputRaw()) {
+                this.intermediateChannel = -1;
+                aggregation = accumulatorFactory.createGroupedAccumulator();
+            }
+            else {
+                //TODO: re-enable this check somehow?
+                //checkArgument(accumulatorFactory.getInputChannels().size() == 1, "expected 1 input channel for intermediate aggregation");
+                this.intermediateChannel = intermediateChannel;
+                aggregation = accumulatorFactory.createGroupedIntermediateAccumulator();
+            }
+            this.step = step;
+        }
+
         public long getEstimatedSize()
         {
             return aggregation.getEstimatedSize();
+        }
+
+        public Type getIntermediateType()
+        {
+            return aggregation.getIntermediateType();
         }
 
         public Type getType()
@@ -423,6 +757,11 @@ public class HashAggregationOperator
             else {
                 aggregation.evaluateFinal(groupId, output);
             }
+        }
+
+        public void setOutputPartial()
+        {
+            step = Step.partialOutput(step);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/MergeSort.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MergeSort.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.Iterators;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class MergeSort
+{
+    private final List<Type> keyTypes;
+    private final List<Type> allTypes;
+
+    public MergeSort(List<Type> keyTypes, List<Type> allTypes)
+    {
+        this.keyTypes = requireNonNull(keyTypes, "keyTypes is null");
+        this.allTypes = requireNonNull(allTypes, "allTypes is null");
+    }
+
+    public Iterator<Page> merge(List<Iterator<Page>> channels)
+    {
+        List<Iterator<PagePosition>> channelIterators = channels.stream().map(SingleChannelPagePositions::new).collect(toList());
+
+        return new PageRewriteIterator(keyTypes, allTypes, Iterators.mergeSorted(channelIterators, this::comparePages));
+    }
+
+    private int comparePages(PagePosition left, PagePosition right)
+    {
+        return comparePages(keyTypes, left, right);
+    }
+
+    private static int comparePages(List<Type> keyTypes, PagePosition left, PagePosition right)
+    {
+        if (left.isPositionOutOfPage() && right.isPositionOutOfPage()) {
+            return 0;
+        }
+        if (left.isPositionOutOfPage()) {
+            return -1;
+        }
+        if (right.isPositionOutOfPage()) {
+            return 1;
+        }
+
+        for (int column = 0; column < keyTypes.size(); column++) {
+            int compare = keyTypes.get(column).compareTo(
+                    left.getPage().getBlock(column),
+                    left.getPosition(),
+                    right.getPage().getBlock(column),
+                    right.getPosition());
+            if (compare != 0) {
+                return compare;
+            }
+        }
+        return 0;
+    }
+
+    public static class PagePosition
+    {
+        private final Page page;
+        private final int position;
+
+        public PagePosition(Page page, int position)
+        {
+            this.page = requireNonNull(page, "page is null");
+            this.position = requireNonNull(position, "position is null");
+        }
+
+        public Page getPage()
+        {
+            return page;
+        }
+
+        public int getPosition()
+        {
+            return position;
+        }
+
+        public boolean isPositionOutOfPage()
+        {
+            return position >= page.getPositionCount();
+        }
+    }
+
+    public static interface PagePositions extends Iterator<PagePosition>
+    {
+    }
+
+    public static class SingleChannelPagePositions
+            implements PagePositions
+    {
+        private final Iterator<Page> channel;
+        private PagePosition current;
+
+        public SingleChannelPagePositions(Iterator<Page> channel)
+        {
+            this.channel = requireNonNull(channel, "channel is null");
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return channel.hasNext() || (current != null && current.getPosition() + 1 < current.getPage().getPositionCount());
+        }
+
+        @Override
+        public PagePosition next()
+        {
+            if (current == null || current.getPosition() + 1 >= current.getPage().getPositionCount()) {
+                current = new PagePosition(channel.next(), 0);
+            }
+            else {
+                current = new PagePosition(current.getPage(), current.getPosition() + 1);
+            }
+            return current;
+        }
+    }
+
+    /**
+     * This class rewrites iterator over PagePosition to iterator over Pages
+     */
+    public static class PageRewriteIterator
+            implements Iterator<Page>
+    {
+        private final List<Type> allTypes;
+        private final Iterator<PagePosition> pagePositions;
+        private final List<Type> keyTypes;
+        private final PageBuilder builder;
+        private PagePosition currentPage = null;
+
+        public PageRewriteIterator(List<Type> keyTypes, List<Type> allTypes, Iterator<PagePosition> pagePositions)
+        {
+            this.keyTypes = keyTypes;
+            this.allTypes = allTypes;
+            this.pagePositions = pagePositions;
+            this.builder = new PageBuilder(allTypes);
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return currentPage != null || pagePositions.hasNext();
+        }
+
+        @Override
+        public Page next()
+        {
+            builder.reset();
+
+            if (currentPage == null) {
+                currentPage = pagePositions.next();
+            }
+
+            PagePosition previousPage = currentPage;
+
+            while (comparePages(keyTypes, currentPage, previousPage) == 0 || !builder.isFull()) {
+                if (!currentPage.isPositionOutOfPage()) {
+                    builder.declarePosition();
+                    for (int column = 0; column < allTypes.size(); column++) {
+                        Type type = allTypes.get(column);
+                        type.appendTo(currentPage.getPage().getBlock(column), currentPage.getPosition(), builder.getBlockBuilder(column));
+                    }
+                    previousPage = currentPage;
+                }
+
+                if (pagePositions.hasNext()) {
+                    currentPage = pagePositions.next();
+                }
+                else {
+                    currentPage = null;
+                    break;
+                }
+            }
+            return builder.build();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/MergeSort.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MergeSort.java
@@ -27,25 +27,20 @@ import static java.util.stream.Collectors.toList;
 
 public class MergeSort
 {
-    private final List<Type> keyTypes;
-    private final List<Type> allTypes;
-
-    public MergeSort(List<Type> keyTypes, List<Type> allTypes)
+    private MergeSort()
     {
-        this.keyTypes = requireNonNull(keyTypes, "keyTypes is null");
-        this.allTypes = requireNonNull(allTypes, "allTypes is null");
     }
 
-    public Iterator<Page> merge(List<Iterator<Page>> channels)
+    public static Iterator<Page> merge(List<Type> keyTypes, List<Type> allTypes, List<Iterator<Page>> channels)
     {
         List<Iterator<PagePosition>> channelIterators = channels.stream().map(SingleChannelPagePositions::new).collect(toList());
 
-        return new PageRewriteIterator(keyTypes, allTypes, Iterators.mergeSorted(channelIterators, this::comparePages));
-    }
-
-    private int comparePages(PagePosition left, PagePosition right)
-    {
-        return comparePages(keyTypes, left, right);
+        return new PageRewriteIterator(
+                keyTypes,
+                allTypes,
+                Iterators.mergeSorted(
+                        channelIterators,
+                        (PagePosition left, PagePosition right) -> comparePages(keyTypes, left, right)));
     }
 
     private static int comparePages(List<Type> keyTypes, PagePosition left, PagePosition right)

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -133,6 +133,26 @@ public class MultiChannelGroupByHash
     }
 
     @Override
+    public int compare(int leftGroupId, int rightGroupId)
+    {
+        long leftAddress = groupAddressByGroupId.get(leftGroupId);
+        int leftBlockIndex = decodeSliceIndex(leftAddress);
+        int leftPosition = decodePosition(leftAddress);
+        long rightAdrress = groupAddressByGroupId.get(rightGroupId);
+        int rightBlockIndex = decodeSliceIndex(rightAdrress);
+        int rightPosition = decodePosition(rightAdrress);
+
+        for (int column = 0; column < channels.length; column++) {
+            int compare = types.get(column).compareTo(channelBuilders.get(column).get(leftBlockIndex), leftPosition,
+                    channelBuilders.get(column).get(rightBlockIndex), rightPosition);
+            if (compare != 0) {
+                return compare;
+            }
+        }
+        return 0;
+    }
+
+    @Override
     public long getEstimatedSize()
     {
         return (sizeOf(channelBuilders.get(0).elements()) * channelBuilders.size()) +

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/HashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/HashAggregationBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.builder;
+
+import com.facebook.presto.spi.Page;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+public interface HashAggregationBuilder
+    extends Closeable
+{
+    void processPage(Page page);
+
+    Iterator<Page> buildResult();
+
+    boolean checkFullAndUpdateMemory();
+
+    boolean isBusy();
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.builder;
+
+import com.facebook.presto.operator.GroupByHash;
+import com.facebook.presto.operator.GroupByIdBlock;
+import com.facebook.presto.operator.OperatorContext;
+import com.facebook.presto.operator.aggregation.AccumulatorFactory;
+import com.facebook.presto.operator.aggregation.GroupedAccumulator;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Ints;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class InMemoryHashAggregationBuilder
+    implements HashAggregationBuilder
+{
+    private GroupByHash groupByHash;
+    private List<Aggregator> aggregators;
+    private final int expectedGroups;
+    private final List<Type> groupByTypes;
+    private List<Integer> groupByChannels;
+    private Optional<Integer> hashChannel;
+    private final OperatorContext operatorContext;
+    private final boolean partial;
+
+    public InMemoryHashAggregationBuilder(
+            List<AccumulatorFactory> accumulatorFactories,
+            AggregationNode.Step step,
+            int expectedGroups,
+            List<Type> groupByTypes,
+            List<Integer> groupByChannels,
+            Optional<Integer> hashChannel,
+            OperatorContext operatorContext)
+    {
+        this(accumulatorFactories,
+                step,
+                expectedGroups,
+                groupByTypes,
+                groupByChannels,
+                hashChannel,
+                operatorContext,
+                Optional.empty());
+    }
+
+    public InMemoryHashAggregationBuilder(
+            List<AccumulatorFactory> accumulatorFactories,
+            AggregationNode.Step step,
+            int expectedGroups,
+            List<Type> groupByTypes,
+            List<Integer> groupByChannels,
+            Optional<Integer> hashChannel,
+            OperatorContext operatorContext,
+            Optional<Integer> overwriteIntermediateChannelOffset)
+    {
+        this.expectedGroups = expectedGroups;
+        this.groupByTypes = groupByTypes;
+        this.groupByChannels = groupByChannels;
+        this.hashChannel = hashChannel;
+        this.operatorContext = operatorContext;
+        this.partial = step.isOutputPartial();
+        this.groupByHash = createGroupByHash();
+        this.aggregators = createAggregators(accumulatorFactories, step, overwriteIntermediateChannelOffset);
+    }
+
+    @Override
+    public void processPage(Page page)
+    {
+        if (aggregators.isEmpty()) {
+            groupByHash.addPage(page);
+            return;
+        }
+
+        GroupByIdBlock groupIds = groupByHash.getGroupIds(page);
+
+        for (Aggregator aggregator : aggregators) {
+            aggregator.processPage(groupIds, page);
+        }
+    }
+
+    @Override
+    public boolean checkFullAndUpdateMemory()
+    {
+        long memorySize = getSizeInMemory();
+        if (partial) {
+            return !operatorContext.trySetMemoryReservation(memorySize);
+        }
+        else {
+            operatorContext.setMemoryReservation(memorySize);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isBusy()
+    {
+        return false;
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    public long getSizeInMemory()
+    {
+        long sizeInMemory = groupByHash.getEstimatedSize();
+        for (Aggregator aggregator : aggregators) {
+            sizeInMemory += aggregator.getEstimatedSize();
+        }
+        sizeInMemory -= operatorContext.getOperatorPreAllocatedMemory().toBytes();
+        if (sizeInMemory < 0) {
+            sizeInMemory = 0;
+        }
+        return sizeInMemory;
+    }
+
+    public void setOutputPartial()
+    {
+        for (Aggregator aggregator : aggregators) {
+            aggregator.setOutputPartial();
+        }
+    }
+
+    public int getKeyChannels()
+    {
+        return groupByHash.getTypes().size();
+    }
+
+    public long getGroupCount()
+    {
+        return groupByHash.getGroupCount();
+    }
+
+    @Override
+    public Iterator<Page> buildResult()
+    {
+        return buildResult(consecutiveGroupIds());
+    }
+
+    public Iterator<Page> buildResultSorted()
+    {
+        return buildResult(sortedGroupIds());
+    }
+
+    public List<Type> buildTypes()
+    {
+        ArrayList<Type> types = new ArrayList<>(groupByHash.getTypes());
+        for (Aggregator aggregator : aggregators) {
+            types.add(aggregator.getType());
+        }
+        return types;
+    }
+
+    public List<Type> buildIntermediateTypes()
+    {
+        ArrayList<Type> types = new ArrayList<>(groupByHash.getTypes());
+        for (InMemoryHashAggregationBuilder.Aggregator aggregator : aggregators) {
+            types.add(aggregator.getIntermediateType());
+        }
+        return types;
+    }
+
+    private Iterator<Page> buildResult(Iterator<Integer> groupIds)
+    {
+        final PageBuilder pageBuilder = new PageBuilder(buildTypes());
+        return new AbstractIterator<Page>()
+        {
+            @Override
+            protected Page computeNext()
+            {
+                if (!groupIds.hasNext()) {
+                    return endOfData();
+                }
+
+                pageBuilder.reset();
+
+                List<Type> types = groupByHash.getTypes();
+                while (!pageBuilder.isFull() && groupIds.hasNext()) {
+                    int groupId = groupIds.next();
+
+                    groupByHash.appendValuesTo(groupId, pageBuilder, 0);
+
+                    pageBuilder.declarePosition();
+                    for (int i = 0; i < aggregators.size(); i++) {
+                        Aggregator aggregator = aggregators.get(i);
+                        BlockBuilder output = pageBuilder.getBlockBuilder(types.size() + i);
+                        aggregator.evaluate(groupId, output);
+                    }
+                }
+
+                return pageBuilder.build();
+            }
+        };
+    }
+
+    private GroupByHash createGroupByHash()
+    {
+        return GroupByHash.createGroupByHash(operatorContext.getSession(), groupByTypes, Ints.toArray(groupByChannels), hashChannel, expectedGroups);
+    }
+
+    private static List<Aggregator> createAggregators(
+            List<AccumulatorFactory> accumulatorFactories,
+            AggregationNode.Step step,
+            Optional<Integer> overwriteIntermediateChannelOffset)
+    {
+        // wrapper each function with an aggregator
+        ImmutableList.Builder<Aggregator> builder = ImmutableList.builder();
+
+        requireNonNull(accumulatorFactories, "accumulatorFactories is null");
+        for (int i = 0; i < accumulatorFactories.size(); i++) {
+            AccumulatorFactory accumulatorFactory = accumulatorFactories.get(i);
+
+            Optional<Integer> overwriteIntermediateChannel = Optional.empty();
+            if (overwriteIntermediateChannelOffset.isPresent()) {
+                overwriteIntermediateChannel = Optional.of(overwriteIntermediateChannelOffset.get() + i);
+            }
+            builder.add(new Aggregator(
+                    accumulatorFactory,
+                    step,
+                    overwriteIntermediateChannel));
+        }
+        return builder.build();
+    }
+
+    private Iterator<Integer> consecutiveGroupIds()
+    {
+        return IntStream.range(0, groupByHash.getGroupCount()).iterator();
+    }
+
+    private Iterator<Integer> sortedGroupIds()
+    {
+        List<Integer> groupIds = Lists.newArrayList(consecutiveGroupIds());
+        groupIds.sort(groupByHash::compare);
+        return groupIds.iterator();
+    }
+
+    private static class Aggregator
+    {
+        private final GroupedAccumulator aggregation;
+        private AggregationNode.Step step;
+        private final int intermediateChannel;
+
+        private Aggregator(AccumulatorFactory accumulatorFactory, AggregationNode.Step step, Optional<Integer> overwriteIntermiediateChannel)
+        {
+            if (step.isInputRaw()) {
+                this.intermediateChannel = -1;
+                this.aggregation = accumulatorFactory.createGroupedAccumulator();
+            }
+            else if (overwriteIntermiediateChannel.isPresent()) {
+                this.intermediateChannel = overwriteIntermiediateChannel.get();
+                aggregation = accumulatorFactory.createGroupedIntermediateAccumulator();
+            }
+            else {
+                checkArgument(accumulatorFactory.getInputChannels().size() == 1, "expected 1 input channel for intermediate aggregation");
+                this.intermediateChannel = accumulatorFactory.getInputChannels().get(0);
+                this.aggregation = accumulatorFactory.createGroupedIntermediateAccumulator();
+            }
+            this.step = step;
+        }
+
+        public long getEstimatedSize()
+        {
+            return aggregation.getEstimatedSize();
+        }
+
+        public Type getIntermediateType()
+        {
+            return aggregation.getIntermediateType();
+        }
+
+        public Type getType()
+        {
+            if (step.isOutputPartial()) {
+                return aggregation.getIntermediateType();
+            }
+            else {
+                return aggregation.getFinalType();
+            }
+        }
+
+        public void processPage(GroupByIdBlock groupIds, Page page)
+        {
+            if (step.isInputRaw()) {
+                aggregation.addInput(groupIds, page);
+            }
+            else {
+                aggregation.addIntermediate(groupIds, page.getBlock(intermediateChannel));
+            }
+        }
+
+        public void evaluate(int groupId, BlockBuilder output)
+        {
+            if (step.isOutputPartial()) {
+                aggregation.evaluateIntermediate(groupId, output);
+            }
+            else {
+                aggregation.evaluateFinal(groupId, output);
+            }
+        }
+
+        public void setOutputPartial()
+        {
+            step = AggregationNode.Step.partialOutput(step);
+        }
+    }
+
+    public static List<Type> toTypes(List<? extends Type> groupByType, AggregationNode.Step step, List<AccumulatorFactory> factories, Optional<Integer> hashChannel)
+    {
+        ImmutableList.Builder<Type> types = ImmutableList.builder();
+        types.addAll(groupByType);
+        if (hashChannel.isPresent()) {
+            types.add(BIGINT);
+        }
+        for (AccumulatorFactory factory : factories) {
+            types.add(new Aggregator(factory, step, Optional.empty()).getType());
+        }
+        return types.build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/MergingHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/MergingHashAggregationBuilder.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.builder;
+
+import com.facebook.presto.memory.LocalMemoryContext;
+import com.facebook.presto.operator.OperatorContext;
+import com.facebook.presto.operator.aggregation.AccumulatorFactory;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.google.common.collect.ImmutableList;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+public class MergingHashAggregationBuilder
+    implements Closeable
+{
+    private final List<AccumulatorFactory> accumulatorFactories;
+    private final AggregationNode.Step step;
+    private final int expectedGroups;
+    private final ImmutableList<Integer> groupByPartialChannels;
+    private final Optional<Integer> hashChannel;
+    private final OperatorContext operatorContext;
+    private final Iterator<Page> sortedPages;
+    private InMemoryHashAggregationBuilder hashAggregationBuilder;
+    private final List<Type> groupByTypes;
+    private final LocalMemoryContext systemMemoryContext;
+    private final long maxEntriesBeforeSpill;
+    private final long memorySizeBeforeSpill;
+    private final int overwriteIntermediateChannelOffset;
+
+    public MergingHashAggregationBuilder(
+            List<AccumulatorFactory> accumulatorFactories,
+            AggregationNode.Step step,
+            int expectedGroups,
+            List<Type> groupByTypes,
+            Optional<Integer> hashChannel,
+            OperatorContext operatorContext,
+            Iterator<Page> sortedPages,
+            LocalMemoryContext systemMemoryContext,
+            long maxEntriesBeforeSpill,
+            long memorySizeBeforeSpill,
+            int overwriteIntermediateChannelOffset)
+    {
+        ImmutableList.Builder<Integer> groupByPartialChannels = ImmutableList.builder();
+        for (int i = 0; i < groupByTypes.size(); i++) {
+            groupByPartialChannels.add(i);
+        }
+
+        this.accumulatorFactories = accumulatorFactories;
+        this.step = AggregationNode.Step.partialInput(step);
+        this.expectedGroups = expectedGroups;
+        this.groupByPartialChannels = groupByPartialChannels.build();
+        this.hashChannel = hashChannel.isPresent() ? Optional.of(groupByTypes.size()) : hashChannel;
+        this.operatorContext = operatorContext;
+        this.sortedPages = sortedPages;
+        this.groupByTypes = groupByTypes;
+        this.systemMemoryContext = systemMemoryContext;
+        this.maxEntriesBeforeSpill = maxEntriesBeforeSpill;
+        this.memorySizeBeforeSpill = memorySizeBeforeSpill;
+        this.overwriteIntermediateChannelOffset = overwriteIntermediateChannelOffset;
+
+        rebuildHashAggregationBuilder();
+    }
+
+    public Iterator<Page> buildResult()
+    {
+        return new Iterator<Page>() {
+            private Iterator<Page> resultPages = Collections.emptyIterator();
+
+            @Override
+            public boolean hasNext()
+            {
+                return sortedPages.hasNext() || resultPages.hasNext();
+            }
+
+            @Override
+            public Page next()
+            {
+                if (!resultPages.hasNext()) {
+                    rebuildHashAggregationBuilder();
+                    long memorySize = 0; // ensure that at least one merged page will be processed
+
+                    while (sortedPages.hasNext() && !shouldProduceOutput(memorySize)) {
+                        hashAggregationBuilder.processPage(sortedPages.next());
+                        memorySize = hashAggregationBuilder.getSizeInMemory();
+                        systemMemoryContext.setBytes(memorySize);
+                    }
+                    resultPages = hashAggregationBuilder.buildResult();
+                }
+
+                return resultPages.next();
+            }
+        };
+    }
+
+    @Override
+    public void close()
+    {
+        hashAggregationBuilder.close();
+    }
+
+    private boolean shouldProduceOutput(long memorySize)
+    {
+        return (maxEntriesBeforeSpill > 0 && hashAggregationBuilder.getGroupCount() > maxEntriesBeforeSpill)
+                || (memorySizeBeforeSpill > 0 && memorySize > memorySizeBeforeSpill);
+    }
+
+    private void rebuildHashAggregationBuilder()
+    {
+        this.hashAggregationBuilder = new InMemoryHashAggregationBuilder(
+                accumulatorFactories,
+                step,
+                expectedGroups,
+                groupByTypes,
+                groupByPartialChannels,
+                hashChannel,
+                operatorContext,
+                Optional.of(overwriteIntermediateChannelOffset));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.builder;
+
+import com.facebook.presto.memory.LocalMemoryContext;
+import com.facebook.presto.operator.MergeSort;
+import com.facebook.presto.operator.OperatorContext;
+import com.facebook.presto.operator.aggregation.AccumulatorFactory;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.spiller.Spiller;
+import com.facebook.presto.spi.spiller.SpillerFactory;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.google.common.base.Throwables;
+import com.google.common.io.Closer;
+import io.airlift.units.DataSize;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class SpillableHashAggregationBuilder
+    implements HashAggregationBuilder
+{
+    private InMemoryHashAggregationBuilder hashAggregationBuilder;
+    private final Optional<SpillerFactory> spillerFactory;
+    private final List<AccumulatorFactory> accumulatorFactories;
+    private final AggregationNode.Step step;
+    private final int expectedGroups;
+    private final List<Type> groupByTypes;
+    private final List<Integer> groupByChannels;
+    private final Optional<Integer> hashChannel;
+    private final OperatorContext operatorContext;
+    private final long maxEntriesBeforeSpill;
+    private final long memorySizeBeforeSpill;
+    private Optional<Spiller> spiller = Optional.empty();
+    private CompletableFuture<?> spillInProgress = CompletableFuture.completedFuture(null);
+    private final LocalMemoryContext systemMemoryContext;
+    private final Closer closer = Closer.create();
+
+    public SpillableHashAggregationBuilder(
+            List<AccumulatorFactory> accumulatorFactories,
+            AggregationNode.Step step,
+            int expectedGroups,
+            List<Type> groupByTypes,
+            List<Integer> groupByChannels,
+            Optional<Integer> hashChannel,
+            OperatorContext operatorContext,
+            long maxEntriesBeforeSpill,
+            DataSize memoryLimitBeforeSpill,
+            Optional<SpillerFactory> spillerFactory)
+    {
+        this.accumulatorFactories = accumulatorFactories;
+        this.step = step;
+        this.expectedGroups = expectedGroups;
+        this.groupByTypes = groupByTypes;
+        this.groupByChannels = groupByChannels;
+        this.hashChannel = hashChannel;
+        this.operatorContext = operatorContext;
+        this.maxEntriesBeforeSpill = maxEntriesBeforeSpill;
+        this.memorySizeBeforeSpill = memoryLimitBeforeSpill.toBytes();
+        this.spillerFactory = spillerFactory;
+        this.systemMemoryContext = operatorContext.getSystemMemoryContext().newLocalMemoryContext();
+
+        rebuildHashAggregationBuilder();
+    }
+
+    public void processPage(Page page)
+    {
+        checkState(!isBusy(), "Previous spill hasn't yet finished");
+
+        hashAggregationBuilder.processPage(page);
+    }
+
+    public boolean checkFullAndUpdateMemory()
+    {
+        if (isBusy()) {
+            return true;
+        }
+
+        long memorySize = hashAggregationBuilder.getSizeInMemory();
+
+        systemMemoryContext.setBytes(memorySize);
+
+        if (shouldSpill(memorySize)) {
+            spillToDisk();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isBusy()
+    {
+        return !spillInProgress.isDone();
+    }
+
+    private boolean shouldSpill(long memorySize)
+    {
+        return (maxEntriesBeforeSpill > 0 && hashAggregationBuilder.getGroupCount() > maxEntriesBeforeSpill)
+                || (memorySizeBeforeSpill > 0 && memorySize > memorySizeBeforeSpill);
+    }
+
+    public Iterator<Page> buildResult()
+    {
+        checkState(!isBusy(), "Previous spill hasn't yet finished");
+
+        if (!spiller.isPresent()) {
+            return hashAggregationBuilder.buildResult();
+        }
+
+        try {
+            // TODO: don't spill here to disk, instead merge disk content with memory content
+            spillToDisk().get();
+            return mergeFromDisk();
+        }
+        catch (InterruptedException | ExecutionException e) {
+            Thread.currentThread().interrupt();
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        closer.close();
+    }
+
+    private CompletableFuture<?> spillToDisk()
+    {
+        hashAggregationBuilder.setOutputPartial();
+
+        if (!spiller.isPresent()) {
+            spiller = Optional.of(spillerFactory.get().create(hashAggregationBuilder.buildTypes()));
+            closer.register(spiller.get());
+        }
+
+        // start spilling process with current content of the hashAggregationBuilder builder...
+        spillInProgress = spiller.get().spill(hashAggregationBuilder.buildResultSorted());
+        // ... and immediately create new hashAggregationBuilder so effectively memory ownership
+        // over hashAggregationBuilder is transferred from this thread to a spilling thread
+        rebuildHashAggregationBuilder();
+
+        return spillInProgress;
+    }
+
+    private Iterator<Page> mergeFromDisk()
+    {
+        checkState(spiller.isPresent());
+
+        Iterator<Page> mergedSpilledPages = MergeSort.merge(
+                groupByTypes,
+                hashAggregationBuilder.buildIntermediateTypes(),
+                spiller.get().getSpills());
+
+        MergingHashAggregationBuilder mergingHashAggregationBuilder = new MergingHashAggregationBuilder(
+                accumulatorFactories,
+                step,
+                expectedGroups,
+                groupByTypes,
+                hashChannel,
+                operatorContext,
+                mergedSpilledPages,
+                systemMemoryContext,
+                maxEntriesBeforeSpill,
+                memorySizeBeforeSpill,
+                hashAggregationBuilder.getKeyChannels());
+
+        closer.register(mergingHashAggregationBuilder);
+
+        return mergingHashAggregationBuilder.buildResult();
+    }
+
+    private void rebuildHashAggregationBuilder()
+    {
+        this.hashAggregationBuilder = new InMemoryHashAggregationBuilder(
+                accumulatorFactories,
+                step,
+                expectedGroups,
+                groupByTypes,
+                groupByChannels,
+                hashChannel,
+                operatorContext);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
@@ -77,7 +77,7 @@ import static com.facebook.presto.operator.aggregation.state.StateCompilerUtils.
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
-import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.UPPER_CAMEL;
@@ -158,7 +158,7 @@ public class StateCompiler
 
         Type type;
         if (fields.size() > 1) {
-            type = VARCHAR;
+            type = VARBINARY;
         }
         else {
             Class<?> stackType = fields.get(0).getType();
@@ -175,7 +175,7 @@ public class StateCompiler
                 type = BIGINT;
             }
             else if (stackType == Slice.class) {
-                type = VARCHAR;
+                type = VARBINARY;
             }
             else {
                 throw new IllegalArgumentException("Unsupported type: " + stackType);

--- a/presto-main/src/main/java/com/facebook/presto/operator/spiller/BinaryFileSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/spiller/BinaryFileSpiller.java
@@ -41,7 +41,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static com.facebook.presto.operator.spiller.BinarySpillerFactory.SPILL_PATH;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -57,12 +56,12 @@ public class BinaryFileSpiller
     private int spillsCount;
     private final ListeningExecutorService executor;
 
-    public BinaryFileSpiller(BlockEncodingSerde blockEncodingSerde, ListeningExecutorService executor)
+    public BinaryFileSpiller(BlockEncodingSerde blockEncodingSerde, ListeningExecutorService executor, Path spillPath)
     {
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
         this.executor = requireNonNull(executor, "executor is null");
         try {
-            this.targetDirectory = Files.createTempDirectory(SPILL_PATH, "presto-spill");
+            this.targetDirectory = Files.createTempDirectory(spillPath, "presto-spill");
         }
         catch (IOException e) {
             throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to create spill directory", e);

--- a/presto-main/src/main/java/com/facebook/presto/operator/spiller/BinaryFileSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/spiller/BinaryFileSpiller.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.spiller;
+
+import com.facebook.presto.block.PagesSerde;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.spiller.Spiller;
+import com.google.common.io.Closer;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import io.airlift.concurrent.MoreFutures;
+import io.airlift.slice.InputStreamSliceInput;
+import io.airlift.slice.OutputStreamSliceOutput;
+import io.airlift.slice.RuntimeIOException;
+import io.airlift.slice.SliceOutput;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.operator.spiller.BinarySpillerFactory.SPILL_PATH;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class BinaryFileSpiller
+        implements Spiller
+{
+    private final Path targetDirectory;
+    private final Closer closer = Closer.create();
+    private final BlockEncodingSerde blockEncodingSerde;
+
+    private int spillsCount;
+    private final ListeningExecutorService executor;
+
+    public BinaryFileSpiller(BlockEncodingSerde blockEncodingSerde, ListeningExecutorService executor)
+    {
+        this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
+        this.executor = requireNonNull(executor, "executor is null");
+        try {
+            this.targetDirectory = Files.createTempDirectory(SPILL_PATH, "presto-spill");
+        }
+        catch (IOException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to create spill directory", e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<?> spill(Iterator<Page> pageIterator)
+    {
+        Path spillPath = getPath(spillsCount++);
+
+        return MoreFutures.toCompletableFuture(executor.submit(
+                () -> writePages(pageIterator, spillPath)
+        ));
+    }
+
+    private void writePages(Iterator<Page> pageIterator, Path spillPath)
+    {
+        try (SliceOutput output = new OutputStreamSliceOutput(new BufferedOutputStream(new FileOutputStream(spillPath.toFile())))) {
+            PagesSerde.writePages(blockEncodingSerde, output, pageIterator);
+        }
+        catch (RuntimeIOException | IOException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to spill pages", e);
+        }
+    }
+
+    @Override
+    public List<Iterator<Page>> getSpills()
+    {
+        return IntStream.range(0, spillsCount)
+                .mapToObj(i -> readPages(getPath(i)))
+                .collect(toImmutableList());
+    }
+
+    private Iterator<Page> readPages(Path spillPath)
+    {
+        try {
+            InputStream input = new BufferedInputStream(new FileInputStream(spillPath.toFile()));
+            closer.register(input);
+            return PagesSerde.readPages(blockEncodingSerde, new InputStreamSliceInput(input));
+        }
+        catch (IOException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to read spilled pages", e);
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        try (Stream<Path> list = Files.list(targetDirectory)) {
+            closer.close();
+            for (Path path : list.collect(toList())) {
+                Files.delete(path);
+            }
+            Files.delete(targetDirectory);
+        }
+        catch (IOException e) {
+            throw new PrestoException(
+                    GENERIC_INTERNAL_ERROR,
+                    String.format("Failed to delete directory [%s]", targetDirectory),
+                    e);
+        }
+    }
+
+    private Path getPath(int spillNumber)
+    {
+        return Paths.get(targetDirectory.toAbsolutePath().toString(), String.format("%d.bin", spillNumber));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/spiller/BinarySpillerFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/spiller/BinarySpillerFactory.java
@@ -18,12 +18,12 @@ import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.spiller.Spiller;
 import com.facebook.presto.spi.spiller.SpillerFactory;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -33,28 +33,27 @@ import static java.util.concurrent.Executors.newFixedThreadPool;
 public class BinarySpillerFactory
         implements SpillerFactory
 {
-    public static final Path SPILL_PATH = Paths.get("/tmp/spills");
-
     private final ListeningExecutorService executor;
     private final BlockEncodingSerde blockEncodingSerde;
+    private final Path spillPath;
 
     @Inject
-    public BinarySpillerFactory(BlockEncodingSerde blockEncodingSerde)
+    public BinarySpillerFactory(BlockEncodingSerde blockEncodingSerde, FeaturesConfig featuresConfig)
     {
-        this(blockEncodingSerde, MoreExecutors.listeningDecorator(newFixedThreadPool(4, daemonThreadsNamed("binary-spiller-%s"))));
+        this(blockEncodingSerde, MoreExecutors.listeningDecorator(newFixedThreadPool(4, daemonThreadsNamed("binary-spiller-%s"))), featuresConfig);
     }
 
-    public BinarySpillerFactory(BlockEncodingSerde blockEncodingSerde, ListeningExecutorService executor)
+    public BinarySpillerFactory(BlockEncodingSerde blockEncodingSerde, ListeningExecutorService executor, FeaturesConfig featuresConfig)
     {
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
         this.executor = requireNonNull(executor, "executor is null");
-
-        SPILL_PATH.toFile().mkdirs();
+        this.spillPath = featuresConfig.getSpillerSpillPath();
+        this.spillPath.toFile().mkdirs();
     }
 
     @Override
     public Spiller create(List<Type> types)
     {
-        return new BinaryFileSpiller(blockEncodingSerde, executor);
+        return new BinaryFileSpiller(blockEncodingSerde, executor, spillPath);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/spiller/BinarySpillerFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/spiller/BinarySpillerFactory.java
@@ -25,6 +25,8 @@ import com.google.inject.Inject;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.util.Objects.requireNonNull;
@@ -33,6 +35,8 @@ import static java.util.concurrent.Executors.newFixedThreadPool;
 public class BinarySpillerFactory
         implements SpillerFactory
 {
+    public static final String SPILLER_THREAD_NAME_PREFIX = "binary-spiller";
+
     private final ListeningExecutorService executor;
     private final BlockEncodingSerde blockEncodingSerde;
     private final Path spillPath;
@@ -40,15 +44,17 @@ public class BinarySpillerFactory
     @Inject
     public BinarySpillerFactory(BlockEncodingSerde blockEncodingSerde, FeaturesConfig featuresConfig)
     {
-        this(blockEncodingSerde, MoreExecutors.listeningDecorator(newFixedThreadPool(4, daemonThreadsNamed("binary-spiller-%s"))), featuresConfig);
-    }
-
-    public BinarySpillerFactory(BlockEncodingSerde blockEncodingSerde, ListeningExecutorService executor, FeaturesConfig featuresConfig)
-    {
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
-        this.executor = requireNonNull(executor, "executor is null");
+        this.executor = createExecutorServiceOfSize(featuresConfig.getSpillerThreads());
         this.spillPath = featuresConfig.getSpillerSpillPath();
         this.spillPath.toFile().mkdirs();
+    }
+
+    private static ListeningExecutorService createExecutorServiceOfSize(int nThreads)
+    {
+        ThreadFactory threadFactory = daemonThreadsNamed(SPILLER_THREAD_NAME_PREFIX + "-%s");
+        ExecutorService executorService = newFixedThreadPool(nThreads, threadFactory);
+        return MoreExecutors.listeningDecorator(executorService);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/spiller/BinarySpillerFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/spiller/BinarySpillerFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.operator.spiller;
+
+import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.spiller.Spiller;
+import com.facebook.presto.spi.spiller.SpillerFactory;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.inject.Inject;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+
+public class BinarySpillerFactory
+        implements SpillerFactory
+{
+    public static final Path SPILL_PATH = Paths.get("/tmp/spills");
+
+    private final ListeningExecutorService executor;
+    private final BlockEncodingSerde blockEncodingSerde;
+
+    @Inject
+    public BinarySpillerFactory(BlockEncodingSerde blockEncodingSerde)
+    {
+        this(blockEncodingSerde, MoreExecutors.listeningDecorator(newFixedThreadPool(4, daemonThreadsNamed("binary-spiller-%s"))));
+    }
+
+    public BinarySpillerFactory(BlockEncodingSerde blockEncodingSerde, ListeningExecutorService executor)
+    {
+        this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
+        this.executor = requireNonNull(executor, "executor is null");
+
+        SPILL_PATH.toFile().mkdirs();
+    }
+
+    @Override
+    public Spiller create(List<Type> types)
+    {
+        return new BinaryFileSpiller(blockEncodingSerde, executor);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -72,6 +72,7 @@ import com.facebook.presto.operator.ExchangeClientFactory;
 import com.facebook.presto.operator.ExchangeClientSupplier;
 import com.facebook.presto.operator.ForExchange;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
+import com.facebook.presto.operator.spiller.BinarySpillerFactory;
 import com.facebook.presto.server.remotetask.HttpLocationFactory;
 import com.facebook.presto.spi.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.ConnectorPageSourceProvider;
@@ -82,6 +83,7 @@ import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockEncodingFactory;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.spiller.SpillerFactory;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.split.PageSinkManager;
@@ -387,6 +389,9 @@ public class ServerMainModule
 
         // Finalizer
         binder.bind(FinalizerService.class).in(Scopes.SINGLETON);
+
+        // Spiller
+        binder.bind(SpillerFactory.class).to(BinarySpillerFactory.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -135,6 +135,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.FLAT;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.LEGACY;
 import static com.facebook.presto.server.ConditionalModule.conditionalModule;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.SpillerImplementation.BINARY_FILE;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.reflect.Reflection.newProxy;
@@ -391,7 +392,10 @@ public class ServerMainModule
         binder.bind(FinalizerService.class).in(Scopes.SINGLETON);
 
         // Spiller
-        binder.bind(SpillerFactory.class).to(BinarySpillerFactory.class).in(Scopes.SINGLETON);
+        install(conditionalModule(
+                FeaturesConfig.class,
+                config -> BINARY_FILE.equalsIgnoreCase(config.getSpillerImplementation()),
+                moduleBinder -> moduleBinder.bind(SpillerFactory.class).to(BinarySpillerFactory.class).in(Scopes.SINGLETON)));
     }
 
     @Provides

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -30,6 +30,7 @@ import com.facebook.presto.server.ServerMainModule;
 import com.facebook.presto.server.ShutdownAction;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.spiller.SpillerFactory;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParserOptions;
@@ -106,6 +107,7 @@ public class TestingPrestoServer
     private final Announcer announcer;
     private final QueryManager queryManager;
     private final TaskManager taskManager;
+    private final SpillerFactory spillerFactory;
     private final GracefulShutdownHandler gracefulShutdownHandler;
     private final ShutdownAction shutdownAction;
     private final boolean coordinator;
@@ -258,6 +260,7 @@ public class TestingPrestoServer
         serviceSelectorManager = injector.getInstance(ServiceSelectorManager.class);
         gracefulShutdownHandler = injector.getInstance(GracefulShutdownHandler.class);
         taskManager = injector.getInstance(TaskManager.class);
+        spillerFactory = injector.getInstance(SpillerFactory.class);
         shutdownAction = injector.getInstance(ShutdownAction.class);
         announcer = injector.getInstance(Announcer.class);
 
@@ -372,6 +375,11 @@ public class TestingPrestoServer
     public TaskManager getTaskManager()
     {
         return taskManager;
+    }
+
+    public SpillerFactory getSpillerFactory()
+    {
+        return spillerFactory;
     }
 
     public ShutdownAction getShutdownAction()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -22,6 +22,8 @@ import io.airlift.units.DataSize;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
@@ -65,6 +67,7 @@ public class FeaturesConfig
     private RegexLibrary regexLibrary = JONI;
     private DataSize operatorMemoryLimitBeforeSpill = new DataSize(0, DataSize.Unit.MEGABYTE);
     private String spillerImplementation = SpillerImplementation.BINARY_FILE;
+    private Path spillerSpillPath = Paths.get(System.getProperty("java.io.tmpdir"), "presto", "spills");
 
     @NotNull
     public String getResourceGroupManager()
@@ -300,6 +303,19 @@ public class FeaturesConfig
     public FeaturesConfig setSpillerImplementation(String spillerImplementation)
     {
         this.spillerImplementation = spillerImplementation;
+        return this;
+    }
+
+    @NotNull
+    public Path getSpillerSpillPath()
+    {
+        return spillerSpillPath;
+    }
+
+    @Config("experimental.spiller-spill-path")
+    public FeaturesConfig setSpillerSpillPath(String spillPath)
+    {
+        this.spillerSpillPath = Paths.get(spillPath);
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -68,6 +68,7 @@ public class FeaturesConfig
     private DataSize operatorMemoryLimitBeforeSpill = new DataSize(0, DataSize.Unit.MEGABYTE);
     private String spillerImplementation = SpillerImplementation.BINARY_FILE;
     private Path spillerSpillPath = Paths.get(System.getProperty("java.io.tmpdir"), "presto", "spills");
+    private int spillerThreads = 4;
 
     @NotNull
     public String getResourceGroupManager()
@@ -316,6 +317,18 @@ public class FeaturesConfig
     public FeaturesConfig setSpillerSpillPath(String spillPath)
     {
         this.spillerSpillPath = Paths.get(spillPath);
+        return this;
+    }
+
+    public int getSpillerThreads()
+    {
+        return spillerThreads;
+    }
+
+    @Config("experimental.spiller-threads")
+    public FeaturesConfig setSpillerThreads(int spillerThreads)
+    {
+        this.spillerThreads = spillerThreads;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -37,6 +37,11 @@ public class FeaturesConfig
         public static final List<String> AVAILABLE_OPTIONS = ImmutableList.of(DISABLED, COLUMNAR, COLUMNAR_DICTIONARY);
     }
 
+    public static class SpillerImplementation
+    {
+        public static final String BINARY_FILE = "binary_file";
+    }
+
     public static final String FILE_BASED_RESOURCE_GROUP_MANAGER = "file";
     private boolean experimentalSyntaxEnabled;
     private boolean distributedIndexJoinsEnabled;
@@ -59,6 +64,7 @@ public class FeaturesConfig
     private int re2JDfaRetries = 5;
     private RegexLibrary regexLibrary = JONI;
     private DataSize operatorMemoryLimitBeforeSpill = new DataSize(0, DataSize.Unit.MEGABYTE);
+    private String spillerImplementation = SpillerImplementation.BINARY_FILE;
 
     @NotNull
     public String getResourceGroupManager()
@@ -281,6 +287,19 @@ public class FeaturesConfig
     public FeaturesConfig setOperatorMemoryLimitBeforeSpill(DataSize operatorMemoryLimitBeforeSpill)
     {
         this.operatorMemoryLimitBeforeSpill = operatorMemoryLimitBeforeSpill;
+        return this;
+    }
+
+    @NotNull
+    public String getSpillerImplementation()
+    {
+        return spillerImplementation;
+    }
+
+    @Config("experimental.spiller-implementation")
+    public FeaturesConfig setSpillerImplementation(String spillerImplementation)
+    {
+        this.spillerImplementation = spillerImplementation;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.LegacyConfig;
+import io.airlift.units.DataSize;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -57,6 +58,7 @@ public class FeaturesConfig
     private int re2JDfaStatesLimit = Integer.MAX_VALUE;
     private int re2JDfaRetries = 5;
     private RegexLibrary regexLibrary = JONI;
+    private DataSize operatorMemoryLimitBeforeSpill = new DataSize(0, DataSize.Unit.MEGABYTE);
 
     @NotNull
     public String getResourceGroupManager()
@@ -267,6 +269,18 @@ public class FeaturesConfig
     public FeaturesConfig setRegexLibrary(RegexLibrary regexLibrary)
     {
         this.regexLibrary = regexLibrary;
+        return this;
+    }
+
+    public DataSize getOperatorMemoryLimitBeforeSpill()
+    {
+        return operatorMemoryLimitBeforeSpill;
+    }
+
+    @Config("experimental.operator-memory-limit-before-spill")
+    public FeaturesConfig setOperatorMemoryLimitBeforeSpill(DataSize operatorMemoryLimitBeforeSpill)
+    {
+        this.operatorMemoryLimitBeforeSpill = operatorMemoryLimitBeforeSpill;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -90,6 +90,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.spi.predicate.NullableValue;
+import com.facebook.presto.spi.spiller.SpillerFactory;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.split.MappedRecordSet;
 import com.facebook.presto.split.PageSinkManager;
@@ -231,6 +232,7 @@ public class LocalExecutionPlanner
     private final IndexJoinLookupStats indexJoinLookupStats;
     private final DataSize maxPartialAggregationMemorySize;
     private final DataSize maxPagePartitioningBufferSize;
+    private final SpillerFactory spillerFactory;
 
     @Inject
     public LocalExecutionPlanner(
@@ -245,7 +247,8 @@ public class LocalExecutionPlanner
             ExpressionCompiler compiler,
             IndexJoinLookupStats indexJoinLookupStats,
             CompilerConfig compilerConfig,
-            TaskManagerConfig taskManagerConfig)
+            TaskManagerConfig taskManagerConfig,
+            SpillerFactory spillerFactory)
     {
         requireNonNull(compilerConfig, "compilerConfig is null");
         this.queryPerformanceFetcher = requireNonNull(queryPerformanceFetcher, "queryPerformanceFetcher is null");
@@ -259,6 +262,7 @@ public class LocalExecutionPlanner
         this.compiler = requireNonNull(compiler, "compiler is null");
         this.indexJoinLookupStats = requireNonNull(indexJoinLookupStats, "indexJoinLookupStats is null");
         this.maxIndexMemorySize = requireNonNull(taskManagerConfig, "taskManagerConfig is null").getMaxIndexMemoryUsage();
+        this.spillerFactory = requireNonNull(spillerFactory, "spillerFactory is null");
         this.maxPartialAggregationMemorySize = taskManagerConfig.getMaxPartialAggregationMemoryUsage();
         this.maxPagePartitioningBufferSize = taskManagerConfig.getMaxPagePartitioningBufferSize();
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1880,6 +1880,12 @@ public class LocalExecutionPlanner
                     .map(entry -> source.getTypes().get(entry))
                     .collect(toImmutableList());
 
+            if (maxEntriesBeforeSpill > 0 || memoryLimitBeforeSpill.toBytes() > 0) {
+                if (!groupByTypes.stream().allMatch(Type::isOrderable)) {
+                    throw new UnsupportedOperationException("Spilling requires all types in GROUP BY key to be orderable");
+                }
+            }
+
             Optional<Integer> hashChannel = node.getHashSymbol().map(channelGetter(source));
 
             OperatorFactory operatorFactory = new HashAggregationOperatorFactory(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
@@ -71,6 +71,26 @@ public class AggregationNode
         {
             return outputPartial;
         }
+
+        public static Step partialOutput(Step step)
+        {
+            if (step.isInputRaw()) {
+                return Step.PARTIAL;
+            }
+            else {
+                return Step.INTERMEDIATE;
+            }
+        }
+
+        public static Step partialInput(Step step)
+        {
+            if (step.isOutputPartial()) {
+                return Step.INTERMEDIATE;
+            }
+            else {
+                return Step.FINAL;
+            }
+        }
     }
 
     @JsonCreator

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -307,7 +307,7 @@ public class LocalQueryRunner
                 .put(Rollback.class, new RollbackTask())
                 .build();
 
-        this.spillerFactory = new BinarySpillerFactory(blockEncodingSerde);
+        this.spillerFactory = new BinarySpillerFactory(blockEncodingSerde, featuresConfig);
     }
 
     public static LocalQueryRunner queryRunnerWithInitialTransaction(Session defaultSession)

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -33,6 +33,7 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.split.PageSinkManager;
 import com.facebook.presto.split.PageSourceManager;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.CompilerConfig;
@@ -123,7 +124,7 @@ public final class TaskTestUtils
                 new IndexJoinLookupStats(),
                 new CompilerConfig(),
                 new TaskManagerConfig(),
-                new BinarySpillerFactory(new BlockEncodingManager(metadata.getTypeManager())));
+                new BinarySpillerFactory(new BlockEncodingManager(metadata.getTypeManager()), new FeaturesConfig()));
     }
 
     public static TaskInfo updateTask(SqlTask sqlTask, List<TaskSource> taskSources, OutputBuffers outputBuffers)

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution;
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.ScheduledSplit;
 import com.facebook.presto.TaskSource;
+import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.execution.TestSqlTaskManager.MockExchangeClientSupplier;
 import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
@@ -26,6 +27,7 @@ import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
+import com.facebook.presto.operator.spiller.BinarySpillerFactory;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
@@ -120,7 +122,8 @@ public final class TaskTestUtils
                 new ExpressionCompiler(metadata),
                 new IndexJoinLookupStats(),
                 new CompilerConfig(),
-                new TaskManagerConfig());
+                new TaskManagerConfig(),
+                new BinarySpillerFactory(new BlockEncodingManager(metadata.getTypeManager())));
     }
 
     public static TaskInfo updateTask(SqlTask sqlTask, List<TaskSource> taskSources, OutputBuffers outputBuffers)

--- a/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.InterleavedBlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.testing.MaterializedResult;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
@@ -61,6 +62,21 @@ public final class OperatorAssertion
     }
 
     public static List<Page> toPages(Operator operator, Iterator<Page> input)
+    {
+        try {
+            return toPagesUnsafe(operator, input);
+        }
+        finally {
+            try {
+                operator.close();
+            }
+            catch (Exception e) {
+                throw Throwables.propagate(e);
+            }
+        }
+    }
+
+    private static List<Page> toPagesUnsafe(Operator operator, Iterator<Page> input)
     {
         ImmutableList.Builder<Page> outputPages = ImmutableList.builder();
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -23,6 +23,8 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.PageBuilderStatus;
+import com.facebook.presto.spi.spiller.Spiller;
+import com.facebook.presto.spi.spiller.SpillerFactory;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
@@ -42,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
@@ -83,6 +86,7 @@ public class TestHashAggregationOperator
 
     private ExecutorService executor;
     private DriverContext driverContext;
+    private Optional<SpillerFactory> spillerFactory = Optional.of(new DummySpillerFactory());
 
     @BeforeMethod
     public void setUp()
@@ -94,10 +98,20 @@ public class TestHashAggregationOperator
                 .addDriverContext();
     }
 
-    @DataProvider(name = "hashEnabledValues")
-    public static Object[][] hashEnabledValuesProvider()
+    @DataProvider(name = "hashEnabled")
+    public static Object[][] hashEnabled()
     {
-        return new Object[][] { { true }, { false } };
+        return new Object[][] {{ true }, { false }};
+    }
+
+    @DataProvider(name = "hashEnabledAndMaxEntriesBeforeSpillValues")
+    public static Object[][] hashEnabledAndMaxEntriesBeforeSpillValuesProvider()
+    {
+        return new Object[][] {
+                { true, Long.MAX_VALUE },
+                { true, 8 },
+                { false, Long.MAX_VALUE },
+                { false, 8 }};
     }
 
     @AfterMethod
@@ -106,8 +120,8 @@ public class TestHashAggregationOperator
         executor.shutdownNow();
     }
 
-    @Test(dataProvider = "hashEnabledValues")
-    public void testHashAggregation(boolean hashEnabled)
+    @Test(dataProvider = "hashEnabledAndMaxEntriesBeforeSpillValues")
+    public void testHashAggregation(boolean hashEnabled, long maxEntriesBeforeSpill)
             throws Exception
     {
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
@@ -139,7 +153,10 @@ public class TestHashAggregationOperator
                         countBooleanColumn.bind(ImmutableList.of(4), Optional.empty(), Optional.empty(), 1.0)),
                 rowPagesBuilder.getHashChannel(),
                 100_000,
-                new DataSize(16, MEGABYTE));
+                new DataSize(16, MEGABYTE),
+                maxEntriesBeforeSpill,
+                new DataSize(0, MEGABYTE),
+                spillerFactory);
 
         Operator operator = operatorFactory.createOperator(driverContext);
 
@@ -159,15 +176,15 @@ public class TestHashAggregationOperator
         assertOperatorEqualsIgnoreOrder(operator, input, expected, hashEnabled, Optional.of(hashChannels.size()));
     }
 
-    @Test(dataProvider = "hashEnabledValues", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of 10B")
-    public void testMemoryLimit(boolean hashEnabled)
+    @Test(dataProvider = "hashEnabledAndMaxEntriesBeforeSpillValues", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of 10B")
+    public void testMemoryLimit(boolean hashEnabled, long maxEntriesBeforeSpill)
     {
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
         InternalAggregationFunction maxVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
                 new Signature("max", AGGREGATE, parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR)));
 
         List<Integer> hashChannels = Ints.asList(1);
-        RowPagesBuilder rowPagesBuilder = rowPagesBuilder(hashEnabled, hashChannels, VARCHAR, VARCHAR, VARCHAR, BIGINT);
+        RowPagesBuilder rowPagesBuilder = rowPagesBuilder(hashEnabled, hashChannels, VARCHAR, BIGINT, VARCHAR, BIGINT);
         List<Page> input = rowPagesBuilder
                 .addSequencePage(10, 100, 0, 100, 0)
                 .addSequencePage(10, 100, 0, 200, 0)
@@ -181,7 +198,7 @@ public class TestHashAggregationOperator
         HashAggregationOperatorFactory operatorFactory = new HashAggregationOperatorFactory(
                 0,
                 new PlanNodeId("test"),
-                ImmutableList.of(VARCHAR),
+                ImmutableList.of(BIGINT),
                 hashChannels,
                 Step.SINGLE,
                 ImmutableList.of(COUNT.bind(ImmutableList.of(0), Optional.empty(), Optional.empty(), 1.0),
@@ -197,8 +214,8 @@ public class TestHashAggregationOperator
         toPages(operator, input);
     }
 
-    @Test(dataProvider = "hashEnabledValues")
-    public void testHashBuilderResize(boolean hashEnabled)
+    @Test(dataProvider = "hashEnabledAndMaxEntriesBeforeSpillValues")
+    public void testHashBuilderResize(boolean hashEnabled, long maxEntriesBeforeSpill)
     {
         BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 1, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES);
         VARCHAR.writeSlice(builder, Slices.allocate(200_000)); // this must be larger than DEFAULT_MAX_BLOCK_SIZE, 64K
@@ -225,15 +242,18 @@ public class TestHashAggregationOperator
                 ImmutableList.of(COUNT.bind(ImmutableList.of(0), Optional.empty(), Optional.empty(), 1.0)),
                 rowPagesBuilder.getHashChannel(),
                 100_000,
-                new DataSize(16, MEGABYTE));
+                new DataSize(16, MEGABYTE),
+                maxEntriesBeforeSpill,
+                new DataSize(0, MEGABYTE),
+                spillerFactory);
 
         Operator operator = operatorFactory.createOperator(driverContext);
 
         toPages(operator, input);
     }
 
-    @Test(dataProvider = "hashEnabledValues", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of 3MB")
-    public void testHashBuilderResizeLimit(boolean hashEnabled)
+    @Test(dataProvider = "hashEnabledAndMaxEntriesBeforeSpillValues", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of 3MB")
+    public void testHashBuilderResizeLimit(boolean hashEnabled, long maxEntriesBeforeSpill)
     {
         BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 1, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES);
         VARCHAR.writeSlice(builder, Slices.allocate(5_000_000)); // this must be larger than DEFAULT_MAX_BLOCK_SIZE, 64K
@@ -267,7 +287,7 @@ public class TestHashAggregationOperator
         toPages(operator, input);
     }
 
-    @Test(dataProvider = "hashEnabledValues")
+    @Test(dataProvider = "hashEnabled")
     public void testMultiSliceAggregationOutput(boolean hashEnabled)
     {
         // estimate the number of entries required to create 1.5 pages of results
@@ -291,15 +311,18 @@ public class TestHashAggregationOperator
                         LONG_AVERAGE.bind(ImmutableList.of(1), Optional.empty(), Optional.empty(), 1.0)),
                 rowPagesBuilder.getHashChannel(),
                 100_000,
-                new DataSize(16, MEGABYTE));
+                new DataSize(16, MEGABYTE),
+                0,
+                new DataSize(0, MEGABYTE),
+                spillerFactory);
 
         Operator operator = operatorFactory.createOperator(driverContext);
 
         assertEquals(toPages(operator, input).size(), 2);
     }
 
-    @Test(dataProvider = "hashEnabledValues")
-    public void testMultiplePartialFlushes(boolean hashEnabled)
+    @Test(dataProvider = "hashEnabledAndMaxEntriesBeforeSpillValues")
+    public void testMultiplePartialFlushes(boolean hashEnabled, long maxEntriesBeforeSpill)
             throws Exception
     {
         List<Integer> hashChannels = Ints.asList(0);
@@ -320,7 +343,10 @@ public class TestHashAggregationOperator
                 ImmutableList.of(LONG_SUM.bind(ImmutableList.of(0), Optional.empty(), Optional.empty(), 1.0)),
                 rowPagesBuilder.getHashChannel(),
                 100_000,
-                new DataSize(16, MEGABYTE));
+                new DataSize(16, MEGABYTE),
+                maxEntriesBeforeSpill,
+                new DataSize(0, MEGABYTE),
+                spillerFactory);
 
         DriverContext driverContext = createTaskContext(executor, TEST_SESSION, new DataSize(1, Unit.KILOBYTE))
                 .addPipelineContext(true, true)
@@ -373,5 +399,35 @@ public class TestHashAggregationOperator
 
         assertEquals(actual.getTypes(), expected.getTypes());
         assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    private static class DummySpillerFactory implements SpillerFactory
+    {
+        @Override
+        public Spiller create(List<Type> types)
+        {
+            return new Spiller()
+            {
+                private final List<Iterator<Page>> spills = new ArrayList<>();
+
+                @Override
+                public CompletableFuture<?> spill(Iterator<Page> pageIterator)
+                {
+                    spills.add(pageIterator);
+                    return CompletableFuture.completedFuture(null);
+                }
+
+                @Override
+                public List<Iterator<Page>> getSpills()
+                {
+                    return spills;
+                }
+
+                @Override
+                public void close()
+                {
+                }
+            };
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -108,9 +108,9 @@ public class TestHashAggregationOperator
     public static Object[][] hashEnabledAndMaxEntriesBeforeSpillValuesProvider()
     {
         return new Object[][] {
-                { true, Long.MAX_VALUE },
+                { true, 0 },
                 { true, 8 },
-                { false, Long.MAX_VALUE },
+                { false, 0 },
                 { false, 8 }};
     }
 
@@ -176,8 +176,8 @@ public class TestHashAggregationOperator
         assertOperatorEqualsIgnoreOrder(operator, input, expected, hashEnabled, Optional.of(hashChannels.size()));
     }
 
-    @Test(dataProvider = "hashEnabledAndMaxEntriesBeforeSpillValues", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of 10B")
-    public void testMemoryLimit(boolean hashEnabled, long maxEntriesBeforeSpill)
+    @Test(dataProvider = "hashEnabled", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of 10B")
+    public void testMemoryLimit(boolean hashEnabled)
     {
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
         InternalAggregationFunction maxVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMergeSort.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMergeSort.java
@@ -66,8 +66,10 @@ public class TestMergeSort
     {
         Page emptyPage = new Page(0, BIGINT.createFixedSizeBlockBuilder(0).build());
 
-        MergeSort mergeSort = new MergeSort(ImmutableList.of(BIGINT), ImmutableList.of(BIGINT));
-        Iterator<Page> mergedPage = mergeSort.merge(ImmutableList.of(ImmutableList.of(emptyPage).iterator()));
+        Iterator<Page> mergedPage = MergeSort.merge(
+                ImmutableList.of(BIGINT),
+                ImmutableList.of(BIGINT),
+                ImmutableList.of(ImmutableList.of(emptyPage).iterator()));
 
         assertTrue(mergedPage.hasNext());
 
@@ -83,8 +85,10 @@ public class TestMergeSort
         Page emptyPage = new Page(0, BIGINT.createFixedSizeBlockBuilder(0).build());
         Page page = rowPagesBuilder(BIGINT).row(42).build().get(0);
 
-        MergeSort mergeSort = new MergeSort(ImmutableList.of(BIGINT), ImmutableList.of(BIGINT));
-        Iterator<Page> mergedPage = mergeSort.merge(ImmutableList.of(ImmutableList.of(emptyPage, page).iterator()));
+        Iterator<Page> mergedPage = MergeSort.merge(
+                ImmutableList.of(BIGINT),
+                ImmutableList.of(BIGINT),
+                ImmutableList.of(ImmutableList.of(emptyPage, page).iterator()));
 
         assertTrue(mergedPage.hasNext());
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMergeSort.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMergeSort.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
+import static com.facebook.presto.operator.PageAssertions.assertPageEquals;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestMergeSort
+{
+    @Test
+    public void testMerge() throws Exception
+    {
+    }
+
+    @Test
+    public void testChannelIterator()
+    {
+        RowPagesBuilder pageBuilder = rowPagesBuilder(BIGINT);
+        pageBuilder.addSequencePage(2, 2);
+        pageBuilder.addSequencePage(2, 10);
+
+        MergeSort.PagePositions iterator = new MergeSort.SingleChannelPagePositions(pageBuilder.build().iterator());
+
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next().getPosition(), 0);
+
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next().getPosition(), 1);
+
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next().getPosition(), 0);
+
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next().getPosition(), 1);
+
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testBinaryMergeIteratorOverEmptyPage()
+    {
+        Page emptyPage = new Page(0, BIGINT.createFixedSizeBlockBuilder(0).build());
+
+        MergeSort mergeSort = new MergeSort(ImmutableList.of(BIGINT), ImmutableList.of(BIGINT));
+        Iterator<Page> mergedPage = mergeSort.merge(ImmutableList.of(ImmutableList.of(emptyPage).iterator()));
+
+        assertTrue(mergedPage.hasNext());
+
+        Page actualPage = mergedPage.next();
+        assertEquals(actualPage.getPositionCount(), 0);
+
+        assertFalse(mergedPage.hasNext());
+    }
+
+    @Test
+    public void testBinaryMergeIteratorOverEmptyPageAndNonEmptyPage()
+    {
+        Page emptyPage = new Page(0, BIGINT.createFixedSizeBlockBuilder(0).build());
+        Page page = rowPagesBuilder(BIGINT).row(42).build().get(0);
+
+        MergeSort mergeSort = new MergeSort(ImmutableList.of(BIGINT), ImmutableList.of(BIGINT));
+        Iterator<Page> mergedPage = mergeSort.merge(ImmutableList.of(ImmutableList.of(emptyPage, page).iterator()));
+
+        assertTrue(mergedPage.hasNext());
+
+        Page actualPage = mergedPage.next();
+        assertEquals(actualPage.getPositionCount(), 1);
+        assertEquals(actualPage.getChannelCount(), 1);
+        assertEquals(actualPage.getBlock(0).getLong(0, 0), 42);
+
+        assertFalse(mergedPage.hasNext());
+    }
+
+    @Test
+    public void testPageRewriteIterator()
+    {
+        ImmutableList<Type> types = ImmutableList.of(BIGINT, BIGINT);
+        RowPagesBuilder pagesBuilder = rowPagesBuilder(types);
+        pagesBuilder.row(0, 42);
+        pagesBuilder.row(0, 43);
+        pagesBuilder.pageBreak();
+        pagesBuilder.row(0, 44);
+        pagesBuilder.row(1, 45);
+        pagesBuilder.pageBreak();
+        pagesBuilder.row(2, 46);
+
+        Iterator<Page> rewriterIterator = new MergeSort.PageRewriteIterator(
+                ImmutableList.of(BIGINT),
+                types,
+                new MergeSort.SingleChannelPagePositions(pagesBuilder.build().iterator()));
+
+        List<Page> pages = Lists.newArrayList(rewriterIterator);
+        assertEquals(pages.size(), 1);
+
+        List<Page> expectedPages = rowPagesBuilder(types)
+                .row(0, 42)
+                .row(0, 43)
+                .row(0, 44)
+                .row(1, 45)
+                .row(2, 46)
+                .build();
+
+        assertPageEquals(types, pages.get(0), expectedPages.get(0));
+    }
+
+    private long readBigint(MergeSort.PagePosition pagePosition)
+    {
+        return BIGINT.getLong(pagePosition.getPage().getBlock(0), pagePosition.getPosition());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/spiller/BenchmarkBinaryFileSpiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/spiller/BenchmarkBinaryFileSpiller.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.spiller;
+
+import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.spiller.Spiller;
+import com.facebook.presto.type.TypeRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.airlift.tpch.LineItem;
+import io.airlift.tpch.LineItemGenerator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@State(Scope.Thread)
+@OutputTimeUnit(SECONDS)
+@Fork(3)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class BenchmarkBinaryFileSpiller
+{
+    private static final BlockEncodingSerde BLOCK_ENCODING_MANAGER = new BlockEncodingManager(new TypeRegistry(ImmutableSet.of(BIGINT, DOUBLE, VARCHAR)));
+
+    @Benchmark
+    public void write(BenchmarkData data)
+            throws ExecutionException, InterruptedException
+    {
+        try (Spiller spiller = new BinaryFileSpiller(BLOCK_ENCODING_MANAGER, data.getExecutor())) {
+            spiller.spill(data.getPages().iterator()).get();
+        }
+    }
+
+    @Benchmark
+    public void read(BenchmarkData data)
+    {
+        List<Iterator<Page>> spills = data.getSpiller().getSpills();
+        for (Iterator<Page> spill : spills) {
+            while (spill.hasNext()) {
+                Page next = spill.next();
+                next.getPositionCount();
+            }
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private ListeningExecutorService executor;
+
+        @Param({"10000"})
+        private int rowsPerPage = 10000;
+
+        @Param({"10"})
+        private int pagesCount = 10;
+
+        private List<Page> pages;
+        private Spiller spiller;
+
+        @Setup
+        public void setup()
+                throws ExecutionException, InterruptedException
+        {
+            executor = listeningDecorator(newSingleThreadScheduledExecutor());
+            pages = createInputPages();
+            spiller = new BinaryFileSpiller(BLOCK_ENCODING_MANAGER, executor);
+            spiller.spill(pages.iterator()).get();
+        }
+
+        @TearDown
+        public void tearDown()
+        {
+            spiller.close();
+            MoreExecutors.shutdownAndAwaitTermination(executor, 5, SECONDS);
+        }
+
+        private List<Page> createInputPages()
+        {
+            ImmutableList.Builder<Page> pages = ImmutableList.builder();
+
+            PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(BIGINT, BIGINT, DOUBLE, createUnboundedVarcharType(), DOUBLE));
+            LineItemGenerator lineItemGenerator = new LineItemGenerator(1, 1, 1);
+            for (int j = 0; j < pagesCount; j++) {
+                Iterator<LineItem> iterator = lineItemGenerator.iterator();
+                for (int i = 0; i < rowsPerPage; i++) {
+                    pageBuilder.declarePosition();
+
+                    LineItem lineItem = iterator.next();
+                    BIGINT.writeLong(pageBuilder.getBlockBuilder(0), lineItem.getOrderKey());
+                    BIGINT.writeLong(pageBuilder.getBlockBuilder(1), lineItem.getDiscountPercent());
+                    DOUBLE.writeDouble(pageBuilder.getBlockBuilder(2), lineItem.getDiscount());
+                    VARCHAR.writeString(pageBuilder.getBlockBuilder(3), lineItem.getReturnFlag());
+                    DOUBLE.writeDouble(pageBuilder.getBlockBuilder(4), lineItem.getExtendedPrice());
+                }
+                pages.add(pageBuilder.build());
+            }
+
+            return pages.build();
+        }
+
+        public List<Page> getPages()
+        {
+            return pages;
+        }
+
+        public Spiller getSpiller()
+        {
+            return spiller;
+        }
+
+        public ListeningExecutorService getExecutor()
+        {
+            return executor;
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/spiller/BinaryFileSpillerTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/spiller/BinaryFileSpillerTest.java
@@ -25,7 +25,6 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.ListeningExecutorService;
 import org.testng.annotations.Test;
 
 import java.util.Iterator;
@@ -37,17 +36,14 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static java.lang.Double.doubleToLongBits;
-import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static org.testng.Assert.assertEquals;
 
 public class BinaryFileSpillerTest
 {
     private static final List<Type> TYPES = ImmutableList.of(BIGINT, VARCHAR, DOUBLE, BIGINT);
-    private final ListeningExecutorService executor = listeningDecorator(newSingleThreadScheduledExecutor());
     private final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager(new TypeRegistry(ImmutableSet.of(BIGINT, DOUBLE, VARBINARY)));
-    private final BinarySpillerFactory factory = new BinarySpillerFactory(blockEncodingSerde, executor, new FeaturesConfig());
+    private final BinarySpillerFactory factory = new BinarySpillerFactory(blockEncodingSerde, new FeaturesConfig());
 
     @Test
     public void testFileSpiller()

--- a/presto-main/src/test/java/com/facebook/presto/operator/spiller/BinaryFileSpillerTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/spiller/BinaryFileSpillerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.spiller;
+
+import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.spiller.Spiller;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.TypeRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static com.facebook.presto.operator.PageAssertions.assertPageEquals;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static java.lang.Double.doubleToLongBits;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static org.testng.Assert.assertEquals;
+
+public class BinaryFileSpillerTest
+{
+    private static final List<Type> TYPES = ImmutableList.of(BIGINT, VARCHAR, DOUBLE, BIGINT);
+    private final ListeningExecutorService executor = listeningDecorator(newSingleThreadScheduledExecutor());
+    private final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager(new TypeRegistry(ImmutableSet.of(BIGINT, DOUBLE, VARBINARY)));
+    private final BinarySpillerFactory factory = new BinarySpillerFactory(blockEncodingSerde, executor);
+
+    @Test
+    public void testFileSpiller()
+            throws Exception
+    {
+        try (Spiller spiller = factory.create(TYPES)) {
+            testSimpleSpiller(spiller);
+        }
+    }
+
+    @Test
+    public void testFileVarbinarySpiller()
+            throws Exception
+    {
+        List<Type> types = ImmutableList.of(BIGINT, DOUBLE, VARBINARY);
+
+        BlockBuilder col1 = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder col2 = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder col3 = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 1);
+
+        col1.writeLong(42).closeEntry();
+        col2.writeLong(doubleToLongBits(43.0)).closeEntry();
+        col3.writeLong(doubleToLongBits(43.0)).writeLong(1).closeEntry();
+
+        Page page = new Page(col1.build(), col2.build(), col3.build());
+
+        try (Spiller spiller = factory.create(TYPES)) {
+            testSpiller(types, spiller, ImmutableList.of(page));
+        }
+    }
+
+    private void testSimpleSpiller(Spiller spiller)
+            throws ExecutionException, InterruptedException
+    {
+        RowPagesBuilder builder = RowPagesBuilder.rowPagesBuilder(TYPES);
+        builder.addSequencePage(10, 0, 5, 10, 15);
+        builder.pageBreak();
+        builder.addSequencePage(10, 0, -5, -10, -15);
+        List<Page> firstSpill = builder.build();
+
+        builder = RowPagesBuilder.rowPagesBuilder(TYPES);
+        builder.addSequencePage(10, 10, 15, 20, 25);
+        builder.pageBreak();
+        builder.addSequencePage(10, -10, -15, -20, -25);
+        List<Page> secondSpill = builder.build();
+
+        testSpiller(TYPES, spiller, firstSpill, secondSpill);
+    }
+
+    private void testSpiller(List<Type> types, Spiller spiller, List<Page>... spills)
+            throws ExecutionException, InterruptedException
+    {
+        for (List<Page> spill : spills) {
+            spiller.spill(spill.iterator()).get();
+        }
+
+        List<Iterator<Page>> actualSpills = spiller.getSpills();
+
+        assertEquals(actualSpills.size(), spills.length);
+
+        for (int i = 0; i < actualSpills.size(); i++) {
+            List<Page> actualSpill = ImmutableList.copyOf(actualSpills.get(i));
+            List<Page> expectedSpill = spills[i];
+
+            assertEquals(actualSpill.size(), expectedSpill.size());
+            for (int j = 0; j < actualSpill.size(); j++) {
+                assertPageEquals(types, actualSpill.get(j), expectedSpill.get(j));
+            }
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/spiller/BinaryFileSpillerTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/spiller/BinaryFileSpillerTest.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.spiller.Spiller;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -46,7 +47,7 @@ public class BinaryFileSpillerTest
     private static final List<Type> TYPES = ImmutableList.of(BIGINT, VARCHAR, DOUBLE, BIGINT);
     private final ListeningExecutorService executor = listeningDecorator(newSingleThreadScheduledExecutor());
     private final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager(new TypeRegistry(ImmutableSet.of(BIGINT, DOUBLE, VARBINARY)));
-    private final BinarySpillerFactory factory = new BinarySpillerFactory(blockEncodingSerde, executor);
+    private final BinarySpillerFactory factory = new BinarySpillerFactory(blockEncodingSerde, executor, new FeaturesConfig());
 
     @Test
     public void testFileSpiller()

--- a/presto-main/src/test/java/com/facebook/presto/operator/spiller/TestSpillerFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/spiller/TestSpillerFactory.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static io.airlift.testing.FileUtils.deleteRecursively;
@@ -40,7 +41,7 @@ public class TestSpillerFactory
             throws Exception
     {
         ImmutableList<Module> additionalModules = ImmutableList.of(new CustomSpillerModule());
-        ImmutableMap<String, String> serverProperties = ImmutableMap.of("experimental.spiller-implementation", "custom");
+        Map<String, String> serverProperties = ImmutableMap.of("experimental.spiller-implementation", "custom");
         try (TestingPrestoServer server = new TestingPrestoServer(true, serverProperties, null, null, additionalModules)) {
             assertInstanceOf(server.getSpillerFactory(), CustomSpillerFactory.class);
         }
@@ -52,7 +53,7 @@ public class TestSpillerFactory
     {
         File tempDir = Files.createTempDir();
         String spillPath = new File(tempDir, "custom_path").getAbsolutePath();
-        ImmutableMap<String, String> serverProperties = ImmutableMap.of("experimental.spiller-spill-path", spillPath);
+        Map<String, String> serverProperties = ImmutableMap.of("experimental.spiller-spill-path", spillPath);
         try (TestingPrestoServer server = new TestingPrestoServer(true, serverProperties, null, null, emptyList())) {
             assertTrue(new File(spillPath).exists());
         } finally {

--- a/presto-main/src/test/java/com/facebook/presto/operator/spiller/TestSpillerFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/spiller/TestSpillerFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.spiller;
+
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.spiller.Spiller;
+import com.facebook.presto.spi.spiller.SpillerFactory;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.airlift.testing.Assertions.assertInstanceOf;
+
+public class TestSpillerFactory
+{
+    @Test
+    public void testOverrideDefaultSpiller()
+            throws Exception
+    {
+        ImmutableList<Module> additionalModules = ImmutableList.of(new CustomSpillerModule());
+        ImmutableMap<String, String> serverProperties = ImmutableMap.of("experimental.spiller-implementation", "custom");
+        try (TestingPrestoServer server = new TestingPrestoServer(true, serverProperties, null, null, additionalModules)) {
+            assertInstanceOf(server.getSpillerFactory(), CustomSpillerFactory.class);
+        }
+    }
+
+    private static class CustomSpillerModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(SpillerFactory.class).to(CustomSpillerFactory.class).in(Scopes.SINGLETON);
+        }
+    }
+
+    private static class CustomSpillerFactory
+            implements SpillerFactory
+    {
+        @Override
+        public Spiller create(List<Type> types)
+        {
+            throw new IllegalStateException("Must not be called");
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.analyzer;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.configuration.testing.ConfigAssertions;
+import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -50,7 +51,8 @@ public class TestFeaturesConfig
                 .setRegexLibrary(JONI)
                 .setRe2JDfaStatesLimit(Integer.MAX_VALUE)
                 .setRe2JDfaRetries(5)
-                .setResourceGroupManager(FILE_BASED_RESOURCE_GROUP_MANAGER));
+                .setResourceGroupManager(FILE_BASED_RESOURCE_GROUP_MANAGER)
+                .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("0MB")));
     }
 
     @Test
@@ -74,6 +76,7 @@ public class TestFeaturesConfig
                 .put("re2j.dfa-states-limit", "42")
                 .put("re2j.dfa-retries", "42")
                 .put("resource-group-manager", "test")
+                .put("experimental.operator-memory-limit-before-spill", "100MB")
                 .build();
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("experimental-syntax-enabled", "true")
@@ -93,6 +96,7 @@ public class TestFeaturesConfig
                 .put("re2j.dfa-states-limit", "42")
                 .put("re2j.dfa-retries", "42")
                 .put("resource-group-manager", "test")
+                .put("experimental.operator-memory-limit-before-spill", "100MB")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -112,7 +116,8 @@ public class TestFeaturesConfig
                 .setRegexLibrary(RE2J)
                 .setRe2JDfaStatesLimit(42)
                 .setRe2JDfaRetries(42)
-                .setResourceGroupManager("test");
+                .setResourceGroupManager("test")
+                .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("100MB"));
 
         assertFullMapping(properties, expected);
         assertDeprecatedEquivalence(FeaturesConfig.class, properties, propertiesLegacy);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.FILE_BASED_RESOURCE_GROUP_MANAGER;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.ProcessingOptimization.COLUMNAR_DICTIONARY;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.ProcessingOptimization.DISABLED;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.SpillerImplementation.BINARY_FILE;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.RE2J;
 import static io.airlift.configuration.testing.ConfigAssertions.assertDeprecatedEquivalence;
@@ -52,7 +53,8 @@ public class TestFeaturesConfig
                 .setRe2JDfaStatesLimit(Integer.MAX_VALUE)
                 .setRe2JDfaRetries(5)
                 .setResourceGroupManager(FILE_BASED_RESOURCE_GROUP_MANAGER)
-                .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("0MB")));
+                .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("0MB"))
+                .setSpillerImplementation(BINARY_FILE));
     }
 
     @Test
@@ -77,6 +79,7 @@ public class TestFeaturesConfig
                 .put("re2j.dfa-retries", "42")
                 .put("resource-group-manager", "test")
                 .put("experimental.operator-memory-limit-before-spill", "100MB")
+                .put("experimental.spiller-implementation", "custom")
                 .build();
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("experimental-syntax-enabled", "true")
@@ -97,6 +100,7 @@ public class TestFeaturesConfig
                 .put("re2j.dfa-retries", "42")
                 .put("resource-group-manager", "test")
                 .put("experimental.operator-memory-limit-before-spill", "100MB")
+                .put("experimental.spiller-implementation", "custom")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -117,7 +121,8 @@ public class TestFeaturesConfig
                 .setRe2JDfaStatesLimit(42)
                 .setRe2JDfaRetries(42)
                 .setResourceGroupManager("test")
-                .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("100MB"));
+                .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("100MB"))
+                .setSpillerImplementation("custom");
 
         assertFullMapping(properties, expected);
         assertDeprecatedEquivalence(FeaturesConfig.class, properties, propertiesLegacy);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -56,7 +56,8 @@ public class TestFeaturesConfig
                 .setResourceGroupManager(FILE_BASED_RESOURCE_GROUP_MANAGER)
                 .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("0MB"))
                 .setSpillerImplementation(BINARY_FILE)
-                .setSpillerSpillPath(Paths.get(System.getProperty("java.io.tmpdir"), "presto", "spills").toString()));
+                .setSpillerSpillPath(Paths.get(System.getProperty("java.io.tmpdir"), "presto", "spills").toString())
+                .setSpillerThreads(4));
     }
 
     @Test
@@ -83,6 +84,7 @@ public class TestFeaturesConfig
                 .put("experimental.operator-memory-limit-before-spill", "100MB")
                 .put("experimental.spiller-implementation", "custom")
                 .put("experimental.spiller-spill-path", "/tmp/custom/spill/path")
+                .put("experimental.spiller-threads", "42")
                 .build();
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("experimental-syntax-enabled", "true")
@@ -105,6 +107,7 @@ public class TestFeaturesConfig
                 .put("experimental.operator-memory-limit-before-spill", "100MB")
                 .put("experimental.spiller-implementation", "custom")
                 .put("experimental.spiller-spill-path", "/tmp/custom/spill/path")
+                .put("experimental.spiller-threads", "42")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -127,7 +130,8 @@ public class TestFeaturesConfig
                 .setResourceGroupManager("test")
                 .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("100MB"))
                 .setSpillerImplementation("custom")
-                .setSpillerSpillPath("/tmp/custom/spill/path");
+                .setSpillerSpillPath("/tmp/custom/spill/path")
+                .setSpillerThreads(42);
 
         assertFullMapping(properties, expected);
         assertDeprecatedEquivalence(FeaturesConfig.class, properties, propertiesLegacy);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -18,6 +18,7 @@ import io.airlift.configuration.testing.ConfigAssertions;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
+import java.nio.file.Paths;
 import java.util.Map;
 
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.FILE_BASED_RESOURCE_GROUP_MANAGER;
@@ -54,7 +55,8 @@ public class TestFeaturesConfig
                 .setRe2JDfaRetries(5)
                 .setResourceGroupManager(FILE_BASED_RESOURCE_GROUP_MANAGER)
                 .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("0MB"))
-                .setSpillerImplementation(BINARY_FILE));
+                .setSpillerImplementation(BINARY_FILE)
+                .setSpillerSpillPath(Paths.get(System.getProperty("java.io.tmpdir"), "presto", "spills").toString()));
     }
 
     @Test
@@ -80,6 +82,7 @@ public class TestFeaturesConfig
                 .put("resource-group-manager", "test")
                 .put("experimental.operator-memory-limit-before-spill", "100MB")
                 .put("experimental.spiller-implementation", "custom")
+                .put("experimental.spiller-spill-path", "/tmp/custom/spill/path")
                 .build();
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("experimental-syntax-enabled", "true")
@@ -101,6 +104,7 @@ public class TestFeaturesConfig
                 .put("resource-group-manager", "test")
                 .put("experimental.operator-memory-limit-before-spill", "100MB")
                 .put("experimental.spiller-implementation", "custom")
+                .put("experimental.spiller-spill-path", "/tmp/custom/spill/path")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -122,7 +126,8 @@ public class TestFeaturesConfig
                 .setRe2JDfaRetries(42)
                 .setResourceGroupManager("test")
                 .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("100MB"))
-                .setSpillerImplementation("custom");
+                .setSpillerImplementation("custom")
+                .setSpillerSpillPath("/tmp/custom/spill/path");
 
         assertFullMapping(properties, expected);
         assertDeprecatedEquivalence(FeaturesConfig.class, properties, propertiesLegacy);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/spiller/Spiller.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/spiller/Spiller.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.spiller;
+
+import com.facebook.presto.spi.Page;
+
+import java.io.Closeable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public interface Spiller
+        extends Closeable
+{
+    /**
+     * Initiate spilling of pages stream. Returns completed future once spilling has finished.
+     */
+    CompletableFuture<?> spill(Iterator<Page> pageIterator);
+
+    /**
+     * Returns list of previously spilled Pages streams.
+     */
+    List<Iterator<Page>> getSpills();
+
+    /**
+     * Close releases/removes all underlying resources used during spilling
+     * like for example all created temporary files.
+     */
+    @Override
+    void close();
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/spiller/SpillerFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/spiller/SpillerFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.spiller;
+
+import com.facebook.presto.spi.type.Type;
+
+import java.util.List;
+
+public interface SpillerFactory
+{
+    Spiller create(List<Type> types);
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalBinarySpilledQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalBinarySpilledQueries.java
@@ -20,6 +20,7 @@ import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.tpch.TpchConnectorFactory;
 import com.facebook.presto.tpch.testing.SampledTpchConnectorFactory;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
 
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
@@ -69,5 +70,37 @@ public class TestLocalBinarySpilledQueries
                 .setCatalog(TPCH_SAMPLED_SCHEMA)
                 .setSchema(TINY_SCHEMA_NAME)
                 .build();
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Spilling requires all types in GROUP BY key to be orderable")
+    @Override
+    public void testGroupByMap()
+            throws Exception
+    {
+        super.testGroupByMap();
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Spilling requires all types in GROUP BY key to be orderable")
+    @Override
+    public void testGroupByComplexMap()
+            throws Exception
+    {
+        super.testGroupByComplexMap();
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Spilling requires all types in GROUP BY key to be orderable")
+    @Override
+    public void testGroupByRow()
+            throws Exception
+    {
+        super.testGroupByRow();
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Spilling requires all types in GROUP BY key to be orderable")
+    @Override
+    public void testRowFieldAccessorInAggregate()
+            throws Exception
+    {
+        super.testRowFieldAccessorInAggregate();
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalBinarySpilledQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalBinarySpilledQueries.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.facebook.presto.tpch.testing.SampledTpchConnectorFactory;
+import com.google.common.collect.ImmutableMap;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+
+public class TestLocalBinarySpilledQueries
+        extends AbstractTestApproximateQueries
+{
+    private static final String TPCH_SAMPLED_SCHEMA = "tpch_sampled";
+
+    public TestLocalBinarySpilledQueries()
+    {
+        super(createLocalQueryRunner(), createDefaultSampledSession());
+    }
+
+    private static LocalQueryRunner createLocalQueryRunner()
+    {
+        Session defaultSession = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema(TINY_SCHEMA_NAME)
+                .setSystemProperties(ImmutableMap.of(
+                        SystemSessionProperties.OPERATOR_MEMORY_LIMIT_BEFORE_SPILL, "100MB",
+                        SystemSessionProperties.MAX_ENTRIES_BEFORE_SPILL, "8")) //spill almost constantly
+                .build();
+
+        LocalQueryRunner localQueryRunner = new LocalQueryRunner(defaultSession);
+
+        // add the tpch catalog
+        // local queries run directly against the generator
+        localQueryRunner.createCatalog(
+                defaultSession.getCatalog().get(),
+                new TpchConnectorFactory(localQueryRunner.getNodeManager(), 1),
+                ImmutableMap.<String, String>of());
+        localQueryRunner.createCatalog(TPCH_SAMPLED_SCHEMA, new SampledTpchConnectorFactory(localQueryRunner.getNodeManager(), 1, 2), ImmutableMap.<String, String>of());
+
+        localQueryRunner.getMetadata().addFunctions(CUSTOM_FUNCTIONS);
+
+        SessionPropertyManager sessionPropertyManager = localQueryRunner.getMetadata().getSessionPropertyManager();
+        sessionPropertyManager.addSystemSessionProperties(AbstractTestQueries.TEST_SYSTEM_PROPERTIES);
+        sessionPropertyManager.addConnectorSessionProperties("connector", AbstractTestQueries.TEST_CATALOG_PROPERTIES);
+
+        return localQueryRunner;
+    }
+
+    private static Session createDefaultSampledSession()
+    {
+        return testSessionBuilder()
+                .setCatalog(TPCH_SAMPLED_SCHEMA)
+                .setSchema(TINY_SCHEMA_NAME)
+                .build();
+    }
+}


### PR DESCRIPTION
This code have some issues, but I think it's some starting point which is worth showing before resolving them. On our test cluster this PoC allowed to pass multiple queries which were previously failing due to lack of memory, for example:

```
select avg(quantity) as aq, avg(extendedprice) as ae, avg(discount) as ad, avg(tax) as at from lineitem group by orderkey order by aq desc, ae desc limit 10;
```

Some of the issues with this code:

1. it only supports one Spiller plugin in the class path 
2. decision what to spill is naive - spill everything and during spilling block aggregation operator
3. Currently spillilng aggregations on array, map and row columns is not supported