### PR TITLE
Split the summary list into two columns

### DIFF
--- a/presto-main/src/main/resources/webapp/query.html
+++ b/presto-main/src/main/resources/webapp/query.html
@@ -70,6 +70,12 @@
         #main {
             display: none;
         }
+
+        dl {
+          columns: 2;
+          -moz-columns: 2;
+          -webkit-columns: 2;
+        }
     </style>
 </head>
 


### PR DESCRIPTION
This seems to be getting quite long now and with the large amount of whitespace on the right hand side it makes sense to use it. [Before](http://files.limi.co.uk/screenshots/split_before.png) & [after](http://files.limi.co.uk/screenshots/split_after.png) screenshots. Tested on Chrome, Firefox and Safari.

