### PR TITLE
Build presto-docs and presto-server-rpm once per Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,14 @@ services:
 before_install:
   # This section can be removed once travis get equipped with docker 1.10 and docker-compose 1.6
   - |
-    sudo apt-get update
-    sudo apt-get -o "Dpkg::Options::=--force-confold" -y install docker-engine
-    sudo rm /usr/local/bin/docker-compose
-    curl -L https://github.com/docker/compose/releases/download/1.7.1/docker-compose-`uname -s`-`uname -m` > docker-compose
-    chmod +x docker-compose
-    sudo mv docker-compose /usr/local/bin
+    if [ -v PRODUCT_TESTS ] || [ -v INTEGRATION_TESTS ]; then
+      sudo apt-get update
+      sudo apt-get -o "Dpkg::Options::=--force-confold" -y install docker-engine
+      sudo rm /usr/local/bin/docker-compose
+      curl -L https://github.com/docker/compose/releases/download/1.7.1/docker-compose-`uname -s`-`uname -m` > docker-compose
+      chmod +x docker-compose
+      sudo mv docker-compose /usr/local/bin
+    fi
 
 install: ./mvnw install -DskipTests=true $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T 2 -pl '!presto-docs,!presto-server-rpm'
 
@@ -47,7 +49,7 @@ script:
   - |
     if [ -v INTEGRATION_TESTS ]; then
       presto-hive-hadoop2/bin/run_on_docker.sh
-      ./mvnw install -DskipTests=true -B;
+      ./mvnw install -DskipTests=true -B
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ language: java
 env:
   global:
     - MAVEN_OPTS="-Xmx256M"
+    - MAVEN_SKIP_CHECKS_AND_DOCS="-Dair.check.skip-all=true -Dmaven.javadoc.skip=true"
   matrix:
     - TEST_MODULES=!presto-tests,!presto-kafka,!presto-redis,!presto-cassandra,!presto-raptor,!presto-postgresql,!presto-mysql
     - TEST_MODULES=presto-tests
     - TEST_MODULES=presto-raptor,presto-redis,presto-cassandra,presto-kafka,presto-postgresql,presto-mysql
-    - RUN_PRODUCT_TESTS="singlenode -x quarantine,big_query,storage_formats,mysql_connector,postgresql_connector,profile_specific_tests"
-    - RUN_PRODUCT_TESTS="singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation"
+    - PRODUCT_TESTS="singlenode -x quarantine,big_query,storage_formats,mysql_connector,postgresql_connector,profile_specific_tests"
+    - PRODUCT_TESTS="singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation"
     - INTEGRATION_TESTS=true
 
 sudo: required
@@ -32,20 +33,21 @@ before_install:
     chmod +x docker-compose
     sudo mv docker-compose /usr/local/bin
 
-install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -q -T 2
+install: ./mvnw install -DskipTests=true $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T 2 -pl '!presto-docs,!presto-server-rpm'
 
 script:
   - |
     if [ -v TEST_MODULES ]; then
-      ./mvnw test -Dair.check.skip-dependency=true -pl $TEST_MODULES;
+      ./mvnw test $MAVEN_SKIP_CHECKS_AND_DOCS -B -pl $TEST_MODULES;
     fi
   - |
-    if [ -v RUN_PRODUCT_TESTS ]; then
-      presto-product-tests/bin/run_on_docker.sh ${RUN_PRODUCT_TESTS}
+    if [ -v PRODUCT_TESTS ]; then
+      presto-product-tests/bin/run_on_docker.sh ${PRODUCT_TESTS}
     fi
   - |
     if [ -v INTEGRATION_TESTS ]; then
       presto-hive-hadoop2/bin/run_on_docker.sh
+      ./mvnw install -DskipTests=true -B;
     fi
 
 notifications:


### PR DESCRIPTION
This cuts at least 100 s on the `install:` step on Travis.

The commit moves parts of build previously executed
for each matrix row to the end of `INTEGRATION_TESTS`
 branch. The mentioned parts are:
  - `presto-docs`
  - `presto-server-rpm`
  - dependency checks
  - style checks
  - all other airbase checks enabled by default

Those parts are moved *after* integration tests because
if the checks fail, it's useful to know that the tests pass
and that only code style / dependencies have to be fixed.