### PR TITLE
Refactor docker compose

### DIFF
--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -96,6 +96,23 @@ VM will have to be re-downloaded when the product tests are kicked
 off. To avoid this unnecessary re-download, do not create new
 VMs often.
 
+## Use the `docker-compose` wrappers
+
+We're using [multiple compose files](https://docs.docker.com/compose/extends/#multiple-compose-files)
+because of the number of overrides needed for different environments,
+and deficiencies of `extends:` syntax (see the note
+[here](https://docs.docker.com/compose/extends/#extending-services)).
+
+
+To ease the pain of passing multiple `-f` arguments to `docker-compose`,
+each environment has a `compose.sh` wrapper script. Thanks to it, instead of e.g.
+
+`docker-compose -f ./docker-compose.yml -f ../common/standard.yml -f ../common/jdbc_db.yml [compose commands]`
+
+one can simply write
+
+`compose.sh [compose commands]`
+
 ## Running the product tests
 
 The Presto product tests must be run explicitly because they do not run
@@ -208,13 +225,13 @@ setup outlined below:
 2. Start Hadoop in pseudo-distributed mode in a Docker container:
 
     ```
-    docker-compose -f presto-product-tests/conf/docker/singlenode/docker-compose.yml up -d hadoop-master
+    presto-product-tests/conf/docker/singlenode/compose.sh up -d hadoop-master
     ```
     
     Tip: To display container logs run:
 
     ```
-    docker-compose -f presto-product-tests/conf/docker/singlenode/docker-compose.yml logs
+    presto-product-tests/conf/docker/singlenode/compose.sh logs
     ```
     
 3. Add an IP-to-host mapping for the `hadoop-master` host in `/etc/hosts`.
@@ -224,7 +241,7 @@ The format of `/etc/hosts` entries is `<ip> <host>`:
     The container IP can be obtained by running:
 
         ```
-        docker inspect $(docker-compose -f presto-product-tests/conf/docker/singlenode/docker-compose.yml ps -q hadoop-master) | grep -i IPAddress
+        docker inspect $(presto-product-tests/conf/docker/singlenode/compose.sh ps -q hadoop-master) | grep -i IPAddress
         ```
 
     - On OS X add the following mapping: `<docker machine ip> hadoop-master`.
@@ -252,7 +269,7 @@ or debug the respective test(s).
 following command:
 
     ```
-    docker-compose -f presto-product-tests/conf/docker/singlenode/docker-compose.yml down
+    presto-product-tests/conf/docker/singlenode/compose.sh down
     ```
 
 ### Debugging convention based tests
@@ -298,13 +315,14 @@ running the debugger.
 
 ## Troubleshooting
 
-Use the `docker-compose` and `docker` utilities to control and troubleshoot
-containers. In the following examples ``<profile>`` is [profile](#profile).
+Use the `docker-compose` (probably using a [wrapper](#use-the-docker-compose-wrappers))
+and `docker` utilities to control and troubleshoot containers.
+In the following examples ``<profile>`` is [profile](#profile).
 
 1. Use the following command to view output from running containers:
 
     ```
-    docker-compose -f presto-product-tests/conf/docker/<profile>/docker-compose.yml logs
+    presto-product-tests/conf/docker/<profile>/compose.sh logs
     ```
 
 2. To connect to a running container in an interactive Bash shell to
@@ -324,8 +342,8 @@ been downloaded:
     ```
     # Stop Hadoop container (the down command stops and removes containers,
     # network, images, and volumes). This effectively resets the container.
-    docker-compose -f presto-product-tests/conf/docker/<profile>/docker-compose.yml down
+    presto-product-tests/conf/docker/<profile>/compose.sh down
     # Pull from Docker Hub to ensure the latest version of the image is
     # downloaded.
-    docker-compose -f presto-product-tests/conf/docker/<profile>/docker-compose.yml pull
+    presto-product-tests/conf/docker/<profile>/compose.sh pull
     ```

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -93,16 +93,8 @@ function stop_docker_compose_containers() {
 }
 
 function environment_docker_compose() {
-  local ENVIRONMENT_DOCKER_COMPOSE_LOCATION="${DOCKER_CONF_LOCATION}/${ENVIRONMENT}/docker-compose.yml"
-  local COMPOSE_FILES=( -f "${DOCKER_CONF_LOCATION}/common/standard.yml" )
-  if [[ $ENVIRONMENT == *"kerberos"* ]]; then
-    COMPOSE_FILES+=( -f "${DOCKER_CONF_LOCATION}/common/kerberos.yml" )
-  fi
-  COMPOSE_FILES+=( \
-    -f "${DOCKER_CONF_LOCATION}/common/jdbc_db.yml" \
-    -f "${ENVIRONMENT_DOCKER_COMPOSE_LOCATION}" \
-  )
-  docker-compose "${COMPOSE_FILES[@]}" "$@"
+  local ENVIRONMENT_COMPOSE_SCRIPT_LOCATION="${DOCKER_CONF_LOCATION}/${ENVIRONMENT}/compose.sh"
+  ${ENVIRONMENT_COMPOSE_SCRIPT_LOCATION} "$@"
 }
 
 function cleanup() {

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -61,6 +61,7 @@ function run_product_tests() {
 
 # docker-compose down is not good enough because it's ignores services created with "run" command
 function stop_application_runner_containers() {
+  local ENVIRONMENT=$1
   APPLICATION_RUNNER_CONTAINERS=$(environment_docker_compose ps -q application-runner)
   for CONTAINER_NAME in ${APPLICATION_RUNNER_CONTAINERS}
   do
@@ -74,22 +75,23 @@ function stop_all_containers() {
   local ENVIRONMENT
   for ENVIRONMENT in $(getAvailableEnvironments)
   do
-     stop_docker_compose_containers
+     stop_docker_compose_containers ${ENVIRONMENT}
   done
 }
 
 function stop_docker_compose_containers() {
+  local ENVIRONMENT=$1
   RUNNING_CONTAINERS=$(environment_docker_compose ps -q)
 
   if [[ ! -z ${RUNNING_CONTAINERS} ]]; then
     # stop application runner containers started with "run"
-    stop_application_runner_containers
+    stop_application_runner_containers ${ENVIRONMENT}
 
     # stop containers started with "up"
     environment_docker_compose down
   fi
 
-  echo "Docker compose containers stopped: [$1]"
+  echo "Docker compose containers stopped: [$ENVIRONMENT]"
 }
 
 function environment_docker_compose() {
@@ -98,10 +100,10 @@ function environment_docker_compose() {
 }
 
 function cleanup() {
-  stop_application_runner_containers
+  stop_application_runner_containers ${ENVIRONMENT}
 
   if [[ "${LEAVE_CONTAINERS_ALIVE_ON_EXIT}" != "true" ]]; then
-    stop_docker_compose_containers
+    stop_docker_compose_containers ${ENVIRONMENT}
   fi
 
   # Ensure that the logs processes are terminated.

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -94,7 +94,11 @@ function stop_docker_compose_containers() {
 
 function environment_docker_compose() {
   local ENVIRONMENT_DOCKER_COMPOSE_LOCATION="${DOCKER_CONF_LOCATION}/${ENVIRONMENT}/docker-compose.yml"
-  local COMPOSE_FILES=( \
+  local COMPOSE_FILES=( -f "${DOCKER_CONF_LOCATION}/common/standard.yml" )
+  if [[ $ENVIRONMENT == *"kerberos"* ]]; then
+    COMPOSE_FILES+=( -f "${DOCKER_CONF_LOCATION}/common/kerberos.yml" )
+  fi
+  COMPOSE_FILES+=( \
     -f "${DOCKER_CONF_LOCATION}/common/jdbc_db.yml" \
     -f "${ENVIRONMENT_DOCKER_COMPOSE_LOCATION}" \
   )

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -93,8 +93,12 @@ function stop_docker_compose_containers() {
 }
 
 function environment_docker_compose() {
-  ENVIRONMENT_DOCKER_COMPOSE_LOCATION="${ENVIRONMENT_LOCATION}/${ENVIRONMENT}/docker-compose.yml"
-  docker-compose -f "${ENVIRONMENT_DOCKER_COMPOSE_LOCATION}" "$@"
+  local ENVIRONMENT_DOCKER_COMPOSE_LOCATION="${DOCKER_CONF_LOCATION}/${ENVIRONMENT}/docker-compose.yml"
+  local COMPOSE_FILES=( \
+    -f "${DOCKER_CONF_LOCATION}/common/jdbc_db.yml" \
+    -f "${ENVIRONMENT_DOCKER_COMPOSE_LOCATION}" \
+  )
+  docker-compose "${COMPOSE_FILES[@]}" "$@"
 }
 
 function cleanup() {
@@ -128,7 +132,7 @@ function terminate() {
 }
 
 function getAvailableEnvironments() {
-  for i in $(ls -d $ENVIRONMENT_LOCATION/*/); do echo ${i%%/}; done\
+  for i in $(ls -d $DOCKER_CONF_LOCATION/*/); do echo ${i%%/}; done\
      | grep -v files | grep -v common | xargs -n1 basename
 }
 
@@ -136,10 +140,10 @@ ENVIRONMENT=$1
 SCRIPT_DIR=$(dirname $(absolutepath "$0"))
 PRODUCT_TESTS_ROOT="${SCRIPT_DIR}/.."
 PROJECT_ROOT="${PRODUCT_TESTS_ROOT}/.."
-ENVIRONMENT_LOCATION="${PRODUCT_TESTS_ROOT}/conf/docker"
+DOCKER_CONF_LOCATION="${PRODUCT_TESTS_ROOT}/conf/docker"
 
 # Get the list of valid environments
-if [[ ! -d "$ENVIRONMENT_LOCATION/$ENVIRONMENT" ]]; then
+if [[ ! -d "$DOCKER_CONF_LOCATION/$ENVIRONMENT" ]]; then
    echo "Usage: run_on_docker.sh <`getAvailableEnvironments | tr '\n' '|'`> <product test args>"
    exit 1
 fi

--- a/presto-product-tests/conf/docker/common/jdbc_db.yml
+++ b/presto-product-tests/conf/docker/common/jdbc_db.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
 
-  postgres-common:
+  postgres:
     hostname: postgres
     image: 'postgres'
     ports:
@@ -11,7 +11,7 @@ services:
       POSTGRES_USER: swarm
       POSTGRES_DB: test
 
-  mysql-common:
+  mysql:
     hostname: mysql
     image: 'mysql'
     ports:

--- a/presto-product-tests/conf/docker/common/kerberos.yml
+++ b/presto-product-tests/conf/docker/common/kerberos.yml
@@ -1,35 +1,16 @@
 version: '2'
 services:
 
-  hadoop-kerberos:
-    # cdh5-hive-kerberized contains keytabs and the `krb5.conf` within
+  # cdh5-hive-kerberized contains keytabs and the `krb5.conf` within
+
+  hadoop-master:
     image: 'teradatalabs/cdh5-hive-kerberized:4'
-    env_file:
-      - ../../../target/classes/presto.env
-    volumes:
-      - ../../../../:/docker/volumes/presto
 
-  hadoop-master-kerberos:
-    extends:
-      service: hadoop-kerberos
-    hostname: hadoop-master
-    ports:
-      - '1080:1080'
-      - '8020:8020'
-      - '8088:8088'
-      - '9083:9083'
-      - '10000:10000'
-      - '50070:50070'
-      - '50075:50075'
-
-  presto-master-kerberos:
-    extends:
-      service: hadoop-kerberos
+  presto-master:
+    image: 'teradatalabs/cdh5-hive-kerberized:4'
     command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode-kerberized run
     volumes:
       - ../../../../presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml
 
-  application-runner-kerberos:
-    extends:
-      service: hadoop-kerberos
-    hostname: application-runner
+  application-runner:
+    image: 'teradatalabs/cdh5-hive-kerberized:4'

--- a/presto-product-tests/conf/docker/common/kerberos.yml
+++ b/presto-product-tests/conf/docker/common/kerberos.yml
@@ -9,8 +9,8 @@ services:
   presto-master:
     image: 'teradatalabs/cdh5-hive-kerberized:4'
     command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode-kerberized run
-    volumes:
-      - ../../../../presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml
 
   application-runner:
     image: 'teradatalabs/cdh5-hive-kerberized:4'
+    volumes:
+      - ../../../../presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml

--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -1,3 +1,4 @@
+#overrides ./jdbc_db.yml
 version: '2'
 services:
 
@@ -26,8 +27,7 @@ services:
     extends:
       service: java-8-base
     hostname: presto-master
-    volumes:
-      - ../../../../presto-product-tests/conf/tempto/tempto-configuration-for-docker-default.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml
+    command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode run
     ports:
       - '8080:8080'
     depends_on:
@@ -39,5 +39,7 @@ services:
     hostname: application-runner
     depends_on:
       - presto-master
+    volumes:
+      - ../../../../presto-product-tests/conf/tempto/tempto-configuration-for-docker-default.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml
     volumes_from:
       - presto-master

--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -8,16 +8,10 @@ services:
     volumes:
       - ../../../../:/docker/volumes/presto
 
-  hadoop-base:
-    image: 'teradatalabs/cdh5-hive:4'
-    env_file:
-      - ../../../target/classes/presto.env
-    volumes:
-      - ../../../../:/docker/volumes/presto
-
-  hadoop-master-common:
+  hadoop-master:
     extends:
-      service: hadoop-base
+      service: java-8-base
+    image: 'teradatalabs/cdh5-hive:4'
     hostname: hadoop-master
     ports:
       - '1080:1080'
@@ -27,8 +21,8 @@ services:
       - '10000:10000'
       - '50070:50070'
       - '50075:50075'
-  
-  presto-master-common:
+
+  presto-master:
     extends:
       service: java-8-base
     hostname: presto-master
@@ -36,13 +30,14 @@ services:
       - ../../../../presto-product-tests/conf/tempto/tempto-configuration-for-docker-default.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml
     ports:
       - '8080:8080'
+    depends_on:
+       - hadoop-master
 
-  presto-worker-common:
-    extends:
-      service: java-8-base
-    command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh multinode-worker run
-
-  application-runner-common:
+  application-runner:
     extends:
       service: java-8-base
     hostname: application-runner
+    depends_on:
+      - presto-master
+    volumes_from:
+      - presto-master

--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -37,8 +37,6 @@ services:
     extends:
       service: java-8-base
     hostname: application-runner
-    depends_on:
-      - presto-master
     volumes:
       - ../../../../presto-product-tests/conf/tempto/tempto-configuration-for-docker-default.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml
     volumes_from:

--- a/presto-product-tests/conf/docker/multinode/compose.sh
+++ b/presto-product-tests/conf/docker/multinode/compose.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker-compose \
+-f ${BASH_SOURCE%/*}/../common/standard.yml \
+-f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \
+-f ${BASH_SOURCE%/*}/docker-compose.yml \
+"$@"

--- a/presto-product-tests/conf/docker/multinode/docker-compose.yml
+++ b/presto-product-tests/conf/docker/multinode/docker-compose.yml
@@ -1,32 +1,15 @@
 version: '2'
 services:
-  hadoop-master:
-    extends:
-      file: ../common/standard.yml
-      service: hadoop-master-common
 
   presto-master:
-    extends:
-      file: ../common/standard.yml
-      service: presto-master-common
     command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh multinode-master run
-    depends_on:
-       - hadoop-master
 
   presto-worker:
     extends:
       file: ../common/standard.yml
-      service: presto-worker-common
+      service: java-8-base
+    command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh multinode-worker run
     depends_on:
-      - 'presto-master'
-    volumes_from:
       - presto-master
-
-  application-runner:
-    extends:
-      file: ../common/standard.yml
-      service: application-runner-common
-    depends_on:
-      - 'presto-master'
     volumes_from:
       - presto-master

--- a/presto-product-tests/conf/docker/multinode/docker-compose.yml
+++ b/presto-product-tests/conf/docker/multinode/docker-compose.yml
@@ -30,13 +30,3 @@ services:
       - 'presto-master'
     volumes_from:
       - presto-master
-
-  postgres:
-    extends:
-      file: ../common/jdbc_db.yml
-      service: postgres-common
-
-  mysql:
-    extends:
-      file: ../common/jdbc_db.yml
-      service: mysql-common

--- a/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/compose.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker-compose \
+-f ${BASH_SOURCE%/*}/../common/standard.yml \
+-f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \
+-f ${BASH_SOURCE%/*}/docker-compose.yml \
+"$@"

--- a/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/docker-compose.yml
@@ -1,25 +1,7 @@
 version: '2'
 services:
-  hadoop-master:
-    extends:
-      file: ../common/standard.yml
-      service: hadoop-master-common
 
   presto-master:
-    extends:
-      file: ../common/standard.yml
-      service: presto-master-common
     command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode run
     volumes:
       - ../../../../presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-hdfs-impersonation/hive.properties:/docker/volumes/presto/presto-product-tests/conf/presto/etc/catalog/hive.properties
-    depends_on:
-       - hadoop-master
-
-  application-runner:
-    extends:
-      file: ../common/standard.yml
-      service: application-runner-common
-    depends_on:
-      - 'presto-master'
-    volumes_from:
-      - presto-master

--- a/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/docker-compose.yml
@@ -23,13 +23,3 @@ services:
       - 'presto-master'
     volumes_from:
       - presto-master
-
-  postgres:
-    extends:
-      file: ../common/jdbc_db.yml
-      service: postgres-common
-
-  mysql:
-    extends:
-      file: ../common/jdbc_db.yml
-      service: mysql-common

--- a/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/docker-compose.yml
@@ -2,6 +2,5 @@ version: '2'
 services:
 
   presto-master:
-    command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode run
     volumes:
       - ../../../../presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-hdfs-impersonation/hive.properties:/docker/volumes/presto/presto-product-tests/conf/presto/etc/catalog/hive.properties

--- a/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-impersonation/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-impersonation/compose.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+docker-compose \
+-f ${BASH_SOURCE%/*}/../common/standard.yml \
+-f ${BASH_SOURCE%/*}/../common/kerberos.yml \
+-f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \
+-f ${BASH_SOURCE%/*}/docker-compose.yml \
+"$@"

--- a/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-impersonation/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-impersonation/docker-compose.yml
@@ -1,24 +1,6 @@
 version: '2'
 services:
-  hadoop-master:
-    extends:
-      file: ../common/kerberos.yml
-      service: hadoop-master-kerberos
 
   presto-master:
-    extends:
-      file: ../common/kerberos.yml
-      service: presto-master-kerberos
     volumes:
       - ../../../../presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties:/docker/volumes/presto/presto-product-tests/conf/presto/etc/catalog/hive.properties
-    depends_on:
-       - hadoop-master
-
-  application-runner:
-    extends:
-      file: ../common/kerberos.yml
-      service: application-runner-kerberos
-    depends_on:
-      - 'presto-master'
-    volumes_from:
-      - presto-master

--- a/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-impersonation/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-impersonation/docker-compose.yml
@@ -22,13 +22,3 @@ services:
       - 'presto-master'
     volumes_from:
       - presto-master
-
-  postgres:
-    extends:
-      file: ../common/jdbc_db.yml
-      service: postgres-common
-
-  mysql:
-    extends:
-      file: ../common/jdbc_db.yml
-      service: mysql-common

--- a/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-no-impersonation/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-no-impersonation/compose.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+docker-compose \
+-f ${BASH_SOURCE%/*}/../common/standard.yml \
+-f ${BASH_SOURCE%/*}/../common/kerberos.yml \
+-f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \
+-f ${BASH_SOURCE%/*}/docker-compose.yml \
+"$@"

--- a/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-no-impersonation/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-no-impersonation/docker-compose.yml
@@ -1,24 +1,6 @@
 version: '2'
 services:
-  hadoop-master:
-    extends:
-      file: ../common/kerberos.yml
-      service: hadoop-master-kerberos
 
   presto-master:
-    extends:
-      file: ../common/kerberos.yml
-      service: presto-master-kerberos
     volumes:
       - ../../../../presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties:/docker/volumes/presto/presto-product-tests/conf/presto/etc/catalog/hive.properties
-    depends_on:
-       - hadoop-master
-
-  application-runner:
-    extends:
-      file: ../common/kerberos.yml
-      service: application-runner-kerberos
-    depends_on:
-      - 'presto-master'
-    volumes_from:
-      - presto-master

--- a/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-no-impersonation/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-no-impersonation/docker-compose.yml
@@ -22,13 +22,3 @@ services:
       - 'presto-master'
     volumes_from:
       - presto-master
-
-  postgres:
-    extends:
-      file: ../common/jdbc_db.yml
-      service: postgres-common
-
-  mysql:
-    extends:
-      file: ../common/jdbc_db.yml
-      service: mysql-common

--- a/presto-product-tests/conf/docker/singlenode/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode/compose.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker-compose \
+-f ${BASH_SOURCE%/*}/../common/standard.yml \
+-f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \
+-f ${BASH_SOURCE%/*}/docker-compose.yml \
+"$@"

--- a/presto-product-tests/conf/docker/singlenode/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode/docker-compose.yml
@@ -1,5 +1,1 @@
 version: '2'
-services:
-
-  presto-master:
-    command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode run

--- a/presto-product-tests/conf/docker/singlenode/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode/docker-compose.yml
@@ -1,23 +1,5 @@
 version: '2'
 services:
-  hadoop-master:
-    extends:
-      file: ../common/standard.yml
-      service: hadoop-master-common
 
   presto-master:
-    extends:
-      file: ../common/standard.yml
-      service: presto-master-common
     command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode run
-    depends_on:
-       - hadoop-master
-
-  application-runner:
-    extends:
-      file: ../common/standard.yml
-      service: application-runner-common
-    depends_on:
-      - 'presto-master'
-    volumes_from:
-      - presto-master

--- a/presto-product-tests/conf/docker/singlenode/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode/docker-compose.yml
@@ -21,13 +21,3 @@ services:
       - 'presto-master'
     volumes_from:
       - presto-master
-
-  postgres:
-    extends:
-      file: ../common/jdbc_db.yml
-      service: postgres-common
-
-  mysql:
-    extends:
-      file: ../common/jdbc_db.yml
-      service: mysql-common


### PR DESCRIPTION
This PR aims at further deduplication of docker-compose files for product tests, following the path set by @brian-rickman in #5309. This will serve the following causes:
 - better readability and maintainability,
 - providing groundwork for running docker containers for product tests in EC2 by making volume definitions clearer.

This PR shifts from the [extending services](https://docs.docker.com/compose/extends/#extending-services) approach to the [multiple compose files](https://docs.docker.com/compose/extends/#multiple-compose-files) one. This allows for defining `volumes_from` and `depends_on` only once for each service (compared to multiple copies forced by the inheritance approach - see 'Note' in the 'extending services' link).

This can also be thought of as a switch from inheritance to composition. Each docker-compose.yml-file describes one aspect of the composition. Aspects applied later override those applied earlier. The application order - as can be seen in [`environment_docker_compose`](https://github.com/prestodb/presto/compare/master...Teradata:refactor-docker-compose?expand=1#diff-d5fa118c169436bb50bbd774dc84d440R95) function is as follows:

1. standard.yml
2. kerberos.yml (only for envs containing `kerberos` in name)
3. jdbc_db.yml
4. environment-specific .yml files