### PR TITLE
Add support for expressions in CUBE/ROLLUP/GROUPING SETS

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -105,6 +105,30 @@ public class TestAnalyzer
     private Metadata metadata;
 
     @Test
+    public void testOrderByByOutputColumnName()
+    {
+        analyze("SELECT a AS col1, b AS col2 FROM t1 ORDER BY col1 ASC, col2 DESC");
+    }
+
+    @Test
+    public void testOrderByByOutputColumnOrdinalNumber()
+    {
+        analyze("SELECT a AS col1, b AS col2 FROM t1 ORDER BY 1 ASC, 2 DESC");
+    }
+
+    @Test
+    public void testGroupByOutputColumnName()
+    {
+        analyze("SELECT a AS col1, b AS col2 FROM t1 GROUP BY col1, col2");
+    }
+
+    @Test
+    public void testGroupByOutputColumnOrdinalNumber()
+    {
+        analyze("SELECT a AS col1, b AS col2 FROM t1 GROUP BY 1, 2");
+    }
+
+    @Test
     public void testNonComparableGroupBy()
             throws Exception
     {

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -138,10 +138,10 @@ groupBy
     ;
 
 groupingElement
-    : groupingExpressions                                               #singleGroupingSet
-    | ROLLUP '(' (qualifiedName (',' qualifiedName)*)? ')'              #rollup
-    | CUBE '(' (qualifiedName (',' qualifiedName)*)? ')'                #cube
-    | GROUPING SETS '(' groupingSet (',' groupingSet)* ')'              #multipleGroupingSets
+    : groupingExpressions                                         #singleGroupingSet
+    | ROLLUP '(' (expression (',' expression)*)? ')'              #rollup
+    | CUBE '(' (expression (',' expression)*)? ')'                #cube
+    | GROUPING SETS '(' groupingSet (',' groupingSet)* ')'        #multipleGroupingSets
     ;
 
 groupingExpressions
@@ -150,8 +150,8 @@ groupingExpressions
     ;
 
 groupingSet
-    : '(' (qualifiedName (',' qualifiedName)*)? ')'
-    | qualifiedName
+    : '(' (expression (',' expression)*)? ')'
+    | expression
     ;
 
 namedQuery

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -637,9 +637,11 @@ public final class ExpressionFormatter
                 .iterator()));
     }
 
-    private static String formatGroupingSet(List<QualifiedName> groupingSet)
+    private static String formatGroupingSet(List<Expression> groupingSet)
     {
-        return format("(%s)", Joiner.on(", ").join(groupingSet));
+        return format("(%s)", Joiner.on(", ").join(groupingSet.stream()
+                .map(ExpressionFormatter::formatExpression)
+                .iterator()));
     }
 
     private static Function<SortItem, String> sortItemFormatterFunction(boolean unmangleNames)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -450,38 +450,37 @@ class AstBuilder
     @Override
     public Node visitGroupBy(SqlBaseParser.GroupByContext context)
     {
-        return new GroupBy(getLocation(context), isDistinct(context.setQuantifier()), visit(context.groupingElement(), GroupingElement.class));
+        return new GroupBy(
+                getLocation(context),
+                isDistinct(context.setQuantifier()),
+                visit(context.groupingElement(), GroupingElement.class));
     }
 
     @Override
     public Node visitSingleGroupingSet(SqlBaseParser.SingleGroupingSetContext context)
     {
-        return new SimpleGroupBy(getLocation(context), visit(context.groupingExpressions().expression(), Expression.class));
+        return new SimpleGroupBy(
+                getLocation(context),
+                visit(context.groupingExpressions().expression(), Expression.class));
     }
 
     @Override
     public Node visitRollup(SqlBaseParser.RollupContext context)
     {
-        return new Rollup(getLocation(context), context.qualifiedName().stream()
-                .map(AstBuilder::getQualifiedName)
-                .collect(toList()));
+        return new Rollup(getLocation(context), visit(context.expression(), Expression.class));
     }
 
     @Override
     public Node visitCube(SqlBaseParser.CubeContext context)
     {
-        return new Cube(getLocation(context), context.qualifiedName().stream()
-                .map(AstBuilder::getQualifiedName)
-                .collect(toList()));
+        return new Cube(getLocation(context), visit(context.expression(), Expression.class));
     }
 
     @Override
     public Node visitMultipleGroupingSets(SqlBaseParser.MultipleGroupingSetsContext context)
     {
         return new GroupingSets(getLocation(context), context.groupingSet().stream()
-                .map(groupingSet -> groupingSet.qualifiedName().stream()
-                        .map(AstBuilder::getQualifiedName)
-                        .collect(toList()))
+                .map(groupingSet -> visit(groupingSet.expression(), Expression.class))
                 .collect(toList()));
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.tree;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import java.util.List;
@@ -23,31 +24,30 @@ import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toSet;
 
 public class Cube
         extends GroupingElement
 {
-    private final List<QualifiedName> columns;
+    private final List<Expression> columns;
 
-    public Cube(List<QualifiedName> columns)
+    public Cube(List<Expression> columns)
     {
         this(Optional.empty(), columns);
     }
 
-    public Cube(NodeLocation location, List<QualifiedName> columns)
+    public Cube(NodeLocation location, List<Expression> columns)
     {
         this(Optional.of(location), columns);
     }
 
-    private Cube(Optional<NodeLocation> location, List<QualifiedName> columns)
+    private Cube(Optional<NodeLocation> location, List<Expression> columns)
     {
         super(location);
         requireNonNull(columns, "columns is null");
         this.columns = columns;
     }
 
-    public List<QualifiedName> getColumns()
+    public List<Expression> getColumns()
     {
         return columns;
     }
@@ -55,9 +55,7 @@ public class Cube
     @Override
     public List<Set<Expression>> enumerateGroupingSets()
     {
-        return ImmutableList.copyOf(Sets.powerSet(columns.stream()
-                .map(QualifiedNameReference::new)
-                .collect(toSet())));
+        return ImmutableList.copyOf(Sets.powerSet(ImmutableSet.copyOf(this.columns)));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
@@ -28,19 +28,19 @@ import static java.util.stream.Collectors.collectingAndThen;
 public class GroupingSets
         extends GroupingElement
 {
-    private final List<List<QualifiedName>> sets;
+    private final List<List<Expression>> sets;
 
-    public GroupingSets(List<List<QualifiedName>> groupingSetList)
+    public GroupingSets(List<List<Expression>> groupingSetList)
     {
         this(Optional.empty(), groupingSetList);
     }
 
-    public GroupingSets(NodeLocation location, List<List<QualifiedName>> sets)
+    public GroupingSets(NodeLocation location, List<List<Expression>> sets)
     {
         this(Optional.of(location), sets);
     }
 
-    private GroupingSets(Optional<NodeLocation> location, List<List<QualifiedName>> sets)
+    private GroupingSets(Optional<NodeLocation> location, List<List<Expression>> sets)
     {
         super(location);
         requireNonNull(sets);
@@ -53,9 +53,8 @@ public class GroupingSets
     {
         return sets.stream()
                 .map(groupingSet -> groupingSet.stream()
-                        .map(QualifiedNameReference::new)
                         .collect(Collectors.<Expression>toSet()))
-                .collect(collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+                        .collect(collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QualifiedNameReference.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QualifiedNameReference.java
@@ -16,10 +16,18 @@ package com.facebook.presto.sql.tree;
 import java.util.Objects;
 import java.util.Optional;
 
+import static java.util.Objects.requireNonNull;
+
 public class QualifiedNameReference
         extends Expression
 {
     private final QualifiedName name;
+
+    public static QualifiedNameReference of(QualifiedName name)
+    {
+        requireNonNull(name, "name is null");
+        return new QualifiedNameReference(name);
+    }
 
     public QualifiedNameReference(QualifiedName name)
     {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
@@ -29,26 +29,26 @@ import static java.util.stream.Collectors.toSet;
 public class Rollup
         extends GroupingElement
 {
-    private final List<QualifiedName> columns;
+    private final List<Expression> columns;
 
-    public Rollup(List<QualifiedName> columns)
+    public Rollup(List<Expression> columns)
     {
         this(Optional.empty(), columns);
     }
 
-    public Rollup(NodeLocation location, List<QualifiedName> columns)
+    public Rollup(NodeLocation location, List<Expression> columns)
     {
         this(Optional.of(location), columns);
     }
 
-    private Rollup(Optional<NodeLocation> location, List<QualifiedName> columns)
+    private Rollup(Optional<NodeLocation> location, List<Expression> columns)
     {
         super(location);
         requireNonNull(columns, "columns is null");
         this.columns = columns;
     }
 
-    public List<QualifiedName> getColumns()
+    public List<Expression> getColumns()
     {
         return columns;
     }
@@ -60,8 +60,6 @@ public class Rollup
         List<Set<Expression>> enumeratedGroupingSets = IntStream.range(0, numColumns)
                 .mapToObj(i -> columns.subList(0, numColumns - i)
                         .stream()
-                        .map(QualifiedNameReference::new)
-                        .map(Expression.class::cast)
                         .collect(toSet()))
                 .collect(toList());
         enumeratedGroupingSets.add(ImmutableSet.of());

--- a/presto-parser/src/test/java/com/facebook/presto/sql/TestExpressionFormatter.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/TestExpressionFormatter.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Expression;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestExpressionFormatter
+{
+    @Test(description = "should create a string representation of a given Expression")
+    public void testFormatExpression()
+            throws Exception
+    {
+        Expression exp = new SqlParser().createExpression("1 + 2 / 3 < a * 10 AND f(z) >= (5 + 5)");
+        String s = ExpressionFormatter.formatExpression(exp);
+
+        assertEquals(s, "(((1 + (2 / 3)) < (\"a\" * 10)) AND (\"f\"(\"z\") >= (5 + 5)))");
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/TestSqlFormatter.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/TestSqlFormatter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Statement;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestSqlFormatter
+{
+    @Test(description = "should create a string from Statement")
+    public void testFormatSqlSelectClauseOnly()
+            throws Exception
+    {
+        Statement ast = new SqlParser().createStatement("SELECT 1+2");
+        String sql = SqlFormatter.formatSql(ast);
+
+        assertEquals(sql, "SELECT (1 + 2)\n\n");
+    }
+
+    @Test(description = "should create a string from Statement")
+    public void testFormatSqlGroupByCube()
+            throws Exception
+    {
+        Statement ast = new SqlParser().createStatement("SELECT a, b, sum(c) GROUP BY CUBE(a, b)");
+        String sql = SqlFormatter.formatSql(ast);
+
+        assertEquals(sql, "SELECT\n  \"a\"\n, \"b\"\n, \"sum\"(\"c\")\n\nGROUP BY CUBE (\"a\", \"b\")\n");
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/TestTreePrinter.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/TestTreePrinter.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Statement;
+
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.IdentityHashMap;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestTreePrinter
+{
+    @Test
+    public void testGroupByClause()
+            throws Exception
+    {
+        Statement ast = new SqlParser().createStatement("SELECT a, b, c FROM t1 GROUP BY CUBE(a, b), ROLLUP(a, c), GROUPING SETS((a, b, c))");
+
+        assertEquals(printToString(ast),
+                "Query \n" +
+                "   QueryBody\n" +
+                "   QuerySpecification \n" +
+                "      Select\n" +
+                "            QualifiedName[a]\n" +
+                "            QualifiedName[b]\n" +
+                "            QualifiedName[c]\n" +
+                "      From\n" +
+                "         Table[t1]\n" +
+                "      GroupBy\n" +
+                "         Cube\n" +
+                "            QualifiedName[a]\n" +
+                "            QualifiedName[b]\n" +
+                "         Rollup\n" +
+                "            QualifiedName[a]\n" +
+                "            QualifiedName[c]\n" +
+                "         GroupingSets\n" +
+                "            GroupingSet[\n" +
+                "               QualifiedName[a]\n" +
+                "               QualifiedName[b]\n" +
+                "               QualifiedName[c]\n" +
+                "            ]" +
+                "\n");
+    }
+
+    static String printToString(Statement ast)
+            throws Exception
+    {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(os);
+        new TreePrinter(new IdentityHashMap<>(), ps).print(ast);
+        return os.toString("UTF8");
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -979,7 +979,7 @@ public class TestSqlParser
                                 selectList(new AllColumns()),
                                 Optional.of(new Table(QualifiedName.of("table1"))),
                                 Optional.empty(),
-                                Optional.of(new GroupBy(false, ImmutableList.of(new GroupingSets(ImmutableList.of(ImmutableList.of(QualifiedName.of("a"))))))),
+                                Optional.of(new GroupBy(false, ImmutableList.of(new GroupingSets(ImmutableList.of(ImmutableList.of(QualifiedNameReference.of(QualifiedName.of("a")))))))),
                                 Optional.empty(),
                                 ImmutableList.of(),
                                 Optional.empty()),
@@ -996,11 +996,11 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.of(new GroupBy(false, ImmutableList.of(
                                         new GroupingSets(
-                                                ImmutableList.of(ImmutableList.of(QualifiedName.of("a"), QualifiedName.of("b")),
-                                                ImmutableList.of(QualifiedName.of("a")),
+                                                ImmutableList.of(ImmutableList.of(QualifiedNameReference.of(QualifiedName.of("a")), QualifiedNameReference.of(QualifiedName.of("b"))),
+                                                ImmutableList.of(QualifiedNameReference.of(QualifiedName.of("a"))),
                                                 ImmutableList.of())),
-                                        new Cube(ImmutableList.of(QualifiedName.of("c"))),
-                                        new Rollup(ImmutableList.of(QualifiedName.of("d")))))),
+                                        new Cube(ImmutableList.of(QualifiedNameReference.of(QualifiedName.of("c")))),
+                                        new Rollup(ImmutableList.of(QualifiedNameReference.of(QualifiedName.of("d"))))))),
                                 Optional.empty(),
                                 ImmutableList.of(),
                                 Optional.empty()),
@@ -1016,18 +1016,18 @@ public class TestSqlParser
                                 Optional.of(new Table(QualifiedName.of("table1"))),
                                 Optional.empty(),
                                 Optional.of(new GroupBy(true, ImmutableList.of(
-                                        new GroupingSets(
-                                                ImmutableList.of(ImmutableList.of(QualifiedName.of("a"), QualifiedName.of("b")),
-                                                        ImmutableList.of(QualifiedName.of("a")),
-                                                        ImmutableList.of())),
-                                        new Cube(ImmutableList.of(QualifiedName.of("c"))),
-                                        new Rollup(ImmutableList.of(QualifiedName.of("d")))))),
-                                Optional.empty(),
-                                ImmutableList.of(),
-                                Optional.empty()),
-                        ImmutableList.<SortItem>of(),
-                        Optional.empty(),
-                        Optional.empty()));
+                                                new GroupingSets(
+                                                        ImmutableList.of(ImmutableList.of(QualifiedNameReference.of(QualifiedName.of("a")), QualifiedNameReference.of(QualifiedName.of("b"))),
+                                                                ImmutableList.of(QualifiedNameReference.of(QualifiedName.of("a"))),
+                                                                ImmutableList.of())),
+                                                        new Cube(ImmutableList.of(QualifiedNameReference.of(QualifiedName.of("c")))),
+                                                        new Rollup(ImmutableList.of(QualifiedNameReference.of(QualifiedName.of("d"))))))),
+                                                Optional.empty(),
+                                                ImmutableList.of(),
+                                                Optional.empty()),
+                                        ImmutableList.<SortItem>of(),
+                                        Optional.empty(),
+                                        Optional.empty()));
     }
 
     @Test


### PR DESCRIPTION
Currently CUBE/ROLLUP/GROUPING SETS support qualified names only (ex. payment.payment_date, etc.) and does not support expressions like year(payment.payment_date), output column names (aliases) or output column ordinal numbers (all supported in ORDER BY clause only).

As described in the [PostgreSQL documentation](https://www.postgresql.org/docs/9.5/static/sql-select.html#SQL-GROUPBY): 

> An expression used inside a grouping_element can be an input column name, or the name or ordinal number of an output column (SELECT list item), or an arbitrary expression formed from input-column values. 

Examples: 

[support added] Using expressions in GROUP BY clause

```
SELECT country.country AS country, year(payment.payment_date) AS year, sum(payment.amount) AS total_payment
FROM ...
GROUP BY CUBE(country.country, year(payment.payment_date));
```

[support added] Using output column names in GROUP BY clause (supported)

```
SELECT country.country AS country, year(payment.payment_date) AS year, sum(payment.amount) AS total_payment
FROM ...
GROUP BY CUBE(country, year);
```

[support added] Using output column ordinal numbers in GROUP BY clause (supported)

```
SELECT country.country AS country, year(payment.payment_date) AS year, sum(payment.amount) AS total_payment
FROM ...
GROUP BY CUBE(1, 2);
```
