### PR TITLE
Avoid calling Page.getBlocks when relatively expensive

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/GenericPageProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GenericPageProcessor.java
@@ -69,7 +69,7 @@ public class GenericPageProcessor
         Block[] inputBlocks = page.getBlocks();
 
         for (; position < end && !pageBuilder.isFull(); position++) {
-            if (filterFunction.filter(position, page.getBlocks())) {
+            if (filterFunction.filter(position, inputBlocks)) {
                 pageBuilder.declarePosition();
                 for (int i = 0; i < projections.size(); i++) {
                     // todo: if the projection function increases the size of the data significantly, this could cause the servers to OOM
@@ -291,8 +291,9 @@ public class GenericPageProcessor
             }
         }
 
+        Block[] blocks = page.getBlocks();
         for (int position = 0; position < page.getPositionCount(); position++) {
-            if (filterFunction.filter(position, page.getBlocks())) {
+            if (filterFunction.filter(position, blocks)) {
                 selected[index] = position;
                 index++;
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupIdOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupIdOperator.java
@@ -200,7 +200,6 @@ public class GroupIdOperator
     private Page generateNextPage()
     {
         // generate 'n' pages for every input page, where n is the number of grouping sets
-        Block[] inputBlocks = currentPage.getBlocks();
         Block[] outputBlocks = new Block[currentPage.getChannelCount() + 1];
 
         for (int channel = 0; channel < currentPage.getChannelCount(); channel++) {
@@ -208,7 +207,7 @@ public class GroupIdOperator
                 outputBlocks[channel] = new RunLengthEncodedBlock(nullBlocks[channel], currentPage.getPositionCount());
             }
             else {
-                outputBlocks[channel] = inputBlocks[channel];
+                outputBlocks[channel] = currentPage.getBlock(channel);
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/InMemoryJoinHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InMemoryJoinHash.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
-import com.facebook.presto.spi.block.Block;
 import com.google.common.primitives.Ints;
 import io.airlift.slice.XxHash64;
 import it.unimi.dsi.fastutil.HashCommon;
@@ -105,7 +104,7 @@ public final class InMemoryJoinHash
     @Override
     public long getJoinPosition(int position, Page page)
     {
-        return getJoinPosition(position, page, pagesHashStrategy.hashRow(position, page.getBlocks()));
+        return getJoinPosition(position, page, pagesHashStrategy.hashRow(position, page));
     }
 
     @Override
@@ -114,7 +113,7 @@ public final class InMemoryJoinHash
         int pos = (int) getHashPosition(rawHash, mask);
 
         while (key[pos] != -1) {
-            if (positionEqualsCurrentRow(key[pos], position, page.getBlocks())) {
+            if (positionEqualsCurrentRow(key[pos], position, page)) {
                 return key[pos];
             }
             // increment position and mask to handler wrap around
@@ -153,13 +152,13 @@ public final class InMemoryJoinHash
         return pagesHashStrategy.hashPosition(blockIndex, blockPosition);
     }
 
-    private boolean positionEqualsCurrentRow(int leftPosition, int rightPosition, Block... rightBlocks)
+    private boolean positionEqualsCurrentRow(int leftPosition, int rightPosition, Page rightPage)
     {
         long pageAddress = addresses.getLong(leftPosition);
         int blockIndex = decodeSliceIndex(pageAddress);
         int blockPosition = decodePosition(pageAddress);
 
-        return pagesHashStrategy.positionEqualsRow(blockIndex, blockPosition, rightPosition, rightBlocks);
+        return pagesHashStrategy.positionEqualsRow(blockIndex, blockPosition, rightPosition, rightPage);
     }
 
     private boolean positionEqualsPosition(int leftPosition, int rightPosition)

--- a/presto-main/src/main/java/com/facebook/presto/operator/InterpretedHashGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InterpretedHashGenerator.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.operator.scalar.CombineHashFunction;
 import com.facebook.presto.spi.Page;
-import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.optimizations.HashGenerationOptimizer;
 import com.facebook.presto.type.TypeUtils;
@@ -43,11 +42,10 @@ public class InterpretedHashGenerator
     @Override
     public long hashPosition(int position, Page page)
     {
-        Block[] blocks = page.getBlocks();
         long result = HashGenerationOptimizer.INITIAL_HASH_VALUE;
         for (int i = 0; i < hashChannels.length; i++) {
             Type type = hashChannelTypes.get(i);
-            result = CombineHashFunction.getHash(result, TypeUtils.hashPosition(type, blocks[hashChannels[i]], position));
+            result = CombineHashFunction.getHash(result, TypeUtils.hashPosition(type, page.getBlock(hashChannels[i]), position));
         }
         return result;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -208,7 +208,7 @@ public class MultiChannelGroupByHash
     @Override
     public boolean contains(int position, Page page, int[] hashChannels)
     {
-        long rawHash = hashStrategy.hashRow(position, page.getBlocks());
+        long rawHash = hashStrategy.hashRow(position, page);
         int hashPosition = (int) getHashPosition(rawHash, mask);
 
         // look for a slot containing this key

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesHashStrategy.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
-import com.facebook.presto.spi.block.Block;
 
 public interface PagesHashStrategy
 {
@@ -41,17 +40,17 @@ public interface PagesHashStrategy
     long hashPosition(int blockIndex, int position);
 
     /**
-     * Calculates the hash code at {@code position} in {@code blocks}. Blocks must have the same number of
-     * entries as the hashed columns and each entry is expected to be the same type.
+     * Calculates the hash code at {@code position} in {@code page}. Page must have the same number of
+     * Blocks as the hashed columns and each entry is expected to be the same type.
      */
-    long hashRow(int position, Block... blocks);
+    long hashRow(int position, Page page);
 
     /**
      * Compares the values in the specified blocks.  The values are compared positionally, so {@code leftBlocks}
      * and {@code rightBlocks} must have the same number of entries as the hashed columns and each entry
      * is expected to be the same type.
      */
-    boolean rowEqualsRow(int leftPosition, Block[] leftBlocks, int rightPosition, Block[] rightBlocks);
+    boolean rowEqualsRow(int leftPosition, Page leftPage, int rightPosition, Page rightPage);
 
     /**
      * Compares the hashed columns in this PagesHashStrategy to the values in the specified blocks.  The
@@ -59,7 +58,7 @@ public interface PagesHashStrategy
      * the hashed columns and each entry is expected to be the same type.
      */
     @Deprecated
-    boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Block... rightBlocks);
+    boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Page rightPage);
 
     /**
      * Compares the hashed columns in this PagesHashStrategy to the hashed columns in the Page. The

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -285,13 +285,13 @@ public class PagesIndex
         return partitionHashStrategy.positionEqualsPosition(leftPageIndex, leftPagePosition, rightPageIndex, rightPagePosition);
     }
 
-    public boolean positionEqualsRow(PagesHashStrategy pagesHashStrategy, int indexPosition, int rowPosition, Block... row)
+    public boolean positionEqualsRow(PagesHashStrategy pagesHashStrategy, int indexPosition, int rightPosition, Page rightPage)
     {
         long pageAddress = valueAddresses.getLong(indexPosition);
         int pageIndex = decodeSliceIndex(pageAddress);
         int pagePosition = decodePosition(pageAddress);
 
-        return pagesHashStrategy.positionEqualsRow(pageIndex, pagePosition, rowPosition, row);
+        return pagesHashStrategy.positionEqualsRow(pageIndex, pagePosition, rightPosition, rightPage);
     }
 
     private PagesIndexOrdering createPagesIndexComparator(List<Integer> sortChannels, List<SortOrder> sortOrders)

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
@@ -92,26 +92,26 @@ public class SimplePagesHashStrategy
     }
 
     @Override
-    public long hashRow(int position, Block... blocks)
+    public long hashRow(int position, Page page)
     {
         long result = 0;
         for (int i = 0; i < hashChannels.size(); i++) {
             int hashChannel = hashChannels.get(i);
             Type type = types.get(hashChannel);
-            Block block = blocks[i];
+            Block block = page.getBlock(i);
             result = result * 31 + TypeUtils.hashPosition(type, block, position);
         }
         return result;
     }
 
     @Override
-    public boolean rowEqualsRow(int leftPosition, Block[] leftBlocks, int rightPosition, Block[] rightBlocks)
+    public boolean rowEqualsRow(int leftPosition, Page leftPage, int rightPosition, Page rightPage)
     {
         for (int i = 0; i < hashChannels.size(); i++) {
             int hashChannel = hashChannels.get(i);
             Type type = types.get(hashChannel);
-            Block leftBlock = leftBlocks[i];
-            Block rightBlock = rightBlocks[i];
+            Block leftBlock = leftPage.getBlock(i);
+            Block rightBlock = rightPage.getBlock(i);
             if (!TypeUtils.positionEqualsPosition(type, leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
@@ -120,13 +120,13 @@ public class SimplePagesHashStrategy
     }
 
     @Override
-    public boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Block... rightBlocks)
+    public boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Page rightPage)
     {
         for (int i = 0; i < hashChannels.size(); i++) {
             int hashChannel = hashChannels.get(i);
             Type type = types.get(hashChannel);
             Block leftBlock = channels.get(hashChannel).get(leftBlockIndex);
-            Block rightBlock = rightBlocks[i];
+            Block rightBlock = rightPage.getBlock(i);
             if (!TypeUtils.positionEqualsPosition(type, leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
@@ -344,7 +344,7 @@ public class WindowOperator
 
         // TODO: Fix pagesHashStrategy to allow specifying channels for comparison, it currently requires us to rearrange the right side blocks in consecutive channel order
         Page preGroupedPage = rearrangePage(page, preGroupedChannels);
-        if (pagesIndex.getPositionCount() == 0 || pagesIndex.positionEqualsRow(preGroupedPartitionHashStrategy, 0, 0, preGroupedPage.getBlocks())) {
+        if (pagesIndex.getPositionCount() == 0 || pagesIndex.positionEqualsRow(preGroupedPartitionHashStrategy, 0, 0, preGroupedPage)) {
             // Find the position where the pre-grouped columns change
             int groupEnd = findGroupEnd(preGroupedPage, preGroupedPartitionHashStrategy, 0);
 
@@ -452,14 +452,14 @@ public class WindowOperator
         checkPositionIndex(startPosition, page.getPositionCount(), "startPosition out of bounds");
 
         // Short circuit if the whole page has the same value
-        if (pagesHashStrategy.rowEqualsRow(startPosition, page.getBlocks(), page.getPositionCount() - 1, page.getBlocks())) {
+        if (pagesHashStrategy.rowEqualsRow(startPosition, page, page.getPositionCount() - 1, page)) {
             return page.getPositionCount();
         }
 
         // TODO: do position binary search
         int endPosition = startPosition + 1;
         while (endPosition < page.getPositionCount() &&
-                pagesHashStrategy.rowEqualsRow(endPosition - 1, page.getBlocks(), endPosition, page.getBlocks())) {
+                pagesHashStrategy.rowEqualsRow(endPosition - 1, page, endPosition, page)) {
             endPosition++;
         }
         return endPosition;

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
@@ -138,7 +138,7 @@ public class BenchmarkGroupByHash
 
         long groupIds = 0;
         for (Page page : data.getPages()) {
-            Block block = page.getBlocks()[0];
+            Block block = page.getBlock(0);
             int positionCount = block.getPositionCount();
             for (int position = 0; position < positionCount; position++) {
                 long value = block.getLong(position, 0);
@@ -167,7 +167,7 @@ public class BenchmarkGroupByHash
 
         long groupIds = 0;
         for (Page page : data.getPages()) {
-            Block block = page.getBlocks()[0];
+            Block block = page.getBlock(0);
             int positionCount = block.getPositionCount();
             for (int position = 0; position < positionCount; position++) {
                 long value = BIGINT.getLong(block, position);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
@@ -439,7 +439,7 @@ public final class AggregationTestUtils
                 newBlocks[channel] = createNullRLEBlock(page.getPositionCount());
             }
             for (int channel = 0; channel < page.getBlocks().length; channel++) {
-                newBlocks[channel + offset] = page.getBlocks()[channel];
+                newBlocks[channel + offset] = page.getBlock(channel);
             }
             newPages[i] = new Page(page.getPositionCount(), newBlocks);
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
@@ -100,8 +100,8 @@ public class TestJoinCompiler
                     Block rightBlock = channel.get(rightBlockIndex);
                     for (int rightBlockPosition = 0; rightBlockPosition < rightBlock.getPositionCount(); rightBlockPosition++) {
                         boolean expected = positionEqualsPosition(VARCHAR, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
-                        assertEquals(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightBlockPosition, rightBlock), expected);
-                        assertEquals(hashStrategy.rowEqualsRow(leftBlockPosition, new Block[] {leftBlock}, rightBlockPosition, new Block[] {rightBlock}), expected);
+                        assertEquals(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightBlockPosition, new Page(rightBlock)), expected);
+                        assertEquals(hashStrategy.rowEqualsRow(leftBlockPosition, new Page(leftBlock), rightBlockPosition, new Page(rightBlock)), expected);
                         assertEquals(hashStrategy.positionEqualsPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition), expected);
                     }
                 }
@@ -111,8 +111,8 @@ public class TestJoinCompiler
                     Block rightBlock = channel.get(rightBlockIndex);
                     for (int rightBlockPosition = 0; rightBlockPosition < rightBlock.getPositionCount(); rightBlockPosition++) {
                         boolean expected = positionEqualsPosition(VARCHAR, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
-                        assertEquals(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightBlockPosition, rightBlock), expected);
-                        assertEquals(hashStrategy.rowEqualsRow(leftBlockPosition, new Block[] {leftBlock}, rightBlockPosition, new Block[] {rightBlock}), expected);
+                        assertEquals(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightBlockPosition, new Page(rightBlock)), expected);
+                        assertEquals(hashStrategy.rowEqualsRow(leftBlockPosition, new Page(leftBlock), rightBlockPosition, new Page(rightBlock)), expected);
                         assertEquals(hashStrategy.positionEqualsPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition), expected);
                     }
                 }
@@ -226,11 +226,11 @@ public class TestJoinCompiler
 
                     int rightPositionCount = varcharChannel.get(rightBlockIndex).getPositionCount();
                     for (int rightPosition = 0; rightPosition < rightPositionCount; rightPosition++) {
-                        boolean expected = expectedHashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightPosition, rightBlocks);
+                        boolean expected = expectedHashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightPosition, new Page(rightBlocks));
 
-                        assertEquals(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightPosition, rightBlocks), expected);
-                        assertEquals(hashStrategy.rowEqualsRow(leftBlockPosition, leftBlocks, rightPosition, rightBlocks), expected);
-                        assertEquals(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightPosition, rightBlocks), expected);
+                        assertEquals(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightPosition, new Page(rightBlocks)), expected);
+                        assertEquals(hashStrategy.rowEqualsRow(leftBlockPosition, new Page(leftBlocks), rightPosition, new Page(rightBlocks)), expected);
+                        assertEquals(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightPosition, new Page(rightBlocks)), expected);
                     }
                 }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorBucketFunction.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorBucketFunction.java
@@ -37,7 +37,8 @@ public class RaptorBucketFunction
     public int getBucket(Page page, int position)
     {
         long hash = 0;
-        for (Block block : page.getBlocks()) {
+        for (int i = 0; i < page.getChannelCount(); i++) {
+            Block block = page.getBlock(i);
             long value = BIGINT.getLong(block, position);
             hash = (hash * 31) + XxHash64.hash(value);
         }


### PR DESCRIPTION
Avoid calling Page.getBlocks when each invocation does not correspond to other
operations that are at least on the order of Page.positionCount.

Perf profiling showed significant CPU time spent inside JVM_Clone. Perf
backtrace points to Page.getBlocks and MultiChannelGroupByHash. Perf also
showed significant CPU time spent inside TypeArrayKlass::allocate_common, which
is likely related.