### PR TITLE
Fix race in task results API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -786,7 +786,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>2.4.3</version>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>54</version>
+        <version>55</version>
     </parent>
 
     <groupId>com.facebook.presto</groupId>
@@ -46,7 +46,7 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.5.1</dep.antlr.version>
-        <dep.airlift.version>0.128</dep.airlift.version>
+        <dep.airlift.version>0.130</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.22</dep.slice.version>
         <dep.aws-sdk.version>1.9.40</dep.aws-sdk.version>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -209,13 +209,12 @@
                                     <excludes>
                                         <exclude>META-INF/maven/**</exclude>
                                         <exclude>META-INF/*.xml</exclude>
+                                        <exclude>META-INF/services/org.eclipse.**</exclude>
+                                        <exclude>META-INF/services/com.fasterxml.**</exclude>
                                         <exclude>LICENSE</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>com.fasterxml.jackson.*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/**</exclude>
+                                        <exclude>*.css</exclude>
+                                        <exclude>*.html</exclude>
+                                        <exclude>jetty-logging.properties</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>
@@ -226,30 +225,6 @@
                                 </filter>
                                 <filter>
                                     <artifact>javax.validation:validation-api</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>io.airlift</artifact>
-                                    <excludes>
-                                        <exclude>jetty-logging.properties</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.eclipse.jetty:jetty-util</artifact>
-                                    <excludes>
-                                        <exclude>jetty-dir.css</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.eclipse.jetty:*</artifact>
-                                    <excludes>
-                                        <exclude>about.html</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>net.sf.opencsv:opencsv</artifact>
                                     <excludes>
                                         <exclude>**</exclude>
                                     </excludes>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -102,12 +102,6 @@
             <artifactId>annotations</artifactId>
         </dependency>
 
-        <!-- TODO: fix this in Airlift and remove this dependency -->
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-util</artifactId>
-        </dependency>
-
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>


### PR DESCRIPTION
A race in Jetty causes the results API to randomly fail with garbage
results (most frequently a 500 status code)