### PR TITLE
Set pivot year for date_parse function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -196,6 +196,8 @@ Specifier Description
 ``%x``    ``x``, for any ``x`` not listed above
 ========= ===========
 
+.. warning:: Two-digit year format assumes range 1970 .. 2069, so "70" will result in year 1970 but "69" will produce 2069.
+
 .. warning:: The following specifiers are not currently supported: ``%D %U %u %V %X``
 
 .. function:: date_format(timestamp, format) -> varchar

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -76,6 +76,7 @@ public final class DateTimeFunctions
     private static final int MILLISECONDS_IN_MINUTE = 60 * MILLISECONDS_IN_SECOND;
     private static final int MILLISECONDS_IN_HOUR = 60 * MILLISECONDS_IN_MINUTE;
     private static final int MILLISECONDS_IN_DAY = 24 * MILLISECONDS_IN_HOUR;
+    private static final int PIVOT_YEAR = 2020; // yy = 70 will correspond to 1970 but 69 to 2069
 
     private DateTimeFunctions() {}
 
@@ -1006,7 +1007,7 @@ public final class DateTimeFunctions
                         builder.appendYear(4, 4);
                         break;
                     case 'y': // %y Year, numeric (two digits)
-                        builder.appendYearOfCentury(2, 2);
+                        builder.appendTwoDigitYear(PIVOT_YEAR);
                         break;
                     case 'U': // %U Week (00..53), where Sunday is the first day of the week
                     case 'u': // %u Week (00..53), where Monday is the first day of the week

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -777,6 +777,18 @@ public class TestDateTimeFunctions
         assertFunction("date_parse('0', '%k')",
                 TimestampType.TIMESTAMP,
                 toTimestamp(new DateTime(1970, 1, 1, 0, 0, 0, 0, DATE_TIME_ZONE)));
+
+        assertFunction("date_parse('28-JAN-16 11.45.46.421000 PM','%d-%b-%y %l.%i.%s.%f %p')",
+                TimestampType.TIMESTAMP,
+                toTimestamp(new DateTime(2016, 1, 28, 23, 45, 46, 421, DATE_TIME_ZONE)));
+
+        assertFunction("date_parse('11-DEC-70 11.12.13.456000 AM','%d-%b-%y %l.%i.%s.%f %p')",
+                TimestampType.TIMESTAMP,
+                toTimestamp(new DateTime(1970, 12, 11, 11, 12, 13, 456, DATE_TIME_ZONE)));
+
+        assertFunction("date_parse('31-MAY-69 04.59.59.999000 AM','%d-%b-%y %l.%i.%s.%f %p')",
+                TimestampType.TIMESTAMP,
+                toTimestamp(new DateTime(2069, 5, 31, 4, 59, 59, 999, DATE_TIME_ZONE)));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -781,11 +781,9 @@ public class TestDateTimeFunctions
         assertFunction("date_parse('28-JAN-16 11.45.46.421000 PM','%d-%b-%y %l.%i.%s.%f %p')",
                 TimestampType.TIMESTAMP,
                 toTimestamp(new DateTime(2016, 1, 28, 23, 45, 46, 421, DATE_TIME_ZONE)));
-
         assertFunction("date_parse('11-DEC-70 11.12.13.456000 AM','%d-%b-%y %l.%i.%s.%f %p')",
                 TimestampType.TIMESTAMP,
                 toTimestamp(new DateTime(1970, 12, 11, 11, 12, 13, 456, DATE_TIME_ZONE)));
-
         assertFunction("date_parse('31-MAY-69 04.59.59.999000 AM','%d-%b-%y %l.%i.%s.%f %p')",
                 TimestampType.TIMESTAMP,
                 toTimestamp(new DateTime(2069, 5, 31, 4, 59, 59, 999, DATE_TIME_ZONE)));


### PR DESCRIPTION
Setting pivot allows more natural parsing of dates, e.g. "16-01-02" is January 2nd 2016 instead of 1916.
Selected pivot (2020), resulting in range 1970 .. 2069,
corresponds to the value currently used by MySql and PostgreSQL.

This fixes https://github.com/prestodb/presto/issues/5215