### PR TITLE
increase protobuf message max limit.

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -43,6 +43,8 @@ public class OrcMetadataReader
 {
     private static final Slice MAX_BYTE = Slices.wrappedBuffer(new byte[] { (byte) 0xFF });
 
+    private static final int PROTOBUF_MESSAGE_MAX_LIMIT = 1024 << 20; // 1GB
+
     @Override
     public PostScript readPostScript(byte[] data, int offset, int length)
             throws IOException
@@ -63,6 +65,7 @@ public class OrcMetadataReader
             throws IOException
     {
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
+        input.setSizeLimit(PROTOBUF_MESSAGE_MAX_LIMIT);
         OrcProto.Metadata metadata = OrcProto.Metadata.parseFrom(input);
         return new Metadata(toStripeStatistics(metadata.getStripeStatsList()));
     }
@@ -82,6 +85,7 @@ public class OrcMetadataReader
             throws IOException
     {
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
+        input.setSizeLimit(PROTOBUF_MESSAGE_MAX_LIMIT);
         OrcProto.Footer footer = OrcProto.Footer.parseFrom(input);
         return new Footer(
                 footer.getNumberOfRows(),


### PR DESCRIPTION
like apache-hive,Use CodedInputStream.setSizeLimit() to increase the protobuf message max limit.
To fix the error `Error opening Hive split hdfs://file (offset=0, length=8613586): Protocol message was too large. May be malicious. Use CodedInputStream.setSizeLimit() to increase the size limit.`
