### PR TITLE
Set finalQueryInfo only when we have the final task info

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.execution.StageInfo.getAllStages;
 import static com.facebook.presto.spi.StandardErrorCode.toErrorType;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -226,6 +227,12 @@ public class QueryInfo
     public ErrorCode getErrorCode()
     {
         return errorCode;
+    }
+
+    @JsonProperty
+    public boolean isFinalQueryInfo()
+    {
+        return state.isDone() && getAllStages(outputStage).stream().allMatch(StageInfo::isFinalStageInfo);
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageInfo.java
@@ -127,6 +127,11 @@ public class StageInfo
         return failureCause;
     }
 
+    public boolean isFinalStageInfo()
+    {
+        return state.isDone() && tasks.stream().allMatch(taskInfo -> taskInfo.getTaskStatus().getState().isDone());
+    }
+
     @Override
     public String toString()
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskInfo.java
@@ -120,4 +120,9 @@ public class TaskInfo
                 taskStats,
                 true);
     }
+
+    public TaskInfo withTaskStatus(TaskStatus taskStatus)
+    {
+        return new TaskInfo(taskStatus, lastHeartbeat, outputBuffers, noMoreSplits, stats, needsPlan);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
@@ -240,7 +240,7 @@ public final class HttpPageBufferClient
             lastUpdate = DateTime.now();
         }
 
-        if (future != null) {
+        if (future != null && !future.isDone()) {
             future.cancel(true);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
@@ -396,7 +396,7 @@ public class StatementResource
 
             // only return a next if the query is not done or there is more data to send (due to buffering)
             URI nextResultsUri = null;
-            if ((!queryInfo.getState().isDone()) || (!exchangeClient.isClosed())) {
+            if ((!queryInfo.isFinalQueryInfo()) || (!exchangeClient.isClosed())) {
                 nextResultsUri = createNextResultsUri(uriInfo);
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -540,7 +540,7 @@ public final class HttpRemoteTask
         }
 
         taskStatusFetcher.stop();
-        taskInfoFetcher.taskStatusDone();
+        taskInfoFetcher.taskStatusDone(getTaskStatus());
     }
 
     @Override


### PR DESCRIPTION
Currently, we set the finalQueryInfo when the query transitions to
finished state. However, we might not have the final task info yet.
This change sets the finalQueryInfo when we get the final taskInfo for
all tasks.