### PR TITLE
Fix grouping on aggregation arguments

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupIdOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupIdOperator.java
@@ -41,25 +41,27 @@ public class GroupIdOperator
     {
         private final int operatorId;
         private final PlanNodeId planNodeId;
-        private final List<Type> inputTypes;
         private final List<Type> outputTypes;
         private final List<List<Integer>> groupingSetChannels;
+        private final List<Integer> groupingChannels;
+        private final List<Integer> copyChannels;
 
         private boolean closed;
 
         public GroupIdOperatorFactory(
                 int operatorId,
                 PlanNodeId planNodeId,
-                List<? extends Type> inputTypes,
-                List<List<Integer>> groupingSetChannels)
+                List<? extends Type> outputTypes,
+                List<List<Integer>> groupingSetChannels,
+                List<Integer> groupingChannels,
+                List<Integer> copyChannels)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.outputTypes = ImmutableList.copyOf(requireNonNull(outputTypes));
             this.groupingSetChannels = ImmutableList.copyOf(requireNonNull(groupingSetChannels));
-            this.inputTypes = ImmutableList.copyOf(requireNonNull(inputTypes));
-
-            // add the groupId channel to the output types
-            this.outputTypes = ImmutableList.<Type>builder().addAll(inputTypes).add(BIGINT).build();
+            this.groupingChannels = ImmutableList.copyOf(requireNonNull(groupingChannels));
+            this.copyChannels = ImmutableList.copyOf(requireNonNull(copyChannels));
         }
 
         @Override
@@ -78,10 +80,11 @@ public class GroupIdOperator
                     .flatMap(Collection::stream)
                     .collect(toImmutableSet());
 
+            // create an array of bitset for fast lookup of which columns are part of a given grouping set
             // will have a 'true' for every channel that should be set to null for each grouping set
             BitSet[] groupingSetNullChannels = new BitSet[groupingSetChannels.size()];
             for (int i = 0; i < groupingSetChannels.size(); i++) {
-                groupingSetNullChannels[i] = new BitSet(inputTypes.size());
+                groupingSetNullChannels[i] = new BitSet(groupingChannels.size() + copyChannels.size());
                 // first set all grouping columns to true
                 for (int groupingColumn : allGroupingColumns) {
                     groupingSetNullChannels[i].set(groupingColumn, true);
@@ -92,13 +95,15 @@ public class GroupIdOperator
                 }
             }
 
-            Block[] nullBlocks = new Block[inputTypes.size()];
-            for (int i = 0; i < nullBlocks.length; i++) {
-                nullBlocks[i] = inputTypes.get(i).createBlockBuilder(new BlockBuilderStatus(), 1)
+            // create null blocks for every grouping channel
+            Block[] nullBlocks = new Block[groupingChannels.size()];
+            for (int i = 0; i < groupingChannels.size(); i++) {
+                nullBlocks[i] = outputTypes.get(i).createBlockBuilder(new BlockBuilderStatus(), 1)
                         .appendNull()
                         .build();
             }
 
+            // create groupid blocks for every group
             Block[] groupIdBlocks = new Block[groupingSetNullChannels.length];
             for (int i = 0; i < groupingSetNullChannels.length; i++) {
                 BlockBuilder builder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 1);
@@ -106,7 +111,13 @@ public class GroupIdOperator
                 groupIdBlocks[i] = builder.build();
             }
 
-            return new GroupIdOperator(operatorContext, outputTypes, groupingSetNullChannels, nullBlocks, groupIdBlocks);
+            // create array of input channels for every grouping channel
+            int[] groupInputs = groupingChannels.stream().mapToInt(Integer::intValue).toArray();
+
+            // create array of input channels for every copy channel
+            int[] copyInputs = copyChannels.stream().mapToInt(Integer::intValue).toArray();
+
+            return new GroupIdOperator(operatorContext, outputTypes, groupingSetNullChannels, nullBlocks, groupIdBlocks, groupInputs, copyInputs);
         }
 
         @Override
@@ -118,7 +129,7 @@ public class GroupIdOperator
         @Override
         public OperatorFactory duplicate()
         {
-            return new GroupIdOperatorFactory(operatorId, planNodeId, inputTypes, groupingSetChannels);
+            return new GroupIdOperatorFactory(operatorId, planNodeId, outputTypes, groupingSetChannels, groupingChannels, copyChannels);
         }
     }
 
@@ -127,6 +138,8 @@ public class GroupIdOperator
     private final BitSet[] groupingSetNullChannels;
     private final Block[] nullBlocks;
     private final Block[] groupIdBlocks;
+    private final int[] groupInputs;
+    private final int[] copyInputs;
 
     private Page currentPage = null;
     private int currentGroupingSet = 0;
@@ -137,15 +150,18 @@ public class GroupIdOperator
             List<Type> types,
             BitSet[] groupingSetNullChannels,
             Block[] nullBlocks,
-            Block[] groupIdBlocks)
+            Block[] groupIdBlocks,
+            int[] groupInputs,
+            int[] copyInputs)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.types = requireNonNull(types, "inputTypes is null");
+        this.types = requireNonNull(types, "types is null");
         this.groupingSetNullChannels =  requireNonNull(groupingSetNullChannels, "groupingSetNullChannels is null");
         this.nullBlocks = requireNonNull(nullBlocks);
-        checkArgument(nullBlocks.length == (types.size() - 1), "length of nullBlocks must be one plus length of types");
         this.groupIdBlocks = requireNonNull(groupIdBlocks);
         checkArgument(groupIdBlocks.length == groupingSetNullChannels.length, "groupIdBlocks and groupingSetNullChannels must have the same length");
+        this.groupInputs = requireNonNull(groupInputs);
+        this.copyInputs = requireNonNull(copyInputs);
     }
 
     @Override
@@ -200,16 +216,19 @@ public class GroupIdOperator
     private Page generateNextPage()
     {
         // generate 'n' pages for every input page, where n is the number of grouping sets
-        Block[] inputBlocks = currentPage.getBlocks();
-        Block[] outputBlocks = new Block[currentPage.getChannelCount() + 1];
+        Block[] outputBlocks = new Block[types.size()];
 
-        for (int channel = 0; channel < currentPage.getChannelCount(); channel++) {
-            if (groupingSetNullChannels[currentGroupingSet].get(channel)) {
-                outputBlocks[channel] = new RunLengthEncodedBlock(nullBlocks[channel], currentPage.getPositionCount());
+        for (int i = 0; i < groupInputs.length; i++) {
+            if (groupingSetNullChannels[currentGroupingSet].get(groupInputs[i])) {
+                outputBlocks[i] = new RunLengthEncodedBlock(nullBlocks[i], currentPage.getPositionCount());
             }
             else {
-                outputBlocks[channel] = inputBlocks[channel];
+                outputBlocks[i] = currentPage.getBlock(groupInputs[i]);
             }
+        }
+
+        for (int i = 0; i < copyInputs.length; i++) {
+            outputBlocks[groupInputs.length + i] = currentPage.getBlock(copyInputs[i]);
         }
 
         outputBlocks[outputBlocks.length - 1] = new RunLengthEncodedBlock(groupIdBlocks[currentGroupingSet], currentPage.getPositionCount());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -860,24 +860,42 @@ public class LocalExecutionPlanner
         public PhysicalOperation visitGroupId(GroupIdNode node, LocalExecutionPlanContext context)
         {
             PhysicalOperation source = node.getSource().accept(this, context);
+            ImmutableMap.Builder<Symbol, Integer> newLayout = ImmutableMap.builder();
+            ImmutableList.Builder<Type> outputTypes = ImmutableList.builder();
 
-            // add groupId to the layout
-            int groupIdChannel = source.getLayout().values().stream()
-                    .mapToInt(Integer::intValue)
-                    .max()
-                    .orElse(-1) + 1;
+            int outputChannel = 0;
 
-            Map<Symbol, Integer> newLayout = ImmutableMap.<Symbol, Integer>builder()
-                    .putAll(source.getLayout())
-                    .put(node.getGroupIdSymbol(), groupIdChannel)
-                    .build();
+            ImmutableList.Builder<Integer> groupingChannels = ImmutableList.builder();
+            for (Symbol inputSymbol : node.getDistinctGroupingColumns()) {
+                int inputChannel = source.getLayout().get(inputSymbol);
+                newLayout.put(inputSymbol, outputChannel++);
+                outputTypes.add(source.getTypes().get(inputChannel));
+                groupingChannels.add(inputChannel);
+            }
+
+            ImmutableList.Builder<Integer> copyChannels = ImmutableList.builder();
+            for (Symbol inputSymbol : node.getIdentityMappings().keySet()) {
+                int inputChannel = source.getLayout().get(inputSymbol);
+                newLayout.put(node.getIdentityMappings().get(inputSymbol), outputChannel++);
+                outputTypes.add(source.getTypes().get(inputChannel));
+                copyChannels.add(inputChannel);
+            }
+
+            newLayout.put(node.getGroupIdSymbol(), outputChannel);
+            outputTypes.add(BIGINT);
 
             List<List<Integer>> groupingSetChannels = node.getGroupingSets().stream()
                     .map(groupingSet -> getChannelsForSymbols(groupingSet, source.getLayout()))
                     .collect(toImmutableList());
 
-            OperatorFactory groupIdOperatorFactory = new GroupIdOperator.GroupIdOperatorFactory(context.getNextOperatorId(), node.getId(), source.getTypes(), groupingSetChannels);
-            return new PhysicalOperation(groupIdOperatorFactory, newLayout, source);
+            OperatorFactory groupIdOperatorFactory = new GroupIdOperator.GroupIdOperatorFactory(context.getNextOperatorId(),
+                    node.getId(),
+                    outputTypes.build(),
+                    groupingSetChannels,
+                    groupingChannels.build(),
+                    copyChannels.build());
+
+            return new PhysicalOperation(groupIdOperatorFactory, newLayout.build(), source);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolExtractor.java
@@ -112,6 +112,7 @@ public final class SymbolExtractor
             node.getSource().accept(this, context);
 
             builder.add(node.getGroupIdSymbol());
+            builder.addAll(node.getIdentityMappings().values());
 
             return null;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -407,12 +407,21 @@ public class PruneUnreferencedOutputs
         {
             checkState(node.getDistinctGroupingColumns().stream().allMatch(column -> context.get().contains(column)));
 
-            PlanNode source = context.rewrite(node.getSource(), ImmutableSet.copyOf(context.get()));
-            List<Symbol> requiredSymbols = context.get().stream()
-                    .filter(symbol -> !symbol.equals(node.getGroupIdSymbol()))
-                    .collect(toImmutableList());
+            ImmutableMap.Builder<Symbol, Symbol> identityMappingBuilder = ImmutableMap.builder();
+            for (Map.Entry<Symbol, Symbol> entry : node.getIdentityMappings().entrySet()) {
+                if (context.get().contains(entry.getValue())) {
+                    identityMappingBuilder.put(entry);
+                }
+            }
 
-            return new GroupIdNode(node.getId(), source, requiredSymbols, node.getGroupingSets(), node.getGroupIdSymbol());
+            Map<Symbol, Symbol> identityMapping = identityMappingBuilder.build();
+
+            PlanNode source = context.rewrite(node.getSource(), ImmutableSet.<Symbol>builder()
+                    .addAll(identityMapping.keySet())
+                    .addAll(node.getDistinctGroupingColumns())
+                    .build());
+
+            return new GroupIdNode(node.getId(), source, node.getGroupingSets(), identityMapping, node.getGroupIdSymbol());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -160,7 +160,12 @@ public class UnaliasSymbolReferences
                     .map(this::canonicalize)
                     .collect(Collectors.toList());
 
-            return new GroupIdNode(node.getId(), source, canonicalize(node.getInputSymbols()), groupingSetsSymbols, canonicalize(node.getGroupIdSymbol()));
+            ImmutableMap.Builder<Symbol, Symbol> newPassthroughMap = ImmutableMap.builder();
+            for (Symbol inputSymbol : node.getIdentityMappings().keySet()) {
+                newPassthroughMap.put(canonicalize(inputSymbol), canonicalize(node.getIdentityMappings().get(inputSymbol)));
+            }
+
+            return new GroupIdNode(node.getId(), source, groupingSetsSymbols, newPassthroughMap.build(), canonicalize(node.getGroupIdSymbol()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
@@ -173,7 +173,7 @@ public class ChildReplacer
     @Override
     public PlanNode visitGroupId(GroupIdNode node, List<PlanNode> newChildren)
     {
-        return new GroupIdNode(node.getId(), Iterables.getOnlyElement(newChildren), node.getInputSymbols(), node.getGroupingSets(), node.getGroupIdSymbol());
+        return new GroupIdNode(node.getId(), Iterables.getOnlyElement(newChildren), node.getGroupingSets(), node.getIdentityMappings(), node.getGroupIdSymbol());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/GroupIdNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/GroupIdNode.java
@@ -17,12 +17,15 @@ import com.facebook.presto.sql.planner.Symbol;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.concurrent.Immutable;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -33,21 +36,21 @@ public class GroupIdNode
         extends PlanNode
 {
     private final PlanNode source;
-    private final List<Symbol> inputSymbols;
     private final List<List<Symbol>> groupingSets;
+    private final Map<Symbol, Symbol> identityMappings;
     private final Symbol groupIdSymbol;
 
     @JsonCreator
     public GroupIdNode(@JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("inputSymbols") List<Symbol> inputSymbols,
             @JsonProperty("groupingSets") List<List<Symbol>> groupingSets,
+            @JsonProperty("identityMappings") Map<Symbol, Symbol> identityMappings,
             @JsonProperty("groupIdSymbol") Symbol groupIdSymbol)
     {
         super(id);
         this.source = requireNonNull(source);
-        this.inputSymbols = ImmutableList.copyOf(requireNonNull(inputSymbols));
         this.groupingSets = ImmutableList.copyOf(requireNonNull(groupingSets));
+        this.identityMappings = ImmutableMap.copyOf(requireNonNull(identityMappings));
         this.groupIdSymbol = requireNonNull(groupIdSymbol);
     }
 
@@ -55,7 +58,8 @@ public class GroupIdNode
     public List<Symbol> getOutputSymbols()
     {
         return ImmutableList.<Symbol>builder()
-                .addAll(source.getOutputSymbols())
+                .addAll(getDistinctGroupingColumns())
+                .addAll(identityMappings.values())
                 .add(groupIdSymbol)
                 .build();
     }
@@ -72,16 +76,24 @@ public class GroupIdNode
         return source;
     }
 
-    @JsonProperty
-    public List<Symbol> getInputSymbols()
+    public Set<Symbol> getInputSymbols()
     {
-        return inputSymbols;
+        return ImmutableSet.<Symbol>builder()
+                .addAll(identityMappings.keySet())
+                .addAll(getDistinctGroupingColumns())
+                .build();
     }
 
     @JsonProperty
     public List<List<Symbol>> getGroupingSets()
     {
         return groupingSets;
+    }
+
+    @JsonProperty
+    public Map<Symbol, Symbol> getIdentityMappings()
+    {
+        return identityMappings;
     }
 
     public List<Symbol> getDistinctGroupingColumns()

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestGroupIdOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestGroupIdOperator.java
@@ -71,23 +71,28 @@ public class TestGroupIdOperator
                 .build();
 
         GroupIdOperatorFactory operatorFactory =
-                new GroupIdOperatorFactory(0, new PlanNodeId("test"), ImmutableList.of(BIGINT, VARCHAR, BOOLEAN, BIGINT), ImmutableList.of(ImmutableList.of(1, 2), ImmutableList.of(3)));
+                new GroupIdOperatorFactory(0,
+                        new PlanNodeId("test"),
+                        ImmutableList.of(VARCHAR, BOOLEAN, BIGINT, BIGINT, BIGINT),
+                        ImmutableList.of(ImmutableList.of(1, 2), ImmutableList.of(3)),
+                        ImmutableList.of(1, 2, 3),
+                        ImmutableList.of(0));
 
         Operator operator = operatorFactory.createOperator(driverContext);
 
-        MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, VARCHAR, BOOLEAN, BIGINT, BIGINT)
-                .row(100, "400", true, null, 0)
-                .row(101, "401", false, null, 0)
-                .row(102, "402", true, null, 0)
-                .row(200, "500", true, null, 0)
-                .row(201, "501", false, null, 0)
-                .row(202, "502", true, null, 0)
-                .row(100, null, null, 1000, 1)
-                .row(101, null, null, 1001, 1)
-                .row(102, null, null, 1002, 1)
-                .row(200, null, null, 1100, 1)
-                .row(201, null, null, 1101, 1)
-                .row(202, null, null, 1102, 1)
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, BOOLEAN, BIGINT, BIGINT, BIGINT)
+                .row("400", true, null, 100L, 0L)
+                .row("401", false, null, 101L, 0L)
+                .row("402", true, null, 102L, 0L)
+                .row("500", true, null, 200L, 0L)
+                .row("501", false, null, 201L, 0L)
+                .row("502", true, null, 202L, 0L)
+                .row(null, null, 1000L, 100L, 1L)
+                .row(null, null, 1001L, 101L, 1L)
+                .row(null, null, 1002L, 102L, 1L)
+                .row(null, null, 1100L, 200L, 1L)
+                .row(null, null, 1101L, 201L, 1L)
+                .row(null, null, 1102L, 202L, 1L)
                 .build();
 
         List<Page> pages = toPages(operator, input.iterator());

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1395,6 +1395,42 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testGroupingSetsAggregateOnGroupedColumn()
+            throws Exception
+    {
+        assertQuery("SELECT orderpriority, COUNT(orderpriority) FROM orders GROUP BY ROLLUP (orderpriority)",
+                "SELECT orderpriority, COUNT(orderpriority) FROM orders GROUP BY orderpriority UNION " +
+                        "SELECT NULL, COUNT(orderpriority) FROM orders");
+    }
+
+    @Test
+    public void testGroupingSetsMultipleAggregatesOnGroupedColumn()
+            throws Exception
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(suppkey), COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
+                "SELECT linenumber, suppkey, SUM(suppkey), COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
+                        "SELECT NULL, NULL, SUM(suppkey), COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsMultipleAggregatesOnUngroupedColumn()
+            throws Exception
+    {
+        assertQuery("SELECT linenumber, suppkey, COUNT(CAST(quantity AS BIGINT)), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
+                "SELECT linenumber, suppkey, COUNT(CAST(quantity AS BIGINT)), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
+                        "SELECT NULL, NULL, COUNT(CAST(quantity AS BIGINT)), SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsMultipleAggregatesWithGroupedColumns()
+            throws Exception
+    {
+        assertQuery("SELECT linenumber, suppkey, COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
+                "SELECT linenumber, suppkey, COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
+                        "SELECT NULL, NULL, COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
     public void testRollup()
             throws Exception
     {


### PR DESCRIPTION
- Modify the GroupIdNode and GroupIdOperator to pass aggregation
arguments through.
- Change PruneUnreferencedOutputs optimizer to only
pass through columns that are also aggregation arguments.

The expected behavior is that arguments to the aggregations reference
values in the source relation rather than the outputs of the GroupId
operation (which can produce nulls for these columns). Prior to this
change, aggregation arguments and grouping columns referenced the same
symbol, producing incorrect results.