### PR TITLE
Support subqueries in non INNER join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -48,6 +48,7 @@ import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.Except;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.Intersect;
 import com.facebook.presto.sql.tree.Join;
 import com.facebook.presto.sql.tree.LongLiteral;
@@ -82,6 +83,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.planner.ExpressionInterpreter.evaluateConstantExpression;
 import static com.facebook.presto.sql.tree.Join.Type.INNER;
+import static com.facebook.presto.sql.util.AstUtils.nodeContains;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.Types.checkType;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -276,10 +278,10 @@ class RelationPlanner
             rightPlanBuilder = rightPlanBuilder.appendProjections(rightComparisonExpressions, symbolAllocator, idAllocator);
 
             for (int i = 0; i < leftComparisonExpressions.size(); i++) {
-                Symbol leftSymbol = leftPlanBuilder.translate(leftComparisonExpressions.get(i));
-                Symbol rightSymbol = rightPlanBuilder.translate(rightComparisonExpressions.get(i));
-
                 if (joinConditionComparisonTypes.get(i) == ComparisonExpression.Type.EQUAL) {
+                    Symbol leftSymbol = leftPlanBuilder.translate(leftComparisonExpressions.get(i));
+                    Symbol rightSymbol = rightPlanBuilder.translate(rightComparisonExpressions.get(i));
+
                     equiClauses.add(new JoinNode.EquiJoinClause(leftSymbol, rightSymbol));
                 }
                 else {
@@ -298,6 +300,23 @@ class RelationPlanner
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
+
+        if (node.getType() != INNER) {
+            List<InPredicate> inPredicateSubqueries = analysis.getInPredicateSubqueries(node);
+            for (Expression complexExpression : complexJoinExpressions) {
+                for (InPredicate inPredicate :  inPredicateSubqueries) {
+                   if (nodeContains(complexExpression, inPredicate)) {
+                       throw new SemanticException(
+                               NOT_SUPPORTED,
+                               inPredicate,
+                               "IN with subquery predicate in join condition not supported");
+                   }
+                }
+            }
+
+            // non inner join subqueries can be applied only to one side of join
+            leftPlanBuilder = subqueryPlanner.handleSubqueries(leftPlanBuilder, complexJoinExpressions, node);
+        }
 
         Optional<Symbol> sampleWeight = Optional.empty();
         RelationPlan intermediateRootRelationPlan = new RelationPlan(root, analysis.getScope(node), outputSymbols, sampleWeight);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -314,7 +314,7 @@ class RelationPlanner
                 }
             }
 
-            // non inner join subqueries can be applied only to one side of join
+            // subqueries can be applied only to one side of join - left side is selected in arbitrary way
             leftPlanBuilder = subqueryPlanner.handleSubqueries(leftPlanBuilder, complexJoinExpressions, node);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
@@ -110,14 +110,6 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
                     replaceInPredicates(node.getPredicate()));
         }
 
-        private Expression replaceInPredicates(Expression expression)
-        {
-            for (Map<InPredicate, Expression> inPredicateMapping : inPredicateMappings) {
-                expression = replaceExpression(expression, inPredicateMapping);
-            }
-            return expression;
-        }
-
         @Override
         public PlanNode visitProject(ProjectNode node, RewriteContext<Void> context)
         {
@@ -165,6 +157,14 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
                 assignmentsBuilder.put(symbol, replaceInPredicates(assignments.get(symbol)));
             }
             return assignmentsBuilder.build();
+        }
+
+        private Expression replaceInPredicates(Expression expression)
+        {
+            for (Map<InPredicate, Expression> inPredicateMapping : inPredicateMappings) {
+                expression = replaceExpression(expression, inPredicateMapping);
+            }
+            return expression;
         }
 
         private List<InPredicate> extractInPredicates(Collection<Expression> expressions)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
@@ -99,32 +99,29 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
         @Override
         public PlanNode visitFilter(FilterNode node, RewriteContext<Void> context)
         {
-            InPredicateRewriteResult inPredicateRewriteResult = rewriteInPredicates(
+            PlanNode rewrittenNode = rewriteInPredicates(
                     context.defaultRewrite(node, context.get()),
                     ImmutableList.of(node.getPredicate()));
-            inPredicateMappings.add(inPredicateRewriteResult.inPredicateMapping);
 
             return new FilterNode(
-                    inPredicateRewriteResult.node.getId(),
-                    getOnlyElement(inPredicateRewriteResult.node.getSources()),
+                    rewrittenNode.getId(),
+                    getOnlyElement(rewrittenNode.getSources()),
                     replaceInPredicates(node.getPredicate()));
         }
 
         @Override
         public PlanNode visitProject(ProjectNode node, RewriteContext<Void> context)
         {
-            InPredicateRewriteResult inPredicateRewriteResult = rewriteInPredicates(
+            PlanNode rewrittenNode = rewriteInPredicates(
                     context.defaultRewrite(node, context.get()),
                     node.getAssignments().values());
 
-            inPredicateMappings.add(inPredicateRewriteResult.inPredicateMapping);
-
-            return new ProjectNode(inPredicateRewriteResult.node.getId(),
-                    getOnlyElement(inPredicateRewriteResult.node.getSources()),
+            return new ProjectNode(rewrittenNode.getId(),
+                    getOnlyElement(rewrittenNode.getSources()),
                     replaceInPredicateInAssignments(node));
         }
 
-        private InPredicateRewriteResult rewriteInPredicates(PlanNode node, Collection<Expression> expressions)
+        private PlanNode rewriteInPredicates(PlanNode node, Collection<Expression> expressions)
         {
             List<InPredicate> inPredicates = extractInPredicates(expressions);
             ImmutableMap.Builder<InPredicate, Expression> inPredicateMapping = ImmutableMap.builder();
@@ -134,19 +131,8 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
                 rewrittenNode = rewriteWith(rewriter, rewrittenNode, null);
                 inPredicateMapping.putAll(rewriter.getInPredicateMapping());
             }
-            return new InPredicateRewriteResult(rewrittenNode, inPredicateMapping.build());
-        }
-
-        private static class InPredicateRewriteResult
-        {
-            private final PlanNode node;
-            private final Map<InPredicate, Expression> inPredicateMapping;
-
-            private InPredicateRewriteResult(PlanNode node, Map<InPredicate, Expression> inPredicateMapping)
-            {
-                this.node = requireNonNull(node, "node is null");
-                this.inPredicateMapping = requireNonNull(inPredicateMapping, "inPredicateMapping is null");
-            }
+            inPredicateMappings.add(inPredicateMapping.build());
+            return rewrittenNode;
         }
 
         private Map<Symbol, Expression> replaceInPredicateInAssignments(ProjectNode node)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
@@ -101,7 +101,7 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
         {
             PlanNode rewrittenNode = rewriteInPredicates(
                     context.defaultRewrite(node, context.get()),
-                    ImmutableList.of(node.getPredicate()));
+                    node.getPredicate());
 
             return new FilterNode(
                     rewrittenNode.getId(),
@@ -119,6 +119,11 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
             return new ProjectNode(rewrittenNode.getId(),
                     getOnlyElement(rewrittenNode.getSources()),
                     replaceInPredicateInAssignments(node));
+        }
+
+        private PlanNode rewriteInPredicates(PlanNode node, Expression expressions)
+        {
+            return rewriteInPredicates(node, ImmutableList.of(expressions));
         }
 
         private PlanNode rewriteInPredicates(PlanNode node, Collection<Expression> expressions)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -146,10 +146,24 @@ public class TestLogicalPlanner
     public void testSameScalarSubqueryIsAppliedOnlyOnce()
     {
         // three subqueries with two duplicates, only two scalar joins should be in plan
-        Plan plan = plan("SELECT * FROM orders WHERE orderkey = (SELECT 1) AND custkey = (SELECT 2) AND custkey != (SELECT 1)");
-        PlanNodeExtractor planNodeExtractor = new PlanNodeExtractor(planNode -> planNode instanceof EnforceSingleRowNode);
+        assertEquals(
+                countOfMatchingNodes(
+                        plan("SELECT * FROM orders WHERE orderkey = (SELECT 1) AND custkey = (SELECT 2) AND custkey != (SELECT 1)"),
+                        EnforceSingleRowNode.class::isInstance),
+                2);
+        // same query used for left, right and complex join condition
+        assertEquals(
+                countOfMatchingNodes(
+                        plan("SELECT * FROM orders o1 JOIN orders o2 ON o1.orderkey = (SELECT 1) AND o2.orderkey = (SELECT 1) AND o1.orderkey + o2.orderkey = (SELECT 1)"),
+                        EnforceSingleRowNode.class::isInstance),
+                2);
+    }
+
+    private int countOfMatchingNodes(Plan plan, Predicate<PlanNode> predicate)
+    {
+        PlanNodeExtractor planNodeExtractor = new PlanNodeExtractor(predicate);
         plan.getRoot().accept(planNodeExtractor, null);
-        assertEquals(planNodeExtractor.getNodes().size(), 2);
+        return planNodeExtractor.getNodes().size();
     }
 
     private void assertPlan(String sql, PlanMatchPattern pattern)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2382,56 +2382,47 @@ public abstract class AbstractTestQueries
     public void testJoinWithMultipleInSubqueryClauses()
             throws Exception
     {
-        Function<String, String> queryPrefix = (String joinType) -> "SELECT * " +
-                "FROM " +
-                "    (VALUES 1,2,3,4) t(x) " +
-                joinType + " JOIN " +
-                "    (VALUES 1,2,3,5) t2(y) " +
-                "  ON ";
+        QueryTemplate.Parameter type = new QueryTemplate.Parameter("type", "");
+        QueryTemplate.Parameter condition = new QueryTemplate.Parameter("condition", "true");
+        QueryTemplate queryTemplate = new QueryTemplate(
+                "SELECT * FROM (VALUES 1,2,3,4) t(x) %type% JOIN (VALUES 1,2,3,5) t2(y) ON %condition%",
+                type,
+                condition);
 
-        String twoDuplicatedInSubqueriesCondition = "(x in (VALUES 1,2,3)) = (y in (VALUES 1,2,3)) AND (x in (VALUES 1,2,4)) = (y in (VALUES 1,2,4))";
+        QueryTemplate.Parameter twoDuplicatedInSubqueriesCondition = condition.of(
+                "(x in (VALUES 1,2,3)) = (y in (VALUES 1,2,3)) AND (x in (VALUES 1,2,4)) = (y in (VALUES 1,2,4))");
         assertQuery(
-                queryPrefix.apply("") + twoDuplicatedInSubqueriesCondition,
+                queryTemplate.resolve(twoDuplicatedInSubqueriesCondition),
                 "VALUES (1,1), (1,2), (2,2), (2,1), (3,3)");
         assertQuery(
-                queryPrefix.apply("")
-                        + "(x in (VALUES 1,2)) = (y in (VALUES 1,2)) AND (x in (VALUES 1)) = (y in (VALUES 3))",
+                queryTemplate.resolve(condition.of("(x in (VALUES 1,2)) = (y in (VALUES 1,2)) AND (x in (VALUES 1)) = (y in (VALUES 3))")),
                 "VALUES (2,2), (2,1), (3,5), (4,5)");
         assertQuery(
-                queryPrefix.apply("")
-                        + "(x in (VALUES 1,2)) = (y in (VALUES 1,2)) AND (x in (VALUES 1)) != (y in (VALUES 3))",
+                queryTemplate.resolve(condition.of("(x in (VALUES 1,2)) = (y in (VALUES 1,2)) AND (x in (VALUES 1)) != (y in (VALUES 3))")),
                 "VALUES (1,2), (1,1), (3, 3), (4,3)");
         assertQuery(
-                queryPrefix.apply("")
-                        + "(x in (VALUES 1)) = (y in (VALUES 1)) AND (x in (SELECT 2)) != (y in (SELECT 2))",
+                queryTemplate.resolve(condition.of("(x in (VALUES 1)) = (y in (VALUES 1)) AND (x in (SELECT 2)) != (y in (SELECT 2))")),
                 "VALUES (2,3), (2,5), (3, 2), (4,2)");
 
-        assertQueryFails(
-                queryPrefix.apply("left") + "x in (VALUES 1)",
-                ".*IN with subquery predicate in join condition not supported");
-        assertQueryFails(
-                queryPrefix.apply("left") + "y in (VALUES 1)",
-                ".*IN with subquery predicate in join condition not supported");
+        QueryTemplate.Parameter left = type.of("left");
+        QueryTemplate.Parameter right = type.of("right");
+        QueryTemplate.Parameter full = type.of("full");
+        for (QueryTemplate.Parameter joinType : ImmutableList.of(left, right, full)) {
+            for (String joinCondition : ImmutableList.of("x IN (VALUES 1)", "y in (VALUES 1)")) {
+                assertQueryFails(
+                        queryTemplate.resolve(joinType, condition.of(joinCondition)),
+                        ".*IN with subquery predicate in join condition not supported");
+            }
+        }
+
         assertQuery(
-                queryPrefix.apply("left") + twoDuplicatedInSubqueriesCondition,
+                queryTemplate.resolve(left, twoDuplicatedInSubqueriesCondition),
                 "VALUES (1,1), (1,2), (2,2), (2,1), (3,3), (4, null)");
-        assertQueryFails(
-                queryPrefix.apply("right") + "x in (VALUES 1)",
-                ".*IN with subquery predicate in join condition not supported");
-        assertQueryFails(
-                queryPrefix.apply("right") + "y in (VALUES 1)",
-                ".*IN with subquery predicate in join condition not supported");
         assertQuery(
-                queryPrefix.apply("right") + twoDuplicatedInSubqueriesCondition,
+                queryTemplate.resolve(right, twoDuplicatedInSubqueriesCondition),
                 "VALUES (1,1), (1,2), (2,2), (2,1), (3,3), (null, 5)");
-        assertQueryFails(
-                queryPrefix.apply("full") + "x in (VALUES 1)",
-                ".*IN with subquery predicate in join condition not supported");
-        assertQueryFails(
-                queryPrefix.apply("full") + "y in (VALUES 1)",
-                ".*IN with subquery predicate in join condition not supported");
         assertQuery(
-                queryPrefix.apply("full") + twoDuplicatedInSubqueriesCondition,
+                queryTemplate.resolve(full, twoDuplicatedInSubqueriesCondition),
                 "VALUES (1,1), (1,2), (2,2), (2,1), (3,3), (4, null), (null, 5)");
     }
 
@@ -2439,42 +2430,33 @@ public abstract class AbstractTestQueries
     public void testJoinWithInSubqueryToBeExecutedAsPostJoinFilter()
             throws Exception
     {
-        Function<String, String> queryPrefix = (String joinType) -> "SELECT * " +
-                "FROM " +
-                "    (VALUES 1,2,3,4) t(x) " +
-                joinType + " JOIN " +
-                "    (VALUES 1,2,3,5) t2(y) " +
-                "  ON ";
+        QueryTemplate.Parameter type = new QueryTemplate.Parameter("type", "");
+        QueryTemplate.Parameter condition = new QueryTemplate.Parameter("condition", "true");
+        QueryTemplate queryTemplate = new QueryTemplate(
+                "SELECT * FROM (VALUES 1,2,3,4) t(x) %type% JOIN (VALUES 1,2,3,5) t2(y) ON %condition%",
+                type,
+                condition);
 
         assertQuery(
-                queryPrefix.apply("")
-                        + " (x+y in (VALUES 4))",
+                queryTemplate.resolve(condition.of("(x+y in (VALUES 4))")),
                 "VALUES (1,3), (2,2), (3,1)");
         assertQuery(
-                queryPrefix.apply("")
-                        + " (x+y in (VALUES 4)) AND (x*y in (VALUES 4,5))",
+                queryTemplate.resolve(condition.of("(x+y in (VALUES 4)) AND (x*y in (VALUES 4,5))")),
                 "VALUES (2,2)");
         assertQuery(
-                queryPrefix.apply("")
-                        + " (x+y in (VALUES 4,5)) AND (x*y IN (VALUES 4,5))",
+                queryTemplate.resolve(condition.of("(x+y in (VALUES 4,5)) AND (x*y IN (VALUES 4,5))")),
                 "VALUES (4,1), (2,2)");
         assertQuery(
-                queryPrefix.apply("")
-                        + "(x+y in (VALUES 4,5)) AND (x in (VALUES 4,5)) != (y in (VALUES 4,5))",
+                queryTemplate.resolve(condition.of("(x+y in (VALUES 4,5)) AND (x in (VALUES 4,5)) != (y in (VALUES 4,5))")),
                 "VALUES (4,1)");
 
-        assertQueryFails(
-                queryPrefix.apply("left")
-                        + "(x+y in (VALUES 4,5)) AND (x in (VALUES 4,5)) != (y in (VALUES 4,5))",
-                ".*IN with subquery predicate in join condition not supported");
-        assertQueryFails(
-                queryPrefix.apply("right")
-                        + "(x+y in (VALUES 4,5)) AND (x in (VALUES 4,5)) != (y in (VALUES 4,5))",
-                ".*IN with subquery predicate in join condition not supported");
-        assertQueryFails(
-                queryPrefix.apply("full")
-                        + "(x+y in (VALUES 4,5)) AND (x in (VALUES 4,5)) != (y in (VALUES 4,5))",
-                ".*IN with subquery predicate in join condition not supported");
+        for (QueryTemplate.Parameter joinType : ImmutableList.of(type.of("left"), type.of("right"), type.of("full"))) {
+            assertQueryFails(
+                    queryTemplate.resolve(
+                            joinType,
+                            condition.of("(x+y in (VALUES 4,5)) AND (x in (VALUES 4,5)) != (y in (VALUES 4,5))")),
+                    ".*IN with subquery predicate in join condition not supported");
+        }
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -46,6 +46,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.INFORMATION_SCHEMA;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -2381,111 +2382,220 @@ public abstract class AbstractTestQueries
     public void testJoinWithMultipleInSubqueryClauses()
             throws Exception
     {
-        String queryPrefix = "SELECT * " +
+        Function<String, String> queryPrefix = (String joinType) -> "SELECT * " +
                 "FROM " +
-                "    (VALUES 1,2,3) t(x) " +
-                "  JOIN " +
-                "    (VALUES 1,2,3) t2(y) " +
+                "    (VALUES 1,2,3,4) t(x) " +
+                joinType + " JOIN " +
+                "    (VALUES 1,2,3,5) t2(y) " +
                 "  ON ";
 
+        String twoDuplicatedInSubqueriesCondition = "(x in (VALUES 1,2,3)) = (y in (VALUES 1,2,3)) AND (x in (VALUES 1,2,4)) = (y in (VALUES 1,2,4))";
         assertQuery(
-                queryPrefix + "(x in (VALUES 1,2,3)) = (y in (VALUES 1,2,3)) AND (x in (VALUES 1,2)) = (y in (VALUES 1,2))",
+                queryPrefix.apply("") + twoDuplicatedInSubqueriesCondition,
                 "VALUES (1,1), (1,2), (2,2), (2,1), (3,3)");
         assertQuery(
-                queryPrefix + "(x in (VALUES 1,2)) = (y in (VALUES 1,2)) AND (x in (VALUES 1)) = (y in (VALUES 3))",
-                "VALUES (2,2), (2,1)");
+                queryPrefix.apply("")
+                        + "(x in (VALUES 1,2)) = (y in (VALUES 1,2)) AND (x in (VALUES 1)) = (y in (VALUES 3))",
+                "VALUES (2,2), (2,1), (3,5), (4,5)");
         assertQuery(
-                queryPrefix + "(x in (VALUES 1,2)) = (y in (VALUES 1,2)) AND (x in (VALUES 1)) != (y in (VALUES 3))",
-                "VALUES (1,2), (1,1), (3, 3)");
+                queryPrefix.apply("")
+                        + "(x in (VALUES 1,2)) = (y in (VALUES 1,2)) AND (x in (VALUES 1)) != (y in (VALUES 3))",
+                "VALUES (1,2), (1,1), (3, 3), (4,3)");
         assertQuery(
-                queryPrefix + "(x in (VALUES 1)) = (y in (VALUES 1)) AND (x in (SELECT 2)) != (y in (SELECT 2))",
-                "VALUES (2,3), (3, 2)");
+                queryPrefix.apply("")
+                        + "(x in (VALUES 1)) = (y in (VALUES 1)) AND (x in (SELECT 2)) != (y in (SELECT 2))",
+                "VALUES (2,3), (2,5), (3, 2), (4,2)");
+
+        assertQueryFails(
+                queryPrefix.apply("left") + "x in (VALUES 1)",
+                ".*IN with subquery predicate in join condition not supported");
+        assertQueryFails(
+                queryPrefix.apply("left") + "y in (VALUES 1)",
+                ".*IN with subquery predicate in join condition not supported");
+        assertQuery(
+                queryPrefix.apply("left") + twoDuplicatedInSubqueriesCondition,
+                "VALUES (1,1), (1,2), (2,2), (2,1), (3,3), (4, null)");
+        assertQueryFails(
+                queryPrefix.apply("right") + "x in (VALUES 1)",
+                ".*IN with subquery predicate in join condition not supported");
+        assertQueryFails(
+                queryPrefix.apply("right") + "y in (VALUES 1)",
+                ".*IN with subquery predicate in join condition not supported");
+        assertQuery(
+                queryPrefix.apply("right") + twoDuplicatedInSubqueriesCondition,
+                "VALUES (1,1), (1,2), (2,2), (2,1), (3,3), (null, 5)");
+        assertQueryFails(
+                queryPrefix.apply("full") + "x in (VALUES 1)",
+                ".*IN with subquery predicate in join condition not supported");
+        assertQueryFails(
+                queryPrefix.apply("full") + "y in (VALUES 1)",
+                ".*IN with subquery predicate in join condition not supported");
+        assertQuery(
+                queryPrefix.apply("full") + twoDuplicatedInSubqueriesCondition,
+                "VALUES (1,1), (1,2), (2,2), (2,1), (3,3), (4, null), (null, 5)");
     }
 
     @Test
     public void testJoinWithInSubqueryToBeExecutedAsPostJoinFilter()
             throws Exception
     {
-        String queryPrefix = "SELECT * " +
+        Function<String, String> queryPrefix = (String joinType) -> "SELECT * " +
                 "FROM " +
-                "    (VALUES 1,2,3) t(x) " +
-                "  JOIN " +
-                "    (VALUES 1,2,3) t2(y) " +
+                "    (VALUES 1,2,3,4) t(x) " +
+                joinType + " JOIN " +
+                "    (VALUES 1,2,3,5) t2(y) " +
                 "  ON ";
 
         assertQuery(
-                queryPrefix + " (x+y in (VALUES 4, 5))",
-                "VALUES (1,3), (2,2), (2,3), (3,1), (3,2)");
+                queryPrefix.apply("")
+                        + " (x+y in (VALUES 4))",
+                "VALUES (1,3), (2,2), (3,1)");
         assertQuery(
-                queryPrefix + " (x+y in (VALUES 4, 5)) AND (x*y in (VALUES 4))",
+                queryPrefix.apply("")
+                        + " (x+y in (VALUES 4)) AND (x*y in (VALUES 4,5))",
                 "VALUES (2,2)");
         assertQuery(
-                queryPrefix + " (x+y in (VALUES 4, 5)) = (x*y IN (VALUES 4,5))",
-                "VALUES (1,1), (1,2), (2,1), (2,2), (3,3)");
+                queryPrefix.apply("")
+                        + " (x+y in (VALUES 4,5)) AND (x*y IN (VALUES 4,5))",
+                "VALUES (4,1), (2,2)");
         assertQuery(
-                queryPrefix + "(x+y in (VALUES (4),(5))) " +
-                        "AND " +
-                        "(x in (VALUES 1)) != (y in (VALUES 3))",
-                "VALUES (2,3)");
-        assertQuery(
-                queryPrefix + "(x+y in (VALUES (4),(5))) " +
-                        "AND " +
-                        "(x in (VALUES 1)) = (y in (VALUES 3))",
-                "VALUES (1,3), (2,2), (3,2), (3,1)");
+                queryPrefix.apply("")
+                        + "(x+y in (VALUES 4,5)) AND (x in (VALUES 4,5)) != (y in (VALUES 4,5))",
+                "VALUES (4,1)");
+
+        assertQueryFails(
+                queryPrefix.apply("left")
+                        + "(x+y in (VALUES 4,5)) AND (x in (VALUES 4,5)) != (y in (VALUES 4,5))",
+                ".*IN with subquery predicate in join condition not supported");
+        assertQueryFails(
+                queryPrefix.apply("right")
+                        + "(x+y in (VALUES 4,5)) AND (x in (VALUES 4,5)) != (y in (VALUES 4,5))",
+                ".*IN with subquery predicate in join condition not supported");
+        assertQueryFails(
+                queryPrefix.apply("full")
+                        + "(x+y in (VALUES 4,5)) AND (x in (VALUES 4,5)) != (y in (VALUES 4,5))",
+                ".*IN with subquery predicate in join condition not supported");
     }
 
     @Test
     public void testJoinWithMultipleScalarSubqueryClauses()
             throws Exception
     {
-        String queryPrefix = "SELECT * " +
+        Function<String, String> queryPrefix = (String joinType) -> "SELECT * " +
                 "FROM " +
-                "    (VALUES 1,2,3) t(x) " +
-                "  JOIN " +
-                "    (VALUES 1,2,3) t2(y) " +
+                "    (VALUES 1,2,3,4) t(x) " +
+                joinType + " JOIN " +
+                "    (VALUES 1,2,3,5) t2(y) " +
                 "  ON ";
 
         assertQuery(
-                queryPrefix + "(x = (VALUES 1)) = (y = (VALUES 2)) AND (x in (VALUES 2)) = (y in (VALUES 1))",
-                "VALUES (1,2), (2,1), (3, 3)");
+                queryPrefix.apply("")
+                        + "(x = (VALUES 1)) AND (y = (VALUES 2)) AND (x in (VALUES 2)) = (y in (VALUES 1))",
+                "VALUES (1,2)");
         assertQuery(
-                queryPrefix + "(x = (VALUES 2)) = (y > (VALUES 0)) AND (x > (VALUES 1)) = (y < (VALUES 3))",
+                queryPrefix.apply("")
+                        + "(x = (VALUES 2)) = (y > (VALUES 0)) AND (x > (VALUES 1)) = (y < (VALUES 3))",
                 "VALUES (2,2), (2,1)");
         assertQuery(
-                queryPrefix + "(x = (VALUES 1)) = (y = (VALUES 1)) AND (x = (SELECT 2)) != (y = (SELECT 3))",
-                "VALUES (2,2), (3,3)");
+                queryPrefix.apply("")
+                        + "(x = (VALUES 1)) = (y = (VALUES 1)) AND (x = (SELECT 2)) != (y = (SELECT 3))",
+                "VALUES (2,5), (2,2), (3,3), (4,3)");
+
+        assertQuery(
+                queryPrefix.apply("left")
+                        + "(x = (VALUES 1)) AND (y = (VALUES 2)) AND (x in (VALUES 2)) = (y in (VALUES 1))",
+                "VALUES (1,2), (2,null), (3, null), (4, null)");
+        assertQuery(
+                queryPrefix.apply("right")
+                        + "(x = (VALUES 1)) AND (y = (VALUES 2)) AND (x in (VALUES 2)) = (y in (VALUES 1))",
+                "VALUES (1,2), (null,1), (null, 3), (null, 5)");
+        assertQuery(
+                queryPrefix.apply("full")
+                        + "(x = (VALUES 1)) AND (y = (VALUES 2)) AND (x in (VALUES 2)) = (y in (VALUES 1))",
+                "VALUES (1,2), (2,null), (3, null), (4, null), (null,1), (null, 3), (null, 5)");
     }
 
     @Test
     public void testJoinWithScalarSubqueryToBeExecutedAsPostJoinFilter()
             throws Exception
     {
-        String queryPrefix = "SELECT * " +
+        Function<String, String> queryPrefix = (String joinType) -> "SELECT * " +
                 "FROM " +
-                "    (VALUES 1,2,3) t(x) " +
-                "  JOIN " +
-                "    (VALUES 1,2,3) t2(y) " +
+                "    (VALUES 1,2,3,4) t(x) " +
+                joinType + " JOIN " +
+                "    (VALUES 1,2,3,5) t2(y) " +
                 "  ON ";
 
         assertQuery(
-                queryPrefix + " (x+y = (SELECT 4))",
+                queryPrefix.apply("") + " (x+y = (SELECT 4))",
                 "VALUES (1,3), (2,2), (3,1)");
         assertQuery(
-                queryPrefix + "(x+y = (VALUES 4)) AND (x*y = (VALUES 4))",
+                queryPrefix.apply("") + "(x+y = (VALUES 4)) AND (x*y = (VALUES 4))",
                 "VALUES (2,2)");
+
+        // all combination of duplicated subquery
         assertQuery(
-                queryPrefix + "(x+y > (VALUES 2)) = (x*y  > (VALUES 8))",
-                "VALUES (1,1), (3,3)");
+                queryPrefix.apply("")
+                        + "x+y > (VALUES 3) AND (x = (VALUES 3)) != (y = (VALUES 3))",
+                "VALUES (3,1), (3,2), (1,3), (2,3), (4,3), (3,5)");
         assertQuery(
-                queryPrefix + "x+y >= (VALUES 4) " +
-                        "AND " +
-                        "(x = (VALUES 2)) != (y = (VALUES 2))",
-                "VALUES (3,2), (2,3)");
+                queryPrefix.apply("")
+                        + "x+y >= (VALUES 5) AND (x = (VALUES 3)) != (y = (VALUES 3))",
+                "VALUES (3,2), (2,3), (4,3), (3,5)");
         assertQuery(
-                queryPrefix + "(x+y >= (VALUES 4)) " +
-                        "AND " +
-                        "(x = (VALUES 3)) = (y = (VALUES 3))",
-                "VALUES (2, 2), (3, 3)");
+                queryPrefix.apply("")
+                        + "x+y >= (VALUES 3) AND (x = (VALUES 5)) != (y = (VALUES 3))",
+                "VALUES (1,3), (2,3), (3,3), (4,3)");
+        assertQuery(
+                queryPrefix.apply("")
+                        + "x+y >= (VALUES 3) AND (x = (VALUES 3)) != (y = (VALUES 5))",
+                "VALUES (3,1), (3,2), (3,3), (1,5), (2,5), (4,5)");
+        assertQuery(
+                queryPrefix.apply("")
+                        + "x+y >= (VALUES 4) AND (x = (VALUES 3)) != (y = (VALUES 5))",
+                "VALUES (3,1), (3,2), (3,3), (1,5), (2,5), (4,5)");
+
+        // non inner joins
+        assertQuery(
+                queryPrefix.apply("left") + " (x+y = (SELECT 4))",
+                "VALUES (1,3), (2,2), (3,1), (4, null)");
+        assertQuery(
+                queryPrefix.apply("right") + " (x+y = (SELECT 4))",
+                "VALUES (1,3), (2,2), (3,1), (null, 5)");
+        assertQuery(
+                queryPrefix.apply("full") + " (x+y = (SELECT 4))",
+                "VALUES (1,3), (2,2), (3,1), (4, null), (null, 5)");
+    }
+
+    @Test
+    public void testJoinWithScalarSubqueryToBeExecutedAsPostJoinFilterWithEmptyInnerTable()
+            throws Exception
+    {
+        String noOutputQuery = "SELECT 1 WHERE false";
+        Function<String, String> queryPrefix = (String joinType) -> "SELECT * " +
+                "FROM " +
+                "    (" + noOutputQuery + ") t(x) " +
+                joinType + " JOIN " +
+                "    (VALUES 1) t2(y) " +
+                "  ON ";
+
+        assertQuery(
+                queryPrefix.apply("") + " (x+y = (SELECT 4))",
+                noOutputQuery);
+        assertQuery(
+                queryPrefix.apply("") + "(x+y = (VALUES 4)) AND (x*y = (VALUES 4))",
+                noOutputQuery);
+
+        // non inner joins
+        assertQuery(
+                queryPrefix.apply("left") + " (x+y = (SELECT 4))",
+                noOutputQuery);
+        assertQuery(
+                queryPrefix.apply("right") + " (x+y = (SELECT 4))",
+                "VALUES (null,1)");
+        assertQuery(
+                queryPrefix.apply("full") + " (x+y = (SELECT 4))",
+                "VALUES (null,1)");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -87,10 +87,10 @@ public final class QueryAssertions
 
         if (actualResults.getUpdateType().isPresent() || actualResults.getUpdateCount().isPresent()) {
             if (!actualResults.getUpdateType().isPresent()) {
-                fail("update count present without update type");
+                fail("update count present without update type for query: \n" + actual);
             }
             if (!compareUpdate) {
-                fail("update type should not be present (use assertUpdate)");
+                fail("update type should not be present (use assertUpdate) for query: \n" + actual);
             }
         }
 
@@ -99,29 +99,34 @@ public final class QueryAssertions
 
         if (compareUpdate) {
             if (!actualResults.getUpdateType().isPresent()) {
-                fail("update type not present");
+                fail("update type not present for query: \n" + actual);
             }
             if (!actualResults.getUpdateCount().isPresent()) {
-                fail("update count not present");
+                fail("update count not present for query: \n" + actual);
             }
-            assertEquals(actualRows.size(), 1);
-            assertEquals(expectedRows.size(), 1);
+            assertEquals(actualRows.size(), 1, "For query: \n " + actual + "\n:");
+            assertEquals(expectedRows.size(), 1, "For query: \n " + actual + "\n:");
             MaterializedRow row = expectedRows.get(0);
-            assertEquals(row.getFieldCount(), 1);
-            assertEquals(row.getField(0), actualResults.getUpdateCount().getAsLong());
+            assertEquals(row.getFieldCount(), 1, "For query: \n " + actual + "\n:");
+            assertEquals(row.getField(0), actualResults.getUpdateCount().getAsLong(), "For query: \n " + actual + "\n:");
         }
 
         if (ensureOrdering) {
             if (!actualRows.equals(expectedRows)) {
-                assertEquals(actualRows, expectedRows);
+                assertEquals(actualRows, expectedRows, "For query: \n " + actual + "\n:");
             }
         }
         else {
-            assertEqualsIgnoreOrder(actualRows, expectedRows);
+            assertEqualsIgnoreOrder(actualRows, expectedRows, "For query: \n " + actual);
         }
     }
 
     public static void assertEqualsIgnoreOrder(Iterable<?> actual, Iterable<?> expected)
+    {
+        assertEqualsIgnoreOrder(actual, expected, null);
+    }
+
+    public static void assertEqualsIgnoreOrder(Iterable<?> actual, Iterable<?> expected, String message)
     {
         assertNotNull(actual, "actual is null");
         assertNotNull(expected, "expected is null");
@@ -129,7 +134,8 @@ public final class QueryAssertions
         ImmutableMultiset<?> actualSet = ImmutableMultiset.copyOf(actual);
         ImmutableMultiset<?> expectedSet = ImmutableMultiset.copyOf(expected);
         if (!actualSet.equals(expectedSet)) {
-            fail(format("not equal\nActual %s rows:\n    %s\nExpected %s rows:\n    %s\n",
+            fail(format("%snot equal\nActual %s rows:\n    %s\nExpected %s rows:\n    %s\n",
+                    message == null ? "" : (message + "\n"),
                     actualSet.size(),
                     Joiner.on("\n    ").join(Iterables.limit(actualSet, 100)),
                     expectedSet.size(),

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryTemplate.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryTemplate.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.tests;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class QueryTemplate
+{
+    private final String queryTemplate;
+    private final List<Parameter> defaultParameters;
+
+    public QueryTemplate(String queryTemplate, Parameter... parameters)
+    {
+        this.queryTemplate = queryTemplate;
+        this.defaultParameters = ImmutableList.copyOf(parameters);
+    }
+
+    public String resolve(Parameter ... parameters)
+    {
+        String query = queryTemplate;
+        for (Parameter parameter : parameters) {
+            query = resolve(query, parameter.getKey(), parameter.getValue());
+        }
+        for (Parameter parameter : defaultParameters) {
+            query = resolve(query, parameter.getKey(), parameter.getValue());
+        }
+
+        return query;
+    }
+
+    private String resolve(String query, String key, String value)
+    {
+        return query.replaceAll("%" + key + "%", value);
+    }
+
+    public static final class Parameter
+    {
+        private final String key;
+        private final String value;
+
+        public Parameter(String key, String value)
+        {
+            this.key = requireNonNull(key, "key is null");
+            this.value = requireNonNull(value, "defaultValue is null");
+        }
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        public String getKey()
+        {
+            return key;
+        }
+
+        public Parameter of(String value)
+        {
+            return new Parameter(key, value);
+        }
+    }
+}


### PR DESCRIPTION
Support subqueries in non INNER join

From now subqueries can be used in join condition for non inner join.
The only lacking support is for IN predicate (semi join) which is using
references from both tables. In such case it is kind of triple side join
which is currently not possible to be executed in Presto.
