### PR TITLE
Add support for Postgres ANY/SOME predicate clause

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/OperatorType.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/OperatorType.java
@@ -131,6 +131,15 @@ public enum OperatorType
                 }
             },
 
+    ANY("ANY")
+            {
+                @Override
+                void validateSignature(TypeSignature returnType, List<TypeSignature> argumentTypes)
+                {
+                    validateComparisonOperatorSignature(this, returnType, argumentTypes, 2);
+                }
+            },
+
     BETWEEN("BETWEEN")
             {
                 @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFunctions.java
@@ -13,12 +13,27 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.DateType;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.TimeType;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarbinaryType;
+import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.type.ArrayType;
 import com.facebook.presto.type.SqlType;
+import com.google.common.base.Throwables;
+import io.airlift.slice.Slice;
 
+import static com.facebook.presto.metadata.OperatorType.ANY;
+import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 
 public final class ArrayFunctions
@@ -33,5 +48,221 @@ public final class ArrayFunctions
     {
         BlockBuilder blockBuilder = new ArrayType(UNKNOWN).createBlockBuilder(new BlockBuilderStatus(), 0);
         return blockBuilder.build();
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyBigint(@SqlType(StandardTypes.BIGINT) long left, @SqlType("array<bigint>") Block right)
+    {
+        return contains(BigintType.BIGINT, right, left);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyBigint(@SqlType("array<bigint>") Block left, @SqlType(StandardTypes.BIGINT) long right)
+    {
+        return contains(BigintType.BIGINT, left, right);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyBoolean(@SqlType(StandardTypes.BOOLEAN) boolean left, @SqlType("array<boolean>") Block right)
+    {
+        return contains(BooleanType.BOOLEAN, right, left);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyBoolean(@SqlType("array<boolean>") Block left, @SqlType(StandardTypes.BOOLEAN) boolean right)
+    {
+        return contains(BooleanType.BOOLEAN, left, right);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyDate(@SqlType(StandardTypes.DATE) long left, @SqlType("array<date>") Block right)
+    {
+        return contains(DateType.DATE, right, left);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyDate(@SqlType("array<date>") Block left, @SqlType(StandardTypes.DATE) long right)
+    {
+        return contains(DateType.DATE, left, right);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyDouble(@SqlType(StandardTypes.DOUBLE) double left, @SqlType("array<double>") Block right)
+    {
+        return contains(DoubleType.DOUBLE, right, left);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyDouble(@SqlType("array<double>") Block left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return contains(DoubleType.DOUBLE, left, right);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyTime(@SqlType(StandardTypes.TIME) long left, @SqlType("array<time>") Block right)
+    {
+        return contains(TimeType.TIME, right, left);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyTime(@SqlType("array<time>") Block left, @SqlType(StandardTypes.TIME) long right)
+    {
+        return contains(TimeType.TIME, left, right);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyTimestamp(@SqlType(StandardTypes.TIMESTAMP) long left, @SqlType("array<timestamp>") Block right)
+    {
+        return contains(TimestampType.TIMESTAMP, right, left);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyTimestamp(@SqlType("array<timestamp>") Block left, @SqlType(StandardTypes.TIMESTAMP) long right)
+    {
+        return contains(TimestampType.TIMESTAMP, left, right);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyVarbinary(@SqlType(StandardTypes.VARBINARY) Slice left, @SqlType("array<varbinary>") Block right)
+    {
+        return contains(VarbinaryType.VARBINARY, right, left);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyVarbinary(@SqlType("array<varbinary>") Block left, @SqlType(StandardTypes.VARBINARY) Slice right)
+    {
+        return contains(VarbinaryType.VARBINARY, left, right);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyVarchar(@SqlType(StandardTypes.VARCHAR) Slice left, @SqlType("array<varchar>") Block right)
+    {
+        return contains(VarcharType.VARCHAR, right, left);
+    }
+
+    @ScalarOperator(ANY)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean anyVarchar(@SqlType("array<varchar>") Block left, @SqlType(StandardTypes.VARCHAR) Slice right)
+    {
+        return contains(VarcharType.VARCHAR, left, right);
+    }
+
+    private static Boolean contains(Type elementType, Block arrayBlock, boolean value)
+    {
+        boolean foundNull = false;
+        for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
+            if (arrayBlock.isNull(i)) {
+                foundNull = true;
+                continue;
+            }
+            try {
+                if (elementType.getBoolean(arrayBlock, i) == value) {
+                    return true;
+                }
+            }
+            catch (Throwable t) {
+                Throwables.propagateIfInstanceOf(t, Error.class);
+                Throwables.propagateIfInstanceOf(t, PrestoException.class);
+
+                throw new PrestoException(INTERNAL_ERROR, t);
+            }
+        }
+        if (foundNull) {
+            return null;
+        }
+        return false;
+    }
+
+    private static Boolean contains(Type elementType, Block arrayBlock, double value)
+    {
+        boolean foundNull = false;
+        for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
+            if (arrayBlock.isNull(i)) {
+                foundNull = true;
+                continue;
+            }
+            try {
+                if (elementType.getDouble(arrayBlock, i) == value) {
+                    return true;
+                }
+            }
+            catch (Throwable t) {
+                Throwables.propagateIfInstanceOf(t, Error.class);
+                Throwables.propagateIfInstanceOf(t, PrestoException.class);
+
+                throw new PrestoException(INTERNAL_ERROR, t);
+            }
+        }
+        if (foundNull) {
+            return null;
+        }
+        return false;
+    }
+
+    private static Boolean contains(Type elementType, Block arrayBlock, long value)
+    {
+        boolean foundNull = false;
+        for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
+            if (arrayBlock.isNull(i)) {
+                foundNull = true;
+                continue;
+            }
+            try {
+                if (elementType.getLong(arrayBlock, i) == value) {
+                    return true;
+                }
+            }
+            catch (Throwable t) {
+                Throwables.propagateIfInstanceOf(t, Error.class);
+                Throwables.propagateIfInstanceOf(t, PrestoException.class);
+
+                throw new PrestoException(INTERNAL_ERROR, t);
+            }
+        }
+        if (foundNull) {
+            return null;
+        }
+        return false;
+    }
+
+    private static Boolean contains(Type elementType, Block arrayBlock, Slice value)
+    {
+        boolean foundNull = false;
+        for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
+            if (arrayBlock.isNull(i)) {
+                foundNull = true;
+                continue;
+            }
+            try {
+                if (elementType.getSlice(arrayBlock, i).equals(value)) {
+                    return true;
+                }
+            }
+            catch (Throwable t) {
+                Throwables.propagateIfInstanceOf(t, Error.class);
+                Throwables.propagateIfInstanceOf(t, PrestoException.class);
+
+                throw new PrestoException(INTERNAL_ERROR, t);
+            }
+        }
+        if (foundNull) {
+            return null;
+        }
+        return false;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -402,6 +402,9 @@ public class ExpressionAnalyzer
             if (node.getType() == ComparisonExpression.Type.IS_DISTINCT_FROM) {
                 operatorType = OperatorType.EQUAL;
             }
+            else if (node.getType() == ComparisonExpression.Type.ANY) {
+                operatorType = OperatorType.ANY;
+            }
             else {
                 operatorType = OperatorType.valueOf(node.getType().name());
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.predicate.SortedRangeSet;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.predicate.Utils;
 import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.FunctionInvoker;
 import com.facebook.presto.sql.analyzer.ExpressionAnalyzer;
@@ -102,6 +103,20 @@ public final class DomainTranslator
     {
         if (domain.getValues().isNone()) {
             return domain.isNullAllowed() ? new IsNullPredicate(reference) : FALSE_LITERAL;
+        }
+
+        if (domain.getValues().isAny()) {
+            List<Expression> disjuncts = new ArrayList<>();
+            for (Object s : domain.getValues().getDiscreteValues().getValues()) {
+                Expression e = new ComparisonExpression(ComparisonExpression.Type.ANY, toExpression(s, domain.getType()), reference);
+                if (!domain.getValues().getDiscreteValues().isWhiteList()) {
+                    disjuncts.add(new NotExpression(e));
+                }
+                else {
+                    disjuncts.add(e);
+                }
+            }
+            return combineDisjunctsWithDefault(disjuncts, TRUE_LITERAL);
         }
 
         if (domain.getValues().isAll()) {
@@ -401,6 +416,24 @@ public final class DomainTranslator
 
             Optional<NullableValue> coercedValue = coerce(value, fieldType);
             if (coercedValue.isPresent()) {
+                // This block of code was written against version 0.131
+                // This whole method has had a lot of changes since then and therefore it may no longer be viable
+                if (node.getType().equals(ComparisonExpression.Type.ANY)) {
+                    if (fieldType.getTypeSignature().getBase().equals(StandardTypes.ARRAY)) {
+                        Type elementType = fieldType.getTypeParameters().get(0);
+                        checkState(value.isNull() || value.getType().equals(elementType), "INVARIANT: ANY comparison array element type must be the same as value");
+                        return createComparisonExtractionResult(normalized.getComparisonType(), symbol, elementType, value.getValue(), complement);
+                    }
+                    else if (value.getType().getTypeSignature().getBase().equals(StandardTypes.ARRAY)) {
+                        Type elementType = value.getType().getTypeParameters().get(0);
+                        checkState(value.isNull() || fieldType.equals(elementType), "INVARIANT: ANY comparison array element type must be the same as value");
+                        return createComparisonExtractionResult(normalized.getComparisonType(), symbol, value.getType(), value.getValue(), complement);
+                    }
+                    else {
+                        throw new IllegalStateException("INVARIANT: ANY comparison array element type must be the same as value");
+                    }
+                }
+
                 return createComparisonExtractionResult(normalized.getComparisonType(), symbol, fieldType, coercedValue.get().getValue(), complement);
             }
 
@@ -470,6 +503,8 @@ public final class DomainTranslator
         {
             checkArgument(value != null);
             switch (comparisonType) {
+                case ANY:
+                    return Domain.create(complementIfNecessary(ValueSet.any(type, value), complement), false);
                 case EQUAL:
                     return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.equal(type, value)), complement), false);
                 case GREATER_THAN:
@@ -494,6 +529,8 @@ public final class DomainTranslator
         {
             checkArgument(value != null);
             switch (comparisonType) {
+                case ANY:
+                    return Domain.create(complementIfNecessary(ValueSet.any(type, value), complement), false);
                 case EQUAL:
                     return Domain.create(complementIfNecessary(ValueSet.of(type, value), complement), false);
                 case NOT_EQUAL:

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -243,6 +243,7 @@ predicate[ParserRuleContext value]
     | NOT? LIKE pattern=valueExpression (ESCAPE escape=valueExpression)?  #like
     | IS NOT? NULL                                                        #nullPredicate
     | IS NOT? DISTINCT FROM right=valueExpression                         #distinctFrom
+    | NOT? (ANY|SOME) right=valueExpression                               #any
     ;
 
 valueExpression

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -838,6 +838,22 @@ class AstBuilder
     }
 
     @Override
+    public Node visitAny(SqlBaseParser.AnyContext context)
+    {
+        Expression expression = new ComparisonExpression(
+                getLocation(context),
+                ComparisonExpression.Type.ANY,
+                (Expression) visit(context.value),
+                (Expression) visit(context.right));
+
+        if (context.NOT() != null) {
+            expression = new NotExpression(getLocation(context), expression);
+        }
+
+        return expression;
+    }
+
+    @Override
     public Node visitBetween(SqlBaseParser.BetweenContext context)
     {
         Expression expression = new BetweenPredicate(

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ComparisonExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ComparisonExpression.java
@@ -29,7 +29,8 @@ public class ComparisonExpression
         LESS_THAN_OR_EQUAL("<="),
         GREATER_THAN(">"),
         GREATER_THAN_OR_EQUAL(">="),
-        IS_DISTINCT_FROM("IS DISTINCT FROM");
+        IS_DISTINCT_FROM("IS DISTINCT FROM"),
+        ANY("ANY");
 
         private final String value;
 
@@ -60,6 +61,8 @@ public class ComparisonExpression
                     return LESS_THAN_OR_EQUAL;
                 case IS_DISTINCT_FROM:
                     return IS_DISTINCT_FROM;
+                case ANY:
+                    return ANY;
                 default:
                     throw new IllegalArgumentException("Unsupported comparison: " + this);
             }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/AllOrNoneValueSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/AllOrNoneValueSet.java
@@ -64,6 +64,12 @@ public class AllOrNoneValueSet
     }
 
     @Override
+    public boolean isAny()
+    {
+        return false;
+    }
+
+    @Override
     @JsonProperty
     public boolean isAll()
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/AnyValueSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/AnyValueSet.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.predicate;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.predicate.EquatableValueSet.ValueEntry;
+import com.facebook.presto.spi.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This class is identical to EquatableValueSet with the exception that we do not
+ * throw an IllegalArgumentException if type isOrderable, as we expect it to be orderable
+ * Likely a better way to handle this.
+ * <p>
+ * We can't extend EquatableValueSet because we can't catch exception thrown by super constructor.
+ */
+public class AnyValueSet
+        implements ValueSet
+{
+    private EquatableValueSet equatableValueSet;
+
+    @JsonCreator
+    public AnyValueSet(
+            @JsonProperty("type") Type type,
+            @JsonProperty("whiteList") boolean whiteList,
+            @JsonProperty("entries") Set<ValueEntry> entries)
+    {
+        try {
+            equatableValueSet = new EquatableValueSet(type, whiteList, entries);
+        }
+        catch (IllegalArgumentException e) {
+            // Re-throw if type is not comparable
+            if (!type.isComparable()) {
+                throw e;
+            }
+        }
+    }
+
+    static AnyValueSet of(Type type, Object first, Object... rest)
+    {
+        HashSet<ValueEntry> set = new HashSet<>(rest.length + 1);
+        set.add(ValueEntry.create(type, first));
+        for (Object value : rest) {
+            set.add(ValueEntry.create(type, value));
+        }
+        return new AnyValueSet(type, true, set);
+    }
+
+    @Override
+    public Type getType()
+    {
+        return equatableValueSet.getType();
+    }
+
+    @Override
+    public boolean isNone()
+    {
+        return equatableValueSet.isNone();
+    }
+
+    @Override
+    public boolean isAny()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isAll()
+    {
+        return equatableValueSet.isAll();
+    }
+
+    @Override
+    public boolean isSingleValue()
+    {
+        return equatableValueSet.isSingleValue();
+    }
+
+    @Override
+    public Object getSingleValue()
+    {
+        return equatableValueSet.getSingleValue();
+    }
+
+    @Override
+    public boolean containsValue(Object value)
+    {
+        return equatableValueSet.containsValue(value);
+    }
+
+    @Override
+    public ValuesProcessor getValuesProcessor()
+    {
+        return equatableValueSet.getValuesProcessor();
+    }
+
+    @Override
+    public ValueSet intersect(ValueSet other)
+    {
+        return equatableValueSet.intersect(other);
+    }
+
+    @Override
+    public ValueSet union(ValueSet other)
+    {
+        return equatableValueSet.union(other);
+    }
+
+    @Override
+    public ValueSet complement()
+    {
+        return equatableValueSet.complement();
+    }
+
+    @Override
+    public String toString(ConnectorSession session)
+    {
+        return equatableValueSet.toString(session);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/EquatableValueSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/EquatableValueSet.java
@@ -126,6 +126,12 @@ public class EquatableValueSet
     }
 
     @Override
+    public boolean isAny()
+    {
+        return false;
+    }
+
+    @Override
     public boolean isAll()
     {
         return !whiteList && entries.isEmpty();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/SortedRangeSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/SortedRangeSet.java
@@ -135,6 +135,12 @@ public final class SortedRangeSet
     }
 
     @Override
+    public boolean isAny()
+    {
+        return false;
+    }
+
+    @Override
     public boolean isAll()
     {
         return lowIndexedRanges.size() == 1 && lowIndexedRanges.values().iterator().next().isAll();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/ValueSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/ValueSet.java
@@ -30,6 +30,7 @@ import static java.util.stream.Collectors.toList;
         @JsonSubTypes.Type(value = EquatableValueSet.class, name = "equatable"),
         @JsonSubTypes.Type(value = SortedRangeSet.class, name = "sortable"),
         @JsonSubTypes.Type(value = AllOrNoneValueSet.class, name = "allOrNone"),
+        @JsonSubTypes.Type(value = AnyValueSet.class, name = "any"),
 })
 public interface ValueSet
 {
@@ -53,6 +54,14 @@ public interface ValueSet
             return EquatableValueSet.all(type);
         }
         return AllOrNoneValueSet.all(type);
+    }
+
+    static ValueSet any(Type type, Object first, Object... rest)
+    {
+        if (type.isComparable()) {
+            return AnyValueSet.of(type, first, rest);
+        }
+        throw new IllegalArgumentException("Cannot create discrete ValueSet with non-comparable type: " + type);
     }
 
     static ValueSet of(Type type, Object first, Object... rest)
@@ -92,6 +101,8 @@ public interface ValueSet
     Type getType();
 
     boolean isNone();
+
+    boolean isAny();
 
     boolean isAll();
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -929,6 +929,22 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testAny()
+            throws Exception
+    {
+        assertQuery("SELECT * FROM orders WHERE clerk ANY ARRAY ['Clerk#000000001', 'Clerk#000000002']");
+        assertQuery("SELECT * FROM orders WHERE ARRAY ['Clerk#000000001', 'Clerk#000000002'] ANY clerk");
+    }
+
+    @Test
+    public void testSome()
+            throws Exception
+    {
+        assertQuery("SELECT * FROM orders WHERE clerk SOME ARRAY ['Clerk#000000001', 'Clerk#000000002']");
+        assertQuery("SELECT * FROM orders WHERE ARRAY ['Clerk#000000001', 'Clerk#000000002'] SOME clerk");
+    }
+
+    @Test
     public void testOrderByLimit()
             throws Exception
     {


### PR DESCRIPTION
Adds grammar and functionality for use of **ANY/SOME** in a query, searching for the existence of a single value against an array of values.  Functionally similar to **contains** function, but pushes the predicate down to a connector.

See [Postgres Row and Array comparisons](http://www.postgresql.org/docs/8.2/static/functions-comparisons.html) for details.

Unsure if this is the best way to implement this feature.  I certainly wouldn't mind some pointers.  May be worth adding **ALL** as well.

@mattsfuller @maciejgrzybek