### PR TITLE
Remove hard JDBC driver dependency on jetty-util

### DIFF
--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -102,12 +102,6 @@
             <artifactId>annotations</artifactId>
         </dependency>
 
-        <!-- TODO: fix this in Airlift and remove this dependency -->
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-util</artifactId>
-        </dependency>
-
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>


### PR DESCRIPTION
This also fixes the useless `Logging initialized ...` log message that several users have complained about.