### PR TITLE
Add ZIP function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -95,3 +95,13 @@ Array Functions
 
     Subsets array ``x`` starting from index ``start`` (or starting from the end
     if ``start`` is negative) with a length of ``length``.
+
+.. function:: zip(array1, array2[, array3[, array4]]) -> array<row>
+
+    | Merges the given arrays, element-wise, into a single array of rows. The M-th element of
+      the N-th argument will be the N-th field of the M-th output element.
+    | If the arguments have uneven length, missing values are filled with NULL.
+
+    ::
+
+        SELECT ZIP(ARRAY[1, 2], ARRAY['1b', NULL, '3b'], ARRAY['1c', '2c', NULL]) => [ROW(1, '1b', '1c'), ROW(2, NULL, '2c'), ROW(NULL, '3b', NULL)]

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -198,6 +198,7 @@ import static com.facebook.presto.operator.scalar.RowToJsonCast.ROW_TO_JSON;
 import static com.facebook.presto.operator.scalar.RowToRowCast.ROW_TO_ROW_CAST;
 import static com.facebook.presto.operator.scalar.TryCastFunction.TRY_CAST;
 import static com.facebook.presto.operator.scalar.VarcharToVarcharCast.VARCHAR_TO_VARCHAR_CAST;
+import static com.facebook.presto.operator.scalar.ZipFunction.ZIP_FUNCTIONS;
 import static com.facebook.presto.operator.window.AggregateWindowFunction.supplier;
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_MISSING;
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
@@ -403,6 +404,7 @@ public class FunctionRegistry
                 .scalar(MapCardinalityFunction.class)
                 .scalar(MapConcatFunction.class)
                 .scalar(MapToMapCast.class)
+                .functions(ZIP_FUNCTIONS)
                 .functions(ARRAY_JOIN, ARRAY_JOIN_WITH_NULL_REPLACEMENT)
                 .functions(ARRAY_TO_ARRAY_CAST, ARRAY_LESS_THAN)
                 .functions(ARRAY_TO_ELEMENT_CONCAT_FUNCTION, ELEMENT_TO_ARRAY_CONCAT_FUNCTION)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipFunction.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.annotation.UsedByGeneratedCode;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.RowType;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static java.lang.String.join;
+import static java.lang.invoke.MethodType.methodType;
+
+public final class ZipFunction
+        extends SqlScalarFunction
+{
+    public static final int MIN_ARITY = 2;
+    public static final int MAX_ARITY = 4;
+    public static final ZipFunction[] ZIP_FUNCTIONS;
+
+    private static final String FUNCTION_NAME = "zip";
+    private static final MethodHandle METHOD_HANDLE = methodHandle(ZipFunction.class, "zip", List.class, Block[].class);
+
+    static
+    {
+        ZIP_FUNCTIONS = new ZipFunction[MAX_ARITY - MIN_ARITY + 1];
+        for (int arity = MIN_ARITY; arity <= MAX_ARITY; ++arity) {
+            ZIP_FUNCTIONS[arity - MIN_ARITY] = new ZipFunction(arity);
+        }
+    }
+
+    private List<String> constraintNames;
+
+    private ZipFunction(int arity)
+    {
+        this(IntStream.rangeClosed(1, arity).mapToObj(s -> "T" + s).collect(toImmutableList()));
+    }
+
+    private ZipFunction(List<String> constraintNames)
+    {
+        super(FUNCTION_NAME,
+                constraintNames.stream().map(Signature::typeVariable).collect(toImmutableList()),
+                ImmutableList.of(),
+                "array(row(" + join(",", constraintNames) + "))",
+                constraintNames.stream().map(name -> "array(" + name + ")").collect(toImmutableList()));
+        this.constraintNames = constraintNames;
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Merges the given arrays, element-wise, into a single array of rows.";
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        List<Type> constraintTypes = this.constraintNames.stream().map(constraintName -> boundVariables.getTypeVariable(constraintName)).collect(toImmutableList());
+        List<Boolean> nullableArguments = constraintTypes.stream().map(constraintType -> false).collect(toImmutableList());
+        List<Class<?>> javaArgumentTypes = constraintTypes.stream().map(constraintType -> Block.class).collect(toImmutableList());
+        MethodHandle methodHandle = METHOD_HANDLE.bindTo(constraintTypes).asVarargsCollector(Block[].class).asType(methodType(Block.class, javaArgumentTypes));
+        return new ScalarFunctionImplementation(false, nullableArguments, methodHandle, isDeterministic());
+    }
+
+    @UsedByGeneratedCode
+    public static Block zip(List<Type> types, Block... arrays)
+    {
+        int biggestCardinality = 0;
+        for (Block array : arrays) {
+            biggestCardinality = Math.max(biggestCardinality, array.getPositionCount());
+        }
+        RowType rowType = new RowType(types, Optional.empty());
+        BlockBuilder outputBuilder = rowType.createBlockBuilder(new BlockBuilderStatus(), biggestCardinality);
+        for (int outputPosition = 0; outputPosition < biggestCardinality; ++outputPosition) {
+            BlockBuilder rowBuilder = outputBuilder.beginBlockEntry();
+            for (int fieldIndex = 0; fieldIndex < arrays.length; ++fieldIndex) {
+                if (arrays[fieldIndex].getPositionCount() <= outputPosition) {
+                    rowBuilder.appendNull();
+                }
+                else {
+                    types.get(fieldIndex).appendTo(arrays[fieldIndex], outputPosition, rowBuilder);
+                }
+            }
+            outputBuilder.closeEntry();
+        }
+        return outputBuilder.build();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestZipFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestZipFunction.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.RowType;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.operator.scalar.ZipFunction.MAX_ARITY;
+import static com.facebook.presto.operator.scalar.ZipFunction.MIN_ARITY;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
+import static java.lang.String.join;
+import static java.util.Arrays.asList;
+
+public class TestZipFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testSameLength()
+            throws Exception
+    {
+        assertFunction("zip(ARRAY[1, 2], ARRAY['a', 'b'])",
+                zipReturnType(INTEGER, createVarcharType(1)),
+                asList(asList(1, "a"), asList(2, "b")));
+
+        assertFunction("zip(ARRAY[1, 2], ARRAY['a', CAST('b' AS VARCHAR)])",
+                zipReturnType(INTEGER, VARCHAR),
+                asList(asList(1, "a"), asList(2, "b")));
+
+        assertFunction("zip(ARRAY[1, 2, 3, 4], ARRAY['a', 'b', 'c', 'd'])",
+                zipReturnType(INTEGER, createVarcharType(1)),
+                asList(asList(1, "a"), asList(2, "b"), asList(3, "c"), asList(4, "d")));
+
+        assertFunction("zip(ARRAY[1, 2], ARRAY['a', 'b'],  ARRAY['c', 'd'])",
+                zipReturnType(INTEGER, createVarcharType(1), createVarcharType(1)),
+                asList(asList(1, "a", "c"), asList(2, "b", "d")));
+
+        assertFunction("zip(ARRAY[1, 2], ARRAY['a', 'b'],  ARRAY['c', 'd'], ARRAY['e', 'f'])",
+                zipReturnType(INTEGER, createVarcharType(1), createVarcharType(1), createVarcharType(1)),
+                asList(asList(1, "a", "c", "e"), asList(2, "b", "d", "f")));
+
+        assertFunction("zip(ARRAY[], ARRAY[])",
+                zipReturnType(UNKNOWN, UNKNOWN),
+                asList());
+
+        assertFunction("zip(ARRAY[], ARRAY[], ARRAY[])",
+                zipReturnType(UNKNOWN, UNKNOWN, UNKNOWN),
+                asList());
+
+        assertFunction("zip(ARRAY[], ARRAY[], ARRAY[], ARRAY[])",
+                zipReturnType(UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN),
+                asList());
+
+        assertFunction("zip(ARRAY[NULL], ARRAY[NULL])",
+                zipReturnType(UNKNOWN, UNKNOWN),
+                asList(asList(null, null)));
+
+        assertFunction("zip(ARRAY[ARRAY[1, 1], ARRAY[1, 2]], ARRAY[ARRAY[2, 1], ARRAY[2, 2]])",
+                zipReturnType(new ArrayType(INTEGER), new ArrayType(INTEGER)),
+                asList((List<List<Integer>>) asList(asList(1, 1), asList(2, 1)), asList(asList(1, 2), asList(2, 2))));
+    }
+
+    @Test
+    public void testDifferentLength()
+            throws Exception
+    {
+        assertFunction("zip(ARRAY[1], ARRAY['a', 'b'])",
+                zipReturnType(INTEGER, createVarcharType(1)),
+                asList(asList(1, "a"), asList(null, "b")));
+
+        assertFunction("zip(ARRAY[NULL, 2], ARRAY['a'])",
+                zipReturnType(INTEGER, createVarcharType(1)),
+                asList(asList(null, "a"), (List<Integer>) asList(2, null)));
+
+        assertFunction("zip(ARRAY[], ARRAY[1], ARRAY[1, 2], ARRAY[1, 2, 3])",
+                zipReturnType(UNKNOWN, INTEGER, INTEGER, INTEGER),
+                asList(asList(null, 1, 1, 1), asList(null, null, 2, 2), asList(null, null, null, 3)));
+
+        assertFunction("zip(ARRAY[], ARRAY[NULL], ARRAY[NULL, NULL])",
+                zipReturnType(UNKNOWN, UNKNOWN, UNKNOWN),
+                asList(asList(null, null, null), asList(null, null, null)));
+    }
+
+    @Test
+    public void testWithNull()
+            throws Exception
+    {
+        assertFunction("zip(CAST(NULL AS ARRAY(UNKNOWN)), ARRAY[],  ARRAY[1])",
+                zipReturnType(UNKNOWN, UNKNOWN, INTEGER),
+                null);
+    }
+
+    @Test
+    public void testAllArities()
+            throws Exception
+    {
+        IntStream.rangeClosed(MIN_ARITY, MAX_ARITY).forEach(
+                arity -> assertFunction(
+                        "zip(" + join(", ", IntStream.rangeClosed(1, arity).mapToObj(index -> "ARRAY[" + index + "]").toArray(size -> new String[size])) + ")",
+                        zipReturnType(IntStream.rangeClosed(1, arity).mapToObj(index -> INTEGER).toArray(size -> new Type[size])),
+                        asList(IntStream.rangeClosed(1, arity).mapToObj(index -> index).collect(toImmutableList())))
+        );
+    }
+
+    private Type zipReturnType(Type... types)
+    {
+        return new ArrayType(new RowType(Arrays.asList(types), Optional.empty()));
+    }
+}


### PR DESCRIPTION
New scalar function: `zip`
Aggregate elements of the arrays passed as arguments into rows. The M-th element of the N-th argument will be the N-th field of the M-th output element.
If the arguments have uneven length, the length of the output will be the biggest length, missing values are filled with NULL. 
Null arguments are treated like empty arrays.
Similar to the combined use of UNNEST and ARRAY_AGG or python's `itertools.zip_longest`.

Choosing to pad with NULLs, like `zip_longest` as that's similar to the behavior of UNNEST where it pads with NULLs.

The class actually registers a certain number functions, since it would be (unnecessarily) complicated to have variable number of type constraints in the framework. So, in this case, we have:
- `zip(array[T1], array[T2]): array(row(T1, T2))`
- `zip(array[T1], array[T2], array[T3]): array(row(T1, T2, T3))`
- `zip(array[T1], array[T2], array[T3], array[T4]): array(row(T1, T2, T3, T4))`
It's easily modifiable by changing MIN_ARITY / MAX_ARITY in `ZipFunction`.

If more than `MAX_ARITY` arguments are necessary in the use of zip, you can use nested calls:
- `zip(array[T1], zip(array[T2], array[T3])): array(row(T1, row(T2, T3)))`