### PR TITLE
Float type - first part

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -111,6 +111,7 @@ import com.facebook.presto.type.DateOperators;
 import com.facebook.presto.type.DateTimeOperators;
 import com.facebook.presto.type.DecimalOperators;
 import com.facebook.presto.type.DoubleOperators;
+import com.facebook.presto.type.FloatOperators;
 import com.facebook.presto.type.HyperLogLogOperators;
 import com.facebook.presto.type.IntegerOperators;
 import com.facebook.presto.type.IntervalDayTimeOperators;
@@ -379,6 +380,7 @@ public class FunctionRegistry
                 .scalar(SmallintOperators.class)
                 .scalar(TinyintOperators.class)
                 .scalar(DoubleOperators.class)
+                .scalar(FloatOperators.class)
                 .scalar(VarcharOperators.class)
                 .scalar(VarbinaryOperators.class)
                 .scalar(DateOperators.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -222,12 +222,14 @@ import static com.facebook.presto.type.DecimalCasts.BOOLEAN_TO_DECIMAL_CAST;
 import static com.facebook.presto.type.DecimalCasts.DECIMAL_TO_BIGINT_CAST;
 import static com.facebook.presto.type.DecimalCasts.DECIMAL_TO_BOOLEAN_CAST;
 import static com.facebook.presto.type.DecimalCasts.DECIMAL_TO_DOUBLE_CAST;
+import static com.facebook.presto.type.DecimalCasts.DECIMAL_TO_FLOAT_CAST;
 import static com.facebook.presto.type.DecimalCasts.DECIMAL_TO_INTEGER_CAST;
 import static com.facebook.presto.type.DecimalCasts.DECIMAL_TO_JSON_CAST;
 import static com.facebook.presto.type.DecimalCasts.DECIMAL_TO_SMALLINT_CAST;
 import static com.facebook.presto.type.DecimalCasts.DECIMAL_TO_TINYINT_CAST;
 import static com.facebook.presto.type.DecimalCasts.DECIMAL_TO_VARCHAR_CAST;
 import static com.facebook.presto.type.DecimalCasts.DOUBLE_TO_DECIMAL_CAST;
+import static com.facebook.presto.type.DecimalCasts.FLOAT_TO_DECIMAL_CAST;
 import static com.facebook.presto.type.DecimalCasts.INTEGER_TO_DECIMAL_CAST;
 import static com.facebook.presto.type.DecimalCasts.JSON_TO_DECIMAL_CAST;
 import static com.facebook.presto.type.DecimalCasts.SMALLINT_TO_DECIMAL_CAST;
@@ -435,8 +437,8 @@ public class FunctionRegistry
                 .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_TO_JSON, JSON_TO_ARRAY)
                 .functions(MAP_CONSTRUCTOR, MAP_SUBSCRIPT, MAP_TO_JSON, JSON_TO_MAP)
                 .functions(MAP_AGG, MULTIMAP_AGG, MAP_UNION)
-                .functions(DECIMAL_TO_VARCHAR_CAST, DECIMAL_TO_INTEGER_CAST, DECIMAL_TO_BIGINT_CAST, DECIMAL_TO_DOUBLE_CAST, DECIMAL_TO_BOOLEAN_CAST, DECIMAL_TO_TINYINT_CAST, DECIMAL_TO_SMALLINT_CAST)
-                .functions(VARCHAR_TO_DECIMAL_CAST, INTEGER_TO_DECIMAL_CAST, BIGINT_TO_DECIMAL_CAST, DOUBLE_TO_DECIMAL_CAST, BOOLEAN_TO_DECIMAL_CAST, TINYINT_TO_DECIMAL_CAST, SMALLINT_TO_DECIMAL_CAST)
+                .functions(DECIMAL_TO_VARCHAR_CAST, DECIMAL_TO_INTEGER_CAST, DECIMAL_TO_BIGINT_CAST, DECIMAL_TO_DOUBLE_CAST, DECIMAL_TO_FLOAT_CAST, DECIMAL_TO_BOOLEAN_CAST, DECIMAL_TO_TINYINT_CAST, DECIMAL_TO_SMALLINT_CAST)
+                .functions(VARCHAR_TO_DECIMAL_CAST, INTEGER_TO_DECIMAL_CAST, BIGINT_TO_DECIMAL_CAST, DOUBLE_TO_DECIMAL_CAST, FLOAT_TO_DECIMAL_CAST, BOOLEAN_TO_DECIMAL_CAST, TINYINT_TO_DECIMAL_CAST, SMALLINT_TO_DECIMAL_CAST)
                 .functions(JSON_TO_DECIMAL_CAST, DECIMAL_TO_JSON_CAST)
                 .functions(DECIMAL_ADD_OPERATOR, DECIMAL_SUBTRACT_OPERATOR, DECIMAL_MULTIPLY_OPERATOR, DECIMAL_DIVIDE_OPERATOR, DECIMAL_MODULUS_OPERATOR)
                 .functions(DECIMAL_EQUAL_OPERATOR, DECIMAL_NOT_EQUAL_OPERATOR)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -573,12 +573,28 @@ public final class MathFunctions
         return Double.NaN;
     }
 
+    @Description("constant representing NaN float")
+    @ScalarFunction("fnan")
+    @SqlType(StandardTypes.FLOAT)
+    public static long floatNaN()
+    {
+        return Float.floatToRawIntBits(Float.NaN);
+    }
+
     @Description("Infinity")
     @ScalarFunction
     @SqlType(StandardTypes.DOUBLE)
     public static double infinity()
     {
         return Double.POSITIVE_INFINITY;
+    }
+
+    @Description("constant representing infinity float")
+    @ScalarFunction("finfinity")
+    @SqlType(StandardTypes.FLOAT)
+    public static long floatInfinity()
+    {
+        return Float.floatToIntBits(Float.POSITIVE_INFINITY);
     }
 
     @Description("convert a number to a string in the given base")

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -30,6 +30,7 @@ import static com.facebook.presto.util.Failures.checkCondition;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Character.MAX_RADIX;
 import static java.lang.Character.MIN_RADIX;
+import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
 
 public final class MathFunctions
@@ -578,7 +579,7 @@ public final class MathFunctions
     @SqlType(StandardTypes.FLOAT)
     public static long floatNaN()
     {
-        return Float.floatToRawIntBits(Float.NaN);
+        return floatToRawIntBits(Float.NaN);
     }
 
     @Description("Infinity")

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -30,7 +30,6 @@ import static com.facebook.presto.util.Failures.checkCondition;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Character.MAX_RADIX;
 import static java.lang.Character.MIN_RADIX;
-import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
 
 public final class MathFunctions
@@ -574,28 +573,12 @@ public final class MathFunctions
         return Double.NaN;
     }
 
-    @Description("constant representing NaN float")
-    @ScalarFunction("fnan")
-    @SqlType(StandardTypes.FLOAT)
-    public static long floatNaN()
-    {
-        return floatToRawIntBits(Float.NaN);
-    }
-
     @Description("Infinity")
     @ScalarFunction
     @SqlType(StandardTypes.DOUBLE)
     public static double infinity()
     {
         return Double.POSITIVE_INFINITY;
-    }
-
-    @Description("constant representing infinity float")
-    @ScalarFunction("finfinity")
-    @SqlType(StandardTypes.FLOAT)
-    public static long floatInfinity()
-    {
-        return Float.floatToIntBits(Float.POSITIVE_INFINITY);
     }
 
     @Description("convert a number to a string in the given base")

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -102,6 +102,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
 import static com.facebook.presto.spi.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
@@ -527,7 +528,7 @@ public class ExpressionAnalyzer
                 case PLUS:
                     Type type = process(node.getValue(), context);
 
-                    if (!type.equals(DOUBLE) && !type.equals(BIGINT) && !type.equals(INTEGER) && !type.equals(SMALLINT) && !type.equals(TINYINT)) {
+                    if (!type.equals(DOUBLE) && !type.equals(FLOAT) && !type.equals(BIGINT) && !type.equals(INTEGER) && !type.equals(SMALLINT) && !type.equals(TINYINT)) {
                         // TODO: figure out a type-agnostic way of dealing with this. Maybe add a special unary operator
                         // that types can chose to implement, or piggyback on the existence of the negation operator
                         throw new SemanticException(TYPE_MISMATCH, node, "Unary '+' operator cannot by applied to %s type", type);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -58,6 +58,7 @@ import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
@@ -133,6 +134,7 @@ public final class LiteralInterpreter
             Double value = (Double) object;
             // WARNING: the ORC predicate code depends on NaN and infinity not appearing in a tuple domain, so
             // if you remove this, you will need to update the TupleDomainOrcPredicate
+            // When changing this, don't forget about similar code for FLOAT below
             if (value.isNaN()) {
                 return new FunctionCall(new QualifiedName("nan"), ImmutableList.<Expression>of());
             }
@@ -144,6 +146,23 @@ public final class LiteralInterpreter
             }
             else {
                 return new DoubleLiteral(object.toString());
+            }
+        }
+
+        if (type.equals(FLOAT)) {
+            Float value = Float.intBitsToFloat(((Long) object).intValue());
+            // WARNING for ORC predicate code as above (for double)
+            if (value.isNaN()) {
+                return new FunctionCall(new QualifiedName("fnan"), ImmutableList.of());
+            }
+            else if (value.equals(Float.NEGATIVE_INFINITY)) {
+                return ArithmeticUnaryExpression.negative(new FunctionCall(new QualifiedName("finfinity"), ImmutableList.of()));
+            }
+            else if (value.equals(Float.POSITIVE_INFINITY)) {
+                return new FunctionCall(new QualifiedName("finfinity"), ImmutableList.of());
+            }
+            else {
+                return new GenericLiteral("FLOAT", value.toString());
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -72,6 +72,7 @@ import static com.facebook.presto.util.DateTimeUtils.parseTimestampLiteral;
 import static com.facebook.presto.util.DateTimeUtils.parseYearMonthInterval;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.intBitsToFloat;
 import static java.util.Objects.requireNonNull;
 
 public final class LiteralInterpreter
@@ -150,7 +151,7 @@ public final class LiteralInterpreter
         }
 
         if (type.equals(FLOAT)) {
-            Float value = Float.intBitsToFloat(((Long) object).intValue());
+            Float value = intBitsToFloat(((Long) object).intValue());
             // WARNING for ORC predicate code as above (for double)
             if (value.isNaN()) {
                 return new FunctionCall(new QualifiedName("fnan"), ImmutableList.of());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -154,13 +154,13 @@ public final class LiteralInterpreter
             Float value = intBitsToFloat(((Long) object).intValue());
             // WARNING for ORC predicate code as above (for double)
             if (value.isNaN()) {
-                return new FunctionCall(new QualifiedName("fnan"), ImmutableList.of());
+                return new Cast(new FunctionCall(new QualifiedName("nan"), ImmutableList.of()), "float");
             }
             else if (value.equals(Float.NEGATIVE_INFINITY)) {
-                return ArithmeticUnaryExpression.negative(new FunctionCall(new QualifiedName("finfinity"), ImmutableList.of()));
+                return ArithmeticUnaryExpression.negative(new Cast(new FunctionCall(new QualifiedName("infinity"), ImmutableList.of()), "float"));
             }
             else if (value.equals(Float.POSITIVE_INFINITY)) {
-                return new FunctionCall(new QualifiedName("finfinity"), ImmutableList.of());
+                return new Cast(new FunctionCall(new QualifiedName("infinity"), ImmutableList.of()), "float");
             }
             else {
                 return new GenericLiteral("FLOAT", value.toString());

--- a/presto-main/src/main/java/com/facebook/presto/testing/MaterializedRow.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/MaterializedRow.java
@@ -178,7 +178,7 @@ public class MaterializedRow
     private static class ApproximateDouble
             extends ApproximateNumeric
     {
-        private final Number value;
+        private final Double value;
         private final int precision;
 
         private ApproximateDouble(Double value, int precision)
@@ -196,8 +196,7 @@ public class MaterializedRow
         @Override
         protected Number getNormalizedValue()
         {
-            Double val = (Double) value;
-            if (val.isNaN() || val.isInfinite()) {
+            if (value.isNaN() || value.isInfinite()) {
                 return value;
             }
             return new BigDecimal(getValue().doubleValue()).round(new MathContext(precision)).doubleValue();
@@ -207,7 +206,7 @@ public class MaterializedRow
     private static class ApproximateFloat
             extends ApproximateNumeric
     {
-        private final Number value;
+        private final Float value;
         private final int precision;
 
         private ApproximateFloat(Float value, int precision)
@@ -225,8 +224,7 @@ public class MaterializedRow
         @Override
         protected Number getNormalizedValue()
         {
-            Float val = (Float) value;
-            if (val.isNaN() || val.isInfinite()) {
+            if (value.isNaN() || value.isInfinite()) {
                 return value;
             }
             return new BigDecimal(getValue().floatValue()).round(new MathContext(precision)).floatValue();

--- a/presto-main/src/main/java/com/facebook/presto/testing/MaterializedRow.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/MaterializedRow.java
@@ -52,8 +52,11 @@ public class MaterializedRow
 
     private static Object processValue(int precision, Object value)
     {
-        if (value instanceof Double || value instanceof Float) {
-            return new ApproximateDouble(((Number) value).doubleValue(), precision);
+        if (value instanceof Double) {
+            return new ApproximateDouble(((Double) value), precision);
+        }
+        if (value instanceof Float) {
+            return new ApproximateFloat(((Float) value), precision);
         }
         if (value instanceof List) {
             return ((List<?>) value).stream()
@@ -95,8 +98,8 @@ public class MaterializedRow
 
     private static Object processField(Object value)
     {
-        if (value instanceof ApproximateDouble) {
-            return ((ApproximateDouble) value).getValue();
+        if (value instanceof ApproximateNumeric) {
+            return ((ApproximateNumeric) value).getValue();
         }
         if (value instanceof List) {
             return ((List<?>) value).stream()
@@ -139,31 +142,16 @@ public class MaterializedRow
         return Objects.hash(values);
     }
 
-    private static class ApproximateDouble
+    private abstract static class ApproximateNumeric
     {
-        private final Double value;
-        private final Double normalizedValue;
+        public abstract Number getValue();
 
-        private ApproximateDouble(Double value, int precision)
-        {
-            this.value = value;
-            if (value.isNaN() || value.isInfinite()) {
-                this.normalizedValue = value;
-            }
-            else {
-                this.normalizedValue = new BigDecimal(value).round(new MathContext(precision)).doubleValue();
-            }
-        }
-
-        public Double getValue()
-        {
-            return value;
-        }
+        protected abstract Number getNormalizedValue();
 
         @Override
         public String toString()
         {
-            return value.toString();
+            return getValue().toString();
         }
 
         @Override
@@ -175,14 +163,73 @@ public class MaterializedRow
             if ((obj == null) || (getClass() != obj.getClass())) {
                 return false;
             }
-            ApproximateDouble o = (ApproximateDouble) obj;
-            return Objects.equals(normalizedValue, o.normalizedValue);
+
+            ApproximateNumeric o = (ApproximateNumeric) obj;
+            return Objects.equals(getNormalizedValue(), o.getNormalizedValue());
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(normalizedValue);
+            return Objects.hash(getNormalizedValue());
+        }
+    }
+
+    private static class ApproximateDouble
+            extends ApproximateNumeric
+    {
+        private final Number value;
+        private final int precision;
+
+        private ApproximateDouble(Double value, int precision)
+        {
+            this.value = requireNonNull(value, "value is null");
+            this.precision = precision;
+        }
+
+        @Override
+        public Number getValue()
+        {
+            return value;
+        }
+
+        @Override
+        protected Number getNormalizedValue()
+        {
+            Double val = (Double) value;
+            if (val.isNaN() || val.isInfinite()) {
+                return value;
+            }
+            return new BigDecimal(getValue().doubleValue()).round(new MathContext(precision)).doubleValue();
+        }
+    }
+
+    private static class ApproximateFloat
+            extends ApproximateNumeric
+    {
+        private final Number value;
+        private final int precision;
+
+        private ApproximateFloat(Float value, int precision)
+        {
+            this.value = requireNonNull(value, "value is null");
+            this.precision = precision;
+        }
+
+        @Override
+        public Number getValue()
+        {
+            return value;
+        }
+
+        @Override
+        protected Number getNormalizedValue()
+        {
+            Float val = (Float) value;
+            if (val.isNaN() || val.isInfinite()) {
+                return value;
+            }
+            return new BigDecimal(getValue().floatValue()).round(new MathContext(precision)).floatValue();
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/BigintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/BigintOperators.java
@@ -230,6 +230,13 @@ public final class BigintOperators
     }
 
     @ScalarOperator(CAST)
+    @SqlType(StandardTypes.FLOAT)
+    public static long castToFloat(@SqlType(StandardTypes.BIGINT) long value)
+    {
+        return (long) Float.floatToRawIntBits((float) value);
+    }
+
+    @ScalarOperator(CAST)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice castToVarchar(@SqlType(StandardTypes.BIGINT) long value)
     {

--- a/presto-main/src/main/java/com/facebook/presto/type/BigintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/BigintOperators.java
@@ -40,6 +40,7 @@ import static com.facebook.presto.metadata.OperatorType.SUBTRACT;
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.valueOf;
 
 public final class BigintOperators
@@ -233,7 +234,7 @@ public final class BigintOperators
     @SqlType(StandardTypes.FLOAT)
     public static long castToFloat(@SqlType(StandardTypes.BIGINT) long value)
     {
-        return (long) Float.floatToRawIntBits((float) value);
+        return (long) floatToRawIntBits((float) value);
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalCasts.java
@@ -61,6 +61,8 @@ import static com.facebook.presto.spi.type.StandardTypes.VARCHAR;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static com.facebook.presto.util.Types.checkType;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.multiplyExact;
 import static java.lang.String.format;
 import static java.math.BigDecimal.ROUND_HALF_UP;
@@ -394,7 +396,7 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static long shortDecimalToFloat(long decimal, long precision, long scale, long tenToScale)
     {
-        return Float.floatToRawIntBits(((float) decimal) / tenToScale);
+        return floatToRawIntBits(((float) decimal) / tenToScale);
     }
 
     @UsedByGeneratedCode
@@ -402,7 +404,7 @@ public final class DecimalCasts
     {
         BigInteger decimalBigInteger = decodeUnscaledValue(decimal);
         BigDecimal bigDecimal = new BigDecimal(decimalBigInteger, (int) scale);
-        return Float.floatToRawIntBits(bigDecimal.floatValue());
+        return floatToRawIntBits(bigDecimal.floatValue());
     }
 
     @UsedByGeneratedCode
@@ -431,10 +433,10 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static long floatToShortDecimal(long value, long precision, long scale, long tenToScale)
     {
-        BigDecimal decimal = new BigDecimal(Float.intBitsToFloat((int) value));
+        BigDecimal decimal = new BigDecimal(intBitsToFloat((int) value));
         decimal = decimal.setScale((int) scale, ROUND_HALF_UP);
         if (overflows(decimal, precision)) {
-            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast FLOAT '%s' to DECIMAL(%s, %s)", Float.intBitsToFloat((int) value), precision, scale));
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast FLOAT '%s' to DECIMAL(%s, %s)", intBitsToFloat((int) value), precision, scale));
         }
         return decimal.unscaledValue().longValue();
     }
@@ -442,10 +444,10 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static Slice floatToLongDecimal(long value, long precision, long scale, long tenToScale)
     {
-        BigDecimal decimal = new BigDecimal(Float.intBitsToFloat((int) value));
+        BigDecimal decimal = new BigDecimal(intBitsToFloat((int) value));
         decimal = decimal.setScale((int) scale, ROUND_HALF_UP);
         if (overflows(decimal, precision)) {
-            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast FLOAT '%s' to DECIMAL(%s, %s)", Float.intBitsToFloat((int) value), precision, scale));
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast FLOAT '%s' to DECIMAL(%s, %s)", intBitsToFloat((int) value), precision, scale));
         }
         BigInteger decimalBigInteger = decimal.unscaledValue();
         return encodeUnscaledValue(decimalBigInteger);

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalCasts.java
@@ -52,6 +52,7 @@ import static com.facebook.presto.spi.type.StandardTypes.BIGINT;
 import static com.facebook.presto.spi.type.StandardTypes.BOOLEAN;
 import static com.facebook.presto.spi.type.StandardTypes.DECIMAL;
 import static com.facebook.presto.spi.type.StandardTypes.DOUBLE;
+import static com.facebook.presto.spi.type.StandardTypes.FLOAT;
 import static com.facebook.presto.spi.type.StandardTypes.INTEGER;
 import static com.facebook.presto.spi.type.StandardTypes.JSON;
 import static com.facebook.presto.spi.type.StandardTypes.SMALLINT;
@@ -80,6 +81,8 @@ public final class DecimalCasts
     public static final SqlScalarFunction DECIMAL_TO_TINYINT_CAST = castFunctionFromDecimalTo(TINYINT, "shortDecimalToTinyint", "longDecimalToTinyint");
     public static final SqlScalarFunction DECIMAL_TO_DOUBLE_CAST = castFunctionFromDecimalTo(DOUBLE, "shortDecimalToDouble", "longDecimalToDouble");
     public static final SqlScalarFunction DOUBLE_TO_DECIMAL_CAST = castFunctionToDecimalFrom(DOUBLE, "doubleToShortDecimal", "doubleToLongDecimal");
+    public static final SqlScalarFunction DECIMAL_TO_FLOAT_CAST = castFunctionFromDecimalTo(FLOAT, "shortDecimalToFloat", "longDecimalToFloat");
+    public static final SqlScalarFunction FLOAT_TO_DECIMAL_CAST = castFunctionToDecimalFrom(FLOAT, "floatToShortDecimal", "floatToLongDecimal");
     public static final SqlScalarFunction DECIMAL_TO_VARCHAR_CAST = castFunctionFromDecimalTo(VARCHAR, "shortDecimalToVarchar", "longDecimalToVarchar");
     public static final SqlScalarFunction VARCHAR_TO_DECIMAL_CAST = castFunctionToDecimalFrom(VARCHAR, "varcharToShortDecimal", "varcharToLongDecimal");
     public static final SqlScalarFunction DECIMAL_TO_JSON_CAST = castFunctionFromDecimalTo(JSON, "shortDecimalToJson", "longDecimalToJson");
@@ -389,6 +392,20 @@ public final class DecimalCasts
     }
 
     @UsedByGeneratedCode
+    public static long shortDecimalToFloat(long decimal, long precision, long scale, long tenToScale)
+    {
+        return Float.floatToRawIntBits(((float) decimal) / tenToScale);
+    }
+
+    @UsedByGeneratedCode
+    public static long longDecimalToFloat(Slice decimal, long precision, long scale, long tenToScale)
+    {
+        BigInteger decimalBigInteger = decodeUnscaledValue(decimal);
+        BigDecimal bigDecimal = new BigDecimal(decimalBigInteger, (int) scale);
+        return Float.floatToRawIntBits(bigDecimal.floatValue());
+    }
+
+    @UsedByGeneratedCode
     public static long doubleToShortDecimal(double value, long precision, long scale, long tenToScale)
     {
         BigDecimal decimal = new BigDecimal(value);
@@ -406,6 +423,29 @@ public final class DecimalCasts
         decimal = decimal.setScale((int) scale, ROUND_HALF_UP);
         if (overflows(decimal, precision)) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast DOUBLE '%s' to DECIMAL(%s, %s)", value, precision, scale));
+        }
+        BigInteger decimalBigInteger = decimal.unscaledValue();
+        return encodeUnscaledValue(decimalBigInteger);
+    }
+
+    @UsedByGeneratedCode
+    public static long floatToShortDecimal(long value, long precision, long scale, long tenToScale)
+    {
+        BigDecimal decimal = new BigDecimal(Float.intBitsToFloat((int) value));
+        decimal = decimal.setScale((int) scale, ROUND_HALF_UP);
+        if (overflows(decimal, precision)) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast FLOAT '%s' to DECIMAL(%s, %s)", Float.intBitsToFloat((int) value), precision, scale));
+        }
+        return decimal.unscaledValue().longValue();
+    }
+
+    @UsedByGeneratedCode
+    public static Slice floatToLongDecimal(long value, long precision, long scale, long tenToScale)
+    {
+        BigDecimal decimal = new BigDecimal(Float.intBitsToFloat((int) value));
+        decimal = decimal.setScale((int) scale, ROUND_HALF_UP);
+        if (overflows(decimal, precision)) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast FLOAT '%s' to DECIMAL(%s, %s)", Float.intBitsToFloat((int) value), precision, scale));
         }
         BigInteger decimalBigInteger = decimal.unscaledValue();
         return encodeUnscaledValue(decimalBigInteger);

--- a/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
@@ -211,6 +211,13 @@ public final class DoubleOperators
     }
 
     @ScalarOperator(CAST)
+    @SqlType(StandardTypes.FLOAT)
+    public static long castToFloat(@SqlType(StandardTypes.DOUBLE) double value)
+    {
+        return Float.floatToRawIntBits((float) value);
+    }
+
+    @ScalarOperator(CAST)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice castToVarchar(@SqlType(StandardTypes.DOUBLE) double value)
     {

--- a/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Double.doubleToLongBits;
+import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.valueOf;
 import static java.math.RoundingMode.FLOOR;
 
@@ -214,7 +215,7 @@ public final class DoubleOperators
     @SqlType(StandardTypes.FLOAT)
     public static long castToFloat(@SqlType(StandardTypes.DOUBLE) double value)
     {
-        return Float.floatToRawIntBits((float) value);
+        return floatToRawIntBits((float) value);
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
@@ -95,50 +95,50 @@ public final class FloatOperators
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean equal(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
     {
-        return Float.intBitsToFloat((int) left) == Float.intBitsToFloat((int) right);
+        return intBitsToFloat((int) left) == intBitsToFloat((int) right);
     }
 
     @ScalarOperator(NOT_EQUAL)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean notEqual(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
     {
-        return Float.intBitsToFloat((int) left) != Float.intBitsToFloat((int) right);
+        return intBitsToFloat((int) left) != intBitsToFloat((int) right);
     }
 
     @ScalarOperator(LESS_THAN)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean lessThan(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
     {
-        return Float.intBitsToFloat((int) left) < Float.intBitsToFloat((int) right);
+        return intBitsToFloat((int) left) < intBitsToFloat((int) right);
     }
 
     @ScalarOperator(LESS_THAN_OR_EQUAL)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean lessThanOrEqual(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
     {
-        return Float.intBitsToFloat((int) left) <= Float.intBitsToFloat((int) right);
+        return intBitsToFloat((int) left) <= intBitsToFloat((int) right);
     }
 
     @ScalarOperator(GREATER_THAN)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean greaterThan(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
     {
-        return Float.intBitsToFloat((int) left) > Float.intBitsToFloat((int) right);
+        return intBitsToFloat((int) left) > intBitsToFloat((int) right);
     }
 
     @ScalarOperator(GREATER_THAN_OR_EQUAL)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
     {
-        return Float.intBitsToFloat((int) left) >= Float.intBitsToFloat((int) right);
+        return intBitsToFloat((int) left) >= intBitsToFloat((int) right);
     }
 
     @ScalarOperator(BETWEEN)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean between(@SqlType(StandardTypes.FLOAT) long value, @SqlType(StandardTypes.FLOAT) long min, @SqlType(StandardTypes.FLOAT) long max)
     {
-        return Float.intBitsToFloat((int) min) <= Float.intBitsToFloat((int) value) &&
-                Float.intBitsToFloat((int) value) <= Float.intBitsToFloat((int) max);
+        return intBitsToFloat((int) min) <= intBitsToFloat((int) value) &&
+                intBitsToFloat((int) value) <= intBitsToFloat((int) max);
     }
 
     @ScalarOperator(HASH_CODE)

--- a/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
@@ -17,10 +17,18 @@ import com.facebook.presto.operator.scalar.ScalarOperator;
 import com.facebook.presto.spi.type.StandardTypes;
 
 import static com.facebook.presto.metadata.OperatorType.ADD;
+import static com.facebook.presto.metadata.OperatorType.BETWEEN;
 import static com.facebook.presto.metadata.OperatorType.DIVIDE;
+import static com.facebook.presto.metadata.OperatorType.EQUAL;
+import static com.facebook.presto.metadata.OperatorType.GREATER_THAN;
+import static com.facebook.presto.metadata.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.metadata.OperatorType.HASH_CODE;
+import static com.facebook.presto.metadata.OperatorType.LESS_THAN;
+import static com.facebook.presto.metadata.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.metadata.OperatorType.MODULUS;
 import static com.facebook.presto.metadata.OperatorType.MULTIPLY;
 import static com.facebook.presto.metadata.OperatorType.NEGATION;
+import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.metadata.OperatorType.SUBTRACT;
 
 public final class FloatOperators
@@ -69,5 +77,62 @@ public final class FloatOperators
     public static long negate(@SqlType(StandardTypes.FLOAT) long value)
     {
         return Float.floatToRawIntBits(-Float.intBitsToFloat((int) value));
+    }
+
+    @ScalarOperator(EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean equal(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
+    {
+        return Float.intBitsToFloat((int) left) == Float.intBitsToFloat((int) right);
+    }
+
+    @ScalarOperator(NOT_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean notEqual(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
+    {
+        return Float.intBitsToFloat((int) left) != Float.intBitsToFloat((int) right);
+    }
+
+    @ScalarOperator(LESS_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThan(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
+    {
+        return Float.intBitsToFloat((int) left) < Float.intBitsToFloat((int) right);
+    }
+
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThanOrEqual(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
+    {
+        return Float.intBitsToFloat((int) left) <= Float.intBitsToFloat((int) right);
+    }
+
+    @ScalarOperator(GREATER_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThan(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
+    {
+        return Float.intBitsToFloat((int) left) > Float.intBitsToFloat((int) right);
+    }
+
+    @ScalarOperator(GREATER_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThanOrEqual(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
+    {
+        return Float.intBitsToFloat((int) left) >= Float.intBitsToFloat((int) right);
+    }
+
+    @ScalarOperator(BETWEEN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean between(@SqlType(StandardTypes.FLOAT) long value, @SqlType(StandardTypes.FLOAT) long min, @SqlType(StandardTypes.FLOAT) long max)
+    {
+        return Float.intBitsToFloat((int) min) <= Float.intBitsToFloat((int) value) &&
+                Float.intBitsToFloat((int) value) <= Float.intBitsToFloat((int) max);
+    }
+
+    @ScalarOperator(HASH_CODE)
+    @SqlType(StandardTypes.BIGINT)
+    public static long hashCode(@SqlType(StandardTypes.FLOAT) long value)
+    {
+        return value;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
@@ -39,6 +39,8 @@ import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.metadata.OperatorType.SUBTRACT;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
 import static java.lang.String.valueOf;
 
 public final class FloatOperators
@@ -86,7 +88,7 @@ public final class FloatOperators
     @SqlType(StandardTypes.FLOAT)
     public static long negate(@SqlType(StandardTypes.FLOAT) long value)
     {
-        return Float.floatToRawIntBits(-Float.intBitsToFloat((int) value));
+        return floatToRawIntBits(-intBitsToFloat((int) value));
     }
 
     @ScalarOperator(EQUAL)

--- a/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.operator.scalar.ScalarOperator;
+import com.facebook.presto.spi.type.StandardTypes;
+
+import static com.facebook.presto.metadata.OperatorType.NEGATION;
+
+public final class FloatOperators
+{
+    private FloatOperators()
+    {
+    }
+
+    @ScalarOperator(NEGATION)
+    @SqlType(StandardTypes.FLOAT)
+    public static long negate(@SqlType(StandardTypes.FLOAT) long value)
+    {
+        return Float.floatToRawIntBits(-Float.intBitsToFloat((int) value));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
@@ -53,35 +53,35 @@ public final class FloatOperators
     @SqlType(StandardTypes.FLOAT)
     public static long add(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
     {
-        return Float.floatToRawIntBits(Float.intBitsToFloat((int) left) + Float.intBitsToFloat((int) right));
+        return floatToRawIntBits(intBitsToFloat((int) left) + intBitsToFloat((int) right));
     }
 
     @ScalarOperator(SUBTRACT)
     @SqlType(StandardTypes.FLOAT)
     public static long subtract(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
     {
-        return Float.floatToRawIntBits(Float.intBitsToFloat((int) left) - Float.intBitsToFloat((int) right));
+        return floatToRawIntBits(intBitsToFloat((int) left) - intBitsToFloat((int) right));
     }
 
     @ScalarOperator(MULTIPLY)
     @SqlType(StandardTypes.FLOAT)
     public static long multiply(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
     {
-        return Float.floatToRawIntBits(Float.intBitsToFloat((int) left) * Float.intBitsToFloat((int) right));
+        return floatToRawIntBits(intBitsToFloat((int) left) * intBitsToFloat((int) right));
     }
 
     @ScalarOperator(DIVIDE)
     @SqlType(StandardTypes.FLOAT)
     public static long divide(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
     {
-        return Float.floatToRawIntBits(Float.intBitsToFloat((int) left) / Float.intBitsToFloat((int) right));
+        return floatToRawIntBits(intBitsToFloat((int) left) / intBitsToFloat((int) right));
     }
 
     @ScalarOperator(MODULUS)
     @SqlType(StandardTypes.FLOAT)
     public static long modulus(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
     {
-        return Float.floatToRawIntBits(Float.intBitsToFloat((int) left) % Float.intBitsToFloat((int) right));
+        return floatToRawIntBits(intBitsToFloat((int) left) % intBitsToFloat((int) right));
     }
 
     @ScalarOperator(NEGATION)

--- a/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
@@ -13,11 +13,18 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.operator.scalar.MathFunctions;
 import com.facebook.presto.operator.scalar.ScalarOperator;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Shorts;
+import com.google.common.primitives.SignedBytes;
+import io.airlift.slice.Slice;
 
 import static com.facebook.presto.metadata.OperatorType.ADD;
 import static com.facebook.presto.metadata.OperatorType.BETWEEN;
+import static com.facebook.presto.metadata.OperatorType.CAST;
 import static com.facebook.presto.metadata.OperatorType.DIVIDE;
 import static com.facebook.presto.metadata.OperatorType.EQUAL;
 import static com.facebook.presto.metadata.OperatorType.GREATER_THAN;
@@ -30,6 +37,9 @@ import static com.facebook.presto.metadata.OperatorType.MULTIPLY;
 import static com.facebook.presto.metadata.OperatorType.NEGATION;
 import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.metadata.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.String.valueOf;
 
 public final class FloatOperators
 {
@@ -134,5 +144,69 @@ public final class FloatOperators
     public static long hashCode(@SqlType(StandardTypes.FLOAT) long value)
     {
         return value;
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice castToVarchar(@SqlType(StandardTypes.FLOAT) long value)
+    {
+        return utf8Slice(valueOf(Float.intBitsToFloat((int) value)));
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.BIGINT)
+    public static long castToLong(@SqlType(StandardTypes.FLOAT) long value)
+    {
+        return (long) MathFunctions.round((double) Float.intBitsToFloat((int) value));
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.INTEGER)
+    public static long castToInteger(@SqlType(StandardTypes.FLOAT) long value)
+    {
+        try {
+            return Ints.checkedCast((long) MathFunctions.round((double) Float.intBitsToFloat((int) value)));
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e);
+        }
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.SMALLINT)
+    public static long castToSmallint(@SqlType(StandardTypes.FLOAT) long value)
+    {
+        try {
+            return Shorts.checkedCast((long) MathFunctions.round((double) Float.intBitsToFloat((int) value)));
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e);
+        }
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.TINYINT)
+    public static long castToTinyint(@SqlType(StandardTypes.FLOAT) long value)
+    {
+        try {
+            return SignedBytes.checkedCast((long) MathFunctions.round((double) Float.intBitsToFloat((int) value)));
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e);
+        }
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.DOUBLE)
+    public static double castToDouble(@SqlType(StandardTypes.FLOAT) long value)
+    {
+        return (double) Float.intBitsToFloat((int) value);
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean castToBoolean(@SqlType(StandardTypes.FLOAT) long value)
+    {
+        return Float.intBitsToFloat((int) value) != 0.0f;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
@@ -152,14 +152,14 @@ public final class FloatOperators
     @SqlType(StandardTypes.VARCHAR)
     public static Slice castToVarchar(@SqlType(StandardTypes.FLOAT) long value)
     {
-        return utf8Slice(valueOf(Float.intBitsToFloat((int) value)));
+        return utf8Slice(valueOf(intBitsToFloat((int) value)));
     }
 
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.BIGINT)
     public static long castToLong(@SqlType(StandardTypes.FLOAT) long value)
     {
-        return (long) MathFunctions.round((double) Float.intBitsToFloat((int) value));
+        return (long) MathFunctions.round((double) intBitsToFloat((int) value));
     }
 
     @ScalarOperator(CAST)
@@ -167,7 +167,7 @@ public final class FloatOperators
     public static long castToInteger(@SqlType(StandardTypes.FLOAT) long value)
     {
         try {
-            return Ints.checkedCast((long) MathFunctions.round((double) Float.intBitsToFloat((int) value)));
+            return Ints.checkedCast((long) MathFunctions.round((double) intBitsToFloat((int) value)));
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e);
@@ -179,7 +179,7 @@ public final class FloatOperators
     public static long castToSmallint(@SqlType(StandardTypes.FLOAT) long value)
     {
         try {
-            return Shorts.checkedCast((long) MathFunctions.round((double) Float.intBitsToFloat((int) value)));
+            return Shorts.checkedCast((long) MathFunctions.round((double) intBitsToFloat((int) value)));
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e);
@@ -191,7 +191,7 @@ public final class FloatOperators
     public static long castToTinyint(@SqlType(StandardTypes.FLOAT) long value)
     {
         try {
-            return SignedBytes.checkedCast((long) MathFunctions.round((double) Float.intBitsToFloat((int) value)));
+            return SignedBytes.checkedCast((long) MathFunctions.round((double) intBitsToFloat((int) value)));
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e);
@@ -202,13 +202,13 @@ public final class FloatOperators
     @SqlType(StandardTypes.DOUBLE)
     public static double castToDouble(@SqlType(StandardTypes.FLOAT) long value)
     {
-        return (double) Float.intBitsToFloat((int) value);
+        return (double) intBitsToFloat((int) value);
     }
 
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean castToBoolean(@SqlType(StandardTypes.FLOAT) long value)
     {
-        return Float.intBitsToFloat((int) value) != 0.0f;
+        return intBitsToFloat((int) value) != 0.0f;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/FloatOperators.java
@@ -16,12 +16,52 @@ package com.facebook.presto.type;
 import com.facebook.presto.operator.scalar.ScalarOperator;
 import com.facebook.presto.spi.type.StandardTypes;
 
+import static com.facebook.presto.metadata.OperatorType.ADD;
+import static com.facebook.presto.metadata.OperatorType.DIVIDE;
+import static com.facebook.presto.metadata.OperatorType.MODULUS;
+import static com.facebook.presto.metadata.OperatorType.MULTIPLY;
 import static com.facebook.presto.metadata.OperatorType.NEGATION;
+import static com.facebook.presto.metadata.OperatorType.SUBTRACT;
 
 public final class FloatOperators
 {
     private FloatOperators()
     {
+    }
+
+    @ScalarOperator(ADD)
+    @SqlType(StandardTypes.FLOAT)
+    public static long add(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
+    {
+        return Float.floatToRawIntBits(Float.intBitsToFloat((int) left) + Float.intBitsToFloat((int) right));
+    }
+
+    @ScalarOperator(SUBTRACT)
+    @SqlType(StandardTypes.FLOAT)
+    public static long subtract(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
+    {
+        return Float.floatToRawIntBits(Float.intBitsToFloat((int) left) - Float.intBitsToFloat((int) right));
+    }
+
+    @ScalarOperator(MULTIPLY)
+    @SqlType(StandardTypes.FLOAT)
+    public static long multiply(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
+    {
+        return Float.floatToRawIntBits(Float.intBitsToFloat((int) left) * Float.intBitsToFloat((int) right));
+    }
+
+    @ScalarOperator(DIVIDE)
+    @SqlType(StandardTypes.FLOAT)
+    public static long divide(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
+    {
+        return Float.floatToRawIntBits(Float.intBitsToFloat((int) left) / Float.intBitsToFloat((int) right));
+    }
+
+    @ScalarOperator(MODULUS)
+    @SqlType(StandardTypes.FLOAT)
+    public static long modulus(@SqlType(StandardTypes.FLOAT) long left, @SqlType(StandardTypes.FLOAT) long right)
+    {
+        return Float.floatToRawIntBits(Float.intBitsToFloat((int) left) % Float.intBitsToFloat((int) right));
     }
 
     @ScalarOperator(NEGATION)

--- a/presto-main/src/main/java/com/facebook/presto/type/IntegerOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntegerOperators.java
@@ -213,6 +213,13 @@ public final class IntegerOperators
     }
 
     @ScalarOperator(CAST)
+    @SqlType(StandardTypes.FLOAT)
+    public static long castToFloat(@SqlType(StandardTypes.INTEGER) long value)
+    {
+        return (long) Float.floatToRawIntBits((float) value);
+    }
+
+    @ScalarOperator(CAST)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice castToVarchar(@SqlType(StandardTypes.INTEGER) long value)
     {

--- a/presto-main/src/main/java/com/facebook/presto/type/IntegerOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntegerOperators.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.metadata.OperatorType.SUBTRACT;
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.valueOf;
 
 public final class IntegerOperators
@@ -216,7 +217,7 @@ public final class IntegerOperators
     @SqlType(StandardTypes.FLOAT)
     public static long castToFloat(@SqlType(StandardTypes.INTEGER) long value)
     {
-        return (long) Float.floatToRawIntBits((float) value);
+        return (long) floatToRawIntBits((float) value);
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/com/facebook/presto/type/SmallintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/SmallintOperators.java
@@ -208,6 +208,13 @@ public final class SmallintOperators
     }
 
     @ScalarOperator(CAST)
+    @SqlType(StandardTypes.FLOAT)
+    public static long castToFloat(@SqlType(StandardTypes.SMALLINT) long value)
+    {
+        return (long) Float.floatToRawIntBits((float) value);
+    }
+
+    @ScalarOperator(CAST)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice castToVarchar(@SqlType(StandardTypes.SMALLINT) long value)
     {

--- a/presto-main/src/main/java/com/facebook/presto/type/SmallintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/SmallintOperators.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.metadata.OperatorType.SUBTRACT;
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.valueOf;
 
 public final class SmallintOperators
@@ -211,7 +212,7 @@ public final class SmallintOperators
     @SqlType(StandardTypes.FLOAT)
     public static long castToFloat(@SqlType(StandardTypes.SMALLINT) long value)
     {
-        return (long) Float.floatToRawIntBits((float) value);
+        return (long) floatToRawIntBits((float) value);
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/com/facebook/presto/type/TinyintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TinyintOperators.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.metadata.OperatorType.SUBTRACT;
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.valueOf;
 
 public final class TinyintOperators
@@ -206,7 +207,7 @@ public final class TinyintOperators
     @SqlType(StandardTypes.FLOAT)
     public static long castToFloat(@SqlType(StandardTypes.TINYINT) long value)
     {
-        return (long) Float.floatToRawIntBits((float) value);
+        return (long) floatToRawIntBits((float) value);
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/com/facebook/presto/type/TinyintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TinyintOperators.java
@@ -203,6 +203,13 @@ public final class TinyintOperators
     }
 
     @ScalarOperator(CAST)
+    @SqlType(StandardTypes.FLOAT)
+    public static long castToFloat(@SqlType(StandardTypes.TINYINT) long value)
+    {
+        return (long) Float.floatToRawIntBits((float) value);
+    }
+
+    @ScalarOperator(CAST)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice castToVarchar(@SqlType(StandardTypes.TINYINT) long value)
     {

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -40,6 +40,7 @@ import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
@@ -96,6 +97,7 @@ public final class TypeRegistry
         addType(SMALLINT);
         addType(TINYINT);
         addType(DOUBLE);
+        addType(FLOAT);
         addType(VARBINARY);
         addType(DATE);
         addType(TIME);

--- a/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
@@ -150,6 +150,19 @@ public final class VarcharOperators
 
     @LiteralParameters("x")
     @ScalarOperator(CAST)
+    @SqlType(StandardTypes.FLOAT)
+    public static long castToFloat(@SqlType("varchar(x)") Slice slice)
+    {
+        try {
+            return Float.floatToIntBits(Float.parseFloat(slice.toStringUtf8()));
+        }
+        catch (Exception e) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Can not cast '%s' to FLOAT", slice.toStringUtf8()));
+        }
+    }
+
+    @LiteralParameters("x")
+    @ScalarOperator(CAST)
     @SqlType(StandardTypes.BIGINT)
     public static long castToBigint(@SqlType("varchar(x)") Slice slice)
     {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -87,6 +87,14 @@ public class TestArrayOperators
     }
 
     @Test
+    public void testTypeConstructor()
+            throws Exception
+    {
+        assertFunction("ARRAY[7]", new ArrayType(INTEGER), ImmutableList.of(7));
+        assertFunction("ARRAY[12.34, 56.78]", new ArrayType(DOUBLE), ImmutableList.of(12.34, 56.78));
+    }
+
+    @Test
     public void testArrayElements()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestBigintOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestBigintOperators.java
@@ -35,6 +35,15 @@ public class TestBigintOperators
     }
 
     @Test
+    public void testTypeConstructor()
+            throws Exception
+    {
+        assertFunction("BIGINT '9223372036854775807'", BIGINT, 9223372036854775807L);
+        assertFunction("BIGINT '-9223372036854775807'", BIGINT, -9223372036854775807L);
+        assertFunction("BIGINT '+754'", BIGINT, 754L);
+    }
+
+    @Test
     public void testUnaryPlus()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestBigintOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestBigintOperators.java
@@ -20,6 +20,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RAN
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 
@@ -216,6 +217,15 @@ public class TestBigintOperators
     {
         assertFunction("cast(37 as double)", DOUBLE, 37.0);
         assertFunction("cast(100000000017 as double)", DOUBLE, 100000000017.0);
+    }
+
+    @Test
+    public void testCastToFloat()
+            throws Exception
+    {
+        assertFunction("cast(37 as float)", FLOAT, 37.0f);
+        assertFunction("cast(-100000000017 as float)", FLOAT, -100000000017.0f);
+        assertFunction("cast(0 as float)", FLOAT, 0.0f);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestBooleanOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestBooleanOperators.java
@@ -31,6 +31,14 @@ public class TestBooleanOperators
     }
 
     @Test
+    public void testTypeConstructor()
+            throws Exception
+    {
+        assertFunction("BOOLEAN 'true'", BOOLEAN, true);
+        assertFunction("BOOLEAN 'false'", BOOLEAN, false);
+    }
+
+    @Test
     public void testEqual()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDecimalCasts.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDecimalCasts.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 
 public class TestDecimalCasts
@@ -123,6 +124,41 @@ public class TestDecimalCasts
 
         assertFunction("CAST(DECIMAL '1234567890.1234567890' AS DOUBLE)", DOUBLE, 1234567890.1234567890);
         assertFunction("CAST(DECIMAL '-1234567890.1234567890' AS DOUBLE)", DOUBLE, -1234567890.1234567890);
+    }
+
+    @Test
+    public void testFloatToDecimalCasts()
+    {
+        assertDecimalFunction("CAST(FLOAT '234.0' AS DECIMAL(4,1))", decimal("234.0"));
+        assertDecimalFunction("CAST(FLOAT '.01' AS DECIMAL(3,3))", decimal(".010"));
+        assertDecimalFunction("CAST(FLOAT '.0' AS DECIMAL(3,3))", decimal(".000"));
+        assertDecimalFunction("CAST(FLOAT '0' AS DECIMAL(1,0))", decimal("0"));
+        assertDecimalFunction("CAST(FLOAT '0' AS DECIMAL(4,0))", decimal("0000"));
+        assertDecimalFunction("CAST(FLOAT '1000' AS DECIMAL(4,0))", decimal("1000"));
+        assertDecimalFunction("CAST(FLOAT '1000.01' AS DECIMAL(7,2))", decimal("01000.01"));
+        assertDecimalFunction("CAST(FLOAT '-234.0' AS DECIMAL(3,0))", decimal("-234"));
+        assertDecimalFunction("CAST(FLOAT '12345678407663616' AS DECIMAL(17,0))", decimal("12345678407663616"));
+        assertDecimalFunction("CAST(FLOAT '-12345678407663616' AS DECIMAL(17,0))", decimal("-12345678407663616"));
+        assertDecimalFunction("CAST(FLOAT '1234567936' AS DECIMAL(20,10))", decimal("1234567936.0000000000"));
+        assertDecimalFunction("CAST(FLOAT '-1234567936' AS DECIMAL(20,10))", decimal("-1234567936.0000000000"));
+
+        assertInvalidCast("CAST(FLOAT '234.0' AS DECIMAL(2,0))", "Cannot cast FLOAT '234.0' to DECIMAL(2, 0)");
+        assertInvalidCast("CAST(FLOAT '1000.01' AS DECIMAL(5,2))", "Cannot cast FLOAT '1000.01' to DECIMAL(5, 2)");
+        assertInvalidCast("CAST(FLOAT '-234.0' AS DECIMAL(2,0))", "Cannot cast FLOAT '-234.0' to DECIMAL(2, 0)");
+        assertInvalidCast("CAST(FLOAT '98765430784.0' AS DECIMAL(20, 10))", "Cannot cast FLOAT '9.8765431E10' to DECIMAL(20, 10)");
+    }
+
+    @Test
+    public void testDecimalToFloatCasts()
+    {
+        assertFunction("CAST(DECIMAL '2.34' AS FLOAT)", FLOAT, 2.34f);
+        assertFunction("CAST(DECIMAL '0' AS FLOAT)", FLOAT, 0.0f);
+        assertFunction("CAST(DECIMAL '-0' AS FLOAT)", FLOAT, 0.0f);
+        assertFunction("CAST(DECIMAL '1' AS FLOAT)", FLOAT, 1.0f);
+        assertFunction("CAST(DECIMAL '-2.49' AS FLOAT)", FLOAT, -2.49f);
+
+        assertFunction("CAST(DECIMAL '1234567890.1234567890' AS FLOAT)", FLOAT, 1234567890.1234567890f);
+        assertFunction("CAST(DECIMAL '-1234567890.1234567890' AS FLOAT)", FLOAT, -1234567890.1234567890f);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDoubleOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDoubleOperators.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 
 public class TestDoubleOperators
@@ -199,6 +200,16 @@ public class TestDoubleOperators
         assertFunction("cast(37.7 as boolean)", BOOLEAN, true);
         assertFunction("cast(17.1 as boolean)", BOOLEAN, true);
         assertFunction("cast(0.0 as boolean)", BOOLEAN, false);
+    }
+
+    @Test
+    public void testCastToFloat()
+            throws Exception
+    {
+        assertFunction("cast('754.1985' as float)", FLOAT, 754.1985f);
+        assertFunction("cast('-754.2008' as float)", FLOAT, -754.2008f);
+        assertFunction("cast('0.0' as float)", FLOAT, 0.0f);
+        assertFunction("cast('-0.0' as float)", FLOAT, -0.0f);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDoubleOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDoubleOperators.java
@@ -33,6 +33,15 @@ public class TestDoubleOperators
     }
 
     @Test
+    public void testTypeConstructor()
+            throws Exception
+    {
+        assertFunction("DOUBLE '12.34'", DOUBLE, 12.34);
+        assertFunction("DOUBLE '-17.6'", DOUBLE, -17.6);
+        assertFunction("DOUBLE '+754'", DOUBLE, 754.0);
+    }
+
+    @Test
     public void testAdd()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestFloatOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestFloatOperators.java
@@ -16,8 +16,14 @@ package com.facebook.presto.type;
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 
 public class TestFloatOperators
         extends AbstractTestFunctions
@@ -167,5 +173,75 @@ public class TestFloatOperators
         assertFunction("FLOAT'0.0' BETWEEN FLOAT'-1.2' AND FLOAT'2.3'", BOOLEAN, true);
         assertFunction("FLOAT'56.78' BETWEEN FLOAT'12.34' AND FLOAT'34.56'", BOOLEAN, false);
         assertFunction("FLOAT'56.78' BETWEEN FLOAT'78.89' AND FLOAT'98.765'", BOOLEAN, false);
+    }
+
+    @Test
+    public void testCastToVarchar()
+            throws Exception
+    {
+        assertFunction("CAST(FLOAT'754.1985' as VARCHAR)", VARCHAR, "754.1985");
+        assertFunction("CAST(FLOAT'-754.2008' as VARCHAR)", VARCHAR, "-754.2008");
+        assertFunction("CAST(FLOAT'Infinity' as VARCHAR)", VARCHAR, "Infinity");
+        assertFunction("CAST(FLOAT'0.0' / FLOAT'0.0' as VARCHAR)", VARCHAR, "NaN");
+    }
+
+    @Test
+    public void testCastToBigInt()
+            throws Exception
+    {
+        assertFunction("CAST(FLOAT'754.1985' as BIGINT)", BIGINT, 754L);
+        assertFunction("CAST(FLOAT'-754.2008' as BIGINT)", BIGINT, -754L);
+        assertFunction("CAST(FLOAT'1.98' as BIGINT)", BIGINT, 2L);
+        assertFunction("CAST(FLOAT'-0.0' as BIGINT)", BIGINT, 0L);
+    }
+
+    @Test
+    public void testCastToInteger()
+            throws Exception
+    {
+        assertFunction("CAST(FLOAT'754.2008' AS INTEGER)", INTEGER, 754);
+        assertFunction("CAST(FLOAT'-754.1985' AS INTEGER)", INTEGER, -754);
+        assertFunction("CAST(FLOAT'9.99' AS INTEGER)", INTEGER, 10);
+        assertFunction("CAST(FLOAT'-0.0' AS INTEGER)", INTEGER, 0);
+    }
+
+    @Test
+    public void testCastToSmallint()
+            throws Exception
+    {
+        assertFunction("CAST(FLOAT'754.2008' AS SMALLINT)", SMALLINT, (short) 754);
+        assertFunction("CAST(FLOAT'-754.1985' AS SMALLINT)", SMALLINT, (short) -754);
+        assertFunction("CAST(FLOAT'9.99' AS SMALLINT)", SMALLINT, (short) 10);
+        assertFunction("CAST(FLOAT'-0.0' AS SMALLINT)", SMALLINT, (short) 0);
+    }
+
+    @Test
+    public void testCastToTinyint()
+            throws Exception
+    {
+        assertFunction("CAST(FLOAT'127.45' AS TINYINT)", TINYINT, (byte) 127);
+        assertFunction("CAST(FLOAT'-128.234' AS TINYINT)", TINYINT, (byte) -128);
+        assertFunction("CAST(FLOAT'9.99' AS TINYINT)", TINYINT, (byte) 10);
+        assertFunction("CAST(FLOAT'-0.0' AS TINYINT)", TINYINT, (byte) 0);
+    }
+
+    @Test
+    public void testCastToDouble()
+            throws Exception
+    {
+        assertFunction("CAST(FLOAT'754.1985' AS DOUBLE)", DOUBLE, (double) 754.1985f);
+        assertFunction("CAST(FLOAT'-754.2008' AS DOUBLE)", DOUBLE, (double) -754.2008f);
+        assertFunction("CAST(FLOAT'0.0' AS DOUBLE)", DOUBLE, (double) 0.0f);
+        assertFunction("CAST(FLOAT'-0.0' AS DOUBLE)", DOUBLE, (double) -0.0f);
+        assertFunction("CAST(CAST(FLOAT'754.1985' AS DOUBLE) AS FLOAT)", FLOAT, 754.1985f);
+    }
+
+    @Test
+    public void testCastToBoolean()
+            throws Exception
+    {
+        assertFunction("CAST(FLOAT'754.1985' AS BOOLEAN)", BOOLEAN, true);
+        assertFunction("CAST(FLOAT'0.0' AS BOOLEAN)", BOOLEAN, false);
+        assertFunction("CAST(FLOAT'-0.0' AS BOOLEAN)", BOOLEAN, false);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestFloatOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestFloatOperators.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+
+public class TestFloatOperators
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testTypeConstructor()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.2'", FLOAT, 12.2f);
+        assertFunction("FLOAT'-17.76'", FLOAT, -17.76f);
+        assertFunction("FLOAT'NaN'", FLOAT, Float.NaN);
+        assertFunction("FLOAT'Infinity'", FLOAT, Float.POSITIVE_INFINITY);
+        assertFunction("FLOAT'-Infinity'", FLOAT, Float.NEGATIVE_INFINITY);
+    }
+
+    @Test
+    public void testNegation()
+            throws Exception
+    {
+        assertFunction("-FLOAT'12.34'", FLOAT, -12.34f);
+        assertFunction("-FLOAT'-17.34'", FLOAT, 17.34f);
+        assertFunction("-FLOAT'-0.0'", FLOAT, -(-0.0f));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestFloatOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestFloatOperators.java
@@ -16,6 +16,7 @@ package com.facebook.presto.type;
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.FloatType.FLOAT;
 
 public class TestFloatOperators
@@ -92,5 +93,79 @@ public class TestFloatOperators
         assertFunction("-FLOAT'12.34'", FLOAT, -12.34f);
         assertFunction("-FLOAT'-17.34'", FLOAT, 17.34f);
         assertFunction("-FLOAT'-0.0'", FLOAT, -(-0.0f));
+    }
+
+    @Test
+    public void testEqual()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.34' = FLOAT'12.34'", BOOLEAN, true);
+        assertFunction("FLOAT'12.340' = FLOAT'12.34'", BOOLEAN, true);
+        assertFunction("FLOAT'-17.34' = FLOAT'-17.34'", BOOLEAN, true);
+        assertFunction("FLOAT'71.17' = FLOAT'23.45'", BOOLEAN, false);
+        assertFunction("FLOAT'-0.0' = FLOAT'0.0'", BOOLEAN, true);
+    }
+
+    @Test
+    public void testNotEqual()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.34' <> FLOAT'12.34'", BOOLEAN, false);
+        assertFunction("FLOAT'12.34' <> FLOAT'12.340'", BOOLEAN, false);
+        assertFunction("FLOAT'-17.34' <> FLOAT'-17.34'", BOOLEAN, false);
+        assertFunction("FLOAT'71.17' <> FLOAT'23.45'", BOOLEAN, true);
+        assertFunction("FLOAT'-0.0' <> FLOAT'0.0'", BOOLEAN, false);
+    }
+
+    @Test
+    public void testLessThan()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.34' < FLOAT'754.123'", BOOLEAN, true);
+        assertFunction("FLOAT'-17.34' < FLOAT'-16.34'", BOOLEAN, true);
+        assertFunction("FLOAT'71.17' < FLOAT'23.45'", BOOLEAN, false);
+        assertFunction("FLOAT'-0.0' < FLOAT'0.0'", BOOLEAN, false);
+    }
+
+    @Test
+    public void testLessThanOrEqual()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.34' <= FLOAT'754.123'", BOOLEAN, true);
+        assertFunction("FLOAT'-17.34' <= FLOAT'-17.34'", BOOLEAN, true);
+        assertFunction("FLOAT'71.17' <= FLOAT'23.45'", BOOLEAN, false);
+        assertFunction("FLOAT'-0.0' <= FLOAT'0.0'", BOOLEAN, true);
+    }
+
+    @Test
+    public void testGreaterThan()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.34' > FLOAT'754.123'", BOOLEAN, false);
+        assertFunction("FLOAT'-17.34' > FLOAT'-17.34'", BOOLEAN, false);
+        assertFunction("FLOAT'71.17' > FLOAT'23.45'", BOOLEAN, true);
+        assertFunction("FLOAT'-0.0' > FLOAT'0.0'", BOOLEAN, false);
+    }
+
+    @Test
+    public void testGreaterThanOrEqual()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.34' >= FLOAT'754.123'", BOOLEAN, false);
+        assertFunction("FLOAT'-17.34' >= FLOAT'-17.34'", BOOLEAN, true);
+        assertFunction("FLOAT'71.17' >= FLOAT'23.45'", BOOLEAN, true);
+        assertFunction("FLOAT'-0.0' >= FLOAT'0.0'", BOOLEAN, true);
+    }
+
+    @Test
+    public void testBetween()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.34' BETWEEN FLOAT'9.12' AND FLOAT'25.89'", BOOLEAN, true);
+        assertFunction("FLOAT'-17.34' BETWEEN FLOAT'-17.34' AND FLOAT'-16.57'", BOOLEAN, true);
+        assertFunction("FLOAT'-17.34' BETWEEN FLOAT'-18.98' AND FLOAT'-17.34'", BOOLEAN, true);
+        assertFunction("FLOAT'0.0' BETWEEN FLOAT'-1.2' AND FLOAT'2.3'", BOOLEAN, true);
+        assertFunction("FLOAT'56.78' BETWEEN FLOAT'12.34' AND FLOAT'34.56'", BOOLEAN, false);
+        assertFunction("FLOAT'56.78' BETWEEN FLOAT'78.89' AND FLOAT'98.765'", BOOLEAN, false);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestFloatOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestFloatOperators.java
@@ -33,6 +33,59 @@ public class TestFloatOperators
     }
 
     @Test
+    public void testAdd()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.34' + FLOAT'56.78'", FLOAT, 12.34f + 56.78f);
+        assertFunction("FLOAT'-17.34' + FLOAT'-22.891'", FLOAT, -17.34f + -22.891f);
+        assertFunction("FLOAT'-89.123' + FLOAT'754.0'", FLOAT, -89.123f + 754.0f);
+        assertFunction("FLOAT'-0.0' + FLOAT'0.0'", FLOAT, -0.0f + 0.0f);
+    }
+
+    @Test
+    public void testSubtract()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.34' - FLOAT'56.78'", FLOAT, 12.34f - 56.78f);
+        assertFunction("FLOAT'-17.34' - FLOAT'-22.891'", FLOAT, -17.34f - -22.891f);
+        assertFunction("FLOAT'-89.123' - FLOAT'754.0'", FLOAT, -89.123f - 754.0f);
+        assertFunction("FLOAT'-0.0' - FLOAT'0.0'", FLOAT, -0.0f - 0.0f);
+    }
+
+    @Test
+    public void testMultiply()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.34' * FLOAT'56.78'", FLOAT, 12.34f * 56.78f);
+        assertFunction("FLOAT'-17.34' * FLOAT'-22.891'", FLOAT, -17.34f * -22.891f);
+        assertFunction("FLOAT'-89.123' * FLOAT'754.0'", FLOAT, -89.123f * 754.0f);
+        assertFunction("FLOAT'-0.0' * FLOAT'0.0'", FLOAT, -0.0f * 0.0f);
+        assertFunction("FLOAT'-17.71' * FLOAT'-1.0'", FLOAT, -17.71f * -1.0f);
+    }
+
+    @Test
+    public void testDivide()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.34' / FLOAT'56.78'", FLOAT, 12.34f / 56.78f);
+        assertFunction("FLOAT'-17.34' / FLOAT'-22.891'", FLOAT, -17.34f / -22.891f);
+        assertFunction("FLOAT'-89.123' / FLOAT'754.0'", FLOAT, -89.123f / 754.0f);
+        assertFunction("FLOAT'-0.0' / FLOAT'0.0'", FLOAT, -0.0f / 0.0f);
+        assertFunction("FLOAT'-17.71' / FLOAT'-1.0'", FLOAT, -17.71f / -1.0f);
+    }
+
+    @Test
+    public void testModulus()
+            throws Exception
+    {
+        assertFunction("FLOAT'12.34' % FLOAT'56.78'", FLOAT, 12.34f % 56.78f);
+        assertFunction("FLOAT'-17.34' % FLOAT'-22.891'", FLOAT, -17.34f % -22.891f);
+        assertFunction("FLOAT'-89.123' % FLOAT'754.0'", FLOAT, -89.123f % 754.0f);
+        assertFunction("FLOAT'-0.0' % FLOAT'0.0'", FLOAT, -0.0f % 0.0f);
+        assertFunction("FLOAT'-17.71' % FLOAT'-1.0'", FLOAT, -17.71f % -1.0f);
+    }
+
+    @Test
     public void testNegation()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestFloatType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestFloatType.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+
+public class TestFloatType
+        extends AbstractTestType
+{
+    public TestFloatType()
+    {
+        super(FLOAT, Float.class, createTestBlock());
+    }
+
+    public static Block createTestBlock()
+    {
+        BlockBuilder blockBuilder = FLOAT.createBlockBuilder(new BlockBuilderStatus(), 30);
+        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(11.11F));
+        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(11.11F));
+        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(11.11F));
+        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(22.22F));
+        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(22.22F));
+        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(22.22F));
+        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(22.22F));
+        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(22.22F));
+        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(33.33F));
+        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(33.33F));
+        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(44.44F));
+        return blockBuilder.build();
+    }
+
+    @Override
+    protected Object getGreaterValue(Object value)
+    {
+        int bits = ((Long) value).intValue();
+        float greaterValue = Float.intBitsToFloat(bits) + 0.1f;
+        return new Long(Float.floatToRawIntBits(greaterValue));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestFloatType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestFloatType.java
@@ -18,6 +18,8 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 
 import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
 
 public class TestFloatType
         extends AbstractTestType
@@ -30,17 +32,17 @@ public class TestFloatType
     public static Block createTestBlock()
     {
         BlockBuilder blockBuilder = FLOAT.createBlockBuilder(new BlockBuilderStatus(), 30);
-        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(11.11F));
-        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(11.11F));
-        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(11.11F));
-        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(22.22F));
-        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(22.22F));
-        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(22.22F));
-        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(22.22F));
-        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(22.22F));
-        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(33.33F));
-        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(33.33F));
-        FLOAT.writeLong(blockBuilder, Float.floatToRawIntBits(44.44F));
+        FLOAT.writeLong(blockBuilder, floatToRawIntBits(11.11F));
+        FLOAT.writeLong(blockBuilder, floatToRawIntBits(11.11F));
+        FLOAT.writeLong(blockBuilder, floatToRawIntBits(11.11F));
+        FLOAT.writeLong(blockBuilder, floatToRawIntBits(22.22F));
+        FLOAT.writeLong(blockBuilder, floatToRawIntBits(22.22F));
+        FLOAT.writeLong(blockBuilder, floatToRawIntBits(22.22F));
+        FLOAT.writeLong(blockBuilder, floatToRawIntBits(22.22F));
+        FLOAT.writeLong(blockBuilder, floatToRawIntBits(22.22F));
+        FLOAT.writeLong(blockBuilder, floatToRawIntBits(33.33F));
+        FLOAT.writeLong(blockBuilder, floatToRawIntBits(33.33F));
+        FLOAT.writeLong(blockBuilder, floatToRawIntBits(44.44F));
         return blockBuilder.build();
     }
 
@@ -48,7 +50,7 @@ public class TestFloatType
     protected Object getGreaterValue(Object value)
     {
         int bits = ((Long) value).intValue();
-        float greaterValue = Float.intBitsToFloat(bits) + 0.1f;
-        return new Long(Float.floatToRawIntBits(greaterValue));
+        float greaterValue = intBitsToFloat(bits) + 0.1f;
+        return new Long(floatToRawIntBits(greaterValue));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestIntegerOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestIntegerOperators.java
@@ -22,6 +22,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RAN
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
@@ -235,6 +236,15 @@ public class TestIntegerOperators
     {
         assertFunction("cast(INTEGER'37' as double)", DOUBLE, 37.0);
         assertFunction("cast(INTEGER'17' as double)", DOUBLE, 17.0);
+    }
+
+    @Test
+    public void testCastToFloat()
+            throws Exception
+    {
+        assertFunction("cast(INTEGER'37' as float)", FLOAT, 37.0f);
+        assertFunction("cast(INTEGER'-2147483648' as float)", FLOAT, -2147483648.0f);
+        assertFunction("cast(INTEGER'0' as float)", FLOAT, 0.0f);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestJsonOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestJsonOperators.java
@@ -57,6 +57,15 @@ public class TestJsonOperators
     }
 
     @Test
+    public void testTypeConstructor()
+            throws Exception
+    {
+        assertFunction("JSON '123'", JSON, "123");
+        assertFunction("JSON '[4,5,6]'", JSON, "[4,5,6]");
+        assertFunction("JSON '{ \"a\": 789 }'", JSON, "{\"a\":789}");
+    }
+
+    @Test
     public void testCastFromIntegrals()
     {
         assertFunction("cast(cast (null as integer) as JSON)", JSON, null);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestSmallintOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestSmallintOperators.java
@@ -22,6 +22,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RAN
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
@@ -235,6 +236,15 @@ public class TestSmallintOperators
     {
         assertFunction("cast(SMALLINT'37' as double)", DOUBLE, 37.0);
         assertFunction("cast(SMALLINT'17' as double)", DOUBLE, 17.0);
+    }
+
+    @Test
+    public void testCastToFloat()
+            throws Exception
+    {
+        assertFunction("cast(SMALLINT'37' as float)", FLOAT, 37.0f);
+        assertFunction("cast(SMALLINT'-32768' as float)", FLOAT, -32768.0f);
+        assertFunction("cast(SMALLINT'0' as float)", FLOAT, 0.0f);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTinyintOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTinyintOperators.java
@@ -23,6 +23,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RAN
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
@@ -236,6 +237,15 @@ public class TestTinyintOperators
     {
         assertFunction("cast(TINYINT'37' as double)", DOUBLE, 37.0);
         assertFunction("cast(TINYINT'17' as double)", DOUBLE, 17.0);
+    }
+
+    @Test
+    public void testCastToFloat()
+            throws Exception
+    {
+        assertFunction("cast(TINYINT'37' as float)", FLOAT, 37.0f);
+        assertFunction("cast(TINYINT'-128' as float)", FLOAT, -128.0f);
+        assertFunction("cast(TINYINT'0' as float)", FLOAT, 0.0f);
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/FloatType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/FloatType.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+
+import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static io.airlift.slice.SizeOf.SIZE_OF_FLOAT;
+
+public final class FloatType
+        extends AbstractFixedWidthType
+{
+    public static final FloatType FLOAT = new FloatType();
+
+    private FloatType()
+    {
+        super(parseTypeSignature(StandardTypes.FLOAT), long.class, SIZE_OF_FLOAT);
+    }
+
+    @Override
+    public boolean isComparable()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isOrderable()
+    {
+        return false;
+    }
+
+    @Override
+    public Object getObjectValue(ConnectorSession session, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+        return block.getFloat(position, 0);
+    }
+
+    @Override
+    public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        float leftValue = leftBlock.getFloat(leftPosition, 0);
+        float rightValue = rightBlock.getFloat(rightPosition, 0);
+        return leftValue == rightValue;
+    }
+
+    @Override
+    public long hash(Block block, int position)
+    {
+        return (long) Float.floatToRawIntBits(block.getFloat(position, 0));
+    }
+
+    @Override
+    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        // WARNING: the correctness of InCodeGenerator is dependent on the implementation of this
+        // function being the equivalence of internal long representation.
+        float leftValue = leftBlock.getFloat(leftPosition, 0);
+        float rightValue = rightBlock.getFloat(rightPosition, 0);
+        return Float.compare(leftValue, rightValue);
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            blockBuilder.appendNull();
+        }
+        else {
+            blockBuilder.writeInt(block.getInt(position, 0)).closeEntry();
+        }
+    }
+
+    @Override
+    public long getLong(Block block, int position)
+    {
+        return (long) block.getInt(position, 0);
+    }
+
+    @Override
+    public void writeLong(BlockBuilder blockBuilder, long value)
+    {
+        try {
+            Math.toIntExact(value);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE,
+                    String.format("Value (%sb) is not a valid single-precision float", value, Long.toBinaryString(value).replace(' ', '0')));
+        }
+        blockBuilder.writeInt((int) value).closeEntry();
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        return other == FLOAT;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getClass().hashCode();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/FloatType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/FloatType.java
@@ -35,13 +35,13 @@ public final class FloatType
     @Override
     public boolean isComparable()
     {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isOrderable()
     {
-        return false;
+        return true;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/FloatType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/FloatType.java
@@ -18,7 +18,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 
-import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
+import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static io.airlift.slice.SizeOf.SIZE_OF_FLOAT;
 import static java.lang.Float.floatToRawIntBits;
@@ -102,7 +102,7 @@ public final class FloatType
             Math.toIntExact(value);
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE,
+            throw new PrestoException(INTERNAL_ERROR,
                     String.format("Value (%sb) is not a valid single-precision float", value, Long.toBinaryString(value).replace(' ', '0')));
         }
         blockBuilder.writeInt((int) value).closeEntry();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/FloatType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/FloatType.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static io.airlift.slice.SizeOf.SIZE_OF_FLOAT;
+import static java.lang.Float.floatToRawIntBits;
 
 public final class FloatType
         extends AbstractFixedWidthType
@@ -64,7 +65,7 @@ public final class FloatType
     @Override
     public long hash(Block block, int position)
     {
-        return (long) Float.floatToRawIntBits(block.getFloat(position, 0));
+        return (long) floatToRawIntBits(block.getFloat(position, 0));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/StandardTypes.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/StandardTypes.java
@@ -22,6 +22,7 @@ public final class StandardTypes
     public static final String BOOLEAN = "boolean";
     public static final String DATE = "date";
     public static final String DECIMAL = "decimal";
+    public static final String FLOAT = "float";
     public static final String DOUBLE = "double";
     public static final String HYPER_LOG_LOG = "HyperLogLog";
     public static final String P4_HYPER_LOG_LOG = "P4HyperLogLog";


### PR DESCRIPTION
This is first part of implementation of https://github.com/prestodb/presto/issues/4942.
It covers:
1. Float literal
2. Arithmetic operators (add, sub, mul, div, mod, negation)
3. Comparison operators (equal, not equal, greater, greater or equal, less, less or equal, between and hash code)
4. Casts (to BigInt, to Int, to Varchar, to Boolean, to Double, from Double, from Varchar)

0c70202, ab063ca and 36695d0 can be squashed onto 1c700a0. Separate commits were created for convenience of code review.

When this is merged, next step is to introduce implicit coersion float -> double to be able to fallback to double whenever float-specific functions are missing.
After coersion is added, Hive support will be added and aggregation functions afterwards.