### PR TITLE
JDBC PrestoConnection to leverage properties

### DIFF
--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
@@ -1145,11 +1145,27 @@ public class TestDriver
     public void testConnectionWithSSL()
             throws Exception
     {
-        String url = format("jdbc:presto://some-ssl-server:443/%s", "blackhole");
+        String url;
+
+        url = format("jdbc:presto://some-ssl-server:443/%s", "blackhole");
         try (PrestoConnection connection = (PrestoConnection) DriverManager.getConnection(url, "test", null)) {
             URI uri = connection.getHttpUri();
             assertEquals(uri.getPort(), 443);
             assertEquals(uri.getScheme(), "https");
+        }
+
+        url = format("jdbc:presto://some-ssl-server:443/%s?ssl=true", "blackhole");
+        try (PrestoConnection connection = (PrestoConnection) DriverManager.getConnection(url, "test", null)) {
+            URI uri = connection.getHttpUri();
+            assertEquals(uri.getPort(), 443);
+            assertEquals(uri.getScheme(), "https");
+        }
+
+        url = format("jdbc:presto://some-ssl-server:443/%s?ssl=false", "blackhole");
+        try (PrestoConnection connection = (PrestoConnection) DriverManager.getConnection(url, "test", null)) {
+            URI uri = connection.getHttpUri();
+            assertEquals(uri.getPort(), 443);
+            assertEquals(uri.getScheme(), "http");
         }
     }
 

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
@@ -37,6 +37,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Properties;
 import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -119,7 +120,9 @@ public class TestProgressMonitor
         HttpClient client = new TestingHttpClient(new TestingHttpClientProcessor(RESPONSES));
         QueryExecutor testQueryExecutor = QueryExecutor.create(client);
         URI uri = URI.create(format("prestotest://%s", SERVER_ADDRESS));
-        return new PrestoConnection(uri, "test", testQueryExecutor);
+        Properties props = new Properties();
+        props.setProperty("user", "test");
+        return new PrestoConnection(uri, props, testQueryExecutor);
     }
 
     private static class TestingHttpClientProcessor


### PR DESCRIPTION
Change PrestoConnection constructor to honor JDBC properties. This
change also parses Query string of URI as JDBC properties like
PostgreSQL JDBC Driver and uses "user" and "ssl" properties.

Now we accept "jdbc:presto://host:8443/name?ssl=true" to communicate with
HTTPS at non default port. Also we accept
"jdbc:presto://host:443/name?ssl=false to communicate in plain HTTP at
443 port, no one would want to do though.