### PR TITLE
Introduce ApplyNode representation of subquery v2

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DependencyExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DependencyExtractor.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.tree.DefaultExpressionTraversalVisitor;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
@@ -24,11 +25,20 @@ import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.facebook.presto.sql.planner.ExpressionExtractor.extractExpressions;
 import static java.util.Objects.requireNonNull;
 
 public final class DependencyExtractor
 {
     private DependencyExtractor() {}
+
+    public static Set<Symbol> extractUnique(PlanNode node)
+    {
+        ImmutableSet.Builder<Symbol> uniqueSymbols = ImmutableSet.builder();
+        extractExpressions(node).forEach(expression -> uniqueSymbols.addAll(extractUnique(expression)));
+
+        return uniqueSymbols.build();
+    }
 
     public static Set<Symbol> extractUnique(Expression expression)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class ExpressionExtractor
+        extends SimplePlanVisitor<ImmutableList.Builder<Expression>>
+{
+    public static List<Expression> extractExpressions(PlanNode plan)
+    {
+        ImmutableList.Builder<Expression> expressionsBuilder = ImmutableList.builder();
+        plan.accept(new ExpressionExtractor(), expressionsBuilder);
+        return expressionsBuilder.build();
+    }
+
+    @Override
+    public Void visitFilter(FilterNode node, ImmutableList.Builder<Expression> context)
+    {
+        context.add(node.getPredicate());
+        return super.visitFilter(node, context);
+    }
+
+    @Override
+    public Void visitProject(ProjectNode node, ImmutableList.Builder<Expression> context)
+    {
+        context.addAll(node.getAssignments().values());
+        return super.visitProject(node, context);
+    }
+
+    @Override
+    public Void visitTableScan(TableScanNode node, ImmutableList.Builder<Expression> context)
+    {
+        if (node.getOriginalConstraint() != null) {
+            context.add(node.getOriginalConstraint());
+        }
+        return super.visitTableScan(node, context);
+    }
+
+    @Override
+    public Void visitValues(ValuesNode node, ImmutableList.Builder<Expression> context)
+    {
+        node.getRows().forEach(context::addAll);
+        return super.visitValues(node, context);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionNodeInliner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionNodeInliner.java
@@ -22,6 +22,11 @@ import java.util.Map;
 public class ExpressionNodeInliner
         extends ExpressionRewriter<Void>
 {
+    public static Expression replaceExpression(Expression expression, Map<? extends Expression, ? extends Expression> mappings)
+    {
+        return ExpressionTreeRewriter.rewriteWith(new ExpressionNodeInliner(mappings), expression);
+    }
+
     private final Map<? extends Expression, ? extends Expression> mappings;
 
     public ExpressionNodeInliner(Map<? extends Expression, ? extends Expression> mappings)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -96,9 +96,6 @@ public class LogicalPlanner
     {
         PlanNode root = planStatement(analysis, analysis.getStatement());
 
-        // make sure we produce a valid plan. This is mainly to catch programming errors
-        PlanSanityChecker.validate(root);
-
         for (PlanOptimizer optimizer : planOptimizers) {
             root = optimizer.optimize(root, session, symbolAllocator.getTypes(), symbolAllocator, idAllocator);
             requireNonNull(root, format("%s returned a null plan", optimizer.getClass().getName()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -37,6 +37,7 @@ import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.TableFinishNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.planner.sanity.PlanSanityChecker;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.Delete;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
@@ -41,6 +41,8 @@ import com.facebook.presto.sql.planner.optimizations.PushTableWriteThroughUnion;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
 import com.facebook.presto.sql.planner.optimizations.SimplifyExpressions;
 import com.facebook.presto.sql.planner.optimizations.SingleDistinctOptimizer;
+import com.facebook.presto.sql.planner.optimizations.TransformUncorrelatedInPredicateSubqueryToSemiJoin;
+import com.facebook.presto.sql.planner.optimizations.TransformUncorrelatedScalarToJoin;
 import com.facebook.presto.sql.planner.optimizations.UnaliasSymbolReferences;
 import com.facebook.presto.sql.planner.optimizations.WindowFilterPushDown;
 import com.google.common.collect.ImmutableList;
@@ -66,6 +68,8 @@ public class PlanOptimizersFactory
         ImmutableList.Builder<PlanOptimizer> builder = ImmutableList.builder();
 
         builder.add(new DesugaringOptimizer(metadata, sqlParser), // Clean up all the sugar in expressions, e.g. AtTimeZone, must be run before all the other optimizers
+                new TransformUncorrelatedScalarToJoin(),
+                new TransformUncorrelatedInPredicateSubqueryToSemiJoin(),
                 new ImplementSampleAsFilter(),
                 new CanonicalizeExpressions(),
                 new SimplifyExpressions(metadata, sqlParser),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SimplePlanVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SimplePlanVisitor.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanVisitor;
+
+public class SimplePlanVisitor<C>
+        extends PlanVisitor<C, Void>
+{
+    @Override
+    protected Void visitPlan(PlanNode node, C context)
+    {
+        for (PlanNode source : node.getSources()) {
+            source.accept(this, context);
+        }
+        return null;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolExtractor.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.DeleteNode;
 import com.facebook.presto.sql.planner.plan.DistinctLimitNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
@@ -363,6 +364,15 @@ public final class SymbolExtractor
             node.getSource().accept(this, context);
 
             builder.addAll(node.getOutputSymbols());
+
+            return null;
+        }
+
+        @Override
+        public Void visitApply(ApplyNode node, Void context)
+        {
+            node.getInput().accept(this, context);
+            node.getSubquery().accept(this, context);
 
             return null;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.DistinctLimitNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
@@ -689,6 +690,12 @@ public class HashGenerationOptimizer
                     "Node %s declares hash symbols not in the output",
                     result.getNode().getClass().getSimpleName());
             return result;
+        }
+
+        @Override
+        public PlanWithProperties visitApply(ApplyNode node, HashComputationSet context)
+        {
+            throw new UnsupportedOperationException("Apply node is unsupported");
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.planner.PartitionFunctionBinding.PartitionFunctio
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.optimizations.ActualProperties.Global;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.DeleteNode;
 import com.facebook.presto.sql.planner.plan.DistinctLimitNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
@@ -146,6 +147,12 @@ class PropertyDerivations
         public ActualProperties visitEnforceSingleRow(EnforceSingleRowNode node, List<ActualProperties> inputProperties)
         {
             return Iterables.getOnlyElement(inputProperties);
+        }
+
+        @Override
+        public ActualProperties visitApply(ApplyNode node, List<ActualProperties> inputProperties)
+        {
+            return inputProperties.get(0); // apply node input (outer query)
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.InPredicate;
+import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.sql.planner.ExpressionNodeInliner.replaceExpression;
+import static com.facebook.presto.sql.planner.plan.SimplePlanRewriter.rewriteWith;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableMap;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This optimizers looks for InPredicate expressions with subqueries, finds matching uncorrelated Apply nodes
+ * and then replace Apply nodes with SemiJoin nodes and updates InPredicates.
+ * <p/>
+ * Plan before optimizer:
+ * <pre>
+ * Filter(a IN b):
+ *   Apply
+ *     - correlation: []  // empty
+ *     - input: some plan A producing symbol a
+ *     - subquery: some plan B producing symbol b
+ * </pre>
+ * <p/>
+ * Plan after optimizer:
+ * <pre>
+ * Filter(semijoinresult):
+ *   SemiJoin
+ *     - source: plan A
+ *     - filteringSource: symbol a
+ *     - sourceJoinSymbol: plan B
+ *     - filteringSourceJoinSymbol: symbol b
+ *     - semiJoinOutput: semijoinresult
+ * </pre>
+ */
+public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
+        implements PlanOptimizer
+{
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, Map<Symbol, Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        return rewriteWith(new InPredicateRewriter(idAllocator, symbolAllocator), plan, null);
+    }
+
+    /**
+     * For each node which contains InPredicate this rewriter calls {@link InsertSemiJoinRewriter} rewriter, then
+     * InPredicate is replaced by semi join symbol returned from the used nested rewriter.
+     */
+    private static class InPredicateRewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private final PlanNodeIdAllocator idAllocator;
+        private final SymbolAllocator symbolAllocator;
+
+        public InPredicateRewriter(PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+        {
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+            this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode node, RewriteContext<Void> context)
+        {
+            InPredicateRewriteResult inPredicateRewriteResult = rewriteInPredicates(
+                    context.defaultRewrite(node, context.get()),
+                    ImmutableList.of(node.getPredicate()));
+
+            return new FilterNode(
+                    inPredicateRewriteResult.node.getId(),
+                    getOnlyElement(inPredicateRewriteResult.node.getSources()),
+                    replaceExpression(node.getPredicate(), inPredicateRewriteResult.inPredicateMapping));
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode node, RewriteContext<Void> context)
+        {
+            InPredicateRewriteResult inPredicateRewriteResult = rewriteInPredicates(
+                    context.defaultRewrite(node, context.get()),
+                    node.getAssignments().values());
+
+            return new ProjectNode(inPredicateRewriteResult.node.getId(),
+                    getOnlyElement(inPredicateRewriteResult.node.getSources()),
+                    rewriteAssignments(node, inPredicateRewriteResult.inPredicateMapping));
+        }
+
+        private InPredicateRewriteResult rewriteInPredicates(PlanNode node, Collection<Expression> expressions)
+        {
+            List<InPredicate> inPredicates = extractInPredicates(expressions);
+            ImmutableMap.Builder<InPredicate, Expression> inPredicateMapping = ImmutableMap.builder();
+            PlanNode rewrittenNode = node;
+            for (InPredicate inPredicate : inPredicates) {
+                InsertSemiJoinRewriter rewriter = new InsertSemiJoinRewriter(idAllocator, symbolAllocator, inPredicate);
+                rewrittenNode = rewriteWith(rewriter, rewrittenNode, null);
+                inPredicateMapping.putAll(rewriter.getInPredicateMapping());
+            }
+            return new InPredicateRewriteResult(rewrittenNode, inPredicateMapping.build());
+        }
+
+        private static class InPredicateRewriteResult
+        {
+            private final PlanNode node;
+            private final Map<InPredicate, Expression> inPredicateMapping;
+
+            private InPredicateRewriteResult(PlanNode node, Map<InPredicate, Expression> inPredicateMapping)
+            {
+                this.node = requireNonNull(node, "node is null");
+                this.inPredicateMapping = requireNonNull(inPredicateMapping, "inPredicateMapping is null");
+            }
+        }
+
+        private Map<Symbol, Expression> rewriteAssignments(ProjectNode node, Map<InPredicate, Expression> inPredicateMapping)
+        {
+            ImmutableMap.Builder<Symbol, Expression> assignmentsBuilder = ImmutableMap.builder();
+            Map<Symbol, Expression> assignments = node.getAssignments();
+            for (Symbol symbol : assignments.keySet()) {
+                assignmentsBuilder.put(symbol, replaceExpression(assignments.get(symbol), inPredicateMapping));
+            }
+            return assignmentsBuilder.build();
+        }
+
+        private List<InPredicate> extractInPredicates(Collection<Expression> expressions)
+        {
+            ImmutableList.Builder<InPredicate> inPredicates = ImmutableList.builder();
+            for (Expression expression : expressions) {
+                new DefaultTraversalVisitor<Void, Void>()
+                {
+                    @Override
+                    protected Void visitInPredicate(InPredicate node, Void context)
+                    {
+                        if (node.getValueList() instanceof QualifiedNameReference) {
+                            inPredicates.add(node);
+                        }
+                        return null;
+                    }
+                }.process(expression, null);
+            }
+            return inPredicates.build();
+        }
+    }
+
+    /**
+     * For given InPredicate (in context) it finds matching Apply node (which produces InPredicate value in apply's input,
+     * and valueList in apply's subquery) and replace it with a SemiJoin node.
+     * Between InPredicate's plan node and Apply node there could be several projections of InPredicate symbols, so they
+     * have to be considered.
+     */
+    private static class InsertSemiJoinRewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private final PlanNodeIdAllocator idAllocator;
+        private final SymbolAllocator symbolAllocator;
+        private InPredicate originalInPredicate;
+        private InPredicate inPredicate;
+        private Optional<Symbol> semiJoinSymbol = Optional.empty();
+
+        public InsertSemiJoinRewriter(PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, InPredicate inPredicate)
+        {
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+            this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
+            this.originalInPredicate = requireNonNull(inPredicate, "inPredicate is null");
+            this.inPredicate = originalInPredicate;
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode node, RewriteContext<Void> context)
+        {
+            inPredicate = (InPredicate) replaceExpression(inPredicate, mapAssignmentSymbolsToExpression(node.getAssignments()));
+
+            ProjectNode rewrittenNode = (ProjectNode) context.defaultRewrite(node, context.get());
+            if (semiJoinSymbol.isPresent()) {
+                return appendIdentityProjection(rewrittenNode, semiJoinSymbol.get());
+            }
+            else {
+                return rewrittenNode;
+            }
+        }
+
+        private Map<Expression, Expression> mapAssignmentSymbolsToExpression(Map<Symbol, Expression> assignments)
+        {
+            return assignments.entrySet().stream()
+                    .collect(toImmutableMap(e -> e.getKey().toQualifiedNameReference(), Entry::getValue));
+        }
+
+        private ProjectNode appendIdentityProjection(ProjectNode node, Symbol symbol)
+        {
+            if (node.getOutputSymbols().contains(symbol)) {
+                return node;
+            }
+            else if (node.getSource().getOutputSymbols().contains(symbol)) {
+                ImmutableMap.Builder<Symbol, Expression> builder = ImmutableMap.builder();
+                builder.putAll(node.getAssignments());
+                builder.put(symbol, symbol.toQualifiedNameReference());
+                return new ProjectNode(node.getId(), node.getSource(), builder.build());
+            }
+            else {
+                return node;
+            }
+        }
+
+        @Override
+        public PlanNode visitApply(ApplyNode node, RewriteContext<Void> context)
+        {
+            Symbol value = asSymbol(inPredicate.getValue());
+            Symbol valueList = asSymbol(inPredicate.getValueList());
+            if (node.getCorrelation().isEmpty() && inPredicateMatchesApply(node, value, valueList)) {
+                checkState(!semiJoinSymbol.isPresent(), "Semi join symbol is already set");
+                semiJoinSymbol = Optional.of(symbolAllocator.newSymbol("semijoin_result", BOOLEAN));
+                return new SemiJoinNode(idAllocator.getNextId(),
+                        node.getInput(),
+                        node.getSubquery(),
+                        value,
+                        valueList,
+                        semiJoinSymbol.get(),
+                        Optional.empty(),
+                        Optional.empty()
+                );
+            }
+            return context.defaultRewrite(node, context.get());
+        }
+
+        private boolean inPredicateMatchesApply(ApplyNode node, Symbol value, Symbol valueList)
+        {
+            return node.getInput().getOutputSymbols().contains(value) && node.getSubquery().getOutputSymbols().contains(valueList);
+        }
+
+        private Symbol asSymbol(Expression expression)
+        {
+            checkState(expression instanceof QualifiedNameReference);
+            return Symbol.fromQualifiedName(((QualifiedNameReference) expression).getName());
+        }
+
+        public Map<InPredicate, Expression> getInPredicateMapping()
+        {
+            if (!semiJoinSymbol.isPresent()) {
+                return ImmutableMap.of();
+            }
+            return ImmutableMap.of(originalInPredicate, semiJoinSymbol.get().toQualifiedNameReference());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedScalarToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedScalarToJoin.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class TransformUncorrelatedScalarToJoin
+        implements PlanOptimizer
+{
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, Map<Symbol, Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        return SimplePlanRewriter.rewriteWith(new Rewriter(idAllocator), plan, null);
+    }
+
+    private class Rewriter
+            extends SimplePlanRewriter<PlanNode>
+    {
+        private final PlanNodeIdAllocator idAllocator;
+
+        public Rewriter(PlanNodeIdAllocator idAllocator)
+        {
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+        }
+
+        @Override
+        public PlanNode visitApply(ApplyNode node, RewriteContext<PlanNode> context)
+        {
+            ApplyNode rewrittenNode = (ApplyNode) context.defaultRewrite(node, context.get());
+
+            if (rewrittenNode.getCorrelation().isEmpty() && rewrittenNode.getSubquery() instanceof EnforceSingleRowNode) {
+                // only scalar subquery wraps expression in EnforceSingleRowNode
+                return new JoinNode(
+                        idAllocator.getNextId(),
+                        JoinNode.Type.FULL,
+                        rewrittenNode.getInput(),
+                        rewrittenNode.getSubquery(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        Optional.empty());
+            }
+            return rewrittenNode;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.DeleteNode;
 import com.facebook.presto.sql.planner.plan.DistinctLimitNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
@@ -414,6 +415,16 @@ public class UnaliasSymbolReferences
             PlanNode source = context.rewrite(node.getSource());
 
             return new EnforceSingleRowNode(node.getId(), source);
+        }
+
+        @Override
+        public PlanNode visitApply(ApplyNode node, RewriteContext<Void> context)
+        {
+            PlanNode source = context.rewrite(node.getInput());
+            PlanNode subquery = context.rewrite(node.getSubquery());
+            List<Symbol> canonicalCorrelation = Lists.transform(node.getCorrelation(), this::canonicalize);
+
+            return new ApplyNode(node.getId(), source, subquery, canonicalCorrelation);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ApplyNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ApplyNode.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class ApplyNode
+        extends PlanNode
+{
+    private final PlanNode input;
+    private final PlanNode subquery;
+
+    /**
+     * Correlation symbols, returned from input (outer plan) used in subquery (inner plan)
+     */
+    private final List<Symbol> correlation;
+
+    @JsonCreator
+    public ApplyNode(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("input") PlanNode input,
+            @JsonProperty("subquery") PlanNode subquery,
+            @JsonProperty("correlation") List<Symbol> correlation)
+    {
+        super(id);
+        requireNonNull(input, "input is null");
+        requireNonNull(subquery, "right is null");
+        requireNonNull(correlation, "correlation is null");
+
+        checkArgument(input.getOutputSymbols().containsAll(correlation), "Input does not contain symbols from correlation");
+
+        this.input = input;
+        this.subquery = subquery;
+        this.correlation = ImmutableList.copyOf(correlation);
+    }
+
+    @JsonProperty("input")
+    public PlanNode getInput()
+    {
+        return input;
+    }
+
+    @JsonProperty("subquery")
+    public PlanNode getSubquery()
+    {
+        return subquery;
+    }
+
+    @JsonProperty("correlation")
+    public List<Symbol> getCorrelation()
+    {
+        return correlation;
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return ImmutableList.of(input, subquery);
+    }
+
+    @Override
+    @JsonProperty("outputSymbols")
+    public List<Symbol> getOutputSymbols()
+    {
+        return ImmutableList.<Symbol>builder()
+                .addAll(input.getOutputSymbols())
+                .addAll(subquery.getOutputSymbols())
+                .build();
+    }
+
+    @Override
+    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    {
+        return visitor.visitApply(this, context);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
@@ -267,4 +267,11 @@ public class ChildReplacer
     {
         return new EnforceSingleRowNode(node.getId(), Iterables.getOnlyElement(newChildren));
     }
+
+    @Override
+    public PlanNode visitApply(ApplyNode node, List<PlanNode> newChildren)
+    {
+        checkArgument(newChildren.size() == 2, "expected newChildren to contain 2 nodes");
+        return new ApplyNode(node.getId(), newChildren.get(0), newChildren.get(1), node.getCorrelation());
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNode.java
@@ -58,6 +58,7 @@ import static java.util.Objects.requireNonNull;
         @JsonSubTypes.Type(value = EnforceSingleRowNode.class, name = "scalar"),
         @JsonSubTypes.Type(value = GroupIdNode.class, name = "groupid"),
         @JsonSubTypes.Type(value = ExplainAnalyzeNode.class, name = "explainAnalyze"),
+        @JsonSubTypes.Type(value = ApplyNode.class, name = "apply"),
 })
 public abstract class PlanNode
 {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanVisitor.java
@@ -174,4 +174,9 @@ public class PlanVisitor<C, R>
     {
         return visitPlan(node, context);
     }
+
+    public R visitApply(ApplyNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoSubqueryExpressionLeftChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoSubqueryExpressionLeftChecker.java
@@ -1,0 +1,76 @@
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.sql.planner.SimplePlanVisitor;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.SubqueryExpression;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.lang.String.format;
+
+public final class NoSubqueryExpressionLeftChecker
+        implements PlanSanityChecker.Checker
+{
+    @Override
+    public void validate(PlanNode plan)
+    {
+        for (Expression expression : ExpressionExtractor.extractExpressions(plan)) {
+            new DefaultTraversalVisitor<Void, Void>()
+            {
+                @Override
+                protected Void visitSubqueryExpression(SubqueryExpression node, Void context)
+                {
+                    throw new IllegalStateException(format("Unexpected subquery expression in logical plan: %s", node));
+                }
+            }.process(expression, null);
+        }
+    }
+
+    private static class ExpressionExtractor
+            extends SimplePlanVisitor<ImmutableList.Builder<Expression>>
+    {
+        public static List<Expression> extractExpressions(PlanNode plan)
+        {
+            ImmutableList.Builder<Expression> expressionsBuilder = ImmutableList.builder();
+            plan.accept(new ExpressionExtractor(), expressionsBuilder);
+            return expressionsBuilder.build();
+        }
+
+        @Override
+        public Void visitFilter(FilterNode node, ImmutableList.Builder<Expression> context)
+        {
+            context.add(node.getPredicate());
+            return super.visitFilter(node, context);
+        }
+
+        @Override
+        public Void visitProject(ProjectNode node, ImmutableList.Builder<Expression> context)
+        {
+            context.addAll(node.getAssignments().values());
+            return super.visitProject(node, context);
+        }
+
+        @Override
+        public Void visitTableScan(TableScanNode node, ImmutableList.Builder<Expression> context)
+        {
+            if (node.getOriginalConstraint() != null) {
+                context.add(node.getOriginalConstraint());
+            }
+            return super.visitTableScan(node, context);
+        }
+
+        @Override
+        public Void visitValues(ValuesNode node, ImmutableList.Builder<Expression> context)
+        {
+            node.getRows().forEach(context::addAll);
+            return super.visitValues(node, context);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanSanityChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanSanityChecker.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * It is going to be executed at the end of logical planner, to verify its correctness
+ */
+public final class PlanSanityChecker
+{
+    private static final List<Checker> CHECKERS = ImmutableList.of(
+            new ValidateDependenciesChecker(),
+            new NoSubqueryExpressionLeftChecker());
+
+    private PlanSanityChecker() {}
+
+    public static void validate(PlanNode planNode)
+    {
+        CHECKERS.forEach(checker -> checker.validate(planNode));
+    }
+
+    public interface Checker
+    {
+        void validate(PlanNode plan);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanSanityChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanSanityChecker.java
@@ -25,7 +25,8 @@ public final class PlanSanityChecker
 {
     private static final List<Checker> CHECKERS = ImmutableList.of(
             new ValidateDependenciesChecker(),
-            new NoSubqueryExpressionLeftChecker());
+            new NoSubqueryExpressionLeftChecker(),
+            new NoApplyNodeLeftChecker());
 
     private PlanSanityChecker() {}
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -11,8 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.sql.planner;
+package com.facebook.presto.sql.planner.sanity;
 
+import com.facebook.presto.sql.planner.DependencyExtractor;
+import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.DeleteNode;
 import com.facebook.presto.sql.planner.plan.DistinctLimitNode;
@@ -65,11 +67,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 /**
  * Ensures that all dependencies (i.e., symbols in expressions) for a plan node are provided by its source nodes
  */
-public final class PlanSanityChecker
+public final class ValidateDependenciesChecker
+        implements PlanSanityChecker.Checker
 {
-    private PlanSanityChecker() {}
-
-    public static void validate(PlanNode plan)
+    @Override
+    public void validate(PlanNode plan)
     {
         plan.accept(new Visitor(), null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.SubPlan;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.DistinctLimitNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
@@ -452,6 +453,18 @@ public final class GraphvizPrinter
 
             node.getSource().accept(this, context);
             node.getFilteringSource().accept(this, context);
+
+            return null;
+        }
+
+        @Override
+        public Void visitApply(ApplyNode node, Void context)
+        {
+            String parameters = Joiner.on(",").join(node.getCorrelation());
+            printNode(node, "Apply", parameters, NODE_COLORS.get(NodeType.JOIN));
+
+            node.getInput().accept(this, context);
+            node.getSubquery().accept(this, context);
 
             return null;
         }

--- a/presto-main/src/main/java/com/facebook/presto/util/ImmutableCollectors.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/ImmutableCollectors.java
@@ -74,4 +74,16 @@ public final class ImmutableCollectors
                 },
                 ImmutableMap.Builder::build);
     }
+
+    public static <K, V, O> Collector<O, ?, ImmutableMap<K, V>> toImmutableMap(Function<O, K> keyMapper, Function<O, V> valueMapper)
+    {
+        return Collector.<O, ImmutableMap.Builder<K, V>, ImmutableMap<K, V>>of(
+                ImmutableMap.Builder::new,
+                (builder, object) -> builder.put(keyMapper.apply(object), valueMapper.apply(object)),
+                (left, right) -> {
+                    left.putAll(right.build());
+                    return left;
+                },
+                ImmutableMap.Builder::build);
+    }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4872,6 +4872,14 @@ public abstract class AbstractTestQueries
                 "FROM lineitem " +
                 "GROUP BY linenumber " +
                 "HAVING min(orderkey) IN (SELECT orderkey FROM orders WHERE orderkey > 1)");
+        //
+        // constant literal versus a subquery
+        assertQuery("SELECT 10 in (SELECT orderkey FROM orders)");
+
+        // the same IN subquery used twice
+        assertQuery(
+                "SELECT * FROM (VALUES (1,1), (2,2), (3, 3)) t(x, y) WHERE (x+y in (VALUES 4, 5)) AND (x*y in (VALUES 4, 5))",
+                "VALUES (2,2)");
 
         // Throw in a bunch of IN subquery predicates
         assertQuery("" +
@@ -5073,6 +5081,7 @@ public abstract class AbstractTestQueries
                 "(SELECT min(orderkey) FROM orders)" +
                 "<" +
                 "(SELECT max(orderkey) FROM orders)");
+        assertQuery("SELECT (SELECT 1), (SELECT 2), (SELECT 3)");
 
         // distinct
         assertQuery("SELECT DISTINCT orderkey FROM lineitem " +


### PR DESCRIPTION
Introduce ApplyNode representation of subquery

For more design details please see:
https://docs.google.com/document/d/18HN7peS2eR8lZsErqcmnoWyMEPb6p4OQeidH1JP_EkA

Apply node is a generic representation of subquery abstract correlation
between outer and nested queries.
Subquery is rewritten into an ApplyNode then if ApplyNode does not have
any correlation it is removed (rewritten to some form of join) by
UncorrelatedInPredicateApplyRemover and UncorrelatedScalarApplyRemover.
