### PR TITLE
Implement DEALLOCATE PREPARE

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -26,6 +26,7 @@ public final class PrestoHeaders
     public static final String PRESTO_CLEAR_SESSION = "X-Presto-Clear-Session";
     public static final String PRESTO_PREPARED_STATEMENT = "X-Presto-Prepared-Statement";
     public static final String PRESTO_ADDED_PREPARE = "X-Presto-Added-Prepare";
+    public static final String PRESTO_DEALLOCATED_PREPARE = "X-Presto-Deallocated-Prepare";
     public static final String PRESTO_TRANSACTION_ID = "X-Presto-Transaction-Id";
     public static final String PRESTO_STARTED_TRANSACTION_ID = "X-Presto-Started-Transaction-Id";
     public static final String PRESTO_CLEAR_TRANSACTION_ID = "X-Presto-Clear-Transaction-Id";

--- a/presto-main/src/main/java/com/facebook/presto/execution/DeallocateTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DeallocateTask.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.execution;
+
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.sql.tree.Deallocate;
+import com.facebook.presto.transaction.TransactionManager;
+
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+public class DeallocateTask
+        implements DataDefinitionTask<Deallocate>
+{
+    @Override
+    public String getName()
+    {
+        return "DEALLOCATE";
+    }
+
+    @Override
+    public CompletableFuture<?> execute(Deallocate statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine)
+    {
+        String statementName = statement.getName();
+        stateMachine.removePreparedStatement(statementName);
+        return completedFuture(null);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -54,6 +54,7 @@ public class QueryInfo
     private final Map<String, String> setSessionProperties;
     private final Set<String> resetSessionProperties;
     private final Map<String, String> addedPreparedStatements;
+    private final Set<String> deallocatedPreparedStatements;
     private final Optional<TransactionId> startedTransactionId;
     private final boolean clearTransactionId;
     private final String updateType;
@@ -77,6 +78,7 @@ public class QueryInfo
             @JsonProperty("setSessionProperties") Map<String, String> setSessionProperties,
             @JsonProperty("resetSessionProperties") Set<String> resetSessionProperties,
             @JsonProperty("addedPreparedStatements") Map<String, String> addedPreparedStatements,
+            @JsonProperty("deallocatedPreparedStatements") Set<String> deallocatedPreparedStatements,
             @JsonProperty("startedTransactionId") Optional<TransactionId> startedTransactionId,
             @JsonProperty("clearTransactionId") boolean clearTransactionId,
             @JsonProperty("updateType") String updateType,
@@ -94,6 +96,7 @@ public class QueryInfo
         requireNonNull(setSessionProperties, "setSessionProperties is null");
         requireNonNull(resetSessionProperties, "resetSessionProperties is null");
         requireNonNull(addedPreparedStatements, "addedPreparedStatemetns is null");
+        requireNonNull(deallocatedPreparedStatements, "deallocatedPreparedStatements is null");
         requireNonNull(startedTransactionId, "startedTransactionId is null");
         requireNonNull(query, "query is null");
         requireNonNull(outputStage, "outputStage is null");
@@ -111,6 +114,7 @@ public class QueryInfo
         this.setSessionProperties = ImmutableMap.copyOf(setSessionProperties);
         this.resetSessionProperties = ImmutableSet.copyOf(resetSessionProperties);
         this.addedPreparedStatements = ImmutableMap.copyOf(addedPreparedStatements);
+        this.deallocatedPreparedStatements = ImmutableSet.copyOf(deallocatedPreparedStatements);
         this.startedTransactionId = startedTransactionId;
         this.clearTransactionId = clearTransactionId;
         this.updateType = updateType;
@@ -191,6 +195,12 @@ public class QueryInfo
     public Map<String, String> getAddedPreparedStatements()
     {
         return addedPreparedStatements;
+    }
+
+    @JsonProperty
+    public Set<String> getDeallocatedPreparedStatements()
+    {
+        return deallocatedPreparedStatements;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -57,6 +57,7 @@ import static com.facebook.presto.execution.QueryState.TERMINAL_QUERY_STATES;
 import static com.facebook.presto.execution.StageInfo.getAllStages;
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.spi.StandardErrorCode.USER_CANCELED;
 import static com.facebook.presto.util.Failures.toFailure;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -104,6 +105,7 @@ public class QueryStateMachine
     private final Set<String> resetSessionProperties = Sets.newConcurrentHashSet();
 
     private final Map<String, String> addedPreparedStatements = new ConcurrentHashMap<>();
+    private final Set<String> deallocatedPreparedStatements = Sets.newConcurrentHashSet();
 
     private final AtomicReference<TransactionId> startedTransactionId = new AtomicReference<>();
     private final AtomicBoolean clearTransactionId = new AtomicBoolean();
@@ -348,6 +350,7 @@ public class QueryStateMachine
                 setSessionProperties,
                 resetSessionProperties,
                 addedPreparedStatements,
+                deallocatedPreparedStatements,
                 Optional.ofNullable(startedTransactionId.get()),
                 clearTransactionId.get(),
                 updateType.get(),
@@ -404,6 +407,11 @@ public class QueryStateMachine
         return addedPreparedStatements;
     }
 
+    public Set<String> getDeallocatedPreparedStatements()
+    {
+        return deallocatedPreparedStatements;
+    }
+
     public void addPreparedStatement(String key, String value)
     {
         requireNonNull(key, "key is null");
@@ -413,6 +421,16 @@ public class QueryStateMachine
                 (addedPreparedStatements.putIfAbsent(key, value) != null)) {
             throw new PrestoException(ALREADY_EXISTS, "Prepared statement already exists: " + key);
         }
+    }
+
+    public void removePreparedStatement(String key)
+    {
+        requireNonNull(key, "key is null");
+
+        if (!session.getPreparedStatements().containsKey(key)) {
+            throw new PrestoException(NOT_FOUND, "Prepared statement not found: " + key);
+        }
+        deallocatedPreparedStatements.add(key);
     }
 
     public void setStartedTransactionId(TransactionId startedTransactionId)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -412,6 +412,7 @@ public final class SqlQueryExecution
                 queryInfo.getSetSessionProperties(),
                 queryInfo.getResetSessionProperties(),
                 queryInfo.getAddedPreparedStatements(),
+                queryInfo.getDeallocatedPreparedStatements(),
                 queryInfo.getStartedTransactionId(),
                 queryInfo.isClearTransactionId(),
                 queryInfo.getUpdateType(),

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -20,6 +20,7 @@ import com.facebook.presto.execution.CommitTask;
 import com.facebook.presto.execution.CreateTableTask;
 import com.facebook.presto.execution.CreateViewTask;
 import com.facebook.presto.execution.DataDefinitionTask;
+import com.facebook.presto.execution.DeallocateTask;
 import com.facebook.presto.execution.DropTableTask;
 import com.facebook.presto.execution.DropViewTask;
 import com.facebook.presto.execution.ForQueryExecution;
@@ -68,6 +69,7 @@ import com.facebook.presto.sql.tree.Commit;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateView;
+import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
@@ -233,6 +235,7 @@ public class CoordinatorModule
         bindDataDefinitionTask(binder, executionBinder, Grant.class, GrantTask.class);
         bindDataDefinitionTask(binder, executionBinder, Revoke.class, RevokeTask.class);
         bindDataDefinitionTask(binder, executionBinder, Prepare.class, PrepareTask.class);
+        bindDataDefinitionTask(binder, executionBinder, Deallocate.class, DeallocateTask.class);
 
         MapBinder<String, ExecutionPolicy> executionPolicyBinder = newMapBinder(binder, String.class, ExecutionPolicy.class);
         executionPolicyBinder.addBinding("all-at-once").to(AllAtOnceExecutionPolicy.class);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -28,6 +28,7 @@ import com.facebook.presto.execution.CommitTask;
 import com.facebook.presto.execution.CreateTableTask;
 import com.facebook.presto.execution.CreateViewTask;
 import com.facebook.presto.execution.DataDefinitionTask;
+import com.facebook.presto.execution.DeallocateTask;
 import com.facebook.presto.execution.DropTableTask;
 import com.facebook.presto.execution.DropViewTask;
 import com.facebook.presto.execution.NodeTaskMap;
@@ -110,6 +111,7 @@ import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.tree.Commit;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateView;
+import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
 import com.facebook.presto.sql.tree.Prepare;
@@ -286,6 +288,7 @@ public class LocalQueryRunner
                 .put(ResetSession.class, new ResetSessionTask())
                 .put(SetSession.class, new SetSessionTask())
                 .put(Prepare.class, new PrepareTask(sqlParser))
+                .put(Deallocate.class, new DeallocateTask())
                 .put(StartTransaction.class, new StartTransactionTask())
                 .put(Commit.class, new CommitTask())
                 .put(Rollback.class, new RollbackTask())

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestDeallocateTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestDeallocateTask.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.security.AllowAllAccessControl;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.sql.tree.Deallocate;
+import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.concurrent.ExecutorService;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.transaction.TransactionManager.createTestTransactionManager;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.testng.Assert.assertEquals;
+
+public class TestDeallocateTask
+{
+    private final MetadataManager metadata = MetadataManager.createTestMetadataManager();
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testDeallocate()
+    {
+        String statementName = "my_query";
+        String query1 = "SELECT bar, baz from foo";
+        Session session = TEST_SESSION.withPreparedStatement(statementName, query1);
+
+        String sqlString = "DEALLOCATE PREPARE my_query";
+        QueryStateMachine stateMachine = executeDeallocate(statementName, sqlString, session);
+        assertEquals(stateMachine.getDeallocatedPreparedStatements(), ImmutableSet.of(statementName));
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testDeallocateNoSuchStatement()
+    {
+        String statementName = "my_query";
+        String sqlString = "DEALLOCATE PREPARE my_query";
+        executeDeallocate(statementName, sqlString, TEST_SESSION);
+    }
+
+    private QueryStateMachine executeDeallocate(String statementName, String sqlString, Session session)
+    {
+        TransactionManager transactionManager = createTestTransactionManager();
+        QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), sqlString, session, URI.create("fake://uri"), false, transactionManager, executor);
+        Deallocate deallocate = new Deallocate(statementName);
+        new DeallocateTask().execute(deallocate, transactionManager, metadata, new AllowAllAccessControl(), stateMachine);
+        return stateMachine;
+    }
+}

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -77,6 +77,7 @@ statement
         (ORDER BY sortItem (',' sortItem)*)?
         (LIMIT limit=(INTEGER_VALUE | ALL))?                           #showPartitions
     | PREPARE identifier FROM statement                                #prepare
+    | DEALLOCATE PREPARE identifier                                    #deallocate
     ;
 
 query
@@ -588,6 +589,7 @@ WRITE: 'WRITE';
 ONLY: 'ONLY';
 CALL: 'CALL';
 PREPARE: 'PREPARE';
+DEALLOCATE: 'DEALLOCATE';
 
 NORMALIZE: 'NORMALIZE';
 NFD : 'NFD';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.tree.Commit;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateView;
+import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
@@ -156,6 +157,14 @@ public final class SqlFormatter
             builder.append(" FROM");
             builder.append("\n");
             process(node.getStatement(), indent + 1);
+            return null;
+        }
+
+        @Override
+        protected Void visitDeallocate(Deallocate node, Integer indent)
+        {
+            append(indent, "DEALLOCATE PREPARE ");
+            builder.append(node.getName());
             return null;
         }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -37,6 +37,7 @@ import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.CurrentTime;
+import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.DecimalLiteral;
 import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DereferenceExpression;
@@ -331,6 +332,13 @@ class AstBuilder
     {
         String name = context.identifier().getText();
         return new Prepare(getLocation(context), name, (Statement) visit(context.statement()));
+    }
+
+    @Override
+    public Node visitDeallocate(SqlBaseParser.DeallocateContext context)
+    {
+        String name = context.identifier().getText();
+        return new Deallocate(getLocation(context), name);
     }
 
     // ********************** query expressions ********************

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -87,6 +87,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitDeallocate(Deallocate node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitQuery(Query node, C context)
     {
         return visitStatement(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Deallocate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Deallocate.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class Deallocate
+        extends Statement
+{
+    private final String name;
+
+    public Deallocate(NodeLocation location, String name)
+    {
+        this(Optional.of(location), name);
+    }
+
+    public Deallocate(String name)
+    {
+        this(Optional.empty(), name);
+    }
+
+    private Deallocate(Optional<NodeLocation> location, String name)
+    {
+        super(location);
+        this.name = requireNonNull(name, "name is null");
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitDeallocate(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        Deallocate o = (Deallocate) obj;
+        return Objects.equals(name, o.name);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .toString();
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.CurrentTime;
+import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.DecimalLiteral;
 import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DereferenceExpression;
@@ -1452,6 +1453,12 @@ public class TestSqlParser
                 new Prepare("myquery", simpleQuery(
                         selectList(new AllColumns()),
                         table(QualifiedName.of("foo")))));
+    }
+
+    @Test
+    public void testDeallocatePrepare()
+    {
+        assertStatement("DEALLOCATE PREPARE myquery", new Deallocate("myquery"));
     }
 
     private static void assertCast(String type)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4152,6 +4152,7 @@ public abstract class AbstractTestQueries
         assertExplainDdl("ALTER TABLE orders RENAME COLUMN orderkey TO new_column_name");
         assertExplainDdl("SET SESSION foo = 'bar'");
         assertExplainDdl("PREPARE my_query FROM SELECT * FROM orders", "PREPARE my_query");
+        assertExplainDdl("DEALLOCATE PREPARE my_query");
         assertExplainDdl("RESET SESSION foo");
         assertExplainDdl("START TRANSACTION");
         assertExplainDdl("COMMIT");


### PR DESCRIPTION
Syntax:
DEALLOCATE PREPARE <name>

Confirms existence of prepared statement with name <name> and adds the
statement to a set of deallocated prepared statements.  Sends the set of
deallocated statements back to the client in an HTTP header.  The
client is responsible for maintaining the prepared statements for a
session.