### PR TITLE
Make EXISTS to be valueExpression

### DIFF
--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -228,7 +228,6 @@ booleanExpression
     | NOT booleanExpression                                        #logicalNot
     | left=booleanExpression operator=AND right=booleanExpression  #logicalBinary
     | left=booleanExpression operator=OR right=booleanExpression   #logicalBinary
-    | EXISTS '(' query ')'                                         #exists
     ;
 
 // workaround for:
@@ -273,6 +272,7 @@ primaryExpression
     | identifier '->' expression                                                     #lambda
     | '(' identifier (',' identifier)* ')' '->' expression                           #lambda
     | '(' query ')'                                                                  #subqueryExpression
+    | EXISTS '(' query ')'                                                           #exists
     | CASE valueExpression whenClause+ (ELSE elseExpression=expression)? END         #simpleCase
     | CASE whenClause+ (ELSE elseExpression=expression)? END                         #searchedCase
     | CAST '(' expression AS type ')'                                                #cast

--- a/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
@@ -141,6 +141,18 @@ public final class QueryUtil
         return ImmutableList.copyOf(items);
     }
 
+    public static Query simpleQuery(Select select)
+    {
+        return query(new QuerySpecification(
+                select,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of(),
+                Optional.empty()));
+    }
+
     public static Query simpleQuery(Select select, Relation from)
     {
         return simpleQuery(select, from, Optional.empty(), ImmutableList.of());


### PR DESCRIPTION
Make EXISTS to be valueExpression

This makes EXISTS to be coherent with regular scalar subqueries.
Thanks to that you user can use EXISTS in complex expressions without
wrapping it with additional parenthesis.
