### PR TITLE
JDBC Driver fix column sizes of types

### DIFF
--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.DateType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.FloatType;
 import com.facebook.presto.spi.type.IntegerType;
 import com.facebook.presto.spi.type.SmallintType;
 import com.facebook.presto.spi.type.TimeType;
@@ -740,6 +741,7 @@ public class TestDriver
                         "c_integer integer, " +
                         "c_smallint smallint, " +
                         "c_tinyint tinyint, " +
+                        "c_float float, " +
                         "c_double double, " +
                         "c_varchar_1234 varchar(1234), " +
                         "c_varchar varchar, " +
@@ -752,37 +754,37 @@ public class TestDriver
                         "c_decimal_8_2 decimal(8,2), " +
                         "c_decimal_38_0 decimal(38,0)" +
                         ")"), 0);
-        }
 
-        try (Connection connection = createConnection()) {
             try (ResultSet rs = connection.getMetaData().getColumns("blackhole", "blackhole", "test_get_columns_table", null)) {
                 assertColumnMetadata(rs);
-                assertColumnSpec(rs, null, null, 0L, BooleanType.BOOLEAN);
-                assertColumnSpec(rs, 19L, null, 0L, BigintType.BIGINT);
-                assertColumnSpec(rs, 10L, null, 0L, IntegerType.INTEGER);
-                assertColumnSpec(rs, 5L, null, 0L, SmallintType.SMALLINT);
-                assertColumnSpec(rs, 3L, null, 0L, TinyintType.TINYINT);
-                assertColumnSpec(rs, null, null, 0L, DoubleType.DOUBLE);
-                assertColumnSpec(rs, 1234L, null, 1234L, VarcharType.createVarcharType(1234));
-                assertColumnSpec(rs, (long) Integer.MAX_VALUE, null, (long) Integer.MAX_VALUE, VarcharType.createUnboundedVarcharType());
-                assertColumnSpec(rs, 2147483647L, null, 0L, VarbinaryType.VARBINARY);
-                assertColumnSpec(rs, 8L, null, 0L, TimeType.TIME);
-                assertColumnSpec(rs, 14L, null, 0L, TimeWithTimeZoneType.TIME_WITH_TIME_ZONE);
-                assertColumnSpec(rs, 23L, null, 0L, TimestampType.TIMESTAMP);
-                assertColumnSpec(rs, 29L, null, 0L, TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE);
-                assertColumnSpec(rs, 15L, null, 0L, DateType.DATE);
-                assertColumnSpec(rs, 8L, 2L, 0L, DecimalType.createDecimalType(8, 2));
-                assertColumnSpec(rs, 38L, 0L, 0L, DecimalType.createDecimalType(38, 0));
+                assertColumnSpec(rs, Types.BOOLEAN, null, null, 0L, BooleanType.BOOLEAN);
+                assertColumnSpec(rs, Types.BIGINT, 19L, null, 0L, BigintType.BIGINT);
+                assertColumnSpec(rs, Types.INTEGER, 10L, null, 0L, IntegerType.INTEGER);
+                assertColumnSpec(rs, Types.SMALLINT, 5L, null, 0L, SmallintType.SMALLINT);
+                assertColumnSpec(rs, Types.TINYINT, 3L, null, 0L, TinyintType.TINYINT);
+                assertColumnSpec(rs, Types.FLOAT, null, null, 0L, FloatType.FLOAT);
+                assertColumnSpec(rs, Types.DOUBLE, null, null, 0L, DoubleType.DOUBLE);
+                assertColumnSpec(rs, Types.LONGNVARCHAR, 1234L, null, 1234L, VarcharType.createVarcharType(1234));
+                assertColumnSpec(rs, Types.LONGNVARCHAR, (long) Integer.MAX_VALUE, null, (long) Integer.MAX_VALUE, VarcharType.createUnboundedVarcharType());
+                assertColumnSpec(rs, Types.LONGVARBINARY, 2147483647L, null, 0L, VarbinaryType.VARBINARY);
+                assertColumnSpec(rs, Types.TIME, 8L, null, 0L, TimeType.TIME);
+                assertColumnSpec(rs, Types.TIME_WITH_TIMEZONE, 14L, null, 0L, TimeWithTimeZoneType.TIME_WITH_TIME_ZONE);
+                assertColumnSpec(rs, Types.TIMESTAMP, 23L, null, 0L, TimestampType.TIMESTAMP);
+                assertColumnSpec(rs, Types.TIMESTAMP_WITH_TIMEZONE, 29L, null, 0L, TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE);
+                assertColumnSpec(rs, Types.DATE, 15L, null, 0L, DateType.DATE);
+                assertColumnSpec(rs, Types.DECIMAL, 8L, 2L, 0L, DecimalType.createDecimalType(8, 2));
+                assertColumnSpec(rs, Types.DECIMAL, 38L, 0L, 0L, DecimalType.createDecimalType(38, 0));
                 assertFalse(rs.next());
             }
         }
     }
 
-    private static void assertColumnSpec(ResultSet rs, Long columnSize, Long decimalDigits, Long charOctetLength, Type type)
+    private static void assertColumnSpec(ResultSet rs, int jdbcType, Long columnSize, Long decimalDigits, Long charOctetLength, Type type)
             throws SQLException
     {
         String message = type.getDisplayName();
         assertTrue(rs.next());
+        assertEquals(rs.getObject("DATA_TYPE"), Long.valueOf(jdbcType), "DATA_TYPE of " + message);
         assertEquals(rs.getObject("COLUMN_SIZE"), columnSize, "COLUMN_SIZE of " + message);
         assertEquals(rs.getObject("DECIMAL_DIGITS"), decimalDigits, "DECIMAL_DIGITS of " + message);
         assertEquals(rs.getObject("CHAR_OCTET_LENGTH"), charOctetLength, "CHAR_OCTET_LENGTH of " + message);

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
@@ -15,6 +15,21 @@ package com.facebook.presto.jdbc;
 
 import com.facebook.presto.plugin.blackhole.BlackHolePlugin;
 import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.DateType;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.SmallintType;
+import com.facebook.presto.spi.type.TimeType;
+import com.facebook.presto.spi.type.TimeWithTimeZoneType;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.TimestampWithTimeZoneType;
+import com.facebook.presto.spi.type.TinyintType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarbinaryType;
+import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.tpch.TpchMetadata;
 import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableList;
@@ -741,33 +756,34 @@ public class TestDriver
         try (Connection connection = createConnection()) {
             try (ResultSet rs = connection.getMetaData().getColumns("blackhole", "blackhole", "test_get_columns_table", null)) {
                 assertColumnMetadata(rs);
-                assertColumnSpec(rs, null,          null,   0L);    // boolean
-                assertColumnSpec(rs, 19L,           null,   0L);    // bigint
-                assertColumnSpec(rs, 10L,           null,   0L);    // integer
-                assertColumnSpec(rs, 5L,            null,   0L);    // smallint
-                assertColumnSpec(rs, 3L,            null,   0L);    // tinyint
-                assertColumnSpec(rs, null,          null,   0L);    // double
-                assertColumnSpec(rs, 1234L,         null,   1234L); // varchar(1234)
-                assertColumnSpec(rs, 2147483647L,   null,   0L);    // varbinary
-                assertColumnSpec(rs, 8L,            null,   0L);    // time
-                assertColumnSpec(rs, 14L,           null,   0L);    // time with time zone
-                assertColumnSpec(rs, 23L,           null,   0L);    // timestamp
-                assertColumnSpec(rs, 29L,           null,   0L);    // timestamp with time zone
-                assertColumnSpec(rs, 15L,           null,   0L);    // date
-                assertColumnSpec(rs, 8L,            2L,     0L);    // decimal
-                assertColumnSpec(rs, 38L,           0L,     0L);    // decimal
+                assertColumnSpec(rs, null, null, 0L, BooleanType.BOOLEAN);
+                assertColumnSpec(rs, 19L, null, 0L, BigintType.BIGINT);
+                assertColumnSpec(rs, 10L, null, 0L, IntegerType.INTEGER);
+                assertColumnSpec(rs, 5L, null, 0L, SmallintType.SMALLINT);
+                assertColumnSpec(rs, 3L, null, 0L, TinyintType.TINYINT);
+                assertColumnSpec(rs, null, null, 0L, DoubleType.DOUBLE);
+                assertColumnSpec(rs, 1234L, null, 1234L, VarcharType.createVarcharType(1234));
+                assertColumnSpec(rs, 2147483647L, null, 0L, VarbinaryType.VARBINARY);
+                assertColumnSpec(rs, 8L, null, 0L, TimeType.TIME);
+                assertColumnSpec(rs, 14L, null, 0L, TimeWithTimeZoneType.TIME_WITH_TIME_ZONE);
+                assertColumnSpec(rs, 23L, null, 0L, TimestampType.TIMESTAMP);
+                assertColumnSpec(rs, 29L, null, 0L, TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE);
+                assertColumnSpec(rs, 15L, null, 0L, DateType.DATE);
+                assertColumnSpec(rs, 8L, 2L, 0L, DecimalType.createDecimalType(8, 2));
+                assertColumnSpec(rs, 38L, 0L, 0L, DecimalType.createDecimalType(38, 0));
                 assertFalse(rs.next());
             }
         }
     }
 
-    private static void assertColumnSpec(ResultSet rs, Long columnSize, Long decimalDigits, Long charOctetLength)
+    private static void assertColumnSpec(ResultSet rs, Long columnSize, Long decimalDigits, Long charOctetLength, Type type)
             throws SQLException
     {
+        String message = type.getDisplayName();
         assertTrue(rs.next());
-        assertEquals(rs.getObject("COLUMN_SIZE"), columnSize);
-        assertEquals(rs.getObject("DECIMAL_DIGITS"), decimalDigits);
-        assertEquals(rs.getObject("CHAR_OCTET_LENGTH"), charOctetLength);
+        assertEquals(rs.getObject("COLUMN_SIZE"), columnSize, "COLUMN_SIZE of " + message);
+        assertEquals(rs.getObject("DECIMAL_DIGITS"), decimalDigits, "DECIMAL_DIGITS of " + message);
+        assertEquals(rs.getObject("CHAR_OCTET_LENGTH"), charOctetLength, "CHAR_OCTET_LENGTH of " + message);
     }
 
     private static void assertColumnMetadata(ResultSet rs)

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
@@ -715,6 +715,59 @@ public class TestDriver
                 assertFalse(rs.next());
             }
         }
+
+        try (Connection connection = createConnection("blackhole", "blackhole");
+            Statement statement = connection.createStatement()) {
+                assertEquals(statement.executeUpdate(
+                    "CREATE TABLE test_get_columns_table (" +
+                        "c1 boolean, " +
+                        "c2 bigint, " +
+                        "c3 integer, " +
+                        "c4 smallint, " +
+                        "c5 tinyint, " +
+                        "c6 double, " +
+                        "c7 varchar(1234), " +
+                        "c8 varbinary, " +
+                        "c9 time, " +
+                        "c10 \"time with time zone\", " +
+                        "c11 timestamp, " +
+                        "c12 \"timestamp with time zone\", " +
+                        "c13 date, " +
+                        "c14 decimal(8,2), " +
+                        "c15 decimal(38,0)" +
+                        ")"), 0);
+        }
+
+        try (Connection connection = createConnection()) {
+            try (ResultSet rs = connection.getMetaData().getColumns("blackhole", "blackhole", "test_get_columns_table", null)) {
+                assertColumnMetadata(rs);
+                assertColumnSpec(rs, null,          null,   0L);    // boolean
+                assertColumnSpec(rs, 19L,           null,   0L);    // bigint
+                assertColumnSpec(rs, 10L,           null,   0L);    // integer
+                assertColumnSpec(rs, 5L,            null,   0L);    // smallint
+                assertColumnSpec(rs, 3L,            null,   0L);    // tinyint
+                assertColumnSpec(rs, null,          null,   0L);    // double
+                assertColumnSpec(rs, 1234L,         null,   1234L); // varchar(1234)
+                assertColumnSpec(rs, 2147483647L,   null,   0L);    // varbinary
+                assertColumnSpec(rs, 8L,            null,   0L);    // time
+                assertColumnSpec(rs, 14L,           null,   0L);    // time with time zone
+                assertColumnSpec(rs, 23L,           null,   0L);    // timestamp
+                assertColumnSpec(rs, 29L,           null,   0L);    // timestamp with time zone
+                assertColumnSpec(rs, 15L,           null,   0L);    // date
+                assertColumnSpec(rs, 8L,            2L,     0L);    // decimal
+                assertColumnSpec(rs, 38L,           0L,     0L);    // decimal
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertColumnSpec(ResultSet rs, Long columnSize, Long decimalDigits, Long charOctetLength)
+            throws SQLException
+    {
+        assertTrue(rs.next());
+        assertEquals(rs.getObject("COLUMN_SIZE"), columnSize);
+        assertEquals(rs.getObject("DECIMAL_DIGITS"), decimalDigits);
+        assertEquals(rs.getObject("CHAR_OCTET_LENGTH"), charOctetLength);
     }
 
     private static void assertColumnMetadata(ResultSet rs)

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
@@ -33,6 +33,8 @@ import com.facebook.presto.spi.type.VarbinaryType;
 import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.tpch.TpchMetadata;
 import com.facebook.presto.tpch.TpchPlugin;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.ColorType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.log.Logging;
@@ -752,28 +754,32 @@ public class TestDriver
                         "c_timestamp_with_time_zone \"timestamp with time zone\", " +
                         "c_date date, " +
                         "c_decimal_8_2 decimal(8,2), " +
-                        "c_decimal_38_0 decimal(38,0)" +
+                        "c_decimal_38_0 decimal(38,0), " +
+                        "c_array array<bigint>, " +
+                        "c_color color" +
                         ")"), 0);
 
             try (ResultSet rs = connection.getMetaData().getColumns("blackhole", "blackhole", "test_get_columns_table", null)) {
                 assertColumnMetadata(rs);
-                assertColumnSpec(rs, Types.BOOLEAN, null, null, 0L, BooleanType.BOOLEAN);
-                assertColumnSpec(rs, Types.BIGINT, 19L, null, 0L, BigintType.BIGINT);
-                assertColumnSpec(rs, Types.INTEGER, 10L, null, 0L, IntegerType.INTEGER);
-                assertColumnSpec(rs, Types.SMALLINT, 5L, null, 0L, SmallintType.SMALLINT);
-                assertColumnSpec(rs, Types.TINYINT, 3L, null, 0L, TinyintType.TINYINT);
-                assertColumnSpec(rs, Types.FLOAT, null, null, 0L, FloatType.FLOAT);
-                assertColumnSpec(rs, Types.DOUBLE, null, null, 0L, DoubleType.DOUBLE);
+                assertColumnSpec(rs, Types.BOOLEAN, null, null, null, BooleanType.BOOLEAN);
+                assertColumnSpec(rs, Types.BIGINT, 19L, null, null, BigintType.BIGINT);
+                assertColumnSpec(rs, Types.INTEGER, 10L, null, null, IntegerType.INTEGER);
+                assertColumnSpec(rs, Types.SMALLINT, 5L, null, null, SmallintType.SMALLINT);
+                assertColumnSpec(rs, Types.TINYINT, 3L, null, null, TinyintType.TINYINT);
+                assertColumnSpec(rs, Types.FLOAT, null, null, null, FloatType.FLOAT);
+                assertColumnSpec(rs, Types.DOUBLE, null, null, null, DoubleType.DOUBLE);
                 assertColumnSpec(rs, Types.LONGNVARCHAR, 1234L, null, 1234L, VarcharType.createVarcharType(1234));
                 assertColumnSpec(rs, Types.LONGNVARCHAR, (long) Integer.MAX_VALUE, null, (long) Integer.MAX_VALUE, VarcharType.createUnboundedVarcharType());
-                assertColumnSpec(rs, Types.LONGVARBINARY, 2147483647L, null, 0L, VarbinaryType.VARBINARY);
-                assertColumnSpec(rs, Types.TIME, 8L, null, 0L, TimeType.TIME);
-                assertColumnSpec(rs, Types.TIME_WITH_TIMEZONE, 14L, null, 0L, TimeWithTimeZoneType.TIME_WITH_TIME_ZONE);
-                assertColumnSpec(rs, Types.TIMESTAMP, 23L, null, 0L, TimestampType.TIMESTAMP);
-                assertColumnSpec(rs, Types.TIMESTAMP_WITH_TIMEZONE, 29L, null, 0L, TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE);
-                assertColumnSpec(rs, Types.DATE, 15L, null, 0L, DateType.DATE);
-                assertColumnSpec(rs, Types.DECIMAL, 8L, 2L, 0L, DecimalType.createDecimalType(8, 2));
-                assertColumnSpec(rs, Types.DECIMAL, 38L, 0L, 0L, DecimalType.createDecimalType(38, 0));
+                assertColumnSpec(rs, Types.LONGVARBINARY, (long) Integer.MAX_VALUE, null, (long) Integer.MAX_VALUE, VarbinaryType.VARBINARY);
+                assertColumnSpec(rs, Types.TIME, 8L, null, null, TimeType.TIME);
+                assertColumnSpec(rs, Types.TIME_WITH_TIMEZONE, 14L, null, null, TimeWithTimeZoneType.TIME_WITH_TIME_ZONE);
+                assertColumnSpec(rs, Types.TIMESTAMP, 23L, null, null, TimestampType.TIMESTAMP);
+                assertColumnSpec(rs, Types.TIMESTAMP_WITH_TIMEZONE, 29L, null, null, TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE);
+                assertColumnSpec(rs, Types.DATE, 15L, null, null, DateType.DATE);
+                assertColumnSpec(rs, Types.DECIMAL, 8L, 2L, null, DecimalType.createDecimalType(8, 2));
+                assertColumnSpec(rs, Types.DECIMAL, 38L, 0L, null, DecimalType.createDecimalType(38, 0));
+                assertColumnSpec(rs, Types.ARRAY, null, null, null, new ArrayType(BigintType.BIGINT));
+                assertColumnSpec(rs, Types.JAVA_OBJECT, null, null, null, ColorType.COLOR);
                 assertFalse(rs.next());
             }
         }

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
@@ -735,21 +735,22 @@ public class TestDriver
             Statement statement = connection.createStatement()) {
                 assertEquals(statement.executeUpdate(
                     "CREATE TABLE test_get_columns_table (" +
-                        "c1 boolean, " +
-                        "c2 bigint, " +
-                        "c3 integer, " +
-                        "c4 smallint, " +
-                        "c5 tinyint, " +
-                        "c6 double, " +
-                        "c7 varchar(1234), " +
-                        "c8 varbinary, " +
-                        "c9 time, " +
-                        "c10 \"time with time zone\", " +
-                        "c11 timestamp, " +
-                        "c12 \"timestamp with time zone\", " +
-                        "c13 date, " +
-                        "c14 decimal(8,2), " +
-                        "c15 decimal(38,0)" +
+                        "c_boolean boolean, " +
+                        "c_bigint bigint, " +
+                        "c_integer integer, " +
+                        "c_smallint smallint, " +
+                        "c_tinyint tinyint, " +
+                        "c_double double, " +
+                        "c_varchar_1234 varchar(1234), " +
+                        "c_varchar varchar, " +
+                        "c_varbinary varbinary, " +
+                        "c_time time, " +
+                        "c_time_with_time_zone \"time with time zone\", " +
+                        "c_timestamp timestamp, " +
+                        "c_timestamp_with_time_zone \"timestamp with time zone\", " +
+                        "c_date date, " +
+                        "c_decimal_8_2 decimal(8,2), " +
+                        "c_decimal_38_0 decimal(38,0)" +
                         ")"), 0);
         }
 
@@ -763,6 +764,7 @@ public class TestDriver
                 assertColumnSpec(rs, 3L, null, 0L, TinyintType.TINYINT);
                 assertColumnSpec(rs, null, null, 0L, DoubleType.DOUBLE);
                 assertColumnSpec(rs, 1234L, null, 1234L, VarcharType.createVarcharType(1234));
+                assertColumnSpec(rs, (long) Integer.MAX_VALUE, null, (long) Integer.MAX_VALUE, VarcharType.createUnboundedVarcharType());
                 assertColumnSpec(rs, 2147483647L, null, 0L, VarbinaryType.VARBINARY);
                 assertColumnSpec(rs, 8L, null, 0L, TimeType.TIME);
                 assertColumnSpec(rs, 14L, null, 0L, TimeWithTimeZoneType.TIME_WITH_TIME_ZONE);

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
@@ -250,7 +250,7 @@ public class ColumnJdbcTable
         return null;
     }
 
-    // DICIMAL_DIGITS represents the number of fractional digits.
+    // DECIMAL_DIGITS represents the number of fractional digits.
     private static Integer decimalDigits(Type type)
     {
         if (type instanceof DecimalType) {

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
@@ -149,7 +149,7 @@ public class ColumnJdbcTable
                     null,
                     null,
                     null,
-                    charOctecLength(column.getType()),
+                    charOctetLength(column.getType()),
                     ordinalPosition,
                     "",
                     null,
@@ -259,7 +259,7 @@ public class ColumnJdbcTable
         return null;
     }
 
-    private static Integer charOctecLength(Type type)
+    private static Integer charOctetLength(Type type)
     {
         if (type instanceof VarcharType) {
             return ((VarcharType) type).getLength();

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TimeType.TIME;
@@ -179,6 +180,9 @@ public class ColumnJdbcTable
         if (type.equals(TINYINT)) {
             return Types.TINYINT;
         }
+        if (type.equals(FLOAT)) {
+            return Types.FLOAT;
+        }
         if (type.equals(DOUBLE)) {
             return Types.DOUBLE;
         }
@@ -205,6 +209,9 @@ public class ColumnJdbcTable
         }
         if (type instanceof ArrayType) {
             return Types.ARRAY;
+        }
+        if (type instanceof DecimalType) {
+            return Types.DECIMAL;
         }
         return Types.JAVA_OBJECT;
     }

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
@@ -271,6 +271,9 @@ public class ColumnJdbcTable
         if (type instanceof VarcharType) {
             return ((VarcharType) type).getLength();
         }
-        return 0;
+        if (type.equals(VARBINARY)) {
+            return Integer.MAX_VALUE;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Implement COLUMN_SIZE, DECIMAL_DIGITS and CHAR_OCTET_LENGTH for
following types.

* BIGINT, INTEGER, SMALLINT, TINYINT, DOUBLE, VARCHAR, VARBINARY, TIME,
  TIME WITH TIME ZONE, TIMESTAMP, TIMESTAMP WITH TIME ZONE, DATE,
  DECIMAL.

Before this commit getColumns() always returns 0 for COLUMN_SIZE and
CHAR_OCTET_LENGTH, and returns 19 for DECIMAL_DIGITS when a type is
BIGINT. For BIGINT, DECIMAL_DIGITS == scale should be 0, not 19.

So this commit is worth applying I think, but so far I've not yet
tested any JDBC Drivers.