### PR TITLE
Improve documentation for MySQL date time functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -167,7 +167,7 @@ Specifier Description
 ``%D``    Day of the month with English suffix (``0th``, ``1st``, ``2nd``, ``3rd``, ...)
 ``%d``    Day of the month, numeric (``00`` .. ``31``)
 ``%e``    Day of the month, numeric (``0`` .. ``31``)
-``%f``    Fraction of second (1 - 9 digits: ``0`` .. ``999999999``)
+``%f``    Fraction of second (6 digits for printing: ``000000`` .. ``999000``; 1 - 9 digits for parsing: ``0`` .. ``999999999`` [#f]_)
 ``%H``    Hour (``00`` .. ``23``)
 ``%h``    Hour (``01`` .. ``12``)
 ``%I``    Hour (``01`` .. ``12``)
@@ -191,20 +191,15 @@ Specifier Description
 ``%X``    Year for the week where Sunday is the first day of the week, numeric, four digits; used with ``%V``
 ``%x``    Year for the week, where Monday is the first day of the week, numeric, four digits; used with ``%v``
 ``%Y``    Year, numeric, four digits
-``%y``    Year, numeric (two digits)
+``%y``    Year, numeric (two digits) [#y]_
 ``%%``    A literal ``%`` character
 ``%x``    ``x``, for any ``x`` not listed above
 ========= ===========
 
-.. warning:: Two-digit year format assumes range 1970 .. 2069, so "70" will result in year 1970 but "69" will produce 2069.
+.. [#f] Timestamp is truncated to milliseconds.
+.. [#y] When parsing, two-digit year format assumes range ``1970`` .. ``2069``, so "70" will result in year ``1970`` but "69" will produce ``2069``.
 
 .. warning:: The following specifiers are not currently supported: ``%D %U %u %V %X``
-
-.. warning:: Timestamp is truncated to milliseconds
-
-.. note:: ``Fraction of second`` behaves the same way as ``Microseconds`` from the MySQL reference manual (for the ``date_format`` function)
-    Similarly to MySQL, it accepts between 1 and 9 digits of input.
-    Timestamps in Presto have millisecond precision, so "12" will result in "120" milliseconds, "1234" will produce "123" because of truncation.
 
 .. function:: date_format(timestamp, format) -> varchar
 


### PR DESCRIPTION
I changed the text slightly after submitting the pull request. Use this screenshot to understand the format only:

![screen shot 2016-07-01 at 11 21 56 am](https://cloud.githubusercontent.com/assets/2020503/16530730/560c4c1a-3f7e-11e6-9462-257176484eaf.png)
