### PR TITLE
Fix PreferredProperties translation when partitioning on empty set

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PreferredProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PreferredProperties.java
@@ -382,8 +382,8 @@ class PreferredProperties
                     .map(Optional::get)
                     .collect(toImmutableSet());
 
-            // If nothing can be translated, then we won't have any partitioning preferences
-            if (newPartitioningColumns.isEmpty()) {
+            // Translation fails if we have prior partitioning columns and none could be translated
+            if (!partitioningColumns.isEmpty() && newPartitioningColumns.isEmpty()) {
                 return Optional.empty();
             }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1517,6 +1517,24 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testRollupOverUnion()
+            throws Exception
+    {
+        assertQuery("" +
+                "SELECT orderstatus, sum(orderkey)\n" +
+                "FROM (SELECT orderkey, orderstatus\n" +
+                "      FROM orders\n" +
+                "      UNION ALL\n" +
+                "      SELECT orderkey, orderstatus\n" +
+                "      FROM orders) x\n" +
+                "GROUP BY ROLLUP (orderstatus)",
+                "VALUES ('P', 21470000),\n" +
+                        "('O', 439774330),\n" +
+                        "('F', 438500670),\n" +
+                        "(NULL, 899745000)");
+    }
+
+    @Test
     public void testIntersect()
             throws Exception
     {


### PR DESCRIPTION
Fixes #5439 