### PR TITLE
Migrate cardinality, contains and array_position to new scalar framework

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -54,6 +54,7 @@ import com.facebook.presto.operator.scalar.ArrayLessThanOrEqualOperator;
 import com.facebook.presto.operator.scalar.ArrayMaxFunction;
 import com.facebook.presto.operator.scalar.ArrayMinFunction;
 import com.facebook.presto.operator.scalar.ArrayNotEqualOperator;
+import com.facebook.presto.operator.scalar.ArrayPositionFunction;
 import com.facebook.presto.operator.scalar.ArrayRemoveFunction;
 import com.facebook.presto.operator.scalar.ArraySliceFunction;
 import com.facebook.presto.operator.scalar.BitwiseFunctions;
@@ -173,7 +174,6 @@ import static com.facebook.presto.operator.scalar.ArrayIntersectFunction.ARRAY_I
 import static com.facebook.presto.operator.scalar.ArrayJoin.ARRAY_JOIN;
 import static com.facebook.presto.operator.scalar.ArrayJoin.ARRAY_JOIN_WITH_NULL_REPLACEMENT;
 import static com.facebook.presto.operator.scalar.ArrayLessThanOperator.ARRAY_LESS_THAN;
-import static com.facebook.presto.operator.scalar.ArrayPositionFunction.ARRAY_POSITION;
 import static com.facebook.presto.operator.scalar.ArraySortFunction.ARRAY_SORT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArraySubscriptOperator.ARRAY_SUBSCRIPT;
 import static com.facebook.presto.operator.scalar.ArrayToArrayCast.ARRAY_TO_ARRAY_CAST;
@@ -374,6 +374,7 @@ public class FunctionRegistry
                 .scalar(ArrayFunctions.class)
                 .scalar(ArrayCardinalityFunction.class)
                 .scalar(ArrayContains.class)
+                .scalar(ArrayPositionFunction.class)
                 .scalar(CombineHashFunction.class)
                 .scalar(JsonOperators.class)
                 .scalar(FailureFunction.class)
@@ -405,7 +406,7 @@ public class FunctionRegistry
                 .functions(ARRAY_TO_ARRAY_CAST, ARRAY_LESS_THAN)
                 .functions(ARRAY_TO_ELEMENT_CONCAT_FUNCTION, ELEMENT_TO_ARRAY_CONCAT_FUNCTION)
                 .function(MAP_HASH_CODE)
-                .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_POSITION, ARRAY_SORT_FUNCTION, ARRAY_TO_JSON, JSON_TO_ARRAY)
+                .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_SORT_FUNCTION, ARRAY_INTERSECT_FUNCTION, ARRAY_TO_JSON, JSON_TO_ARRAY)
                 .functions(MAP_CONSTRUCTOR, MAP_SUBSCRIPT, MAP_TO_JSON, JSON_TO_MAP)
                 .functions(MAP_AGG, MULTIMAP_AGG)
                 .functions(DECIMAL_TO_VARCHAR_CAST, DECIMAL_TO_INTEGER_CAST, DECIMAL_TO_BIGINT_CAST, DECIMAL_TO_DOUBLE_CAST, DECIMAL_TO_BOOLEAN_CAST)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -41,6 +41,7 @@ import com.facebook.presto.operator.aggregation.RegressionAggregation;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
 import com.facebook.presto.operator.scalar.ArrayCardinalityFunction;
 import com.facebook.presto.operator.scalar.ArrayConcatFunction;
+import com.facebook.presto.operator.scalar.ArrayContains;
 import com.facebook.presto.operator.scalar.ArrayDistinctFunction;
 import com.facebook.presto.operator.scalar.ArrayElementAtFunction;
 import com.facebook.presto.operator.scalar.ArrayEqualOperator;
@@ -168,7 +169,7 @@ import static com.facebook.presto.operator.aggregation.MinByNAggregationFunction
 import static com.facebook.presto.operator.aggregation.MinNAggregationFunction.MIN_N_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.MultimapAggregationFunction.MULTIMAP_AGG;
 import static com.facebook.presto.operator.scalar.ArrayConstructor.ARRAY_CONSTRUCTOR;
-import static com.facebook.presto.operator.scalar.ArrayContains.ARRAY_CONTAINS;
+import static com.facebook.presto.operator.scalar.ArrayIntersectFunction.ARRAY_INTERSECT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayJoin.ARRAY_JOIN;
 import static com.facebook.presto.operator.scalar.ArrayJoin.ARRAY_JOIN_WITH_NULL_REPLACEMENT;
 import static com.facebook.presto.operator.scalar.ArrayLessThanOperator.ARRAY_LESS_THAN;
@@ -372,6 +373,7 @@ public class FunctionRegistry
                 .scalar(LikeFunctions.class)
                 .scalar(ArrayFunctions.class)
                 .scalar(ArrayCardinalityFunction.class)
+                .scalar(ArrayContains.class)
                 .scalar(CombineHashFunction.class)
                 .scalar(JsonOperators.class)
                 .scalar(FailureFunction.class)
@@ -399,7 +401,7 @@ public class FunctionRegistry
                 .scalar(MapCardinalityFunction.class)
                 .scalar(MapConcatFunction.class)
                 .scalar(MapToMapCast.class)
-                .functions(ARRAY_CONTAINS, ARRAY_JOIN, ARRAY_JOIN_WITH_NULL_REPLACEMENT)
+                .functions(ARRAY_JOIN, ARRAY_JOIN_WITH_NULL_REPLACEMENT)
                 .functions(ARRAY_TO_ARRAY_CAST, ARRAY_LESS_THAN)
                 .functions(ARRAY_TO_ELEMENT_CONCAT_FUNCTION, ELEMENT_TO_ARRAY_CONCAT_FUNCTION)
                 .function(MAP_HASH_CODE)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayContains.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayContains.java
@@ -13,85 +13,42 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.metadata.BoundVariables;
-import com.facebook.presto.metadata.FunctionRegistry;
-import com.facebook.presto.metadata.OperatorType;
-import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.operator.Description;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.SqlType;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
+import javax.annotation.Nullable;
+
 import java.lang.invoke.MethodHandle;
-import java.util.List;
 
-import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
-import static com.facebook.presto.metadata.Signature.internalOperator;
+import static com.facebook.presto.metadata.OperatorType.EQUAL;
 import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
-import static com.facebook.presto.util.Reflection.methodHandle;
 
+@Description("Determines whether given value exists in the array")
+@ScalarFunction("contains")
 public final class ArrayContains
-        extends SqlScalarFunction
 {
-    public static final ArrayContains ARRAY_CONTAINS = new ArrayContains();
-    private static final String FUNCTION_NAME = "contains";
-    private static final MethodHandle METHOD_HANDLE_UNKNOWN = methodHandle(ArrayContains.class, "arrayWithUnknownType", Type.class, MethodHandle.class, Block.class, Void.class);
+    private ArrayContains() {}
 
-    public ArrayContains()
-    {
-        super(FUNCTION_NAME, ImmutableList.of(comparableTypeParameter("T")), ImmutableList.of(), StandardTypes.BOOLEAN, ImmutableList.of("array(T)", "T"));
-    }
-
-    @Override
-    public boolean isHidden()
-    {
-        return false;
-    }
-
-    @Override
-    public boolean isDeterministic()
-    {
-        return true;
-    }
-
-    @Override
-    public String getDescription()
-    {
-        return "Determines whether given value exists in the array";
-    }
-
-    @Override
-    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
-    {
-        Type type = boundVariables.getTypeVariable("T");
-
-        MethodHandle methodHandle;
-        MethodHandle equalsHandle = functionRegistry.getScalarFunctionImplementation(internalOperator(OperatorType.EQUAL, BooleanType.BOOLEAN, ImmutableList.of(type, type))).getMethodHandle();
-
-        List<Boolean> nullableArguments;
-        if (type.getJavaType() == void.class) {
-            nullableArguments = ImmutableList.of(false, true);
-            methodHandle = METHOD_HANDLE_UNKNOWN;
-        }
-        else {
-            nullableArguments = ImmutableList.of(false, false);
-            methodHandle = methodHandle(ArrayContains.class, "contains", Type.class, MethodHandle.class, Block.class, type.getJavaType());
-        }
-
-        return new ScalarFunctionImplementation(true, nullableArguments, methodHandle.bindTo(type).bindTo(equalsHandle), isDeterministic());
-    }
-
-    public static Boolean arrayWithUnknownType(Type elementType, MethodHandle equals, Block arrayBlock, Void value)
+    @SqlType(StandardTypes.BOOLEAN)
+    @Nullable
+    public static Boolean arrayWithUnknownType(@SqlType("array(unknown)") Block arrayBlock, @Nullable @SqlType("unknown") Void value)
     {
         return null;
     }
 
-    public static Boolean contains(Type elementType, MethodHandle equals, Block arrayBlock, Block value)
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BOOLEAN)
+    @Nullable
+    public static Boolean contains(@TypeParameter("T") Type elementType,
+                                   @OperatorDependency(operator = EQUAL, returnType = StandardTypes.BOOLEAN, argumentTypes = {"T", "T"}) MethodHandle equals,
+                                   @SqlType("array(T)") Block arrayBlock,
+                                   @SqlType("T") Block value)
     {
         boolean foundNull = false;
         for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
@@ -117,7 +74,13 @@ public final class ArrayContains
         return false;
     }
 
-    public static Boolean contains(Type elementType, MethodHandle equals, Block arrayBlock, Slice value)
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BOOLEAN)
+    @Nullable
+    public static Boolean contains(@TypeParameter("T") Type elementType,
+                                   @OperatorDependency(operator = EQUAL, returnType = StandardTypes.BOOLEAN, argumentTypes = {"T", "T"}) MethodHandle equals,
+                                   @SqlType("array(T)") Block arrayBlock,
+                                   @SqlType("T") Slice value)
     {
         boolean foundNull = false;
         for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
@@ -143,7 +106,13 @@ public final class ArrayContains
         return false;
     }
 
-    public static Boolean contains(Type elementType, MethodHandle equals, Block arrayBlock, long value)
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BOOLEAN)
+    @Nullable
+    public static Boolean contains(@TypeParameter("T") Type elementType,
+                                   @OperatorDependency(operator = EQUAL, returnType = StandardTypes.BOOLEAN, argumentTypes = {"T", "T"}) MethodHandle equals,
+                                   @SqlType("array(T)") Block arrayBlock,
+                                   @SqlType("T") long value)
     {
         boolean foundNull = false;
         for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
@@ -169,7 +138,13 @@ public final class ArrayContains
         return false;
     }
 
-    public static Boolean contains(Type elementType, MethodHandle equals, Block arrayBlock, boolean value)
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BOOLEAN)
+    @Nullable
+    public static Boolean contains(@TypeParameter("T") Type elementType,
+                                   @OperatorDependency(operator = EQUAL, returnType = StandardTypes.BOOLEAN, argumentTypes = {"T", "T"}) MethodHandle equals,
+                                   @SqlType("array(T)") Block arrayBlock,
+                                   @SqlType("T") boolean value)
     {
         boolean foundNull = false;
         for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
@@ -195,7 +170,13 @@ public final class ArrayContains
         return false;
     }
 
-    public static Boolean contains(Type elementType, MethodHandle equals, Block arrayBlock, double value)
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BOOLEAN)
+    @Nullable
+    public static Boolean contains(@TypeParameter("T") Type elementType,
+                                   @OperatorDependency(operator = EQUAL, returnType = StandardTypes.BOOLEAN, argumentTypes = {"T", "T"}) MethodHandle equals,
+                                   @SqlType("array(T)") Block arrayBlock,
+                                   @SqlType("T") double value)
     {
         boolean foundNull = false;
         for (int i = 0; i < arrayBlock.getPositionCount(); i++) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayPositionFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayPositionFunction.java
@@ -13,86 +13,34 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.annotation.UsedByGeneratedCode;
-import com.facebook.presto.metadata.BoundVariables;
-import com.facebook.presto.metadata.FunctionRegistry;
-import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.operator.Description;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.SqlType;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
+
+import javax.annotation.Nullable;
 
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.OperatorType.EQUAL;
-import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
-import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
-import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
-import static com.facebook.presto.util.Reflection.methodHandle;
 
+@Description("Returns the position of the first occurrence of the given value in array (or 0 if not found)")
+@ScalarFunction("array_position")
 public final class ArrayPositionFunction
-        extends SqlScalarFunction
 {
-    public static final ArrayPositionFunction ARRAY_POSITION = new ArrayPositionFunction();
-    private static final MethodHandle METHOD_HANDLE_BOOLEAN = methodHandle(ArrayPositionFunction.class, "arrayPosition", Type.class, MethodHandle.class, Block.class, boolean.class);
-    private static final MethodHandle METHOD_HANDLE_LONG = methodHandle(ArrayPositionFunction.class, "arrayPosition", Type.class, MethodHandle.class, Block.class, long.class);
-    private static final MethodHandle METHOD_HANDLE_DOUBLE = methodHandle(ArrayPositionFunction.class, "arrayPosition", Type.class, MethodHandle.class, Block.class, double.class);
-    private static final MethodHandle METHOD_HANDLE_SLICE = methodHandle(ArrayPositionFunction.class, "arrayPosition", Type.class, MethodHandle.class, Block.class, Slice.class);
-    private static final MethodHandle METHOD_HANDLE_OBJECT = methodHandle(ArrayPositionFunction.class, "arrayPosition", Type.class, MethodHandle.class, Block.class, Object.class);
+    private ArrayPositionFunction() {}
 
-    public ArrayPositionFunction()
-    {
-        super("array_position", ImmutableList.of(comparableTypeParameter("E")), ImmutableList.of(), "bigint", ImmutableList.of("array(E)", "E"));
-    }
-
-    @Override
-    public boolean isHidden()
-    {
-        return false;
-    }
-
-    @Override
-    public boolean isDeterministic()
-    {
-        return true;
-    }
-
-    @Override
-    public String getDescription()
-    {
-        return "Returns the position of the first occurrence of the given value in array (or 0 if not found)";
-    }
-
-    @Override
-    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
-    {
-        Type type = boundVariables.getTypeVariable("E");
-        MethodHandle equalMethodHandle = functionRegistry.getScalarFunctionImplementation(internalOperator(EQUAL, BOOLEAN, ImmutableList.of(type, type))).getMethodHandle();
-        MethodHandle arrayPositionMethodHandle;
-        if (type.getJavaType() == boolean.class) {
-            arrayPositionMethodHandle = METHOD_HANDLE_BOOLEAN;
-        }
-        else if (type.getJavaType() == long.class) {
-            arrayPositionMethodHandle = METHOD_HANDLE_LONG;
-        }
-        else if (type.getJavaType() == double.class) {
-            arrayPositionMethodHandle = METHOD_HANDLE_DOUBLE;
-        }
-        else if (type.getJavaType() == Slice.class) {
-            arrayPositionMethodHandle = METHOD_HANDLE_SLICE;
-        }
-        else {
-            arrayPositionMethodHandle = METHOD_HANDLE_OBJECT;
-        }
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false, false), arrayPositionMethodHandle.bindTo(type).bindTo(equalMethodHandle), isDeterministic());
-    }
-
-    @UsedByGeneratedCode
-    public static long arrayPosition(Type type, MethodHandle equalMethodHandle, Block array, boolean element)
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BIGINT)
+    public static long arrayPosition(@TypeParameter("T") Type type,
+                                     @OperatorDependency(operator = EQUAL, returnType = StandardTypes.BOOLEAN, argumentTypes = {"T", "T"}) MethodHandle equalMethodHandle,
+                                     @SqlType("array(T)") Block array,
+                                     @SqlType("T") boolean element)
     {
         int size = array.getPositionCount();
         for (int i = 0; i < size; i++) {
@@ -113,8 +61,12 @@ public final class ArrayPositionFunction
         return 0;
     }
 
-    @UsedByGeneratedCode
-    public static long arrayPosition(Type type, MethodHandle equalMethodHandle, Block array, long element)
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BIGINT)
+    public static long arrayPosition(@TypeParameter("T") Type type,
+                                     @OperatorDependency(operator = EQUAL, returnType = StandardTypes.BOOLEAN, argumentTypes = {"T", "T"}) MethodHandle equalMethodHandle,
+                                     @SqlType("array(T)") Block array,
+                                     @SqlType("T") long element)
     {
         int size = array.getPositionCount();
         for (int i = 0; i < size; i++) {
@@ -135,8 +87,12 @@ public final class ArrayPositionFunction
         return 0;
     }
 
-    @UsedByGeneratedCode
-    public static long arrayPosition(Type type, MethodHandle equalMethodHandle, Block array, double element)
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BIGINT)
+    public static long arrayPosition(@TypeParameter("T") Type type,
+                                     @OperatorDependency(operator = EQUAL, returnType = StandardTypes.BOOLEAN, argumentTypes = {"T", "T"}) MethodHandle equalMethodHandle,
+                                     @SqlType("array(T)") Block array,
+                                     @SqlType("T") double element)
     {
         int size = array.getPositionCount();
         for (int i = 0; i < size; i++) {
@@ -157,8 +113,12 @@ public final class ArrayPositionFunction
         return 0;
     }
 
-    @UsedByGeneratedCode
-    public static long arrayPosition(Type type, MethodHandle equalMethodHandle, Block array, Slice element)
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BIGINT)
+    public static long arrayPosition(@TypeParameter("T") Type type,
+                                     @OperatorDependency(operator = EQUAL, returnType = StandardTypes.BOOLEAN, argumentTypes = {"T", "T"}) MethodHandle equalMethodHandle,
+                                     @SqlType("array(T)") Block array,
+                                     @SqlType("T") Slice element)
     {
         int size = array.getPositionCount();
         for (int i = 0; i < size; i++) {
@@ -179,8 +139,12 @@ public final class ArrayPositionFunction
         return 0;
     }
 
-    @UsedByGeneratedCode
-    public static long arrayPosition(Type type, MethodHandle equalMethodHandle, Block array, Object element)
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BIGINT)
+    public static long arrayPosition(@TypeParameter("T") Type type,
+                                     @OperatorDependency(operator = EQUAL, returnType = StandardTypes.BOOLEAN, argumentTypes = {"T", "T"}) MethodHandle equalMethodHandle,
+                                     @SqlType("array(T)") Block array,
+                                     @SqlType("T") Block element)
     {
         int size = array.getPositionCount();
         for (int i = 0; i < size; i++) {
@@ -199,5 +163,12 @@ public final class ArrayPositionFunction
             }
         }
         return 0;
+    }
+
+    @SqlType(StandardTypes.BIGINT)
+    @Nullable
+    public static Long arrayPosition(@SqlType("array(unknown)") Block array, @Nullable @SqlType("unknown") Void element)
+    {
+        return null;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -376,6 +376,13 @@ public class TestArrayOperators
 
         assertFunction("ARRAY_POSITION(ARRAY [DATE '2000-01-01', DATE '2000-01-02', DATE '2000-01-03', DATE '2000-01-04'], DATE '2000-01-03')", BIGINT, 3L);
         assertFunction("ARRAY_POSITION(ARRAY [ARRAY [1, 11], ARRAY [2, 12], ARRAY [3, 13], ARRAY [4, 14]], ARRAY [3, 13])", BIGINT, 3L);
+
+        assertFunction("ARRAY_POSITION(ARRAY [], NULL)", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY [NULL], NULL)", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY [1, NULL, 2], NULL)", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY [1, CAST(NULL AS BIGINT), 2], CAST(NULL AS BIGINT))", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY [1, NULL, 2], CAST(NULL AS BIGINT))", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY [1, CAST(NULL AS BIGINT), 2], NULL)", BIGINT, null);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -272,6 +272,7 @@ public class TestArrayOperators
         assertFunction("CONTAINS(ARRAY [CAST (NULL AS BIGINT)], 1)", BOOLEAN, null);
         assertFunction("CONTAINS(ARRAY [CAST (NULL AS BIGINT)], NULL)", BOOLEAN, null);
         assertFunction("CONTAINS(ARRAY [], NULL)", BOOLEAN, null);
+        assertFunction("CONTAINS(ARRAY [], 1)", BOOLEAN, false);
     }
 
     @Test


### PR DESCRIPTION
Migrates `cardinality`, `contains` for arrays as well as `array_position`.

Closes #4664 #4665 #4667.

