### PR TITLE
[WIP] Fix grouping on aggregation arguments

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -64,12 +64,14 @@ import com.google.common.collect.Iterables;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -372,11 +374,63 @@ class QueryPlanner
         }
 
         // 2. Aggregate
+
+        // 2.a. Rewrite group by expressions in terms of pre-projected inputs
+        TranslationMap translations = new TranslationMap(subPlan.getRelationPlan(), analysis);
+        ImmutableList.Builder<List<Symbol>> groupingSetsSymbolsBuilder = ImmutableList.builder();
+        ImmutableSet.Builder<Symbol> distinctGroupingSymbolsBuilder = ImmutableSet.builder();
+        for (List<Expression> groupingSet : groupingSets) {
+            ImmutableList.Builder<Symbol> groupingColumns = ImmutableList.builder();
+            for (Expression expression : groupingSet) {
+                Symbol symbol = subPlan.translate(expression);
+                groupingColumns.add(symbol);
+                distinctGroupingSymbolsBuilder.add(symbol);
+                translations.put(expression, symbol);
+            }
+            groupingSetsSymbolsBuilder.add(groupingColumns.build());
+        }
+
+        // 2.b. Find aggregation arguments are grouping columns, because they need to be passed through
+        Set<Expression> passthroughAggregationArguments = new HashSet<>();
+        Set<Expression> rewrittenGroupingColumns = distinctGroupingColumns.stream()
+                .map(subPlan::rewrite)
+                .collect(Collectors.toSet());
+
+        ImmutableList.Builder<Symbol> groupIdInputSymbols = ImmutableList.<Symbol>builder()
+                .addAll(distinctGroupingColumns.stream()
+                        .map(subPlan::translate)
+                        .collect(Collectors.toList()));
+
+        for (Expression aggregationArgument : arguments) {
+            if (rewrittenGroupingColumns.contains(subPlan.rewrite(aggregationArgument))) {
+                passthroughAggregationArguments.add(aggregationArgument);
+            }
+            else {
+                groupIdInputSymbols.add(subPlan.translate(aggregationArgument));
+            }
+        }
+
+        // 2.c. Add a groupIdNode and groupIdSymbol if there are multiple grouping sets
+        List<List<Symbol>> groupingSetsSymbols = groupingSetsSymbolsBuilder.build();
+        if (groupingSets.size() > 1) {
+            ImmutableMap.Builder<Symbol, Symbol> passthroughSymbolMap = ImmutableMap.builder();
+            for (Expression passthroughAggregationArgument : passthroughAggregationArguments) {
+                Symbol passthroughSymbol = symbolAllocator.newSymbol(passthroughAggregationArgument, analysis.getTypeWithCoercions(passthroughAggregationArgument), "passthrough");
+                passthroughSymbolMap.put(subPlan.translate(passthroughAggregationArgument), passthroughSymbol);
+
+                // relies on the fact that group by expressions have already been re-written, and will not be affected by this mapping change
+                subPlan.getTranslations().put(passthroughAggregationArgument, passthroughSymbol);
+            }
+
+            Symbol groupIdSymbol = symbolAllocator.newSymbol("groupId", BIGINT);
+            GroupIdNode groupId = new GroupIdNode(idAllocator.getNextId(), subPlan.getRoot(), groupIdInputSymbols.build(), groupingSetsSymbols, passthroughSymbolMap.build(), groupIdSymbol);
+            subPlan = subPlan.withNewRoot(groupId);
+            distinctGroupingSymbolsBuilder.add(groupIdSymbol);
+        }
+
+        // 2.d. Rewrite aggregates in terms of pre-projected inputs
         ImmutableMap.Builder<Symbol, FunctionCall> aggregationAssignments = ImmutableMap.builder();
         ImmutableMap.Builder<Symbol, Signature> functions = ImmutableMap.builder();
-
-        // 2.a. Rewrite aggregates in terms of pre-projected inputs
-        TranslationMap translations = new TranslationMap(subPlan.getRelationPlan(), analysis);
         boolean needPostProjectionCoercion = false;
         for (FunctionCall aggregate : analysis.getAggregates(node)) {
             Expression rewritten = subPlan.rewrite(aggregate);
@@ -394,31 +448,7 @@ class QueryPlanner
             functions.put(newSymbol, analysis.getFunctionSignature(aggregate));
         }
 
-        // 2.b. Rewrite group by expressions in terms of pre-projected inputs
-        ImmutableList.Builder<List<Symbol>> groupingSetsSymbolsBuilder = ImmutableList.builder();
-        ImmutableSet.Builder<Symbol> distinctGroupingSymbolsBuilder = ImmutableSet.builder();
-        for (List<Expression> groupingSet : groupingSets) {
-            ImmutableList.Builder<Symbol> groupingColumns = ImmutableList.builder();
-            for (Expression expression : groupingSet) {
-                Symbol symbol = subPlan.translate(expression);
-                groupingColumns.add(symbol);
-                distinctGroupingSymbolsBuilder.add(symbol);
-                translations.put(expression, symbol);
-            }
-            groupingSetsSymbolsBuilder.add(groupingColumns.build());
-        }
-
-        List<List<Symbol>> groupingSetsSymbols = groupingSetsSymbolsBuilder.build();
-        // 2.c. Add a groupIdNode and groupIdSymbol if there are multiple grouping sets
-        if (groupingSets.size() > 1) {
-            Symbol groupIdSymbol = symbolAllocator.newSymbol("groupId", BIGINT);
-            GroupIdNode groupId = new GroupIdNode(idAllocator.getNextId(), subPlan.getRoot(), subPlan.getRoot().getOutputSymbols(), groupingSetsSymbols, groupIdSymbol);
-            subPlan = subPlan.withNewRoot(groupId);
-            distinctGroupingSymbolsBuilder.add(groupIdSymbol);
-        }
-        List<Symbol> distinctGroupingSymbols = distinctGroupingSymbolsBuilder.build().asList();
-
-        // 2.d. Mark distinct rows for each aggregate that has DISTINCT
+        // 2.e. Mark distinct rows for each aggregate that has DISTINCT
         // Map from aggregate function arguments to marker symbols, so that we can reuse the markers, if two aggregates have the same argument
         Map<Set<Expression>, Symbol> argumentMarkers = new HashMap<>();
         // Map from aggregate functions to marker symbols
@@ -440,6 +470,7 @@ class QueryPlanner
             masks.put(aggregateSymbol, marker);
         }
 
+        List<Symbol> distinctGroupingSymbols = distinctGroupingSymbolsBuilder.build().asList();
         for (Map.Entry<Set<Expression>, Symbol> entry : argumentMarkers.entrySet()) {
             ImmutableList.Builder<Symbol> builder = ImmutableList.builder();
             builder.addAll(distinctGroupingSymbols);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolExtractor.java
@@ -113,6 +113,7 @@ public final class SymbolExtractor
             node.getSource().accept(this, context);
 
             builder.add(node.getGroupIdSymbol());
+            builder.addAll(node.getPassthroughSymbolMap().values());
 
             return null;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -404,13 +404,11 @@ public class PruneUnreferencedOutputs
         public PlanNode visitGroupId(GroupIdNode node, RewriteContext<Set<Symbol>> context)
         {
             checkState(node.getDistinctGroupingColumns().stream().allMatch(column -> context.get().contains(column)));
+            checkState(node.getPassthroughSymbolMap().keySet().stream().allMatch(column -> context.get().contains(column)));
 
             PlanNode source = context.rewrite(node.getSource(), ImmutableSet.copyOf(context.get()));
-            List<Symbol> requiredSymbols = context.get().stream()
-                    .filter(symbol -> !symbol.equals(node.getGroupIdSymbol()))
-                    .collect(toImmutableList());
 
-            return new GroupIdNode(node.getId(), source, requiredSymbols, node.getGroupingSets(), node.getGroupIdSymbol());
+            return new GroupIdNode(node.getId(), source, node.getInputSymbols(), node.getGroupingSets(), node.getPassthroughSymbolMap(), node.getGroupIdSymbol());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -162,7 +162,12 @@ public class UnaliasSymbolReferences
                     .map(this::canonicalize)
                     .collect(Collectors.toList());
 
-            return new GroupIdNode(node.getId(), source, canonicalize(node.getInputSymbols()), groupingSetsSymbols, canonicalize(node.getGroupIdSymbol()));
+            ImmutableMap.Builder<Symbol, Symbol> newPassthroughMap = ImmutableMap.builder();
+            for (Symbol inputSymbol : node.getPassthroughSymbolMap().keySet()) {
+                newPassthroughMap.put(canonicalize(inputSymbol), canonicalize(node.getPassthroughSymbolMap().get(inputSymbol)));
+            }
+
+            return new GroupIdNode(node.getId(), source, canonicalize(node.getInputSymbols()), groupingSetsSymbols, newPassthroughMap.build(), canonicalize(node.getGroupIdSymbol()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
@@ -174,7 +174,7 @@ public class ChildReplacer
     @Override
     public PlanNode visitGroupId(GroupIdNode node, List<PlanNode> newChildren)
     {
-        return new GroupIdNode(node.getId(), Iterables.getOnlyElement(newChildren), node.getInputSymbols(), node.getGroupingSets(), node.getGroupIdSymbol());
+        return new GroupIdNode(node.getId(), Iterables.getOnlyElement(newChildren), node.getInputSymbols(), node.getGroupingSets(), node.getPassthroughSymbolMap(), node.getGroupIdSymbol());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/GroupIdNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/GroupIdNode.java
@@ -17,12 +17,14 @@ import com.facebook.presto.sql.planner.Symbol;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.concurrent.Immutable;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -35,6 +37,7 @@ public class GroupIdNode
     private final PlanNode source;
     private final List<Symbol> inputSymbols;
     private final List<List<Symbol>> groupingSets;
+    private final Map<Symbol, Symbol> passthroughSymbolMap;
     private final Symbol groupIdSymbol;
 
     @JsonCreator
@@ -42,12 +45,14 @@ public class GroupIdNode
             @JsonProperty("source") PlanNode source,
             @JsonProperty("inputSymbols") List<Symbol> inputSymbols,
             @JsonProperty("groupingSets") List<List<Symbol>> groupingSets,
+            @JsonProperty("passthroughSymbolMap") Map<Symbol, Symbol> passthroughSymbolMap,
             @JsonProperty("groupIdSymbol") Symbol groupIdSymbol)
     {
         super(id);
         this.source = requireNonNull(source);
         this.inputSymbols = ImmutableList.copyOf(requireNonNull(inputSymbols));
         this.groupingSets = ImmutableList.copyOf(requireNonNull(groupingSets));
+        this.passthroughSymbolMap = ImmutableMap.copyOf(requireNonNull(passthroughSymbolMap));
         this.groupIdSymbol = requireNonNull(groupIdSymbol);
     }
 
@@ -56,6 +61,7 @@ public class GroupIdNode
     {
         return ImmutableList.<Symbol>builder()
                 .addAll(source.getOutputSymbols())
+                .addAll(passthroughSymbolMap.values())
                 .add(groupIdSymbol)
                 .build();
     }
@@ -82,6 +88,12 @@ public class GroupIdNode
     public List<List<Symbol>> getGroupingSets()
     {
         return groupingSets;
+    }
+
+    @JsonProperty
+    public Map<Symbol, Symbol> getPassthroughSymbolMap()
+    {
+        return passthroughSymbolMap;
     }
 
     public List<Symbol> getDistinctGroupingColumns()

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestGroupIdOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestGroupIdOperator.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.MaterializedResult;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -71,23 +72,28 @@ public class TestGroupIdOperator
                 .build();
 
         GroupIdOperatorFactory operatorFactory =
-                new GroupIdOperatorFactory(0, new PlanNodeId("test"), ImmutableList.of(BIGINT, VARCHAR, BOOLEAN, BIGINT), ImmutableList.of(ImmutableList.of(1, 2), ImmutableList.of(3)));
+                new GroupIdOperatorFactory(0,
+                        new PlanNodeId("test"),
+                        ImmutableList.of(BIGINT, VARCHAR, BOOLEAN, BIGINT),
+                        ImmutableList.of(BIGINT, VARCHAR, BOOLEAN, BIGINT, BIGINT, BIGINT),
+                        ImmutableList.of(ImmutableList.of(1, 2), ImmutableList.of(3)),
+                        ImmutableMap.of(0, 4));
 
         Operator operator = operatorFactory.createOperator(driverContext);
 
-        MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, VARCHAR, BOOLEAN, BIGINT, BIGINT)
-                .row(100L, "400", true, null, 0L)
-                .row(101L, "401", false, null, 0L)
-                .row(102L, "402", true, null, 0L)
-                .row(200L, "500", true, null, 0L)
-                .row(201L, "501", false, null, 0L)
-                .row(202L, "502", true, null, 0L)
-                .row(100L, null, null, 1000L, 1L)
-                .row(101L, null, null, 1001L, 1L)
-                .row(102L, null, null, 1002L, 1L)
-                .row(200L, null, null, 1100L, 1L)
-                .row(201L, null, null, 1101L, 1L)
-                .row(202L, null, null, 1102L, 1L)
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, VARCHAR, BOOLEAN, BIGINT, BIGINT, BIGINT)
+                .row(100L, "400", true, null, 100L, 0L)
+                .row(101L, "401", false, null, 101L, 0L)
+                .row(102L, "402", true, null, 102L, 0L)
+                .row(200L, "500", true, null, 200L, 0L)
+                .row(201L, "501", false, null, 201L, 0L)
+                .row(202L, "502", true, null, 202L, 0L)
+                .row(100L, null, null, 1000L, 100L, 1L)
+                .row(101L, null, null, 1001L, 101L, 1L)
+                .row(102L, null, null, 1002L, 102L, 1L)
+                .row(200L, null, null, 1100L, 200L, 1L)
+                .row(201L, null, null, 1101L, 201L, 1L)
+                .row(202L, null, null, 1102L, 202L, 1L)
                 .build();
 
         List<Page> pages = toPages(operator, input.iterator());


### PR DESCRIPTION
Modify the GroupIdNode and GroupIdOperator to pass aggregation
arguments through when they are also grouped on. Previously, the
aggregation arguments and grouping columns would reference the same
symbol, which leads to unintuitive behavior. The problem only occurred
when there were multiple grouping sets, only some of which contained
the column that happens to be the aggregation argument.