### PR TITLE
Avoid logging exception when canceling a query

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -139,6 +139,12 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
+    public void cancelQuery()
+    {
+        stateMachine.transitionToCanceled();
+    }
+
+    @Override
     public void cancelStage(StageId stageId)
     {
         // no-op

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -116,6 +116,12 @@ public class FailedQueryExecution
     }
 
     @Override
+    public void cancelQuery()
+    {
+        // no-op
+    }
+
+    @Override
     public void cancelStage(StageId stageId)
     {
         // no-op

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -44,6 +44,8 @@ public interface QueryExecution
 
     void fail(Throwable cause);
 
+    void cancelQuery();
+
     void cancelStage(StageId stageId);
 
     void recordHeartbeat();

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -341,6 +341,12 @@ public final class SqlQueryExecution
     }
 
     @Override
+    public void cancelQuery()
+    {
+        stateMachine.transitionToCanceled();
+    }
+
+    @Override
     public void cancelStage(StageId stageId)
     {
         requireNonNull(stageId, "stageId is null");

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -60,7 +60,6 @@ import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TIME_LIMIT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_QUEUE_FULL;
 import static com.facebook.presto.spi.StandardErrorCode.SERVER_SHUTTING_DOWN;
-import static com.facebook.presto.spi.StandardErrorCode.USER_CANCELED;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.concurrent.Threads.threadsNamed;
@@ -351,7 +350,7 @@ public class SqlQueryManager
 
         QueryExecution query = queries.get(queryId);
         if (query != null) {
-            query.fail(new PrestoException(USER_CANCELED, "Query was canceled"));
+            query.cancelQuery();
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -66,7 +66,6 @@ import static com.facebook.presto.execution.StageState.RUNNING;
 import static com.facebook.presto.execution.StageState.SCHEDULED;
 import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
-import static com.facebook.presto.spi.StandardErrorCode.USER_CANCELED;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
 import static com.facebook.presto.util.Failures.checkCondition;
@@ -150,7 +149,7 @@ public class SqlQueryScheduler
             }
             else if (state == CANCELED) {
                 // output stage was canceled
-                queryStateMachine.transitionToFailed(new PrestoException(USER_CANCELED, "Query was canceled"));
+                queryStateMachine.transitionToCanceled();
             }
         });
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -126,6 +126,13 @@ public class MockQueryExecution
     }
 
     @Override
+    public void cancelQuery()
+    {
+        state = FAILED;
+        fireStateChange();
+    }
+
+    @Override
     public void cancelStage(StageId stageId)
     {
         throw new UnsupportedOperationException();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.memory.MemoryPoolId;
 import com.facebook.presto.memory.VersionedMemoryPoolId;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -42,6 +43,8 @@ import static com.facebook.presto.execution.QueryState.PLANNING;
 import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.execution.QueryState.STARTING;
+import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.USER_CANCELED;
 import static com.facebook.presto.transaction.TransactionManager.createTestTransactionManager;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.testng.Assert.assertEquals;
@@ -121,7 +124,7 @@ public class TestQueryStateMachine
 
         stateMachine = createQueryStateMachine();
         assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
-        assertState(stateMachine, FAILED);
+        assertState(stateMachine, FAILED, FAILED_CAUSE);
     }
 
     @Test
@@ -152,7 +155,7 @@ public class TestQueryStateMachine
         stateMachine = createQueryStateMachine();
         stateMachine.transitionToPlanning();
         assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
-        assertState(stateMachine, FAILED);
+        assertState(stateMachine, FAILED, FAILED_CAUSE);
     }
 
     @Test
@@ -181,7 +184,7 @@ public class TestQueryStateMachine
         stateMachine = createQueryStateMachine();
         stateMachine.transitionToStarting();
         assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
-        assertState(stateMachine, FAILED);
+        assertState(stateMachine, FAILED, FAILED_CAUSE);
     }
 
     @Test
@@ -208,7 +211,7 @@ public class TestQueryStateMachine
         stateMachine = createQueryStateMachine();
         stateMachine.transitionToRunning();
         assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
-        assertState(stateMachine, FAILED);
+        assertState(stateMachine, FAILED, FAILED_CAUSE);
     }
 
     @Test
@@ -226,35 +229,53 @@ public class TestQueryStateMachine
     {
         QueryStateMachine stateMachine = createQueryStateMachine();
         assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
-        assertFinalState(stateMachine, FAILED);
+        assertFinalState(stateMachine, FAILED, FAILED_CAUSE);
+    }
+
+    @Test
+    public void testCanceled()
+    {
+        QueryStateMachine stateMachine = createQueryStateMachine();
+        assertTrue(stateMachine.transitionToCanceled());
+        assertFinalState(stateMachine, FAILED, new PrestoException(USER_CANCELED, "canceled"));
     }
 
     private static void assertFinalState(QueryStateMachine stateMachine, QueryState expectedState)
     {
+        assertFinalState(stateMachine, expectedState, null);
+    }
+
+    private static void assertFinalState(QueryStateMachine stateMachine, QueryState expectedState, Exception expectedException)
+    {
         assertTrue(expectedState.isDone());
-        assertState(stateMachine, expectedState);
+        assertState(stateMachine, expectedState, expectedException);
 
         assertFalse(stateMachine.transitionToPlanning());
-        assertState(stateMachine, expectedState);
+        assertState(stateMachine, expectedState, expectedException);
 
         assertFalse(stateMachine.transitionToStarting());
-        assertState(stateMachine, expectedState);
+        assertState(stateMachine, expectedState, expectedException);
 
         assertFalse(stateMachine.transitionToRunning());
-        assertState(stateMachine, expectedState);
+        assertState(stateMachine, expectedState, expectedException);
 
         assertFalse(stateMachine.transitionToFinishing());
-        assertState(stateMachine, expectedState);
+        assertState(stateMachine, expectedState, expectedException);
 
         assertFalse(stateMachine.transitionToFailed(FAILED_CAUSE));
-        assertState(stateMachine, expectedState);
+        assertState(stateMachine, expectedState, expectedException);
 
         // attempt to fail with another exception, which will fail
         assertFalse(stateMachine.transitionToFailed(new IOException("failure after finish")));
-        assertState(stateMachine, expectedState);
+        assertState(stateMachine, expectedState, expectedException);
     }
 
     private static void assertState(QueryStateMachine stateMachine, QueryState expectedState)
+    {
+        assertState(stateMachine, expectedState, null);
+    }
+
+    private static void assertState(QueryStateMachine stateMachine, QueryState expectedState, Exception expectedException)
     {
         assertEquals(stateMachine.getQueryId(), QUERY_ID);
         assertEqualSessions(stateMachine.getSession().withoutTransactionId(), TEST_SESSION);
@@ -323,8 +344,13 @@ public class TestQueryStateMachine
         if (expectedState == FAILED) {
             FailureInfo failure = queryInfo.getFailureInfo();
             assertNotNull(failure);
-            assertEquals(failure.getMessage(), FAILED_CAUSE.getMessage());
-            assertEquals(failure.getType(), FAILED_CAUSE.getClass().getName());
+            assertEquals(failure.getType(), expectedException.getClass().getName());
+            if (expectedException instanceof PrestoException) {
+                assertEquals(queryInfo.getErrorCode(), ((PrestoException) expectedException).getErrorCode());
+            }
+            else {
+                assertEquals(queryInfo.getErrorCode(), INTERNAL_ERROR.toErrorCode());
+            }
         }
         else {
             assertNull(queryInfo.getFailureInfo());


### PR DESCRIPTION
A query is canceled by failing the query with a user canceled error code.  When
a query is failed the exception is logged, but this is not needed for a canceled
query.