### PR TITLE
Fix the failure when chaining `AT TIME ZONE`

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DesugaringRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DesugaringRewriter.java
@@ -45,7 +45,7 @@ public class DesugaringRewriter
     public Expression rewriteAtTimeZone(AtTimeZone node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
     {
         Expression value = treeRewriter.rewrite(node.getValue(), context);
-        Type type = expressionTypes.get(value);
+        Type type = expressionTypes.get(node.getValue());
         if (type.equals(TIME)) {
             value = new Cast(value, TIME_WITH_TIME_ZONE.getDisplayName());
         }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4401,6 +4401,13 @@ public abstract class AbstractTestQueries
                 "values TIMESTAMP '1969-12-31 16:01:00-08:00', TIMESTAMP '1970-01-01 00:01:00-08:00', TIMESTAMP '1969-12-31 08:01:00-08:00'");
         assertQuery("SELECT min(x) AT TIME ZONE 'America/Los_Angeles' FROM (values TIMESTAMP '1970-01-01 00:01:00+00:00', TIMESTAMP '1970-01-01 08:01:00+08:00', TIMESTAMP '1969-12-31 16:01:00-08:00') t(x)",
                 "values TIMESTAMP '1969-12-31 16:01:00-08:00'");
+
+        // with chained AT TIME ZONE
+        assertQuery("SELECT TIMESTAMP '2012-10-31 01:00' AT TIME ZONE 'America/Los_Angeles' AT TIME ZONE 'UTC'", "SELECT TIMESTAMP '2012-10-30 18:00:00.000 America/Los_Angeles'");
+        assertQuery("SELECT TIMESTAMP '2012-10-31 01:00' AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'America/Los_Angeles'", "SELECT TIMESTAMP '2012-10-30 18:00:00.000 America/Los_Angeles'");
+        assertQuery("SELECT TIMESTAMP '2012-10-31 01:00' AT TIME ZONE 'America/Los_Angeles' AT TIME ZONE 'Asia/Shanghai'", "SELECT TIMESTAMP '2012-10-30 18:00:00.000 America/Los_Angeles'");
+        assertQuery("SELECT min(x) AT TIME ZONE 'America/Los_Angeles' AT TIME ZONE 'UTC' FROM (values TIMESTAMP '1970-01-01 00:01:00+00:00', TIMESTAMP '1970-01-01 08:01:00+08:00', TIMESTAMP '1969-12-31 16:01:00-08:00') t(x)",
+                "values TIMESTAMP '1969-12-31 16:01:00-08:00'");
     }
 
     @Test


### PR DESCRIPTION
Fix #5332 .

Chaining `AT TIME ZONE` results in the value part of the outer `AT TIME ZONE` being rewritten, while the map of types is not updated, then `getType` with the rewritten value expression will return a `null`,
which causes the query failure.

In this commit, we invoke `getType` the old value part of the outer `AT TIME ZONE`, which should fix the problem without updating the map of types.