### PR TITLE
Add parentRelationType to AnalysisContext

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -307,7 +307,12 @@ public class ExpressionAnalyzer
                     return field.getType();
                 }
 
-                assertColumnPrefix(qualifiedName, node);
+                if (!isColumnPrefix(qualifiedName, tupleDescriptor)) {
+                    if (isReferenceToOuterRelation(context.getContext(), qualifiedName)) {
+                        throw new SemanticException(NOT_SUPPORTED, node, "Accessing outer relation symbol '%s', while correlated subqueries are not yet supported", node);
+                    }
+                    throw createMissingAttributeException(node);
+                }
             }
 
             Type baseType = process(node.getBase(), context);
@@ -332,19 +337,37 @@ public class ExpressionAnalyzer
             return rowFieldType;
         }
 
-        private void assertColumnPrefix(QualifiedName qualifiedName, Expression node)
+        private boolean isColumnPrefix(QualifiedName qualifiedName, RelationType tupleDescriptor)
         {
             // Recursively check if its prefix is a column.
             while (qualifiedName.getPrefix().isPresent()) {
                 qualifiedName = qualifiedName.getPrefix().get();
                 List<Field> matches = tupleDescriptor.resolveFields(qualifiedName);
                 if (!matches.isEmpty()) {
-                    // The AMBIGUOUS_ATTRIBUTE exception will be thrown later with the right node if matches.size() > 1
-                    return;
+                    return true;
                 }
             }
+            return false;
+        }
 
-            throw createMissingAttributeException(node);
+        private boolean isReferenceToOuterRelation(AnalysisContext context, QualifiedName qualifiedName)
+        {
+            while (true) {
+                RelationType parentRelationType = context.getParentRelationType();
+                if (!parentRelationType.resolveFields(qualifiedName).isEmpty()) {
+                    return true;
+                }
+                if (isColumnPrefix(qualifiedName, parentRelationType)) {
+                    return true;
+                }
+                if (context.getParent().isPresent()) {
+                    context = context.getParent().get();
+                }
+                else {
+                    break;
+                }
+            }
+            return false;
         }
 
         private SemanticException createMissingAttributeException(Expression node)
@@ -883,7 +906,7 @@ public class ExpressionAnalyzer
         protected Type visitSubqueryExpression(SubqueryExpression node, StackableAstVisitorContext<AnalysisContext> context)
         {
             StatementAnalyzer analyzer = statementAnalyzerFactory.apply(node);
-            RelationType descriptor = analyzer.process(node.getQuery(), context.getContext());
+            RelationType descriptor = analyzer.process(node.getQuery(), new AnalysisContext(context.getContext(), tupleDescriptor));
 
             // Subquery should only produce one column
             if (descriptor.getVisibleFieldCount() != 1) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -819,7 +819,7 @@ class StatementAnalyzer
     @Override
     protected RelationType visitQuery(Query node, AnalysisContext parentContext)
     {
-        AnalysisContext context = new AnalysisContext(parentContext);
+        AnalysisContext context = new AnalysisContext(parentContext, new RelationType());
 
         if (node.getApproximate().isPresent()) {
             if (!experimentalSyntaxEnabled) {
@@ -1062,7 +1062,7 @@ class StatementAnalyzer
         // TODO: extract candidate names from SELECT, WHERE, HAVING, GROUP BY and ORDER BY expressions
         // to pass down to analyzeFrom
 
-        AnalysisContext context = new AnalysisContext(parentContext);
+        AnalysisContext context = new AnalysisContext(parentContext, new RelationType());
 
         RelationType sourceType = analyzeFrom(node, context);
 
@@ -1162,7 +1162,7 @@ class StatementAnalyzer
             throw new SemanticException(NOT_SUPPORTED, node, "Natural join not supported");
         }
 
-        AnalysisContext leftContext = new AnalysisContext(context);
+        AnalysisContext leftContext = new AnalysisContext(context, new RelationType());
         RelationType left = process(node.getLeft(), context);
         leftContext.setLateralTupleDescriptor(left);
         RelationType right = process(node.getRight(), leftContext);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5085,6 +5085,50 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testCorrelatedScalarSubqueries()
+            throws Exception
+    {
+        String errorMsg = "line .*: Accessing outer relation symbol '.*', while correlated subqueries are not yet supported";
+
+        assertQueryFails("SELECT (SELECT l.orderkey) FROM lineitem l", errorMsg);
+        assertQueryFails("SELECT * FROM lineitem l WHERE 1 = (SELECT l.orderkey)", errorMsg);
+        assertQueryFails("SELECT * FROM lineitem l ORDER BY (SELECT l.orderkey)", errorMsg);
+
+        // group by
+        assertQueryFails("SELECT max(l.quantity), l.orderkey, (SELECT l.orderkey) FROM lineitem l GROUP BY l.orderkey", errorMsg);
+        assertQueryFails("SELECT max(l.quantity), l.orderkey FROM lineitem l GROUP BY l.orderkey HAVING max(l.quantity) < (SELECT l.orderkey)", errorMsg);
+        assertQueryFails("SELECT max(l.quantity), l.orderkey FROM lineitem l GROUP BY l.orderkey, (SELECT l.orderkey)", errorMsg);
+
+        // join
+        assertQueryFails("SELECT * FROM lineitem l1 JOIN lineitem l2 ON l1.orderkey= (SELECT l2.orderkey)", errorMsg);
+        assertQueryFails("SELECT * FROM lineitem l1 WHERE 1 = (SELECT count(*) FROM lineitem l2 CROSS JOIN (SELECT l1.orderkey) l3)", errorMsg);
+
+        // subrelation
+        assertQueryFails("SELECT * FROM lineitem l WHERE l.orderkey= (SELECT * FROM (SELECT l.orderkey))", errorMsg);
+    }
+
+    @Test
+    public void testCorrelatedInPredicateSubqueries()
+    {
+        String errorMsg = "line .*: Accessing outer relation symbol '.*', while correlated subqueries are not yet supported";
+
+        assertQueryFails("SELECT 1 IN (SELECT l.orderkey) FROM lineitem l", errorMsg);
+        assertQueryFails("SELECT * FROM lineitem l WHERE 1 IN (SELECT l.orderkey)", errorMsg);
+        assertQueryFails("SELECT * FROM lineitem l ORDER BY 1 IN (SELECT l.orderkey)", errorMsg);
+
+        // group by
+        assertQueryFails("SELECT max(l.quantity), l.orderkey, 1 IN (SELECT l.orderkey) FROM lineitem l GROUP BY l.orderkey", errorMsg);
+        assertQueryFails("SELECT max(l.quantity), l.orderkey FROM lineitem l GROUP BY l.orderkey HAVING max(l.quantity) IN (SELECT l.orderkey)", errorMsg);
+        assertQueryFails("SELECT max(l.quantity), l.orderkey FROM lineitem l GROUP BY l.orderkey, 1 IN (SELECT l.orderkey)", errorMsg);
+
+        // join
+        assertQueryFails("SELECT * FROM lineitem l1 JOIN lineitem l2 ON l1.orderkey IN (SELECT l2.orderkey)", errorMsg);
+
+        // subrelation
+        assertQueryFails("SELECT * FROM lineitem l WHERE l.orderkey = (SELECT * FROM (SELECT 1 IN (SELECT l.orderkey)))", errorMsg);
+    }
+
+    @Test
     public void testPredicatePushdown()
             throws Exception
     {


### PR DESCRIPTION
Add parentRelationType to AnalysisContext

Thanks to that ExpressionAnalyzer is able to recognize that reference to
outer relation was used.
