### PR TITLE
Prevent running Presto on Java versions prior to 1.8u60

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See the [User Manual](https://prestodb.io/docs/current/) for deployment instruct
 ## Requirements
 
 * Mac OS X or Linux
-* Java 8 Update 40 or higher (8u40+), 64-bit
+* Java 8 Update 60 or higher (8u60+), 64-bit
 * Maven 3.3.9+ (for building)
 * Python 2.4+ (for running with the launcher script)
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
@@ -36,22 +36,31 @@ final class PrestoSystemRequirements
 
     public static void verifyJvmRequirements()
     {
-        String javaVersion = StandardSystemProperty.JAVA_VERSION.value();
-        int sep = (javaVersion == null) ? -1 : javaVersion.lastIndexOf('_');
-        String majorVersion = null;
-        String minorVersion = null;
-        if (sep >= 0) {
-            majorVersion = javaVersion.substring(0, sep);
-            minorVersion = javaVersion.substring(sep + 1);
-        }
-        if ((majorVersion == null) || (minorVersion == null) || (majorVersion.compareTo("1.8.0") < 0) ||
-                (majorVersion.compareTo("1.8.0") == 0 && minorVersion.compareTo("60") < 0)) {
-            failRequirement("Presto requires Java 1.8.0_60+ (found %s_%s)", majorVersion, minorVersion);
-        }
-
         String vendor = StandardSystemProperty.JAVA_VENDOR.value();
         if (!"Oracle Corporation".equals(vendor)) {
             failRequirement("Presto requires an Oracle or OpenJDK JVM (found %s)", vendor);
+        }
+
+        String javaVersion = StandardSystemProperty.JAVA_VERSION.value();
+        if (javaVersion == null) {
+            failRequirement("Java version not defined");
+        }
+        String[] versionParts = javaVersion.split("_");
+        if (versionParts.length != 2) {
+            failRequirement("Java version has an unknown format: %s", javaVersion);
+        }
+        String majorVersion = versionParts[0];
+        int minorVersion;
+        try {
+            minorVersion = Integer.parseInt(versionParts[1]);
+        }
+        catch (Exception e) {
+            minorVersion = 0;
+        }
+
+        if ((majorVersion == null) || (majorVersion.compareTo("1.8.0") < 0) ||
+                (majorVersion.compareTo("1.8.0") == 0 && minorVersion < 60)) {
+            failRequirement("Presto requires Java 1.8.0_60+ (found %s_%d)", majorVersion, minorVersion);
         }
 
         String dataModel = System.getProperty("sun.arch.data.model");

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
@@ -36,9 +36,17 @@ final class PrestoSystemRequirements
 
     public static void verifyJvmRequirements()
     {
-        String specVersion = StandardSystemProperty.JAVA_SPECIFICATION_VERSION.value();
-        if ((specVersion == null) || (specVersion.compareTo("1.8") < 0)) {
-            failRequirement("Presto requires Java 1.8+ (found %s)", specVersion);
+        String javaVersion = StandardSystemProperty.JAVA_VERSION.value();
+        int sep = (javaVersion == null) ? -1 : javaVersion.lastIndexOf('_');
+        String majorVersion = null;
+        String minorVersion = null;
+        if (sep >= 0) {
+            majorVersion = javaVersion.substring(0, sep);
+            minorVersion = javaVersion.substring(sep + 1);
+        }
+        if ((majorVersion == null) || (minorVersion == null) || (majorVersion.compareTo("1.8.0") < 0) ||
+                (majorVersion.compareTo("1.8.0") == 0 && minorVersion.compareTo("60") < 0)) {
+            failRequirement("Presto requires Java 1.8.0_60+ (found %s_%s)", majorVersion, minorVersion);
         }
 
         String vendor = StandardSystemProperty.JAVA_VENDOR.value();

--- a/presto-server-rpm/src/main/rpm/preinstall
+++ b/presto-server-rpm/src/main/rpm/preinstall
@@ -31,7 +31,7 @@ check_if_correct_java_version() {
   JAVA_VERSION=$(java_version "$1")
   JAVA_VENDOR=$(java_vendor "$1")
   JAVA_UPDATE=$(echo $JAVA_VERSION | cut -d'_' -f2)
-  if [[ ("$JAVA_VERSION" > "1.8") && ($JAVA_UPDATE -ge 40) && ("$JAVA_VENDOR" = "Oracle Corporation") ]]; then
+  if [[ ("$JAVA_VERSION" > "1.8") && ($JAVA_UPDATE -ge 60) && ("$JAVA_VENDOR" = "Oracle Corporation") ]]; then
     echo "JAVA8_HOME=$1" > /tmp/presto_env.sh
     return 0
   else
@@ -39,7 +39,7 @@ check_if_correct_java_version() {
   fi
 }
 
-# if Java version of $JAVA_HOME is not 1.8 update 40 (8u40) and is not Oracle Java, then try to find it again below
+# if Java version of $JAVA_HOME is not 1.8 update 60 (8u60) and is not Oracle Java, then try to find it again below
 if ! check_if_correct_java_version "$JAVA8_HOME" && ! check_if_correct_java_version "$JAVA_HOME"; then
   java_found=false
   for candidate in \
@@ -71,7 +71,7 @@ if [ "$java_found" = false ]; then
 | Please download the latest Oracle JDK/JRE from the Java web site     |
 |       > http://www.oracle.com/technetwork/java/javase/downloads <    |
 |                                                                      |
-| Presto requires Java 1.8 update 40 (8u40)                            |
+| Presto requires Java 1.8 update 60 (8u60)                            |
 | NOTE: This script will attempt to find Java whether you install      |
 |       using the binary or the RPM based installer.                   |
 +======================================================================+


### PR DESCRIPTION
This patch is to address issue: https://github.com/prestodb/presto/issues/5150

Test major version first, if major version equals to "1.8.0",
compare minor version with "60".