### PR TITLE
Use Math.round for rounding doubles

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -465,15 +465,8 @@ public final class MathFunctions
     @SqlType(StandardTypes.DOUBLE)
     public static double round(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.BIGINT) long decimals)
     {
-        if (num == 0.0) {
-            return 0;
-        }
-        if (num < 0) {
-            return -round(-num, decimals);
-        }
-
         double factor = Math.pow(10, decimals);
-        return Math.floor(num * factor + 0.5) / factor;
+        return Math.round(num * factor) / factor;
     }
 
     @Description("signum")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkRoundFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkRoundFunction.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.operator.Description;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 30, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 30, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class BenchmarkRoundFunction
+{
+    private double operand0;
+    private double operand1;
+    private double operand2;
+    private double operand3;
+    private double operand4;
+    private float floatOperand0;
+    private float floatOperand1;
+    private float floatOperand2;
+    private float floatOperand3;
+    private float floatOperand4;
+
+    @Param({"0", "1", "2", "3", "4"})
+    private int numberOfDecimals = 0;
+
+    @Setup
+    public void setup()
+    {
+        operand0 = 0.5;
+        operand1 = 754.1985;
+        operand2 = -754.2008;
+        operand3 = 0x1.fffffffffffffp-2;
+        operand4 = -0x1.fffffffffffffp-2;
+
+        floatOperand0 = 0.5f;
+        floatOperand1 = 754.1985f;
+        floatOperand2 = -754.2008f;
+        floatOperand3 = 0x1.fffffep-2f;
+        floatOperand4 = -0x1.fffffep-2f;
+    }
+
+    @Benchmark
+    public void doubleActual(Blackhole bh)
+    {
+        bh.consume(MathFunctions.round(operand0, numberOfDecimals));
+        bh.consume(MathFunctions.round(operand1, numberOfDecimals));
+        bh.consume(MathFunctions.round(operand2, numberOfDecimals));
+        bh.consume(MathFunctions.round(operand3, numberOfDecimals));
+        bh.consume(MathFunctions.round(operand4, numberOfDecimals));
+    }
+
+    @Benchmark
+    public void doubleBaseline(Blackhole bh)
+    {
+        bh.consume(roundBaseline(operand0, numberOfDecimals));
+        bh.consume(roundBaseline(operand1, numberOfDecimals));
+        bh.consume(roundBaseline(operand2, numberOfDecimals));
+        bh.consume(roundBaseline(operand3, numberOfDecimals));
+        bh.consume(roundBaseline(operand4, numberOfDecimals));
+    }
+
+    @Benchmark
+    public void floatActual(Blackhole bh)
+    {
+        bh.consume(MathFunctions.round(floatOperand0, numberOfDecimals));
+        bh.consume(MathFunctions.round(floatOperand1, numberOfDecimals));
+        bh.consume(MathFunctions.round(floatOperand2, numberOfDecimals));
+        bh.consume(MathFunctions.round(floatOperand3, numberOfDecimals));
+        bh.consume(MathFunctions.round(floatOperand4, numberOfDecimals));
+    }
+
+    @Benchmark
+    public void floatBaseline(Blackhole bh)
+    {
+        bh.consume(roundBaseline(floatOperand0, numberOfDecimals));
+        bh.consume(roundBaseline(floatOperand1, numberOfDecimals));
+        bh.consume(roundBaseline(floatOperand2, numberOfDecimals));
+        bh.consume(roundBaseline(floatOperand3, numberOfDecimals));
+        bh.consume(roundBaseline(floatOperand4, numberOfDecimals));
+    }
+
+    @Description("round to given number of decimal places")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double roundBaseline(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.BIGINT) long decimals)
+    {
+        if (num == 0.0) {
+            return 0;
+        }
+        if (num < 0) {
+            return -roundBaseline(-num, decimals);
+        }
+
+        double factor = Math.pow(10, decimals);
+        return Math.floor(num * factor + 0.5) / factor;
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkRoundFunction.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -439,7 +439,7 @@ public class TestMathFunctions
         assertFunction("round( 3.499)", DOUBLE, 3.0);
         assertFunction("round(-3.499)", DOUBLE, -3.0);
         assertFunction("round( 3.5)", DOUBLE, 4.0);
-        assertFunction("round(-3.5)", DOUBLE, -4.0);
+        assertFunction("round(-3.5)", DOUBLE, -3.0);
         assertFunction("round(-3.5001)", DOUBLE, -4.0);
         assertFunction("round(-3.99)", DOUBLE, -4.0);
         assertFunction("round(CAST(NULL as DOUBLE))", DOUBLE, null);
@@ -458,7 +458,7 @@ public class TestMathFunctions
         assertFunction("round( 3.499, 0)", DOUBLE, 3.0);
         assertFunction("round(-3.499, 0)", DOUBLE, -3.0);
         assertFunction("round( 3.5, 0)", DOUBLE, 4.0);
-        assertFunction("round(-3.5, 0)", DOUBLE, -4.0);
+        assertFunction("round(-3.5, 0)", DOUBLE, -3.0);
         assertFunction("round(-3.5001, 0)", DOUBLE, -4.0);
         assertFunction("round(-3.99, 0)", DOUBLE, -4.0);
         assertFunction("round(" + GREATEST_DOUBLE_LESS_THAN_HALF + ", 0)", DOUBLE, 0.0);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -34,6 +34,7 @@ public class TestMathFunctions
     private static final int[] intRights = {3, -3};
     private static final double[] doubleLefts = {9, 10, 11, -9, -10, -11, 9.1, 10.1, 11.1, -9.1, -10.1, -11.1};
     private static final double[] doubleRights = {3, -3, 3.1, -3.1};
+    private static final double GREATEST_DOUBLE_LESS_THAN_HALF = 0x1.fffffffffffffp-2;
 
     @Test
     public void testAbs()
@@ -442,6 +443,9 @@ public class TestMathFunctions
         assertFunction("round(-3.5001)", DOUBLE, -4.0);
         assertFunction("round(-3.99)", DOUBLE, -4.0);
         assertFunction("round(CAST(NULL as DOUBLE))", DOUBLE, null);
+        assertFunction("round(" + GREATEST_DOUBLE_LESS_THAN_HALF + ")", DOUBLE, 0.0);
+        assertFunction("round(-" + 0x1p-1 + ")", DOUBLE, 0.0); // -0.5
+        assertFunction("round(-" + GREATEST_DOUBLE_LESS_THAN_HALF + ")", DOUBLE, 0.0);
 
         assertFunction("round(3, 0)", INTEGER, 3);
         assertFunction("round(-3, 0)", INTEGER, -3);
@@ -457,6 +461,9 @@ public class TestMathFunctions
         assertFunction("round(-3.5, 0)", DOUBLE, -4.0);
         assertFunction("round(-3.5001, 0)", DOUBLE, -4.0);
         assertFunction("round(-3.99, 0)", DOUBLE, -4.0);
+        assertFunction("round(" + GREATEST_DOUBLE_LESS_THAN_HALF + ", 0)", DOUBLE, 0.0);
+        assertFunction("round(-" + 0x1p-1 + ")", DOUBLE, 0.0); // -0.5
+        assertFunction("round(-" + GREATEST_DOUBLE_LESS_THAN_HALF + ", 0)", DOUBLE, 0.0);
 
         assertFunction("round(3, 1)", INTEGER, 3);
         assertFunction("round(-3, 1)", INTEGER, -3);


### PR DESCRIPTION
This supersedes #5344 as a fix for #5343.
As per discussion with @martint decided to propose solution based on `Math.round()` to follow Java's strategy of rounding - towards positive infinity.

Benchmark result:
```
# Run complete. Total time: 00:20:13

Benchmark                              (numberOfDecimals)   Mode  Cnt         Score        Error  Units
BenchmarkRoundFunction.doubleActual                     0  thrpt   60   2244262.436 ±  14162.468  ops/s
BenchmarkRoundFunction.doubleActual                     1  thrpt   60   2180249.575 ±  20698.548  ops/s
BenchmarkRoundFunction.doubleActual                     2  thrpt   60  30778365.240 ± 118806.597  ops/s
BenchmarkRoundFunction.doubleActual                     3  thrpt   60   2251585.116 ±   3780.141  ops/s
BenchmarkRoundFunction.doubleActual                     4  thrpt   60   2222213.426 ±   3246.700  ops/s
BenchmarkRoundFunction.doubleBaseline                   0  thrpt   60   2305410.679 ±   2499.174  ops/s
BenchmarkRoundFunction.doubleBaseline                   1  thrpt   60   2212599.569 ±   8741.775  ops/s
BenchmarkRoundFunction.doubleBaseline                   2  thrpt   60  26942602.519 ± 514896.648  ops/s
BenchmarkRoundFunction.doubleBaseline                   3  thrpt   60   2277871.478 ±   2749.483  ops/s
BenchmarkRoundFunction.doubleBaseline                   4  thrpt   60   2218442.595 ±   4250.772  ops/s
BenchmarkRoundFunction.floatActual                      0  thrpt   60   2286232.715 ±   3230.054  ops/s
BenchmarkRoundFunction.floatActual                      1  thrpt   60   2225405.177 ±   3883.159  ops/s
BenchmarkRoundFunction.floatActual                      2  thrpt   60  18685356.487 ±  54620.425  ops/s
BenchmarkRoundFunction.floatActual                      3  thrpt   60   2257646.692 ±   3061.512  ops/s
BenchmarkRoundFunction.floatActual                      4  thrpt   60   2226975.451 ±   3581.543  ops/s
BenchmarkRoundFunction.floatBaseline                    0  thrpt   60   2332700.404 ±   3095.481  ops/s
BenchmarkRoundFunction.floatBaseline                    1  thrpt   60   2219148.001 ±   3562.977  ops/s
BenchmarkRoundFunction.floatBaseline                    2  thrpt   60  26276474.648 ±  90887.552  ops/s
BenchmarkRoundFunction.floatBaseline                    3  thrpt   60   2253528.838 ±   3518.084  ops/s
BenchmarkRoundFunction.floatBaseline                    4  thrpt   60   2220569.064 ±   3112.510  ops/s
```