### PR TITLE
Equate 'varchar' and 'varchar(MAX_LENGTH)' in TypeSignature

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -391,13 +392,32 @@ public class TypeSignature
 
         TypeSignature other = (TypeSignature) o;
 
+        // TODO remove this hack together with hack from toString()
+        if (magicVarcharEquals(other, this)) {
+            return true;
+        }
+
         return Objects.equals(this.base.toLowerCase(Locale.ENGLISH), other.base.toLowerCase(Locale.ENGLISH)) &&
                 Objects.equals(this.parameters, other.parameters);
+    }
+
+    private static boolean magicVarcharEquals(TypeSignature first, TypeSignature second)
+    {
+        // treat `varchar` and `varchar(MAX_LONG)` are equivalent
+        // should replaced with hack in parser as soon as we change declarations of all functions taking varachar parameters to use parameterization
+        return first.getBase().equals(StandardTypes.VARCHAR)
+                && second.getBase().equals(StandardTypes.VARCHAR)
+                && ((first.getParameters().isEmpty() && second.getParameters().equals(Arrays.asList(TypeSignatureParameter.of(VarcharType.MAX_LENGTH))))
+                || (second.getParameters().isEmpty() && first.getParameters().equals(Arrays.asList(TypeSignatureParameter.of(VarcharType.MAX_LENGTH)))));
     }
 
     @Override
     public int hashCode()
     {
+        // TODO remove this hack together with hack from toString()
+        if (getBase().equals(StandardTypes.VARCHAR) && parameters.isEmpty()) {
+            return VarcharType.createUnboundedVarcharType().getTypeSignature().hashCode();
+        }
         return Objects.hash(base.toLowerCase(Locale.ENGLISH), parameters);
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -22,11 +22,13 @@ import java.util.Set;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.google.common.collect.Lists.transform;
 import static java.util.Arrays.asList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -188,6 +190,10 @@ public class TestTypeSignature
     {
         assertEquals(VARCHAR.getTypeSignature().toString(), "varchar");
         assertEquals(createVarcharType(42).getTypeSignature().toString(), "varchar(42)");
+        assertEquals(parseTypeSignature("varchar"), createUnboundedVarcharType().getTypeSignature());
+        assertEquals(createUnboundedVarcharType().getTypeSignature(), parseTypeSignature("varchar"));
+        assertEquals(parseTypeSignature("varchar").hashCode(), createUnboundedVarcharType().getTypeSignature().hashCode());
+        assertNotEquals(createUnboundedVarcharType().getTypeSignature(), parseTypeSignature("varchar(10)"));
     }
 
     @Test


### PR DESCRIPTION
This is intermediate step. 
Next intermediate step - when all varchar related UDFs definitions are changed to take `VARCHAR(x)` instead of `VARCHAR` - will be to:
 * remove these hacks from `equals` and `hashCode`
 * disallow users to explicitly use `VARCHAR(MAX_LENGTH)` as data type
 * hack `TypeSignature` parser to parse `"varchar"` as `VARCHAR(MAX_LENGTH)`