### PR TITLE
Support for detailed error messages on presto-client side (+CLI support)

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
@@ -66,6 +66,9 @@ public class BenchmarkDriverOptions
     @Option(name = "--debug", title = "debug", description = "Enable debug information (default: false)")
     public boolean debug;
 
+    @Option(name = "--quiet", title = "quiet", description = "Enable quiet mode (less verbose error messages) (default: false)")
+    public boolean quiet;
+
     @Option(name = "--session", title = "session", description = "Session property (property can be used multiple times; format is key=value)")
     public final List<ClientSessionProperty> sessionProperties = new ArrayList<>();
 
@@ -98,6 +101,7 @@ public class BenchmarkDriverOptions
                 toProperties(this.sessionProperties),
                 null,
                 debug,
+                quiet,
                 clientRequestTimeout);
     }
 

--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -26,6 +26,11 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-parser</artifactId>
         </dependency>
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -99,6 +99,9 @@ public class ClientOptions
     @Option(name = "--debug", title = "debug", description = "Enable debug information")
     public boolean debug;
 
+    @Option(name = {"--quiet", "-q"}, title = "quiet", description = "Enable quiet mode (less verbose error messages)")
+    public boolean quiet;
+
     @Option(name = "--log-levels-file", title = "log levels file", description = "Configure log levels for debugging using this file")
     public String logLevelsFile;
 
@@ -143,6 +146,7 @@ public class ClientOptions
                 emptyMap(),
                 null,
                 debug,
+                quiet,
                 clientRequestTimeout);
     }
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -50,7 +50,7 @@ import java.util.regex.Pattern;
 
 import static com.facebook.presto.cli.Completion.commandCompleter;
 import static com.facebook.presto.cli.Completion.lowerCaseCommandCompleter;
-import static com.facebook.presto.cli.ErrorMessages.createErrorMessage;
+import static com.facebook.presto.cli.ErrorMessages.createExceptionMessage;
 import static com.facebook.presto.cli.Help.getHelpText;
 import static com.facebook.presto.cli.QueryPreprocessor.preprocessQuery;
 import static com.facebook.presto.client.ClientSession.stripTransactionId;
@@ -363,7 +363,7 @@ public class Console
             queryRunner.setSession(session);
         }
         catch (RuntimeException e) {
-            System.err.println(createErrorMessage(e, queryRunner.getSession()));
+            System.err.println(createExceptionMessage(e, queryRunner.getSession()));
         }
     }
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 
 import static com.facebook.presto.cli.Completion.commandCompleter;
 import static com.facebook.presto.cli.Completion.lowerCaseCommandCompleter;
+import static com.facebook.presto.cli.ErrorMessages.createErrorMessage;
 import static com.facebook.presto.cli.Help.getHelpText;
 import static com.facebook.presto.cli.QueryPreprocessor.preprocessQuery;
 import static com.facebook.presto.client.ClientSession.stripTransactionId;
@@ -362,10 +363,7 @@ public class Console
             queryRunner.setSession(session);
         }
         catch (RuntimeException e) {
-            System.err.println("Error running command: " + e.getMessage());
-            if (queryRunner.getSession().isDebug()) {
-                e.printStackTrace();
-            }
+            System.err.println(createErrorMessage(e, queryRunner.getSession()));
         }
     }
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -168,6 +168,10 @@ public class ErrorMessages
     private static void serverNotFoundErrorMessage(StringBuilder builder, ClientSession session)
     {
         builder.append(PRESTO_COORDINATOR_NOT_FOUND);
+        if (session.isQuiet()) {
+            return;
+        }
+
         Tip.Builder tipsBuilder = Tip.builder();
         tipsBuilder.addTip(Tip.VERIFY_PRESTO_RUNNING, session.getServer())
                 .addTip(Tip.DEFINE_SERVER_AS_CLI_PARAM)
@@ -181,6 +185,10 @@ public class ErrorMessages
     private static void serverStartingUpErrorMessage(StringBuilder builder, ClientSession session)
     {
         builder.append(PRESTO_STARTING_UP);
+        if (session.isQuiet()) {
+            return;
+        }
+
         Tip.Builder tipsBuilder = Tip.builder();
         tipsBuilder.addTip(Tip.WAIT_FOR_INITIALIZATION);
         if (!session.isDebug()) {
@@ -192,6 +200,10 @@ public class ErrorMessages
     private static void serverShuttingDownErrorMessage(StringBuilder builder, ClientSession session)
     {
         builder.append(PRESTO_SHUTTING_DOWN);
+        if (session.isQuiet()) {
+            return;
+        }
+
         Tip.Builder tipsBuilder = Tip.builder();
         tipsBuilder.addTip(Tip.WAIT_FOR_SERVER_RESTART)
                 .addTip(Tip.START_SERVER_AGAIN);
@@ -204,6 +216,10 @@ public class ErrorMessages
     private static void serverFileNotFoundErrorMessage(StringBuilder builder, ClientSession session)
     {
         builder.append(PRESTO_COORDINATOR_404);
+        if (session.isQuiet()) {
+            return;
+        }
+
         Tip.Builder tipsBuilder = Tip.builder();
         tipsBuilder.addTip(Tip.VERIFY_PRESTO_RUNNING, session.getServer())
                 .addTip(Tip.DEFINE_SERVER_AS_CLI_PARAM)

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -14,19 +14,132 @@
 package com.facebook.presto.cli;
 
 import com.facebook.presto.client.ClientSession;
+import com.facebook.presto.client.ErrorLocation;
+import com.facebook.presto.client.QueryError;
+import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.StatementClient;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import org.fusesource.jansi.Ansi;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import static com.facebook.presto.cli.ConsolePrinter.REAL_TERMINAL;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
 
 public class ErrorMessages
 {
+    private static final String TECHNICAL_DETAILS_HEADER = "\n=========   TECHNICAL DETAILS   =========\n";
+    private static final String SESSION_INTRO = "[ Session information ]\n";
+    private static final String ERROR_MESSAGE_INTRO = "[ Error message ]\n";
+    private static final String STACKTRACE_INTRO = "[ Stack trace ]\n";
+    private static final String TECHNICAL_DETAILS_END = "========= TECHNICAL DETAILS END =========\n\n";
+
     private ErrorMessages() {}
 
-    public static String createErrorMessage(Throwable throwable, ClientSession session)
+
+    public static String createQueryErrorMessage(StatementClient client)
+    {
+        return standardQueryErrorMessage(client);
+    }
+
+    public static String createExceptionMessage(Throwable throwable, ClientSession session)
+    {
+        return runtimeExceptionErrorMessage(throwable, session);
+    }
+
+    private static String runtimeExceptionErrorMessage(Throwable throwable, ClientSession session)
     {
         StringBuilder builder = new StringBuilder();
-        builder.append("Error running command: " + throwable.getMessage());
+
+        // We have no clue about what went wrong, just display what we obtained.
+        builder.append("Error running command:\n" + throwable.getMessage() + "\n");
+
         if (session.isDebug()) {
-            builder.append(Throwables.getStackTraceAsString(throwable));
+            technicalDetailsRuntimeExceptionErrorMessage(builder, throwable, session);
         }
+
         return builder.toString();
+    }
+
+    private static void technicalDetailsRuntimeExceptionErrorMessage(StringBuilder builder, Throwable throwable, ClientSession session)
+    {
+        builder.append(TECHNICAL_DETAILS_HEADER);
+        builder.append(ERROR_MESSAGE_INTRO);
+        builder.append(throwable.getMessage() + "\n\n");
+        builder.append(SESSION_INTRO);
+        builder.append(session + "\n\n");
+        builder.append(STACKTRACE_INTRO);
+        builder.append(Throwables.getStackTraceAsString(throwable));
+        builder.append(TECHNICAL_DETAILS_END);
+    }
+
+    private static String standardQueryErrorMessage(StatementClient client)
+    {
+        StringBuilder builder = new StringBuilder();
+        QueryError error = extractQueryError(client);
+
+        builder.append(String.format("Query %s failed: %s%n", client.finalResults().getId(), error.getMessage()));
+        if (client.isDebug() && (error.getFailureInfo() != null)) {
+            StringWriter errors = new StringWriter();
+            error.getFailureInfo().toException().printStackTrace(new PrintWriter(errors));
+            builder.append(errors.toString());
+        }
+        if (error.getErrorLocation() != null) {
+            errorLocationMessage(builder, client.getQuery(), error.getErrorLocation());
+        }
+
+        return builder.toString();
+    }
+
+    private static void errorLocationMessage(StringBuilder builder, String query, ErrorLocation location)
+    {
+        List<String> lines = ImmutableList.copyOf(Splitter.on('\n').split(query).iterator());
+
+        String errorLine = lines.get(location.getLineNumber() - 1);
+        String good = errorLine.substring(0, location.getColumnNumber() - 1);
+        String bad = errorLine.substring(location.getColumnNumber() - 1);
+
+        if ((location.getLineNumber() == lines.size()) && bad.trim().isEmpty()) {
+            bad = " <EOF>";
+        }
+
+        if (REAL_TERMINAL) {
+            Ansi ansi = Ansi.ansi();
+
+            ansi.fg(Ansi.Color.CYAN);
+            for (int i = 1; i < location.getLineNumber(); i++) {
+                ansi.a(lines.get(i - 1)).newline();
+            }
+            ansi.a(good);
+
+            ansi.fg(Ansi.Color.RED);
+            ansi.a(bad).newline();
+            for (int i = location.getLineNumber(); i < lines.size(); i++) {
+                ansi.a(lines.get(i)).newline();
+            }
+
+            ansi.reset();
+            builder.append(ansi);
+        }
+        else {
+            String prefix = format("LINE %s: ", location.getLineNumber());
+            String padding = Strings.repeat(" ", prefix.length() + (location.getColumnNumber() - 1));
+            builder.append(prefix + errorLine);
+            builder.append(padding + "^");
+        }
+    }
+
+    private static QueryError extractQueryError(StatementClient client)
+    {
+        QueryResults results = client.finalResults();
+        QueryError error = results.getError();
+        checkState(error != null);
+        return error;
     }
 }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -104,6 +104,7 @@ public class ErrorMessages
         ClientSession session = client.getSession();
         QueryError error = extractQueryError(client);
 
+        // Try to recognize error and provide custom error message
         if (error.getErrorCode() == SERVER_STARTING_UP.toErrorCode().getCode()) {
             serverStartingUpErrorMessage(builder, session);
         }
@@ -111,9 +112,11 @@ public class ErrorMessages
             serverShuttingDownErrorMessage(builder, session);
         }
         else {
+            // Fallback to standard QueryError message
             standardQueryErrorMessage(builder, client);
         }
 
+        // Display common part of all QueryError (position, debug details)
         if (error.getErrorLocation() != null) {
             errorLocationMessage(builder, client.getQuery(), error.getErrorLocation(), useAnsiEscapeCodes);
         }
@@ -129,6 +132,7 @@ public class ErrorMessages
     {
         StringBuilder builder = new StringBuilder();
 
+        // Try to recognize exception type and provide custom error message
         if (throwable instanceof PrestoClientException) {
             createPrestoClientExceptionErrorMessage(builder, (PrestoClientException) throwable, session);
         }
@@ -136,6 +140,7 @@ public class ErrorMessages
             runtimeExceptionErrorMessage(builder, throwable, session);
         }
 
+        // Display common part of all Throwable error messages
         if (session.isDebug()) {
             technicalDetailsRuntimeExceptionErrorMessage(builder, throwable, session);
         }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -41,7 +41,7 @@ public class ErrorMessages
 
         builder.append(String.format("Query %s failed: %s%n", client.finalResults().getId(), error.getMessage()));
         if (client.isDebug() && (error.getFailureInfo() != null)) {
-            builder.append(Throwables.getStackTraceAsString(error.getFailureInfo().toException()));
+            technicalDetailsRuntimeExceptionErrorMessage(builder, error.getFailureInfo().toException(), client.getSession());
         }
         if (error.getErrorLocation() != null) {
             errorLocationMessage(builder, client.getQuery(), error.getErrorLocation(), useAnsiEscapeCodes);

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cli;
+
+import com.facebook.presto.client.ClientSession;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class ErrorMessages
+{
+    private ErrorMessages()
+    {}
+
+    public static String createErrorMessage(Throwable throwable, ClientSession session)
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Error running command: " + throwable.getMessage());
+        if (session.isDebug()) {
+            builder.append(getStackTraceString(throwable));
+        }
+        return builder.toString();
+    }
+
+    private static String getStackTraceString(Throwable throwable)
+    {
+        StringWriter errors = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(errors));
+        return errors.toString();
+    }
+}

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -14,29 +14,19 @@
 package com.facebook.presto.cli;
 
 import com.facebook.presto.client.ClientSession;
-
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import com.google.common.base.Throwables;
 
 public class ErrorMessages
 {
-    private ErrorMessages()
-    {}
+    private ErrorMessages() {}
 
     public static String createErrorMessage(Throwable throwable, ClientSession session)
     {
         StringBuilder builder = new StringBuilder();
         builder.append("Error running command: " + throwable.getMessage());
         if (session.isDebug()) {
-            builder.append(getStackTraceString(throwable));
+            builder.append(Throwables.getStackTraceAsString(throwable));
         }
         return builder.toString();
-    }
-
-    private static String getStackTraceString(Throwable throwable)
-    {
-        StringWriter errors = new StringWriter();
-        throwable.printStackTrace(new PrintWriter(errors));
-        return errors.toString();
     }
 }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -250,6 +250,7 @@ public class ErrorMessages
         builder.append("========= TECHNICAL DETAILS END =========\n\n");
     }
 
+    //region Standard QueryError format
     private static void standardQueryErrorMessage(StringBuilder builder, StatementClient client)
     {
         QueryError error = extractQueryError(client);
@@ -293,7 +294,9 @@ public class ErrorMessages
             builder.append(padding + "^");
         }
     }
+    //endregion
 
+    //region Helpers
     private static QueryError extractQueryError(StatementClient client)
     {
         QueryResults results = client.finalResults();
@@ -301,4 +304,5 @@ public class ErrorMessages
         checkState(error != null);
         return error;
     }
+    //endregion
 }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -30,6 +30,8 @@ import java.io.EOFException;
 import java.net.ConnectException;
 import java.util.List;
 
+import static com.facebook.presto.spi.StandardErrorCode.SERVER_SHUTTING_DOWN;
+import static com.facebook.presto.spi.StandardErrorCode.SERVER_STARTING_UP;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.getCausalChain;
 import static java.lang.String.format;
@@ -38,12 +40,17 @@ public class ErrorMessages
 {
     private static final String PRESTO_COORDINATOR_NOT_FOUND = "There was a problem with a response from Presto Coordinator.\n";
     private static final String PRESTO_COORDINATOR_404 = "Presto HTTP interface returned 404 (file not found).\n";
+    private static final String PRESTO_STARTING_UP  = "Presto is still starting up.\n";
+    private static final String PRESTO_SHUTTING_DOWN  = "Presto is shutting down\n";
 
     private enum Tip {
         VERIFY_PRESTO_RUNNING("Verify that Presto is running on %s."),
         DEFINE_SERVER_AS_CLI_PARAM("Use '--server' argument when starting Presto CLI to define server host and port."),
         CHECK_NETWORK("Check the network conditions between client and server."),
         USE_DEBUG_MODE("Use '--debug' argument to get more technical details."),
+        WAIT_FOR_INITIALIZATION("Wait for server to complete initialization."),
+        WAIT_FOR_SERVER_RESTART("Wait for server to restart as it may have restart scheduled."),
+        START_SERVER_AGAIN("Start server again manually."),
         CHECK_OTHER_HTTP_SERVICE("Make sure that none other HTTP service is running on %s."),
         CLIENT_IS_UP_TO_DATE_WITH_SERVER("Update CLI to match Presto server version.");
 
@@ -94,14 +101,25 @@ public class ErrorMessages
     public static String createQueryErrorMessage(StatementClient client, boolean useAnsiEscapeCodes)
     {
         StringBuilder builder = new StringBuilder();
+        ClientSession session = client.getSession();
         QueryError error = extractQueryError(client);
 
-        builder.append(String.format("Query %s failed: %s%n", client.finalResults().getId(), error.getMessage()));
-        if (client.isDebug() && (error.getFailureInfo() != null)) {
-            technicalDetailsRuntimeExceptionErrorMessage(builder, error.getFailureInfo().toException(), client.getSession());
+        if (error.getErrorCode() == SERVER_STARTING_UP.toErrorCode().getCode()) {
+            serverStartingUpErrorMessage(builder, session);
         }
+        else if (error.getErrorCode() == SERVER_SHUTTING_DOWN.toErrorCode().getCode()) {
+            serverShuttingDownErrorMessage(builder, session);
+        }
+        else {
+            standardQueryErrorMessage(builder, client);
+        }
+
         if (error.getErrorLocation() != null) {
             errorLocationMessage(builder, client.getQuery(), error.getErrorLocation(), useAnsiEscapeCodes);
+        }
+
+        if (client.isDebug() && (error.getFailureInfo() != null)) {
+            technicalDetailsRuntimeExceptionErrorMessage(builder, error.getFailureInfo().toException(), session);
         }
 
         return builder.toString();
@@ -160,6 +178,29 @@ public class ErrorMessages
         builder.append(tipsBuilder.build());
     }
 
+    private static void serverStartingUpErrorMessage(StringBuilder builder, ClientSession session)
+    {
+        builder.append(PRESTO_STARTING_UP);
+        Tip.Builder tipsBuilder = Tip.builder();
+        tipsBuilder.addTip(Tip.WAIT_FOR_INITIALIZATION);
+        if (!session.isDebug()) {
+            tipsBuilder.addTip(Tip.USE_DEBUG_MODE);
+        }
+        builder.append(tipsBuilder.build());
+    }
+
+    private static void serverShuttingDownErrorMessage(StringBuilder builder, ClientSession session)
+    {
+        builder.append(PRESTO_SHUTTING_DOWN);
+        Tip.Builder tipsBuilder = Tip.builder();
+        tipsBuilder.addTip(Tip.WAIT_FOR_SERVER_RESTART)
+                .addTip(Tip.START_SERVER_AGAIN);
+        if (!session.isDebug()) {
+            tipsBuilder.addTip(Tip.USE_DEBUG_MODE);
+        }
+        builder.append(tipsBuilder.build());
+    }
+
     private static void serverFileNotFoundErrorMessage(StringBuilder builder, ClientSession session)
     {
         builder.append(PRESTO_COORDINATOR_404);
@@ -186,6 +227,12 @@ public class ErrorMessages
         builder.append("[ Stack trace ]\n");
         builder.append(Throwables.getStackTraceAsString(throwable));
         builder.append("========= TECHNICAL DETAILS END =========\n\n");
+    }
+
+    private static void standardQueryErrorMessage(StringBuilder builder, StatementClient client)
+    {
+        QueryError error = extractQueryError(client);
+        builder.append(String.format("Query %s failed: %s%n", client.finalResults().getId(), error.getMessage()));
     }
 
     private static void errorLocationMessage(StringBuilder builder, String query, ErrorLocation location, boolean useAnsiEscapeCodes)

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -15,17 +15,11 @@ package com.facebook.presto.cli;
 
 import com.facebook.presto.cli.ClientOptions.OutputFormat;
 import com.facebook.presto.client.Column;
-import com.facebook.presto.client.ErrorLocation;
-import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.StatementClient;
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.airlift.log.Logger;
-import org.fusesource.jansi.Ansi;
 import sun.misc.Signal;
 import sun.misc.SignalHandler;
 
@@ -40,8 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.facebook.presto.cli.ConsolePrinter.REAL_TERMINAL;
-import static com.google.common.base.Preconditions.checkState;
+import static com.facebook.presto.cli.ErrorMessages.createQueryErrorMessage;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -151,7 +144,7 @@ public class Query
             errorChannel.println("Query is gone (server restarted?)");
         }
         else if (client.isFailed()) {
-            renderFailure(errorChannel);
+            errorChannel.println(createQueryErrorMessage(client));
         }
     }
 
@@ -278,60 +271,6 @@ public class Query
     public void close()
     {
         client.close();
-    }
-
-    public void renderFailure(PrintStream out)
-    {
-        QueryResults results = client.finalResults();
-        QueryError error = results.getError();
-        checkState(error != null);
-
-        out.printf("Query %s failed: %s%n", results.getId(), error.getMessage());
-        if (client.isDebug() && (error.getFailureInfo() != null)) {
-            error.getFailureInfo().toException().printStackTrace(out);
-        }
-        if (error.getErrorLocation() != null) {
-            renderErrorLocation(client.getQuery(), error.getErrorLocation(), out);
-        }
-        out.println();
-    }
-
-    private static void renderErrorLocation(String query, ErrorLocation location, PrintStream out)
-    {
-        List<String> lines = ImmutableList.copyOf(Splitter.on('\n').split(query).iterator());
-
-        String errorLine = lines.get(location.getLineNumber() - 1);
-        String good = errorLine.substring(0, location.getColumnNumber() - 1);
-        String bad = errorLine.substring(location.getColumnNumber() - 1);
-
-        if ((location.getLineNumber() == lines.size()) && bad.trim().isEmpty()) {
-            bad = " <EOF>";
-        }
-
-        if (REAL_TERMINAL) {
-            Ansi ansi = Ansi.ansi();
-
-            ansi.fg(Ansi.Color.CYAN);
-            for (int i = 1; i < location.getLineNumber(); i++) {
-                ansi.a(lines.get(i - 1)).newline();
-            }
-            ansi.a(good);
-
-            ansi.fg(Ansi.Color.RED);
-            ansi.a(bad).newline();
-            for (int i = location.getLineNumber(); i < lines.size(); i++) {
-                ansi.a(lines.get(i)).newline();
-            }
-
-            ansi.reset();
-            out.print(ansi);
-        }
-        else {
-            String prefix = format("LINE %s: ", location.getLineNumber());
-            String padding = Strings.repeat(" ", prefix.length() + (location.getColumnNumber() - 1));
-            out.println(prefix + errorLine);
-            out.println(padding + "^");
-        }
     }
 
     private static class ThreadInterruptor

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.facebook.presto.cli.ConsolePrinter.REAL_TERMINAL;
 import static com.facebook.presto.cli.ErrorMessages.createQueryErrorMessage;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -144,7 +145,7 @@ public class Query
             errorChannel.println("Query is gone (server restarted?)");
         }
         else if (client.isFailed()) {
-            errorChannel.println(createQueryErrorMessage(client));
+            errorChannel.println(createQueryErrorMessage(client, REAL_TERMINAL));
         }
     }
 

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
@@ -43,6 +43,7 @@ public class ClientSession
     private final Map<String, String> preparedStatements;
     private final String transactionId;
     private final boolean debug;
+    private final boolean quiet;
     private final Duration clientRequestTimeout;
 
     public static ClientSession withCatalogAndSchema(ClientSession session, String catalog, String schema)
@@ -60,6 +61,7 @@ public class ClientSession
                 session.getPreparedStatements(),
                 session.getTransactionId(),
                 session.isDebug(),
+                session.isQuiet(),
                 session.getClientRequestTimeout());
     }
 
@@ -78,6 +80,7 @@ public class ClientSession
                 session.getPreparedStatements(),
                 session.getTransactionId(),
                 session.isDebug(),
+                session.isQuiet(),
                 session.getClientRequestTimeout());
     }
 
@@ -96,6 +99,7 @@ public class ClientSession
                 preparedStatements,
                 session.getTransactionId(),
                 session.isDebug(),
+                session.isQuiet(),
                 session.getClientRequestTimeout());
     }
 
@@ -114,6 +118,7 @@ public class ClientSession
                 session.getPreparedStatements(),
                 transactionId,
                 session.isDebug(),
+                session.isQuiet(),
                 session.getClientRequestTimeout());
     }
 
@@ -132,6 +137,7 @@ public class ClientSession
                 session.getPreparedStatements(),
                 null,
                 session.isDebug(),
+                session.isQuiet(),
                 session.getClientRequestTimeout());
     }
 
@@ -147,9 +153,10 @@ public class ClientSession
             Map<String, String> properties,
             String transactionId,
             boolean debug,
+            boolean quiet,
             Duration clientRequestTimeout)
     {
-        this(server, user, source, clientInfo, catalog, schema, timeZoneId, locale, properties, emptyMap(), transactionId, debug, clientRequestTimeout);
+        this(server, user, source, clientInfo, catalog, schema, timeZoneId, locale, properties, emptyMap(), transactionId, debug, quiet, clientRequestTimeout);
     }
 
     public ClientSession(
@@ -165,6 +172,7 @@ public class ClientSession
             Map<String, String> preparedStatements,
             String transactionId,
             boolean debug,
+            boolean quiet,
             Duration clientRequestTimeout)
     {
         this.server = requireNonNull(server, "server is null");
@@ -177,6 +185,7 @@ public class ClientSession
         this.timeZone = TimeZoneKey.getTimeZoneKey(timeZoneId);
         this.transactionId = transactionId;
         this.debug = debug;
+        this.quiet = quiet;
         this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
         this.preparedStatements = ImmutableMap.copyOf(requireNonNull(preparedStatements, "preparedStatements is null"));
         this.clientRequestTimeout = clientRequestTimeout;
@@ -251,6 +260,11 @@ public class ClientSession
         return debug;
     }
 
+    public boolean isQuiet()
+    {
+        return quiet;
+    }
+
     public Duration getClientRequestTimeout()
     {
         return clientRequestTimeout;
@@ -270,6 +284,7 @@ public class ClientSession
                 .add("properties", properties)
                 .add("transactionId", transactionId)
                 .add("debug", debug)
+                .add("quiet", quiet)
                 .toString();
     }
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoClientException.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoClientException.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
+import io.airlift.http.client.Request;
+
+import static java.lang.String.format;
+
+public class PrestoClientException
+        extends RuntimeException
+{
+    private final String task;
+    private final Request request;
+    private final JsonResponse<QueryResults> response;
+
+    public PrestoClientException(String task, Request request, JsonResponse<QueryResults> response)
+    {
+        super(getDefaultMessage(task, request, response));
+        this.task = task;
+        this.request = request;
+        this.response = response;
+    }
+
+    private static String getDefaultMessage(String task, Request request, JsonResponse<QueryResults> response)
+    {
+        StringBuilder message = new StringBuilder();
+        message.append(format("Error %s at %s returned HTTP response code %s.\n", task, request.getUri(), response.getStatusCode()));
+        message.append(format("Response info:\n%s\n", response));
+        message.append(format("Response body:\n%s\n", response.getResponseBody()));
+        if (response.hasValue()) {
+            message.append(format("Response status:\n%s\n", response.getStatusMessage()));
+        }
+        return message.toString();
+    }
+
+    public String getTask()
+    {
+        return task;
+    }
+
+    public Request getRequest()
+    {
+        return request;
+    }
+
+    public JsonResponse<QueryResults> getResponse()
+    {
+        return response;
+    }
+}

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -347,9 +347,7 @@ public class StatementClient
     {
         gone.set(true);
         if (!response.hasValue()) {
-            return new RuntimeException(
-                    format("Error %s at %s returned an invalid response: %s [Error: %s]", task, request.getUri(), response, response.getResponseBody()),
-                    response.getException());
+            return new PrestoClientException(task, request, response);
         }
         return new RuntimeException(format("Error %s at %s returned %s: %s", task, request.getUri(), response.getStatusCode(), response.getStatusMessage()));
     }

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -81,7 +81,6 @@ public class StatementClient
 
     private final HttpClient httpClient;
     private final FullJsonResponseHandler<QueryResults> responseHandler;
-    private final boolean debug;
     private final String query;
     private final AtomicReference<QueryResults> currentResults = new AtomicReference<>();
     private final Map<String, String> setSessionProperties = new ConcurrentHashMap<>();
@@ -93,9 +92,9 @@ public class StatementClient
     private final AtomicBoolean closed = new AtomicBoolean();
     private final AtomicBoolean gone = new AtomicBoolean();
     private final AtomicBoolean valid = new AtomicBoolean(true);
-    private final TimeZoneKey timeZone;
     private final long requestTimeoutNanos;
-    private final String user;
+
+    private final ClientSession session;
 
     public StatementClient(HttpClient httpClient, JsonCodec<QueryResults> queryResultsCodec, ClientSession session, String query)
     {
@@ -106,11 +105,9 @@ public class StatementClient
 
         this.httpClient = httpClient;
         this.responseHandler = createFullJsonResponseHandler(queryResultsCodec);
-        this.debug = session.isDebug();
-        this.timeZone = session.getTimeZone();
         this.query = query;
         this.requestTimeoutNanos = session.getClientRequestTimeout().roundTo(NANOSECONDS);
-        this.user = session.getUser();
+        this.session = session;
 
         Request request = buildQueryRequest(session, query);
         JsonResponse<QueryResults> response = httpClient.execute(request, responseHandler);
@@ -166,12 +163,17 @@ public class StatementClient
 
     public TimeZoneKey getTimeZone()
     {
-        return timeZone;
+        return session.getTimeZone();
     }
 
     public boolean isDebug()
     {
-        return debug;
+        return session.isDebug();
+    }
+
+    public ClientSession getSession()
+    {
+        return session;
     }
 
     public boolean isClosed()
@@ -243,7 +245,7 @@ public class StatementClient
 
     private Request.Builder prepareRequest(Request.Builder builder, URI nextUri)
     {
-        builder.setHeader(PrestoHeaders.PRESTO_USER, user);
+        builder.setHeader(PrestoHeaders.PRESTO_USER, session.getUser());
         builder.setHeader(USER_AGENT, USER_AGENT_VALUE)
                 .setUri(nextUri);
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -600,6 +600,7 @@ public class PrestoConnection
                 ImmutableMap.copyOf(allProperties),
                 transactionId.get(),
                 false,
+                false,
                 new Duration(2, MINUTES));
 
         return queryExecutor.startQuery(session, sql);

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionFactory.java
@@ -1,3 +1,4 @@
+
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -46,6 +46,7 @@ function check_presto() {
   run_in_application_runner_container \
     java -jar "/docker/volumes/presto-cli/presto-cli-executable.jar" \
     --server presto-master:8080 \
+    --quiet \
     --execute "SHOW CATALOGS" | grep -i hive
 }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -87,7 +87,7 @@ public abstract class AbstractTestingPrestoClient<T>
     {
         ResultsSession<T> resultsSession = getResultSession(session);
 
-        ClientSession clientSession = toClientSession(session, prestoServer.getBaseUrl(), true, new Duration(2, TimeUnit.MINUTES));
+        ClientSession clientSession = toClientSession(session, prestoServer.getBaseUrl(), true, false, new Duration(2, TimeUnit.MINUTES));
 
         try (StatementClient client = new StatementClient(httpClient, QUERY_RESULTS_CODEC, clientSession, sql)) {
             while (client.isValid()) {
@@ -123,7 +123,7 @@ public abstract class AbstractTestingPrestoClient<T>
         }
     }
 
-    private static ClientSession toClientSession(Session session, URI server, boolean debug, Duration clientRequestTimeout)
+    private static ClientSession toClientSession(Session session, URI server, boolean debug, boolean quiet, Duration clientRequestTimeout)
     {
         ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
         properties.putAll(session.getSystemProperties());
@@ -146,6 +146,7 @@ public abstract class AbstractTestingPrestoClient<T>
                 session.getPreparedStatements(),
                 session.getTransactionId().map(Object::toString).orElse(null),
                 debug,
+                quiet,
                 clientRequestTimeout);
     }
 


### PR DESCRIPTION
This change tries to make message of some known problems more informative for presto users.
The message does not cover all possibilities, however it covers our best known scenario for that exception, so it would be nice to have that tips at this point.
Also technical details are hidden and will require `--debug` to be shown. Note that stacktrace was visible only with `--debug` even before this change.
