### PR TITLE
Fix grouping set bug with predicate pushdown

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -29,6 +29,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.ChildReplacer;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
@@ -218,7 +219,27 @@ public class PredicatePushDown
         public PlanNode visitGroupId(GroupIdNode node, RewriteContext<Expression> context)
         {
             checkState(!DependencyExtractor.extractUnique(context.get()).contains(node.getGroupIdSymbol()), "groupId symbol cannot be referenced in predicate");
-            return context.defaultRewrite(node, context.get());
+
+            List<Symbol> commonGroupingSymbols = node.getCommonGroupingColumns();
+            java.util.function.Predicate<Expression> pushdownEligiblePredicate = conjunct -> DependencyExtractor.extractAll(conjunct).stream()
+                    .allMatch(commonGroupingSymbols::contains);
+
+            Map<Boolean, List<Expression>> conjuncts = extractConjuncts(context.get()).stream().collect(Collectors.partitioningBy(pushdownEligiblePredicate));
+
+            // Push down conjuncts from the inherited predicate that apply to the common grouping columns, or don't apply to any grouping columns
+            PlanNode rewrittenSource = context.rewrite(node.getSource(),  combineConjuncts(conjuncts.get(true)));
+
+            PlanNode output = node;
+            if (rewrittenSource != node.getSource()) {
+                output = ChildReplacer.replaceChildren(node, ImmutableList.of(rewrittenSource));
+            }
+
+            // All other conjuncts, if any, will be in the filter node.
+            if (!conjuncts.get(false).isEmpty()) {
+                output = new FilterNode(idAllocator.getNextId(), output, combineConjuncts(conjuncts.get(false)));
+            }
+
+            return output;
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/GroupIdNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/GroupIdNode.java
@@ -21,7 +21,9 @@ import com.google.common.collect.ImmutableList;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -88,6 +90,15 @@ public class GroupIdNode
                 .flatMap(Collection::stream)
                 .distinct()
                 .collect(toList());
+    }
+
+    public List<Symbol> getCommonGroupingColumns()
+    {
+        Set<Symbol> intersection = new HashSet<>(groupingSets.get(0));
+        for (int i = 1; i < getGroupingSets().size(); i++) {
+            intersection.retainAll(groupingSets.get(i));
+        }
+        return ImmutableList.copyOf(intersection);
     }
 
     @JsonProperty

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1408,6 +1408,16 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testGroupingSetPredicatePushdown()
+            throws Exception
+    {
+        assertQuery("SELECT * FROM (" +
+                        "SELECT COALESCE(orderpriority, 'ALL'), COALESCE(shippriority, -1) sp FROM (" +
+                        "SELECT orderpriority, shippriority, COUNT(1) FROM orders GROUP BY GROUPING SETS ((orderpriority), (shippriority)))) WHERE sp=-1",
+                "SELECT orderpriority, -1 FROM orders GROUP BY orderpriority");
+    }
+
+    @Test
     public void testRollup()
             throws Exception
     {


### PR DESCRIPTION
Predicates should not be pushed down through aggregation nodes unless
the predicate can be applied to the intersection of the grouping set
columns.