### PR TITLE
support openjdk for rpm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ See the [User Manual](https://prestodb.io/docs/current/) for deployment instruct
 
 * Mac OS X or Linux
 * Java 8 Update 60 or higher (8u60+), 64-bit
+  * Presto supports only Oracle Java
 * Maven 3.3.9+ (for building)
 * Python 2.4+ (for running with the launcher script)
 

--- a/presto-server-rpm/src/main/rpm/preinstall
+++ b/presto-server-rpm/src/main/rpm/preinstall
@@ -6,7 +6,7 @@ java_version() {
 # The one argument is the location of java (either $JAVA_HOME or a potential
 # candidate for JAVA_HOME.
   JAVA="$1"/bin/java
-  "$JAVA" -version 2>&1 | grep "java version" | awk '{ print substr($3, 2, length($3)-2); }'
+  "$JAVA" -version 2>&1 | grep "\(java\|openjdk\) version" | awk '{ print substr($3, 2, length($3)-2); }'
 }
 
 java_vendor() {


### PR DESCRIPTION
Hello.

I use openjdk.
When it is openjdk, cannot install it in RPM.
## openjdk

```
$ java -version
openjdk version "1.8.0_91"
OpenJDK Runtime Environment (build 1.8.0_91-b14)
OpenJDK 64-Bit Server VM (build 25.91-b14, mixed mode)
```
## oracle

```
$ java -version
java version "1.8.0_77"
Java(TM) SE Runtime Environment (build 1.8.0_77-b03)
Java HotSpot(TM) 64-Bit Server VM (build 25.77-b03, mixed mode)
```
