### PR TITLE
Update partition split count when task status changes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -240,6 +240,9 @@ public final class HttpRemoteTask
                 if (state.isDone()) {
                     cleanUpTask();
                 }
+                else {
+                    partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+                }
             });
 
             long timeout = minErrorDuration.toMillis() / 3;


### PR DESCRIPTION
The count must be updated whenever the task status changes or
the cluster may deadlock since split slots marked as free.