### PR TITLE
Introduce CardinalityExctractor

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -61,6 +61,7 @@ public final class SystemSessionProperties
     public static final String SPLIT_CONCURRENCY_ADJUSTMENT_INTERVAL = "split_concurrency_adjustment_interval";
     public static final String OPTIMIZE_METADATA_QUERIES = "optimize_metadata_queries";
     public static final String QUERY_PRIORITY = "query_priority";
+    public static final String BROADCAST_JOIN_CARDINALITY = "broadcast_join_cardinality";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -219,7 +220,12 @@ public final class SystemSessionProperties
                         COLOCATED_JOIN,
                         "Experimental: Use a colocated join when possible",
                         featuresConfig.isColocatedJoinsEnabled(),
-                        false));
+                        false),
+                integerSessionProperty(
+                        BROADCAST_JOIN_CARDINALITY,
+                        "Right side join cardinality for which (if it is known) broadcast join will be used",
+                        1_000_000,
+                        true));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -342,5 +348,12 @@ public final class SystemSessionProperties
     public static Duration getQueryMaxCpuTime(Session session)
     {
         return session.getProperty(QUERY_MAX_CPU_TIME, Duration.class);
+    }
+
+    public static int getBroadcastJoinCardinality(Session session)
+    {
+        Integer cardinality = session.getProperty(BROADCAST_JOIN_CARDINALITY, Integer.class);
+        checkArgument(cardinality > 0, "Cardinality must be positive");
+        return cardinality;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -37,6 +37,8 @@ public class FeaturesConfig
     }
 
     public static final String FILE_BASED_RESOURCE_GROUP_MANAGER = "file";
+    public static final int DEFAULT_BROADCAST_JOIN_CARDINALITY = 1_000_000;
+
     private boolean experimentalSyntaxEnabled;
     private boolean distributedIndexJoinsEnabled;
     private boolean distributedJoinsEnabled = true;
@@ -46,6 +48,7 @@ public class FeaturesConfig
     private boolean optimizeHashGeneration = true;
     private boolean optimizeSingleDistinct = true;
     private boolean pushTableWriteThroughUnion = true;
+    private int broadcastJoinCardinality = DEFAULT_BROADCAST_JOIN_CARDINALITY;
 
     private String processingOptimization = ProcessingOptimization.DISABLED;
     private boolean dictionaryAggregation;
@@ -216,6 +219,19 @@ public class FeaturesConfig
     public FeaturesConfig setDictionaryAggregation(boolean dictionaryAggregation)
     {
         this.dictionaryAggregation = dictionaryAggregation;
+        return this;
+    }
+
+    @Min(1)
+    public int getBroadcastJoinCardinality()
+    {
+        return broadcastJoinCardinality;
+    }
+
+    @Config("optimizer.broadcast-join-cardinality")
+    public FeaturesConfig setBroadcastJoinCardinality(int broadcastJoinCardinality)
+    {
+        this.broadcastJoinCardinality = broadcastJoinCardinality;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
@@ -68,8 +68,8 @@ public class PlanOptimizersFactory
         ImmutableList.Builder<PlanOptimizer> builder = ImmutableList.builder();
 
         builder.add(new DesugaringOptimizer(metadata, sqlParser), // Clean up all the sugar in expressions, e.g. AtTimeZone, must be run before all the other optimizers
-                new TransformUncorrelatedScalarToJoin(),
                 new TransformUncorrelatedInPredicateSubqueryToSemiJoin(),
+                new TransformUncorrelatedScalarToJoin(),
                 new ImplementSampleAsFilter(),
                 new CanonicalizeExpressions(),
                 new SimplifyExpressions(metadata, sqlParser),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -113,7 +113,6 @@ import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DI
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.partitionedOn;
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.singleStreamPartition;
 import static com.facebook.presto.sql.planner.optimizations.LocalProperties.grouped;
-import static com.facebook.presto.sql.planner.optimizations.ScalarQueryUtil.isScalar;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.FINAL;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.PARTIAL;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE;
@@ -835,7 +834,8 @@ public class AddExchanges
             PlanWithProperties right;
 
             boolean isCrossJoin = type == INNER && leftSymbols.isEmpty();
-            if ((distributedJoins && !isCrossJoin && !isScalar(node.getRight())) || (type == FULL) || (type == RIGHT)) {
+            boolean preferBroadcast = JoinUtil.isJoinEligibleToBroadcast(node, session);
+            if ((distributedJoins && !isCrossJoin && !preferBroadcast) || (type == FULL) || (type == RIGHT)) {
                 // The implementation of full outer join only works if the data is hash partitioned. See LookupJoinOperators#buildSideOuterJoinUnvisitedPositions
 
                 SetMultimap<Symbol, Symbol> rightToLeft = createMapping(rightSymbols, leftSymbols);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+
+import static com.facebook.presto.sql.planner.optimizations.PlanCardinalityExtractor.extractCardinality;
+
+public final class JoinUtil
+{
+    private JoinUtil() {}
+
+    public static boolean isJoinEligibleToBroadcast(JoinNode node, Session session)
+    {
+        long broadcastJoinCardinality = SystemSessionProperties.getBroadcastJoinCardinality(session);
+        return extractCardinality(node.getRight()).map(rightCardinality -> rightCardinality <= broadcastJoinCardinality).orElse(false);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanCardinalityExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanCardinalityExtractor.java
@@ -16,51 +16,62 @@ package com.facebook.presto.sql.planner.optimizations;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 
+import java.util.Optional;
+
 import static com.google.common.collect.Iterables.getOnlyElement;
 
-public final class ScalarQueryUtil
+public final class PlanCardinalityExtractor
 {
-    private ScalarQueryUtil() {}
+    private PlanCardinalityExtractor() {}
 
-    public static boolean isScalar(PlanNode node)
+    public static Optional<Long> extractCardinality(PlanNode node)
     {
         return node.accept(new IsScalarPlanVisitor(), null);
     }
 
     private static final class IsScalarPlanVisitor
-            extends PlanVisitor<Void, Boolean>
+            extends PlanVisitor<Void, Optional<Long>>
     {
         @Override
-        protected Boolean visitPlan(PlanNode node, Void context)
+        protected Optional<Long> visitPlan(PlanNode node, Void context)
         {
-            return false;
+            return Optional.empty();
         }
 
         @Override
-        public Boolean visitEnforceSingleRow(EnforceSingleRowNode node, Void context)
+        public Optional<Long> visitEnforceSingleRow(EnforceSingleRowNode node, Void context)
         {
-            return true;
+            return Optional.of(1L);
         }
 
         @Override
-        public Boolean visitExchange(ExchangeNode node, Void context)
+        public Optional<Long> visitLimit(LimitNode node, Void context)
         {
-            return (node.getSources().size() == 1) &&
-                    getOnlyElement(node.getSources()).accept(this, null);
+            return Optional.of(node.getCount());
         }
 
         @Override
-        public Boolean visitProject(ProjectNode node, Void context)
+        public Optional<Long> visitExchange(ExchangeNode node, Void context)
+        {
+            if (node.getSources().size() == 1) {
+                return getOnlyElement(node.getSources()).accept(this, null);
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Long> visitProject(ProjectNode node, Void context)
         {
             return node.getSource().accept(this, null);
         }
 
         @Override
-        public Boolean visitFilter(FilterNode node, Void context)
+        public Optional<Long> visitFilter(FilterNode node, Void context)
         {
             return node.getSource().accept(this, null);
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 
 import java.util.Map;
 
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.DEFAULT_BROADCAST_JOIN_CARDINALITY;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.FILE_BASED_RESOURCE_GROUP_MANAGER;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.ProcessingOptimization.COLUMNAR_DICTIONARY;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.ProcessingOptimization.DISABLED;
@@ -49,7 +50,8 @@ public class TestFeaturesConfig
                 .setRegexLibrary(JONI)
                 .setRe2JDfaStatesLimit(Integer.MAX_VALUE)
                 .setRe2JDfaRetries(5)
-                .setResourceGroupManager(FILE_BASED_RESOURCE_GROUP_MANAGER));
+                .setResourceGroupManager(FILE_BASED_RESOURCE_GROUP_MANAGER)
+                .setBroadcastJoinCardinality(DEFAULT_BROADCAST_JOIN_CARDINALITY));
     }
 
     @Test
@@ -72,6 +74,7 @@ public class TestFeaturesConfig
                 .put("re2j.dfa-states-limit", "42")
                 .put("re2j.dfa-retries", "42")
                 .put("resource-group-manager", "test")
+                .put("optimizer.broadcast-join-cardinality", "10")
                 .build();
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("experimental-syntax-enabled", "true")
@@ -90,6 +93,7 @@ public class TestFeaturesConfig
                 .put("re2j.dfa-states-limit", "42")
                 .put("re2j.dfa-retries", "42")
                 .put("resource-group-manager", "test")
+                .put("optimizer.broadcast-join-cardinality", "10")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -108,7 +112,8 @@ public class TestFeaturesConfig
                 .setRegexLibrary(RE2J)
                 .setRe2JDfaStatesLimit(42)
                 .setRe2JDfaRetries(42)
-                .setResourceGroupManager("test");
+                .setResourceGroupManager("test")
+                .setBroadcastJoinCardinality(10);
 
         assertFullMapping(properties, expected);
         assertDeprecatedEquivalence(FeaturesConfig.class, properties, propertiesLegacy);


### PR DESCRIPTION
Introduce `CardinalityExctractor`

This is kind of idea pull request. I am not sure if it thing has a value. I extracted this from https://github.com/prestodb/presto/pull/5369 where `CardinalityExctractor` is no longer needed.

Sometimes plan contains information about maximum cardinality of its sub-plan parts. This knowledge can be used for example to determine if broadcast join can be used.