### PR TITLE
Make round() return -0.0 for small negative numbers

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -471,7 +471,7 @@ public final class MathFunctions
 
         double factor = Math.pow(10, decimals);
         if (num < 0) {
-            return -Math.round(-num * factor) / factor;
+            return -(Math.round(-num * factor) / factor);
         }
 
         return Math.round(num * factor) / factor;

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -465,7 +465,7 @@ public final class MathFunctions
     @SqlType(StandardTypes.DOUBLE)
     public static double round(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.BIGINT) long decimals)
     {
-        if (Double.isNaN(num)) {
+        if (Double.isNaN(num) || Double.isInfinite(num)) {
             return num;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -489,6 +489,8 @@ public class TestMathFunctions
         assertFunction("round(CAST(NULL as DOUBLE), 1)", DOUBLE, null);
 
         assertFunction("round(nan(), 2)", DOUBLE, Double.NaN);
+        assertFunction("round(1.0 / 0, 2)", DOUBLE, Double.POSITIVE_INFINITY);
+        assertFunction("round(-1.0 / 0, 2)", DOUBLE, Double.NEGATIVE_INFINITY);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -445,7 +445,7 @@ public class TestMathFunctions
         assertFunction("round(CAST(NULL as DOUBLE))", DOUBLE, null);
         assertFunction("round(" + GREATEST_DOUBLE_LESS_THAN_HALF + ")", DOUBLE, 0.0);
         assertFunction("round(-" + 0x1p-1 + ")", DOUBLE, -1.0); // -0.5
-        assertFunction("round(-" + GREATEST_DOUBLE_LESS_THAN_HALF + ")", DOUBLE, 0.0);
+        assertFunction("round(-" + GREATEST_DOUBLE_LESS_THAN_HALF + ")", DOUBLE, -0.0);
 
         assertFunction("round(3, 0)", INTEGER, 3);
         assertFunction("round(-3, 0)", INTEGER, -3);
@@ -463,7 +463,9 @@ public class TestMathFunctions
         assertFunction("round(-3.99, 0)", DOUBLE, -4.0);
         assertFunction("round(" + GREATEST_DOUBLE_LESS_THAN_HALF + ", 0)", DOUBLE, 0.0);
         assertFunction("round(-" + 0x1p-1 + ")", DOUBLE, -1.0); // -0.5
-        assertFunction("round(-" + GREATEST_DOUBLE_LESS_THAN_HALF + ", 0)", DOUBLE, 0.0);
+        assertFunction("round(-" + GREATEST_DOUBLE_LESS_THAN_HALF + ", 0)", DOUBLE, -0.0);
+        assertFunction("round(0.3)", DOUBLE, 0.0);
+        assertFunction("round(-0.3)", DOUBLE, -0.0);
 
         assertFunction("round(3, 1)", INTEGER, 3);
         assertFunction("round(-3, 1)", INTEGER, -3);


### PR DESCRIPTION
The implementation calls Math.round, which returns a Java long.
The trick of negating the value does not work in that case,
so make sure we negate the value after it has been converted
back to double.