### PR TITLE
Fix for rounding a double problem

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -22,6 +22,8 @@ import com.facebook.presto.type.SqlType;
 import com.google.common.primitives.Doubles;
 import io.airlift.slice.Slice;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -465,15 +467,7 @@ public final class MathFunctions
     @SqlType(StandardTypes.DOUBLE)
     public static double round(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.BIGINT) long decimals)
     {
-        if (num == 0.0) {
-            return 0;
-        }
-        if (num < 0) {
-            return -round(-num, decimals);
-        }
-
-        double factor = Math.pow(10, decimals);
-        return Math.floor(num * factor + 0.5) / factor;
+        return new BigDecimal(num).setScale((int) decimals, RoundingMode.HALF_EVEN).doubleValue();
     }
 
     @Description("signum")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkRoundFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkRoundFunction.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.operator.Description;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class BenchmarkRoundFunction
+{
+    private double operand0;
+    private double operand1;
+    private double operand2;
+    private double operand3;
+    private double operand4;
+    private float floatOperand0;
+    private float floatOperand1;
+    private float floatOperand2;
+    private float floatOperand3;
+    private float floatOperand4;
+
+    @Param({"0", "1", "2", "3", "4"})
+    private int numberOfDecimals = 0;
+
+    @Setup
+    public void setup()
+    {
+        operand0 = 0.5;
+        operand1 = 754.1985;
+        operand2 = -754.2008;
+        operand3 = 0x1.fffffffffffffp-2;
+        operand4 = -0x1.fffffffffffffp-2;
+
+        floatOperand0 = 0.5f;
+        floatOperand1 = 754.1985f;
+        floatOperand2 = -754.2008f;
+        floatOperand3 = 0x1.fffffep-2f;
+        floatOperand4 = -0x1.fffffep-2f;
+    }
+
+    @Benchmark
+    public void doubleActual(Blackhole bh)
+    {
+        bh.consume(MathFunctions.round(operand0, numberOfDecimals));
+        bh.consume(MathFunctions.round(operand1, numberOfDecimals));
+        bh.consume(MathFunctions.round(operand2, numberOfDecimals));
+        bh.consume(MathFunctions.round(operand3, numberOfDecimals));
+        bh.consume(MathFunctions.round(operand4, numberOfDecimals));
+    }
+
+    @Benchmark
+    public void doubleBaseline(Blackhole bh)
+    {
+        bh.consume(roundBaseline(operand0, numberOfDecimals));
+        bh.consume(roundBaseline(operand1, numberOfDecimals));
+        bh.consume(roundBaseline(operand2, numberOfDecimals));
+        bh.consume(roundBaseline(operand3, numberOfDecimals));
+        bh.consume(roundBaseline(operand4, numberOfDecimals));
+    }
+
+    @Benchmark
+    public void floatActual(Blackhole bh)
+    {
+        bh.consume(MathFunctions.round(floatOperand0, numberOfDecimals));
+        bh.consume(MathFunctions.round(floatOperand1, numberOfDecimals));
+        bh.consume(MathFunctions.round(floatOperand2, numberOfDecimals));
+        bh.consume(MathFunctions.round(floatOperand3, numberOfDecimals));
+        bh.consume(MathFunctions.round(floatOperand4, numberOfDecimals));
+    }
+
+    @Benchmark
+    public void floatBaseline(Blackhole bh)
+    {
+        bh.consume(roundBaseline(floatOperand0, numberOfDecimals));
+        bh.consume(roundBaseline(floatOperand1, numberOfDecimals));
+        bh.consume(roundBaseline(floatOperand2, numberOfDecimals));
+        bh.consume(roundBaseline(floatOperand3, numberOfDecimals));
+        bh.consume(roundBaseline(floatOperand4, numberOfDecimals));
+    }
+
+    @Description("round to given number of decimal places")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double roundBaseline(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.BIGINT) long decimals)
+    {
+        if (num == 0.0) {
+            return 0;
+        }
+        if (num < 0) {
+            return -roundBaseline(-num, decimals);
+        }
+
+        double factor = Math.pow(10, decimals);
+        return Math.floor(num * factor + 0.5) / factor;
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkRoundFunction.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -34,6 +34,7 @@ public class TestMathFunctions
     private static final int[] intRights = {3, -3};
     private static final double[] doubleLefts = {9, 10, 11, -9, -10, -11, 9.1, 10.1, 11.1, -9.1, -10.1, -11.1};
     private static final double[] doubleRights = {3, -3, 3.1, -3.1};
+    private static final double GREATEST_DOUBLE_LESS_THAN_HALF = 0x1.fffffffffffffp-2;
 
     @Test
     public void testAbs()
@@ -442,6 +443,9 @@ public class TestMathFunctions
         assertFunction("round(-3.5001)", DOUBLE, -4.0);
         assertFunction("round(-3.99)", DOUBLE, -4.0);
         assertFunction("round(CAST(NULL as DOUBLE))", DOUBLE, null);
+        assertFunction("round(" + GREATEST_DOUBLE_LESS_THAN_HALF + ")", DOUBLE, 0.0);
+        assertFunction("round(-" + 0x1p-1 + ")", DOUBLE, 0.0); // -0.5
+        assertFunction("round(-" + GREATEST_DOUBLE_LESS_THAN_HALF + ")", DOUBLE, 0.0);
 
         assertFunction("round(3, 0)", INTEGER, 3);
         assertFunction("round(-3, 0)", INTEGER, -3);
@@ -457,6 +461,9 @@ public class TestMathFunctions
         assertFunction("round(-3.5, 0)", DOUBLE, -4.0);
         assertFunction("round(-3.5001, 0)", DOUBLE, -4.0);
         assertFunction("round(-3.99, 0)", DOUBLE, -4.0);
+        assertFunction("round(" + GREATEST_DOUBLE_LESS_THAN_HALF + ", 0)", DOUBLE, 0.0);
+        assertFunction("round(-" + 0x1p-1 + ")", DOUBLE, 0.0); // -0.5
+        assertFunction("round(-" + GREATEST_DOUBLE_LESS_THAN_HALF + ", 0)", DOUBLE, 0.0);
 
         assertFunction("round(3, 1)", INTEGER, 3);
         assertFunction("round(-3, 1)", INTEGER, -3);


### PR DESCRIPTION
This fixes https://github.com/prestodb/presto/issues/5343.

This PR contains two solutions:
1. using `BigDecimal`
2. hardcoded check for corner case (similar solution was applied in http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6430675)

I ran benchmarks for `BigDecimal` solution and looks like it's at least 5x slower than previous implementation. This led me to provide a "hacky" (but better performing) solution.

Pasting benchmark results for convenience:

```
# Run complete. Total time: 00:06:54

Benchmark                              (numberOfDecimals)   Mode  Cnt         Score        Error  Units
BenchmarkRoundFunction.doubleActual                     0  thrpt   20    435487.457 ±  16361.454  ops/s
BenchmarkRoundFunction.doubleActual                     1  thrpt   20    379300.643 ±  10850.794  ops/s
BenchmarkRoundFunction.doubleActual                     2  thrpt   20    386400.409 ±   6465.372  ops/s
BenchmarkRoundFunction.doubleActual                     3  thrpt   20    386923.585 ±   4762.201  ops/s
BenchmarkRoundFunction.doubleActual                     4  thrpt   20    330516.550 ±  69125.214  ops/s
BenchmarkRoundFunction.doubleBaseline                   0  thrpt   20   2304178.117 ±   6363.767  ops/s
BenchmarkRoundFunction.doubleBaseline                   1  thrpt   20   2164311.225 ± 101803.646  ops/s
BenchmarkRoundFunction.doubleBaseline                   2  thrpt   20  26408893.444 ± 881636.451  ops/s
BenchmarkRoundFunction.doubleBaseline                   3  thrpt   20   2200873.795 ±  84785.748  ops/s
BenchmarkRoundFunction.doubleBaseline                   4  thrpt   20   2147854.894 ±  96063.493  ops/s
BenchmarkRoundFunction.floatActual                      0  thrpt   20    892910.153 ± 155311.051  ops/s
BenchmarkRoundFunction.floatActual                      1  thrpt   20    774102.695 ±   9900.449  ops/s
BenchmarkRoundFunction.floatActual                      2  thrpt   20    757777.797 ±  21498.882  ops/s
BenchmarkRoundFunction.floatActual                      3  thrpt   20    769198.014 ±   4798.123  ops/s
BenchmarkRoundFunction.floatActual                      4  thrpt   20    761709.084 ±  19017.604  ops/s
BenchmarkRoundFunction.floatBaseline                    0  thrpt   20   2362053.037 ±   4305.527  ops/s
BenchmarkRoundFunction.floatBaseline                    1  thrpt   20   2229121.635 ±   8725.110  ops/s
BenchmarkRoundFunction.floatBaseline                    2  thrpt   20  26477617.225 ± 155130.833  ops/s
BenchmarkRoundFunction.floatBaseline                    3  thrpt   20   2276204.473 ±   5586.145  ops/s
BenchmarkRoundFunction.floatBaseline                    4  thrpt   20   2173226.196 ±  46753.248  ops/s
```

Providing both solutions. One should be discarded: commit 8c00bf20b1258a9f6465e81df184d7968eee49b1 or 18f5857cdc56491d0ccffa0568661016abaf9963.
Thorough description of an issue is included in commit b096f5166833287b412b25d9cc40ece24214b021.