### PR TITLE
Add maven plugin profiling extension

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -10,4 +10,9 @@
     <artifactId>takari-concurrent-localrepo</artifactId>
      <version>0.0.7</version>
   </extension>
+  <extension>
+    <groupId>co.leantechniques</groupId>
+    <artifactId>maven-buildtime-extension</artifactId>
+    <version>3.0.0</version>
+  </extension>
 </extensions>


### PR DESCRIPTION
This can be enabled with `-Dbuildtime.output.log=true` and profiles the
time spent in each Maven plugin