### PR TITLE
Extended support for ppc64le

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
@@ -55,8 +55,8 @@ final class PrestoSystemRequirements
         String osName = StandardSystemProperty.OS_NAME.value();
         String osArch = StandardSystemProperty.OS_ARCH.value();
         if ("Linux".equals(osName)) {
-	    if (!"amd64".equals(osArch) && !"ppc64le".equals(osArch)) {
-                failRequirement("Presto requires x86-64 (amd64) or ppc64le on Linux (found %s)", osArch);
+            if (!"amd64".equals(osArch) && !"ppc64le".equals(osArch)) {
+              failRequirement("Presto requires x86-64 (amd64) or ppc64le on Linux (found %s)", osArch);
             }
         }
         else if ("Mac OS X".equals(osName)) {

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
@@ -56,7 +56,7 @@ final class PrestoSystemRequirements
         String osArch = StandardSystemProperty.OS_ARCH.value();
         if ("Linux".equals(osName)) {
 	    if (!"amd64".equals(osArch) && !"ppc64le".equals(osArch)) {
-                failRequirement("Presto requires x86-64 or amd64 on Linux (found %s)", osArch);
+                failRequirement("Presto requires x86-64 (amd64) or ppc64le on Linux (found %s)", osArch);
             }
         }
         else if ("Mac OS X".equals(osName)) {

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
@@ -55,7 +55,7 @@ final class PrestoSystemRequirements
         String osName = StandardSystemProperty.OS_NAME.value();
         String osArch = StandardSystemProperty.OS_ARCH.value();
         if ("Linux".equals(osName)) {
-            if (!"amd64".equals(osArch)) {
+	    if (!"amd64".equals(osArch) && !"ppc64le".equals(osArch)) {
                 failRequirement("Presto requires x86-64 or amd64 on Linux (found %s)", osArch);
             }
         }


### PR DESCRIPTION
Hi,

Presto-main failed on ppc64le system . Failure log seen was

**2016-06-30T10:40:48.699+0545    INFO    pool-200-thread-2       stderr  Presto requires x86-64 or amd64 on Linux (found ppc64le)**

Extended the if loop to add support for ppc64le.

Regards.
