### PR TITLE
Unquarantine testSelectPartitionedHiveTableDifferentFormats

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestTablePartitioningSelect.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestTablePartitioningSelect.java
@@ -30,7 +30,6 @@ import java.sql.SQLException;
 import java.util.Optional;
 
 import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
-import static com.facebook.presto.tests.TestGroups.QUARANTINE;
 import static com.teradata.tempto.Requirements.allOf;
 import static com.teradata.tempto.assertions.QueryAssert.Row.row;
 import static com.teradata.tempto.assertions.QueryAssert.assertThat;
@@ -91,7 +90,7 @@ public class TestTablePartitioningSelect
         );
     }
 
-    @Test(groups = {HIVE_CONNECTOR, QUARANTINE})
+    @Test(groups = {HIVE_CONNECTOR})
     public void testSelectPartitionedHiveTableDifferentFormats()
             throws SQLException
     {


### PR DESCRIPTION
This test was fixed by https://github.com/prestodb/presto/commit/39f65662ab3949fe8994763273c96a2edc489bf4. Prior to that it was unstable because it relied on `QueryStats`. After the fix, it was quarantined by https://github.com/prestodb/presto/commit/ae664f895670060f71f773b780ce7bfa4f1645c9. My guess is that the quarantining happened because of a bad rebase (the author was working on the commit and quarantined the test because it was failing intermittently and then forgot to un-quarantine it after).

Here's the travis build passing with the test un-quarantined https://travis-ci.org/Teradata/presto/builds/141104953.