### PR TITLE
Use varchar instead of date for Redis hash tests

### DIFF
--- a/presto-redis/src/test/resources/tpch/hash/lineitem.json
+++ b/presto-redis/src/test/resources/tpch/hash/lineitem.json
@@ -67,19 +67,19 @@
             {
                 "name": "shipdate",
                 "mapping": "shipdate",
-                "type": "DATE",
+                "type": "VARCHAR(10)",
                 "dataFormat": "iso8601"
             },
             {
                 "name": "commitdate",
                 "mapping": "commitdate",
-                "type": "DATE",
+                "type": "VARCHAR(10)",
                 "dataFormat": "iso8601"
             },
             {
                 "name": "receiptdate",
                 "mapping": "receiptdate",
-                "type": "DATE",
+                "type": "VARCHAR(10)",
                 "dataFormat": "iso8601"
             },
             {

--- a/presto-redis/src/test/resources/tpch/hash/orders.json
+++ b/presto-redis/src/test/resources/tpch/hash/orders.json
@@ -37,7 +37,7 @@
             {
                 "name": "orderdate",
                 "mapping": "orderdate",
-                "type": "DATE",
+                "type": "VARCHAR(10)",
                 "dataFormat": "iso8601"
             },
             {


### PR DESCRIPTION
We should make dates work, but this fixes the tests for now.