### PR TITLE
Reduce number of Travis jobs by running product tests together

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ env:
     - TEST_MODULES=!presto-tests,!presto-kafka,!presto-redis,!presto-cassandra,!presto-raptor,!presto-postgresql,!presto-mysql
     - TEST_MODULES=presto-tests
     - TEST_MODULES=presto-raptor,presto-redis,presto-cassandra,presto-kafka,presto-postgresql,presto-mysql
-    - PRODUCT_TESTS="singlenode -x quarantine,big_query,storage_formats,mysql_connector,postgresql_connector,profile_specific_tests"
-    - PRODUCT_TESTS="singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation"
+    - PRODUCT_TESTS=true
     - INTEGRATION_TESTS=true
 
 sudo: required
@@ -44,7 +43,8 @@ script:
     fi
   - |
     if [ -v PRODUCT_TESTS ]; then
-      presto-product-tests/bin/run_on_docker.sh ${PRODUCT_TESTS}
+      presto-product-tests/bin/run_on_docker.sh singlenode -x quarantine,big_query,storage_formats,mysql_connector,postgresql_connector,profile_specific_tests
+      presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation
     fi
   - |
     if [ -v INTEGRATION_TESTS ]; then


### PR DESCRIPTION
This reduces Travis build waiting time from 49 to 35 mins because
all the jobs can start at once (vs 5 starting at once and the 6th once
one of the previous jobs ends).