### PR TITLE
Fix race condition when task is aborted before it is started

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -285,6 +285,7 @@ public class SqlTaskManager
         return sqlTask.getTaskInstanceId();
     }
 
+    @Override
     public CompletableFuture<TaskStatus> getTaskStatus(TaskId taskId, TaskState currentState)
     {
         requireNonNull(taskId, "taskId is null");

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -509,8 +509,6 @@ public final class HttpRemoteTask
                 return;
             }
 
-            checkState(taskStatusFetcher.isRunning(), "Cannot cancel task when it is not running");
-
             // send cancel to task and ignore response
             HttpUriBuilder uriBuilder = uriBuilderFrom(taskStatus.getSelf()).addParameter("abort", "false");
             if (summarizeTaskInfo) {
@@ -559,6 +557,7 @@ public final class HttpRemoteTask
 
         try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
             taskStatusFetcher.updateTaskStatus(status);
+            taskInfoFetcher.abort(status);
 
             // send abort to task and ignore response
             HttpUriBuilder uriBuilder = uriBuilderFrom(getTaskStatus().getSelf());


### PR DESCRIPTION
When a task is aborted before calling start on the remote task, the
state changes were not propogated correctly in the
ContinuousTaskInfoFetcher.