### PR TITLE
Add sanity check that RemoteSource is not locally parallelized

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -533,6 +533,12 @@ public class LocalExecutionPlanner
         @Override
         public PhysicalOperation visitRemoteSource(RemoteSourceNode node, LocalExecutionPlanContext context)
         {
+            // Having multiple remote ExchangeClients per outputId is not acceptable for an OutputBuffer (e.g. SharedBuffer).
+            // Setting the driver instance count to 1 here:
+            // * validates that it was either unset or set to 1
+            // * pins it so that it can not later be set to a different value
+            context.setDriverInstanceCount(1);
+
             List<Type> types = getSourceOperatorTypes(node, context.getTypes());
 
             OperatorFactory operatorFactory = new ExchangeOperatorFactory(context.getNextOperatorId(), node.getId(), exchangeClientSupplier, types);


### PR DESCRIPTION
This commit mitigates a bug in trunk that can produce invalid local execution
plans that can result incorrect results. With this commit, known reproduction
of the bug will fail at local execution planning time.

The bug involves having a task.writer-count config set to 1 on coordinator and
at least 2 on worker. Under such circumstance, an invalid plan will be
generated. Executing such a plan can result in writing duplicated data to
tables.