### PR TITLE
bugfix: replace InPredicate in all plan nodes

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5377,6 +5377,21 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testSameInPredicateInProjectionAndFilter()
+            throws Exception
+    {
+        assertQuery("SELECT x IN (SELECT * FROM (VALUES 1))\n" +
+                        "FROM (VALUES 1) t(x)\n" +
+                        "WHERE x IN (SELECT * FROM (VALUES 1))",
+                "SELECT 1");
+
+        assertQuery("SELECT x IN (SELECT * FROM (VALUES 1))\n" +
+                "FROM (VALUES 2) t(x)\n" +
+                "WHERE x IN (SELECT * FROM (VALUES 1))",
+                "SELECT 1 WHERE false");
+    }
+
+    @Test
     public void testScalarSubquery()
             throws Exception
     {


### PR DESCRIPTION
bugfix: replace InPredicate in all plan nodes

So far InPredicate was replaced only in the node where visitor found as
first. Subsequent occurrences were not replaced. This commit fixes that.

Fixes #5346
