### PR TITLE
Fix query rejection to fail query

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryQueueManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryQueueManager.java
@@ -55,7 +55,7 @@ public class SqlQueryQueueManager
     {
         List<QueryQueue> queues;
         try {
-            queues = selectQueues(statement, queryExecution.getSession(), executor);
+            queues = selectQueues(queryExecution.getSession(), executor);
         }
         catch (PrestoException e) {
             queryExecution.fail(e);
@@ -75,7 +75,7 @@ public class SqlQueryQueueManager
     }
 
     // Queues returned have already been created and added queryQueues
-    private List<QueryQueue> selectQueues(Statement statement, Session session, Executor executor)
+    private List<QueryQueue> selectQueues(Session session, Executor executor)
     {
         for (QueryQueueRule rule : rules) {
             Optional<List<QueryQueueDefinition>> queues = rule.match(session.toSessionRepresentation());

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryQueueManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryQueueManager.java
@@ -53,7 +53,14 @@ public class SqlQueryQueueManager
     @Override
     public boolean submit(Statement statement, QueryExecution queryExecution, Executor executor)
     {
-        List<QueryQueue> queues = selectQueues(statement, queryExecution.getSession(), executor);
+        List<QueryQueue> queues;
+        try {
+            queues = selectQueues(statement, queryExecution.getSession(), executor);
+        }
+        catch (PrestoException e) {
+            queryExecution.fail(e);
+            return false;
+        }
 
         for (QueryQueue queue : queues) {
             if (!queue.reserve(queryExecution)) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupManager.java
@@ -77,7 +77,14 @@ public class ResourceGroupManager
     @Override
     public boolean submit(Statement statement, QueryExecution queryExecution, Executor executor)
     {
-        ResourceGroupId group = selectGroup(statement, queryExecution.getSession());
+        ResourceGroupId group;
+        try {
+            group = selectGroup(statement, queryExecution.getSession());
+        }
+        catch (PrestoException e) {
+            queryExecution.fail(e);
+            return false;
+        }
         createGroupIfNecessary(group, queryExecution.getSession(), executor);
         return groups.get(group).add(queryExecution);
     }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import static com.facebook.presto.execution.QueryState.FAILED;
 import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.spi.StandardErrorCode.QUERY_REJECTED;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
@@ -182,6 +183,41 @@ public class TestQueues
         }
     }
 
+    @Test(timeOut = 240_000)
+    public void testSqlQueryQueueManagerRejection()
+            throws Exception
+    {
+        testRejection(false);
+    }
+
+    @Test(timeOut = 240_000)
+    public void testResourceGroupManagerRejection()
+            throws Exception
+    {
+        testRejection(true);
+    }
+
+    private void testRejection(boolean resourceGroups)
+            throws Exception
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        if (resourceGroups) {
+            builder.put("experimental.resource-groups-enabled", "true");
+            builder.put("resource-groups.config-file", getResourceFilePath("resource_groups_config_dashboard.json"));
+        }
+        else {
+            builder.put("query.queue-config-file", getResourceFilePath("queue_config_dashboard.json"));
+        }
+        Map<String, String> properties = builder.build();
+
+        try (DistributedQueryRunner queryRunner = createQueryRunner(properties)) {
+            QueryId queryId = createQuery(queryRunner, newRejectionSession(), LONG_LASTING_QUERY);
+            waitForQueryState(queryRunner, queryId, FAILED);
+            QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+            assertEquals(queryManager.getQueryInfo(queryId).getErrorCode(), QUERY_REJECTED.toErrorCode());
+        }
+    }
+
     private static QueryId createQuery(DistributedQueryRunner queryRunner, Session session, String sql)
     {
         return queryRunner.getCoordinator().getQueryManager().createQuery(session, sql).getQueryId();
@@ -234,6 +270,7 @@ public class TestQueues
         return testSessionBuilder()
                 .setCatalog("tpch")
                 .setSchema("sf100000")
+                .setSource("adhoc")
                 .build();
     }
 
@@ -243,6 +280,15 @@ public class TestQueues
                 .setCatalog("tpch")
                 .setSchema("sf100000")
                 .setSource("dashboard")
+                .build();
+    }
+
+    private static Session newRejectionSession()
+    {
+        return testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema("sf100000")
+                .setSource("reject")
                 .build();
     }
 }

--- a/presto-tests/src/test/resources/queue_config_dashboard.json
+++ b/presto-tests/src/test/resources/queue_config_dashboard.json
@@ -27,6 +27,7 @@
       ]
     },
     {
+      "source": "(?i).*adhoc.*",
       "queues": [
         "adhoc-${USER}",
         "user-${USER}",

--- a/presto-tests/src/test/resources/resource_groups_config_dashboard.json
+++ b/presto-tests/src/test/resources/resource_groups_config_dashboard.json
@@ -35,6 +35,7 @@
       "group": "global.user-${USER}.dashboard-${USER}"
     },
     {
+      "source": "(?i).*adhoc.*",
       "group": "global.user-${USER}.adhoc-${USER}"
     }
   ]


### PR DESCRIPTION
Previously a 500 error was returned to the client, but the query was
reported in the QUEUED state. However, it wasn't actually queued and
would never execute.