### PR TITLE
Remove incompatible varchar Hive integration tests

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -147,7 +147,6 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
-import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.testing.MaterializedResult.materializeSourceDataStream;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -664,7 +663,6 @@ public abstract class AbstractTestHiveClient
         Map<String, ColumnMetadata> map = uniqueIndex(tableMetadata.getColumns(), ColumnMetadata::getName);
 
         assertPrimitiveField(map, "t_string", createUnboundedVarcharType(), false);
-        assertPrimitiveField(map, "t_varchar", createVarcharType(50), false);
         assertPrimitiveField(map, "t_tinyint", INTEGER, false);
         assertPrimitiveField(map, "t_smallint", INTEGER, false);
         assertPrimitiveField(map, "t_int", INTEGER, false);
@@ -968,24 +966,6 @@ public abstract class AbstractTestHiveClient
                     }
                     else {
                         assertEquals(value, "test");
-                    }
-
-                    value = row.getField(columnIndex.get("t_varchar"));
-                    if (rowNumber % 39 == 0) {
-                        assertNull(value);
-                    }
-                    else if (rowNumber % 39 == 1) {
-                        // https://issues.apache.org/jira/browse/HIVE-13289
-                        // RCBINARY reads empty VARCHAR as Null
-                        if (fileType == RCBINARY) {
-                            assertNull(value);
-                        }
-                        else {
-                            assertEquals(value, "");
-                        }
-                    }
-                    else {
-                        assertEquals(value, "test varchar");
                     }
 
                     assertEquals(row.getField(columnIndex.get("t_tinyint")), 1 + (int) rowNumber);

--- a/presto-hive/src/test/sql/create-test-hive12.sql
+++ b/presto-hive/src/test/sql/create-test-hive12.sql
@@ -9,7 +9,6 @@ CREATE TABLE presto_test_types_textfile (
 , t_boolean BOOLEAN
 , t_timestamp TIMESTAMP
 , t_binary BINARY
-, t_varchar VARCHAR(50)
 , t_map MAP<STRING, STRING>
 , t_array_string ARRAY<STRING>
 , t_array_struct ARRAY<STRUCT<s_string: STRING, s_double:DOUBLE>>
@@ -30,7 +29,6 @@ SELECT
 , CASE n % 3 WHEN 0 THEN false WHEN 1 THEN true ELSE NULL END
 , CASE WHEN n % 17 = 0 THEN NULL ELSE '2011-05-06 07:08:09.1234567' END
 , CASE WHEN n % 23 = 0 THEN NULL ELSE CAST('test binary' AS BINARY) END
-, CASE n % 39 WHEN 0 THEN NULL WHEN 1 THEN '' ELSE 'test varchar' END
 , CASE WHEN n % 27 = 0 THEN NULL ELSE map('test key', 'test value') END
 , CASE WHEN n % 29 = 0 THEN NULL ELSE array('abc', 'xyz', 'data') END
 , CASE WHEN n % 31 = 0 THEN NULL ELSE

--- a/presto-hive/src/test/sql/create-test-hive13.sql
+++ b/presto-hive/src/test/sql/create-test-hive13.sql
@@ -10,7 +10,6 @@ CREATE TABLE presto_test_types_textfile (
 , t_timestamp TIMESTAMP
 , t_binary BINARY
 , t_date DATE
-, t_varchar VARCHAR(50)
 , t_char CHAR(25)
 , t_map MAP<STRING, STRING>
 , t_array_string ARRAY<STRING>
@@ -95,7 +94,6 @@ CREATE TABLE presto_test_types_parquet (
 , t_boolean BOOLEAN
 , t_timestamp TIMESTAMP
 , t_binary BINARY
-, t_varchar VARCHAR(50)
 , t_map MAP<STRING, STRING>
 , t_array_string ARRAY<STRING>
 , t_array_struct ARRAY<STRUCT<s_string: STRING, s_double:DOUBLE>>
@@ -115,7 +113,6 @@ SELECT
 , t_boolean
 , t_timestamp
 , t_binary
-, t_varchar
 , t_map
 , t_array_string
 , t_array_struct

--- a/presto-hive/src/test/sql/create-test.sql
+++ b/presto-hive/src/test/sql/create-test.sql
@@ -7,7 +7,6 @@ TBLPROPERTIES ('RETENTION'='-1')
 
 CREATE TABLE presto_test_partition_format (
   t_string STRING,
-  t_varchar VARCHAR(50),
   t_tinyint TINYINT,
   t_smallint SMALLINT,
   t_int INT,
@@ -48,7 +47,6 @@ TBLPROPERTIES ('RETENTION'='-1')
 
 CREATE TABLE presto_test_bucketed_by_string_int (
   t_string STRING,
-  t_varchar VARCHAR(50),
   t_tinyint TINYINT,
   t_smallint SMALLINT,
   t_int INT,
@@ -66,7 +64,6 @@ TBLPROPERTIES ('RETENTION'='-1')
 
 CREATE TABLE presto_test_bucketed_by_bigint_boolean (
   t_string STRING,
-  t_varchar VARCHAR(50),
   t_tinyint TINYINT,
   t_smallint SMALLINT,
   t_int INT,
@@ -84,7 +81,6 @@ TBLPROPERTIES ('RETENTION'='-1')
 
 CREATE TABLE presto_test_bucketed_by_double_float (
   t_string STRING,
-  t_varchar VARCHAR(50),
   t_tinyint TINYINT,
   t_smallint SMALLINT,
   t_int INT,
@@ -142,7 +138,6 @@ DROP TABLE tmp_presto_test_load;
 DROP TABLE IF EXISTS tmp_presto_test;
 CREATE TABLE tmp_presto_test (
   t_string STRING,
-  t_varchar VARCHAR(50),
   t_tinyint TINYINT,
   t_smallint SMALLINT,
   t_int INT,
@@ -155,7 +150,6 @@ CREATE TABLE tmp_presto_test (
 INSERT INTO TABLE tmp_presto_test
 SELECT
   CASE n % 19 WHEN 0 THEN NULL WHEN 1 THEN '' ELSE 'test' END
-, CASE n % 39 WHEN 0 THEN NULL WHEN 1 THEN '' ELSE 'test varchar' END
 , 1 + n
 , 2 + n
 , 3 + n
@@ -213,19 +207,19 @@ SET hive.enforce.bucketing = true;
 
 INSERT OVERWRITE TABLE presto_test_bucketed_by_string_int
 PARTITION (ds='2012-12-29')
-SELECT t_string, t_varchar, t_tinyint, t_smallint, t_int, t_bigint, t_float, t_double, t_boolean
+SELECT t_string, t_tinyint, t_smallint, t_int, t_bigint, t_float, t_double, t_boolean
 FROM tmp_presto_test
 ;
 
 INSERT OVERWRITE TABLE presto_test_bucketed_by_bigint_boolean
 PARTITION (ds='2012-12-29')
-SELECT t_string, t_varchar, t_tinyint, t_smallint, t_int, t_bigint, t_float, t_double, t_boolean
+SELECT t_string, t_tinyint, t_smallint, t_int, t_bigint, t_float, t_double, t_boolean
 FROM tmp_presto_test
 ;
 
 INSERT OVERWRITE TABLE presto_test_bucketed_by_double_float
 PARTITION (ds='2012-12-29')
-SELECT t_string, t_varchar, t_tinyint, t_smallint, t_int, t_bigint, t_float, t_double, t_boolean
+SELECT t_string, t_tinyint, t_smallint, t_int, t_bigint, t_float, t_double, t_boolean
 FROM tmp_presto_test
 ;
 


### PR DESCRIPTION
Not all supported versions of Hive support varchar, so these tests
need to be written the same way as other non-universal types.