### PR TITLE
Optimize bit packed long decoding in ORC reader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dep.antlr.version>4.5.1</dep.antlr.version>
         <dep.airlift.version>0.128</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.slice.version>0.19</dep.slice.version>
+        <dep.slice.version>0.21</dep.slice.version>
         <dep.aws-sdk.version>1.9.40</dep.aws-sdk.version>
         <dep.tempto.version>1.8</dep.tempto.version>
 

--- a/presto-docs/src/main/sphinx/release/release-0.148.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.148.rst
@@ -61,6 +61,7 @@ Hive Changes
 * Support ``DELETE`` from unpartitioned tables.
 * Add support for Kerberos authentication when talking to Hive/HDFS.
 * Push down filters for columns of type ``DECIMAL``.
+* Improve CPU efficiency when reading ORC files.
 
 Cassandra Changes
 -----------------

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -90,6 +90,18 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <scope>test</scope>

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongBitPacker.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongBitPacker.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.UnsafeSlice.getIntUnchecked;
+import static io.airlift.slice.UnsafeSlice.getLongUnchecked;
+import static io.airlift.slice.UnsafeSlice.getShortUnchecked;
+
+public final class LongBitPacker
+{
+    // ORC uses no more than 9 bits to store run lengths (https://orc.apache.org/docs/run-length.html#direct)
+    private static final int MAX_BUFFERED_POSITIONS = 512;
+
+    // We use this temp buffer to work around poor read performance of single bytes from Slice.
+    // Benchmarks show that reading from this byte[] is ~3x faster, even after accounting for the
+    // extra write to this buffer, than reading byte at a time from the InputStream.
+    private final byte[] tmp = new byte[SIZE_OF_LONG * MAX_BUFFERED_POSITIONS];
+    private final Slice slice = Slices.wrappedBuffer(tmp);
+
+    // TODO: refactor calling code, so that input can be a byte[]. (See comment above about performance)
+    public void unpack(long[] buffer, int offset, int len, int bitSize, InputStream input)
+            throws IOException
+    {
+        checkArgument(len <= MAX_BUFFERED_POSITIONS, "Expected ORC files to have runs of at most 512 bit packed longs");
+        switch (bitSize) {
+            case 1:
+                unpack1(buffer, offset, len, input);
+                break;
+            case 2:
+                unpack2(buffer, offset, len, input);
+                break;
+            case 4:
+                unpack4(buffer, offset, len, input);
+                break;
+            case 8:
+                unpack8(buffer, offset, len, input);
+                break;
+            case 16:
+                unpack16(buffer, offset, len, input);
+                break;
+            case 24:
+                unpack24(buffer, offset, len, input);
+                break;
+            case 32:
+                unpack32(buffer, offset, len, input);
+                break;
+            case 40:
+                unpack40(buffer, offset, len, input);
+                break;
+            case 48:
+                unpack48(buffer, offset, len, input);
+                break;
+            case 56:
+                unpack56(buffer, offset, len, input);
+                break;
+            case 64:
+                unpack64(buffer, offset, len, input);
+                break;
+            default:
+                unpackGeneric(buffer, offset, len, bitSize, input);
+        }
+    }
+
+    private static void unpackGeneric(long[] buffer, int offset, int len, int bitSize, InputStream input)
+            throws IOException
+    {
+        int bitsLeft = 0;
+        int current = 0;
+
+        for (int i = offset; i < (offset + len); i++) {
+            long result = 0;
+            int bitsLeftToRead = bitSize;
+            while (bitsLeftToRead > bitsLeft) {
+                result <<= bitsLeft;
+                result |= current & ((1 << bitsLeft) - 1);
+                bitsLeftToRead -= bitsLeft;
+                current = input.read();
+                bitsLeft = 8;
+            }
+
+            // handle the left over bits
+            if (bitsLeftToRead > 0) {
+                result <<= bitsLeftToRead;
+                bitsLeft -= bitsLeftToRead;
+                result |= (current >> bitsLeft) & ((1 << bitsLeftToRead) - 1);
+            }
+            buffer[i] = result;
+        }
+    }
+
+    private void unpack1(long[] buffer, int offset, int len, InputStream input)
+            throws IOException
+    {
+        if (len != 0 && len < 8) {
+            unpack1Unaligned(buffer, offset, len, input.read());
+            return;
+        }
+
+        int blockReadableBytes = (len + 7) / 8;
+        for (int i = 0; i < blockReadableBytes; ) {
+            i += input.read(tmp, i, blockReadableBytes - i);
+        }
+        int outputIndex = offset;
+        int end = offset + len;
+        int tmpIndex = 0;
+        for (; outputIndex + 7 < end; outputIndex += 8) {
+            long value;
+            value = tmp[tmpIndex];
+            tmpIndex++;
+            buffer[outputIndex] = (0b1000_0000 & value) >>> 7;
+            buffer[outputIndex + 1] = (0b0100_0000 & value) >>> 6;
+            buffer[outputIndex + 2] = (0b0010_0000 & value) >>> 5;
+            buffer[outputIndex + 3] = (0b0001_0000 & value) >>> 4;
+            buffer[outputIndex + 4] = (0b0000_1000 & value) >>> 3;
+            buffer[outputIndex + 5] = (0b0000_0100 & value) >>> 2;
+            buffer[outputIndex + 6] = (0b0000_0010 & value) >>> 1;
+            buffer[outputIndex + 7] = 0b0000_0001 & value;
+        }
+
+        // Get the last byte and decode it, if necessary
+        if (outputIndex < end) {
+            unpack1Unaligned(buffer, outputIndex, end - outputIndex, tmp[blockReadableBytes - 1]);
+        }
+    }
+
+    private static void unpack1Unaligned(long[] buffer, int outputIndex, int length, int value)
+    {
+        switch (length) {
+            case 7:
+                buffer[outputIndex + 6] = (0b0000_0010 & value) >>> 1;
+                //noinspection fallthrough
+            case 6:
+                buffer[outputIndex + 5] = (0b0000_0100 & value) >>> 2;
+                //noinspection fallthrough
+            case 5:
+                buffer[outputIndex + 4] = (0b0000_1000 & value) >>> 3;
+                //noinspection fallthrough
+            case 4:
+                buffer[outputIndex + 3] = (0b0001_0000 & value) >>> 4;
+                //noinspection fallthrough
+            case 3:
+                buffer[outputIndex + 2] = (0b0010_0000 & value) >>> 5;
+                //noinspection fallthrough
+            case 2:
+                buffer[outputIndex + 1] = (0b0100_0000 & value) >>> 6;
+                //noinspection fallthrough
+            case 1:
+                buffer[outputIndex] = (0b1000_0000 & value) >>> 7;
+        }
+    }
+
+    private void unpack2(long[] buffer, int offset, int len, InputStream input)
+            throws IOException
+    {
+        if (len != 0 && len < 4) {
+            unpack2Unaligned(buffer, offset, len, input.read());
+            return;
+        }
+
+        int blockReadableBytes = (2 * len + 7) / 8;
+        for (int i = 0; i < blockReadableBytes; ) {
+            i += input.read(tmp, i, blockReadableBytes - i);
+        }
+        int outputIndex = offset;
+        int end = offset + len;
+        int tmpIndex = 0;
+        for (; outputIndex + 3 < end; outputIndex += 4) {
+            long value;
+            value = tmp[tmpIndex];
+            tmpIndex++;
+            buffer[outputIndex] = (0b1100_0000 & value) >>> 6;
+            buffer[outputIndex + 1] = (0b0011_0000 & value) >>> 4;
+            buffer[outputIndex + 2] = (0b0000_1100 & value) >>> 2;
+            buffer[outputIndex + 3] = 0b0000_0011 & value;
+        }
+
+        // Get the last byte and decode it, if necessary
+        if (outputIndex < end) {
+            unpack2Unaligned(buffer, outputIndex, end - outputIndex, tmp[blockReadableBytes - 1]);
+        }
+    }
+
+    private static void unpack2Unaligned(long[] buffer, int outputIndex, int length, int value)
+    {
+        switch (length) {
+            case 3:
+                buffer[outputIndex + 2] = (0b0000_1100 & value) >>> 2;
+                //noinspection fallthrough
+            case 2:
+                buffer[outputIndex + 1] = (0b0011_0000 & value) >>> 4;
+                //noinspection fallthrough
+            case 1:
+                buffer[outputIndex] = (0b1100_0000 & value) >>> 6;
+        }
+    }
+
+    private void unpack4(long[] buffer, int offset, int len, InputStream input)
+            throws IOException
+    {
+        if (len != 0 && len < 3) {
+            int value = input.read();
+            buffer[offset] = (0b1111_0000 & value) >>> 4;
+            if (len == 2) {
+                buffer[offset + 1] = 0b0000_1111 & value;
+            }
+            return;
+        }
+
+        int blockReadableBytes = (4 * len + 7) / 8;
+        for (int i = 0; i < blockReadableBytes; ) {
+            i += input.read(tmp, i, blockReadableBytes - i);
+        }
+        int outputIndex = offset;
+        int end = offset + len;
+        int tmpIndex = 0;
+        for (; outputIndex + 1 < end; outputIndex += 2) {
+            long value;
+            value = tmp[tmpIndex];
+            tmpIndex++;
+            buffer[outputIndex] = (0b1111_0000 & value) >>> 4;
+            buffer[outputIndex + 1] = 0b0000_1111 & value;
+        }
+
+        // Get the last byte and decode it, if necessary
+        if (outputIndex != end) {
+            buffer[outputIndex] = (0b1111_0000 & tmp[blockReadableBytes - 1]) >>> 4;
+        }
+    }
+
+    private void unpack8(long[] buffer, int offset, int len, InputStream input)
+            throws IOException
+    {
+        for (int i = 0; i < len; ) {
+            i += input.read(tmp, i, len - i);
+        }
+        for (int i = 0; i < len; i++) {
+            buffer[offset + i] = 0xFFL & tmp[i];
+        }
+    }
+
+    private void unpack16(long[] buffer, int offset, int len, InputStream input)
+            throws IOException
+    {
+        int blockReadableBytes = len * 16 / 8;
+        for (int i = 0; i < blockReadableBytes; ) {
+            i += input.read(tmp, i, blockReadableBytes - i);
+        }
+        for (int i = 0; i < len; i++) {
+            buffer[offset + i] = 0xFFFFL & Short.reverseBytes(getShortUnchecked(slice, 2 * i));
+        }
+    }
+
+    private void unpack24(long[] buffer, int offset, int len, InputStream input)
+            throws IOException
+    {
+        int blockReadableBytes = len * 24 / 8;
+        for (int i = 0; i < blockReadableBytes; ) {
+            i += input.read(tmp, i, blockReadableBytes - i);
+        }
+        for (int i = 0; i < len; i++) {
+            // It's safe to read 4-bytes at a time and shift, because slice is a view over tmp,
+            // which has 8 bytes of buffer space for every position
+            buffer[offset + i] = 0xFF_FFFFL & (Integer.reverseBytes(getIntUnchecked(slice, 3 * i)) >>> 8);
+        }
+    }
+
+    private void unpack32(long[] buffer, int offset, int len, InputStream input)
+            throws IOException
+    {
+        int blockReadableBytes = len * 32 / 8;
+        for (int i = 0; i < blockReadableBytes; ) {
+            i += input.read(tmp, i, blockReadableBytes - i);
+        }
+        for (int i = 0; i < len; i++) {
+            buffer[offset + i] = 0xFFFF_FFFFL & Integer.reverseBytes(getIntUnchecked(slice, 4 * i));
+        }
+    }
+
+    private void unpack40(long[] buffer, int offset, int len, InputStream input)
+            throws IOException
+    {
+        int blockReadableBytes = len * 40 / 8;
+        for (int i = 0; i < blockReadableBytes; ) {
+            i += input.read(tmp, i, blockReadableBytes - i);
+        }
+        for (int i = 0; i < len; i++) {
+            // It's safe to read 8-bytes at a time and shift, because slice is a view over tmp,
+            // which has 8 bytes of buffer space for every position
+            buffer[offset + i] = Long.reverseBytes(getLongUnchecked(slice, 5 * i)) >>> 24;
+        }
+    }
+
+    private void unpack48(long[] buffer, int offset, int len, InputStream input)
+            throws IOException
+    {
+        int blockReadableBytes = len * 48 / 8;
+        for (int i = 0; i < blockReadableBytes; ) {
+            i += input.read(tmp, i, blockReadableBytes - i);
+        }
+        for (int i = 0; i < len; i++) {
+            // It's safe to read 8-bytes at a time and shift, because slice is a view over tmp,
+            // which has 8 bytes of buffer space for every position
+            buffer[offset + i] = Long.reverseBytes(getLongUnchecked(slice, 6 * i)) >>> 16;
+        }
+    }
+
+    private void unpack56(long[] buffer, int offset, int len, InputStream input)
+            throws IOException
+    {
+        int blockReadableBytes = len * 56 / 8;
+        for (int i = 0; i < blockReadableBytes; ) {
+            i += input.read(tmp, i, blockReadableBytes - i);
+        }
+        for (int i = 0; i < len; i++) {
+            // It's safe to read 8-bytes at a time and shift, because slice is a view over tmp,
+            // which has 8 bytes of buffer space for every position
+            buffer[offset + i] = Long.reverseBytes(getLongUnchecked(slice, 7 * i)) >>> 8;
+        }
+    }
+
+    private void unpack64(long[] buffer, int offset, int len, InputStream input)
+            throws IOException
+    {
+        int blockReadableBytes = len * 64 / 8;
+        for (int i = 0; i < blockReadableBytes; ) {
+            i += input.read(tmp, i, blockReadableBytes - i);
+        }
+        for (int i = 0; i < len; i++) {
+            buffer[offset + i] = Long.reverseBytes(getLongUnchecked(slice, 8 * i));
+        }
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/BenchmarkLongBitPacker.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/BenchmarkLongBitPacker.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.orc.stream.TestingBitPackingUtils.unpackGeneric;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkLongBitPacker
+{
+    @Benchmark
+    public Object baselineLength1(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        unpackGeneric(data.buffer, 0, 1, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(2)
+    public Object baselineLength2(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        unpackGeneric(data.buffer, 0, 2, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(3)
+    public Object baselineLength3(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        unpackGeneric(data.buffer, 0, 3, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(4)
+    public Object baselineLength4(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        unpackGeneric(data.buffer, 0, 4, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(5)
+    public Object baselineLength5(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        unpackGeneric(data.buffer, 0, 5, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(6)
+    public Object baselineLength6(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        unpackGeneric(data.buffer, 0, 6, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(7)
+    public Object baselineLength7(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        unpackGeneric(data.buffer, 0, 7, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(256)
+    public Object baselineLength256(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        unpackGeneric(data.buffer, 0, 256, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    public Object optimizedLength1(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        data.packer.unpack(data.buffer, 0, 1, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(2)
+    public Object optimizedLength2(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        data.packer.unpack(data.buffer, 0, 2, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(3)
+    public Object optimizedLength3(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        data.packer.unpack(data.buffer, 0, 3, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(4)
+    public Object optimizedLength4(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        data.packer.unpack(data.buffer, 0, 4, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(5)
+    public Object optimizedLength5(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        data.packer.unpack(data.buffer, 0, 5, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(6)
+    public Object optimizedLength6(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        data.packer.unpack(data.buffer, 0, 6, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(7)
+    public Object optimizedLength7(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        data.packer.unpack(data.buffer, 0, 7, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(256)
+    public Object optimizedLength256(BenchmarkData data)
+            throws Throwable
+    {
+        data.input.setPosition(0);
+        data.packer.unpack(data.buffer, 0, 256, data.bits, data.input);
+        return data.buffer;
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private final long[] buffer = new long[256];
+        private final LongBitPacker packer = new LongBitPacker();
+
+        @Param({"1", "2", "4", "8", "16", "24", "32", "40", "48", "56", "64"})
+        private int bits;
+
+        private BasicSliceInput input;
+
+        @Setup
+        public void setup()
+        {
+            byte[] bytes = new byte[256 * 64];
+            ThreadLocalRandom.current().nextBytes(bytes);
+            input = Slices.wrappedBuffer(bytes).getInput();
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkLongBitPacker().baselineLength256(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkLongBitPacker.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongBitPacker.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongBitPacker.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Random;
+
+import static com.facebook.presto.orc.stream.TestingBitPackingUtils.unpackGeneric;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+
+public class TestLongBitPacker
+{
+    public static final int LENGTHS = 128;
+    public static final int OFFSETS = 4;
+    public static final int WIDTHS = 64;
+
+    @Test
+    public void testBasic()
+            throws Throwable
+    {
+        LongBitPacker packer = new LongBitPacker();
+        for (int length = 0; length < LENGTHS; length++) {
+            assertUnpacking(packer, length);
+        }
+    }
+
+    private static void assertUnpacking(LongBitPacker packer, int length)
+            throws IOException
+    {
+        for (int width = 1; width <= WIDTHS; width++) {
+            for (int offset = 0; offset < OFFSETS; offset++) {
+                long[] expected = new long[length + offset];
+                long[] actual = new long[length + offset];
+                RandomByteInputStream expectedInput = new RandomByteInputStream();
+                unpackGeneric(expected, offset, length, width, expectedInput);
+                RandomByteInputStream actualInput = new RandomByteInputStream();
+                packer.unpack(actual, offset, length, width, actualInput);
+                for (int i = offset; i < length + offset; i++) {
+                    assertEquals(actual[i], expected[i], format("index = %s, length = %s, width = %s, offset = %s", i, length, width, offset));
+                }
+                assertEquals(actualInput.getReadBytes(), expectedInput.getReadBytes(), format("Wrong number of bytes read for length = %s, width = %s, offset = %s", length, width, offset));
+            }
+        }
+    }
+
+    private static final class RandomByteInputStream
+            extends InputStream
+    {
+        private final Random rand = new Random(0);
+        private int readBytes;
+
+        @Override
+        public int read()
+                throws IOException
+        {
+            readBytes++;
+            return rand.nextInt(256);
+        }
+
+        public int getReadBytes()
+        {
+            return readBytes;
+        }
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestingBitPackingUtils.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestingBitPackingUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class TestingBitPackingUtils
+{
+    private TestingBitPackingUtils() {}
+
+    // Old implementation of bit unpacking code from Hive ORC reader
+    public static void unpackGeneric(long[] buffer, int offset, int len, int bitSize, InputStream input)
+            throws IOException
+    {
+        int bitsLeft = 0;
+        int current = 0;
+
+        for (int i = offset; i < (offset + len); i++) {
+            long result = 0;
+            int bitsLeftToRead = bitSize;
+            while (bitsLeftToRead > bitsLeft) {
+                result <<= bitsLeft;
+                result |= current & ((1 << bitsLeft) - 1);
+                bitsLeftToRead -= bitsLeft;
+                current = input.read();
+                bitsLeft = 8;
+            }
+
+            // handle the left over bits
+            if (bitsLeftToRead > 0) {
+                result <<= bitsLeftToRead;
+                bitsLeft -= bitsLeftToRead;
+                result |= (current >> bitsLeft) & ((1 << bitsLeftToRead) - 1);
+            }
+            buffer[i] = result;
+        }
+    }
+}


### PR DESCRIPTION
This makes the bit unpacking ~5x faster in synthetic benchmarks and
improves overall CPU efficiency by 25% for the query I'm running (a
scan-filter-aggregate)