### PR TITLE
Bug fix for ROW constructor with null values

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/RowConstructorCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/RowConstructorCodeGenerator.java
@@ -60,7 +60,8 @@ public class RowConstructorCodeGenerator
             }
             else {
                 Variable field = scope.createTempVariable(javaType);
-                block.comment("Generate + " + i + "-th field of row");
+                block.comment("Clean wasNull and Generate + " + i + "-th field of row");
+                block.append(context.wasNull().set(constantFalse()));
                 block.append(context.generate(arguments.get(i)));
                 block.putVariable(field);
                 block.append(new IfStatement()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -512,6 +512,8 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT CONTAINS(ARRAY_AGG(ROW(a, b)), ROW(1, 2)) FROM (VALUES (1, 2), (3, 4), (5, 6)) t(a, b)", "SELECT TRUE");
         assertQuery("SELECT JSON_FORMAT(CAST(ARRAY_AGG(ROW(c, d)) AS JSON)) FROM (VALUES (ARRAY[1, 3, 5], ARRAY[2, 4, 6])) AS t(a, b) CROSS JOIN UNNEST(a, b) AS u(c, d)",
                 "SELECT '[[1,2],[3,4],[5,6]]'");
+        assertQuery("SELECT JSON_FORMAT(CAST(ROW(x, y, z) AS JSON)) FROM (VALUES ROW(1, NULL, '3')) t(x,y,z)", "SELECT '[1,null,\"3\"]'");
+        assertQuery("SELECT JSON_FORMAT(CAST(ROW(x, y, z) AS JSON)) FROM (VALUES ROW(1, CAST(NULL AS INTEGER), '3')) t(x,y,z)", "SELECT '[1,null,\"3\"]'");
     }
 
     @Test


### PR DESCRIPTION
Fix for Issue https://github.com/prestodb/presto/issues/5367

Not all generators set `wasNull`, causing following values (generated from one generator that also doesn't set `wasNull`) to be `null`.

Also adding test cases that capture this.