### PR TITLE
Implement IndexLookupSourceSupplier.destroy

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceSupplier.java
@@ -83,6 +83,6 @@ public class IndexLookupSourceSupplier
     @Override
     public void destroy()
     {
-        throw new UnsupportedOperationException();
+        // nothing to do
     }
 }


### PR DESCRIPTION
This method is alwasy called and currently throws UnsupportedOperationException, which
does not fail queries, but causes a stacktrace in the logs.