### PR TITLE
Free DriverContext memory at failure

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -179,6 +179,8 @@ public class DriverContext
     {
         pipelineContext.failed(cause);
         finished.set(true);
+
+        freeMemory(memoryReservation.get());
     }
 
     public boolean isDone()


### PR DESCRIPTION
Sometimes I've got a situation that worker {{MemoryPool}} contains memory usage of already canceled query.

Here're statuses from `/v1/memory` response
```
{
  "totalNodeMemory":"180388626432B",
  "pools":{
    "reserved":{
      "maxBytes":85899345920,
      "freeBytes":-2381144251,
      "queryMemoryReservations":{
        "20160605_091834_30199_6pfte":75724973259,      # already canceled query, two queries at the reserved pool
        "20160605_151155_46530_6pfte":12555516912
      }
    },
    ...
}
```
```
{
  "totalNodeMemory":"180388626432B",
  "pools":{
    "reserved":{
      "maxBytes":85899345920,
      "freeBytes":85899345920,
      "queryMemoryReservations":{

      }
    },
    "general":{
      "maxBytes":94489280512,
      "freeBytes":11905267186,
      "queryMemoryReservations":{
        "20160605_165633_53492_6pfte":103675026,
        "20160605_120134_38029_6pfte":76424997947,     # already canceled query      
        "20160605_165640_53500_6pfte":2028,
        "20160605_165639_53494_6pfte":5032288,
        "20160605_155439_48612_6pfte":4355464493,
        "20160605_165710_53531_6pfte":5849632,
        "20160605_165917_53645_6pfte":5560400,
        "20160605_145551_45221_6pfte":1620917176,
        "20160605_165709_53528_6pfte":62514336
      }
     ...
}
```

Both queries were all *canceled by user* query during long running order by operation. My guess is that `Driver.lockHolder.interrupt` had been called by cancellation, then `DriverContext.failed` called on running thread. So `DriverContext.finished` seemed to loose a chance to release its memory by the `finished` flage.