### PR TITLE
Fix force local scheduling for Hive

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -476,7 +476,7 @@ public class BackgroundHiveSplitLoader
                             partitionKeys,
                             addresses,
                             bucketNumber,
-                            forceLocalScheduling,
+                            forceLocalScheduling && hasRealAddress(addresses),
                             effectivePredicate));
 
                     chunkOffset += chunkLength;
@@ -502,10 +502,16 @@ public class BackgroundHiveSplitLoader
                     partitionKeys,
                     addresses,
                     bucketNumber,
-                    forceLocalScheduling,
+                    forceLocalScheduling && hasRealAddress(addresses),
                     effectivePredicate));
         }
         return builder.build();
+    }
+
+    private static boolean hasRealAddress(List<HostAddress> addresses)
+    {
+        // Hadoop FileSystem returns "localhost" as a default
+        return addresses.stream().anyMatch(address -> !address.getHostText().equals("localhost"));
     }
 
     private static List<HostAddress> toHostAddress(String[] hosts)


### PR DESCRIPTION
Only force local scheduling for splits when at least one address is
available for scheduling. This prevents a "No nodes available" error
for file systems like S3 that require remote access.
