### PR TITLE
Update JDK version to 1.8u92 in product tests

### DIFF
--- a/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   hadoop-master:
     hostname: hadoop-master
-    image: 'teradatalabs/cdh5-hive:2'
+    image: 'teradatalabs/cdh5-hive:3'
     ports:
       - '1080:1080'
       - '8020:8020'
@@ -14,7 +14,7 @@ services:
 
   presto-master:
     hostname: presto-master
-    image: 'teradatalabs/centos6-java8-oracle:jdk1.8.0_40-4e54a19'
+    image: 'teradatalabs/centos6-java8-oracle:jdk1.8.0_92-80a011f'
     depends_on:
       - 'hadoop-master'
     command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode run
@@ -27,7 +27,7 @@ services:
 
   application-runner:
     hostname: application-runner
-    image: 'teradatalabs/centos6-java8-oracle:jdk1.8.0_40-4e54a19'
+    image: 'teradatalabs/centos6-java8-oracle:jdk1.8.0_92-80a011f'
     depends_on:
       - 'presto-master'
     volumes_from:

--- a/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-impersonation/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-impersonation/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   hadoop-master:
     hostname: hadoop-master
-    image: 'teradatalabs/cdh5-hive-kerberized:2'
+    image: 'teradatalabs/cdh5-hive-kerberized:3'
     ports:
       - '1080:1080'
       - '8020:8020'
@@ -15,7 +15,7 @@ services:
   presto-master:
     hostname: presto-master
     # cdh5-hive-kerberized contains keytabs and the `krb5.conf` within
-    image: 'teradatalabs/cdh5-hive-kerberized:2'
+    image: 'teradatalabs/cdh5-hive-kerberized:3'
     depends_on:
       - 'hadoop-master'
     command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode-kerberized run
@@ -29,7 +29,7 @@ services:
   application-runner:
     hostname: application-runner
     # cdh5-hive-kerberized contains keytabs and the `krb5.conf` within
-    image: 'teradatalabs/cdh5-hive-kerberized:2'
+    image: 'teradatalabs/cdh5-hive-kerberized:3'
     depends_on:
       - 'presto-master'
     volumes_from:

--- a/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-no-impersonation/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-no-impersonation/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   hadoop-master:
     hostname: hadoop-master
-    image: 'teradatalabs/cdh5-hive-kerberized:2'
+    image: 'teradatalabs/cdh5-hive-kerberized:3'
     ports:
       - '1080:1080'
       - '8020:8020'
@@ -15,7 +15,7 @@ services:
   presto-master:
     hostname: presto-master
     # cdh5-hive-kerberized contains keytabs and the `krb5.conf` within
-    image: 'teradatalabs/cdh5-hive-kerberized:2'
+    image: 'teradatalabs/cdh5-hive-kerberized:3'
     depends_on:
       - 'hadoop-master'
     command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode-kerberized run
@@ -29,7 +29,7 @@ services:
   application-runner:
     hostname: application-runner
     # cdh5-hive-kerberized contains keytabs and the `krb5.conf` within
-    image: 'teradatalabs/cdh5-hive-kerberized:2'
+    image: 'teradatalabs/cdh5-hive-kerberized:3'
     depends_on:
       - 'presto-master'
     volumes_from:


### PR DESCRIPTION
Updating JDK version for the additional profiles 
singlenode-hdfs-impersonation
singlenode-kerberos-hdfs-impersonation
singlenode-kerberos-hdfs-no-impersonation

This is in continuation to https://github.com/prestodb/presto/pull/5229.