### PR TITLE
Add type matching checker for PlanSanityChecker

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -276,7 +276,7 @@ public final class SqlQueryExecution
 
         // plan query
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
-        LogicalPlanner logicalPlanner = new LogicalPlanner(stateMachine.getSession(), planOptimizers, idAllocator, metadata);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(stateMachine.getSession(), planOptimizers, idAllocator, metadata, sqlParser);
         Plan plan = logicalPlanner.plan(analysis);
 
         // extract inputs

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -130,7 +130,7 @@ public class QueryExplainer
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
 
         // plan statement
-        LogicalPlanner logicalPlanner = new LogicalPlanner(session, planOptimizers, idAllocator, metadata);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(session, planOptimizers, idAllocator, metadata, sqlParser);
         return logicalPlanner.plan(analysis);
     }
 
@@ -143,7 +143,7 @@ public class QueryExplainer
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
 
         // plan statement
-        LogicalPlanner logicalPlanner = new LogicalPlanner(session, planOptimizers, idAllocator, metadata);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(session, planOptimizers, idAllocator, metadata, sqlParser);
         Plan plan = logicalPlanner.plan(analysis);
 
         return new PlanFragmenter().createSubPlans(session, metadata, plan);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoApplyNodeLeftChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoApplyNodeLeftChecker.java
@@ -13,15 +13,22 @@
  */
 package com.facebook.presto.sql.planner.sanity;
 
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.SimplePlanVisitor;
+import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.Map;
 
 public class NoApplyNodeLeftChecker
         implements PlanSanityChecker.Checker
 {
     @Override
-    public void validate(PlanNode plan)
+    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, Map<Symbol, Type> types)
     {
         plan.accept(new SimplePlanVisitor()
         {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoSubqueryExpressionLeftChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoSubqueryExpressionLeftChecker.java
@@ -13,11 +13,18 @@
  */
 package com.facebook.presto.sql.planner.sanity;
 
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.ExpressionExtractor;
+import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.SubqueryExpression;
+
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -25,7 +32,7 @@ public final class NoSubqueryExpressionLeftChecker
         implements PlanSanityChecker.Checker
 {
     @Override
-    public void validate(PlanNode plan)
+    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, Map<Symbol, Type> types)
     {
         for (Expression expression : ExpressionExtractor.extractExpressions(plan)) {
             new DefaultTraversalVisitor<Void, Void>()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanSanityChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanSanityChecker.java
@@ -13,10 +13,16 @@
  */
 package com.facebook.presto.sql.planner.sanity;
 
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * It is going to be executed at the end of logical planner, to verify its correctness
@@ -25,18 +31,19 @@ public final class PlanSanityChecker
 {
     private static final List<Checker> CHECKERS = ImmutableList.of(
             new ValidateDependenciesChecker(),
+            new TypeValidator(),
             new NoSubqueryExpressionLeftChecker(),
             new NoApplyNodeLeftChecker());
 
     private PlanSanityChecker() {}
 
-    public static void validate(PlanNode planNode)
+    public static void validate(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, Map<Symbol, Type> types)
     {
-        CHECKERS.forEach(checker -> checker.validate(planNode));
+        CHECKERS.forEach(checker -> checker.validate(planNode, session, metadata, sqlParser, types));
     }
 
     public interface Checker
     {
-        void validate(PlanNode plan);
+        void validate(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, Map<Symbol, Type> types);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/TypeValidator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/TypeValidator.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.SimplePlanVisitor;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.UnionNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.collect.ListMultimap;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Ensures that all the expressions and FunctionCalls matches their output symbols
+ */
+public final class TypeValidator
+        implements PlanSanityChecker.Checker
+{
+    public TypeValidator() {}
+
+    @Override
+    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, Map<Symbol, Type> types)
+    {
+        plan.accept(new Visitor(session, metadata, sqlParser, types), null);
+    }
+
+    private static class Visitor
+            extends SimplePlanVisitor<Void>
+    {
+        private final Session session;
+        private final Metadata metadata;
+        private final SqlParser sqlParser;
+        private final Map<Symbol, Type> types;
+
+        public Visitor(Session session, Metadata metadata, SqlParser sqlParser, Map<Symbol, Type> types)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.metadata = requireNonNull(metadata, "metadata is null");
+            this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+            this.types = requireNonNull(types, "types is null");
+        }
+
+        @Override
+        public Void visitAggregation(AggregationNode node, Void context)
+        {
+            visitPlan(node, context);
+
+            AggregationNode.Step step = node.getStep();
+
+            switch (step) {
+                case SINGLE:
+                    checkFunctionSignature(node.getFunctions());
+                    checkFunctionCall(node.getAggregations());
+                    break;
+                case FINAL:
+                    checkFunctionSignature(node.getFunctions());
+                    break;
+            }
+
+            return null;
+        }
+
+        @Override
+        public Void visitWindow(WindowNode node, Void context)
+        {
+            visitPlan(node, context);
+
+            checkFunctionSignature(node.getSignatures());
+            checkFunctionCall(node.getWindowFunctions());
+
+            return null;
+        }
+
+        @Override
+        public Void visitProject(ProjectNode node, Void context)
+        {
+            visitPlan(node, context);
+
+            for (Map.Entry<Symbol, Expression> entry : node.getAssignments().entrySet()) {
+                Type expectedType = types.get(entry.getKey());
+                if (entry.getValue() instanceof SymbolReference) {
+                    SymbolReference symbolReference = (SymbolReference) entry.getValue();
+                    verifyTypeSignature(entry.getKey(), expectedType.getTypeSignature(), types.get(Symbol.from(symbolReference)).getTypeSignature());
+                    continue;
+                }
+                Type actualType = getExpressionTypes(session, metadata, sqlParser, types, entry.getValue()).get(entry.getValue());
+                verifyTypeSignature(entry.getKey(), expectedType.getTypeSignature(), actualType.getTypeSignature());
+            }
+
+            return null;
+        }
+
+        @Override
+        public Void visitUnion(UnionNode node, Void context)
+        {
+            visitPlan(node, context);
+
+            ListMultimap<Symbol, Symbol> symbolMapping = node.getSymbolMapping();
+            for (Symbol keySymbol : symbolMapping.keySet()) {
+                List<Symbol> valueSymbols = symbolMapping.get(keySymbol);
+                Type expectedType = types.get(keySymbol);
+                for (Symbol valueSymbol : valueSymbols) {
+                    verifyTypeSignature(keySymbol, expectedType.getTypeSignature(), types.get(valueSymbol).getTypeSignature());
+                }
+            }
+
+            return null;
+        }
+
+        private void checkFunctionSignature(Map<Symbol, Signature> functions)
+        {
+            for (Map.Entry<Symbol, Signature> entry : functions.entrySet()) {
+                TypeSignature expectedTypeSignature = types.get(entry.getKey()).getTypeSignature();
+                TypeSignature actualTypeSignature = entry.getValue().getReturnType();
+                verifyTypeSignature(entry.getKey(), expectedTypeSignature, actualTypeSignature);
+            }
+        }
+
+        private void checkFunctionCall(Map<Symbol, FunctionCall> functionCalls)
+        {
+            for (Map.Entry<Symbol, FunctionCall> entry : functionCalls.entrySet()) {
+                Type expectedType = types.get(entry.getKey());
+                Type actualType = getExpressionTypes(session, metadata, sqlParser, types, entry.getValue()).get(entry.getValue());
+                verifyTypeSignature(entry.getKey(), expectedType.getTypeSignature(), actualType.getTypeSignature());
+            }
+        }
+
+        private static void verifyTypeSignature(Symbol symbol, TypeSignature expected, TypeSignature actual)
+        {
+            // UNKNOWN should be considered as a wildcard type, which matches all the other types
+            if (!actual.equals(UNKNOWN.getTypeSignature())) {
+                checkArgument(expected.equals(actual), "type of symbol '%s' is expected to be %s, but the actual type is %s", symbol, expected, actual);
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -13,6 +13,10 @@
  */
 package com.facebook.presto.sql.planner.sanity;
 
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.DependencyExtractor;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
@@ -72,7 +76,7 @@ public final class ValidateDependenciesChecker
         implements PlanSanityChecker.Checker
 {
     @Override
-    public void validate(PlanNode plan)
+    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, Map<Symbol, Type> types)
     {
         plan.accept(new Visitor(), null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -606,7 +606,7 @@ public class LocalQueryRunner
         Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.of(queryExplainer), featuresConfig.isExperimentalSyntaxEnabled());
 
         Analysis analysis = analyzer.analyze(statement);
-        return new LogicalPlanner(session, planOptimizersFactory.get(), idAllocator, metadata).plan(analysis);
+        return new LogicalPlanner(session, planOptimizersFactory.get(), idAllocator, metadata, sqlParser).plan(analysis);
     }
 
     public OperatorFactory createTableScanOperator(int operatorId, PlanNodeId planNodeId, String tableName, String... columnNames)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeMatchingChecker.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeMatchingChecker.java
@@ -1,0 +1,384 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.sql.planner.plan.UnionNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.planner.sanity.TypeValidator;
+import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FrameBound;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.WindowFrame;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.SINGLE;
+
+@Test(singleThreaded = true)
+public class TestTypeMatchingChecker
+{
+    private static final TableHandle TEST_TABLE_HANDLE = new TableHandle("test", new TestingTableHandle());
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final TypeValidator TYPE_VALIDATOR = new TypeValidator();
+
+    private SymbolAllocator symbolAllocator;
+    private TableScanNode baseTableScan;
+    private Symbol columnA;
+    private Symbol columnB;
+    private Symbol columnC;
+    private Symbol columnD;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        symbolAllocator = new SymbolAllocator();
+        columnA = symbolAllocator.newSymbol("a", BIGINT);
+        columnB = symbolAllocator.newSymbol("b", INTEGER);
+        columnC = symbolAllocator.newSymbol("c", DOUBLE);
+        columnD = symbolAllocator.newSymbol("d", DATE);
+
+        Map<Symbol, ColumnHandle> assignments = ImmutableMap.<Symbol, ColumnHandle>builder()
+                .put(columnA, new TestingColumnHandle("a"))
+                .put(columnB, new TestingColumnHandle("b"))
+                .put(columnC, new TestingColumnHandle("c"))
+                .put(columnD, new TestingColumnHandle("d"))
+                .build();
+
+        baseTableScan = new TableScanNode(
+                newId(),
+                TEST_TABLE_HANDLE,
+                ImmutableList.copyOf(assignments.keySet()),
+                assignments,
+                Optional.empty(),
+                TupleDomain.all(),
+                null);
+    }
+
+    @Test
+    public void testValidProject()
+            throws Exception
+    {
+        Expression expression1 = new Cast(columnB.toSymbolReference(), StandardTypes.BIGINT);
+        Expression expression2 = new Cast(columnC.toSymbolReference(), StandardTypes.BIGINT);
+        Map<Symbol, Expression> assignments = ImmutableMap.<Symbol, Expression>builder()
+                .put(symbolAllocator.newSymbol(expression1, BIGINT), expression1)
+                .put(symbolAllocator.newSymbol(expression2, BIGINT), expression2)
+                .build();
+        PlanNode node = new ProjectNode(
+                newId(),
+                baseTableScan,
+                assignments);
+
+        assertTypesValid(node);
+    }
+
+    @Test
+    public void testValidUnion()
+            throws Exception
+    {
+        Symbol outputSymbol = symbolAllocator.newSymbol("output", DATE);
+        ListMultimap<Symbol, Symbol> mappings = ImmutableListMultimap.<Symbol, Symbol>builder()
+                .put(outputSymbol, columnD)
+                .put(outputSymbol, columnD)
+                .build();
+
+        PlanNode node = new UnionNode(
+                newId(),
+                ImmutableList.of(baseTableScan, baseTableScan),
+                mappings,
+                ImmutableList.copyOf(mappings.keySet()));
+
+        assertTypesValid(node);
+    }
+
+    @Test
+    public void testValidWindow()
+            throws Exception
+    {
+        Symbol windowSymbol = symbolAllocator.newSymbol("sum", DOUBLE);
+        Map<Symbol, Signature> signatures = ImmutableMap.of(
+                windowSymbol, new Signature(
+                        "sum",
+                        FunctionKind.WINDOW,
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        DOUBLE.getTypeSignature(),
+                        ImmutableList.of(DOUBLE.getTypeSignature()),
+                        false));
+        Map<Symbol, FunctionCall> functions = ImmutableMap.of(windowSymbol, new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())));
+        WindowNode.Frame frame = new WindowNode.Frame(
+                WindowFrame.Type.RANGE,
+                FrameBound.Type.UNBOUNDED_PRECEDING,
+                Optional.empty(),
+                FrameBound.Type.UNBOUNDED_FOLLOWING,
+                Optional.empty());
+        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of(), frame);
+
+        PlanNode node = new WindowNode(
+                newId(),
+                baseTableScan,
+                specification,
+                functions,
+                signatures,
+                Optional.empty(),
+                ImmutableSet.of(),
+                0);
+
+        assertTypesValid(node);
+    }
+
+    @Test
+    public void testValidAggregation()
+            throws Exception
+    {
+        Symbol aggregationSymbol = symbolAllocator.newSymbol("sum", DOUBLE);
+        Map<Symbol, Signature> functions = ImmutableMap.of(
+                aggregationSymbol, new Signature(
+                        "sum",
+                        FunctionKind.AGGREGATE,
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        DOUBLE.getTypeSignature(),
+                        ImmutableList.of(DOUBLE.getTypeSignature()),
+                        false));
+        Map<Symbol, FunctionCall> aggregations = ImmutableMap.of(aggregationSymbol, new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())));
+
+        PlanNode node = new AggregationNode(
+                newId(),
+                baseTableScan,
+                ImmutableList.of(columnA, columnB),
+                aggregations,
+                functions,
+                ImmutableMap.of(),
+                ImmutableList.of(ImmutableList.of(columnA, columnB)),
+                SINGLE,
+                Optional.empty(),
+                0,
+                Optional.empty());
+
+        assertTypesValid(node);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "type of symbol 'expr(_[0-9]+)?' is expected to be bigint, but the actual type is integer")
+    public void testInvalidProject()
+            throws Exception
+    {
+        Expression expression1 = new Cast(columnB.toSymbolReference(), StandardTypes.INTEGER);
+        Expression expression2 = new Cast(columnA.toSymbolReference(), StandardTypes.INTEGER);
+        Map<Symbol, Expression> assignments = ImmutableMap.<Symbol, Expression>builder()
+                .put(symbolAllocator.newSymbol(expression1, BIGINT), expression1) // should be INTEGER
+                .put(symbolAllocator.newSymbol(expression1, INTEGER), expression2)
+                .build();
+        PlanNode node = new ProjectNode(
+                newId(),
+                baseTableScan,
+                assignments);
+
+        assertTypesValid(node);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "type of symbol 'sum(_[0-9]+)?' is expected to be double, but the actual type is bigint")
+    public void testInvalidAggregationFunctionCall()
+            throws Exception
+    {
+        Symbol aggregationSymbol = symbolAllocator.newSymbol("sum", DOUBLE);
+        Map<Symbol, Signature> functions = ImmutableMap.of(
+                aggregationSymbol, new Signature(
+                        "sum",
+                        FunctionKind.AGGREGATE,
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        DOUBLE.getTypeSignature(),
+                        ImmutableList.of(DOUBLE.getTypeSignature()),
+                        false));
+        Map<Symbol, FunctionCall> aggregations = ImmutableMap.of(aggregationSymbol, new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnA.toSymbolReference()))); // should be columnC
+
+        PlanNode node = new AggregationNode(
+                newId(),
+                baseTableScan,
+                ImmutableList.of(columnA, columnB),
+                aggregations,
+                functions,
+                ImmutableMap.of(),
+                ImmutableList.of(ImmutableList.of(columnA, columnB)),
+                SINGLE,
+                Optional.empty(),
+                0,
+                Optional.empty());
+
+        assertTypesValid(node);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "type of symbol 'sum(_[0-9]+)?' is expected to be double, but the actual type is bigint")
+    public void testInvalidAggregationFunctionSignature()
+            throws Exception
+    {
+        Symbol aggregationSymbol = symbolAllocator.newSymbol("sum", DOUBLE);
+        Map<Symbol, Signature> functions = ImmutableMap.of(
+                aggregationSymbol, new Signature(
+                        "sum",
+                        FunctionKind.AGGREGATE,
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        BIGINT.getTypeSignature(), // should be DOUBLE
+                        ImmutableList.of(DOUBLE.getTypeSignature()),
+                        false));
+        Map<Symbol, FunctionCall> aggregations = ImmutableMap.of(aggregationSymbol, new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())));
+
+        PlanNode node = new AggregationNode(
+                newId(),
+                baseTableScan,
+                ImmutableList.of(columnA, columnB),
+                aggregations,
+                functions,
+                ImmutableMap.of(),
+                ImmutableList.of(ImmutableList.of(columnA, columnB)),
+                SINGLE,
+                Optional.empty(),
+                0,
+                Optional.empty());
+
+        assertTypesValid(node);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "type of symbol 'sum(_[0-9]+)?' is expected to be double, but the actual type is bigint")
+    public void testInvalidWindowFunctionCall()
+            throws Exception
+    {
+        Symbol windowSymbol = symbolAllocator.newSymbol("sum", DOUBLE);
+        Map<Symbol, Signature> signatures = ImmutableMap.of(
+                windowSymbol, new Signature(
+                        "sum",
+                        FunctionKind.WINDOW,
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        DOUBLE.getTypeSignature(),
+                        ImmutableList.of(DOUBLE.getTypeSignature()),
+                        false));
+        Map<Symbol, FunctionCall> functions = ImmutableMap.of(windowSymbol, new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnA.toSymbolReference()))); // shoud be columnC
+        WindowNode.Frame frame = new WindowNode.Frame(
+                WindowFrame.Type.RANGE,
+                FrameBound.Type.UNBOUNDED_PRECEDING,
+                Optional.empty(),
+                FrameBound.Type.UNBOUNDED_FOLLOWING,
+                Optional.empty());
+        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of(), frame);
+
+        PlanNode node = new WindowNode(
+                newId(),
+                baseTableScan,
+                specification,
+                functions,
+                signatures,
+                Optional.empty(),
+                ImmutableSet.of(),
+                0);
+
+        assertTypesValid(node);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "type of symbol 'sum(_[0-9]+)?' is expected to be double, but the actual type is bigint")
+    public void testInvalidWindowFunctionSignature()
+            throws Exception
+    {
+        Symbol windowSymbol = symbolAllocator.newSymbol("sum", DOUBLE);
+        Map<Symbol, Signature> signatures = ImmutableMap.of(
+                windowSymbol, new Signature(
+                        "sum",
+                        FunctionKind.WINDOW,
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        BIGINT.getTypeSignature(), // should be DOUBLE
+                        ImmutableList.of(DOUBLE.getTypeSignature()),
+                        false));
+        Map<Symbol, FunctionCall> functions = ImmutableMap.of(windowSymbol, new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())));
+        WindowNode.Frame frame = new WindowNode.Frame(
+                WindowFrame.Type.RANGE,
+                FrameBound.Type.UNBOUNDED_PRECEDING,
+                Optional.empty(),
+                FrameBound.Type.UNBOUNDED_FOLLOWING,
+                Optional.empty());
+        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of(), frame);
+
+        PlanNode node = new WindowNode(
+                newId(),
+                baseTableScan,
+                specification,
+                functions,
+                signatures,
+                Optional.empty(),
+                ImmutableSet.of(),
+                0);
+
+        assertTypesValid(node);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "type of symbol 'output(_[0-9]+)?' is expected to be date, but the actual type is bigint")
+    public void testInvalidUnion()
+            throws Exception
+    {
+        Symbol outputSymbol = symbolAllocator.newSymbol("output", DATE);
+        ListMultimap<Symbol, Symbol> mappings = ImmutableListMultimap.<Symbol, Symbol>builder()
+                .put(outputSymbol, columnD)
+                .put(outputSymbol, columnA) // should be a symbol with DATE type
+                .build();
+
+        PlanNode node = new UnionNode(
+                newId(),
+                ImmutableList.of(baseTableScan, baseTableScan),
+                mappings,
+                ImmutableList.copyOf(mappings.keySet()));
+
+        assertTypesValid(node);
+    }
+
+    private void assertTypesValid(PlanNode node)
+    {
+        TYPE_VALIDATOR.validate(node, TEST_SESSION, createTestMetadataManager(), SQL_PARSER, symbolAllocator.getTypes());
+    }
+
+    private static PlanNodeId newId()
+    {
+        return new PlanNodeId(UUID.randomUUID().toString());
+    }
+}


### PR DESCRIPTION
Fix #5076 

In order to use `getExpressionTypes` in `PlanSanityChecker.Checker` to calculate the type of expressions, we need to pass `SqlParser` into `LogicalPlanner`.