### PR TITLE
Fix: MongoDB ObjectId handling in queries

### DIFF
--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <mongo-java.version>3.1.0</mongo-java.version>
+        <mongo-java.version>3.2.2</mongo-java.version>
         <mongo-server.version>1.5.0</mongo-server.version>
         <netty.version>4.0.32.Final</netty.version>
     </properties>

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -280,6 +280,8 @@ public class MongoSession
     private static Document buildPredicate(MongoColumnHandle column, Domain domain)
     {
         String name = column.getName();
+        Type type = column.getType();
+
         if (domain.getValues().isNone() && domain.isNullAllowed()) {
             return documentOf(name, isNullPredicate());
         }
@@ -331,11 +333,11 @@ public class MongoSession
 
         // Add back all of the possible single values either as an equality or an IN predicate
         if (singleValues.size() == 1) {
-            disjuncts.add(documentOf(EQ_OP, translateValue(singleValues.get(0))));
+            disjuncts.add(documentOf(EQ_OP, translateValue(singleValues.get(0), type)));
         }
         else if (singleValues.size() > 1) {
             disjuncts.add(documentOf(IN_OP, singleValues.stream()
-                    .map(MongoSession::translateValue)
+                    .map(value -> translateValue(value, type))
                     .collect(toList())));
         }
 
@@ -348,10 +350,15 @@ public class MongoSession
                             .collect(toList()));
     }
 
-    private static Object translateValue(Object source)
+    private static Object translateValue(Object source, Type type)
     {
         if (source instanceof Slice) {
-            return ((Slice) source).toStringUtf8();
+            if (type instanceof ObjectIdType) {
+                return new ObjectId(((Slice) source).getBytes());
+            }
+            else {
+                return ((Slice) source).toStringUtf8();
+            }
         }
 
         return source;

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -193,6 +193,9 @@ public class TestingPrestoClient
         else if (VARBINARY.equals(type)) {
             return value;
         }
+        else if (type.toString().equals("ObjectId")) { // So there's no circular dependency (presto-mongodb -> presto-tests -> presto-mongodb)
+            return value;
+        }
         else if (DATE.equals(type)) {
             int days = parseDate((String) value);
             return new Date(TimeUnit.DAYS.toMillis(days));


### PR DESCRIPTION
Presto-mongodb fails to return results when querying ObjectId columns.
## The Symptom

For example, a query to show the first few records in a collection:

```
presto> SELECT _id, * FROM mongodb.test.things LIMIT 5;
                 _id                 |  status  
-------------------------------------+----------
 54 f8 6a 93 9e 5b c3 d6 27 87 57 c5 | dead     
 54 f8 72 01 c6 4f a0 66 28 d5 96 ca | dead     
 54 f8 73 65 c6 4f a0 66 28 d5 96 cb | dead     
 54 f8 80 eb f8 41 a3 0f 29 19 78 96 | dead     
 54 f8 80 f0 f8 41 a3 0f 29 19 78 97 | dead     
(5 rows)
```

However, when trying to filter on an ObjectId column:

```
presto> SELECT _id, * FROM mongodb.test.things WHERE _id = ObjectId('54f86a939e5bc3d6278757c5');
(0 rows)
```
## The Problem

After turning on MongoDB query logging, the problem was pretty clear:

This:

```
presto> SELECT _id, * FROM mongodb.test.things WHERE _id = ObjectId('54f86a939e5bc3d6278757c5');
```

Turned into this:

```
2016-06-25T18:59:43.180+0000 [conn2] query test.things query: { _id: { $eq: "T�j��[��'�W�" } } planSummary: IXSCAN { _id: 1 } ntoreturn:0 ntoskip:0 nscanned:0 nscannedObjects:0 keyUpdates:0 numYields:0 locks(micros) r:193 nreturned:0 reslen:20 0ms
```

The plugin is converting the 12-byte ObjectId into a UTF-8 string. That, clearly, won't work!
## The Solution

To fix the issue, I added column-type checking to the query builder process. If the column is known to be of type ObjectId, then the translator takes that into account when building the BSON query.

So now, these:

```
presto> SELECT _id, * FROM mongodb.test.things WHERE _id = ObjectId('54f86a939e5bc3d6278757c5');
(1 row)

presto> SELECT _id, * FROM mongodb.test.things WHERE _id IN (ObjectId('54f86a939e5bc3d6278757c5'), ObjectId('54f88195f3550d2129e71abb'));
(2 rows)
```

Return the desired result and translate into (respectively):

```
2016-06-25T20:01:51.980+0000 [conn37] query test.things query: { _id: { $eq: ObjectId('54f86a939e5bc3d6278757c5') } } planSummary: IXSCAN { _id: 1 } ntoreturn:0 ntoskip:0 nscanned:1 nscannedObjects:1 keyUpdates:0 numYields:0 locks(micros) r:287 nreturned:1 reslen:519 0ms

2016-06-25T20:02:29.033+0000 [conn37] query test.things query: { _id: { $in: [ ObjectId('54f86a939e5bc3d6278757c5'), ObjectId('54f88195f3550d2129e71abb') ] } } planSummary: IXSCAN { _id: 1 } ntoreturn:0 ntoskip:0 nscanned:3 nscannedObjects:2 keyUpdates:0 numYields:0 locks(micros) r:298 nreturned:2 reslen:1409 0ms
```
## Testing

Additionally, to ensure this doesn't regress, I've added tests to ensure that the ObjectId functionality continues to work. There were previously no tests checking ObjectIds. This may have been due to the fact that the presto-tests system wouldn't convert ObjectId types. As such, I added a basic handling in `convertToRowValue` to deal with it.

Lastly, for good housekeeping, I bumped the mongo-java dependency version to 3.2.2, up from 3.1.0, since it hasn't been updated in almost a year. This should not be an issue, as the 3.2 driver is compatible with the 3.1 driver.
