### PR TITLE
Add support for https connection in JDBC

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -16,6 +16,7 @@ package com.facebook.presto.jdbc;
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.client.StatementClient;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
@@ -571,12 +572,12 @@ public class PrestoConnection
 
     ServerInfo getServerInfo()
     {
-        return queryExecutor.getServerInfo(createHttpUri(address));
+        return queryExecutor.getServerInfo(getHttpUri());
     }
 
     StatementClient startQuery(String sql)
     {
-        URI uri = createHttpUri(address);
+        URI uri = getHttpUri();
 
         String source = firstNonNull(clientInfo.get("ApplicationName"), "presto-jdbc");
 
@@ -642,10 +643,17 @@ public class PrestoConnection
         }
     }
 
+    @VisibleForTesting
+    URI getHttpUri()
+    {
+        return createHttpUri(address);
+    }
+
     private static URI createHttpUri(HostAndPort address)
     {
+        String scheme = address.getPort() == 443 ? "https" : "http";
         return uriBuilder()
-                .scheme("http")
+                .scheme(scheme)
                 .host(address.getHostText())
                 .port(address.getPort())
                 .build();

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
@@ -27,6 +27,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
+import java.net.URI;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.DriverManager;
@@ -1137,6 +1138,17 @@ public class TestDriver
                     assertEquals(rs.getString("table_catalog"), TEST_CATALOG);
                 }
             }
+        }
+    }
+
+    @Test
+    public void testConnectionWithSSL()
+            throws Exception
+    {
+        String url = format("jdbc:presto://some-ssl-server:443/%s", "blackhole");
+        try (PrestoConnection connection = (PrestoConnection) DriverManager.getConnection(url, "test", null)) {
+            URI uri = connection.getHttpUri();
+            assertEquals("https", uri.getScheme());
         }
     }
 


### PR DESCRIPTION
Current presto-jdbc doesn't support https connection. For simplicity this PR assumes using port 443 for https connection.