### PR TITLE
Fix interval type handling in REST API

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.148.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.148.rst
@@ -19,6 +19,10 @@ General Changes
 * Fix data duplication when ``task.writer-count`` configuration mismatches between coordinator and worker.
 * Fix bug where ``node-scheduler.max-pending-splits-per-node-per-task`` config is not always
   honored by node scheduler. This bug could stop the cluster from making further progress.
+* Fix handling of ``INTERVAL DAY TO SECOND`` type in REST API. Previously, intervals greater than
+  ``2,147,483,647`` milliseconds (about ``24`` days) were returned as the wrong value.
+* Fix handling of ``INTERVAL YEAR TO MONTH`` type in REST API. Previously, intervals greater than
+  ``2,147,483,647`` months were returned as the wrong value.
 * Add ``colocated-joins-enabled`` to enable colocated joins by default for
   connectors that expose node-partitioned data.
 * Add support for colocated unions.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/IntervalDayTimeType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/IntervalDayTimeType.java
@@ -48,7 +48,7 @@ public final class IntervalDayTimeType
         if (block.isNull(position)) {
             return null;
         }
-        return new SqlIntervalDayTime((int) block.getLong(position, 0));
+        return new SqlIntervalDayTime(block.getLong(position, 0));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/IntervalYearMonthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/IntervalYearMonthType.java
@@ -48,7 +48,7 @@ public final class IntervalYearMonthType
         if (block.isNull(position)) {
             return null;
         }
-        return new SqlIntervalYearMonth((int) block.getLong(position, 0));
+        return new SqlIntervalYearMonth(block.getLong(position, 0));
     }
 
     @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -17,6 +17,8 @@ import com.facebook.presto.Session;
 import com.facebook.presto.metadata.FunctionListBuilder;
 import com.facebook.presto.metadata.SqlFunction;
 import com.facebook.presto.spi.session.PropertyMetadata;
+import com.facebook.presto.spi.type.SqlIntervalDayTime;
+import com.facebook.presto.spi.type.SqlIntervalYearMonth;
 import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.SemanticException;
@@ -133,6 +135,19 @@ public abstract class AbstractTestQueries
             throws Exception
     {
         computeActual("SELECT foo FROM");
+    }
+
+    @Test
+    public void selectLargeInterval()
+            throws Exception
+    {
+        MaterializedResult result = computeActual("SELECT INTERVAL '30' DAY");
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getMaterializedRows().get(0).getField(0), new SqlIntervalDayTime(30, 0, 0, 0, 0));
+
+        result = computeActual("SELECT INTERVAL '" + Integer.MAX_VALUE + "' YEAR");
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getMaterializedRows().get(0).getField(0), new SqlIntervalYearMonth(Integer.MAX_VALUE, 0));
     }
 
     @Test


### PR DESCRIPTION
Previously, intervals greater than 24 days returned the wrong value due
to integer overflow.