### PR TITLE
Refactoring of SqlFunction and Signature.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
@@ -142,8 +142,7 @@ public class FunctionListBuilder
             String description,
             boolean hidden,
             boolean nullable,
-            List<Boolean> nullableArguments,
-            Set<String> literalParameters)
+            List<Boolean> nullableArguments)
     {
         functions.add(SqlScalarFunction.create(
                 signature,
@@ -153,8 +152,7 @@ public class FunctionListBuilder
                 instanceFactory,
                 deterministic,
                 nullable,
-                nullableArguments,
-                literalParameters));
+                nullableArguments));
         return this;
     }
 
@@ -167,8 +165,7 @@ public class FunctionListBuilder
             MethodHandle function,
             Optional<MethodHandle> instanceFactory,
             boolean nullable,
-            List<Boolean> nullableArguments,
-            Set<String> literalParameters)
+            List<Boolean> nullableArguments)
     {
         operatorType.validateSignature(returnType, argumentTypes);
         functions.add(SqlOperator.create(
@@ -180,8 +177,7 @@ public class FunctionListBuilder
                 function,
                 instanceFactory,
                 nullable,
-                nullableArguments,
-                literalParameters));
+                nullableArguments));
         return this;
     }
 
@@ -259,16 +255,14 @@ public class FunctionListBuilder
 
         List<Boolean> nullableArguments = getNullableArguments(method);
 
-        scalar(
-                signature,
+        scalar(signature,
                 methodHandle,
                 instanceFactory,
                 scalarFunction.deterministic(),
                 getDescription(method),
                 scalarFunction.hidden(),
                 method.isAnnotationPresent(Nullable.class),
-                nullableArguments,
-                literalParameters);
+                nullableArguments);
         for (String alias : scalarFunction.alias()) {
             scalar(signature.withAlias(alias.toLowerCase(ENGLISH)),
                     methodHandle,
@@ -277,8 +271,7 @@ public class FunctionListBuilder
                     getDescription(method),
                     scalarFunction.hidden(),
                     method.isAnnotationPresent(Nullable.class),
-                    nullableArguments,
-                    literalParameters);
+                    nullableArguments);
         }
         return true;
     }
@@ -443,8 +436,7 @@ public class FunctionListBuilder
                 methodHandle,
                 instanceFactory,
                 method.isAnnotationPresent(Nullable.class),
-                nullableArguments,
-                literalParameters);
+                nullableArguments);
         return true;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
@@ -19,16 +19,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.metadata.FunctionRegistry.mangleOperatorName;
-import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Stream.concat;
@@ -66,51 +63,7 @@ public final class Signature
         this.variableArity = variableArity;
     }
 
-    public Signature(
-            String name,
-            FunctionKind kind,
-            List<TypeVariableConstraint> typeVariableConstraints,
-            List<LongVariableConstraint> longVariableConstraints,
-            String returnType,
-            List<String> argumentTypes,
-            boolean variableArity)
-    {
-        this(name, kind, typeVariableConstraints, longVariableConstraints, returnType, argumentTypes, variableArity, ImmutableSet.of());
-    }
-
-    public Signature(
-            String name,
-            FunctionKind kind,
-            List<TypeVariableConstraint> typeVariableConstraints,
-            List<LongVariableConstraint> longVariableConstraints,
-            String returnType,
-            List<String> argumentTypes,
-            boolean variableArity,
-            Set<String> literalParameters)
-    {
-        this(name,
-                kind,
-                typeVariableConstraints,
-                longVariableConstraints,
-                parseTypeSignature(returnType, literalParameters),
-                argumentTypes.stream().map(argument -> parseTypeSignature(argument, literalParameters)).collect(toImmutableList()),
-                variableArity
-        );
-    }
-
-    public Signature(String name, FunctionKind kind, String returnType, List<String> argumentTypes)
-    {
-        this(name,
-                kind,
-                ImmutableList.<TypeVariableConstraint>of(),
-                ImmutableList.<LongVariableConstraint>of(),
-                parseTypeSignature(returnType),
-                argumentTypes.stream().map(TypeSignature::parseTypeSignature).collect(toImmutableList()),
-                false
-        );
-    }
-
-    public Signature(String name, FunctionKind kind, String returnType, String... argumentTypes)
+    public Signature(String name, FunctionKind kind, TypeSignature returnType, TypeSignature... argumentTypes)
     {
         this(name, kind, returnType, ImmutableList.copyOf(argumentTypes));
     }
@@ -120,17 +73,12 @@ public final class Signature
         this(name, kind, ImmutableList.<TypeVariableConstraint>of(), ImmutableList.<LongVariableConstraint>of(), returnType, argumentTypes, false);
     }
 
-    public Signature(String name, FunctionKind kind, TypeSignature returnType, TypeSignature... argumentTypes)
-    {
-        this(name, kind, returnType, ImmutableList.copyOf(argumentTypes));
-    }
-
     public static Signature internalOperator(OperatorType operator, Type returnType, List<? extends Type> argumentTypes)
     {
         return internalScalarFunction(mangleOperatorName(operator.name()), returnType.getTypeSignature(), argumentTypes.stream().map(Type::getTypeSignature).collect(toImmutableList()));
     }
 
-    public static Signature internalOperator(OperatorType operator, String returnType, List<String> argumentTypes)
+    public static Signature internalOperator(OperatorType operator, TypeSignature returnType, List<TypeSignature> argumentTypes)
     {
         return internalScalarFunction(mangleOperatorName(operator.name()), returnType, argumentTypes);
     }
@@ -143,16 +91,6 @@ public final class Signature
     public static Signature internalOperator(String name, TypeSignature returnType, TypeSignature... argumentTypes)
     {
         return internalScalarFunction(mangleOperatorName(name), returnType, ImmutableList.copyOf(argumentTypes));
-    }
-
-    public static Signature internalScalarFunction(String name, String returnType, String... argumentTypes)
-    {
-        return internalScalarFunction(name, returnType, ImmutableList.copyOf(argumentTypes));
-    }
-
-    public static Signature internalScalarFunction(String name, String returnType, List<String> argumentTypes)
-    {
-        return new Signature(name, SCALAR, ImmutableList.<TypeVariableConstraint>of(), ImmutableList.<LongVariableConstraint>of(), returnType, argumentTypes, false, ImmutableSet.of());
     }
 
     public static Signature internalScalarFunction(String name, TypeSignature returnType, TypeSignature... argumentTypes)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SignatureBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SignatureBuilder.java
@@ -13,16 +13,15 @@
  */
 package com.facebook.presto.metadata;
 
-import java.util.HashSet;
+import com.facebook.presto.spi.type.TypeSignature;
+
 import java.util.List;
-import java.util.Set;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.metadata.FunctionRegistry.mangleOperatorName;
 import static com.google.common.collect.ImmutableList.copyOf;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
 import static java.util.Objects.requireNonNull;
 
 public final class SignatureBuilder
@@ -31,10 +30,9 @@ public final class SignatureBuilder
     private FunctionKind kind;
     private List<TypeVariableConstraint> typeVariableConstraints = emptyList();
     private List<LongVariableConstraint> longVariableConstraints = emptyList();
-    private String returnType;
-    private List<String> argumentTypes;
+    private TypeSignature returnType;
+    private List<TypeSignature> argumentTypes = emptyList();
     private boolean variableArity;
-    private Set<String> literalParameters = emptySet();
 
     public SignatureBuilder() {}
 
@@ -68,6 +66,12 @@ public final class SignatureBuilder
         return this;
     }
 
+    public SignatureBuilder returnType(TypeSignature returnType)
+    {
+        this.returnType = requireNonNull(returnType, "returnType is null");
+        return this;
+    }
+
     public SignatureBuilder longVariableConstraints(LongVariableConstraint... longVariableConstraints)
     {
         return longVariableConstraints(asList(requireNonNull(longVariableConstraints, "longVariableConstraints is null")));
@@ -79,18 +83,12 @@ public final class SignatureBuilder
         return this;
     }
 
-    public SignatureBuilder returnType(String returnType)
-    {
-        this.returnType = requireNonNull(returnType, "returnType is null");
-        return this;
-    }
-
-    public SignatureBuilder argumentTypes(String... argumentTypes)
+    public SignatureBuilder argumentTypes(TypeSignature... argumentTypes)
     {
         return argumentTypes(asList(requireNonNull(argumentTypes, "argumentTypes is Null")));
     }
 
-    public SignatureBuilder argumentTypes(List<String> argumentTypes)
+    public SignatureBuilder argumentTypes(List<TypeSignature> argumentTypes)
     {
         this.argumentTypes = copyOf(requireNonNull(argumentTypes, "argumentTypes is null"));
         return this;
@@ -102,19 +100,8 @@ public final class SignatureBuilder
         return this;
     }
 
-    public SignatureBuilder literalParameters(String... literalParameters)
-    {
-        return literalParameters(new HashSet<>(asList(literalParameters)));
-    }
-
-    public SignatureBuilder literalParameters(Set<String> literalParameters)
-    {
-        this.literalParameters = literalParameters;
-        return this;
-    }
-
     public Signature build()
     {
-        return new Signature(name, kind, typeVariableConstraints, longVariableConstraints, returnType, argumentTypes, variableArity, literalParameters);
+        return new Signature(name, kind, typeVariableConstraints, longVariableConstraints, returnType, argumentTypes, variableArity);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SqlAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SqlAggregationFunction.java
@@ -19,10 +19,8 @@ import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.util.ImmutableCollectors;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
-import java.util.Set;
 
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.metadata.FunctionKind.APPROXIMATE_AGGREGATE;
@@ -43,27 +41,25 @@ public abstract class SqlAggregationFunction
             String name,
             List<TypeVariableConstraint> typeVariableConstraints,
             List<LongVariableConstraint> longVariableConstraints,
-            String returnType,
-            List<String> argumentTypes)
+            TypeSignature returnType,
+            List<TypeSignature> argumentTypes)
     {
-        this(name, typeVariableConstraints, longVariableConstraints, returnType, argumentTypes, AGGREGATE, ImmutableSet.of());
+        this(name, typeVariableConstraints, longVariableConstraints, returnType, argumentTypes, AGGREGATE);
     }
 
     protected SqlAggregationFunction(
             String name,
             List<TypeVariableConstraint> typeVariableConstraints,
             List<LongVariableConstraint> longVariableConstraints,
-            String returnType,
-            List<String> argumentTypes,
-            FunctionKind kind,
-            Set<String> literalParameters)
+            TypeSignature returnType,
+            List<TypeSignature> argumentTypes,
+            FunctionKind kind)
     {
         requireNonNull(name, "name is null");
         requireNonNull(typeVariableConstraints, "typeVariableConstraints is null");
         requireNonNull(longVariableConstraints, "longVariableConstraints is null");
         requireNonNull(returnType, "returnType is null");
         requireNonNull(argumentTypes, "argumentTypes is null");
-        requireNonNull(literalParameters, "argumentTypes is null");
         checkArgument(kind == AGGREGATE || kind == APPROXIMATE_AGGREGATE, "kind must be an aggregate");
         this.signature = new Signature(
                 name,
@@ -72,8 +68,7 @@ public abstract class SqlAggregationFunction
                 ImmutableList.copyOf(longVariableConstraints),
                 returnType,
                 ImmutableList.copyOf(argumentTypes),
-                false,
-                literalParameters);
+                false);
     }
 
     @Override
@@ -110,13 +105,11 @@ public abstract class SqlAggregationFunction
             super(name,
                     ImmutableList.<TypeVariableConstraint>of(),
                     ImmutableList.<LongVariableConstraint>of(),
-                    function.getFinalType().getTypeSignature().toString(),
+                    function.getFinalType().getTypeSignature(),
                     function.getParameterTypes().stream()
                             .map(Type::getTypeSignature)
-                            .map(TypeSignature::toString)
                             .collect(ImmutableCollectors.toImmutableList()),
-                    function.isApproximate() ? APPROXIMATE_AGGREGATE : AGGREGATE,
-                    ImmutableSet.of());
+                    function.isApproximate() ? APPROXIMATE_AGGREGATE : AGGREGATE);
             this.description = description;
             this.function = requireNonNull(function, "function is null");
         }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SqlOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SqlOperator.java
@@ -21,8 +21,6 @@ import com.google.common.collect.ImmutableList;
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.facebook.presto.metadata.FunctionRegistry.mangleOperatorName;
 import static java.util.Objects.requireNonNull;
@@ -39,26 +37,31 @@ public abstract class SqlOperator
             MethodHandle methodHandle,
             Optional<MethodHandle> instanceFactory,
             boolean nullable,
-            List<Boolean> nullableArguments,
-            Set<String> literalParameters)
+            List<Boolean> nullableArguments)
     {
-        List<String> arugmentTypesAsString = argumentTypes.stream().map(TypeSignature::toString).collect(Collectors.toList());
-        return new SimpleSqlOperator(operatorType, typeVariableConstraints, longVariableConstraints, arugmentTypesAsString, returnType, methodHandle, instanceFactory, nullable, nullableArguments, literalParameters);
+        // TODO This should take Signature!
+        return new SimpleSqlOperator(operatorType,
+                typeVariableConstraints,
+                longVariableConstraints,
+                argumentTypes,
+                returnType,
+                methodHandle,
+                instanceFactory,
+                nullable,
+                nullableArguments);
     }
 
-    protected SqlOperator(OperatorType operatorType, TypeSignature returnType, List<TypeSignature> argumentTypes, Set<String> literalParameters)
+    protected SqlOperator(OperatorType operatorType, List<TypeVariableConstraint> typeVariableConstraints, List<LongVariableConstraint> longVariableConstraints, TypeSignature returnType, List<TypeSignature> argumentTypes)
     {
-        super(mangleOperatorName(operatorType), returnType, argumentTypes, literalParameters);
-    }
-
-    protected SqlOperator(OperatorType operatorType, List<TypeVariableConstraint> typeVariableConstraints, List<LongVariableConstraint> longVariableConstraints,  String returnType, List<String> argumentTypes)
-    {
-        super(mangleOperatorName(operatorType), typeVariableConstraints, longVariableConstraints, returnType, argumentTypes);
-    }
-
-    protected SqlOperator(OperatorType operatorType, List<TypeVariableConstraint> typeVariableConstraints, List<LongVariableConstraint> longVariableConstraints, String returnType, List<String> argumentTypes, Set<String> literalParameters)
-    {
-        super(mangleOperatorName(operatorType), typeVariableConstraints, longVariableConstraints, returnType, argumentTypes, false, literalParameters);
+        // TODO This should take Signature!
+        super(new Signature(
+                mangleOperatorName(operatorType),
+                FunctionKind.SCALAR,
+                typeVariableConstraints,
+                longVariableConstraints,
+                returnType,
+                argumentTypes,
+                false));
     }
 
     @Override
@@ -92,15 +95,15 @@ public abstract class SqlOperator
                 OperatorType operatorType,
                 List<TypeVariableConstraint> typeVariableConstraints,
                 List<LongVariableConstraint> longVariableConstraints,
-                List<String> argumentTypes,
+                List<TypeSignature> argumentTypes,
                 TypeSignature returnType,
                 MethodHandle methodHandle,
                 Optional<MethodHandle> instanceFactory,
                 boolean nullable,
-                List<Boolean> nullableArguments,
-                Set<String> literalParameters)
+                List<Boolean> nullableArguments)
         {
-            super(operatorType, typeVariableConstraints, longVariableConstraints, returnType.toString(), argumentTypes, literalParameters);
+            // TODO This should take Signature!
+            super(operatorType, typeVariableConstraints, longVariableConstraints, returnType, argumentTypes);
             this.methodHandle = requireNonNull(methodHandle, "methodHandle is null");
             this.instanceFactory = requireNonNull(instanceFactory, "instanceFactory is null");
             this.nullable = nullable;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SqlScalarFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SqlScalarFunction.java
@@ -15,15 +15,11 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
 import com.facebook.presto.spi.type.TypeManager;
-import com.facebook.presto.spi.type.TypeSignature;
-import com.facebook.presto.util.ImmutableCollectors;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -42,8 +38,7 @@ public abstract class SqlScalarFunction
             Optional<MethodHandle> instanceFactory,
             boolean deterministic,
             boolean nullable,
-            List<Boolean> nullableArguments,
-            Set<String> literalParameters)
+            List<Boolean> nullableArguments)
     {
         return new SimpleSqlScalarFunction(
                 signature,
@@ -53,69 +48,7 @@ public abstract class SqlScalarFunction
                 instanceFactory,
                 deterministic,
                 nullable,
-                nullableArguments,
-                literalParameters);
-    }
-
-    public SqlScalarFunction(String name, TypeSignature returnType, List<TypeSignature> argumentTypes, Set<String> literalParameters)
-    {
-        requireNonNull(name, "name is null");
-        requireNonNull(returnType, "returnType is null");
-        requireNonNull(argumentTypes, "argumentTypes is null");
-        this.signature = new Signature(
-                name,
-                SCALAR,
-                ImmutableList.of(),
-                ImmutableList.of(),
-                returnType,
-                ImmutableList.copyOf(argumentTypes),
-                false
-        );
-    }
-
-    protected SqlScalarFunction(String name,
-            List<TypeVariableConstraint> typeVariableConstraints,
-            List<LongVariableConstraint> longVariableConstraints,
-            String returnType,
-            List<String> argumentTypes)
-    {
-        this(name, typeVariableConstraints, longVariableConstraints, returnType, argumentTypes, false, ImmutableSet.of());
-    }
-
-    protected SqlScalarFunction(
-            String name,
-            List<TypeVariableConstraint> typeParameterConstraints,
-            List<LongVariableConstraint> longVariableConstraints,
-            String returnType,
-            List<String> argumentTypes,
-            boolean variableArity)
-    {
-        this(name, typeParameterConstraints, longVariableConstraints, returnType, argumentTypes, variableArity, ImmutableSet.of());
-    }
-
-    protected SqlScalarFunction(
-            String name,
-            List<TypeVariableConstraint> typeParameterConstraints,
-            List<LongVariableConstraint> longVariableConstraints,
-            String returnType,
-            List<String> argumentTypes,
-            boolean variableArity,
-            Set<String> literalParameters)
-    {
-        requireNonNull(name, "name is null");
-        requireNonNull(typeParameterConstraints, "typeVariableConstraints is null");
-        requireNonNull(returnType, "returnType is null");
-        requireNonNull(argumentTypes, "argumentTypes is null");
-        requireNonNull(literalParameters, "literalParameters is null");
-        this.signature = new Signature(
-                name,
-                SCALAR,
-                ImmutableList.copyOf(typeParameterConstraints),
-                ImmutableList.copyOf(longVariableConstraints),
-                returnType,
-                ImmutableList.copyOf(argumentTypes),
-                variableArity,
-                literalParameters);
+                nullableArguments);
     }
 
     protected SqlScalarFunction(Signature signature)
@@ -156,18 +89,16 @@ public abstract class SqlScalarFunction
                 Optional<MethodHandle> instanceFactory,
                 boolean deterministic,
                 boolean nullable,
-                List<Boolean> nullableArguments,
-                Set<String> literalParameters)
+                List<Boolean> nullableArguments)
         {
-            super(signature.getName(),
+            super(new Signature(
+                    signature.getName(),
+                    FunctionKind.SCALAR,
                     ImmutableList.of(),
                     ImmutableList.of(),
-                    signature.getReturnType().toString(),
-                    signature.getArgumentTypes().stream()
-                            .map(TypeSignature::toString)
-                            .collect(ImmutableCollectors.toImmutableList()),
-                    false,
-                    literalParameters);
+                    signature.getReturnType(),
+                    signature.getArgumentTypes(),
+                    false));
             checkArgument(signature.getTypeVariableConstraints().isEmpty(), "%s is parametric", signature);
             this.description = description;
             this.hidden = hidden;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SqlScalarFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SqlScalarFunction.java
@@ -15,7 +15,6 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
@@ -91,14 +90,7 @@ public abstract class SqlScalarFunction
                 boolean nullable,
                 List<Boolean> nullableArguments)
         {
-            super(new Signature(
-                    signature.getName(),
-                    FunctionKind.SCALAR,
-                    ImmutableList.of(),
-                    ImmutableList.of(),
-                    signature.getReturnType(),
-                    signature.getArgumentTypes(),
-                    false));
+            super(signature);
             checkArgument(signature.getTypeVariableConstraints().isEmpty(), "%s is parametric", signature);
             this.description = description;
             this.hidden = hidden;

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxAggregationFunction.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.util.Objects.requireNonNull;
 
@@ -72,7 +73,11 @@ public abstract class AbstractMinMaxAggregationFunction
 
     protected AbstractMinMaxAggregationFunction(String name, OperatorType operatorType)
     {
-        super(name, ImmutableList.of(orderableTypeParameter("E")), ImmutableList.of(), "E", ImmutableList.of("E"));
+        super(name,
+                ImmutableList.of(orderableTypeParameter("E")),
+                ImmutableList.of(),
+                parseTypeSignature("E"),
+                ImmutableList.of(parseTypeSignature("E")));
         requireNonNull(operatorType);
         this.operatorType = operatorType;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxBy.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.NULLABLE_BLOCK_INPUT_CHANNEL;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.lang.invoke.MethodHandles.insertArguments;
 
@@ -50,7 +51,11 @@ public abstract class AbstractMinMaxBy
 
     protected AbstractMinMaxBy(boolean min)
     {
-        super((min ? "min" : "max") + "_by", ImmutableList.of(orderableTypeParameter("K"), typeVariable("V")), ImmutableList.of(), "V", ImmutableList.of("V", "K"));
+        super((min ? "min" : "max") + "_by",
+                ImmutableList.of(orderableTypeParameter("K"), typeVariable("V")),
+                ImmutableList.of(),
+                parseTypeSignature("V"),
+                ImmutableList.of(parseTypeSignature("V"), parseTypeSignature("K")));
         this.min = min;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxByNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxByNAggregationFunction.java
@@ -45,6 +45,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.util.Objects.requireNonNull;
 
@@ -60,7 +61,11 @@ public abstract class AbstractMinMaxByNAggregationFunction
 
     protected AbstractMinMaxByNAggregationFunction(String name, Function<Type, BlockComparator> typeToComparator)
     {
-        super(name, ImmutableList.of(typeVariable("V"), orderableTypeParameter("K")), ImmutableList.of(), "array(V)", ImmutableList.of("V", "K", StandardTypes.BIGINT));
+        super(name,
+                ImmutableList.of(typeVariable("V"), orderableTypeParameter("K")),
+                ImmutableList.of(),
+                parseTypeSignature("array(V)"),
+                ImmutableList.of(parseTypeSignature("V"), parseTypeSignature("K"), parseTypeSignature(StandardTypes.BIGINT)));
         this.name = requireNonNull(name, "name is null");
         this.typeToComparator = requireNonNull(typeToComparator, "typeToComparator is null");
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.util.Objects.requireNonNull;
 
@@ -58,7 +59,11 @@ public abstract class AbstractMinMaxNAggregationFunction
 
     protected AbstractMinMaxNAggregationFunction(String name, Function<Type, BlockComparator> typeToComparator)
     {
-        super(name, ImmutableList.of(orderableTypeParameter("E")), ImmutableList.of(), "array(E)", ImmutableList.of("E", StandardTypes.BIGINT));
+        super(name,
+                ImmutableList.of(orderableTypeParameter("E")),
+                ImmutableList.of(),
+                parseTypeSignature("array(E)"),
+                ImmutableList.of(parseTypeSignature("E"), parseTypeSignature(StandardTypes.BIGINT)));
         requireNonNull(typeToComparator);
         this.typeToComparator = typeToComparator;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
@@ -42,6 +42,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public class ArbitraryAggregationFunction
@@ -66,7 +67,11 @@ public class ArbitraryAggregationFunction
 
     protected ArbitraryAggregationFunction()
     {
-        super(NAME, ImmutableList.of(typeVariable("T")), ImmutableList.of(), "T", ImmutableList.of("T"));
+        super(NAME,
+                ImmutableList.of(typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature("T"),
+                ImmutableList.of(parseTypeSignature("T")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArrayAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArrayAggregationFunction.java
@@ -40,6 +40,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public class ArrayAggregationFunction
@@ -53,7 +54,11 @@ public class ArrayAggregationFunction
 
     public ArrayAggregationFunction()
     {
-        super(NAME, ImmutableList.of(typeVariable("T")), ImmutableList.of(), "array(T)", ImmutableList.of("T"));
+        super(NAME,
+                ImmutableList.of(typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature("array(T)"),
+                ImmutableList.of(parseTypeSignature("T")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ChecksumAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ChecksumAggregationFunction.java
@@ -37,6 +37,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static io.airlift.slice.Slices.wrappedLongArray;
@@ -54,7 +55,11 @@ public class ChecksumAggregationFunction
 
     public ChecksumAggregationFunction()
     {
-        super(NAME, ImmutableList.of(comparableTypeParameter("T")), ImmutableList.of(), StandardTypes.VARBINARY, ImmutableList.of("T"));
+        super(NAME,
+                ImmutableList.of(comparableTypeParameter("T")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.VARBINARY),
+                ImmutableList.of(parseTypeSignature("T")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountColumn.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountColumn.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public class CountColumn
@@ -51,7 +52,11 @@ public class CountColumn
 
     public CountColumn()
     {
-        super(NAME, ImmutableList.of(typeVariable("T")), ImmutableList.of(), StandardTypes.BIGINT, ImmutableList.of("T"));
+        super(NAME,
+                ImmutableList.of(typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.BIGINT),
+                ImmutableList.of(parseTypeSignature("T")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Histogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Histogram.java
@@ -40,6 +40,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.lang.String.format;
 
@@ -56,7 +57,11 @@ public class Histogram
 
     public Histogram()
     {
-        super(NAME, ImmutableList.of(comparableTypeParameter("K")), ImmutableList.of(), "map(K,bigint)", ImmutableList.of("K"));
+        super(NAME,
+                ImmutableList.of(comparableTypeParameter("K")),
+                ImmutableList.of(),
+                parseTypeSignature("map(K,bigint)"),
+                ImmutableList.of(parseTypeSignature("K")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregationFunction.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.lang.String.format;
 
@@ -55,7 +56,11 @@ public class MapAggregationFunction
 
     public MapAggregationFunction()
     {
-        super(NAME, ImmutableList.of(comparableTypeParameter("K"), typeVariable("V")), ImmutableList.of(), "map(K,V)", ImmutableList.of("K", "V"));
+        super(NAME,
+                ImmutableList.of(comparableTypeParameter("K"), typeVariable("V")),
+                ImmutableList.of(),
+                parseTypeSignature("map(K,V)"),
+                ImmutableList.of(parseTypeSignature("K"), parseTypeSignature("V")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MultimapAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MultimapAggregationFunction.java
@@ -42,6 +42,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.lang.String.format;
 
@@ -56,7 +57,11 @@ public class MultimapAggregationFunction
 
     public MultimapAggregationFunction()
     {
-        super(NAME, ImmutableList.of(comparableTypeParameter("K"), typeVariable("V")), ImmutableList.of(), "map(K,array(V))", ImmutableList.of("K", "V"));
+        super(NAME,
+                ImmutableList.of(comparableTypeParameter("K"), typeVariable("V")),
+                ImmutableList.of(),
+                parseTypeSignature("map(K,array(V))"),
+                ImmutableList.of(parseTypeSignature("K"), parseTypeSignature("V")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/AbstractGreatestLeast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/AbstractGreatestLeast.java
@@ -24,8 +24,10 @@ import com.facebook.presto.bytecode.Scope;
 import com.facebook.presto.bytecode.Variable;
 import com.facebook.presto.bytecode.control.IfStatement;
 import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.OperatorType;
+import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.StandardTypes;
@@ -51,6 +53,7 @@ import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.orderableTypeParameter;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.gen.BytecodeUtils.invoke;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -68,7 +71,14 @@ public abstract class AbstractGreatestLeast
 
     protected AbstractGreatestLeast(String name, OperatorType operatorType)
     {
-        super(name, ImmutableList.of(orderableTypeParameter("E")), ImmutableList.of(), "E", ImmutableList.of("E"), true);
+        super(new Signature(
+                name,
+                FunctionKind.SCALAR,
+                ImmutableList.of(orderableTypeParameter("E")),
+                ImmutableList.of(),
+                parseTypeSignature("E"),
+                ImmutableList.of(parseTypeSignature("E")),
+                true));
         this.operatorType = requireNonNull(operatorType, "operatorType is null");
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
@@ -33,7 +33,6 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.sql.gen.CallSiteBinder;
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
@@ -59,6 +58,7 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.consta
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.equal;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newInstance;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -75,8 +75,8 @@ public final class ArrayConstructor
                 FunctionKind.SCALAR,
                 ImmutableList.of(typeVariable("E")),
                 ImmutableList.of(),
-                TypeSignature.parseTypeSignature("array(E)"),
-                ImmutableList.of(TypeSignature.parseTypeSignature("E"), TypeSignature.parseTypeSignature("E")),
+                parseTypeSignature("array(E)"),
+                ImmutableList.of(parseTypeSignature("E"), parseTypeSignature("E")),
                 true));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
@@ -24,13 +24,16 @@ import com.facebook.presto.bytecode.Variable;
 import com.facebook.presto.bytecode.control.IfStatement;
 import com.facebook.presto.bytecode.expression.BytecodeExpression;
 import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.sql.gen.CallSiteBinder;
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
@@ -68,7 +71,13 @@ public final class ArrayConstructor
 
     public ArrayConstructor()
     {
-        super("array_constructor", ImmutableList.of(typeVariable("E")), ImmutableList.of(), "array(E)", ImmutableList.of("E", "E"), true);
+        super(new Signature("array_constructor",
+                FunctionKind.SCALAR,
+                ImmutableList.of(typeVariable("E")),
+                ImmutableList.of(),
+                TypeSignature.parseTypeSignature("array(E)"),
+                ImmutableList.of(TypeSignature.parseTypeSignature("E"), TypeSignature.parseTypeSignature("E")),
+                true));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFlattenFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFlattenFunction.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
@@ -28,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public class ArrayFlattenFunction
@@ -39,7 +42,13 @@ public class ArrayFlattenFunction
 
     private ArrayFlattenFunction()
     {
-        super(FUNCTION_NAME, ImmutableList.of(typeVariable("E")), ImmutableList.of(), "array(E)", ImmutableList.of("array(array(E))"));
+        super(new Signature(FUNCTION_NAME,
+                FunctionKind.SCALAR,
+                ImmutableList.of(typeVariable("E")),
+                ImmutableList.of(),
+                parseTypeSignature("array(E)"),
+                ImmutableList.of(parseTypeSignature("array(array(E))")),
+                false));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayJoin.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.annotation.UsedByGeneratedCode;
 import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
@@ -40,6 +41,7 @@ import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -63,7 +65,13 @@ public final class ArrayJoin
 
         public ArrayJoinWithNullReplacement()
         {
-            super(FUNCTION_NAME, ImmutableList.of(typeVariable("T")), ImmutableList.of(), StandardTypes.VARCHAR, ImmutableList.of("array(T)", StandardTypes.VARCHAR, StandardTypes.VARCHAR));
+            super(new Signature(FUNCTION_NAME,
+                    FunctionKind.SCALAR,
+                    ImmutableList.of(typeVariable("T")),
+                    ImmutableList.of(),
+                    parseTypeSignature(StandardTypes.VARCHAR),
+                    ImmutableList.of(parseTypeSignature("array(T)"), parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR)),
+                    false));
         }
 
         @Override
@@ -96,7 +104,13 @@ public final class ArrayJoin
 
     public ArrayJoin()
     {
-        super(FUNCTION_NAME, ImmutableList.of(typeVariable("T")), ImmutableList.of(), StandardTypes.VARCHAR, ImmutableList.of("array(T)", StandardTypes.VARCHAR));
+        super(new Signature(FUNCTION_NAME,
+                FunctionKind.SCALAR,
+                ImmutableList.of(typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.VARCHAR),
+                ImmutableList.of(parseTypeSignature("array(T)"), parseTypeSignature(StandardTypes.VARCHAR)),
+                false));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOperator.java
@@ -31,6 +31,7 @@ import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.orderableTypeParameter;
 import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.type.ArrayType.ARRAY_NULL_ELEMENT_MSG;
 import static com.facebook.presto.type.TypeUtils.checkElementNotNull;
@@ -44,7 +45,11 @@ public class ArrayLessThanOperator
 
     private ArrayLessThanOperator()
     {
-        super(LESS_THAN, ImmutableList.of(orderableTypeParameter("T")), ImmutableList.of(), StandardTypes.BOOLEAN, ImmutableList.of("array(T)", "array(T)"));
+        super(LESS_THAN,
+                ImmutableList.of(orderableTypeParameter("T")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.BOOLEAN),
+                ImmutableList.of(parseTypeSignature("array(T)"), parseTypeSignature("array(T)")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
@@ -30,6 +32,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import static com.facebook.presto.metadata.Signature.orderableTypeParameter;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
@@ -43,7 +46,14 @@ public final class ArraySortFunction
 
     public ArraySortFunction()
     {
-        super(FUNCTION_NAME, ImmutableList.of(orderableTypeParameter("E")), ImmutableList.of(), "array(E)", ImmutableList.of("array(E)"));
+        super(new Signature(
+                FUNCTION_NAME,
+                FunctionKind.SCALAR,
+                ImmutableList.of(orderableTypeParameter("E")),
+                ImmutableList.of(),
+                parseTypeSignature("array(E)"),
+                ImmutableList.of(parseTypeSignature("array(E)")),
+                false));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySubscriptOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySubscriptOperator.java
@@ -30,6 +30,7 @@ import java.lang.invoke.MethodHandle;
 import static com.facebook.presto.metadata.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -48,7 +49,11 @@ public class ArraySubscriptOperator
 
     protected ArraySubscriptOperator()
     {
-        super(SUBSCRIPT, ImmutableList.of(typeVariable("E")), ImmutableList.of(), "E", ImmutableList.of("array(E)", "bigint"));
+        super(SUBSCRIPT,
+                ImmutableList.of(typeVariable("E")),
+                ImmutableList.of(),
+                parseTypeSignature("E"),
+                ImmutableList.of(parseTypeSignature("array(E)"), parseTypeSignature("bigint")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToArrayCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToArrayCast.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.consta
 import static com.facebook.presto.metadata.OperatorType.CAST;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -58,7 +59,11 @@ public class ArrayToArrayCast
 
     private ArrayToArrayCast()
     {
-        super(CAST, ImmutableList.of(typeVariable("F"), typeVariable("T")), ImmutableList.of(), "array(T)", ImmutableList.of("array(F)"));
+        super(CAST,
+                ImmutableList.of(typeVariable("F"), typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature("array(T)"),
+                ImmutableList.of(parseTypeSignature("array(F)")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToElementConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToElementConcatFunction.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
@@ -25,6 +27,7 @@ import io.airlift.slice.Slice;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public class ArrayToElementConcatFunction
@@ -41,7 +44,13 @@ public class ArrayToElementConcatFunction
 
     public ArrayToElementConcatFunction()
     {
-        super(FUNCTION_NAME, ImmutableList.of(typeVariable("E")), ImmutableList.of(), "array(E)", ImmutableList.of("array(E)", "E"));
+        super(new Signature(FUNCTION_NAME,
+                FunctionKind.SCALAR,
+                ImmutableList.of(typeVariable("E")),
+                ImmutableList.of(),
+                parseTypeSignature("array(E)"),
+                ImmutableList.of(parseTypeSignature("array(E)"), parseTypeSignature("E")),
+                false));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToJsonCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToJsonCast.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -52,7 +53,11 @@ public class ArrayToJsonCast
 
     private ArrayToJsonCast()
     {
-        super(OperatorType.CAST, ImmutableList.of(typeVariable("T")), ImmutableList.of(), StandardTypes.JSON, ImmutableList.of("array(T)"));
+        super(OperatorType.CAST,
+                ImmutableList.of(typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.JSON),
+                ImmutableList.of(parseTypeSignature("array(T)")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/CastFromUnknownOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/CastFromUnknownOperator.java
@@ -26,6 +26,7 @@ import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.OperatorType.CAST;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public final class CastFromUnknownOperator
@@ -40,7 +41,11 @@ public final class CastFromUnknownOperator
 
     public CastFromUnknownOperator()
     {
-        super(CAST, ImmutableList.of(typeVariable("E")), ImmutableList.of(), "E", ImmutableList.of("unknown"));
+        super(CAST,
+                ImmutableList.of(typeVariable("E")),
+                ImmutableList.of(),
+                parseTypeSignature("E"),
+                ImmutableList.of(parseTypeSignature("unknown")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ConcatFunction.java
@@ -23,10 +23,11 @@ import com.facebook.presto.bytecode.Scope;
 import com.facebook.presto.bytecode.Variable;
 import com.facebook.presto.bytecode.expression.BytecodeExpression;
 import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -50,6 +51,7 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.add;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantInt;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.invokeStatic;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.lang.Math.addExact;
@@ -61,7 +63,15 @@ public final class ConcatFunction
 
     public ConcatFunction()
     {
-        super("concat", ImmutableList.of(), ImmutableList.of(), StandardTypes.VARCHAR, ImmutableList.of(StandardTypes.VARCHAR), true);
+        // TODO design new variadic functions binding mechanism that will allow to produce VARCHAR(x) where x < MAX_LENGTH.
+        super(new Signature(
+                "concat",
+                FunctionKind.SCALAR,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                createUnboundedVarcharType().getTypeSignature(),
+                ImmutableList.of(createUnboundedVarcharType().getTypeSignature()),
+                true));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ElementToArrayConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ElementToArrayConcatFunction.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
@@ -25,6 +27,7 @@ import io.airlift.slice.Slice;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public class ElementToArrayConcatFunction
@@ -41,7 +44,14 @@ public class ElementToArrayConcatFunction
 
     public ElementToArrayConcatFunction()
     {
-        super(FUNCTION_NAME, ImmutableList.of(typeVariable("E")), ImmutableList.of(), "array(E)", ImmutableList.of("E", "array(E)"));
+        super(new Signature(
+                FUNCTION_NAME,
+                FunctionKind.SCALAR,
+                ImmutableList.of(typeVariable("E")),
+                ImmutableList.of(),
+                parseTypeSignature("array(E)"),
+                ImmutableList.of(parseTypeSignature("E"), parseTypeSignature("array(E)")),
+                false));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/IdentityCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/IdentityCast.java
@@ -25,6 +25,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class IdentityCast
@@ -34,7 +35,11 @@ public class IdentityCast
 
     protected IdentityCast()
     {
-        super(OperatorType.CAST, ImmutableList.of(typeVariable("T")), ImmutableList.of(), "T", ImmutableList.of("T"));
+        super(OperatorType.CAST,
+                ImmutableList.of(typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature("T"),
+                ImmutableList.of(parseTypeSignature("T")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToArrayCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToArrayCast.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.type.TypeJsonUtils.appendToBlockBuilder;
 import static com.facebook.presto.type.TypeJsonUtils.canCastFromJson;
 import static com.facebook.presto.type.TypeJsonUtils.stackRepresentationToObject;
@@ -50,7 +51,11 @@ public class JsonToArrayCast
 
     private JsonToArrayCast()
     {
-        super(OperatorType.CAST, ImmutableList.of(typeVariable("T")), ImmutableList.of(), "array(T)", ImmutableList.of(StandardTypes.JSON));
+        super(OperatorType.CAST,
+                ImmutableList.of(typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature("array(T)"),
+                ImmutableList.of(parseTypeSignature(StandardTypes.JSON)));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToMapCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToMapCast.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.type.TypeJsonUtils.appendToBlockBuilder;
 import static com.facebook.presto.type.TypeJsonUtils.canCastFromJson;
 import static com.facebook.presto.type.TypeJsonUtils.stackRepresentationToObject;
@@ -52,7 +53,11 @@ public class JsonToMapCast
 
     private JsonToMapCast()
     {
-        super(OperatorType.CAST, ImmutableList.of(comparableTypeParameter("K"), typeVariable("V")), ImmutableList.of(), "map(K,V)", ImmutableList.of(StandardTypes.JSON));
+        super(OperatorType.CAST,
+                ImmutableList.of(comparableTypeParameter("K"), typeVariable("V")),
+                ImmutableList.of(),
+                parseTypeSignature("map(K,V)"),
+                ImmutableList.of(parseTypeSignature(StandardTypes.JSON)));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
@@ -23,6 +25,7 @@ import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.InterleavedBlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.facebook.presto.type.MapType;
 import com.google.common.collect.ImmutableList;
@@ -46,7 +49,14 @@ public final class MapConstructor
 
     public MapConstructor()
     {
-        super("map", ImmutableList.of(comparableTypeParameter("K"), typeVariable("V")), ImmutableList.of(), "map(K,V)", ImmutableList.of("array(K)", "array(V)"));
+        super(new Signature(
+                "map",
+                FunctionKind.SCALAR,
+                ImmutableList.of(comparableTypeParameter("K"), typeVariable("V")),
+                ImmutableList.of(),
+                TypeSignature.parseTypeSignature("map(K,V)"),
+                ImmutableList.of(TypeSignature.parseTypeSignature("array(K)"), TypeSignature.parseTypeSignature("array(V)")),
+                false));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapElementAtFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapElementAtFunction.java
@@ -15,8 +15,10 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.annotation.UsedByGeneratedCode;
 import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.OperatorType;
+import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
@@ -33,6 +35,7 @@ import java.lang.invoke.MethodHandle;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
@@ -49,7 +52,14 @@ public class MapElementAtFunction
 
     protected MapElementAtFunction()
     {
-        super("element_at", ImmutableList.of(typeVariable("K"), typeVariable("V")), ImmutableList.of(), "V", ImmutableList.of("map(K,V)", "K"));
+        super(new Signature(
+                "element_at",
+                FunctionKind.SCALAR,
+                ImmutableList.of(typeVariable("K"), typeVariable("V")),
+                ImmutableList.of(),
+                parseTypeSignature("V"),
+                ImmutableList.of(parseTypeSignature("map(K,V)"), parseTypeSignature("K")),
+                false));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapHashCodeOperator.java
@@ -28,6 +28,7 @@ import static com.facebook.presto.metadata.OperatorType.HASH_CODE;
 import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.type.TypeUtils.hashPosition;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
@@ -39,7 +40,11 @@ public class MapHashCodeOperator
 
     private MapHashCodeOperator()
     {
-        super(HASH_CODE, ImmutableList.of(comparableTypeParameter("K"), comparableTypeParameter("V")), ImmutableList.of(), StandardTypes.BIGINT, ImmutableList.of("map(K,V)"));
+        super(HASH_CODE,
+                ImmutableList.of(comparableTypeParameter("K"), comparableTypeParameter("V")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.BIGINT),
+                ImmutableList.of(parseTypeSignature("map(K,V)")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
@@ -34,6 +34,7 @@ import static com.facebook.presto.metadata.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
@@ -50,7 +51,11 @@ public class MapSubscriptOperator
 
     protected MapSubscriptOperator()
     {
-        super(SUBSCRIPT, ImmutableList.of(typeVariable("K"), typeVariable("V")), ImmutableList.of(), "V", ImmutableList.of("map(K,V)", "K"));
+        super(SUBSCRIPT,
+                ImmutableList.of(typeVariable("K"), typeVariable("V")),
+                ImmutableList.of(),
+                parseTypeSignature("V"),
+                ImmutableList.of(parseTypeSignature("map(K,V)"), parseTypeSignature("K")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToJsonCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToJsonCast.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -56,7 +57,11 @@ public class MapToJsonCast
 
     private MapToJsonCast()
     {
-        super(OperatorType.CAST, ImmutableList.of(typeVariable("K"), typeVariable("V")), ImmutableList.of(), StandardTypes.JSON, ImmutableList.of("map(K,V)"));
+        super(OperatorType.CAST,
+                ImmutableList.of(typeVariable("K"), typeVariable("V")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.JSON),
+                ImmutableList.of(parseTypeSignature("map(K,V)")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowEqualOperator.java
@@ -28,6 +28,7 @@ import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.OperatorType.EQUAL;
 import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public class RowEqualOperator
@@ -38,7 +39,11 @@ public class RowEqualOperator
 
     private RowEqualOperator()
     {
-        super(EQUAL, ImmutableList.of(comparableWithVariadicBound("T", "row")), ImmutableList.of(), StandardTypes.BOOLEAN, ImmutableList.of("T", "T"));
+        super(EQUAL,
+                ImmutableList.of(comparableWithVariadicBound("T", "row")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.BOOLEAN),
+                ImmutableList.of(parseTypeSignature("T"), parseTypeSignature("T")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowHashCodeOperator.java
@@ -28,6 +28,7 @@ import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.OperatorType.HASH_CODE;
 import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public class RowHashCodeOperator
@@ -38,7 +39,11 @@ public class RowHashCodeOperator
 
     private RowHashCodeOperator()
     {
-        super(HASH_CODE, ImmutableList.of(comparableWithVariadicBound("T", "row")), ImmutableList.of(), StandardTypes.BIGINT, ImmutableList.of("T"));
+        super(HASH_CODE,
+                ImmutableList.of(comparableWithVariadicBound("T", "row")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.BIGINT),
+                ImmutableList.of(parseTypeSignature("T")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowNotEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowNotEqualOperator.java
@@ -26,6 +26,7 @@ import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public class RowNotEqualOperator
@@ -36,7 +37,11 @@ public class RowNotEqualOperator
 
     private RowNotEqualOperator()
     {
-        super(NOT_EQUAL, ImmutableList.of(comparableWithVariadicBound("T", "row")), ImmutableList.of(), StandardTypes.BOOLEAN, ImmutableList.of("T", "T"));
+        super(NOT_EQUAL,
+                ImmutableList.of(comparableWithVariadicBound("T", "row")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.BOOLEAN),
+                ImmutableList.of(parseTypeSignature("T"), parseTypeSignature("T")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToJsonCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToJsonCast.java
@@ -40,6 +40,7 @@ import java.util.List;
 
 import static com.facebook.presto.metadata.Signature.withVariadicBound;
 import static com.facebook.presto.operator.scalar.JsonFunctions.getJsonObjectValue;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -52,7 +53,11 @@ public class RowToJsonCast
 
     private RowToJsonCast()
     {
-        super(OperatorType.CAST, ImmutableList.of(withVariadicBound("T", "row")), ImmutableList.of(), StandardTypes.JSON, ImmutableList.of("T"));
+        super(OperatorType.CAST,
+                ImmutableList.of(withVariadicBound("T", "row")),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.JSON),
+                ImmutableList.of(parseTypeSignature("T")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToRowCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToRowCast.java
@@ -58,6 +58,7 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newIns
 import static com.facebook.presto.metadata.OperatorType.CAST;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.withVariadicBound;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.gen.InvokeFunctionBytecodeExpression.invokeFunction;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -70,7 +71,7 @@ public class RowToRowCast
 
     private RowToRowCast()
     {
-        super(CAST, ImmutableList.of(withVariadicBound("F", "row"), withVariadicBound("T", "row")), ImmutableList.of(), "T", ImmutableList.of("F"));
+        super(CAST, ImmutableList.of(withVariadicBound("F", "row"), withVariadicBound("T", "row")), ImmutableList.of(), parseTypeSignature("T"), ImmutableList.of(parseTypeSignature("F")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TryCastFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TryCastFunction.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
@@ -25,6 +26,7 @@ import com.google.common.primitives.Primitives;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static java.lang.invoke.MethodHandles.catchException;
 import static java.lang.invoke.MethodHandles.constant;
@@ -38,7 +40,14 @@ public class TryCastFunction
 
     public TryCastFunction()
     {
-        super("TRY_CAST", ImmutableList.of(typeVariable("F"), typeVariable("T")), ImmutableList.of(), "T", ImmutableList.of("F"));
+        super(new Signature(
+                "TRY_CAST",
+                FunctionKind.SCALAR,
+                ImmutableList.of(typeVariable("F"), typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature("T"),
+                ImmutableList.of(parseTypeSignature("F")),
+                false));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarcharToVarcharCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarcharToVarcharCast.java
@@ -29,6 +29,7 @@ import static com.facebook.presto.metadata.OperatorType.CAST;
 import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.Varchars.truncateToLength;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -42,7 +43,11 @@ public class VarcharToVarcharCast
 
     private VarcharToVarcharCast()
     {
-        super(CAST, ImmutableList.of(comparableWithVariadicBound("F", VARCHAR), comparableWithVariadicBound("T", VARCHAR)), ImmutableList.of(), "T", ImmutableList.of("F"));
+        super(CAST,
+                ImmutableList.of(comparableWithVariadicBound("F", VARCHAR), comparableWithVariadicBound("T", VARCHAR)),
+                ImmutableList.of(),
+                parseTypeSignature("T"),
+                ImmutableList.of(parseTypeSignature("F")));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CountConstantOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CountConstantOptimizer.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static java.util.Objects.requireNonNull;
 
 public class CountConstantOptimizer
@@ -72,7 +73,7 @@ public class CountConstantOptimizer
                     Signature signature = node.getFunctions().get(symbol);
                     if (isCountConstant(projectNode, functionCall, signature)) {
                         aggregations.put(symbol, new FunctionCall(functionCall.getName(), functionCall.isDistinct(), ImmutableList.<Expression>of()));
-                        functions.put(symbol, new Signature("count", AGGREGATE, StandardTypes.BIGINT));
+                        functions.put(symbol, new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT)));
                     }
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAsUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAsUnion.java
@@ -48,6 +48,7 @@ import java.util.function.Function;
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Type.GREATER_THAN_OR_EQUAL;
@@ -96,7 +97,7 @@ public class ImplementIntersectAsUnion
             extends SimplePlanRewriter<Void>
     {
         private static final String INTERSECT_MARKER = "intersect_marker";
-        private static final Signature COUNT_AGGREGATION = new Signature("count", AGGREGATE, "bigint", "boolean");
+        private static final Signature COUNT_AGGREGATION = new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BOOLEAN));
         private final PlanNodeIdAllocator idAllocator;
         private final SymbolAllocator symbolAllocator;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -46,6 +46,7 @@ import java.util.OptionalInt;
 import static com.facebook.presto.metadata.FunctionKind.WINDOW;
 import static com.facebook.presto.spi.predicate.Marker.Bound.BELOW;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.planner.DomainTranslator.ExtractionResult;
 import static com.facebook.presto.sql.planner.DomainTranslator.fromPredicate;
 import static com.facebook.presto.sql.planner.DomainTranslator.toPredicate;
@@ -58,7 +59,7 @@ import static java.util.stream.Collectors.toMap;
 public class WindowFilterPushDown
         implements PlanOptimizer
 {
-    private static final Signature ROW_NUMBER_SIGNATURE = new Signature("row_number", WINDOW, StandardTypes.BIGINT, ImmutableList.<String>of());
+    private static final Signature ROW_NUMBER_SIGNATURE = new Signature("row_number", WINDOW, parseTypeSignature(StandardTypes.BIGINT), ImmutableList.of());
 
     private final Metadata metadata;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/Signatures.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/Signatures.java
@@ -59,7 +59,7 @@ public final class Signatures
     // **************** sql operators ****************
     public static Signature notSignature()
     {
-        return new Signature("not", SCALAR, StandardTypes.BOOLEAN, ImmutableList.of(StandardTypes.BOOLEAN));
+        return new Signature("not", SCALAR, parseTypeSignature(StandardTypes.BOOLEAN), ImmutableList.of(parseTypeSignature(StandardTypes.BOOLEAN)));
     }
 
     public static Signature betweenSignature(Type valueType, Type minType, Type maxType)
@@ -69,12 +69,12 @@ public final class Signatures
 
     public static Signature likeSignature()
     {
-        return internalScalarFunction("LIKE", StandardTypes.BOOLEAN, StandardTypes.VARCHAR, LikePatternType.NAME);
+        return internalScalarFunction("LIKE", parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(LikePatternType.NAME));
     }
 
     public static Signature likePatternSignature()
     {
-        return internalScalarFunction("LIKE_PATTERN", LikePatternType.NAME, StandardTypes.VARCHAR, StandardTypes.VARCHAR);
+        return internalScalarFunction("LIKE_PATTERN", parseTypeSignature(LikePatternType.NAME), parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR));
     }
 
     public static Signature castSignature(Type returnType, Type valueType)
@@ -90,7 +90,7 @@ public final class Signatures
 
     public static Signature logicalExpressionSignature(LogicalBinaryExpression.Type expressionType)
     {
-        return internalScalarFunction(expressionType.name(), StandardTypes.BOOLEAN, StandardTypes.BOOLEAN, StandardTypes.BOOLEAN);
+        return internalScalarFunction(expressionType.name(), parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.BOOLEAN));
     }
 
     public static Signature arithmeticNegationSignature(Type returnType, Type valueType)
@@ -157,7 +157,7 @@ public final class Signatures
     // **************** functions that require varargs and/or complex types (e.g., lists) ****************
     public static Signature inSignature()
     {
-        return internalScalarFunction(IN, StandardTypes.BOOLEAN);
+        return internalScalarFunction(IN, parseTypeSignature(StandardTypes.BOOLEAN));
     }
 
     public static Signature rowConstructorSignature(Type returnType, List<Type> argumentTypes)

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalCasts.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.type.Decimals;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
@@ -52,6 +53,7 @@ import static com.facebook.presto.spi.type.StandardTypes.DOUBLE;
 import static com.facebook.presto.spi.type.StandardTypes.INTEGER;
 import static com.facebook.presto.spi.type.StandardTypes.JSON;
 import static com.facebook.presto.spi.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static com.facebook.presto.util.Types.checkType;
 import static java.lang.Math.multiplyExact;
@@ -80,9 +82,8 @@ public final class DecimalCasts
         Signature signature = Signature.builder()
                 .kind(SCALAR)
                 .operatorType(CAST)
-                .argumentTypes("decimal(precision,scale)")
-                .literalParameters("precision", "scale")
-                .returnType(to)
+                .argumentTypes(parseTypeSignature("decimal(precision,scale)", ImmutableSet.of("precision", "scale")))
+                .returnType(parseTypeSignature(to, ImmutableSet.of("x", "precision", "scale")))
                 .build();
         return SqlScalarFunction.builder(DecimalCasts.class)
                 .signature(signature)
@@ -109,8 +110,8 @@ public final class DecimalCasts
                 .kind(SCALAR)
                 .operatorType(CAST)
                 .typeVariableConstraints(withVariadicBound("X", DECIMAL))
-                .argumentTypes(from)
-                .returnType("X")
+                .argumentTypes(parseTypeSignature(from))
+                .returnType(parseTypeSignature("X"))
                 .build();
         return SqlScalarFunction.builder(DecimalCasts.class)
                 .signature(signature)

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalSaturatedFloorCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalSaturatedFloorCasts.java
@@ -17,6 +17,7 @@ import com.facebook.presto.annotation.UsedByGeneratedCode;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import io.airlift.slice.Slice;
 
@@ -28,6 +29,7 @@ import static com.facebook.presto.metadata.OperatorType.SATURATED_FLOOR_CAST;
 import static com.facebook.presto.spi.type.Decimals.bigIntegerTenToNth;
 import static com.facebook.presto.spi.type.Decimals.decodeUnscaledValue;
 import static com.facebook.presto.spi.type.Decimals.encodeUnscaledValue;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static java.math.BigInteger.ONE;
 import static java.math.RoundingMode.FLOOR;
 
@@ -39,9 +41,8 @@ public final class DecimalSaturatedFloorCasts
             .signature(Signature.builder()
                     .kind(SCALAR)
                     .operatorType(SATURATED_FLOOR_CAST)
-                    .literalParameters("source_precision", "source_scale", "result_precision", "result_scale")
-                    .argumentTypes("decimal(source_precision,source_scale)")
-                    .returnType("decimal(result_precision,result_scale)")
+                    .argumentTypes(parseTypeSignature("decimal(source_precision,source_scale)", ImmutableSet.of("source_precision", "source_scale")))
+                    .returnType(parseTypeSignature("decimal(result_precision,result_scale)", ImmutableSet.of("result_precision", "result_scale")))
                     .build()
             )
             .implementation(b -> b

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalToDecimalCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalToDecimalCasts.java
@@ -35,6 +35,7 @@ import static com.facebook.presto.spi.type.Decimals.encodeUnscaledValue;
 import static com.facebook.presto.spi.type.Decimals.longTenToNth;
 import static com.facebook.presto.spi.type.Decimals.overflows;
 import static com.facebook.presto.spi.type.StandardTypes.DECIMAL;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static java.lang.String.format;
 
 public final class DecimalToDecimalCasts
@@ -43,8 +44,8 @@ public final class DecimalToDecimalCasts
             .kind(SCALAR)
             .operatorType(CAST)
             .typeVariableConstraints(withVariadicBound("F", DECIMAL), withVariadicBound("T", DECIMAL))
-            .argumentTypes("F")
-            .returnType("T")
+            .argumentTypes(parseTypeSignature("F"))
+            .returnType(parseTypeSignature("T"))
             .build();
 
     // TODO: filtering mechanism could be used to return NoOp method when only precision is increased

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestPolymorphicScalarFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestPolymorphicScalarFunction.java
@@ -15,10 +15,12 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
+import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -40,9 +42,8 @@ public class TestPolymorphicScalarFunction
     private static final Signature SIGNATURE = Signature.builder()
             .name("foo")
             .kind(SCALAR)
-            .returnType("bigint")
-            .argumentTypes("varchar(x)")
-            .literalParameters("x")
+            .returnType(parseTypeSignature(StandardTypes.BIGINT))
+            .argumentTypes(parseTypeSignature("varchar(x)", ImmutableSet.of("x")))
             .build();
     private static final long INPUT_VARCHAR_LENGTH = 10;
     private static final String INPUT_VARCHAR_SIGNATURE = "varchar(" + INPUT_VARCHAR_LENGTH + ")";
@@ -131,9 +132,8 @@ public class TestPolymorphicScalarFunction
         Signature signature = Signature.builder()
                 .name("foo")
                 .kind(SCALAR)
-                .returnType("varchar(x)")
-                .argumentTypes("varchar(x)")
-                .literalParameters("x")
+                .returnType(parseTypeSignature("varchar(x)", ImmutableSet.of("x")))
+                .argumentTypes(parseTypeSignature("varchar(x)", ImmutableSet.of("x")))
                 .build();
 
         SqlScalarFunction function = SqlScalarFunction.builder(TestMethods.class)
@@ -154,8 +154,8 @@ public class TestPolymorphicScalarFunction
                 .name("foo")
                 .kind(SCALAR)
                 .typeVariableConstraints(comparableWithVariadicBound("V", VARCHAR))
-                .returnType("V")
-                .argumentTypes("V")
+                .returnType(parseTypeSignature("V"))
+                .argumentTypes(parseTypeSignature("V"))
                 .build();
 
         SqlScalarFunction function = SqlScalarFunction.builder(TestMethods.class)
@@ -174,9 +174,8 @@ public class TestPolymorphicScalarFunction
         Signature signature = Signature.builder()
                 .operatorType(ADD)
                 .kind(SCALAR)
-                .returnType("varchar(x)")
-                .argumentTypes("varchar(x)")
-                .literalParameters("x")
+                .returnType(parseTypeSignature("varchar(x)", ImmutableSet.of("x")))
+                .argumentTypes(parseTypeSignature("varchar(x)", ImmutableSet.of("x")))
                 .build();
 
         SqlScalarFunction function = SqlScalarFunction.builder(TestMethods.class)

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestSignature.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestSignature.java
@@ -26,6 +26,7 @@ import io.airlift.json.ObjectMapperProvider;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static org.testng.Assert.assertEquals;
 
 public class TestSignature
@@ -37,7 +38,11 @@ public class TestSignature
         objectMapperProvider.setJsonDeserializers(ImmutableMap.<Class<?>, JsonDeserializer<?>>of(Type.class, new TypeDeserializer(new TypeRegistry())));
         JsonCodec<Signature> codec = new JsonCodecFactory(objectMapperProvider, true).jsonCodec(Signature.class);
 
-        Signature expected = new Signature("function", SCALAR, StandardTypes.BIGINT, ImmutableList.of(StandardTypes.BOOLEAN, StandardTypes.DOUBLE, StandardTypes.VARCHAR));
+        Signature expected = new Signature(
+                "function",
+                SCALAR,
+                parseTypeSignature(StandardTypes.BIGINT),
+                ImmutableList.of(parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.VARCHAR)));
 
         String json = codec.toJson(expected);
         Signature actual = codec.fromJson(json);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.operator.aggregation.DoubleSumAggregation.DOUB
 import static com.facebook.presto.operator.aggregation.LongSumAggregation.LONG_SUM;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
@@ -74,8 +75,10 @@ public class TestAggregationOperator
             throws Exception
     {
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
-        InternalAggregationFunction countVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("count", AGGREGATE, StandardTypes.BIGINT, StandardTypes.VARCHAR));
-        InternalAggregationFunction maxVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("max", AGGREGATE, StandardTypes.VARCHAR, StandardTypes.VARCHAR));
+        InternalAggregationFunction countVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.VARCHAR)));
+        InternalAggregationFunction maxVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("max", AGGREGATE, parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR)));
         List<Page> input = rowPagesBuilder(VARCHAR, BIGINT, VARCHAR, BIGINT, DOUBLE, VARCHAR)
                 .addSequencePage(100, 0, 0, 300, 500, 500, 500)
                 .build();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -59,6 +59,7 @@ import static com.facebook.presto.spi.block.BlockBuilderStatus.DEFAULT_MAX_BLOCK
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
@@ -104,9 +105,12 @@ public class TestHashAggregationOperator
             throws Exception
     {
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
-        InternalAggregationFunction countVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("count", AGGREGATE, StandardTypes.BIGINT, StandardTypes.VARCHAR));
-        InternalAggregationFunction countBooleanColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("count", AGGREGATE, StandardTypes.BIGINT, StandardTypes.BOOLEAN));
-        InternalAggregationFunction maxVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("max", AGGREGATE, StandardTypes.VARCHAR, StandardTypes.VARCHAR));
+        InternalAggregationFunction countVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.VARCHAR)));
+        InternalAggregationFunction countBooleanColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BOOLEAN)));
+        InternalAggregationFunction maxVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("max", AGGREGATE, parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR)));
         List<Integer> hashChannels = Ints.asList(1);
         RowPagesBuilder rowPagesBuilder = rowPagesBuilder(hashEnabled, hashChannels, VARCHAR, VARCHAR, VARCHAR, BIGINT, BOOLEAN);
         List<Page> input = rowPagesBuilder
@@ -153,7 +157,8 @@ public class TestHashAggregationOperator
     public void testMemoryLimit(boolean hashEnabled)
     {
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
-        InternalAggregationFunction maxVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("max", AGGREGATE, StandardTypes.VARCHAR, StandardTypes.VARCHAR));
+        InternalAggregationFunction maxVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("max", AGGREGATE, parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR)));
 
         List<Integer> hashChannels = Ints.asList(1);
         RowPagesBuilder rowPagesBuilder = rowPagesBuilder(hashEnabled, hashChannels, VARCHAR, VARCHAR, VARCHAR, BIGINT);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArbitraryAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArbitraryAggregation.java
@@ -30,6 +30,7 @@ import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
 import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static org.testng.Assert.assertNotNull;
 
@@ -51,7 +52,8 @@ public class TestArbitraryAggregation
     public void testNullBoolean()
             throws Exception
     {
-        InternalAggregationFunction booleanAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("arbitrary", AGGREGATE, StandardTypes.BOOLEAN, StandardTypes.BOOLEAN));
+        InternalAggregationFunction booleanAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary", AGGREGATE, parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.BOOLEAN)));
         assertAggregation(
                 booleanAgg,
                 1.0,
@@ -63,7 +65,8 @@ public class TestArbitraryAggregation
     public void testValidBoolean()
             throws Exception
     {
-        InternalAggregationFunction booleanAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("arbitrary", AGGREGATE, StandardTypes.BOOLEAN, StandardTypes.BOOLEAN));
+        InternalAggregationFunction booleanAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary", AGGREGATE, parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.BOOLEAN)));
         assertAggregation(
                 booleanAgg,
                 1.0,
@@ -75,7 +78,8 @@ public class TestArbitraryAggregation
     public void testNullLong()
             throws Exception
     {
-        InternalAggregationFunction longAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("arbitrary", AGGREGATE, StandardTypes.BIGINT, StandardTypes.BIGINT));
+        InternalAggregationFunction longAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 longAgg,
                 1.0,
@@ -87,7 +91,8 @@ public class TestArbitraryAggregation
     public void testValidLong()
             throws Exception
     {
-        InternalAggregationFunction longAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("arbitrary", AGGREGATE, StandardTypes.BIGINT, StandardTypes.BIGINT));
+        InternalAggregationFunction longAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 longAgg,
                 1.0,
@@ -99,7 +104,8 @@ public class TestArbitraryAggregation
     public void testNullDouble()
             throws Exception
     {
-        InternalAggregationFunction doubleAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("arbitrary", AGGREGATE, StandardTypes.DOUBLE, StandardTypes.DOUBLE));
+        InternalAggregationFunction doubleAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary", AGGREGATE, parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE)));
         assertAggregation(
                 doubleAgg,
                 1.0,
@@ -111,7 +117,8 @@ public class TestArbitraryAggregation
     public void testValidDouble()
             throws Exception
     {
-        InternalAggregationFunction doubleAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("arbitrary", AGGREGATE, StandardTypes.DOUBLE, StandardTypes.DOUBLE));
+        InternalAggregationFunction doubleAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary", AGGREGATE, parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE)));
         assertAggregation(
                 doubleAgg,
                 1.0,
@@ -123,7 +130,8 @@ public class TestArbitraryAggregation
     public void testNullString()
             throws Exception
     {
-        InternalAggregationFunction stringAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("arbitrary", AGGREGATE, StandardTypes.VARCHAR, StandardTypes.VARCHAR));
+        InternalAggregationFunction stringAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary", AGGREGATE, parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR)));
         assertAggregation(
                 stringAgg,
                 1.0,
@@ -135,7 +143,8 @@ public class TestArbitraryAggregation
     public void testValidString()
             throws Exception
     {
-        InternalAggregationFunction stringAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("arbitrary", AGGREGATE, StandardTypes.VARCHAR, StandardTypes.VARCHAR));
+        InternalAggregationFunction stringAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary", AGGREGATE, parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR)));
         assertAggregation(
                 stringAgg,
                 1.0,
@@ -147,7 +156,8 @@ public class TestArbitraryAggregation
     public void testNullArray()
             throws Exception
     {
-        InternalAggregationFunction arrayAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("arbitrary", AGGREGATE, "array(bigint)", "array(bigint)"));
+        InternalAggregationFunction arrayAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary", AGGREGATE, parseTypeSignature("array(bigint)"), parseTypeSignature("array(bigint)")));
         assertAggregation(
                 arrayAgg,
                 1.0,
@@ -159,7 +169,8 @@ public class TestArbitraryAggregation
     public void testValidArray()
             throws Exception
     {
-        InternalAggregationFunction arrayAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("arbitrary", AGGREGATE, "array(bigint)", "array(bigint)"));
+        InternalAggregationFunction arrayAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary", AGGREGATE, parseTypeSignature("array(bigint)"), parseTypeSignature("array(bigint)")));
         assertAggregation(
                 arrayAgg,
                 1.0,

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayAggregation.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.type.SqlDate;
+import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
@@ -27,6 +28,7 @@ import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
 import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 
 public class TestArrayAggregation
 {
@@ -36,7 +38,8 @@ public class TestArrayAggregation
     public void testEmpty()
             throws Exception
     {
-        InternalAggregationFunction bigIntAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("array_agg", AGGREGATE, "array(bigint)", "bigint"));
+        InternalAggregationFunction bigIntAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("array_agg", AGGREGATE, parseTypeSignature("array(bigint)"), parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 bigIntAgg,
                 1.0,
@@ -48,7 +51,8 @@ public class TestArrayAggregation
     public void testNullOnly()
             throws Exception
     {
-        InternalAggregationFunction bigIntAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("array_agg", AGGREGATE, "array(bigint)", "bigint"));
+        InternalAggregationFunction bigIntAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("array_agg", AGGREGATE, parseTypeSignature("array(bigint)"), parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 bigIntAgg,
                 1.0,
@@ -60,7 +64,8 @@ public class TestArrayAggregation
     public void testNullPartial()
             throws Exception
     {
-        InternalAggregationFunction bigIntAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("array_agg", AGGREGATE, "array(bigint)", "bigint"));
+        InternalAggregationFunction bigIntAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("array_agg", AGGREGATE, parseTypeSignature("array(bigint)"), parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 bigIntAgg,
                 1.0,
@@ -72,7 +77,8 @@ public class TestArrayAggregation
     public void testBoolean()
         throws Exception
     {
-        InternalAggregationFunction booleanAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("array_agg", AGGREGATE, "array(boolean)", "boolean"));
+        InternalAggregationFunction booleanAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("array_agg", AGGREGATE, parseTypeSignature("array(boolean)"), parseTypeSignature(StandardTypes.BOOLEAN)));
         assertAggregation(
                 booleanAgg,
                 1.0,
@@ -84,7 +90,8 @@ public class TestArrayAggregation
     public void testBigInt()
         throws Exception
     {
-        InternalAggregationFunction bigIntAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("array_agg", AGGREGATE, "array(bigint)", "bigint"));
+        InternalAggregationFunction bigIntAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("array_agg", AGGREGATE, parseTypeSignature("array(bigint)"), parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 bigIntAgg,
                 1.0,
@@ -96,7 +103,8 @@ public class TestArrayAggregation
     public void testVarchar()
         throws Exception
     {
-        InternalAggregationFunction varcharAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("array_agg", AGGREGATE, "array(varchar)", "varchar"));
+        InternalAggregationFunction varcharAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("array_agg", AGGREGATE, parseTypeSignature("array(varchar)"), parseTypeSignature(StandardTypes.VARCHAR)));
         assertAggregation(
                 varcharAgg,
                 1.0,
@@ -108,7 +116,8 @@ public class TestArrayAggregation
     public void testDate()
             throws Exception
     {
-        InternalAggregationFunction varcharAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("array_agg", AGGREGATE, "array(date)", "date"));
+        InternalAggregationFunction varcharAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("array_agg", AGGREGATE, parseTypeSignature("array(date)"), parseTypeSignature(StandardTypes.DATE)));
         assertAggregation(
                 varcharAgg,
                 1.0,
@@ -120,7 +129,8 @@ public class TestArrayAggregation
     public void testArray()
             throws Exception
     {
-        InternalAggregationFunction varcharAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("array_agg", AGGREGATE, "array(array(bigint))", "array(bigint)"));
+        InternalAggregationFunction varcharAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("array_agg", AGGREGATE, parseTypeSignature("array(array(bigint))"), parseTypeSignature("array(bigint)")));
 
         assertAggregation(
                 varcharAgg,

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestChecksumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestChecksumAggregation.java
@@ -39,6 +39,7 @@ import static com.facebook.presto.spi.type.StandardTypes.BOOLEAN;
 import static com.facebook.presto.spi.type.StandardTypes.DOUBLE;
 import static com.facebook.presto.spi.type.StandardTypes.VARBINARY;
 import static com.facebook.presto.spi.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static io.airlift.slice.Slices.wrappedLongArray;
 import static java.util.Arrays.asList;
 
@@ -50,7 +51,11 @@ public class TestChecksumAggregation
     public void testEmpty()
             throws Exception
     {
-        InternalAggregationFunction booleanAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("checksum", AGGREGATE, VARBINARY, BOOLEAN));
+        InternalAggregationFunction booleanAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("checksum",
+                        AGGREGATE,
+                        parseTypeSignature(VARBINARY),
+                        parseTypeSignature(BOOLEAN)));
         assertAggregation(booleanAgg, 1.0, null, createBooleansBlock());
     }
 
@@ -58,7 +63,11 @@ public class TestChecksumAggregation
     public void testBoolean()
         throws Exception
     {
-        InternalAggregationFunction booleanAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("checksum", AGGREGATE, VARBINARY, BOOLEAN));
+        InternalAggregationFunction booleanAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("checksum",
+                        AGGREGATE,
+                        parseTypeSignature(VARBINARY),
+                        parseTypeSignature(BOOLEAN)));
         Block block = createBooleansBlock(null, null, true, false, false);
         assertAggregation(booleanAgg, 1.0, expectedChecksum(BooleanType.BOOLEAN, block), block);
     }
@@ -67,7 +76,11 @@ public class TestChecksumAggregation
     public void testLong()
             throws Exception
     {
-        InternalAggregationFunction longAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("checksum", AGGREGATE, VARBINARY, BIGINT));
+        InternalAggregationFunction longAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("checksum",
+                        AGGREGATE,
+                        parseTypeSignature(VARBINARY),
+                        parseTypeSignature(BIGINT)));
         Block block = createLongsBlock(null, 1L, 2L, 100L, null, Long.MAX_VALUE, Long.MIN_VALUE);
         assertAggregation(longAgg, 1.0, expectedChecksum(BigintType.BIGINT, block), block);
     }
@@ -76,7 +89,11 @@ public class TestChecksumAggregation
     public void testDouble()
             throws Exception
     {
-        InternalAggregationFunction doubleAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("checksum", AGGREGATE, VARBINARY, DOUBLE));
+        InternalAggregationFunction doubleAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("checksum",
+                        AGGREGATE,
+                        parseTypeSignature(VARBINARY),
+                        parseTypeSignature(DOUBLE)));
         Block block = createDoublesBlock(null, 2.0, null, 3.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN);
         assertAggregation(doubleAgg, 1.0, expectedChecksum(DoubleType.DOUBLE, block), block);
     }
@@ -85,7 +102,11 @@ public class TestChecksumAggregation
     public void testString()
             throws Exception
     {
-        InternalAggregationFunction stringAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("checksum", AGGREGATE, VARBINARY, VARCHAR));
+        InternalAggregationFunction stringAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("checksum",
+                        AGGREGATE,
+                        parseTypeSignature(VARBINARY),
+                        parseTypeSignature(VARCHAR)));
         Block block = createStringsBlock("a", "a", null, "b", "c");
         assertAggregation(stringAgg, 1.0, expectedChecksum(VarcharType.VARCHAR, block), block);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestHistogram.java
@@ -46,6 +46,7 @@ import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.TimeZoneKey.getTimeZoneKey;
 import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.util.DateTimeZoneIndex.getDateTimeZone;
 import static com.facebook.presto.util.StructuralTestUtil.mapBlockOf;
@@ -61,7 +62,11 @@ public class TestHistogram
             throws Exception
     {
         MapType mapType = new MapType(VARCHAR, BIGINT);
-        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.VARCHAR));
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.VARCHAR)));
         assertAggregation(
                 aggregationFunction,
                 1.0,
@@ -69,7 +74,11 @@ public class TestHistogram
                 createStringsBlock("a", "b", "c"));
 
         mapType = new MapType(BIGINT, BIGINT);
-        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT));
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 aggregationFunction,
                 1.0,
@@ -77,7 +86,11 @@ public class TestHistogram
                 createLongsBlock(100L, 200L, 300L));
 
         mapType = new MapType(DOUBLE, BIGINT);
-        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.DOUBLE));
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.DOUBLE)));
         assertAggregation(
                 aggregationFunction,
                 1.0,
@@ -85,7 +98,11 @@ public class TestHistogram
                 createDoublesBlock(0.1, 0.3, 0.2));
 
         mapType = new MapType(BOOLEAN, BIGINT);
-        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BOOLEAN));
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.BOOLEAN)));
         assertAggregation(
                 aggregationFunction,
                 1.0,
@@ -98,7 +115,11 @@ public class TestHistogram
             throws Exception
     {
         MapType mapType = new MapType(VARCHAR, BIGINT);
-        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.VARCHAR));
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.VARCHAR)));
         assertAggregation(
                 aggregationFunction,
                 1.0,
@@ -106,7 +127,11 @@ public class TestHistogram
                 createStringsBlock("a", "b", "a"));
 
         mapType = new MapType(TIMESTAMP_WITH_TIME_ZONE, BIGINT);
-        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.TIMESTAMP_WITH_TIME_ZONE));
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE)));
         long timestampWithTimeZone1 = packDateTimeWithZone(new DateTime(1970, 1, 1, 0, 0, 0, 0, DATE_TIME_ZONE).getMillis(), TIME_ZONE_KEY);
         long timestampWithTimeZone2 = packDateTimeWithZone(new DateTime(2015, 1, 1, 0, 0, 0, 0, DATE_TIME_ZONE).getMillis(), TIME_ZONE_KEY);
         assertAggregation(
@@ -121,7 +146,11 @@ public class TestHistogram
             throws Exception
     {
         MapType mapType = new MapType(BIGINT, BIGINT);
-        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT));
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 aggregationFunction,
                 1.0,
@@ -129,7 +158,11 @@ public class TestHistogram
                 createLongsBlock(2L, null, 1L));
 
         mapType = new MapType(BIGINT, BIGINT);
-        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.BIGINT));
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 aggregationFunction,
                 1.0,
@@ -143,7 +176,11 @@ public class TestHistogram
     {
         ArrayType arrayType = new ArrayType(VARCHAR);
         MapType mapType = new MapType(arrayType, BIGINT);
-        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), arrayType.getTypeSignature().toString()));
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        arrayType.getTypeSignature()));
 
         assertAggregation(
                 aggregationFunction,
@@ -158,7 +195,11 @@ public class TestHistogram
     {
         MapType innerMapType = new MapType(VARCHAR, VARCHAR);
         MapType mapType = new MapType(innerMapType, BIGINT);
-        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), innerMapType.getTypeSignature().toString()));
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        innerMapType.getTypeSignature()));
 
         BlockBuilder builder = innerMapType.createBlockBuilder(new BlockBuilderStatus(), 3);
         innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("a", "b")));
@@ -178,7 +219,11 @@ public class TestHistogram
     {
         RowType innerRowType = new RowType(ImmutableList.of(BIGINT, DOUBLE), Optional.of(ImmutableList.of("f1", "f2")));
         MapType mapType = new MapType(innerRowType, BIGINT);
-        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), innerRowType.getTypeSignature().toString()));
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        innerRowType.getTypeSignature()));
 
         BlockBuilder builder = innerRowType.createBlockBuilder(new BlockBuilderStatus(), 3);
         innerRowType.writeObject(builder, testRowBigintBigint(1L, 1.0));
@@ -197,7 +242,11 @@ public class TestHistogram
             throws Exception
     {
         MapType mapType = new MapType(VARCHAR, BIGINT);
-        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.VARCHAR));
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.VARCHAR)));
         assertAggregation(
                 aggregationFunction,
                 1.0,

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMapAggAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMapAggAggregation.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.operator.scalar.TestingRowConstructor.testRowI
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.util.StructuralTestUtil.mapBlockOf;
 
@@ -53,7 +54,12 @@ public class TestMapAggAggregation
             throws Exception
     {
         MapType mapType = new MapType(DOUBLE, VARCHAR);
-        InternalAggregationFunction aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.DOUBLE, StandardTypes.VARCHAR));
+        InternalAggregationFunction aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.VARCHAR)));
         assertAggregation(
                 aggFunc,
                 1.0,
@@ -62,7 +68,12 @@ public class TestMapAggAggregation
                 createStringsBlock("a", "b", "c"));
 
         mapType = new MapType(DOUBLE, INTEGER);
-        aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.DOUBLE, StandardTypes.INTEGER));
+        aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.INTEGER)));
         assertAggregation(
                 aggFunc,
                 1.0,
@@ -76,7 +87,12 @@ public class TestMapAggAggregation
             throws Exception
     {
         MapType mapType = new MapType(DOUBLE, VARCHAR);
-        InternalAggregationFunction aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.DOUBLE, StandardTypes.VARCHAR));
+        InternalAggregationFunction aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.VARCHAR)));
         assertAggregation(
                 aggFunc,
                 1.0,
@@ -85,7 +101,12 @@ public class TestMapAggAggregation
                 createStringsBlock("a", "b", "c"));
 
         mapType = new MapType(DOUBLE, INTEGER);
-        aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.DOUBLE, StandardTypes.INTEGER));
+        aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.INTEGER)));
         assertAggregation(
                 aggFunc,
                 1.0,
@@ -94,7 +115,12 @@ public class TestMapAggAggregation
                 createLongsBlock(3, 2, 1));
 
         mapType = new MapType(DOUBLE, BOOLEAN);
-        aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature().toString(), StandardTypes.DOUBLE, StandardTypes.BOOLEAN));
+        aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        mapType.getTypeSignature(),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.BOOLEAN)));
         assertAggregation(
                 aggFunc,
                 1.0,
@@ -107,7 +133,12 @@ public class TestMapAggAggregation
     public void testNull()
             throws Exception
     {
-        InternalAggregationFunction doubleDouble = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, new MapType(DOUBLE, DOUBLE).getTypeSignature().toString(), StandardTypes.DOUBLE, StandardTypes.DOUBLE));
+        InternalAggregationFunction doubleDouble = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature(NAME,
+                        AGGREGATE,
+                        new MapType(DOUBLE, DOUBLE).getTypeSignature(),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.DOUBLE)));
         assertAggregation(
                 doubleDouble,
                 1.0,
@@ -142,9 +173,9 @@ public class TestMapAggAggregation
         MapType mapType = new MapType(DOUBLE, arrayType);
         InternalAggregationFunction aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME,
                                                                                     AGGREGATE,
-                                                                                    mapType.getTypeSignature().toString(),
-                                                                                    StandardTypes.DOUBLE,
-                                                                                    arrayType.getTypeSignature().toString()));
+                                                                                    mapType.getTypeSignature(),
+                                                                                    parseTypeSignature(StandardTypes.DOUBLE),
+                                                                                    arrayType.getTypeSignature()));
 
         assertAggregation(
                 aggFunc,
@@ -164,9 +195,9 @@ public class TestMapAggAggregation
         MapType mapType = new MapType(DOUBLE, innerMapType);
         InternalAggregationFunction aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME,
                 AGGREGATE,
-                mapType.getTypeSignature().toString(),
-                StandardTypes.DOUBLE,
-                innerMapType.getTypeSignature().toString()));
+                mapType.getTypeSignature(),
+                parseTypeSignature(StandardTypes.DOUBLE),
+                innerMapType.getTypeSignature()));
 
         BlockBuilder builder = innerMapType.createBlockBuilder(new BlockBuilderStatus(), 3);
         innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("a", "b")));
@@ -191,9 +222,9 @@ public class TestMapAggAggregation
         MapType mapType = new MapType(DOUBLE, innerRowType);
         InternalAggregationFunction aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME,
                 AGGREGATE,
-                mapType.getTypeSignature().toString(),
-                StandardTypes.DOUBLE,
-                innerRowType.getTypeSignature().toString()));
+                mapType.getTypeSignature(),
+                parseTypeSignature(StandardTypes.DOUBLE),
+                innerRowType.getTypeSignature()));
 
         BlockBuilder builder = innerRowType.createBlockBuilder(new BlockBuilderStatus(), 3);
         innerRowType.writeObject(builder, testRowIntegerInteger(1L, 1.0));
@@ -219,9 +250,9 @@ public class TestMapAggAggregation
         InternalAggregationFunction aggFunc = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(
                 NAME,
                 AGGREGATE,
-                mapType.getTypeSignature().toString(),
-                arrayType.getTypeSignature().toString(),
-                StandardTypes.DOUBLE
+                mapType.getTypeSignature(),
+                arrayType.getTypeSignature(),
+                parseTypeSignature(StandardTypes.DOUBLE)
         ));
 
         assertAggregation(

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMinMaxByAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMinMaxByAggregation.java
@@ -79,7 +79,8 @@ public class TestMinMaxByAggregation
     @Test
     public void testMinNull()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("min_by", AGGREGATE, StandardTypes.DOUBLE, StandardTypes.DOUBLE, StandardTypes.DOUBLE));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("min_by", AGGREGATE, parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE)));
         assertAggregation(
                 function,
                 1.0,
@@ -91,7 +92,8 @@ public class TestMinMaxByAggregation
     @Test
     public void testMaxNull()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("max_by", AGGREGATE, StandardTypes.DOUBLE, StandardTypes.DOUBLE, StandardTypes.DOUBLE));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("max_by", AGGREGATE, parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE)));
         assertAggregation(
                 function,
                 1.0,
@@ -104,7 +106,8 @@ public class TestMinMaxByAggregation
     public void testMinDoubleDouble()
             throws Exception
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("min_by", AGGREGATE, StandardTypes.DOUBLE, StandardTypes.DOUBLE, StandardTypes.DOUBLE));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("min_by", AGGREGATE, parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE)));
         assertAggregation(
                 function,
                 1.0,
@@ -123,7 +126,8 @@ public class TestMinMaxByAggregation
     @Test
     public void testMaxDoubleDouble()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("max_by", AGGREGATE, StandardTypes.DOUBLE, StandardTypes.DOUBLE, StandardTypes.DOUBLE));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("max_by", AGGREGATE, parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE)));
         assertAggregation(
                 function,
                 1.0,
@@ -142,7 +146,8 @@ public class TestMinMaxByAggregation
     @Test
     public void testMinDoubleVarchar()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("min_by", AGGREGATE, StandardTypes.VARCHAR, StandardTypes.VARCHAR, StandardTypes.DOUBLE));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("min_by", AGGREGATE, parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.DOUBLE)));
         assertAggregation(
                 function,
                 1.0,
@@ -161,7 +166,8 @@ public class TestMinMaxByAggregation
     @Test
     public void testMaxDoubleVarchar()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("max_by", AGGREGATE, StandardTypes.VARCHAR, StandardTypes.VARCHAR, StandardTypes.DOUBLE));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("max_by", AGGREGATE, parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.DOUBLE)));
         assertAggregation(
                 function,
                 1.0,
@@ -180,7 +186,8 @@ public class TestMinMaxByAggregation
     @Test
     public void testMinLongLongArray()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("min_by", AGGREGATE, "array(bigint)", "array(bigint)", StandardTypes.BIGINT));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("min_by", AGGREGATE, parseTypeSignature("array(bigint)"), parseTypeSignature("array(bigint)"), parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 function,
                 1.0,
@@ -199,7 +206,8 @@ public class TestMinMaxByAggregation
     @Test
     public void testMaxLongLongArray()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("max_by", AGGREGATE, "array(bigint)", "array(bigint)", StandardTypes.BIGINT));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("max_by", AGGREGATE, parseTypeSignature("array(bigint)"), parseTypeSignature("array(bigint)"), parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 function,
                 1.0,

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMinMaxByNAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMinMaxByNAggregation.java
@@ -27,6 +27,7 @@ import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
 import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 
 public class TestMinMaxByNAggregation
 {
@@ -36,7 +37,13 @@ public class TestMinMaxByNAggregation
     public void testMaxDoubleDouble()
             throws Exception
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("max_by", AGGREGATE, "array(double)", StandardTypes.DOUBLE, StandardTypes.DOUBLE, StandardTypes.BIGINT));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("max_by",
+                        AGGREGATE,
+                        parseTypeSignature("array(double)"),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 function,
                 1.0,
@@ -98,7 +105,13 @@ public class TestMinMaxByNAggregation
     public void testMinDoubleDouble()
             throws Exception
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("min_by", AGGREGATE, "array(double)", StandardTypes.DOUBLE, StandardTypes.DOUBLE, StandardTypes.BIGINT));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("min_by",
+                        AGGREGATE,
+                        parseTypeSignature("array(double)"),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 function,
                 1.0,
@@ -135,7 +148,13 @@ public class TestMinMaxByNAggregation
     @Test
     public void testMinDoubleVarchar()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("min_by", AGGREGATE, "array(varchar)", StandardTypes.VARCHAR, StandardTypes.DOUBLE, StandardTypes.BIGINT));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("min_by",
+                        AGGREGATE,
+                        parseTypeSignature("array(varchar)"),
+                        parseTypeSignature(StandardTypes.VARCHAR),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 function,
                 1.0,
@@ -164,7 +183,13 @@ public class TestMinMaxByNAggregation
     @Test
     public void testMaxDoubleVarchar()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("max_by", AGGREGATE, "array(varchar)", StandardTypes.VARCHAR, StandardTypes.DOUBLE, StandardTypes.BIGINT));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("max_by",
+                        AGGREGATE,
+                        parseTypeSignature("array(varchar)"),
+                        parseTypeSignature(StandardTypes.VARCHAR),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 function,
                 1.0,
@@ -193,7 +218,13 @@ public class TestMinMaxByNAggregation
     @Test
     public void testMinVarcharDouble()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("min_by", AGGREGATE, "array(double)", StandardTypes.DOUBLE, StandardTypes.VARCHAR, StandardTypes.BIGINT));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("min_by",
+                        AGGREGATE,
+                        parseTypeSignature("array(double)"),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.VARCHAR),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 function,
                 1.0,
@@ -222,7 +253,13 @@ public class TestMinMaxByNAggregation
     @Test
     public void testMaxVarcharDouble()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("max_by", AGGREGATE, "array(double)", StandardTypes.DOUBLE, StandardTypes.VARCHAR, StandardTypes.BIGINT));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("max_by",
+                        AGGREGATE,
+                        parseTypeSignature("array(double)"),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.VARCHAR),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 function,
                 1.0,
@@ -251,7 +288,13 @@ public class TestMinMaxByNAggregation
     @Test
     public void testMinVarcharArray()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("min_by", AGGREGATE, "array(array(bigint))", "array(bigint)", StandardTypes.VARCHAR, StandardTypes.BIGINT));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("min_by",
+                        AGGREGATE,
+                        parseTypeSignature("array(array(bigint))"),
+                        parseTypeSignature("array(bigint)"),
+                        parseTypeSignature(StandardTypes.VARCHAR),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 function,
                 1.0,
@@ -264,7 +307,13 @@ public class TestMinMaxByNAggregation
     @Test
     public void testMaxVarcharArray()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("max_by", AGGREGATE, "array(array(bigint))", "array(bigint)", StandardTypes.VARCHAR, StandardTypes.BIGINT));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("max_by",
+                        AGGREGATE,
+                        parseTypeSignature("array(array(bigint))"),
+                        parseTypeSignature("array(bigint)"),
+                        parseTypeSignature(StandardTypes.VARCHAR),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 function,
                 1.0,
@@ -277,7 +326,13 @@ public class TestMinMaxByNAggregation
     @Test
     public void testMinArrayVarchar()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("min_by", AGGREGATE, "array(varchar)", StandardTypes.VARCHAR, "array(bigint)", StandardTypes.BIGINT));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("min_by",
+                        AGGREGATE,
+                        parseTypeSignature("array(varchar)"),
+                        parseTypeSignature(StandardTypes.VARCHAR),
+                        parseTypeSignature("array(bigint)"),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 function,
                 1.0,
@@ -290,7 +345,13 @@ public class TestMinMaxByNAggregation
     @Test
     public void testMaxArrayVarchar()
     {
-        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("max_by", AGGREGATE, "array(varchar)", StandardTypes.VARCHAR, "array(bigint)", StandardTypes.BIGINT));
+        InternalAggregationFunction function = METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("max_by",
+                        AGGREGATE,
+                        parseTypeSignature("array(varchar)"),
+                        parseTypeSignature(StandardTypes.VARCHAR),
+                        parseTypeSignature("array(bigint)"),
+                        parseTypeSignature(StandardTypes.BIGINT)));
         assertAggregation(
                 function,
                 1.0,

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestNumericHistogramAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestNumericHistogramAggregation.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.operator.aggregation.AggregationTestUtils.getF
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.getIntermediateBlock;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -48,7 +49,13 @@ public class TestNumericHistogramAggregation
     {
         TypeRegistry typeRegistry = new TypeRegistry();
         FunctionRegistry functionRegistry = new FunctionRegistry(typeRegistry, new BlockEncodingManager(typeRegistry), true);
-        InternalAggregationFunction function = functionRegistry.getAggregateFunctionImplementation(new Signature("numeric_histogram", AGGREGATE, "map(double,double)", StandardTypes.BIGINT, StandardTypes.DOUBLE, StandardTypes.DOUBLE));
+        InternalAggregationFunction function = functionRegistry.getAggregateFunctionImplementation(
+                new Signature("numeric_histogram",
+                        AGGREGATE,
+                        parseTypeSignature("map(double,double)"),
+                        parseTypeSignature(StandardTypes.BIGINT),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.DOUBLE)));
         factory = function.bind(ImmutableList.of(0, 1, 2), Optional.empty(), Optional.empty(), 1.0);
 
         input = makeInput(10);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPageProcessorCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPageProcessorCompiler.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.block.SliceArrayBlock;
+import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.relational.CallExpression;
 import com.facebook.presto.sql.relational.ConstantExpression;
@@ -41,6 +42,7 @@ import static com.facebook.presto.metadata.OperatorType.LESS_THAN;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static io.airlift.slice.Slices.wrappedIntArray;
 import static java.lang.Boolean.TRUE;
@@ -96,7 +98,8 @@ public class TestPageProcessorCompiler
     public void testSanityFilterOnDictionary()
             throws Exception
     {
-        CallExpression lengthVarchar = new CallExpression(new Signature("length", SCALAR, "bigint", "varchar"), BIGINT, ImmutableList.of(new InputReferenceExpression(0, VARCHAR)));
+        CallExpression lengthVarchar = new CallExpression(
+                new Signature("length", SCALAR, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.VARCHAR)), BIGINT, ImmutableList.of(new InputReferenceExpression(0, VARCHAR)));
         Signature lessThan = internalOperator(LESS_THAN, BOOLEAN, ImmutableList.of(BIGINT, BIGINT));
         CallExpression filter = new CallExpression(lessThan, BOOLEAN, ImmutableList.of(lengthVarchar, new ConstantExpression(10L, BIGINT)));
 
@@ -164,7 +167,8 @@ public class TestPageProcessorCompiler
             throws Exception
     {
         Signature lessThan = internalOperator(LESS_THAN, BOOLEAN, ImmutableList.of(BIGINT, BIGINT));
-        CallExpression random = new CallExpression(new Signature("random", SCALAR, "bigint", "bigint"), BIGINT, singletonList(new ConstantExpression(10L, BIGINT)));
+        CallExpression random = new CallExpression(
+                new Signature("random", SCALAR, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BIGINT)), BIGINT, singletonList(new ConstantExpression(10L, BIGINT)));
         InputReferenceExpression col0 = new InputReferenceExpression(0, BIGINT);
         CallExpression lessThanRandomExpression = new CallExpression(lessThan, BOOLEAN, ImmutableList.of(col0, random));
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/BenchmarkPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/BenchmarkPageProcessor.java
@@ -50,6 +50,7 @@ import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
@@ -194,37 +195,37 @@ public class BenchmarkPageProcessor
     //    and discount >= 0.05
     //    and discount <= 0.07
     //    and quantity < 24;
-    private static final RowExpression FILTER = call(new Signature("AND", SCALAR, StandardTypes.BOOLEAN),
+    private static final RowExpression FILTER = call(new Signature("AND", SCALAR, parseTypeSignature(StandardTypes.BOOLEAN)),
             BOOLEAN,
-            call(new Signature(OperatorType.GREATER_THAN_OR_EQUAL.name(), SCALAR, StandardTypes.BOOLEAN, StandardTypes.VARCHAR, StandardTypes.VARCHAR),
+            call(new Signature(OperatorType.GREATER_THAN_OR_EQUAL.name(), SCALAR, parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR)),
                     BOOLEAN,
                     field(SHIP_DATE, VARCHAR),
                     constant(MIN_SHIP_DATE, VARCHAR)),
-            call(new Signature("AND", SCALAR, StandardTypes.BOOLEAN),
+            call(new Signature("AND", SCALAR, parseTypeSignature(StandardTypes.BOOLEAN)),
                     BOOLEAN,
-                    call(new Signature(OperatorType.LESS_THAN.name(), SCALAR, StandardTypes.BOOLEAN, StandardTypes.VARCHAR, StandardTypes.VARCHAR),
+                    call(new Signature(OperatorType.LESS_THAN.name(), SCALAR, parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR)),
                             BOOLEAN,
                             field(SHIP_DATE, VARCHAR),
                             constant(MAX_SHIP_DATE, VARCHAR)),
-                    call(new Signature("AND", SCALAR, StandardTypes.BOOLEAN),
+                    call(new Signature("AND", SCALAR, parseTypeSignature(StandardTypes.BOOLEAN)),
                             BOOLEAN,
-                            call(new Signature(OperatorType.GREATER_THAN_OR_EQUAL.name(), SCALAR, StandardTypes.BOOLEAN, StandardTypes.DOUBLE, StandardTypes.DOUBLE),
+                            call(new Signature(OperatorType.GREATER_THAN_OR_EQUAL.name(), SCALAR, parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE)),
                                     BOOLEAN,
                                     field(DISCOUNT, DOUBLE),
                                     constant(0.05, DOUBLE)),
-                            call(new Signature("AND", SCALAR, StandardTypes.BOOLEAN),
+                            call(new Signature("AND", SCALAR, parseTypeSignature(StandardTypes.BOOLEAN)),
                                     BOOLEAN,
-                                    call(new Signature(OperatorType.LESS_THAN_OR_EQUAL.name(), SCALAR, StandardTypes.BOOLEAN, StandardTypes.DOUBLE, StandardTypes.DOUBLE),
+                                    call(new Signature(OperatorType.LESS_THAN_OR_EQUAL.name(), SCALAR, parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE)),
                                             BOOLEAN,
                                             field(DISCOUNT, DOUBLE),
                                             constant(0.07, DOUBLE)),
-                                    call(new Signature(OperatorType.LESS_THAN.name(), SCALAR, StandardTypes.BOOLEAN, StandardTypes.DOUBLE, StandardTypes.DOUBLE),
+                                    call(new Signature(OperatorType.LESS_THAN.name(), SCALAR, parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE)),
                                             BOOLEAN,
                                             field(QUANTITY, DOUBLE),
                                             constant((long) 24, DOUBLE))))));
 
     private static final RowExpression PROJECT = call(
-            new Signature(OperatorType.MULTIPLY.name(), SCALAR, StandardTypes.DOUBLE, StandardTypes.DOUBLE, StandardTypes.DOUBLE),
+            new Signature(OperatorType.MULTIPLY.name(), SCALAR, parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE)),
             DOUBLE,
             field(EXTENDED_PRICE, DOUBLE),
             field(DISCOUNT, DOUBLE));

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/InCodeGeneratorBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/InCodeGeneratorBenchmark.java
@@ -46,6 +46,7 @@ import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
@@ -123,7 +124,7 @@ public class InCodeGeneratorBenchmark
         inputPage = pageBuilder.build();
 
         RowExpression filter = call(
-                new Signature(IN, SCALAR, StandardTypes.BOOLEAN),
+                new Signature(IN, SCALAR, parseTypeSignature(StandardTypes.BOOLEAN)),
                 BOOLEAN,
                 arguments);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestInCodeGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestInCodeGenerator.java
@@ -54,8 +54,8 @@ public class TestInCodeGenerator
                 new Signature(
                         CAST,
                         SCALAR,
-                        INTEGER.getDisplayName(),
-                        DOUBLE.getDisplayName()
+                        INTEGER.getTypeSignature(),
+                        DOUBLE.getTypeSignature()
                 ),
                 INTEGER,
                 Collections.singletonList(new ConstantExpression(12345678901234.0, DOUBLE))
@@ -86,8 +86,8 @@ public class TestInCodeGenerator
                 new Signature(
                         CAST,
                         SCALAR,
-                        BIGINT.getDisplayName(),
-                        DOUBLE.getDisplayName()
+                        BIGINT.getTypeSignature(),
+                        DOUBLE.getTypeSignature()
                 ),
                 BIGINT,
                 Collections.singletonList(new ConstantExpression(12345678901234.0, DOUBLE))

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -724,7 +725,7 @@ public class TestEffectivePredicateExtractor
 
     private static Signature fakeFunctionHandle(String name, FunctionKind kind)
     {
-        return new Signature(name, kind, UnknownType.NAME, ImmutableList.<String>of());
+        return new Signature(name, kind, TypeSignature.parseTypeSignature(UnknownType.NAME), ImmutableList.<TypeSignature>of());
     }
 
     private Set<Expression> normalizeConjuncts(Expression... conjuncts)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCountConstantOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCountConstantOptimizer.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
@@ -33,6 +34,7 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -45,7 +47,7 @@ public class TestCountConstantOptimizer
         CountConstantOptimizer optimizer = new CountConstantOptimizer();
         PlanNodeIdAllocator planNodeIdAllocator = new PlanNodeIdAllocator();
         Symbol countAggregationSymbol = new Symbol("count");
-        Signature countAggregationSignature = new Signature("count", FunctionKind.AGGREGATE, "bigint", "bigint");
+        Signature countAggregationSignature = new Signature("count", FunctionKind.AGGREGATE, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BIGINT));
         ImmutableMap<Symbol, FunctionCall> aggregations = ImmutableMap.of(countAggregationSymbol, new FunctionCall(QualifiedName.of("count"), ImmutableList.of(new QualifiedNameReference(QualifiedName.of("expr")))));
         ImmutableMap<Symbol, Signature> functions = ImmutableMap.of(countAggregationSymbol, countAggregationSignature);
         ValuesNode valuesNode = new ValuesNode(planNodeIdAllocator.getNextId(), ImmutableList.of(new Symbol("col")), ImmutableList.of(ImmutableList.of()));

--- a/presto-main/src/test/java/com/facebook/presto/sql/relational/TestDeterminismEvaluator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/relational/TestDeterminismEvaluator.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.relational;
 
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
@@ -23,6 +24,7 @@ import static com.facebook.presto.metadata.OperatorType.LESS_THAN;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static java.util.Collections.singletonList;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -35,7 +37,14 @@ public class TestDeterminismEvaluator
     {
         DeterminismEvaluator determinismEvaluator = new DeterminismEvaluator(createTestMetadataManager().getFunctionRegistry());
 
-        CallExpression random = new CallExpression(new Signature("random", SCALAR, "bigint", "bigint"), BIGINT, singletonList(new ConstantExpression(10L, BIGINT)));
+        CallExpression random = new CallExpression(
+                new Signature(
+                        "random",
+                        SCALAR,
+                        parseTypeSignature(StandardTypes.BIGINT),
+                        parseTypeSignature(StandardTypes.BIGINT)),
+                BIGINT,
+                singletonList(new ConstantExpression(10L, BIGINT)));
         assertFalse(determinismEvaluator.isDeterministic(random));
 
         InputReferenceExpression col0 = new InputReferenceExpression(0, BIGINT);

--- a/presto-ml/src/test/java/com/facebook/presto/ml/TestEvaluateClassifierPredictions.java
+++ b/presto-ml/src/test/java/com/facebook/presto/ml/TestEvaluateClassifierPredictions.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static org.testng.Assert.assertEquals;
 
@@ -54,7 +55,10 @@ public class TestEvaluateClassifierPredictions
         typeRegistry.addType(RegressorType.REGRESSOR);
         typeRegistry.addType(ModelType.MODEL);
         metadata.addFunctions(new MLFunctionFactory(typeRegistry).listFunctions());
-        InternalAggregationFunction aggregation = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("evaluate_classifier_predictions", AGGREGATE, StandardTypes.VARCHAR, StandardTypes.BIGINT, StandardTypes.BIGINT));
+        InternalAggregationFunction aggregation = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("evaluate_classifier_predictions",
+                        AGGREGATE,
+                        parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BIGINT)));
         Accumulator accumulator = aggregation.bind(ImmutableList.of(0, 1), Optional.empty(), Optional.empty(), 1.0).createAccumulator();
         accumulator.addInput(getPage());
         BlockBuilder finalOut = accumulator.getFinalType().createBlockBuilder(new BlockBuilderStatus(), 1);


### PR DESCRIPTION
The general purpose of this change is to clean up type consistency around Functions.
Included commits do two basic things:

1. Avoid using parts of Signature as SqlScalarFunction constructor arguments. Instead only one constructor obtaining single argument (Signature) is available for the user. This makes code more consistent, relief SqlScalarFunction constructors from the responsibility of being Singature factory and keeps semantic of what is passed around this code clean
2. Avoid using Strings instead of TypeSignatures in Signature type. The Signature type had responsibility of translating Strings into TypeSignatures, this was moved outside of this class, and all constructors allowing to pass types as Strings + LiteralParameters where removed. This decreases scope of this class, allows to use better defined semantic and avoid passing LiteralParamterers through the code.

The further step would be to continue same strategy for rest of SqlFunction's.

**If it is possible, please try to response quickly (even with just letting me know that those changes are not welcome), as this refactoring will be expensive to rebase. Thanks in advance :-)**