### PR TITLE
Added standard SIGN(x) function for INTEGER, BIGINT and DOUBLE ``x``.

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -110,6 +110,20 @@ Mathematical Functions
 
     Returns ``x`` rounded to ``d`` decimal places.
 
+.. function:: sign(x) -> [same as input]
+
+    Returns the signum function of ``x``, that is:
+
+    * 0 if the argument is 0,
+    * 1 if the argument is greater than 0,
+    * -1 if the argument is less than 0.
+
+    For double arguments, the function additionally returns:
+
+    * NaN if tha argument is NaN,
+    * 1 if the argument is +Infinity,
+    * -1 if the argument is -Infinity.
+
 .. function:: sqrt(x) -> double
 
     Returns the square root of ``x``.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -359,6 +359,30 @@ public final class MathFunctions
         return Math.floor(num * factor + 0.5) / factor;
     }
 
+    @Description("signum")
+    @ScalarFunction
+    @SqlType(StandardTypes.BIGINT)
+    public static long sign(@SqlType(StandardTypes.BIGINT) long num)
+    {
+        return (long) Math.signum(num);
+    }
+
+    @Description("signum")
+    @ScalarFunction("sign")
+    @SqlType(StandardTypes.INTEGER)
+    public static long signInt(@SqlType(StandardTypes.INTEGER) long num)
+    {
+        return (long) Math.signum(num);
+    }
+
+    @Description("signum")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double sign(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return Math.signum(num);
+    }
+
     @Description("sine")
     @ScalarFunction
     @SqlType(StandardTypes.DOUBLE)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -27,8 +27,8 @@ import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 public class TestMathFunctions
         extends AbstractTestFunctions
 {
-    private static final double[] DOUBLE_VALUES = {123, -123, 123.45, -123.45};
-    private static final int[] intLefts = {9, 10, 11, -9, -10, -11};
+    private static final double[] DOUBLE_VALUES = {123, -123, 123.45, -123.45, 0};
+    private static final int[] intLefts = {9, 10, 11, -9, -10, -11, 0};
     private static final int[] intRights = {3, -3};
     private static final double[] doubleLefts = {9, 10, 11, -9, -10, -11, 9.1, 10.1, 11.1, -9.1, -10.1, -11.1};
     private static final double[] doubleRights = {3, -3, 3.1, -3.1};
@@ -455,6 +455,39 @@ public class TestMathFunctions
         assertFunction("round(CAST(NULL as DOUBLE), CAST(NULL as BIGINT))", DOUBLE, null);
         assertFunction("round(-3.0, CAST(NULL as BIGINT))", DOUBLE, null);
         assertFunction("round(CAST(NULL as DOUBLE), 1)", DOUBLE, null);
+    }
+
+    @Test
+    public void testSign()
+    {
+        //retains type for NULL values
+        assertFunction("sign(CAST(NULL as INTEGER))", INTEGER, null);
+        assertFunction("sign(CAST(NULL as BIGINT))", BIGINT, null);
+        assertFunction("sign(CAST(NULL as DOUBLE))", DOUBLE, null);
+
+        //integer
+        for (int intValue : intLefts) {
+            Float signum = Math.signum(intValue);
+            assertFunction("sign(INTEGER '" + intValue + "')", INTEGER, signum.intValue());
+        }
+
+        //bigint
+        for (int intValue : intLefts) {
+            Float signum = Math.signum(intValue);
+            assertFunction("sign(BIGINT '" + intValue + "')", BIGINT, signum.longValue());
+        }
+
+        //double
+        for (double doubleValue : DOUBLE_VALUES) {
+            assertFunction("sign(" + doubleValue + ")", DOUBLE, Math.signum(doubleValue));
+        }
+
+        //returns NaN for NaN input
+        assertFunction("sign(DOUBLE 'NaN')", DOUBLE, Double.NaN);
+
+        //returns proper sign for +/-Infinity input
+        assertFunction("sign(DOUBLE '+Infinity')", DOUBLE, 1.0);
+        assertFunction("sign(DOUBLE '-Infinity')", DOUBLE, -1.0);
     }
 
     @Test


### PR DESCRIPTION
The return type is [same as input] instead of INTEGER because of the DOUBLE NaN case (the function returns NaN for NaN arguments).