### PR TITLE
Handle large split count in CLI

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/ColumnAligner.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ColumnAligner.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cli;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class ColumnAligner
+{
+    private final int leftMargin;
+    private final List<String> values;
+
+    private int currentLength;
+
+    public ColumnAligner(String header, int minimalLength, int leftMargin)
+    {
+        requireNonNull(header, "header is null");
+        this.values = new ArrayList<>();
+        this.values.add(header);
+        if (header.length() >= minimalLength) {
+            this.currentLength = header.length();
+        }
+        else {
+            this.currentLength = minimalLength;
+        }
+        this.leftMargin = leftMargin;
+    }
+
+    public void feedValue(Object value)
+    {
+        requireNonNull(value, "value is null");
+
+        String valueString = value.toString();
+        if (currentLength < valueString.length()) {
+            currentLength = valueString.length();
+        }
+        values.add(valueString);
+    }
+
+    public List<String> buildColumn()
+    {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        for (String value : values) {
+            int gapLength = currentLength - value.length();
+            builder.add(Strings.repeat(" ", gapLength + leftMargin) + value);
+        }
+        return builder.build();
+    }
+}

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestColumnAligner.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestColumnAligner.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cli;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestColumnAligner
+{
+    private static final String HEADER = "test";
+    private static final List<String> INPUT_VALUES = ImmutableList.of("1123123123324234", "123", "12546456", "45", "6785467467", "67", "6", "6475674567"); // max length is 16
+    private static final List<String> RAW_OUTPUT = ImmutableList.<String>builder()
+            .add(HEADER)
+            .addAll(INPUT_VALUES)
+            .build();
+
+    @Test
+    public void testMinimalLength()
+            throws Exception
+    {
+        testColumnAligner(8, 0, "%16s");
+    }
+
+    @Test
+    public void testLargeMinimalLength()
+            throws Exception
+    {
+        testColumnAligner(20, 0, "%20s");
+    }
+
+    @Test
+    public void testMargin()
+            throws Exception
+    {
+        testColumnAligner(8, 2, "%18s");
+    }
+
+    private static void testColumnAligner(int minimalLength, int leftMargin, String expectedFormat)
+    {
+        ColumnAligner columnAligner = new ColumnAligner(HEADER, minimalLength, leftMargin);
+        for (String value : INPUT_VALUES) {
+            columnAligner.feedValue(value);
+        }
+
+        List<String> expected = alignedValues(expectedFormat, RAW_OUTPUT);
+        assertEquals(columnAligner.buildColumn(), expected);
+    }
+
+    private static List<String> alignedValues(String format, List<String> values)
+    {
+        return values.stream()
+                .map(value -> String.format(format, value))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Fix #5600 

The output now looks like:

```
     STAGES   ROWS  ROWS/s  BYTES  BYTES/s   QUEUED        RUN      DONE
0.........R    131       5  1.15K      47B  1000000  100000001  10000000
  1.......S   215K   8.71K   916K    37.2K  1000089  100000010  10000131
```
