### PR TITLE
Update remote task stats to be less expensive 

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/RemoteTaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/RemoteTaskStats.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.server.remotetask;
 
-import io.airlift.stats.CounterStat;
 import io.airlift.stats.DistributionStat;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
@@ -25,8 +24,8 @@ public class RemoteTaskStats
     private final DistributionStat statusRoundTripMillis = new DistributionStat();
     private final DistributionStat responseSizeBytes = new DistributionStat();
 
-    private final CounterStat requestSuccess = new CounterStat();
-    private final CounterStat requestFailure = new CounterStat();
+    private long requestSuccess;
+    private long requestFailure;
 
     public void statusRoundTripMillis(long roundTripMillis)
     {
@@ -50,12 +49,12 @@ public class RemoteTaskStats
 
     public void updateSuccess()
     {
-        requestSuccess.update(1);
+        requestSuccess++;
     }
 
     public void updateFailure()
     {
-        requestFailure.update(1);
+        requestFailure++;
     }
 
     @Managed
@@ -87,15 +86,13 @@ public class RemoteTaskStats
     }
 
     @Managed
-    @Nested
-    public CounterStat getRequestSuccess()
+    public long getRequestSuccess()
     {
         return requestSuccess;
     }
 
     @Managed
-    @Nested
-    public CounterStat getRequestFailure()
+    public long getRequestFailure()
     {
         return requestFailure;
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/RemoteTaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/RemoteTaskStats.java
@@ -48,6 +48,16 @@ public class RemoteTaskStats
         this.responseSizeBytes.add(responseSizeBytes);
     }
 
+    public void updateSuccess()
+    {
+        requestSuccess.update(1);
+    }
+
+    public void updateFailure()
+    {
+        requestFailure.update(1);
+    }
+
     @Managed
     @Nested
     public DistributionStat getResponseSizeBytes()
@@ -74,16 +84,6 @@ public class RemoteTaskStats
     public DistributionStat getInfoRoundTripMillis()
     {
         return infoRoundTripMillis;
-    }
-
-    public void updateSuccess()
-    {
-        requestSuccess.update(1);
-    }
-
-    public void updateFailure()
-    {
-        requestFailure.update(1);
     }
 
     @Managed

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/RemoteTaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/RemoteTaskStats.java
@@ -76,17 +76,27 @@ public class RemoteTaskStats
         return infoRoundTripMillis;
     }
 
-    @Managed
-    @Nested
     public void updateSuccess()
     {
         requestSuccess.update(1);
     }
 
-    @Managed
-    @Nested
     public void updateFailure()
     {
         requestFailure.update(1);
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getRequestSuccess()
+    {
+        return requestSuccess;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getRequestFailure()
+    {
+        return requestFailure;
     }
 }


### PR DESCRIPTION
For busy clusters remote task stats can take up ~3% of the coordinator CPU, replace these stats with less expensive stats. 