### PR TITLE
Introduce SymbolReference expression node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/Serialization.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/Serialization.java
@@ -27,6 +27,8 @@ import javax.inject.Inject;
 
 import java.io.IOException;
 
+import static com.facebook.presto.sql.ExpressionUtils.rewriteQualifiedNamesToSymbolReferences;
+
 public final class Serialization
 {
     private Serialization() {}
@@ -57,7 +59,7 @@ public final class Serialization
         public Expression deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
                 throws IOException
         {
-            return sqlParser.createExpression(jsonParser.readValueAs(String.class));
+            return rewriteQualifiedNamesToSymbolReferences(sqlParser.createExpression(jsonParser.readValueAs(String.class)));
         }
     }
 
@@ -76,7 +78,7 @@ public final class Serialization
         public FunctionCall deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
                 throws IOException
         {
-            return (FunctionCall) sqlParser.createExpression(jsonParser.readValueAs(String.class));
+            return (FunctionCall) rewriteQualifiedNamesToSymbolReferences(sqlParser.createExpression(jsonParser.readValueAs(String.class)));
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DependencyExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DependencyExtractor.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -73,9 +74,9 @@ public final class DependencyExtractor
             extends DefaultExpressionTraversalVisitor<Void, ImmutableList.Builder<Symbol>>
     {
         @Override
-        protected Void visitQualifiedNameReference(QualifiedNameReference node, ImmutableList.Builder<Symbol> builder)
+        protected Void visitSymbolReference(SymbolReference node, ImmutableList.Builder<Symbol> builder)
         {
-            builder.add(Symbol.fromQualifiedName(node.getName()));
+            builder.add(Symbol.from(node));
             return null;
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -71,6 +71,7 @@ import com.facebook.presto.sql.tree.SimpleCaseExpression;
 import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.SubqueryExpression;
 import com.facebook.presto.sql.tree.SubscriptExpression;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.sql.tree.TryExpression;
 import com.facebook.presto.sql.tree.WhenClause;
 import com.facebook.presto.type.ArrayType;
@@ -392,13 +393,13 @@ public class ExpressionInterpreter
         @Override
         protected Object visitQualifiedNameReference(QualifiedNameReference node, Object context)
         {
-            if (node.getName().getPrefix().isPresent()) {
-                // not a symbol
-                return node;
-            }
+            return node;
+        }
 
-            Symbol symbol = Symbol.fromQualifiedName(node.getName());
-            return ((SymbolResolver) context).getValue(symbol);
+        @Override
+        protected Object visitSymbolReference(SymbolReference node, Object context)
+        {
+            return ((SymbolResolver) context).getValue(Symbol.from(node));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionSymbolInliner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionSymbolInliner.java
@@ -16,7 +16,7 @@ package com.facebook.presto.sql.planner;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 
 import java.util.Map;
 
@@ -33,9 +33,9 @@ public class ExpressionSymbolInliner
     }
 
     @Override
-    public Expression rewriteQualifiedNameReference(QualifiedNameReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    public Expression rewriteSymbolReference(SymbolReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
     {
-        Expression expression = mappings.get(Symbol.fromQualifiedName(node.getName()));
+        Expression expression = mappings.get(Symbol.from(node));
         checkState(expression != null, "Cannot resolve symbol %s", node.getName());
         return expression;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -139,7 +139,7 @@ import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FunctionCall;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -688,7 +688,7 @@ public class LocalExecutionPlanner
             for (Map.Entry<Symbol, FunctionCall> entry : node.getWindowFunctions().entrySet()) {
                 ImmutableList.Builder<Integer> arguments = ImmutableList.builder();
                 for (Expression argument : entry.getValue().getArguments()) {
-                    Symbol argumentSymbol = Symbol.fromQualifiedName(((QualifiedNameReference) argument).getName());
+                    Symbol argumentSymbol = Symbol.from(argument);
                     arguments.add(source.getLayout().get(argumentSymbol));
                 }
                 Symbol symbol = entry.getKey();
@@ -908,7 +908,7 @@ public class LocalExecutionPlanner
             List<Symbol> outputSymbols = node.getOutputSymbols();
 
             Map<Symbol, Expression> projectionExpressions = outputSymbols.stream()
-                    .collect(Collectors.toMap(x -> x, Symbol::toQualifiedNameReference));
+                    .collect(Collectors.toMap(x -> x, Symbol::toSymbolReference));
 
             return visitScanFilterAndProject(context, node.getId(), sourceNode, filterExpression, projectionExpressions, outputSymbols);
         }
@@ -1054,9 +1054,9 @@ public class LocalExecutionPlanner
             for (Symbol symbol : outputSymbols) {
                 Expression expression = projectionExpressions.get(symbol);
                 ProjectionFunction function;
-                if (expression instanceof QualifiedNameReference) {
+                if (expression instanceof SymbolReference) {
                     // fast path when we know it's a direct symbol reference
-                    Symbol reference = Symbol.fromQualifiedName(((QualifiedNameReference) expression).getName());
+                    Symbol reference = Symbol.from(expression);
                     function = ProjectionFunctions.singleColumn(context.getTypes().get(reference), sourceLayout.get(reference));
                 }
                 else {
@@ -1785,7 +1785,7 @@ public class LocalExecutionPlanner
         {
             List<Integer> arguments = new ArrayList<>();
             for (Expression argument : call.getArguments()) {
-                Symbol argumentSymbol = Symbol.fromQualifiedName(((QualifiedNameReference) argument).getName());
+                Symbol argumentSymbol = Symbol.from(argument);
                 arguments.add(source.getLayout().get(argumentSymbol));
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -192,10 +192,10 @@ public class LogicalPlanner
                 Type queryType = symbolAllocator.getTypes().get(input);
 
                 if (queryType.equals(tableType) || metadata.getTypeManager().isTypeOnlyCoercion(queryType, tableType)) {
-                    assignments.put(output, input.toQualifiedNameReference());
+                    assignments.put(output, input.toSymbolReference());
                 }
                 else {
-                    Expression cast = new Cast(input.toQualifiedNameReference(), tableType.getTypeSignature().toString());
+                    Expression cast = new Cast(input.toSymbolReference(), tableType.getTypeSignature().toString());
                     assignments.put(output, cast);
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LookupSymbolResolver.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LookupSymbolResolver.java
@@ -15,7 +15,6 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.predicate.NullableValue;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -45,7 +44,7 @@ public class LookupSymbolResolver
         checkArgument(column != null, "Missing column assignment for %s", symbol);
 
         if (!bindings.containsKey(column)) {
-            return new QualifiedNameReference(symbol.toQualifiedName());
+            return symbol.toSymbolReference();
         }
 
         return bindings.get(column).getValue();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NoOpSymbolResolver.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NoOpSymbolResolver.java
@@ -13,8 +13,6 @@
  */
 package com.facebook.presto.sql.planner;
 
-import com.facebook.presto.sql.tree.QualifiedNameReference;
-
 public class NoOpSymbolResolver
         implements SymbolResolver
 {
@@ -23,6 +21,6 @@ public class NoOpSymbolResolver
     @Override
     public Object getValue(Symbol symbol)
     {
-        return new QualifiedNameReference(symbol.toQualifiedName());
+        return symbol.toSymbolReference();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanBuilder.java
@@ -17,7 +17,6 @@ import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -102,8 +101,7 @@ class PlanBuilder
 
         // add an identity projection for underlying plan
         for (Symbol symbol : getRoot().getOutputSymbols()) {
-            Expression expression = new QualifiedNameReference(symbol.toQualifiedName());
-            projections.put(symbol, expression);
+            projections.put(symbol, symbol.toSymbolReference());
         }
 
         ImmutableMap.Builder<Symbol, Expression> newTranslations = ImmutableMap.builder();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -45,7 +45,6 @@ import com.facebook.presto.sql.tree.FieldReference;
 import com.facebook.presto.sql.tree.FrameBound;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.Node;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.SortItem;
@@ -283,7 +282,7 @@ class QueryPlanner
 
         if (subPlan.getSampleWeight().isPresent()) {
             Symbol symbol = subPlan.getSampleWeight().get();
-            projections.put(symbol, new QualifiedNameReference(symbol.toQualifiedName()));
+            projections.put(symbol, symbol.toSymbolReference());
         }
 
         return new PlanBuilder(outputTranslations, new ProjectNode(idAllocator.getNextId(), subPlan.getRoot(), projections.build()), subPlan.getSampleWeight());
@@ -337,7 +336,7 @@ class QueryPlanner
         projections.putAll(coerce(uncoerced, subPlan, translations));
 
         for (Symbol symbol : alreadyCoerced) {
-            projections.put(symbol, new QualifiedNameReference(symbol.toQualifiedName()));
+            projections.put(symbol, symbol.toSymbolReference());
         }
 
         return new PlanBuilder(translations, new ProjectNode(idAllocator.getNextId(), subPlan.getRoot(), projections.build()), subPlan.getSampleWeight());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -22,8 +22,8 @@ import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.Node;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.SubqueryExpression;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
 
 import java.util.Collection;
@@ -99,7 +99,7 @@ class SubqueryPlanner
         RelationPlan valueListRelation = createRelationPlan((SubqueryExpression) inPredicate.getValueList());
 
         TranslationMap translationMap = subPlan.copyTranslations();
-        QualifiedNameReference valueList = getOnlyElement(valueListRelation.getOutputSymbols()).toQualifiedNameReference();
+        SymbolReference valueList = getOnlyElement(valueListRelation.getOutputSymbols()).toSymbolReference();
         translationMap.setExpressionAsAlreadyTranslated(valueList);
         translationMap.put(inPredicate, new InPredicate(inPredicate.getValue(), valueList));
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -100,7 +100,6 @@ class SubqueryPlanner
 
         TranslationMap translationMap = subPlan.copyTranslations();
         SymbolReference valueList = getOnlyElement(valueListRelation.getOutputSymbols()).toSymbolReference();
-        translationMap.setExpressionAsAlreadyTranslated(valueList);
         translationMap.put(inPredicate, new InPredicate(inPredicate.getValue(), valueList));
 
         return new PlanBuilder(translationMap,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Symbol.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Symbol.java
@@ -13,18 +13,24 @@
  */
 package com.facebook.presto.sql.planner;
 
-import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.base.Preconditions;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class Symbol
         implements Comparable<Symbol>
 {
     private final String name;
+
+    public static Symbol from(Expression expression)
+    {
+        checkArgument(expression instanceof SymbolReference, "Unexpected expression: %s", expression);
+        return new Symbol(((SymbolReference) expression).getName());
+    }
 
     @JsonCreator
     public Symbol(String name)
@@ -39,20 +45,9 @@ public class Symbol
         return name;
     }
 
-    public QualifiedName toQualifiedName()
+    public SymbolReference toSymbolReference()
     {
-        return QualifiedName.of(name);
-    }
-
-    public QualifiedNameReference toQualifiedNameReference()
-    {
-        return new QualifiedNameReference(toQualifiedName());
-    }
-
-    public static Symbol fromQualifiedName(QualifiedName name)
-    {
-        Preconditions.checkArgument(!name.getPrefix().isPresent(), "Can't create a symbol from a qualified name with prefix");
-        return new Symbol(name.getSuffix());
+        return new SymbolReference(name);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolAllocator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolAllocator.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.analyzer.Field;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.primitives.Ints;
 
 import java.util.HashMap;
@@ -89,6 +90,9 @@ public class SymbolAllocator
         }
         else if (expression instanceof FunctionCall) {
             nameHint = ((FunctionCall) expression).getName().getSuffix();
+        }
+        else if (expression instanceof SymbolReference) {
+            nameHint = ((SymbolReference) expression).getName();
         }
 
         return newSymbol(nameHint, type, suffix);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolToInputRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolToInputRewriter.java
@@ -17,7 +17,7 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FieldReference;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
@@ -37,9 +37,9 @@ public class SymbolToInputRewriter
     }
 
     @Override
-    public Expression rewriteQualifiedNameReference(QualifiedNameReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    public Expression rewriteSymbolReference(SymbolReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
     {
-        Integer channel = symbolToChannelMapping.get(Symbol.fromQualifiedName(node.getName()));
+        Integer channel = symbolToChannelMapping.get(Symbol.from(node));
         Preconditions.checkArgument(channel != null, "Cannot resolve symbol %s", node.getName());
 
         return new FieldReference(channel);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslationMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslationMap.java
@@ -106,7 +106,7 @@ class TranslationMap
             public Expression rewriteExpression(Expression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
             {
                 if (expressionToSymbols.containsKey(node)) {
-                    return new QualifiedNameReference(expressionToSymbols.get(node).toQualifiedName());
+                    return expressionToSymbols.get(node).toSymbolReference();
                 }
                 else if (expressionToExpressions.containsKey(node)) {
                     Expression mapping = expressionToExpressions.get(node);
@@ -125,7 +125,7 @@ class TranslationMap
         if (expression instanceof FieldReference) {
             int fieldIndex = ((FieldReference) expression).getFieldIndex();
             fieldSymbols[fieldIndex] = symbol;
-            expressionToSymbols.put(new QualifiedNameReference(rewriteBase.getSymbol(fieldIndex).toQualifiedName()), symbol);
+            expressionToSymbols.put(rewriteBase.getSymbol(fieldIndex).toSymbolReference(), symbol);
             return;
         }
 
@@ -192,7 +192,7 @@ class TranslationMap
             {
                 Symbol symbol = rewriteBase.getSymbol(node.getFieldIndex());
                 checkState(symbol != null, "No symbol mapping for node '%s' (%s)", node, node.getFieldIndex());
-                return new QualifiedNameReference(symbol.toQualifiedName());
+                return symbol.toSymbolReference();
             }
 
             @Override
@@ -211,7 +211,7 @@ class TranslationMap
 
                 Symbol symbol = rewriteBase.getSymbol(fieldIndex.get());
                 checkState(symbol != null, "No symbol mapping for node '%s' (%s)", node, fieldIndex.get());
-                Expression rewrittenExpression = new QualifiedNameReference(symbol.toQualifiedName());
+                Expression rewrittenExpression = symbol.toSymbolReference();
 
                 return coerceIfNecessary(node, rewrittenExpression);
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -71,7 +71,7 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -348,7 +348,7 @@ public class AddExchanges
                 }
 
                 // rewrite final aggregation in terms of intermediate function
-                finalCalls.put(entry.getKey(), new FunctionCall(QualifiedName.of(signature.getName()), ImmutableList.<Expression>of(new QualifiedNameReference(intermediateSymbol.toQualifiedName()))));
+                finalCalls.put(entry.getKey(), new FunctionCall(QualifiedName.of(signature.getName()), ImmutableList.of(intermediateSymbol.toSymbolReference())));
             }
 
             PlanWithProperties partial = withDerivedProperties(
@@ -1242,8 +1242,8 @@ public class AddExchanges
     {
         Map<Symbol, Symbol> outputToInput = new HashMap<>();
         for (Map.Entry<Symbol, Expression> assignment : assignments.entrySet()) {
-            if (assignment.getValue() instanceof QualifiedNameReference) {
-                outputToInput.put(assignment.getKey(), Symbol.fromQualifiedName(((QualifiedNameReference) assignment.getValue()).getName()));
+            if (assignment.getValue() instanceof SymbolReference) {
+                outputToInput.put(assignment.getKey(), Symbol.from(assignment.getValue()));
             }
         }
         return outputToInput;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -51,10 +51,8 @@ import com.facebook.presto.sql.planner.plan.TopNNode;
 import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
-import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -297,7 +295,7 @@ public class AddLocalExchanges
                 }
 
                 // rewrite final aggregation in terms of intermediate function
-                finalCalls.put(entry.getKey(), new FunctionCall(QualifiedName.of(signature.getName()), ImmutableList.<Expression>of(new QualifiedNameReference(intermediateSymbol.toQualifiedName()))));
+                finalCalls.put(entry.getKey(), new FunctionCall(QualifiedName.of(signature.getName()), ImmutableList.of(intermediateSymbol.toSymbolReference())));
             }
 
             PlanWithProperties source = deriveProperties(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CountConstantOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CountConstantOptimizer.java
@@ -28,8 +28,7 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.Literal;
 import com.facebook.presto.sql.tree.NullLiteral;
-import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
 
 import java.util.LinkedHashMap;
@@ -105,10 +104,8 @@ public class CountConstantOptimizer
                 return true;
             }
 
-            if (argument instanceof QualifiedNameReference) {
-                QualifiedNameReference qualifiedNameReference = (QualifiedNameReference) argument;
-                QualifiedName qualifiedName = qualifiedNameReference.getName();
-                Symbol argumentSymbol = Symbol.fromQualifiedName(qualifiedName);
+            if (argument instanceof SymbolReference) {
+                Symbol argumentSymbol = Symbol.from(argument);
                 Expression argumentExpression = projectNode.getAssignments().get(argumentSymbol);
                 return (argumentExpression instanceof Literal) && (!(argumentExpression instanceof NullLiteral));
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ProjectionPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ProjectionPushDown.java
@@ -27,7 +27,7 @@ import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -93,7 +93,7 @@ public class ProjectionPushDown
             ImmutableList.Builder<PlanNode> outputSources = ImmutableList.builder();
 
             for (int i = 0; i < source.getSources().size(); i++) {
-                Map<Symbol, QualifiedNameReference> outputToInput = source.sourceSymbolMap(i);   // Map: output of union -> input of this source to the union
+                Map<Symbol, SymbolReference> outputToInput = source.sourceSymbolMap(i);   // Map: output of union -> input of this source to the union
                 ImmutableMap.Builder<Symbol, Expression> assignments = ImmutableMap.builder();      // assignments for the new ProjectNode
 
                 // mapping from current ProjectNode to new ProjectNode, used to identify the output layout
@@ -119,7 +119,7 @@ public class ProjectionPushDown
             ImmutableList.Builder<PlanNode> newSourceBuilder = ImmutableList.builder();
             ImmutableList.Builder<List<Symbol>> inputsBuilder = ImmutableList.builder();
             for (int i = 0; i < exchange.getSources().size(); i++) {
-                Map<Symbol, QualifiedNameReference> outputToInputMap = extractExchangeOutputToInput(exchange, i);
+                Map<Symbol, SymbolReference> outputToInputMap = extractExchangeOutputToInput(exchange, i);
 
                 Map<Symbol, Expression> projections = new LinkedHashMap<>(); // Use LinkedHashMap to make output symbol order deterministic
                 ImmutableList.Builder<Symbol> inputs = ImmutableList.builder();
@@ -128,14 +128,14 @@ public class ProjectionPushDown
                 exchange.getPartitioningScheme().getPartitioning().getColumns().stream()
                         .map(outputToInputMap::get)
                         .forEach(nameReference -> {
-                            Symbol symbol = Symbol.fromQualifiedName(nameReference.getName());
+                            Symbol symbol = Symbol.from(nameReference);
                             projections.put(symbol, nameReference);
                             inputs.add(symbol);
                         });
 
                 if (exchange.getPartitioningScheme().getHashColumn().isPresent()) {
                     // Need to retain the hash symbol for the exchange
-                    projections.put(exchange.getPartitioningScheme().getHashColumn().get(), exchange.getPartitioningScheme().getHashColumn().get().toQualifiedNameReference());
+                    projections.put(exchange.getPartitioningScheme().getHashColumn().get(), exchange.getPartitioningScheme().getHashColumn().get().toSymbolReference());
                     inputs.add(exchange.getPartitioningScheme().getHashColumn().get());
                 }
                 for (Map.Entry<Symbol, Expression> projection : node.getAssignments().entrySet()) {
@@ -178,16 +178,16 @@ public class ProjectionPushDown
         }
     }
 
-    private static Map<Symbol, QualifiedNameReference> extractExchangeOutputToInput(ExchangeNode exchange, int sourceIndex)
+    private static Map<Symbol, SymbolReference> extractExchangeOutputToInput(ExchangeNode exchange, int sourceIndex)
     {
-        Map<Symbol, QualifiedNameReference> outputToInputMap = new HashMap<>();
+        Map<Symbol, SymbolReference> outputToInputMap = new HashMap<>();
         for (int i = 0; i < exchange.getOutputSymbols().size(); i++) {
-            outputToInputMap.put(exchange.getOutputSymbols().get(i), exchange.getInputs().get(sourceIndex).get(i).toQualifiedNameReference());
+            outputToInputMap.put(exchange.getOutputSymbols().get(i), exchange.getInputs().get(sourceIndex).get(i).toSymbolReference());
         }
         return outputToInputMap;
     }
 
-    private static Expression translateExpression(Expression inputExpression, Map<Symbol, QualifiedNameReference> symbolMapping)
+    private static Expression translateExpression(Expression inputExpression, Map<Symbol, SymbolReference> symbolMapping)
     {
         return ExpressionTreeRewriter.rewriteWith(new ExpressionSymbolInliner(symbolMapping), inputExpression);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -61,7 +61,7 @@ import com.facebook.presto.sql.planner.plan.UnnestNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -489,8 +489,8 @@ class PropertyDerivations
                 // ("ROW comparison not supported for fields with null elements", etc)
                 Object value = optimizer.optimize(NoOpSymbolResolver.INSTANCE);
 
-                if (value instanceof QualifiedNameReference) {
-                    Symbol symbol = Symbol.fromQualifiedName(((QualifiedNameReference) value).getName());
+                if (value instanceof SymbolReference) {
+                    Symbol symbol = Symbol.from((SymbolReference) value);
                     NullableValue existingConstantValue = constants.get(symbol);
                     if (existingConstantValue != null) {
                         constants.put(assignment.getKey(), new NullableValue(type, value));
@@ -632,8 +632,8 @@ class PropertyDerivations
         {
             Map<Symbol, Symbol> inputToOutput = new HashMap<>();
             for (Map.Entry<Symbol, Expression> assignment : assignments.entrySet()) {
-                if (assignment.getValue() instanceof QualifiedNameReference) {
-                    inputToOutput.put(Symbol.fromQualifiedName(((QualifiedNameReference) assignment.getValue()).getName()), assignment.getKey());
+                if (assignment.getValue() instanceof SymbolReference) {
+                    inputToOutput.put(Symbol.from(assignment.getValue()), assignment.getKey());
                 }
             }
             return inputToOutput;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneIdentityProjections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneIdentityProjections.java
@@ -22,7 +22,7 @@ import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
 
 import java.util.Map;
@@ -65,7 +65,7 @@ public class PruneIdentityProjections
             for (Map.Entry<Symbol, Expression> entry : node.getAssignments().entrySet()) {
                 Expression expression = entry.getValue();
                 Symbol symbol = entry.getKey();
-                if (!(expression instanceof QualifiedNameReference && ((QualifiedNameReference) expression).getName().equals(symbol.toQualifiedName()))) {
+                if (!(expression instanceof SymbolReference && ((SymbolReference) expression).getName().equals(symbol.getName()))) {
                     canElide = false;
                     break;
                 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SingleDistinctOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SingleDistinctOptimizer.java
@@ -26,7 +26,6 @@ import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.NullLiteral;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -119,8 +118,7 @@ public class SingleDistinctOptimizer
 
                 ImmutableMap.Builder<Symbol, Expression> outputSymbols = ImmutableMap.builder();
                 for (Symbol symbol : aggregationNode.getOutputSymbols()) {
-                    Expression expression = new QualifiedNameReference(symbol.toQualifiedName());
-                    outputSymbols.put(symbol, expression);
+                    outputSymbols.put(symbol, symbol.toSymbolReference());
                 }
 
                 // add null assignment for mask

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -53,7 +53,7 @@ import com.facebook.presto.sql.planner.plan.UnnestNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
@@ -282,8 +282,8 @@ final class StreamPropertyDerivations
         {
             Map<Symbol, Symbol> inputToOutput = new HashMap<>();
             for (Map.Entry<Symbol, Expression> assignment : assignments.entrySet()) {
-                if (assignment.getValue() instanceof QualifiedNameReference) {
-                    inputToOutput.put(Symbol.fromQualifiedName(((QualifiedNameReference) assignment.getValue()).getName()), assignment.getKey());
+                if (assignment.getValue() instanceof SymbolReference) {
+                    inputToOutput.put(Symbol.from(assignment.getValue()), assignment.getKey());
                 }
             }
             return inputToOutput;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -61,7 +61,7 @@ import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.NullLiteral;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
@@ -372,9 +372,9 @@ public class UnaliasSymbolReferences
             for (Map.Entry<Symbol, Expression> entry : node.getAssignments().entrySet()) {
                 Expression expression = canonicalize(entry.getValue());
 
-                if (expression instanceof QualifiedNameReference) {
+                if (expression instanceof SymbolReference) {
                     // Always map a trivial symbol projection
-                    Symbol symbol = Symbol.fromQualifiedName(((QualifiedNameReference) expression).getName());
+                    Symbol symbol = Symbol.from(expression);
                     if (!symbol.equals(entry.getKey())) {
                         map(entry.getKey(), symbol);
                     }
@@ -572,10 +572,10 @@ public class UnaliasSymbolReferences
             return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
             {
                 @Override
-                public Expression rewriteQualifiedNameReference(QualifiedNameReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+                public Expression rewriteSymbolReference(SymbolReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
                 {
-                    Symbol canonical = canonicalize(Symbol.fromQualifiedName(node.getName()));
-                    return new QualifiedNameReference(canonical.toQualifiedName());
+                    Symbol canonical = canonicalize(Symbol.from(node));
+                    return canonical.toSymbolReference();
                 }
             }, value);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SetOperationNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SetOperationNode.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
@@ -106,11 +106,11 @@ public abstract class SetOperationNode
     /**
      * Returns the output to input symbol mapping for the given source channel
      */
-    public Map<Symbol, QualifiedNameReference> sourceSymbolMap(int sourceIndex)
+    public Map<Symbol, SymbolReference> sourceSymbolMap(int sourceIndex)
     {
-        ImmutableMap.Builder<Symbol, QualifiedNameReference> builder = ImmutableMap.<Symbol, QualifiedNameReference>builder();
+        ImmutableMap.Builder<Symbol, SymbolReference> builder = ImmutableMap.builder();
         for (Map.Entry<Symbol, Collection<Symbol>> entry : outputToInputs.asMap().entrySet()) {
-            builder.put(entry.getKey(), Iterables.get(entry.getValue(), sourceIndex).toQualifiedNameReference());
+            builder.put(entry.getKey(), Iterables.get(entry.getValue(), sourceIndex).toSymbolReference());
         }
 
         return builder.build();
@@ -120,12 +120,12 @@ public abstract class SetOperationNode
      * Returns the input to output symbol mapping for the given source channel.
      * A single input symbol can map to multiple output symbols, thus requiring a Multimap.
      */
-    public Multimap<Symbol, QualifiedNameReference> outputSymbolMap(int sourceIndex)
+    public Multimap<Symbol, SymbolReference> outputSymbolMap(int sourceIndex)
     {
         return Multimaps.transformValues(FluentIterable.from(getOutputSymbols())
                 .toMap(outputToSourceSymbolFunction(sourceIndex))
                 .asMultimap()
-                .inverse(), Symbol::toQualifiedNameReference);
+                .inverse(), Symbol::toSymbolReference);
     }
 
     private Function<Symbol, Symbol> outputToSourceSymbolFunction(final int sourceIndex)

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -51,7 +51,7 @@ import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -352,8 +352,8 @@ public final class GraphvizPrinter
         {
             StringBuilder builder = new StringBuilder();
             for (Map.Entry<Symbol, Expression> entry : node.getAssignments().entrySet()) {
-                if ((entry.getValue() instanceof QualifiedNameReference) &&
-                        ((QualifiedNameReference) entry.getValue()).getName().equals(entry.getKey().toQualifiedName())) {
+                if ((entry.getValue() instanceof SymbolReference) &&
+                        ((SymbolReference) entry.getValue()).getName().equals(entry.getKey().getName())) {
                     // skip identity assignments
                     continue;
                 }
@@ -433,8 +433,8 @@ public final class GraphvizPrinter
             List<Expression> joinExpressions = new ArrayList<>();
             for (JoinNode.EquiJoinClause clause : node.getCriteria()) {
                 joinExpressions.add(new ComparisonExpression(ComparisonExpression.Type.EQUAL,
-                        new QualifiedNameReference(clause.getLeft().toQualifiedName()),
-                        new QualifiedNameReference(clause.getRight().toQualifiedName())));
+                        clause.getLeft().toSymbolReference(),
+                        clause.getRight().toSymbolReference()));
             }
 
             String criteria = Joiner.on(" AND ").join(joinExpressions);
@@ -482,8 +482,8 @@ public final class GraphvizPrinter
             List<Expression> joinExpressions = new ArrayList<>();
             for (IndexJoinNode.EquiJoinClause clause : node.getCriteria()) {
                 joinExpressions.add(new ComparisonExpression(ComparisonExpression.Type.EQUAL,
-                        new QualifiedNameReference(clause.getProbe().toQualifiedName()),
-                        new QualifiedNameReference(clause.getIndex().toQualifiedName())));
+                        clause.getProbe().toSymbolReference(),
+                        clause.getIndex().toSymbolReference()));
             }
 
             String criteria = Joiner.on(" AND ").join(joinExpressions);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -60,7 +60,7 @@ import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.TestingTransactionHandle;
@@ -101,6 +101,7 @@ import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.ExpressionUtils.rewriteQualifiedNamesToSymbolReferences;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.analyzeExpressionsWithSymbols;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypesFromInput;
 import static com.facebook.presto.sql.planner.LocalExecutionPlanner.toTypes;
@@ -431,6 +432,8 @@ public final class FunctionAssertions
     {
         Expression parsedExpression = SQL_PARSER.createExpression(expression);
 
+        parsedExpression = rewriteQualifiedNamesToSymbolReferences(parsedExpression);
+
         final ExpressionAnalysis analysis = analyzeExpressionsWithSymbols(TEST_SESSION, metadata, SQL_PARSER, symbolTypes, ImmutableList.of(parsedExpression));
         Expression rewrittenExpression = ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
         {
@@ -528,18 +531,18 @@ public final class FunctionAssertions
 
     private static boolean needsBoundValue(Expression projectionExpression)
     {
-        final AtomicBoolean hasQualifiedNameReference = new AtomicBoolean();
+        final AtomicBoolean hasSymbolReferences = new AtomicBoolean();
         new DefaultTraversalVisitor<Void, Void>()
         {
             @Override
-            protected Void visitQualifiedNameReference(QualifiedNameReference node, Void context)
+            protected Void visitSymbolReference(SymbolReference node, Void context)
             {
-                hasQualifiedNameReference.set(true);
+                hasSymbolReferences.set(true);
                 return null;
             }
         }.process(projectionExpression, null);
 
-        return hasQualifiedNameReference.get();
+        return hasSymbolReferences.get();
     }
 
     private Operator interpretedFilterProject(Expression filter, Expression projection, Session session)

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -24,14 +24,12 @@ import com.facebook.presto.spi.type.VarbinaryType;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.planner.SymbolResolver;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.StringLiteral;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -626,90 +624,90 @@ public class TestExpressionInterpreter
             throws Exception
     {
         assertOptimizedEquals("case " +
-                "when true then 33 " +
-                "end",
+                        "when true then 33 " +
+                        "end",
                 "33");
         assertOptimizedEquals("case " +
-                "when false then 1 " +
-                "else 33 " +
-                "end",
-                "33");
-
-        assertOptimizedEquals("case " +
-                "when false then 10000000000 " +
-                "else 33 " +
-                "end",
+                        "when false then 1 " +
+                        "else 33 " +
+                        "end",
                 "33");
 
         assertOptimizedEquals("case " +
-                "when bound_long = 1234 then 33 " +
-                "end",
+                        "when false then 10000000000 " +
+                        "else 33 " +
+                        "end",
+                "33");
+
+        assertOptimizedEquals("case " +
+                        "when bound_long = 1234 then 33 " +
+                        "end",
                 "33");
         assertOptimizedEquals("case " +
-                "when true then bound_long " +
-                "end",
+                        "when true then bound_long " +
+                        "end",
                 "1234");
         assertOptimizedEquals("case " +
-                "when false then 1 " +
-                "else bound_long " +
-                "end",
+                        "when false then 1 " +
+                        "else bound_long " +
+                        "end",
                 "1234");
 
         assertOptimizedEquals("case " +
-                "when bound_integer = 1234 then 33 " +
-                "end",
+                        "when bound_integer = 1234 then 33 " +
+                        "end",
                 "33");
         assertOptimizedEquals("case " +
-                "when true then bound_integer " +
-                "end",
+                        "when true then bound_integer " +
+                        "end",
                 "1234");
         assertOptimizedEquals("case " +
-                "when false then 1 " +
-                "else bound_integer " +
-                "end",
+                        "when false then 1 " +
+                        "else bound_integer " +
+                        "end",
                 "1234");
 
         assertOptimizedEquals("case " +
-                "when bound_long = 1234 then 33 " +
-                "else unbound_long " +
-                "end",
+                        "when bound_long = 1234 then 33 " +
+                        "else unbound_long " +
+                        "end",
                 "33");
         assertOptimizedEquals("case " +
-                "when true then bound_long " +
-                "else unbound_long " +
-                "end",
+                        "when true then bound_long " +
+                        "else unbound_long " +
+                        "end",
                 "1234");
         assertOptimizedEquals("case " +
-                "when false then unbound_long " +
-                "else bound_long " +
-                "end",
+                        "when false then unbound_long " +
+                        "else bound_long " +
+                        "end",
                 "1234");
 
         assertOptimizedEquals("case " +
-                "when bound_integer = 1234 then 33 " +
-                "else unbound_integer " +
-                "end",
+                        "when bound_integer = 1234 then 33 " +
+                        "else unbound_integer " +
+                        "end",
                 "33");
         assertOptimizedEquals("case " +
-                "when true then bound_integer " +
-                "else unbound_integer " +
-                "end",
+                        "when true then bound_integer " +
+                        "else unbound_integer " +
+                        "end",
                 "1234");
         assertOptimizedEquals("case " +
-                "when false then unbound_integer " +
-                "else bound_integer " +
-                "end",
+                        "when false then unbound_integer " +
+                        "else bound_integer " +
+                        "end",
                 "1234");
 
         assertOptimizedEquals("case " +
-                "when unbound_long = 1234 then 33 " +
-                "else 1 " +
-                "end",
+                        "when unbound_long = 1234 then 33 " +
+                        "else 1 " +
+                        "end",
                 "" +
-                "case " +
-                "when unbound_long = 1234 then 33 " +
-                "else 1 " +
-                "end");
+                        "case " +
+                        "when unbound_long = 1234 then 33 " +
+                        "else 1 " +
+                        "end");
 
         assertOptimizedMatches("case when 0 / 0 = 0 then 1 end",
                 "case when cast(fail() as boolean) then 1 end");
@@ -722,106 +720,106 @@ public class TestExpressionInterpreter
             throws Exception
     {
         assertOptimizedEquals("case 1 " +
-                "when 1 then 32 + 1 " +
-                "when 1 then 34 " +
-                "end",
+                        "when 1 then 32 + 1 " +
+                        "when 1 then 34 " +
+                        "end",
                 "33");
 
         assertOptimizedEquals("case null " +
-                "when true then 33 " +
-                "end",
+                        "when true then 33 " +
+                        "end",
                 "null");
         assertOptimizedEquals("case null " +
-                "when true then 33 " +
-                "else 33 " +
-                "end",
+                        "when true then 33 " +
+                        "else 33 " +
+                        "end",
                 "33");
         assertOptimizedEquals("case 33 " +
-                "when null then 1 " +
-                "else 33 " +
-                "end",
+                        "when null then 1 " +
+                        "else 33 " +
+                        "end",
                 "33");
 
         assertOptimizedEquals("case null " +
-                "when true then 3300000000 " +
-                "end",
+                        "when true then 3300000000 " +
+                        "end",
                 "null");
         assertOptimizedEquals("case null " +
-                "when true then 3300000000 " +
-                "else 3300000000 " +
-                "end",
+                        "when true then 3300000000 " +
+                        "else 3300000000 " +
+                        "end",
                 "3300000000");
         assertOptimizedEquals("case 33 " +
-                "when null then 3300000000 " +
-                "else 33 " +
-                "end",
+                        "when null then 3300000000 " +
+                        "else 33 " +
+                        "end",
                 "33");
 
         assertOptimizedEquals("case true " +
-                "when true then 33 " +
-                "end",
+                        "when true then 33 " +
+                        "end",
                 "33");
         assertOptimizedEquals("case true " +
-                "when false then 1 " +
-                "else 33 end",
+                        "when false then 1 " +
+                        "else 33 end",
                 "33");
 
         assertOptimizedEquals("case bound_long " +
-                "when 1234 then 33 " +
-                "end",
+                        "when 1234 then 33 " +
+                        "end",
                 "33");
         assertOptimizedEquals("case 1234 " +
-                "when bound_long then 33 " +
-                "end",
+                        "when bound_long then 33 " +
+                        "end",
                 "33");
         assertOptimizedEquals("case true " +
-                "when true then bound_long " +
-                "end",
+                        "when true then bound_long " +
+                        "end",
                 "1234");
         assertOptimizedEquals("case true " +
-                "when false then 1 " +
-                "else bound_long " +
-                "end",
+                        "when false then 1 " +
+                        "else bound_long " +
+                        "end",
                 "1234");
 
         assertOptimizedEquals("case bound_integer " +
-                "when 1234 then 33 " +
-                "end",
+                        "when 1234 then 33 " +
+                        "end",
                 "33");
         assertOptimizedEquals("case 1234 " +
-                "when bound_integer then 33 " +
-                "end",
+                        "when bound_integer then 33 " +
+                        "end",
                 "33");
         assertOptimizedEquals("case true " +
-                "when true then bound_integer " +
-                "end",
+                        "when true then bound_integer " +
+                        "end",
                 "1234");
         assertOptimizedEquals("case true " +
-                "when false then 1 " +
-                "else bound_integer " +
-                "end",
+                        "when false then 1 " +
+                        "else bound_integer " +
+                        "end",
                 "1234");
 
         assertOptimizedEquals("case bound_long " +
-                "when 1234 then 33 " +
-                "else unbound_long " +
-                "end",
+                        "when 1234 then 33 " +
+                        "else unbound_long " +
+                        "end",
                 "33");
         assertOptimizedEquals("case true " +
-                "when true then bound_long " +
-                "else unbound_long " +
-                "end",
+                        "when true then bound_long " +
+                        "else unbound_long " +
+                        "end",
                 "1234");
         assertOptimizedEquals("case true " +
-                "when false then unbound_long " +
-                "else bound_long " +
-                "end",
+                        "when false then unbound_long " +
+                        "else bound_long " +
+                        "end",
                 "1234");
 
         assertOptimizedEquals("case unbound_long " +
-                "when 1234 then 33 " +
-                "else 1 " +
-                "end",
+                        "when 1234 then 33 " +
+                        "else 1 " +
+                        "end",
                 "" +
                         "case unbound_long " +
                         "when 1234 then 33 " +
@@ -833,21 +831,21 @@ public class TestExpressionInterpreter
                         "when 33 then unbound_long " +
                         "else 1 " +
                         "end",
-                        "unbound_long");
+                "unbound_long");
         assertOptimizedEquals("case 33 " +
                         "when 0 then 0 " +
                         "when 33 then 1 " +
                         "when unbound_long then 2 " +
                         "else 1 " +
                         "end",
-                        "1");
+                "1");
         assertOptimizedEquals("case 33 " +
                         "when unbound_long then 0 " +
                         "when 1 then 1 " +
                         "when 33 then 2 " +
                         "else 0 " +
                         "end",
-                        "case 33 " +
+                "case 33 " +
                         "when unbound_long then 0 " +
                         "else 2 " +
                         "end");
@@ -856,23 +854,23 @@ public class TestExpressionInterpreter
                         "when 1 then 1 " +
                         "else unbound_long " +
                         "end",
-                        "unbound_long");
+                "unbound_long");
         assertOptimizedEquals("case 33 " +
                         "when unbound_long then 0 " +
                         "when 1 then 1 " +
                         "when unbound_long2 then 2 " +
                         "else 3 " +
                         "end",
-                        "case 33 " +
+                "case 33 " +
                         "when unbound_long then 0 " +
                         "when unbound_long2 then 2 " +
                         "else 3 " +
                         "end");
 
         assertOptimizedEquals("case true " +
-                "when unbound_long = 1 then 1 " +
-                "when 0 / 0 = 0 then 2 " +
-                "else 33 end",
+                        "when unbound_long = 1 then 1 " +
+                        "when 0 / 0 = 0 then 2 " +
+                        "else 33 end",
                 "" +
                         "case true " +
                         "when unbound_long = 1 then 1 " +
@@ -880,37 +878,37 @@ public class TestExpressionInterpreter
                         "end");
 
         assertOptimizedEquals("case bound_long " +
-                "when 123 * 10 + unbound_long then 1 = 1 " +
-                "else 1 = 2 " +
-                "end",
+                        "when 123 * 10 + unbound_long then 1 = 1 " +
+                        "else 1 = 2 " +
+                        "end",
                 "" +
                         "case bound_long when 1230 + unbound_long then true " +
                         "else false " +
                         "end");
 
         assertOptimizedEquals("case bound_long " +
-                "when unbound_long then 2 + 2 " +
-                "end",
+                        "when unbound_long then 2 + 2 " +
+                        "end",
                 "" +
                         "case bound_long " +
                         "when unbound_long then 4 " +
                         "end");
 
         assertOptimizedEquals("case bound_long " +
-                "when unbound_long then 2 + 2 " +
-                "when 1 then null " +
-                "when 2 then null " +
-                "end",
+                        "when unbound_long then 2 + 2 " +
+                        "when 1 then null " +
+                        "when 2 then null " +
+                        "end",
                 "" +
                         "case bound_long " +
                         "when unbound_long then 4 " +
                         "end");
 
         assertOptimizedMatches("case 1 " +
-                "when unbound_long then 1 " +
-                "when 0 / 0 then 2 " +
-                "else 1 " +
-                "end",
+                        "when unbound_long then 1 " +
+                        "when 0 / 0 then 2 " +
+                        "else 1 " +
+                        "end",
                 "" +
                         "case BIGINT '1' " +
                         "when unbound_long then 1 " +
@@ -919,10 +917,10 @@ public class TestExpressionInterpreter
                         "end");
 
         assertOptimizedMatches("case 1 " +
-                "when 0 / 0 then 1 " +
-                "when 0 / 0 then 2 " +
-                "else 1 " +
-                "end",
+                        "when 0 / 0 then 1 " +
+                        "when 0 / 0 then 2 " +
+                        "else 1 " +
+                        "end",
                 "" +
                         "case 1 " +
                         "when cast(fail() as integer) then 1 " +

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -61,6 +61,7 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.facebook.presto.sql.ExpressionFormatter.formatExpression;
+import static com.facebook.presto.sql.ExpressionUtils.rewriteQualifiedNamesToSymbolReferences;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
 import static com.facebook.presto.sql.planner.ExpressionInterpreter.expressionInterpreter;
 import static com.facebook.presto.sql.planner.ExpressionInterpreter.expressionOptimizer;
@@ -1223,11 +1224,6 @@ public class TestExpressionInterpreter
         assertEquals(optimize(actual), optimize(expected));
     }
 
-    private static void assertOptimizedEqualsSelf(@Language("SQL") String expression)
-    {
-        assertEquals(optimize(expression), SQL_PARSER.createExpression(expression));
-    }
-
     private static void assertOptimizedMatches(@Language("SQL") String actual, @Language("SQL") String expected)
     {
         // replaces FunctionCalls to FailureFunction by fail()
@@ -1235,7 +1231,9 @@ public class TestExpressionInterpreter
         if (actualOptimized instanceof Expression) {
             actualOptimized = ExpressionTreeRewriter.rewriteWith(new FailedFunctionRewriter(), (Expression) actualOptimized);
         }
-        assertEquals(actualOptimized, SQL_PARSER.createExpression(expected));
+        assertEquals(
+                actualOptimized,
+                rewriteQualifiedNamesToSymbolReferences(SQL_PARSER.createExpression(expected)));
     }
 
     private static Object optimize(@Language("SQL") String expression)
@@ -1246,36 +1244,31 @@ public class TestExpressionInterpreter
 
         IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, SYMBOL_TYPES, parsedExpression);
         ExpressionInterpreter interpreter = expressionOptimizer(parsedExpression, METADATA, TEST_SESSION, expressionTypes);
-        return interpreter.optimize(new SymbolResolver()
-        {
-            @Override
-            public Object getValue(Symbol symbol)
-            {
-                switch (symbol.getName().toLowerCase(ENGLISH)) {
-                    case "bound_integer":
-                        return 1234L;
-                    case "bound_long":
-                        return 1234L;
-                    case "bound_string":
-                        return utf8Slice("hello");
-                    case "bound_double":
-                        return 12.34;
-                    case "bound_date":
-                        return new LocalDate(2001, 8, 22).toDateMidnight(DateTimeZone.UTC).getMillis();
-                    case "bound_time":
-                        return new LocalTime(3, 4, 5, 321).toDateTime(new DateTime(0, DateTimeZone.UTC)).getMillis();
-                    case "bound_timestamp":
-                        return new DateTime(2001, 8, 22, 3, 4, 5, 321, DateTimeZone.UTC).getMillis();
-                    case "bound_pattern":
-                        return utf8Slice("%el%");
-                    case "bound_timestamp_with_timezone":
-                        return new SqlTimestampWithTimeZone(new DateTime(1970, 1, 1, 1, 0, 0, 999, DateTimeZone.UTC).getMillis(), getTimeZoneKey("Z"));
-                    case "bound_varbinary":
-                        return Slices.wrappedBuffer((byte) 0xab);
-                }
-
-                return new QualifiedNameReference(symbol.toQualifiedName());
+        return interpreter.optimize(symbol -> {
+            switch (symbol.getName().toLowerCase(ENGLISH)) {
+                case "bound_integer":
+                    return 1234L;
+                case "bound_long":
+                    return 1234L;
+                case "bound_string":
+                    return utf8Slice("hello");
+                case "bound_double":
+                    return 12.34;
+                case "bound_date":
+                    return new LocalDate(2001, 8, 22).toDateMidnight(DateTimeZone.UTC).getMillis();
+                case "bound_time":
+                    return new LocalTime(3, 4, 5, 321).toDateTime(new DateTime(0, DateTimeZone.UTC)).getMillis();
+                case "bound_timestamp":
+                    return new DateTime(2001, 8, 22, 3, 4, 5, 321, DateTimeZone.UTC).getMillis();
+                case "bound_pattern":
+                    return utf8Slice("%el%");
+                case "bound_timestamp_with_timezone":
+                    return new SqlTimestampWithTimeZone(new DateTime(1970, 1, 1, 1, 0, 0, 999, DateTimeZone.UTC).getMillis(), getTimeZoneKey("Z"));
+                case "bound_varbinary":
+                    return Slices.wrappedBuffer((byte) 0xab);
             }
+
+            return symbol.toSymbolReference();
         });
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
@@ -38,7 +38,6 @@ import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.StringLiteral;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -588,57 +587,57 @@ public class TestDomainTranslator
             throws Exception
     {
         // Test out the extraction of all basic comparisons where the reference literal ordering is flipped
-        ComparisonExpression originalExpression = comparison(GREATER_THAN, bigintLiteral(2L), reference(A));
+        ComparisonExpression originalExpression = comparison(GREATER_THAN, bigintLiteral(2L), A.toSymbolReference());
         ExtractionResult result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(A, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L)), false))));
 
-        originalExpression = comparison(GREATER_THAN_OR_EQUAL, bigintLiteral(2L), reference(A));
+        originalExpression = comparison(GREATER_THAN_OR_EQUAL, bigintLiteral(2L), A.toSymbolReference());
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(A, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(BIGINT, 2L)), false))));
 
-        originalExpression = comparison(LESS_THAN, bigintLiteral(2L), reference(A));
+        originalExpression = comparison(LESS_THAN, bigintLiteral(2L), A.toSymbolReference());
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(A, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 2L)), false))));
 
-        originalExpression = comparison(LESS_THAN_OR_EQUAL, bigintLiteral(2L), reference(A));
+        originalExpression = comparison(LESS_THAN_OR_EQUAL, bigintLiteral(2L), A.toSymbolReference());
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(A, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(BIGINT, 2L)), false))));
 
-        originalExpression = comparison(EQUAL, bigintLiteral(2L), reference(A));
+        originalExpression = comparison(EQUAL, bigintLiteral(2L), A.toSymbolReference());
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(A, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 2L)), false))));
 
-        originalExpression = comparison(EQUAL, colorLiteral(COLOR_VALUE_1), reference(J));
+        originalExpression = comparison(EQUAL, colorLiteral(COLOR_VALUE_1), J.toSymbolReference());
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(J, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1), false))));
 
-        originalExpression = comparison(NOT_EQUAL, bigintLiteral(2L), reference(A));
+        originalExpression = comparison(NOT_EQUAL, bigintLiteral(2L), A.toSymbolReference());
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(A, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L), Range.greaterThan(BIGINT, 2L)), false))));
 
-        originalExpression = comparison(NOT_EQUAL, colorLiteral(COLOR_VALUE_1), reference(J));
+        originalExpression = comparison(NOT_EQUAL, colorLiteral(COLOR_VALUE_1), J.toSymbolReference());
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(J, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1).complement(), false))));
 
-        originalExpression = comparison(IS_DISTINCT_FROM, bigintLiteral(2L), reference(A));
+        originalExpression = comparison(IS_DISTINCT_FROM, bigintLiteral(2L), A.toSymbolReference());
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(A, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L), Range.greaterThan(BIGINT, 2L)), true))));
 
-        originalExpression = comparison(IS_DISTINCT_FROM, colorLiteral(COLOR_VALUE_1), reference(J));
+        originalExpression = comparison(IS_DISTINCT_FROM, colorLiteral(COLOR_VALUE_1), J.toSymbolReference());
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(J, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1).complement(), true))));
 
-        originalExpression = comparison(IS_DISTINCT_FROM, nullLiteral(), reference(A));
+        originalExpression = comparison(IS_DISTINCT_FROM, nullLiteral(), A.toSymbolReference());
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(A, Domain.notNull(BIGINT))));
@@ -938,18 +937,18 @@ public class TestDomainTranslator
         assertEquals(result.getRemainingExpression(), originalExpression);
         assertTrue(result.getTupleDomain().isAll());
 
-        originalExpression = new InPredicate(reference(D), new InListExpression(ImmutableList.of(unprocessableExpression1(D))));
+        originalExpression = new InPredicate(D.toSymbolReference(), new InListExpression(ImmutableList.of(unprocessableExpression1(D))));
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), equal(D, unprocessableExpression1(D)));
         assertTrue(result.getTupleDomain().isAll());
 
-        originalExpression = new InPredicate(reference(D), new InListExpression(ImmutableList.of(TRUE_LITERAL, unprocessableExpression1(D))));
+        originalExpression = new InPredicate(D.toSymbolReference(), new InListExpression(ImmutableList.of(TRUE_LITERAL, unprocessableExpression1(D))));
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), or(equal(D, TRUE_LITERAL), equal(D, unprocessableExpression1(D))));
         assertTrue(result.getTupleDomain().isAll());
 
         // Test complement
-        originalExpression = not(new InPredicate(reference(D), new InListExpression(ImmutableList.of(unprocessableExpression1(D)))));
+        originalExpression = not(new InPredicate(D.toSymbolReference(), new InListExpression(ImmutableList.of(unprocessableExpression1(D)))));
         result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), not(equal(D, unprocessableExpression1(D))));
         assertTrue(result.getTupleDomain().isAll());
@@ -1141,14 +1140,14 @@ public class TestDomainTranslator
     public void testExpressionConstantFolding()
             throws Exception
     {
-        Expression originalExpression = comparison(GREATER_THAN, reference(L), function("from_hex", stringLiteral("123456")));
+        Expression originalExpression = comparison(GREATER_THAN, L.toSymbolReference(), function("from_hex", stringLiteral("123456")));
         ExtractionResult result = fromPredicate(originalExpression);
         assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
         Slice value = Slices.wrappedBuffer(BaseEncoding.base16().decode("123456"));
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(L, Domain.create(ValueSet.ofRanges(Range.greaterThan(VARBINARY, value)), false))));
 
         Expression expression = toPredicate(result.getTupleDomain());
-        assertEquals(expression, comparison(GREATER_THAN, reference(L), varbinaryLiteral(value)));
+        assertEquals(expression, comparison(GREATER_THAN, L.toSymbolReference(), varbinaryLiteral(value)));
     }
 
     @Test
@@ -1333,22 +1332,17 @@ public class TestDomainTranslator
 
     private static Expression unprocessableExpression1(Symbol symbol)
     {
-        return comparison(GREATER_THAN, reference(symbol), reference(symbol));
+        return comparison(GREATER_THAN, symbol.toSymbolReference(), symbol.toSymbolReference());
     }
 
     private static Expression unprocessableExpression2(Symbol symbol)
     {
-        return comparison(LESS_THAN, reference(symbol), reference(symbol));
+        return comparison(LESS_THAN, symbol.toSymbolReference(), symbol.toSymbolReference());
     }
 
     private static Expression randPredicate(Symbol symbol)
     {
-        return comparison(GREATER_THAN, reference(symbol), new FunctionCall(new QualifiedName("rand"), ImmutableList.<Expression>of()));
-    }
-
-    private static QualifiedNameReference reference(Symbol symbol)
-    {
-        return new QualifiedNameReference(symbol.toQualifiedName());
+        return comparison(GREATER_THAN, symbol.toSymbolReference(), new FunctionCall(new QualifiedName("rand"), ImmutableList.<Expression>of()));
     }
 
     private static NotExpression not(Expression expression)
@@ -1363,59 +1357,59 @@ public class TestDomainTranslator
 
     private static ComparisonExpression equal(Symbol symbol, Expression expression)
     {
-        return comparison(EQUAL, reference(symbol), expression);
+        return comparison(EQUAL, symbol.toSymbolReference(), expression);
     }
 
     private static ComparisonExpression notEqual(Symbol symbol, Expression expression)
     {
-        return comparison(NOT_EQUAL, reference(symbol), expression);
+        return comparison(NOT_EQUAL, symbol.toSymbolReference(), expression);
     }
 
     private static ComparisonExpression greaterThan(Symbol symbol, Expression expression)
     {
-        return comparison(GREATER_THAN, reference(symbol), expression);
+        return comparison(GREATER_THAN, symbol.toSymbolReference(), expression);
     }
 
     private static ComparisonExpression greaterThanOrEqual(Symbol symbol, Expression expression)
     {
-        return comparison(GREATER_THAN_OR_EQUAL, reference(symbol), expression);
+        return comparison(GREATER_THAN_OR_EQUAL, symbol.toSymbolReference(), expression);
     }
 
     private static ComparisonExpression lessThan(Symbol symbol, Expression expression)
     {
-        return comparison(LESS_THAN, reference(symbol), expression);
+        return comparison(LESS_THAN, symbol.toSymbolReference(), expression);
     }
 
     private static ComparisonExpression lessThanOrEqual(Symbol symbol, Expression expression)
     {
-        return comparison(LESS_THAN_OR_EQUAL, reference(symbol), expression);
+        return comparison(LESS_THAN_OR_EQUAL, symbol.toSymbolReference(), expression);
     }
 
     private static ComparisonExpression isDistinctFrom(Symbol symbol, Expression expression)
     {
-        return comparison(IS_DISTINCT_FROM, reference(symbol), expression);
+        return comparison(IS_DISTINCT_FROM, symbol.toSymbolReference(), expression);
     }
 
     private static Expression isNotNull(Symbol symbol)
     {
-        return new NotExpression(new IsNullPredicate(reference(symbol)));
+        return new NotExpression(new IsNullPredicate(symbol.toSymbolReference()));
     }
 
     private static IsNullPredicate isNull(Symbol symbol)
     {
-        return new IsNullPredicate(reference(symbol));
+        return new IsNullPredicate(symbol.toSymbolReference());
     }
 
     private static InPredicate in(Symbol symbol, List<?> values)
     {
         List<Type> types = nCopies(values.size(), TYPES.get(symbol));
         List<Expression> expressions = LiteralInterpreter.toExpressions(values, types);
-        return new InPredicate(reference(symbol), new InListExpression(expressions));
+        return new InPredicate(symbol.toSymbolReference(), new InListExpression(expressions));
     }
 
     private static BetweenPredicate between(Symbol symbol, Expression min, Expression max)
     {
-        return new BetweenPredicate(reference(symbol), min, max);
+        return new BetweenPredicate(symbol.toSymbolReference(), min, max);
     }
 
     private static Literal bigintLiteral(long value)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -45,7 +45,6 @@ import com.facebook.presto.sql.tree.GenericLiteral;
 import com.facebook.presto.sql.tree.IsNullPredicate;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.WindowFrame;
 import com.facebook.presto.type.UnknownType;
 import com.google.common.base.Preconditions;
@@ -87,12 +86,12 @@ public class TestEffectivePredicateExtractor
     private static final Symbol D = new Symbol("d");
     private static final Symbol E = new Symbol("e");
     private static final Symbol F = new Symbol("f");
-    private static final Expression AE = symbolExpr(A);
-    private static final Expression BE = symbolExpr(B);
-    private static final Expression CE = symbolExpr(C);
-    private static final Expression DE = symbolExpr(D);
-    private static final Expression EE = symbolExpr(E);
-    private static final Expression FE = symbolExpr(F);
+    private static final Expression AE = A.toSymbolReference();
+    private static final Expression BE = B.toSymbolReference();
+    private static final Expression CE = C.toSymbolReference();
+    private static final Expression DE = D.toSymbolReference();
+    private static final Expression EE = E.toSymbolReference();
+    private static final Expression FE = F.toSymbolReference();
 
     private static final Map<Symbol, Type> TYPES = ImmutableMap.<Symbol, Type>builder()
             .put(A, BIGINT)
@@ -689,11 +688,6 @@ public class TestEffectivePredicateExtractor
     private static FilterNode filter(PlanNode source, Expression predicate)
     {
         return new FilterNode(newId(), source, predicate);
-    }
-
-    private static Expression symbolExpr(Symbol symbol)
-    {
-        return new QualifiedNameReference(symbol.toQualifiedName());
     }
 
     private static Expression bigintLiteral(long number)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEqualityInference.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEqualityInference.java
@@ -18,7 +18,7 @@ import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.LongLiteral;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -376,9 +376,9 @@ public class TestEqualityInference
         return new ComparisonExpression(EQUAL, expression1, expression2);
     }
 
-    private static QualifiedNameReference nameReference(String symbol)
+    private static SymbolReference nameReference(String symbol)
     {
-        return new QualifiedNameReference(new Symbol(symbol).toQualifiedName());
+        return new SymbolReference(symbol);
     }
 
     private static LongLiteral number(long number)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -115,17 +116,17 @@ final class ExpressionVerifier
     protected Boolean visitQualifiedNameReference(QualifiedNameReference actual, Expression expected)
     {
         if (isReference(expected)) {
-            symbolAliases.put(asQualifiedName(expected).toString(), Symbol.fromQualifiedName(asQualifiedName(actual)));
+            symbolAliases.put(asQualifiedName(expected).toString(), Symbol.from(actual));
             return true;
         }
         return false;
     }
 
     @Override
-    protected Boolean visitDereferenceExpression(DereferenceExpression actual, Expression expected)
+    protected Boolean visitSymbolReference(SymbolReference actual, Expression expected)
     {
         if (isReference(expected)) {
-            symbolAliases.put(asQualifiedName(expected).toString(), Symbol.fromQualifiedName(asQualifiedName(actual)));
+            symbolAliases.put(asQualifiedName(expected).toString(), Symbol.from(actual));
             return true;
         }
         return false;
@@ -133,7 +134,7 @@ final class ExpressionVerifier
 
     private boolean isReference(Expression expression)
     {
-        return expression instanceof DereferenceExpression || expression instanceof QualifiedNameReference;
+        return expression instanceof DereferenceExpression || expression instanceof QualifiedNameReference || expression instanceof SymbolReference;
     }
 
     private QualifiedName asQualifiedName(Expression expression)
@@ -143,6 +144,9 @@ final class ExpressionVerifier
         }
         else if (expression instanceof QualifiedNameReference) {
             return ((QualifiedNameReference) expression).getName();
+        }
+        else if (expression instanceof SymbolReference) {
+            return QualifiedName.of(((SymbolReference) expression).getName());
         }
         else {
             throw new IllegalArgumentException("Expression is not a DereferenceExpression or QualifiedNameReference");

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TestExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TestExpressionVerifier.java
@@ -17,6 +17,7 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.Expression;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.sql.ExpressionUtils.rewriteQualifiedNamesToSymbolReferences;
 import static org.testng.Assert.assertTrue;
 
 public class TestExpressionVerifier
@@ -37,7 +38,7 @@ public class TestExpressionVerifier
 
     private Expression expression(String sql)
     {
-        return parser.createExpression(sql);
+        return rewriteQualifiedNamesToSymbolReferences(parser.createExpression(sql));
     }
 
     private static void assertThrows(Runnable runnable)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCountConstantOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCountConstantOptimizer.java
@@ -27,6 +27,7 @@ import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
@@ -48,7 +49,7 @@ public class TestCountConstantOptimizer
         PlanNodeIdAllocator planNodeIdAllocator = new PlanNodeIdAllocator();
         Symbol countAggregationSymbol = new Symbol("count");
         Signature countAggregationSignature = new Signature("count", FunctionKind.AGGREGATE, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BIGINT));
-        ImmutableMap<Symbol, FunctionCall> aggregations = ImmutableMap.of(countAggregationSymbol, new FunctionCall(QualifiedName.of("count"), ImmutableList.of(new QualifiedNameReference(QualifiedName.of("expr")))));
+        ImmutableMap<Symbol, FunctionCall> aggregations = ImmutableMap.of(countAggregationSymbol, new FunctionCall(QualifiedName.of("count"), ImmutableList.of(new SymbolReference("expr"))));
         ImmutableMap<Symbol, Signature> functions = ImmutableMap.of(countAggregationSymbol, countAggregationSignature);
         ValuesNode valuesNode = new ValuesNode(planNodeIdAllocator.getNextId(), ImmutableList.of(new Symbol("col")), ImmutableList.of(ImmutableList.of()));
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestExpressionEquivalence.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestExpressionEquivalence.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.sql.ExpressionUtils.rewriteQualifiedNamesToSymbolReferences;
 import static com.facebook.presto.sql.planner.DependencyExtractor.extractUnique;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
@@ -95,8 +96,8 @@ public class TestExpressionEquivalence
 
     private static void assertEquivalent(@Language("SQL") String left, @Language("SQL") String right)
     {
-        Expression leftExpression = SQL_PARSER.createExpression(left);
-        Expression rightExpression = SQL_PARSER.createExpression(right);
+        Expression leftExpression = rewriteQualifiedNamesToSymbolReferences(SQL_PARSER.createExpression(left));
+        Expression rightExpression = rewriteQualifiedNamesToSymbolReferences(SQL_PARSER.createExpression(right));
 
         Set<Symbol> symbols = extractUnique(ImmutableList.of(leftExpression, rightExpression));
         Map<Symbol, Type> types = symbols.stream()
@@ -141,8 +142,8 @@ public class TestExpressionEquivalence
 
     private static void assertNotEquivalent(@Language("SQL") String left, @Language("SQL") String right)
     {
-        Expression leftExpression = SQL_PARSER.createExpression(left);
-        Expression rightExpression = SQL_PARSER.createExpression(right);
+        Expression leftExpression = rewriteQualifiedNamesToSymbolReferences(SQL_PARSER.createExpression(left));
+        Expression rightExpression = rewriteQualifiedNamesToSymbolReferences(SQL_PARSER.createExpression(right));
 
         Set<Symbol> symbols = extractUnique(ImmutableList.of(leftExpression, rightExpression));
         Map<Symbol, Type> types = symbols.stream()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSimplifyExpressions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSimplifyExpressions.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.metadata.MetadataManager.createTestMetadataMan
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.sql.ExpressionUtils.binaryExpression;
 import static com.facebook.presto.sql.ExpressionUtils.extractPredicates;
+import static com.facebook.presto.sql.ExpressionUtils.rewriteQualifiedNamesToSymbolReferences;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
@@ -89,9 +90,11 @@ public class TestSimplifyExpressions
 
     private static void assertSimplifies(String expression, String expected)
     {
+        Expression actualExpression = rewriteQualifiedNamesToSymbolReferences(SQL_PARSER.createExpression(expression));
+        Expression expectedExpression = rewriteQualifiedNamesToSymbolReferences(SQL_PARSER.createExpression(expected));
         assertEquals(
-                normalize(simplifyExpressions(SQL_PARSER.createExpression(expression))),
-                normalize(SQL_PARSER.createExpression(expected)));
+                normalize(simplifyExpressions(actualExpression)),
+                normalize(expectedExpression));
     }
 
     private static Expression simplifyExpressions(Expression expression)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -64,6 +64,7 @@ import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.SubqueryExpression;
 import com.facebook.presto.sql.tree.SubscriptExpression;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.sql.tree.TimeLiteral;
 import com.facebook.presto.sql.tree.TimestampLiteral;
 import com.facebook.presto.sql.tree.TryExpression;
@@ -260,6 +261,12 @@ public final class ExpressionFormatter
         protected String visitQualifiedNameReference(QualifiedNameReference node, Boolean unmangleNames)
         {
             return formatQualifiedName(node.getName());
+        }
+
+        @Override
+        protected String visitSymbolReference(SymbolReference node, Boolean context)
+        {
+            return formatIdentifier(node.getName());
         }
 
         @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -601,4 +601,9 @@ public abstract class AstVisitor<R, C>
     {
         return visitGroupingElement(node, context);
     }
+
+    protected R visitSymbolReference(SymbolReference node, C context)
+    {
+        return visitExpression(node, context);
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionRewriter.java
@@ -179,4 +179,9 @@ public class ExpressionRewriter<C>
     {
         return rewriteExpression(node, context, treeRewriter);
     }
+
+    public Expression rewriteSymbolReference(SymbolReference node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteExpression(node, context, treeRewriter);
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -752,6 +752,19 @@ public final class ExpressionTreeRewriter<C>
 
             return node;
         }
+
+        @Override
+        protected Expression visitSymbolReference(SymbolReference node, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                Expression result = rewriter.rewriteSymbolReference(node, context.get(), ExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            return node;
+        }
     }
 
     public static class Context<C>

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SymbolReference.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SymbolReference.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class SymbolReference
+        extends Expression
+{
+    private final String name;
+
+    public SymbolReference(String name)
+    {
+        super(Optional.empty());
+        this.name = name;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitSymbolReference(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SymbolReference that = (SymbolReference) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name);
+    }
+}


### PR DESCRIPTION
Introduce SymbolReference expression node

Until now relation object reference and symbol reference were modeled in
expression tree as QualifiedNameReference. This was misleading as these
two references points to different domain AST or logical plan.
They were used interchangeably and so it was not clear to which domain
given reference points. To avoid that SymbolReference get introduced.
Now these two domains are separated.
