### PR TITLE
Document Kerberos auth should be enabled with Kerberized Hive.

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive-security.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-security.rst
@@ -51,6 +51,20 @@ Lists)` to provide additional security for data.
 
 .. _hive-security-kerberos-support:
 
+.. warning::
+
+  Access to the Presto coordinator should be secured using Kerberos when using
+  Kerberos authentication to Hadoop services. Failure to secure access to the
+  Presto coordinator could result in unauthorized access to sensitive data on
+  the Hadoop cluster.
+
+  See the following sections of the documentation for information on setting up
+  Kerberos authentication.
+
+  :doc:`/security/server`
+
+  :doc:`/security/cli`
+
 Kerberos Support
 ================
 


### PR DESCRIPTION
Found this one hanging out locally and realized I'd never put up a PR for it. This should go in after #5217.

@electrum: Want to look this one over? I don't love the wording; the gist we're trying to convey is "If you've kerberized your Hadoop cluster, you've probably done so for a reason, so don't create a gaping hole by not securing Presto unless you're quite sure that's what you meant to do"