### PR TITLE
Bump docker-compose version to 1.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
     sudo apt-get update
     sudo apt-get -o "Dpkg::Options::=--force-confold" -y install docker-engine
     sudo rm /usr/local/bin/docker-compose
-    curl -L https://github.com/docker/compose/releases/download/1.6.2/docker-compose-`uname -s`-`uname -m` > docker-compose
+    curl -L https://github.com/docker/compose/releases/download/1.7.1/docker-compose-`uname -s`-`uname -m` > docker-compose
     chmod +x docker-compose
     sudo mv docker-compose /usr/local/bin
 


### PR DESCRIPTION
Since new version of docker-engine was published to apt-get repository
it is necessary to bump the version of it's dependency - docker-compose.