### PR TITLE
Add FLOAT coercions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -330,6 +330,7 @@ public final class TypeRegistry
                     case StandardTypes.BIGINT:
                     case StandardTypes.INTEGER:
                     case StandardTypes.DOUBLE:
+                    case StandardTypes.FLOAT:
                     case StandardTypes.VARBINARY:
                     case StandardTypes.DATE:
                     case StandardTypes.TIME:
@@ -362,6 +363,8 @@ public final class TypeRegistry
                         return Optional.of(INTEGER);
                     case StandardTypes.BIGINT:
                         return Optional.of(BIGINT);
+                    case StandardTypes.FLOAT:
+                        return Optional.of(FLOAT);
                     case StandardTypes.DOUBLE:
                         return Optional.of(DOUBLE);
                     case StandardTypes.DECIMAL:
@@ -376,6 +379,8 @@ public final class TypeRegistry
                         return Optional.of(INTEGER);
                     case StandardTypes.BIGINT:
                         return Optional.of(BIGINT);
+                    case StandardTypes.FLOAT:
+                        return Optional.of(FLOAT);
                     case StandardTypes.DOUBLE:
                         return Optional.of(DOUBLE);
                     case StandardTypes.DECIMAL:
@@ -388,6 +393,8 @@ public final class TypeRegistry
                 switch (resultTypeBase) {
                     case StandardTypes.BIGINT:
                         return Optional.of(BIGINT);
+                    case StandardTypes.FLOAT:
+                        return Optional.of(FLOAT);
                     case StandardTypes.DOUBLE:
                         return Optional.of(DOUBLE);
                     case StandardTypes.DECIMAL:
@@ -398,6 +405,8 @@ public final class TypeRegistry
             }
             case StandardTypes.BIGINT: {
                 switch (resultTypeBase) {
+                    case StandardTypes.FLOAT:
+                        return Optional.of(FLOAT);
                     case StandardTypes.DOUBLE:
                         return Optional.of(DOUBLE);
                     case StandardTypes.DECIMAL:
@@ -407,6 +416,16 @@ public final class TypeRegistry
                 }
             }
             case StandardTypes.DECIMAL: {
+                switch (resultTypeBase) {
+                    case StandardTypes.FLOAT:
+                        return Optional.of(FLOAT);
+                    case StandardTypes.DOUBLE:
+                        return Optional.of(DOUBLE);
+                    default:
+                        return Optional.empty();
+                }
+            }
+            case StandardTypes.FLOAT: {
                 switch (resultTypeBase) {
                     case StandardTypes.DOUBLE:
                         return Optional.of(DOUBLE);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -58,6 +58,7 @@ public class TestMathFunctions
         assertFunction("abs(123.45)", DOUBLE, 123.45);
         assertFunction("abs(-123.45)", DOUBLE, 123.45);
         assertFunction("abs(CAST(NULL AS DOUBLE))", DOUBLE, null);
+        assertFunction("abs(FLOAT '-754.1985')", DOUBLE, (double) 754.1985f);
         assertInvalidFunction("abs(TINYINT'" + Byte.MIN_VALUE + "')", NUMERIC_VALUE_OUT_OF_RANGE);
         assertInvalidFunction("abs(SMALLINT'" + Short.MIN_VALUE + "')", NUMERIC_VALUE_OUT_OF_RANGE);
         assertInvalidFunction("abs(INTEGER'" + Integer.MIN_VALUE + "')", NUMERIC_VALUE_OUT_OF_RANGE);
@@ -69,6 +70,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("acos(" + doubleValue + ")", DOUBLE, Math.acos(doubleValue));
+            assertFunction("acos(FLOAT '" + (float) doubleValue + "')", DOUBLE, Math.acos((float) doubleValue));
         }
         assertFunction("acos(NULL)", DOUBLE, null);
     }
@@ -78,6 +80,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("asin(" + doubleValue + ")", DOUBLE, Math.asin(doubleValue));
+            assertFunction("asin(FLOAT '" + (float) doubleValue + "')", DOUBLE, Math.asin((float) doubleValue));
         }
         assertFunction("asin(NULL)", DOUBLE, null);
     }
@@ -87,6 +90,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("atan(" + doubleValue + ")", DOUBLE, Math.atan(doubleValue));
+            assertFunction("atan(FLOAT '" + (float) doubleValue + "')", DOUBLE, Math.atan((float) doubleValue));
         }
         assertFunction("atan(NULL)", DOUBLE, null);
     }
@@ -96,6 +100,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("atan2(" + doubleValue + ", " + doubleValue + ")", DOUBLE, Math.atan2(doubleValue, doubleValue));
+            assertFunction("atan2(FLOAT '" + (float) doubleValue + "', FLOAT '" + (float) doubleValue + "')", DOUBLE, Math.atan2((float) doubleValue, (float) doubleValue));
         }
         assertFunction("atan2(NULL, NULL)", DOUBLE, null);
         assertFunction("atan2(1.0, NULL)", DOUBLE, null);
@@ -107,6 +112,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("cbrt(" + doubleValue + ")", DOUBLE, Math.cbrt(doubleValue));
+            assertFunction("cbrt(FLOAT '" + (float) doubleValue + "')", DOUBLE, Math.cbrt((float) doubleValue));
         }
         assertFunction("cbrt(NULL)", DOUBLE, null);
     }
@@ -132,6 +138,10 @@ public class TestMathFunctions
         assertFunction("ceil(-123.0)", DOUBLE, -123.0);
         assertFunction("ceil(123.45)", DOUBLE, 124.0);
         assertFunction("ceil(-123.45)", DOUBLE, -123.0);
+        assertFunction("ceil(FLOAT '123.0')", DOUBLE, 123.0);
+        assertFunction("ceil(FLOAT '-123.0')", DOUBLE, -123.0);
+        assertFunction("ceil(FLOAT '123.45')", DOUBLE, 124.0);
+        assertFunction("ceil(FLOAT '-123.45')", DOUBLE, -123.0);
         assertFunction("ceil(CAST(NULL as DOUBLE))", DOUBLE, null);
         assertFunction("ceiling(12300000000)", BIGINT, 12300000000L);
         assertFunction("ceiling(-12300000000)", BIGINT, -12300000000L);
@@ -140,6 +150,10 @@ public class TestMathFunctions
         assertFunction("ceiling(-123.0)", DOUBLE, -123.0);
         assertFunction("ceiling(123.45)", DOUBLE, 124.0);
         assertFunction("ceiling(-123.45)", DOUBLE, -123.0);
+        assertFunction("ceiling(FLOAT '123.0')", DOUBLE, (double) 123.0f);
+        assertFunction("ceiling(FLOAT '-123.0')", DOUBLE, (double) -123.0f);
+        assertFunction("ceiling(FLOAT '123.45')", DOUBLE, (double) 124.0f);
+        assertFunction("ceiling(FLOAT '-123.45')", DOUBLE, (double) -123.0f);
         assertFunction("ceiling(CAST(NULL AS DOUBLE))", DOUBLE, null);
     }
 
@@ -152,6 +166,10 @@ public class TestMathFunctions
         assertFunction("truncate(-17.18)", DOUBLE, -17.0);
         assertFunction("truncate(17.88)", DOUBLE, 17.0);
         assertFunction("truncate(-17.88)", DOUBLE, -17.0);
+        assertFunction("truncate(FLOAT '17.18')", DOUBLE, (double) 17.0f);
+        assertFunction("truncate(FLOAT '-17.18')", DOUBLE, (double) -17.0f);
+        assertFunction("truncate(FLOAT '17.88')", DOUBLE, (double) 17.0f);
+        assertFunction("truncate(FLOAT '-17.88')", DOUBLE, (double) -17.0f);
         assertFunction("truncate(NULL)", DOUBLE, null);
         assertFunction("truncate(CAST(NULL AS DOUBLE))", DOUBLE, null);
         assertFunction("truncate(" + maxDouble + ")", DOUBLE, Double.MAX_VALUE);
@@ -163,6 +181,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("cos(" + doubleValue + ")", DOUBLE, Math.cos(doubleValue));
+            assertFunction("cos(FLOAT '" + (float) doubleValue + "')", DOUBLE, Math.cos((float) doubleValue));
         }
         assertFunction("cos(NULL)", DOUBLE, null);
     }
@@ -172,6 +191,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("cosh(" + doubleValue + ")", DOUBLE, Math.cosh(doubleValue));
+            assertFunction("cosh(FLOAT '" + (float) doubleValue + "')", DOUBLE, Math.cosh((float) doubleValue));
         }
         assertFunction("cosh(NULL)", DOUBLE, null);
     }
@@ -181,6 +201,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction(String.format("degrees(%s)", doubleValue), DOUBLE, Math.toDegrees(doubleValue));
+            assertFunction(String.format("degrees(FLOAT '%s')", (float) doubleValue), DOUBLE, Math.toDegrees((float) doubleValue));
         }
         assertFunction("degrees(NULL)", DOUBLE, null);
     }
@@ -196,6 +217,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("exp(" + doubleValue + ")", DOUBLE, Math.exp(doubleValue));
+            assertFunction("exp(FLOAT '" + (float) doubleValue + "')", DOUBLE, Math.exp((float) doubleValue));
         }
         assertFunction("exp(NULL)", DOUBLE, null);
     }
@@ -221,6 +243,10 @@ public class TestMathFunctions
         assertFunction("floor(-123.0)", DOUBLE, -123.0);
         assertFunction("floor(123.45)", DOUBLE, 123.0);
         assertFunction("floor(-123.45)", DOUBLE, -124.0);
+        assertFunction("floor(FLOAT '123.0')", DOUBLE, (double) 123.0f);
+        assertFunction("floor(FLOAT '-123.0')", DOUBLE, (double) -123.0f);
+        assertFunction("floor(FLOAT '123.45')", DOUBLE, (double) 123.0f);
+        assertFunction("floor(FLOAT '-123.45')", DOUBLE, (double) -124.0f);
         assertFunction("floor(CAST(NULL as DOUBLE))", DOUBLE, null);
     }
 
@@ -257,6 +283,7 @@ public class TestMathFunctions
         for (double doubleValue : DOUBLE_VALUES) {
             for (double base : DOUBLE_VALUES) {
                 assertFunction("log(" + doubleValue + ", " + base + ")", DOUBLE, Math.log(doubleValue) / Math.log(base));
+                assertFunction("log(FLOAT '" + (float) doubleValue + "', FLOAT'" + (float) base + "')", DOUBLE, Math.log((float) doubleValue) / Math.log((float) base));
             }
         }
         assertFunction("log(NULL, NULL)", DOUBLE, null);
@@ -291,6 +318,12 @@ public class TestMathFunctions
             }
         }
 
+        for (int left : intLefts) {
+            for (double right : doubleRights) {
+                assertFunction("mod(" + left + ", FLOAT '" + (float) right + "')", DOUBLE, (double) (left % (float) right));
+            }
+        }
+
         for (double left : doubleLefts) {
             for (long right : intRights) {
                 assertFunction("mod(" + left + ", " + right + ")", DOUBLE, left % right);
@@ -298,8 +331,20 @@ public class TestMathFunctions
         }
 
         for (double left : doubleLefts) {
+            for (long right : intRights) {
+                assertFunction("mod(FLOAT '" + (float) left + "', " + right + ")", DOUBLE, (double) ((float) left % right));
+            }
+        }
+
+        for (double left : doubleLefts) {
             for (double right : doubleRights) {
                 assertFunction("mod(" + left + ", " + right + ")", DOUBLE, left % right);
+            }
+        }
+
+        for (double left : doubleLefts) {
+            for (double right : doubleRights) {
+                assertFunction("mod(FLOAT '" + (float) left + "', FLOAT '" + (float) right + "')", DOUBLE, (double) ((float) left % (float) right));
             }
         }
         assertFunction("mod(5.0, NULL)", DOUBLE, null);
@@ -332,6 +377,9 @@ public class TestMathFunctions
         assertFunction("is_infinite(1.0 / 0.0)", BOOLEAN, true);
         assertFunction("is_infinite(0.0 / 0.0)", BOOLEAN, false);
         assertFunction("is_infinite(1.0 / 1.0)", BOOLEAN, false);
+        assertFunction("is_infinite(FLOAT '1.0' / FLOAT '0.0')", BOOLEAN, true);
+        assertFunction("is_infinite(FLOAT '0.0' / FLOAT '0.0')", BOOLEAN, false);
+        assertFunction("is_infinite(FLOAT '1.0' / FLOAT '1.0')", BOOLEAN, false);
         assertFunction("is_infinite(NULL)", BOOLEAN, null);
     }
 
@@ -340,6 +388,8 @@ public class TestMathFunctions
     {
         assertFunction("is_finite(100000)", BOOLEAN, true);
         assertFunction("is_finite(rand() / 0.0)", BOOLEAN, false);
+        assertFunction("is_finite(FLOAT '754.2008')", BOOLEAN, true);
+        assertFunction("is_finite(rand() / FLOAT '0.0')", BOOLEAN, false);
         assertFunction("is_finite(NULL)", BOOLEAN, null);
     }
 
@@ -348,6 +398,10 @@ public class TestMathFunctions
     {
         assertFunction("is_nan(0.0 / 0.0)", BOOLEAN, true);
         assertFunction("is_nan(0.0 / 1.0)", BOOLEAN, false);
+        assertFunction("is_nan(infinity() / infinity())", BOOLEAN, true);
+        assertFunction("is_nan(nan())", BOOLEAN, true);
+        assertFunction("is_nan(FLOAT '0.0' / FLOAT '0.0')", BOOLEAN, true);
+        assertFunction("is_nan(FLOAT '0.0' / 1.0)", BOOLEAN, false);
         assertFunction("is_nan(infinity() / infinity())", BOOLEAN, true);
         assertFunction("is_nan(nan())", BOOLEAN, true);
         assertFunction("is_nan(NULL)", BOOLEAN, null);
@@ -377,18 +431,21 @@ public class TestMathFunctions
         for (long left : intLefts) {
             for (double right : doubleRights) {
                 assertFunction("power(" + left + ", " + right + ")", DOUBLE, Math.pow(left, right));
+                assertFunction("power(" + left + ", FLOAT '" + (float) right + "')", DOUBLE, Math.pow(left, (float) right));
             }
         }
 
         for (double left : doubleLefts) {
             for (long right : intRights) {
                 assertFunction("power(" + left + ", " + right + ")", DOUBLE, Math.pow(left, right));
+                assertFunction("power(FLOAT '" + (float) left + "', " + right + ")", DOUBLE, Math.pow((float) left, right));
             }
         }
 
         for (double left : doubleLefts) {
             for (double right : doubleRights) {
                 assertFunction("power(" + left + ", " + right + ")", DOUBLE, Math.pow(left, right));
+                assertFunction("power(FLOAT '" + left + "', FLOAT '" + right + "')", DOUBLE, Math.pow((float) left, (float) right));
             }
         }
 
@@ -405,6 +462,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction(String.format("radians(%s)", doubleValue), DOUBLE, Math.toRadians(doubleValue));
+            assertFunction(String.format("radians(FLOAT '%s')", (float) doubleValue), DOUBLE, Math.toRadians((float) doubleValue));
         }
         assertFunction("radians(NULL)", DOUBLE, null);
     }
@@ -442,6 +500,14 @@ public class TestMathFunctions
         assertFunction("round(-3.5)", DOUBLE, -4.0);
         assertFunction("round(-3.5001)", DOUBLE, -4.0);
         assertFunction("round(-3.99)", DOUBLE, -4.0);
+        assertFunction("round(FLOAT '3.0')", DOUBLE, (double) 3.0f);
+        assertFunction("round(FLOAT '-3.0')", DOUBLE, (double) -3.0f);
+        assertFunction("round(FLOAT '3.499')", DOUBLE, (double) 3.0f);
+        assertFunction("round(FLOAT '-3.499')", DOUBLE, (double) -3.0f);
+        assertFunction("round(FLOAT '3.5')", DOUBLE, (double) 4.0f);
+        assertFunction("round(FLOAT '-3.5')", DOUBLE, (double) -4.0f);
+        assertFunction("round(FLOAT '-3.5001')", DOUBLE, (double) -4.0f);
+        assertFunction("round(FLOAT '-3.99')", DOUBLE, (double) -4.0f);
         assertFunction("round(CAST(NULL as DOUBLE))", DOUBLE, null);
         assertFunction("round(" + GREATEST_DOUBLE_LESS_THAN_HALF + ")", DOUBLE, 0.0);
         assertFunction("round(-" + 0x1p-1 + ")", DOUBLE, -1.0); // -0.5
@@ -467,6 +533,15 @@ public class TestMathFunctions
         assertFunction("round(0.3)", DOUBLE, 0.0);
         assertFunction("round(-0.3)", DOUBLE, -0.0);
 
+        assertFunction("round(FLOAT '3.0', 0)", DOUBLE, (double) 3.0f);
+        assertFunction("round(FLOAT '-3.0', 0)", DOUBLE, (double) -3.0f);
+        assertFunction("round(FLOAT '3.499', 0)", DOUBLE, (double) 3.0f);
+        assertFunction("round(FLOAT '-3.499', 0)", DOUBLE, (double) -3.0f);
+        assertFunction("round(FLOAT '3.5', 0)", DOUBLE, (double) 4.0f);
+        assertFunction("round(FLOAT '-3.5', 0)", DOUBLE, (double) -4.0f);
+        assertFunction("round(FLOAT '-3.5001', 0)", DOUBLE, (double) -4.0f);
+        assertFunction("round(FLOAT '-3.99', 0)", DOUBLE, (double) -4.0f);
+
         assertFunction("round(3, 1)", INTEGER, 3);
         assertFunction("round(-3, 1)", INTEGER, -3);
         assertFunction("round(BIGINT '3', 1)", BIGINT, 3L);
@@ -484,6 +559,15 @@ public class TestMathFunctions
         assertFunction("round(-3.5, 1)", DOUBLE, -3.5);
         assertFunction("round(-3.5001, 1)", DOUBLE, -3.5);
         assertFunction("round(-3.99, 1)", DOUBLE, -4.0);
+
+        assertFunction("round(FLOAT '3.0', 1)", DOUBLE, (double) 3.0f);
+        assertFunction("round(FLOAT '-3.0', 1)", DOUBLE, (double) -3.0f);
+        assertFunction("round(FLOAT '3.499', 1)", DOUBLE, (double) 3.5f);
+        assertFunction("round(FLOAT '-3.499', 1)", DOUBLE, (double) -3.5f);
+        assertFunction("round(FLOAT '3.5', 1)", DOUBLE, (double) 3.5f);
+        assertFunction("round(FLOAT '-3.5', 1)", DOUBLE, (double) -3.5f);
+        assertFunction("round(FLOAT '-3.5001', 1)", DOUBLE, (double) -3.5f);
+        assertFunction("round(FLOAT '-3.99', 1)", DOUBLE, (double) -4.0f);
         assertFunction("round(CAST(NULL as DOUBLE), CAST(NULL as BIGINT))", DOUBLE, null);
         assertFunction("round(-3.0, CAST(NULL as BIGINT))", DOUBLE, null);
         assertFunction("round(CAST(NULL as DOUBLE), 1)", DOUBLE, null);
@@ -516,6 +600,7 @@ public class TestMathFunctions
         //double
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("sign(" + doubleValue + ")", DOUBLE, Math.signum(doubleValue));
+            assertFunction("sign(FLOAT '" + (float) doubleValue + "')", DOUBLE, Math.signum((double) ((float) doubleValue)));
         }
 
         //returns NaN for NaN input
@@ -531,6 +616,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("sin(" + doubleValue + ")", DOUBLE, Math.sin(doubleValue));
+            assertFunction("sin(FLOAT '" + (float) doubleValue + "')", DOUBLE, Math.sin((float) doubleValue));
         }
         assertFunction("sin(NULL)", DOUBLE, null);
     }
@@ -540,6 +626,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("sqrt(" + doubleValue + ")", DOUBLE, Math.sqrt(doubleValue));
+            assertFunction("sqrt(FLOAT '" + doubleValue + "')", DOUBLE, Math.sqrt((float) doubleValue));
         }
         assertFunction("sqrt(NULL)", DOUBLE, null);
     }
@@ -549,6 +636,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("tan(" + doubleValue + ")", DOUBLE, Math.tan(doubleValue));
+            assertFunction("tan(FLOAT '" + (float) doubleValue + "')", DOUBLE, Math.tan((float) doubleValue));
         }
         assertFunction("tan(NULL)", DOUBLE, null);
     }
@@ -558,6 +646,7 @@ public class TestMathFunctions
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("tanh(" + doubleValue + ")", DOUBLE, Math.tanh(doubleValue));
+            assertFunction("tanh(FLOAT '" + doubleValue + "')", DOUBLE, Math.tanh((float) doubleValue));
         }
         assertFunction("tanh(NULL)", DOUBLE, null);
     }
@@ -600,6 +689,13 @@ public class TestMathFunctions
         assertFunction("greatest(-1.5, -2.3, -5/3)", DOUBLE, -1.0);
         assertFunction("greatest(1.5, -1.0 / 0.0, 1.0 / 0.0)", DOUBLE, Double.POSITIVE_INFINITY);
         assertFunction("greatest(5, 4, CAST(NULL as DOUBLE), 3)", DOUBLE, null);
+
+        // float
+        assertFunction("greatest(FLOAT '1.5', 2.3)", DOUBLE, 2.3);
+        assertFunction("greatest(FLOAT '-1.5', -2.3)", DOUBLE, (double) -1.5f);
+        assertFunction("greatest(-1.5, FLOAT '-2.3', -5/3)", DOUBLE, -1.0);
+        assertFunction("greatest(FLOAT '1.5', FLOAT '-1.0' / 0.0, 1.0 / FLOAT '0.0')", DOUBLE, (double) (1.0f / 0.0f));
+        assertFunction("greatest(5, FLOAT '4', CAST(NULL as DOUBLE), 3)", DOUBLE, null);
 
         // mixed
         assertFunction("greatest(1, 20000000000)", BIGINT, 20000000000L);
@@ -653,6 +749,13 @@ public class TestMathFunctions
         assertFunction("least(1.5, -1.0 / 0.0, 1.0 / 0.0)", DOUBLE, Double.NEGATIVE_INFINITY);
         assertFunction("least(5, 4, CAST(NULL as DOUBLE), 3)", DOUBLE, null);
 
+        // float
+        assertFunction("least(FLOAT '1.5', 2.3)", DOUBLE, (double) 1.5f);
+        assertFunction("least(FLOAT '-1.5', -2.3)", DOUBLE, -2.3);
+        assertFunction("least(-2.3, FLOAT '-0.4', -5/3)", DOUBLE, -2.3);
+        assertFunction("least(1.5, FLOAT '-1.0' / 0.0, 1.0 / 0.0)", DOUBLE, (double) (-1.0f / 0.0f));
+        assertFunction("least(FLOAT '5', 4, CAST(NULL as DOUBLE), 3)", DOUBLE, null);
+
         // mixed
         assertFunction("least(1, 20000000000)", BIGINT, 1L);
         assertFunction("least(1, BIGINT '2')", BIGINT, 1L);
@@ -671,6 +774,7 @@ public class TestMathFunctions
             throws Exception
     {
         functionAssertions.tryEvaluate("greatest(1.5, 0.0 / 0.0)", DOUBLE);
+        functionAssertions.tryEvaluate("greatest(1.5, FLOAT '0.0' / FLOAT '0.0')", DOUBLE);
     }
 
     @Test
@@ -738,6 +842,7 @@ public class TestMathFunctions
             throws Exception
     {
         functionAssertions.tryEvaluate("width_bucket(infinity(), 0, 4, " + Long.MAX_VALUE + ")", DOUBLE);
+        functionAssertions.tryEvaluate("width_bucket(cast(infinity() as float), 0, 4, " + Long.MAX_VALUE + ")", DOUBLE);
     }
 
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Bucket for value Infinity is out of range")
@@ -745,6 +850,7 @@ public class TestMathFunctions
             throws Exception
     {
         functionAssertions.tryEvaluate("width_bucket(infinity(), 4, 0, " + Long.MAX_VALUE + ")", DOUBLE);
+        functionAssertions.tryEvaluate("width_bucket(cast(infinity() as float), 4, 0, " + Long.MAX_VALUE + ")", DOUBLE);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTypeRegistry.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTypeRegistry.java
@@ -25,6 +25,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TimeType.TIME;
@@ -96,10 +97,20 @@ public class TestTypeRegistry
         assertTrue(typeRegistry.canCoerce(VARCHAR, LIKE_PATTERN));
         assertTrue(typeRegistry.canCoerce(VARCHAR, JSON_PATH));
 
+        assertTrue(typeRegistry.canCoerce(FLOAT, DOUBLE));
+        assertTrue(typeRegistry.canCoerce(TINYINT, FLOAT));
+        assertTrue(typeRegistry.canCoerce(SMALLINT, FLOAT));
+        assertTrue(typeRegistry.canCoerce(INTEGER, FLOAT));
+        assertTrue(typeRegistry.canCoerce(BIGINT, FLOAT));
+
         assertFalse(typeRegistry.canCoerce(DOUBLE, BIGINT));
         assertFalse(typeRegistry.canCoerce(TIMESTAMP, TIME_WITH_TIME_ZONE));
         assertFalse(typeRegistry.canCoerce(TIMESTAMP_WITH_TIME_ZONE, TIMESTAMP));
         assertFalse(typeRegistry.canCoerce(VARBINARY, VARCHAR));
+        assertFalse(canCoerce("float", "decimal(37,1)"));
+        assertFalse(canCoerce("float", "decimal(37,37)"));
+        assertFalse(canCoerce("double", "decimal(37,1)"));
+        assertFalse(canCoerce("double", "decimal(37,37)"));
 
         assertTrue(canCoerce("unknown", "array(bigint)"));
         assertFalse(canCoerce("array(bigint)", "unknown"));
@@ -123,6 +134,8 @@ public class TestTypeRegistry
 
         assertTrue(canCoerce("decimal(3,2)", "double"));
         assertTrue(canCoerce("decimal(22,1)", "double"));
+        assertTrue(canCoerce("decimal(3,2)", "float"));
+        assertTrue(canCoerce("decimal(22,1)", "float"));
 
         assertFalse(canCoerce("integer", "decimal(9,0)"));
         assertTrue(canCoerce("integer", "decimal(10,0)"));
@@ -154,6 +167,12 @@ public class TestTypeRegistry
         assertCommonSuperType(VARCHAR, LIKE_PATTERN, LIKE_PATTERN);
         assertCommonSuperType(VARCHAR, JSON_PATH, JSON_PATH);
 
+        assertCommonSuperType(FLOAT, DOUBLE, DOUBLE);
+        assertCommonSuperType(FLOAT, TINYINT, FLOAT);
+        assertCommonSuperType(FLOAT, SMALLINT, FLOAT);
+        assertCommonSuperType(FLOAT, INTEGER, FLOAT);
+        assertCommonSuperType(FLOAT, BIGINT, FLOAT);
+
         assertCommonSuperType(TIMESTAMP, TIME_WITH_TIME_ZONE, null);
         assertCommonSuperType(VARBINARY, VARCHAR, null);
 
@@ -169,6 +188,7 @@ public class TestTypeRegistry
         assertCommonSuperType("bigint", "decimal(18,0)", "decimal(19,0)");
         assertCommonSuperType("bigint", "decimal(19,0)", "decimal(19,0)");
         assertCommonSuperType("bigint", "decimal(37,1)", "decimal(37,1)");
+        assertCommonSuperType("float", "decimal(37,1)", "float");
         assertCommonSuperType("array(decimal(23,1))", "array(decimal(22,1))", "array(decimal(23,1))");
         assertCommonSuperType("array(bigint)", "array(decimal(2,1))", "array(decimal(20,1))");
 


### PR DESCRIPTION
Available coercions:
* NULL to FLOAT
* TINYINT to FLOAT
* SMALLINT to FLOAT
* INTEGER to FLOAT
* BIGINT to FLOAT (this is to allow coercing e.g. greatest(float, bigint)). PostgreSQL allows similar coercion.
* DECIMAL to FLOAT
* FLOAT to DOUBLE

This is continuation of https://github.com/prestodb/presto/pull/5388 (issue https://github.com/prestodb/presto/issues/4942).