### PR TITLE
Capture partition count in Plan

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/OutputBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/OutputBuffers.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 
 import static com.facebook.presto.OutputBuffers.BufferType.BROADCAST;
 import static com.facebook.presto.OutputBuffers.BufferType.PARTITIONED;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.isFixedBroadcastPartitioning;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -45,7 +45,7 @@ public final class OutputBuffers
     public static OutputBuffers createInitialEmptyOutputBuffers(PartitioningHandle partitioningHandle)
     {
         BufferType type;
-        if (partitioningHandle.equals(FIXED_BROADCAST_DISTRIBUTION)) {
+        if (isFixedBroadcastPartitioning(partitioningHandle)) {
             type = BROADCAST;
         }
         else {

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -310,7 +310,7 @@ public final class SqlQueryExecution
         // record field names
         stateMachine.setOutputFieldNames(outputStageExecutionPlan.getFieldNames());
 
-        PartitioningHandle partitioningHandle = plan.getRoot().getFragment().getPartitioningScheme().getPartitioning().getHandle();
+        PartitioningHandle partitioningHandle = plan.getRoot().getFragment().getOutputPartitioningScheme().getPartitioning().getHandle();
         OutputBuffers rootOutputBuffers = createInitialEmptyOutputBuffers(partitioningHandle)
                 .withBuffer(OUTPUT_BUFFER_ID, BROADCAST_PARTITION_ID)
                 .withNoMoreBufferIds();

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -162,7 +162,7 @@ public class SqlTaskExecution
                         taskContext.getSession(),
                         fragment.getRoot(),
                         fragment.getSymbols(),
-                        fragment.getPartitioningScheme(),
+                        fragment.getOutputPartitioningScheme(),
                         outputBuffer);
                 driverFactories = localExecutionPlan.getDriverFactories();
             }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -427,11 +427,11 @@ public class SqlQueryScheduler
             this.parent = parent;
             this.childOutputBufferManagers = children.stream()
                     .map(childStage -> {
-                        if (childStage.getFragment().getPartitioningScheme().getPartitioning().getHandle().equals(FIXED_BROADCAST_DISTRIBUTION)) {
+                        if (childStage.getFragment().getOutputPartitioningScheme().getPartitioning().getHandle().equals(FIXED_BROADCAST_DISTRIBUTION)) {
                             return new BroadcastOutputBufferManager(childStage::setOutputBuffers);
                         }
                         else {
-                            int partitionCount = Ints.max(childStage.getFragment().getPartitioningScheme().getBucketToPartition().get()) + 1;
+                            int partitionCount = Ints.max(childStage.getFragment().getOutputPartitioningScheme().getBucketToPartition().get()) + 1;
                             return new PartitionedOutputBufferManager(partitionCount, childStage::setOutputBuffers);
                         }
                     })

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchange.java
@@ -15,7 +15,7 @@ package com.facebook.presto.operator.exchange;
 
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.sql.planner.PartitioningHandle;
+import com.facebook.presto.sql.planner.Partitioning;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 
@@ -31,12 +31,11 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.operator.exchange.LocalExchangeSink.finishedLocalExchangeSink;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_RANDOM_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.isFixedBroadcastPartitioning;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.isFixedHashPartitioning;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.isFixedRandomPartitioning;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.isSinglePartitioning;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
@@ -65,7 +64,7 @@ public class LocalExchange
     private final Set<LocalExchangeSink> sinks = new HashSet<>();
 
     public LocalExchange(
-            PartitioningHandle partitioning,
+            Partitioning partitioning,
             int defaultConcurrency,
             List<? extends Type> types,
             List<Integer> partitionChannels,
@@ -75,7 +74,7 @@ public class LocalExchange
     }
 
     public LocalExchange(
-            PartitioningHandle partitioning,
+            Partitioning partitioning,
             int defaultConcurrency,
             List<? extends Type> types,
             List<Integer> partitionChannels,
@@ -85,24 +84,11 @@ public class LocalExchange
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
 
         int bufferCount;
-        if (partitioning.equals(SINGLE_DISTRIBUTION)) {
+        if (isSinglePartitioning(partitioning)) {
             bufferCount = 1;
-            checkArgument(partitionChannels.isEmpty(), "Gather exchange must not have partition channels");
-        }
-        else if (partitioning.equals(FIXED_BROADCAST_DISTRIBUTION)) {
-            bufferCount = defaultConcurrency;
-            checkArgument(partitionChannels.isEmpty(), "Broadcast exchange must not have partition channels");
-        }
-        else if (partitioning.equals(FIXED_RANDOM_DISTRIBUTION)) {
-            bufferCount = defaultConcurrency;
-            checkArgument(partitionChannels.isEmpty(), "Random exchange must not have partition channels");
-        }
-        else if (partitioning.equals(FIXED_HASH_DISTRIBUTION)) {
-            bufferCount = defaultConcurrency;
-            checkArgument(!partitionChannels.isEmpty(), "Partitioned exchange must have partition channels");
         }
         else {
-            throw new IllegalArgumentException("Unsupported local exchange partitioning " + partitioning);
+            bufferCount = defaultConcurrency;
         }
 
         ImmutableList.Builder<LocalExchangeSource> sources = ImmutableList.builder();
@@ -116,16 +102,17 @@ public class LocalExchange
                 .collect(toImmutableList());
 
         this.memoryManager = new LocalExchangeMemoryManager(maxBufferedBytes.toBytes());
-        if (partitioning.equals(SINGLE_DISTRIBUTION)) {
+        if (bufferCount == 1) {
+            // if there is only one buffer, the partitioning doesn't matter, so choose the most efficient implementation
             exchangerSupplier = () -> new BroadcastExchanger(buffers, memoryManager::updateMemoryUsage);
         }
-        else if (partitioning.equals(FIXED_BROADCAST_DISTRIBUTION)) {
+        else if (isFixedBroadcastPartitioning(partitioning)) {
             exchangerSupplier = () -> new BroadcastExchanger(buffers, memoryManager::updateMemoryUsage);
         }
-        else if (partitioning.equals(FIXED_RANDOM_DISTRIBUTION)) {
+        else if (isFixedRandomPartitioning(partitioning)) {
             exchangerSupplier = () -> new RandomExchanger(buffers, memoryManager::updateMemoryUsage);
         }
-        else if (partitioning.equals(FIXED_HASH_DISTRIBUTION)) {
+        else if (isFixedHashPartitioning(partitioning)) {
             exchangerSupplier = () -> new PartitioningExchanger(buffers, memoryManager::updateMemoryUsage, types, partitionChannels, partitionHashChannel);
         }
         else {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -173,8 +173,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
-import static com.facebook.presto.SystemSessionProperties.getTaskWriterCount;
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.operator.DistinctLimitOperator.DistinctLimitOperatorFactory;
 import static com.facebook.presto.operator.NestedLoopBuildOperator.NestedLoopBuildOperatorFactory;
@@ -202,7 +200,6 @@ import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static com.google.common.base.Functions.forMap;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
@@ -1219,6 +1216,7 @@ public class LocalExecutionPlanner
         public PhysicalOperation visitIndexSource(IndexSourceNode node, LocalExecutionPlanContext context)
         {
             checkState(context.getIndexSourceContext().isPresent(), "Must be in an index source context");
+            checkArgument(!context.getDriverInstanceCount().isPresent(), "Plan context must not have driver instance count set for index source");
             IndexSourceContext indexSourceContext = context.getIndexSourceContext().get();
 
             SetMultimap<Symbol, Integer> indexLookupToProbeInput = indexSourceContext.getIndexLookupToProbeInput();
@@ -1616,16 +1614,11 @@ public class LocalExecutionPlanner
         @Override
         public PhysicalOperation visitTableWriter(TableWriterNode node, LocalExecutionPlanContext context)
         {
-            // Set table writer count
-            if (node.getPartitioningScheme().isPresent()) {
-                context.setDriverInstanceCount(1);
-            }
-            else {
-                context.setDriverInstanceCount(getTaskWriterCount(session));
-            }
-
             // serialize writes by forcing data through a single writer
             PhysicalOperation source = node.getSource().accept(this, context);
+
+            // planning the source must establish a fixed driver count
+            checkArgument(context.getDriverInstanceCount().isPresent(), "Table writer must have a fixed partition count");
 
             Optional<Integer> sampleWeightChannel = node.getSampleWeightSymbol().map(source::symbolToChannel);
 
@@ -1706,19 +1699,7 @@ public class LocalExecutionPlanner
         public PhysicalOperation visitExchange(ExchangeNode node, LocalExecutionPlanContext context)
         {
             checkArgument(node.getScope() == LOCAL, "Only local exchanges are supported in the local planner");
-
-            int driverInstanceCount;
-            if (node.getType() == ExchangeNode.Type.GATHER) {
-                driverInstanceCount = 1;
-                context.setDriverInstanceCount(1);
-            }
-            else if (context.getDriverInstanceCount().isPresent()) {
-                driverInstanceCount = context.getDriverInstanceCount().getAsInt();
-            }
-            else {
-                driverInstanceCount = getTaskConcurrency(session);
-                context.setDriverInstanceCount(driverInstanceCount);
-            }
+            checkArgument(!context.getDriverInstanceCount().isPresent(), "Plan context must not have driver instance count set for local exchange");
 
             List<Type> types = getSourceOperatorTypes(node, context.getTypes());
             List<Integer> channels = node.getPartitioningScheme().getPartitioning().getArguments().stream()
@@ -1727,7 +1708,8 @@ public class LocalExecutionPlanner
             Optional<Integer> hashChannel = node.getPartitioningScheme().getHashColumn()
                     .map(symbol -> node.getOutputSymbols().indexOf(symbol));
 
-            LocalExchange localExchange = new LocalExchange(node.getPartitioningScheme().getPartitioning(), driverInstanceCount, types, channels, hashChannel);
+            LocalExchange localExchange = new LocalExchange(node.getPartitioningScheme().getPartitioning(), types, channels, hashChannel);
+            context.setDriverInstanceCount(localExchange.getBufferCount());
 
             for (int i = 0; i < node.getSources().size(); i++) {
                 PlanNode sourceNode = node.getSources().get(i);
@@ -1746,10 +1728,6 @@ public class LocalExecutionPlanner
 
             // the main driver is not an input... the exchange sources are the input for the plan
             context.setInputDriver(false);
-
-            // instance count must match the number of partitions in the exchange
-            verify(context.getDriverInstanceCount().getAsInt() == localExchange.getBufferCount(),
-                    "driver instance count must match the number of exchange partitions");
 
             return new PhysicalOperation(new LocalExchangeSourceOperatorFactory(context.getNextOperatorId(), node.getId(), localExchange), makeLayout(node));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
@@ -93,7 +93,7 @@ public class NodePartitioningManager
         requireNonNull(partitioningHandle, "partitioningHandle is null");
 
         if (partitioningHandle.getConnectorHandle() instanceof SystemPartitioningHandle) {
-            return ((SystemPartitioningHandle) partitioningHandle.getConnectorHandle()).getNodePartitionMap(session, nodeScheduler);
+            return ((SystemPartitioningHandle) partitioningHandle.getConnectorHandle()).getNodePartitionMap(nodeScheduler);
         }
 
         ConnectorNodePartitioningProvider partitioningProvider = partitioningProviders.get(partitioningHandle.getConnectorId().get());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragment.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragment.java
@@ -48,7 +48,7 @@ public class PlanFragment
     private final List<Type> types;
     private final Set<PlanNode> partitionedSourceNodes;
     private final List<RemoteSourceNode> remoteSourceNodes;
-    private final PartitioningScheme partitioningScheme;
+    private final PartitioningScheme outputPartitioningScheme;
 
     @JsonCreator
     public PlanFragment(
@@ -57,7 +57,7 @@ public class PlanFragment
             @JsonProperty("symbols") Map<Symbol, Type> symbols,
             @JsonProperty("partitioning") PartitioningHandle partitioning,
             @JsonProperty("partitionedSources") List<PlanNodeId> partitionedSources,
-            @JsonProperty("partitioningScheme") PartitioningScheme partitioningScheme)
+            @JsonProperty("outputPartitioningScheme") PartitioningScheme outputPartitioningScheme)
     {
         this.id = requireNonNull(id, "id is null");
         this.root = requireNonNull(root, "root is null");
@@ -67,10 +67,10 @@ public class PlanFragment
         this.partitionedSourcesSet = ImmutableSet.copyOf(partitionedSources);
 
         checkArgument(partitionedSourcesSet.size() == partitionedSources.size(), "partitionedSources contains duplicates");
-        checkArgument(ImmutableSet.copyOf(root.getOutputSymbols()).containsAll(partitioningScheme.getOutputLayout()),
-                "Root node outputs (%s) does not include all fragment outputs (%s)", root.getOutputSymbols(), partitioningScheme.getOutputLayout());
+        checkArgument(ImmutableSet.copyOf(root.getOutputSymbols()).containsAll(outputPartitioningScheme.getOutputLayout()),
+                "Root node outputs (%s) does not include all fragment outputs (%s)", root.getOutputSymbols(), outputPartitioningScheme.getOutputLayout());
 
-        types = partitioningScheme.getOutputLayout().stream()
+        types = outputPartitioningScheme.getOutputLayout().stream()
                 .map(symbols::get)
                 .collect(toImmutableList());
 
@@ -80,7 +80,7 @@ public class PlanFragment
         findRemoteSourceNodes(root, remoteSourceNodes);
         this.remoteSourceNodes = remoteSourceNodes.build();
 
-        this.partitioningScheme = requireNonNull(partitioningScheme, "partitioningScheme is null");
+        this.outputPartitioningScheme = requireNonNull(outputPartitioningScheme, "outputPartitioningScheme is null");
     }
 
     @JsonProperty
@@ -119,9 +119,9 @@ public class PlanFragment
     }
 
     @JsonProperty
-    public PartitioningScheme getPartitioningScheme()
+    public PartitioningScheme getOutputPartitioningScheme()
     {
-        return partitioningScheme;
+        return outputPartitioningScheme;
     }
 
     public List<Type> getTypes()
@@ -175,7 +175,7 @@ public class PlanFragment
 
     public PlanFragment withBucketToPartition(Optional<int[]> bucketToPartition)
     {
-        return new PlanFragment(id, root, symbols, partitioning, partitionedSources, partitioningScheme.withBucketToPartition(bucketToPartition));
+        return new PlanFragment(id, root, symbols, partitioning, partitionedSources, outputPartitioningScheme.withBucketToPartition(bucketToPartition));
     }
 
     @Override
@@ -185,7 +185,7 @@ public class PlanFragment
                 .add("id", id)
                 .add("partitioning", partitioning)
                 .add("partitionedSource", partitionedSources)
-                .add("partitionFunction", partitioningScheme)
+                .add("outputPartitioningScheme", outputPartitioningScheme)
                 .toString();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -118,7 +118,7 @@ public class PlanFragmenter
                     Maps.filterKeys(types, in(dependencies)),
                     properties.getPartitioningHandle(),
                     schedulingOrder,
-                    properties.getPartitioningScheme());
+                    properties.getOutputPartitioningScheme());
 
             return new SubPlan(fragment, properties.getChildren());
         }
@@ -224,14 +224,14 @@ public class PlanFragmenter
     {
         private final List<SubPlan> children = new ArrayList<>();
 
-        private final PartitioningScheme partitioningScheme;
+        private final PartitioningScheme outputPartitioningScheme;
 
         private Optional<PartitioningHandle> partitioningHandle = Optional.empty();
         private final Set<PlanNodeId> partitionedSources = new HashSet<>();
 
-        public FragmentProperties(PartitioningScheme partitioningScheme)
+        public FragmentProperties(PartitioningScheme outputPartitioningScheme)
         {
-            this.partitioningScheme = partitioningScheme;
+            this.outputPartitioningScheme = outputPartitioningScheme;
         }
 
         public List<SubPlan> getChildren()
@@ -319,9 +319,9 @@ public class PlanFragmenter
             return this;
         }
 
-        public PartitioningScheme getPartitioningScheme()
+        public PartitioningScheme getOutputPartitioningScheme()
         {
-            return partitioningScheme;
+            return outputPartitioningScheme;
         }
 
         public PartitioningHandle getPartitioningHandle()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -48,9 +48,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.coordinatorOnlyPartition;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.isSinglePartitioning;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.singlePartition;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.unknownPartitioning;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -67,7 +68,7 @@ public class PlanFragmenter
     {
         Fragmenter fragmenter = new Fragmenter(session, metadata, plan.getSymbolAllocator().getTypes());
 
-        FragmentProperties properties = new FragmentProperties(new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), plan.getRoot().getOutputSymbols()))
+        FragmentProperties properties = new FragmentProperties(new PartitioningScheme(singlePartition(), plan.getRoot().getOutputSymbols()))
                 .setSingleNodeDistribution();
         PlanNode root = SimplePlanRewriter.rewriteWith(fragmenter, plan.getRoot(), properties);
 
@@ -159,7 +160,7 @@ public class PlanFragmenter
                     .map(layout -> metadata.getLayout(session, layout))
                     .flatMap(TableLayout::getNodePartitioning)
                     .map(NodePartitioning::getPartitioningHandle)
-                    .orElse(SOURCE_DISTRIBUTION);
+                    .orElse(unknownPartitioning().getHandle());
 
             context.get().addSourceDistribution(node.getId(), partitioning);
             return context.defaultRewrite(node, context.get());
@@ -248,17 +249,17 @@ public class PlanFragmenter
 
             checkState(!partitioningHandle.isPresent(),
                     "Cannot overwrite partitioning with %s (currently set to %s)",
-                    SINGLE_DISTRIBUTION,
+                    singlePartition(),
                     partitioningHandle);
 
-            partitioningHandle = Optional.of(SINGLE_DISTRIBUTION);
+            partitioningHandle = Optional.of(singlePartition().getHandle());
 
             return this;
         }
 
         public FragmentProperties setDistribution(PartitioningHandle distribution)
         {
-            if (partitioningHandle.isPresent() && !partitioningHandle.get().equals(distribution) && !partitioningHandle.get().equals(SOURCE_DISTRIBUTION)) {
+            if (partitioningHandle.isPresent() && !partitioningHandle.get().equals(distribution) && !isSinglePartitioning(partitioningHandle.get())) {
                 checkState(partitioningHandle.get().isSingleNode(),
                         "Cannot set distribution to %s. Already set to %s",
                         distribution,
@@ -278,12 +279,12 @@ public class PlanFragmenter
             }
 
             // only system SINGLE can be upgraded to COORDINATOR_ONLY
-            checkState(!partitioningHandle.isPresent() || partitioningHandle.get().equals(SINGLE_DISTRIBUTION),
+            checkState(!partitioningHandle.isPresent() || isSinglePartitioning(partitioningHandle.get()),
                     "Cannot overwrite partitioning with %s (currently set to %s)",
-                    COORDINATOR_DISTRIBUTION,
+                    coordinatorOnlyPartition(),
                     partitioningHandle);
 
-            partitioningHandle = Optional.of(COORDINATOR_DISTRIBUTION);
+            partitioningHandle = Optional.of(coordinatorOnlyPartition().getHandle());
 
             return this;
         }
@@ -298,9 +299,9 @@ public class PlanFragmenter
             if (partitioningHandle.isPresent()) {
                 PartitioningHandle currentPartitioning = partitioningHandle.get();
                 if (!currentPartitioning.equals(distribution)) {
-                    // If already system SINGLE or COORDINATOR_ONLY, leave it as is (this is for single-node execution)
+                    // If already a system single node partitioning, leave it as is (this is for single-node execution)
                     checkState(
-                            currentPartitioning.equals(SINGLE_DISTRIBUTION) || currentPartitioning.equals(COORDINATOR_DISTRIBUTION),
+                            isSinglePartitioning(currentPartitioning),
                             "Cannot overwrite distribution with %s (currently set to %s)",
                             distribution,
                             currentPartitioning);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
@@ -100,7 +100,7 @@ import java.util.stream.Stream;
 import static com.facebook.presto.execution.StageInfo.getAllStages;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.DomainUtils.simplifyDomain;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.singlePartition;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -322,9 +322,9 @@ public class PlanPrinter
                 new PlanFragmentId("graphviz_plan"),
                 plan,
                 types,
-                SINGLE_DISTRIBUTION,
+                singlePartition().getHandle(),
                 ImmutableList.of(plan.getId()),
-                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), plan.getOutputSymbols()));
+                new PartitioningScheme(singlePartition(), plan.getOutputSymbols()));
         return GraphvizPrinter.printLogical(ImmutableList.of(fragment));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
@@ -276,13 +276,13 @@ public class PlanPrinter
                             stageStats.get().getOutputDataSize()));
         }
 
-        PartitioningScheme partitioningScheme = fragment.getPartitioningScheme();
+        PartitioningScheme outputPartitioningScheme = fragment.getOutputPartitioningScheme();
         builder.append(indentString(1))
                 .append(format("Output layout: [%s]\n",
-                        Joiner.on(", ").join(partitioningScheme.getOutputLayout())));
+                        Joiner.on(", ").join(outputPartitioningScheme.getOutputLayout())));
 
-        boolean replicateNulls = partitioningScheme.isReplicateNulls();
-        List<String> arguments = partitioningScheme.getPartitioning().getArguments().stream()
+        boolean replicateNulls = outputPartitioningScheme.isReplicateNulls();
+        List<String> arguments = outputPartitioningScheme.getPartitioning().getArguments().stream()
                 .map(argument -> {
                     if (argument.isConstant()) {
                         NullableValue constant = argument.getConstant();
@@ -295,12 +295,12 @@ public class PlanPrinter
         builder.append(indentString(1));
         if (replicateNulls) {
             builder.append(format("Output partitioning: %s (replicate nulls) [%s]\n",
-                    partitioningScheme.getPartitioning().getHandle(),
+                    outputPartitioningScheme.getPartitioning().getHandle(),
                     Joiner.on(", ").join(arguments)));
         }
         else {
             builder.append(format("Output partitioning: %s [%s]\n",
-                    partitioningScheme.getPartitioning().getHandle(),
+                    outputPartitioningScheme.getPartitioning().getHandle(),
                     Joiner.on(", ").join(arguments)));
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
@@ -35,9 +35,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.coordinatorOnlyPartition;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.singlePartition;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.unknownPartitioning;
 import static com.google.common.collect.Iterables.transform;
 import static java.util.Objects.requireNonNull;
 
@@ -298,18 +298,12 @@ class ActualProperties
 
         public static Global coordinatorSingleStreamPartition()
         {
-            return partitionedOn(
-                    COORDINATOR_DISTRIBUTION,
-                    ImmutableList.of(),
-                    Optional.of(ImmutableList.of()));
+            return partitionedOn(coordinatorOnlyPartition(), Optional.of(unknownPartitioning()));
         }
 
         public static Global singleStreamPartition()
         {
-            return partitionedOn(
-                    SINGLE_DISTRIBUTION,
-                    ImmutableList.of(),
-                    Optional.of(ImmutableList.of()));
+            return partitionedOn(singlePartition(), Optional.of(unknownPartitioning()));
         }
 
         public static Global arbitraryPartition()
@@ -321,7 +315,7 @@ class ActualProperties
         {
             return new Global(
                     Optional.of(Partitioning.create(nodePartitioningHandle, nodePartitioning)),
-                    streamPartitioning.map(columns -> Partitioning.create(SOURCE_DISTRIBUTION, columns)),
+                    streamPartitioning.map(columns -> unknownPartitioning(columns)),
                     false);
         }
 
@@ -337,7 +331,7 @@ class ActualProperties
         {
             return new Global(
                     Optional.empty(),
-                    Optional.of(Partitioning.create(SOURCE_DISTRIBUTION, streamPartitioning)),
+                    Optional.of(unknownPartitioning(streamPartitioning)),
                     false);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -100,6 +100,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static com.facebook.presto.SystemSessionProperties.getHashPartitionCount;
+import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
 import static com.facebook.presto.SystemSessionProperties.isColocatedJoinEnabled;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
@@ -310,13 +312,14 @@ public class AddExchanges
                                     REMOTE,
                                     partial,
                                     node.getGroupBy(),
-                                    node.getHashSymbol());
+                                    node.getHashSymbol(),
+                                    getHashPartitionCount(session));
                         }
                         return splitAggregation(node, child, exchanger);
                     }
                     else {
                         child = withDerivedProperties(
-                                partitionedExchange(idAllocator.getNextId(), REMOTE, child.getNode(), node.getGroupBy(), node.getHashSymbol()),
+                                partitionedExchange(idAllocator.getNextId(), REMOTE, child.getNode(), node.getGroupBy(), node.getHashSymbol(), getHashPartitionCount(session)),
                                 child.getProperties());
                         return rebaseAndDeriveProperties(node, child);
                     }
@@ -424,7 +427,8 @@ public class AddExchanges
                                 REMOTE,
                                 child.getNode(),
                                 node.getDistinctSymbols(),
-                                node.getHashSymbol()),
+                                node.getHashSymbol(),
+                                getHashPartitionCount(session)),
                         child.getProperties());
             }
 
@@ -456,7 +460,7 @@ public class AddExchanges
                 }
                 else {
                     child = withDerivedProperties(
-                            partitionedExchange(idAllocator.getNextId(), REMOTE, child.getNode(), node.getPartitionBy(), node.getHashSymbol()),
+                            partitionedExchange(idAllocator.getNextId(), REMOTE, child.getNode(), node.getPartitionBy(), node.getHashSymbol(), getHashPartitionCount(session)),
                             child.getProperties());
                 }
             }
@@ -491,7 +495,8 @@ public class AddExchanges
                                 REMOTE,
                                 child.getNode(),
                                 node.getPartitionBy(),
-                                node.getHashSymbol()),
+                                node.getHashSymbol(),
+                                getHashPartitionCount(session)),
                         child.getProperties());
             }
 
@@ -513,7 +518,7 @@ public class AddExchanges
             else {
                 preferredChildProperties = PreferredProperties.partitionedWithLocal(ImmutableSet.copyOf(node.getPartitionBy()), grouped(node.getPartitionBy()))
                         .mergeWithParent(context.getPreferredProperties());
-                addExchange = partial -> partitionedExchange(idAllocator.getNextId(), REMOTE, partial, node.getPartitionBy(), node.getHashSymbol());
+                addExchange = partial -> partitionedExchange(idAllocator.getNextId(), REMOTE, partial, node.getPartitionBy(), node.getHashSymbol(), getHashPartitionCount(session));
             }
 
             PlanWithProperties child = planChild(node, context.withPreferredProperties(preferredChildProperties));
@@ -628,7 +633,7 @@ public class AddExchanges
 
             Optional<PartitioningScheme> partitioningScheme = node.getPartitioningScheme();
             if (!partitioningScheme.isPresent() && redistributeWrites) {
-                partitioningScheme = Optional.of(new PartitioningScheme(fixedRandomPartitioning(), source.getNode().getOutputSymbols()));
+                partitioningScheme = Optional.of(new PartitioningScheme(fixedRandomPartitioning(getHashPartitionCount(session)), source.getNode().getOutputSymbols()));
             }
 
             if (partitioningScheme.isPresent()) {
@@ -863,10 +868,10 @@ public class AddExchanges
                     }
                     else {
                         left = withDerivedProperties(
-                                partitionedExchange(idAllocator.getNextId(), REMOTE, left.getNode(), leftSymbols, Optional.empty()),
+                                partitionedExchange(idAllocator.getNextId(), REMOTE, left.getNode(), leftSymbols, Optional.empty(), getHashPartitionCount(session)),
                                 left.getProperties());
                         right = withDerivedProperties(
-                                partitionedExchange(idAllocator.getNextId(), REMOTE, right.getNode(), rightSymbols, Optional.empty()),
+                                partitionedExchange(idAllocator.getNextId(), REMOTE, right.getNode(), rightSymbols, Optional.empty(), getHashPartitionCount(session)),
                                 right.getProperties());
                     }
                 }
@@ -897,7 +902,7 @@ public class AddExchanges
                 }
                 else {
                     right = withDerivedProperties(
-                            replicatedExchange(idAllocator.getNextId(), REMOTE, right.getNode()),
+                            replicatedExchange(idAllocator.getNextId(), REMOTE, right.getNode(), getHashPartitionCount(session)),
                             right.getProperties());
                 }
             }
@@ -962,10 +967,17 @@ public class AddExchanges
                     }
                     else {
                         source = withDerivedProperties(
-                                partitionedExchange(idAllocator.getNextId(), REMOTE, source.getNode(), sourceSymbols, Optional.empty()),
+                                partitionedExchange(idAllocator.getNextId(), REMOTE, source.getNode(), sourceSymbols, Optional.empty(), getHashPartitionCount(session)),
                                 source.getProperties());
                         filteringSource = withDerivedProperties(
-                                partitionedExchange(idAllocator.getNextId(), REMOTE, filteringSource.getNode(), filteringSourceSymbols, Optional.empty(), true),
+                                partitionedExchange(
+                                        idAllocator.getNextId(),
+                                        REMOTE,
+                                        filteringSource.getNode(),
+                                        filteringSourceSymbols,
+                                        Optional.empty(),
+                                        true,
+                                        getHashPartitionCount(session)),
                                 filteringSource.getProperties());
                     }
                 }
@@ -1002,7 +1014,7 @@ public class AddExchanges
                 }
                 else {
                     filteringSource = withDerivedProperties(
-                            replicatedExchange(idAllocator.getNextId(), REMOTE, filteringSource.getNode()),
+                            replicatedExchange(idAllocator.getNextId(), REMOTE, filteringSource.getNode(), getHashPartitionCount(session)),
                             filteringSource.getProperties());
                 }
             }
@@ -1028,7 +1040,7 @@ public class AddExchanges
             // TODO: allow repartitioning if unpartitioned to increase parallelism
             if (shouldRepartitionForIndexJoin(joinColumns, context.getPreferredProperties(), probeProperties)) {
                 probeSource = withDerivedProperties(
-                        partitionedExchange(idAllocator.getNextId(), REMOTE, probeSource.getNode(), joinColumns, node.getProbeHashSymbol()),
+                        partitionedExchange(idAllocator.getNextId(), REMOTE, probeSource.getNode(), joinColumns, node.getProbeHashSymbol(), getHashPartitionCount(session)),
                         probeProperties);
             }
 
@@ -1109,7 +1121,7 @@ public class AddExchanges
             }
 
             // Otherwise, choose an arbitrary partitioning over the columns
-            return fixedHashPartitioning(ImmutableList.copyOf(parentPreference.getPartitioningColumns()));
+            return fixedHashPartitioning(getTaskConcurrency(session), ImmutableList.copyOf(parentPreference.getPartitioningColumns()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -107,9 +107,9 @@ import static com.facebook.presto.sql.ExpressionUtils.stripDeterministicConjunct
 import static com.facebook.presto.sql.ExpressionUtils.stripNonDeterministicConjuncts;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
 import static com.facebook.presto.sql.planner.FragmentTableScanCounter.hasMultipleSources;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_RANDOM_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.fixedHashPartitioning;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.fixedRandomPartitioning;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.singlePartition;
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.partitionedOn;
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.singleStreamPartition;
 import static com.facebook.presto.sql.planner.optimizations.LocalProperties.grouped;
@@ -628,7 +628,7 @@ public class AddExchanges
 
             Optional<PartitioningScheme> partitioningScheme = node.getPartitioningScheme();
             if (!partitioningScheme.isPresent() && redistributeWrites) {
-                partitioningScheme = Optional.of(new PartitioningScheme(Partitioning.create(FIXED_RANDOM_DISTRIBUTION, ImmutableList.of()), source.getNode().getOutputSymbols()));
+                partitioningScheme = Optional.of(new PartitioningScheme(fixedRandomPartitioning(), source.getNode().getOutputSymbols()));
             }
 
             if (partitioningScheme.isPresent()) {
@@ -1109,7 +1109,7 @@ public class AddExchanges
             }
 
             // Otherwise, choose an arbitrary partitioning over the columns
-            return Partitioning.create(FIXED_HASH_DISTRIBUTION, ImmutableList.copyOf(parentPreference.getPartitioningColumns()));
+            return fixedHashPartitioning(ImmutableList.copyOf(parentPreference.getPartitioningColumns()));
         }
 
         @Override
@@ -1198,7 +1198,7 @@ public class AddExchanges
                         idAllocator.getNextId(),
                         GATHER,
                         REMOTE,
-                        new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), node.getOutputSymbols()),
+                        new PartitioningScheme(singlePartition(), node.getOutputSymbols()),
                         partitionedChildren,
                         partitionedOutputLayouts);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -425,8 +425,8 @@ public class AddLocalExchanges
             StreamPreferredProperties requiredProperties;
             StreamPreferredProperties preferredProperties;
             if (getTaskWriterCount(session) > 1) {
-                requiredProperties = fixedParallelism();
-                preferredProperties = fixedParallelism();
+                requiredProperties = fixedParallelism(getTaskWriterCount(session));
+                preferredProperties = fixedParallelism(getTaskWriterCount(session));
             }
             else {
                 requiredProperties = singleStream();
@@ -486,7 +486,7 @@ public class AddLocalExchanges
                         REPARTITION,
                         LOCAL,
                         new PartitioningScheme(
-                                fixedHashPartitioning(preferredPartitionColumns.get()),
+                                fixedHashPartitioning(getTaskConcurrency(session), preferredPartitionColumns.get()),
                                 node.getOutputSymbols(),
                                 Optional.empty()),
                         sources,
@@ -499,7 +499,7 @@ public class AddLocalExchanges
                     idAllocator.getNextId(),
                     REPARTITION,
                     LOCAL,
-                    new PartitioningScheme(fixedRandomPartitioning(), node.getOutputSymbols()),
+                    new PartitioningScheme(fixedRandomPartitioning(getTaskConcurrency(session)), node.getOutputSymbols()),
                     sources,
                     inputLayouts);
             ExchangeNode exchangeNode = result;
@@ -616,7 +616,7 @@ public class AddLocalExchanges
                         LOCAL,
                         planWithProperties.getNode(),
                         new PartitioningScheme(
-                                fixedRandomPartitioning(),
+                                fixedRandomPartitioning(getTaskConcurrency(session)),
                                 planWithProperties.getNode().getOutputSymbols()));
 
                 return deriveProperties(exchangeNode, planWithProperties.getProperties());
@@ -629,7 +629,8 @@ public class AddLocalExchanges
                         LOCAL,
                         planWithProperties.getNode(),
                         requiredPartitionColumns.get(),
-                        Optional.empty());
+                        Optional.empty(),
+                        requiredProperties.getStreamCount().orElse(getTaskConcurrency(session)));
                 return deriveProperties(exchangeNode, planWithProperties.getProperties());
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -69,7 +69,7 @@ import java.util.function.Function;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.LiteralInterpreter.toExpression;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.isFixedHashPartitioning;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
@@ -434,7 +434,7 @@ public class HashGenerationOptimizer
             // Currently, precomputed hash values are only supported for system hash distributions without constants
             Optional<HashComputation> partitionSymbols = Optional.empty();
             PartitioningScheme partitioningScheme = node.getPartitioningScheme();
-            if (partitioningScheme.getPartitioning().getHandle().equals(FIXED_HASH_DISTRIBUTION) &&
+            if (isFixedHashPartitioning(partitioningScheme.getPartitioning()) &&
                     partitioningScheme.getPartitioning().getArguments().stream().allMatch(ArgumentBinding::isVariable)) {
                 // add precomputed hash for exchange
                 partitionSymbols = computeHash(partitioningScheme.getPartitioning().getArguments().stream()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -73,7 +73,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static com.facebook.presto.spi.predicate.TupleDomain.extractFixedValues;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_RANDOM_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.isFixedRandomPartitioning;
 import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties.StreamDistribution.FIXED;
 import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties.StreamDistribution.MULTIPLE;
 import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties.StreamDistribution.SINGLE;
@@ -248,7 +248,7 @@ final class StreamPropertyDerivations
                 case GATHER:
                     return StreamProperties.singleStream();
                 case REPARTITION:
-                    if (node.getPartitioningScheme().getPartitioning().getHandle().equals(FIXED_RANDOM_DISTRIBUTION)) {
+                    if (isFixedRandomPartitioning(node.getPartitioningScheme().getPartitioning())) {
                         return new StreamProperties(FIXED, false, Optional.empty(), false);
                     }
                     return new StreamProperties(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
@@ -96,19 +96,26 @@ public class ExchangeNode
         this.inputs = ImmutableList.copyOf(inputs);
     }
 
-    public static ExchangeNode partitionedExchange(PlanNodeId id, Scope scope, PlanNode child, List<Symbol> partitioningColumns, Optional<Symbol> hashColumns)
+    public static ExchangeNode partitionedExchange(PlanNodeId id, Scope scope, PlanNode child, List<Symbol> partitioningColumns, Optional<Symbol> hashColumns, int partitionCount)
     {
-        return partitionedExchange(id, scope, child, partitioningColumns, hashColumns, false);
+        return partitionedExchange(id, scope, child, partitioningColumns, hashColumns, false, partitionCount);
     }
 
-    public static ExchangeNode partitionedExchange(PlanNodeId id, Scope scope, PlanNode child, List<Symbol> partitioningColumns, Optional<Symbol> hashColumns, boolean nullsReplicated)
+    public static ExchangeNode partitionedExchange(
+            PlanNodeId id,
+            Scope scope,
+            PlanNode child,
+            List<Symbol> partitioningColumns,
+            Optional<Symbol> hashColumns,
+            boolean nullsReplicated,
+            int partitionCount)
     {
         return partitionedExchange(
                 id,
                 scope,
                 child,
                 new PartitioningScheme(
-                        fixedHashPartitioning(partitioningColumns),
+                        fixedHashPartitioning(partitionCount, partitioningColumns),
                         child.getOutputSymbols(),
                         hashColumns,
                         nullsReplicated,
@@ -129,13 +136,13 @@ public class ExchangeNode
                 ImmutableList.of(child.getOutputSymbols()));
     }
 
-    public static ExchangeNode replicatedExchange(PlanNodeId id, Scope scope, PlanNode child)
+    public static ExchangeNode replicatedExchange(PlanNodeId id, Scope scope, PlanNode child, int partitionCount)
     {
         return new ExchangeNode(
                 id,
                 ExchangeNode.Type.REPLICATE,
                 scope,
-                new PartitioningScheme(fixedBroadcastPartitioning(), child.getOutputSymbols()),
+                new PartitioningScheme(fixedBroadcastPartitioning(partitionCount), child.getOutputSymbols()),
                 ImmutableList.of(child),
                 ImmutableList.of(child.getOutputSymbols()));
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.sql.planner.plan;
 
-import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.Partitioning.ArgumentBinding;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.Symbol;
@@ -26,9 +25,9 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.fixedBroadcastPartitioning;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.fixedHashPartitioning;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.singlePartition;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
@@ -109,7 +108,7 @@ public class ExchangeNode
                 scope,
                 child,
                 new PartitioningScheme(
-                        Partitioning.create(FIXED_HASH_DISTRIBUTION, partitioningColumns),
+                        fixedHashPartitioning(partitioningColumns),
                         child.getOutputSymbols(),
                         hashColumns,
                         nullsReplicated,
@@ -136,7 +135,7 @@ public class ExchangeNode
                 id,
                 ExchangeNode.Type.REPLICATE,
                 scope,
-                new PartitioningScheme(Partitioning.create(FIXED_BROADCAST_DISTRIBUTION, ImmutableList.of()), child.getOutputSymbols()),
+                new PartitioningScheme(fixedBroadcastPartitioning(), child.getOutputSymbols()),
                 ImmutableList.of(child),
                 ImmutableList.of(child.getOutputSymbols()));
     }
@@ -147,7 +146,7 @@ public class ExchangeNode
                 id,
                 ExchangeNode.Type.GATHER,
                 scope,
-                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), child.getOutputSymbols()),
+                new PartitioningScheme(singlePartition(), child.getOutputSymbols()),
                 ImmutableList.of(child),
                 ImmutableList.of(child.getOutputSymbols()));
     }
@@ -158,7 +157,7 @@ public class ExchangeNode
                 id,
                 ExchangeNode.Type.GATHER,
                 scope,
-                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), outputLayout),
+                new PartitioningScheme(singlePartition(), outputLayout),
                 children,
                 children.stream()
                         .map(PlanNode::getOutputSymbols)

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -526,7 +526,7 @@ public class LocalQueryRunner
         LocalExecutionPlan localExecutionPlan = executionPlanner.plan(
                 session,
                 subplan.getFragment().getRoot(),
-                subplan.getFragment().getPartitioningScheme().getOutputLayout(),
+                subplan.getFragment().getOutputPartitioningScheme().getOutputLayout(),
                 plan.getTypes(),
                 outputFactory);
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -28,7 +28,6 @@ import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.Symbol;
@@ -69,8 +68,8 @@ import static com.facebook.presto.OutputBuffers.createInitialEmptyOutputBuffers;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.execution.StateMachine.StateChangeListener;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.singlePartition;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.unknownPartitioning;
 import static com.facebook.presto.util.Failures.toFailures;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
@@ -103,9 +102,9 @@ public class MockRemoteTaskFactory
                         TupleDomain.all(),
                         null),
                 ImmutableMap.<Symbol, Type>of(symbol, VARCHAR),
-                SOURCE_DISTRIBUTION,
+                unknownPartitioning().getHandle(),
                 ImmutableList.of(sourceId),
-                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)));
+                new PartitioningScheme(singlePartition(), ImmutableList.of(symbol)));
 
         ImmutableMultimap.Builder<PlanNodeId, Split> initialSplits = ImmutableMultimap.builder();
         for (Split sourceSplit : splits) {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -36,7 +36,6 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.CompilerConfig;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
-import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.Symbol;
@@ -56,8 +55,8 @@ import java.util.Optional;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.singlePartition;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.unknownPartitioning;
 
 public final class TaskTestUtils
 {
@@ -86,9 +85,9 @@ public final class TaskTestUtils
                     TupleDomain.all(),
                     null),
             ImmutableMap.<Symbol, Type>of(SYMBOL, VARCHAR),
-            SOURCE_DISTRIBUTION,
+            unknownPartitioning().getHandle(),
             ImmutableList.of(TABLE_SCAN_NODE_ID),
-            new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(SYMBOL))
+            new PartitioningScheme(singlePartition(), ImmutableList.of(SYMBOL))
                     .withBucketToPartition(Optional.of(new int[1])));
 
     public static LocalExecutionPlanner createTestingPlanner()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageStateMachine.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.Symbol;
@@ -34,8 +33,8 @@ import java.util.concurrent.ExecutorService;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.singlePartition;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.unknownPartitioning;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -326,9 +325,9 @@ public class TestStageStateMachine
                         ImmutableList.of(symbol),
                         ImmutableList.of(ImmutableList.of(new StringLiteral("foo")))),
                 ImmutableMap.<Symbol, Type>of(symbol, VARCHAR),
-                SOURCE_DISTRIBUTION,
+                unknownPartitioning().getHandle(),
                 ImmutableList.of(valuesNodeId),
-                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)));
+                new PartitioningScheme(singlePartition(), ImmutableList.of(symbol)));
 
         return planFragment;
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -16,7 +16,6 @@ package com.facebook.presto.execution.scheduler;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.Symbol;
@@ -42,8 +41,8 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.singlePartition;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.unknownPartitioning;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
@@ -241,8 +240,8 @@ public class TestPhasedExecutionSchedule
                 new PlanFragmentId(planNode.getId() + "_fragment_id"),
                 planNode,
                 types.build(),
-                SOURCE_DISTRIBUTION,
+                unknownPartitioning().getHandle(),
                 ImmutableList.of(planNode.getId()),
-                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), planNode.getOutputSymbols()));
+                new PartitioningScheme(singlePartition(), planNode.getOutputSymbols()));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -158,7 +158,7 @@ public class TestPhasedExecutionSchedule
                 Stream.of(fragments)
                         .map(PlanFragment::getId)
                         .collect(toImmutableList()),
-                fragments[0].getPartitioningScheme().getOutputLayout());
+                fragments[0].getOutputPartitioningScheme().getOutputLayout());
 
         return createFragment(planNode);
     }
@@ -168,7 +168,7 @@ public class TestPhasedExecutionSchedule
         PlanNode planNode = new UnionNode(
                 new PlanNodeId(name + "_id"),
                 Stream.of(fragments)
-                        .map(fragment -> new RemoteSourceNode(new PlanNodeId(fragment.getId().toString()), fragment.getId(), fragment.getPartitioningScheme().getOutputLayout()))
+                        .map(fragment -> new RemoteSourceNode(new PlanNodeId(fragment.getId().toString()), fragment.getId(), fragment.getOutputPartitioningScheme().getOutputLayout()))
                         .collect(toImmutableList()),
                 ImmutableListMultimap.of(),
                 ImmutableList.of());

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -37,7 +37,6 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.split.ConnectorAwareSplitSource;
 import com.facebook.presto.split.SplitSource;
-import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.StageExecutionPlan;
@@ -73,8 +72,8 @@ import static com.facebook.presto.OutputBuffers.createInitialEmptyOutputBuffers;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.singlePartition;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.unknownPartitioning;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.lang.Integer.min;
@@ -441,9 +440,9 @@ public class TestSourcePartitionedScheduler
                         Optional.<Symbol>empty(),
                         Optional.<Symbol>empty()),
                 ImmutableMap.<Symbol, Type>of(symbol, VARCHAR),
-                SOURCE_DISTRIBUTION,
+                unknownPartitioning().getHandle(),
                 ImmutableList.of(tableScanNodeId),
-                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)));
+                new PartitioningScheme(singlePartition(), ImmutableList.of(symbol)));
 
         return new StageExecutionPlan(
                 testFragment,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -48,7 +48,7 @@ import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.fixedHashPartitioning;
 import static com.google.common.collect.Iterables.concat;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
@@ -690,7 +690,7 @@ public class TestHashJoinOperator
     private static LookupSourceSupplier buildHash(boolean parallelBuild, TaskContext taskContext, List<Integer> hashChannels, RowPagesBuilder buildPages, Optional<JoinFilterFunction> filterFunction)
     {
         if (parallelBuild) {
-            LocalExchange localExchange = new LocalExchange(FIXED_HASH_DISTRIBUTION, PARTITION_COUNT, buildPages.getTypes(), hashChannels, buildPages.getHashChannel());
+            LocalExchange localExchange = new LocalExchange(fixedHashPartitioning(ImmutableList.of()), PARTITION_COUNT, buildPages.getTypes(), hashChannels, buildPages.getHashChannel());
             LocalExchangeSinkFactory sinkFactory = localExchange.createSinkFactory();
             sinkFactory.noMoreSinkFactories();
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -690,7 +690,7 @@ public class TestHashJoinOperator
     private static LookupSourceSupplier buildHash(boolean parallelBuild, TaskContext taskContext, List<Integer> hashChannels, RowPagesBuilder buildPages, Optional<JoinFilterFunction> filterFunction)
     {
         if (parallelBuild) {
-            LocalExchange localExchange = new LocalExchange(fixedHashPartitioning(ImmutableList.of()), PARTITION_COUNT, buildPages.getTypes(), hashChannels, buildPages.getHashChannel());
+            LocalExchange localExchange = new LocalExchange(fixedHashPartitioning(PARTITION_COUNT, ImmutableList.of()), buildPages.getTypes(), hashChannels, buildPages.getHashChannel());
             LocalExchangeSinkFactory sinkFactory = localExchange.createSinkFactory();
             sinkFactory.noMoreSinkFactories();
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/exchange/TestLocalExchange.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/exchange/TestLocalExchange.java
@@ -48,7 +48,7 @@ public class TestLocalExchange
     @Test
     public void testGatherSingleWriter()
     {
-        LocalExchange exchange = new LocalExchange(singlePartition(), 8, TYPES, ImmutableList.of(), Optional.empty(), new DataSize(retainedSizeOfPages(99), BYTE));
+        LocalExchange exchange = new LocalExchange(singlePartition(), TYPES, ImmutableList.of(), Optional.empty(), new DataSize(retainedSizeOfPages(99), BYTE));
         assertEquals(exchange.getBufferCount(), 1);
         assertExchangeTotalBufferedBytes(exchange, 0);
 
@@ -108,7 +108,7 @@ public class TestLocalExchange
     @Test
     public void testBroadcast()
     {
-        LocalExchange exchange = new LocalExchange(fixedBroadcastPartitioning(), 2, TYPES, ImmutableList.of(), Optional.empty());
+        LocalExchange exchange = new LocalExchange(fixedBroadcastPartitioning(2), TYPES, ImmutableList.of(), Optional.empty());
         assertEquals(exchange.getBufferCount(), 2);
         assertExchangeTotalBufferedBytes(exchange, 0);
 
@@ -183,7 +183,7 @@ public class TestLocalExchange
     @Test
     public void testRandom()
     {
-        LocalExchange exchange = new LocalExchange(fixedRandomPartitioning(), 2, TYPES, ImmutableList.of(), Optional.empty());
+        LocalExchange exchange = new LocalExchange(fixedRandomPartitioning(2), TYPES, ImmutableList.of(), Optional.empty());
         assertEquals(exchange.getBufferCount(), 2);
         assertExchangeTotalBufferedBytes(exchange, 0);
 
@@ -219,7 +219,7 @@ public class TestLocalExchange
     @Test
     public void testPartition()
     {
-        LocalExchange exchange = new LocalExchange(fixedHashPartitioning(ImmutableList.of()), 2, TYPES, ImmutableList.of(0), Optional.empty());
+        LocalExchange exchange = new LocalExchange(fixedHashPartitioning(2, ImmutableList.of()), TYPES, ImmutableList.of(0), Optional.empty());
         assertEquals(exchange.getBufferCount(), 2);
         assertExchangeTotalBufferedBytes(exchange, 0);
 
@@ -275,7 +275,7 @@ public class TestLocalExchange
     {
         ImmutableList<BigintType> types = ImmutableList.of(BIGINT);
 
-        LocalExchange exchange = new LocalExchange(fixedBroadcastPartitioning(), 2, types, ImmutableList.of(), Optional.empty());
+        LocalExchange exchange = new LocalExchange(fixedBroadcastPartitioning(2), types, ImmutableList.of(), Optional.empty());
         assertEquals(exchange.getBufferCount(), 2);
         assertExchangeTotalBufferedBytes(exchange, 0);
 
@@ -309,7 +309,7 @@ public class TestLocalExchange
     @Test
     public void writeUnblockWhenAllReadersFinishAndPagesConsumed()
     {
-        LocalExchange exchange = new LocalExchange(fixedBroadcastPartitioning(), 2, TYPES, ImmutableList.of(), Optional.empty(), new DataSize(1, BYTE));
+        LocalExchange exchange = new LocalExchange(fixedBroadcastPartitioning(2), TYPES, ImmutableList.of(), Optional.empty(), new DataSize(1, BYTE));
         assertEquals(exchange.getBufferCount(), 2);
         assertExchangeTotalBufferedBytes(exchange, 0);
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/exchange/TestLocalExchange.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/exchange/TestLocalExchange.java
@@ -29,10 +29,10 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_RANDOM_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.fixedBroadcastPartitioning;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.fixedHashPartitioning;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.fixedRandomPartitioning;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.singlePartition;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -48,7 +48,7 @@ public class TestLocalExchange
     @Test
     public void testGatherSingleWriter()
     {
-        LocalExchange exchange = new LocalExchange(SINGLE_DISTRIBUTION, 8, TYPES, ImmutableList.of(), Optional.empty(), new DataSize(retainedSizeOfPages(99), BYTE));
+        LocalExchange exchange = new LocalExchange(singlePartition(), 8, TYPES, ImmutableList.of(), Optional.empty(), new DataSize(retainedSizeOfPages(99), BYTE));
         assertEquals(exchange.getBufferCount(), 1);
         assertExchangeTotalBufferedBytes(exchange, 0);
 
@@ -108,7 +108,7 @@ public class TestLocalExchange
     @Test
     public void testBroadcast()
     {
-        LocalExchange exchange = new LocalExchange(FIXED_BROADCAST_DISTRIBUTION, 2, TYPES, ImmutableList.of(), Optional.empty());
+        LocalExchange exchange = new LocalExchange(fixedBroadcastPartitioning(), 2, TYPES, ImmutableList.of(), Optional.empty());
         assertEquals(exchange.getBufferCount(), 2);
         assertExchangeTotalBufferedBytes(exchange, 0);
 
@@ -183,7 +183,7 @@ public class TestLocalExchange
     @Test
     public void testRandom()
     {
-        LocalExchange exchange = new LocalExchange(FIXED_RANDOM_DISTRIBUTION, 2, TYPES, ImmutableList.of(), Optional.empty());
+        LocalExchange exchange = new LocalExchange(fixedRandomPartitioning(), 2, TYPES, ImmutableList.of(), Optional.empty());
         assertEquals(exchange.getBufferCount(), 2);
         assertExchangeTotalBufferedBytes(exchange, 0);
 
@@ -219,7 +219,7 @@ public class TestLocalExchange
     @Test
     public void testPartition()
     {
-        LocalExchange exchange = new LocalExchange(FIXED_HASH_DISTRIBUTION, 2, TYPES, ImmutableList.of(0), Optional.empty());
+        LocalExchange exchange = new LocalExchange(fixedHashPartitioning(ImmutableList.of()), 2, TYPES, ImmutableList.of(0), Optional.empty());
         assertEquals(exchange.getBufferCount(), 2);
         assertExchangeTotalBufferedBytes(exchange, 0);
 
@@ -275,7 +275,7 @@ public class TestLocalExchange
     {
         ImmutableList<BigintType> types = ImmutableList.of(BIGINT);
 
-        LocalExchange exchange = new LocalExchange(FIXED_BROADCAST_DISTRIBUTION, 2, types, ImmutableList.of(), Optional.empty());
+        LocalExchange exchange = new LocalExchange(fixedBroadcastPartitioning(), 2, types, ImmutableList.of(), Optional.empty());
         assertEquals(exchange.getBufferCount(), 2);
         assertExchangeTotalBufferedBytes(exchange, 0);
 
@@ -309,7 +309,7 @@ public class TestLocalExchange
     @Test
     public void writeUnblockWhenAllReadersFinishAndPagesConsumed()
     {
-        LocalExchange exchange = new LocalExchange(FIXED_BROADCAST_DISTRIBUTION, 2, TYPES, ImmutableList.of(), Optional.empty(), new DataSize(1, BYTE));
+        LocalExchange exchange = new LocalExchange(fixedBroadcastPartitioning(), 2, TYPES, ImmutableList.of(), Optional.empty(), new DataSize(1, BYTE));
         assertEquals(exchange.getBufferCount(), 2);
         assertExchangeTotalBufferedBytes(exchange, 0);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchanges.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchanges.java
@@ -761,7 +761,7 @@ public class TestAddExchanges
 
     private static Global hashDistributedOn(String... columnNames)
     {
-        return partitionedOn(fixedHashPartitioning(arguments(columnNames)), Optional.of(unknownPartitioning(arguments(columnNames))));
+        return partitionedOn(fixedHashPartitioning(8, arguments(columnNames)), Optional.of(unknownPartitioning(arguments(columnNames))));
     }
 
     public static Global singleStream()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchanges.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchanges.java
@@ -32,7 +32,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_FIRST;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.fixedHashPartitioning;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.unknownPartitioning;
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.arbitraryPartition;
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.partitionedOn;
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.singleStreamPartition;
@@ -760,7 +761,7 @@ public class TestAddExchanges
 
     private static Global hashDistributedOn(String... columnNames)
     {
-        return partitionedOn(FIXED_HASH_DISTRIBUTION, arguments(columnNames), Optional.of(arguments(columnNames)));
+        return partitionedOn(fixedHashPartitioning(arguments(columnNames)), Optional.of(unknownPartitioning(arguments(columnNames))));
     }
 
     public static Global singleStream()


### PR DESCRIPTION
When local parallel is enabled, the coordinator creates a query plan that
requires parallel execution, but parallelism is set on each working using
the task concurrency property.  If the coordinator and worker have
different settings for this property, the execution can fail.

Instead of dividing the parallelism planning between the coordinator and
the worker, the coordinator makes the decision and records this in the
plan.