### PR TITLE
Update to Kafka client 0.8.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -651,7 +651,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_2.10</artifactId>
-                <version>0.8.1.1</version>
+                <version>0.8.2.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>log4j</groupId>
@@ -659,7 +659,7 @@
                     </exclusion>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-jdk14</artifactId>
+                        <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -667,13 +667,13 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.1.3</version>
+                <version>1.1.1.7</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.3.6</version>
+                <version>3.4.6</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>junit</artifactId>
@@ -683,17 +683,25 @@
                         <artifactId>log4j</artifactId>
                         <groupId>log4j</groupId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
             <dependency>
                 <groupId>com.101tec</groupId>
                 <artifactId>zkclient</artifactId>
-                <version>0.4</version>
+                <version>0.8</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>log4j</artifactId>
                         <groupId>log4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestManySegments.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestManySegments.java
@@ -59,7 +59,7 @@ public class TestManySegments
         topicName = "test_" + UUID.randomUUID().toString().replaceAll("-", "_");
 
         Properties topicProperties = new Properties();
-        topicProperties.setProperty("segment.bytes", "256");
+        topicProperties.setProperty("segment.bytes", "1048576");
 
         embeddedKafka.createTopics(1, 1, topicProperties, topicName);
 

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/EmbeddedZookeeper.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/EmbeddedZookeeper.java
@@ -14,7 +14,8 @@
 package com.facebook.presto.kafka.util;
 
 import com.google.common.io.Files;
-import org.apache.zookeeper.server.NIOServerCnxn;
+import org.apache.zookeeper.server.NIOServerCnxnFactory;
+import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 
@@ -32,7 +33,7 @@ public class EmbeddedZookeeper
     private final int port;
     private final File zkDataDir;
     private final ZooKeeperServer zkServer;
-    private final NIOServerCnxn.Factory cnxnFactory;
+    private final ServerCnxnFactory cnxnFactory;
 
     private final AtomicBoolean started = new AtomicBoolean();
     private final AtomicBoolean stopped = new AtomicBoolean();
@@ -53,7 +54,7 @@ public class EmbeddedZookeeper
         FileTxnSnapLog ftxn = new FileTxnSnapLog(zkDataDir, zkDataDir);
         zkServer.setTxnLogFactory(ftxn);
 
-        cnxnFactory = new NIOServerCnxn.Factory(new InetSocketAddress(this.port), 0);
+        cnxnFactory = NIOServerCnxnFactory.createFactory(new InetSocketAddress(this.port), 0);
     }
 
     public void start()


### PR DESCRIPTION
Enables support for LZ4 data and other changes added in Kafka 0.8.2.

Changes include updates to dependencies (and exclusions due to dependency changes), minor unit test repair (config + API changes).

A larger later change might be to migrate to the Kafka 0.9+ client but I wanted to fix the immediate issue we had with LZ4 data.

(CLA Signed ~1 hr ago)