### PR TITLE
Support old style row type with angle brackets

### DIFF
--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -75,6 +75,33 @@ public class TestTypeSignature
                 "row(a decimal(p1,s1),b decimal(p2,s2))",
                 ImmutableSet.of("p1", "s1", "p2", "s2"),
                 rowSignature(namedParameter("a", decimal("p1", "s1")), namedParameter("b", decimal("p2", "s2"))));
+
+        // TODO: remove the following tests when the old style row type has been completely dropped
+        assertOldRowSignature(
+                "row<bigint,varchar>('a','b')",
+                rowSignature(namedParameter("a", signature("bigint")), namedParameter("b", varchar())));
+        assertOldRowSignature(
+                "row<bigint,array(bigint),row<bigint>('a')>('a','b','c')",
+                rowSignature(
+                        namedParameter("a", signature("bigint")),
+                        namedParameter("b", array(signature("bigint"))),
+                        namedParameter("c", rowSignature(namedParameter("a", signature("bigint"))))));
+        assertOldRowSignature(
+                "row<varchar(10),row<bigint>('a')>('a','b')",
+                rowSignature(
+                        namedParameter("a", varchar(10)),
+                        namedParameter("b", rowSignature(namedParameter("a", signature("bigint"))))));
+        assertOldRowSignature(
+                "array(row<bigint,double>('col0','col1'))",
+                array(rowSignature(namedParameter("col0", signature("bigint")), namedParameter("col1", signature("double")))));
+        assertOldRowSignature(
+                "row<array(row<bigint,double>('col0','col1'))>('col0')",
+                rowSignature(namedParameter("col0", array(
+                        rowSignature(namedParameter("col0", signature("bigint")), namedParameter("col1", signature("double")))))));
+        assertOldRowSignature(
+                "row<decimal(p1,s1),decimal(p2,s2)>('a','b')",
+                ImmutableSet.of("p1", "s1", "p2", "s2"),
+                rowSignature(namedParameter("a", decimal("p1", "s1")), namedParameter("b", decimal("p2", "s2"))));
     }
 
     private TypeSignature varchar()
@@ -207,6 +234,26 @@ public class TestTypeSignature
             String expected)
     {
         assertSignature(typeName, base, parameters, expected);
+    }
+
+    // TODO: remove this when old style row type is removed
+    @Deprecated
+    private static void assertOldRowSignature(
+            String typeName,
+            Set<String> literalParameters,
+            TypeSignature expectedSignature)
+    {
+        TypeSignature signature = parseTypeSignature(typeName, literalParameters);
+        assertEquals(signature, expectedSignature);
+    }
+
+    // TODO: remove this when old style row type is removed
+    @Deprecated
+    private static void assertOldRowSignature(
+            String typeName,
+            TypeSignature expectedSignature)
+    {
+        assertOldRowSignature(typeName, ImmutableSet.of(), expectedSignature);
     }
 
     private static void assertSignature(


### PR DESCRIPTION
Put back the support of the old style row type like:
    `row<bigint,double>('col0','col1')`

So that the new server could correctly parse the data from the old
version Presto server.

I will also run it on verifier to see if it really solve the problem.