### PR TITLE
Make presto-mongodb tests actually parallel

### DIFF
--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -314,13 +314,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <!--Integrations tests fail when parallel, due-->
-                    <!--to a bug or configuration error in the embedded-->
-                    <!--cassandra instance.  This problem results in either-->
-                    <!--a hang in Thrift calls or broken sockets.-->
-                    <parallel />
-                    <threadCount>1</threadCount>
-
                     <!-- integration tests take a very long time so only run them in the CI server -->
                     <excludes>
                         <exclude>**/TestCassandraDistributed.java</exclude>

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -20,6 +20,8 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.cassandra.CassandraQueryRunner.createCassandraQueryRunner;
 import static com.facebook.presto.cassandra.CassandraQueryRunner.createSampledSession;
 
+//Integrations tests fail when parallel, due to a bug or configuration error in the embedded
+//cassandra instance. This problem results in either a hang in Thrift calls or broken sockets.
 @Test(singleThreaded = true)
 public class TestCassandraDistributed
         extends AbstractTestDistributedQueries

--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -181,37 +181,4 @@
 
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- integration tests take a very long time so only run them in the CI server -->
-                    <parallel />
-                    <threadCount>1</threadCount>
-                    <excludes>
-                        <exclude>**/TestMongoDistributed.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-    <profiles>
-        <profile>
-            <id>ci</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes combine.self="override" />
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoDistributedQueries.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoDistributedQueries.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 
 import static com.facebook.presto.mongodb.MongoQueryRunner.createMongoQueryRunner;
 
-@Test(singleThreaded = true)
+@Test
 public class TestMongoDistributedQueries
         extends AbstractTestQueries
 {


### PR DESCRIPTION
This shaves off 2 min (of 13) from the longest Travis job
and 6 min (of 11) on my machine.