### PR TITLE
Reimplement getRange and copyRange for InterleavedBlock

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/block/TestInterleavedBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestInterleavedBlock.java
@@ -134,16 +134,17 @@ public class TestInterleavedBlock
         Type type = TYPES.get(position % TYPES.size());
         assertInterleavedPosition(ImmutableList.of(type), block.getSingleValueBlock(position), 0, expectedValue);
 
-        assertInterleavedPosition(ImmutableList.of(type), block.getRegion(position, 1), 0, expectedValue);
-        assertInterleavedPosition(TYPES, block.getRegion(0, position + 1), position, expectedValue);
-        assertInterleavedPosition(ImmutableList.of(type), block.getRegion(position, block.getPositionCount() - position), 0, expectedValue);
+        int alignedPosition = position - position % COLUMN_COUNT;
 
-        assertInterleavedPosition(ImmutableList.of(type), block.copyRegion(position, 1), 0, expectedValue);
-        assertInterleavedPosition(TYPES, block.copyRegion(0, position + 1), position, expectedValue);
-        assertInterleavedPosition(ImmutableList.of(type), block.copyRegion(position, block.getPositionCount() - position), 0, expectedValue);
+        assertInterleavedPosition(ImmutableList.of(type), block.getRegion(alignedPosition, COLUMN_COUNT), position - alignedPosition, expectedValue);
+        assertInterleavedPosition(TYPES, block.getRegion(0, alignedPosition + COLUMN_COUNT), position, expectedValue);
+        assertInterleavedPosition(ImmutableList.of(type), block.getRegion(alignedPosition, block.getPositionCount() - alignedPosition), position - alignedPosition, expectedValue);
 
-        int positionFloored = position / COLUMN_COUNT * COLUMN_COUNT;
-        assertInterleavedPosition(TYPES, block.copyPositions(IntStream.range(positionFloored, positionFloored + COLUMN_COUNT).boxed().collect(Collectors.toList())), position % COLUMN_COUNT, expectedValue);
+        assertInterleavedPosition(ImmutableList.of(type), block.copyRegion(alignedPosition, COLUMN_COUNT), position - alignedPosition, expectedValue);
+        assertInterleavedPosition(TYPES, block.copyRegion(0, alignedPosition + COLUMN_COUNT), position, expectedValue);
+        assertInterleavedPosition(ImmutableList.of(type), block.copyRegion(alignedPosition, block.getPositionCount() - alignedPosition), position - alignedPosition, expectedValue);
+
+        assertInterleavedPosition(TYPES, block.copyPositions(IntStream.range(alignedPosition, alignedPosition + COLUMN_COUNT).boxed().collect(Collectors.toList())), position % COLUMN_COUNT, expectedValue);
     }
 
     private <T> void assertInterleavedPosition(List<Type> types, Block block, int position, T expectedValue)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlock.java
@@ -35,37 +35,17 @@ public class InterleavedBlock
         super(blocks.length);
         this.blocks = blocks;
 
-        // Aside from calculating sizeInBytes, retainedSizeInBytes, and positionCount,
-        // the loop below verifies that the position count of sub-blocks in the InterleavedBlock
-        // * differs by at most one
-        // * is non-ascending
         int sizeInBytes = 0;
         int retainedSizeInBytes = INSTANCE_SIZE;
         int positionCount = 0;
-        if (blocks.length != 0) {
-            int firstSubBlockPositionCount = blocks[0].getPositionCount();
-            boolean subBlockHasDifferentSize = false;
-            for (int i = 0; i < getBlockCount(); i++) {
-                sizeInBytes += blocks[i].getSizeInBytes();
-                retainedSizeInBytes += blocks[i].getRetainedSizeInBytes();
-                positionCount += blocks[i].getPositionCount();
+        int firstSubBlockPositionCount = blocks[0].getPositionCount();
+        for (int i = 0; i < getBlockCount(); i++) {
+            sizeInBytes += blocks[i].getSizeInBytes();
+            retainedSizeInBytes += blocks[i].getRetainedSizeInBytes();
+            positionCount += blocks[i].getPositionCount();
 
-                if (subBlockHasDifferentSize) {
-                    if (firstSubBlockPositionCount - 1 != blocks[i].getPositionCount()) {
-                        throw new IllegalArgumentException(
-                                "length of sub blocks differ by at least 2 or is not non-ascending: block 0: " + firstSubBlockPositionCount + ", block " + i + ": " + blocks[i].getPositionCount());
-                    }
-                }
-                else {
-                    if (firstSubBlockPositionCount != blocks[i].getPositionCount()) {
-                        if (firstSubBlockPositionCount - 1 == blocks[i].getPositionCount()) {
-                            subBlockHasDifferentSize = true;
-                        }
-                        else {
-                            throw new IllegalArgumentException("length of sub blocks differ by at least 2: block 0: " + firstSubBlockPositionCount + ", block " + i + ": " + blocks[i].getPositionCount());
-                        }
-                    }
-                }
+            if (firstSubBlockPositionCount != blocks[i].getPositionCount()) {
+                throw new IllegalArgumentException("length of sub blocks differ: block 0: " + firstSubBlockPositionCount + ", block " + i + ": " + blocks[i].getPositionCount());
             }
         }
 
@@ -90,9 +70,7 @@ public class InterleavedBlock
     @Override
     public Block getRegion(int position, int length)
     {
-        if (position < 0 || length < 0 || position + length > positionCount) {
-            throw new IndexOutOfBoundsException("Invalid position (" + position + "), length (" + length + ") in block with " + positionCount + " positions");
-        }
+        validateRange(position, length);
         return new InterleavedBlock(blocks, computePosition(position), length, retainedSizeInBytes, blockEncoding);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlockBuilder.java
@@ -238,7 +238,8 @@ public class InterleavedBlockBuilder
     @Override
     public Block getRegion(int position, int length)
     {
-        return getRegion(position, length, false);
+        validateRange(position, length);
+        return sliceRange(position, length, false);
     }
 
     @Override


### PR DESCRIPTION
Fixes #5516 

* The new implementation does not support non-aligned getRange and copyRange.
* Special handling for zero-column InterleavedBlock is removed because they
  are no longer constructed.
* This fixes bugs related handling of zero-column InterleavedBlock
  and zero-position InterleavedBlock. Specifically,
  * Before this commit, calling copyRegion on a zero-column InterleavedBlock
    causes div-by-zero exception
  * Before this commit, calling getRegion and semiCompact subsequently on a
    zero-length block can produce a zero-column InterleavedBlock