### PR TITLE
Upgrade to Sphinx 1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -802,9 +802,9 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.tomdz.maven</groupId>
+                    <groupId>kr.motd.maven</groupId>
                     <artifactId>sphinx-maven-plugin</artifactId>
-                    <version>1.0.3</version>
+                    <version>1.3.1.Final</version>
                 </plugin>
 
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->

--- a/presto-docs/pom.xml
+++ b/presto-docs/pom.xml
@@ -45,7 +45,7 @@
 
         <plugins>
             <plugin>
-                <groupId>org.tomdz.maven</groupId>
+                <groupId>kr.motd.maven</groupId>
                 <artifactId>sphinx-maven-plugin</artifactId>
                 <configuration>
                     <fork>true</fork>

--- a/presto-docs/src/main/sphinx/connector/kafka-tutorial.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka-tutorial.rst
@@ -579,7 +579,7 @@ RFC 2822 format as ``created_at`` attribute in each tweet.
 The topic definition file for the tweets table contains a mapping onto a
 timestamp using the ``rfc2822`` converter:
 
-.. code-block:: json
+.. code-block:: none
 
     ...
     {

--- a/presto-docs/src/main/sphinx/connector/kafka.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka.rst
@@ -165,7 +165,7 @@ this data must be mapped into columns to allow queries against the data.
 A table definition file consists of a JSON definition for a table. The
 name of the file can be arbitrary but must end in ``.json``.
 
-.. code-block:: json
+.. code-block:: none
 
     {
         "tableName": ...,
@@ -214,7 +214,7 @@ Field           Required  Type           Description
 
 Each field definition is a JSON object:
 
-.. code-block:: json
+.. code-block:: none
 
     {
         "name": ...,

--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -173,7 +173,7 @@ MongoDB maintains table definitions on the special collection where ``mongodb.sc
 
 A schema collection consists of a MongoDB document for a table.
 
-.. code-block:: json
+.. code-block:: none
 
     {
         "table": ...,
@@ -195,7 +195,7 @@ Field           Required  Type           Description
 
 Each field definition:
 
-.. code-block:: json
+.. code-block:: none
 
     {
         "name": ...,

--- a/presto-docs/src/main/sphinx/connector/redis.rst
+++ b/presto-docs/src/main/sphinx/connector/redis.rst
@@ -172,7 +172,7 @@ will define new columns that can be further queried from Presto.
 A table definition file consists of a JSON definition for a table. The
 name of the file can be arbitrary but must end in ``.json``.
 
-.. code-block:: json
+.. code-block:: none
 
     {
         "tableName": ...,
@@ -204,7 +204,7 @@ Please refer to the `Kafka connector`_ page for the description of the ``dataFor
 
 In addition to the above Kafka types, the Redis connector supports ``hash`` type for the ``value`` field which represent data stored in the Redis hash.
 
-.. code-block:: json
+.. code-block:: none
 
     {
         "tableName": ...,

--- a/presto-docs/src/main/sphinx/ext/download.py
+++ b/presto-docs/src/main/sphinx/ext/download.py
@@ -56,5 +56,4 @@ def setup(app):
         node = nodes.reference(title, title, internal=False, refuri=uri)
 
         return [node], []
-
-    app.add_role('download', download_link_role)
+    app.add_role('maven_download', download_link_role)

--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -24,7 +24,7 @@ Map Functions
 
 .. function:: map(array<K>, array<V>) -> map<K,V>
 
-    Returns a map created using the given key/value arrays. ::
+    Returns a map created using the given key/value arrays. :: none
 
         SELECT map(ARRAY[1,3], ARRAY[2,4]); => {1 -> 2, 3 -> 4}
 

--- a/presto-docs/src/main/sphinx/installation/benchmark-driver.rst
+++ b/presto-docs/src/main/sphinx/installation/benchmark-driver.rst
@@ -5,7 +5,7 @@ Benchmark Driver
 The benchmark driver can be used to measure the performance of queries in a
 Presto cluster. We use it to continuously measure the performance of trunk.
 
-Download :download:`benchmark-driver`, rename it to ``presto-benchmark-driver``,
+Download :maven_download:`benchmark-driver`, rename it to ``presto-benchmark-driver``,
 then make it executable with ``chmod +x``.
 
 Suites

--- a/presto-docs/src/main/sphinx/installation/cli.rst
+++ b/presto-docs/src/main/sphinx/installation/cli.rst
@@ -7,7 +7,7 @@ queries. The CLI is a
 `self-executing <http://skife.org/java/unix/2011/06/20/really_executable_jars.html>`_
 JAR file, which means it acts like a normal UNIX executable.
 
-Download :download:`cli`, rename it to ``presto``,
+Download :maven_download:`cli`, rename it to ``presto``,
 make it executable with ``chmod +x``, then run it:
 
 .. code-block:: none

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -5,7 +5,7 @@ Deploying Presto
 Installing Presto
 -----------------
 
-Download the Presto server tarball, :download:`server`, and unpack it.
+Download the Presto server tarball, :maven_download:`server`, and unpack it.
 The tarball will contain a single top-level directory,
 |presto_server_release|, which we will call the *installation* directory.
 

--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -3,7 +3,7 @@ JDBC Driver
 ===========
 
 Presto can be accessed from Java using the JDBC driver.
-Download :download:`jdbc` and add it to the class path of your Java application.
+Download :maven_download:`jdbc` and add it to the class path of your Java application.
 The following JDBC URL formats are supported:
 
 .. code-block:: none

--- a/presto-docs/src/main/sphinx/installation/verifier.rst
+++ b/presto-docs/src/main/sphinx/installation/verifier.rst
@@ -41,7 +41,7 @@ Next, create a properties file to configure the verifier:
     test.gateway=jdbc:presto://localhost:8081
     thread-count=1
 
-Lastly, download :download:`verifier`, rename it to ``verifier``,
+Lastly, download :maven_download:`verifier`, rename it to ``verifier``,
 make it executable with ``chmod +x``, then run it:
 
 .. code-block:: none

--- a/presto-docs/src/main/sphinx/release/release-0.66.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.66.rst
@@ -119,7 +119,7 @@ For example, if we set the language to Spanish::
     =>
     enero
 
-If we set the language to Japanese::
+If we set the language to Japanese:: none
 
     SELECT date_format(TIMESTAMP '2001-01-09 09:04', '%M');
     =>


### PR DESCRIPTION
Replace the sphinx-maven-plugin with another one that is better maintained and uses a Sphinx 1.4
http://trustin.github.io/sphinx-maven-plugin/

Sphinx 1.4 is more strict about code blocks being syntactically correct for the language specified. In the cases where the syntax was not correct, the code block style was changed to 'none.'
The role 'dowload' needed to be changed to 'maven_download' since it conflicts with an included role in Sphinx that is also named 'download.'