### PR TITLE
Make round() return NaN when input is NaN

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -465,6 +465,10 @@ public final class MathFunctions
     @SqlType(StandardTypes.DOUBLE)
     public static double round(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.BIGINT) long decimals)
     {
+        if (Double.isNaN(num)) {
+            return num;
+        }
+
         double factor = Math.pow(10, decimals);
         return Math.round(num * factor) / factor;
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -485,6 +485,8 @@ public class TestMathFunctions
         assertFunction("round(CAST(NULL as DOUBLE), CAST(NULL as BIGINT))", DOUBLE, null);
         assertFunction("round(-3.0, CAST(NULL as BIGINT))", DOUBLE, null);
         assertFunction("round(CAST(NULL as DOUBLE), 1)", DOUBLE, null);
+
+        assertFunction("round(nan(), 2)", DOUBLE, Double.NaN);
     }
 
     @Test


### PR DESCRIPTION
This was a regression in a recent change: 54eeef93

Fixes https://github.com/prestodb/presto/issues/5429