### PR TITLE
Spread travis job build time more evenly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ env:
   global:
     - MAVEN_OPTS="-Xmx256M"
   matrix:
-    - TEST_MODULES=!presto-tests,!presto-kafka,!presto-redis,!presto-cassandra,!presto-raptor,!presto-postgresql,!presto-mysql
+    - TEST_MODULES=!presto-tests,!presto-kafka,!presto-redis,!presto-cassandra,!presto-raptor,!presto-postgresql,!presto-mysql,!presto-mongodb
     - TEST_MODULES=presto-tests
-    - TEST_MODULES=presto-raptor,presto-redis,presto-cassandra,presto-kafka,presto-postgresql,presto-mysql
+    - TEST_MODULES=presto-raptor,presto-postgresql,presto-mysql
+    - TEST_MODULES=presto-mongodb,presto-redis,presto-cassandra,presto-kafka
     - RUN_PRODUCT_TESTS="singlenode -x quarantine,big_query,storage_formats,mysql_connector,postgresql_connector,profile_specific_tests"
     - RUN_PRODUCT_TESTS="singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation"
     - INTEGRATION_TESTS=true


### PR DESCRIPTION
Travis for Open Source plan has a job build time limitation of 50 minutes, which caused build failures for us. The jobs we observed failing due to this limitation were #.1 (~28 min ./mvn test time) and #.3 (~24 min). Failures were also caused by #.2 (TEST_MODULES=presto-tests), but this cant be split that easily.

This commit spreads the build time more evenly by moving the longest part of #.1 - presto-mongodb  (~12 min) - to a new job along with presto-{redis,cassandra,kafka} (each ~1.5 min). The expected ./mvn test times will now be:

 #.1: 14 min (vs 28 min)
 #.3: 18 min (vs 24 min)
 #.4: 18 min (new job)