### PR TITLE
Update default jvm.config

### DIFF
--- a/presto-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/presto-server-rpm/src/main/resources/dist/config/jvm.config
@@ -6,3 +6,4 @@
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:+UseGCOverheadLimit
 -XX:OnOutOfMemoryError=kill -9 %p
+-XX:ReservedCodeCacheSize=512M


### PR DESCRIPTION
We need a higher value of reserved code cache size as the vm
stops compiling code if the cache is full due to a jvm bug.
The bug has been fixed in Java 9.