### PR TITLE
Move static aggregation fields out of aggregation implementations

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountDistinctAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountDistinctAggregations.java
@@ -13,45 +13,22 @@
  */
 package com.facebook.presto.operator.aggregation;
 
-import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.operator.aggregation.state.HyperLogLogState;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.StandardTypes;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.type.LiteralParameters;
 import com.facebook.presto.type.SqlType;
-import com.facebook.presto.type.TypeRegistry;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.stats.cardinality.HyperLogLog;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
-import static com.facebook.presto.testing.AggregationTestUtils.generateInternalAggregationFunction;
 import static com.facebook.presto.util.Failures.checkCondition;
 
 @AggregationFunction("approx_distinct")
 public final class ApproximateCountDistinctAggregations
 {
-    public static final InternalAggregationFunction LONG_APPROXIMATE_COUNT_DISTINCT_AGGREGATIONS =
-            generateInternalAggregationFunction(
-                    ApproximateCountDistinctAggregations.class,
-                    BIGINT.getTypeSignature(),
-                    ImmutableList.of(BIGINT.getTypeSignature(), DOUBLE.getTypeSignature()));
-    public static final InternalAggregationFunction DOUBLE_APPROXIMATE_COUNT_DISTINCT_AGGREGATIONS =
-            generateInternalAggregationFunction(
-                    ApproximateCountDistinctAggregations.class,
-                    BIGINT.getTypeSignature(),
-                    ImmutableList.of(DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
-    public static final InternalAggregationFunction VARBINARY_APPROXIMATE_COUNT_DISTINCT_AGGREGATIONS =
-            generateInternalAggregationFunction(
-                    ApproximateCountDistinctAggregations.class,
-                    BIGINT.getTypeSignature(),
-                    ImmutableList.of(VarcharType.getParametrizedVarcharSignature("x"), DOUBLE.getTypeSignature()),
-                    new TypeRegistry(), BoundVariables.builder().setLongVariable("x", (long) Integer.MAX_VALUE).build(), 1);
-
     private static final double DEFAULT_STANDARD_ERROR = 0.023;
     private static final double LOWEST_MAX_STANDARD_ERROR = 0.01150;
     private static final double HIGHEST_MAX_STANDARD_ERROR = 0.26000;

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctDouble.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctDouble.java
@@ -17,12 +17,20 @@ import com.facebook.presto.spi.type.Type;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import static com.facebook.presto.operator.aggregation.ApproximateCountDistinctAggregations.DOUBLE_APPROXIMATE_COUNT_DISTINCT_AGGREGATIONS;
+import com.google.common.collect.ImmutableList;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.testing.AggregationTestUtils.generateInternalAggregationFunction;
 
 public class TestApproximateCountDistinctDouble
         extends AbstractTestApproximateCountDistinct
 {
+    public static final InternalAggregationFunction DOUBLE_APPROXIMATE_COUNT_DISTINCT_AGGREGATIONS =
+            generateInternalAggregationFunction(
+                    ApproximateCountDistinctAggregations.class,
+                    BIGINT.getTypeSignature(),
+                    ImmutableList.of(DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
     @Override
     public InternalAggregationFunction getAggregationFunction()
     {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctLong.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctLong.java
@@ -14,15 +14,23 @@
 package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import static com.facebook.presto.operator.aggregation.ApproximateCountDistinctAggregations.LONG_APPROXIMATE_COUNT_DISTINCT_AGGREGATIONS;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.testing.AggregationTestUtils.generateInternalAggregationFunction;
 
 public class TestApproximateCountDistinctLong
         extends AbstractTestApproximateCountDistinct
 {
+    public static final InternalAggregationFunction LONG_APPROXIMATE_COUNT_DISTINCT_AGGREGATIONS =
+      generateInternalAggregationFunction(
+              ApproximateCountDistinctAggregations.class,
+              BIGINT.getTypeSignature(),
+              ImmutableList.of(BIGINT.getTypeSignature(), DOUBLE.getTypeSignature()));
+
     @Override
     public InternalAggregationFunction getAggregationFunction()
     {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctVarBinary.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctVarBinary.java
@@ -13,17 +13,30 @@
  */
 package com.facebook.presto.operator.aggregation;
 
+import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.type.TypeRegistry;
+import com.google.common.collect.ImmutableList;
+
 import io.airlift.slice.Slices;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import static com.facebook.presto.operator.aggregation.ApproximateCountDistinctAggregations.VARBINARY_APPROXIMATE_COUNT_DISTINCT_AGGREGATIONS;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.testing.AggregationTestUtils.generateInternalAggregationFunction;
 
 public class TestApproximateCountDistinctVarBinary
         extends AbstractTestApproximateCountDistinct
 {
+    public static final InternalAggregationFunction VARBINARY_APPROXIMATE_COUNT_DISTINCT_AGGREGATIONS =
+      generateInternalAggregationFunction(
+              ApproximateCountDistinctAggregations.class,
+              BIGINT.getTypeSignature(),
+              ImmutableList.of(VarcharType.getParametrizedVarcharSignature("x"), DOUBLE.getTypeSignature()),
+              new TypeRegistry(), BoundVariables.builder().setLongVariable("x", (long) Integer.MAX_VALUE).build(), 1);
+
     @Override
     public InternalAggregationFunction getAggregationFunction()
     {


### PR DESCRIPTION
This is for https://github.com/prestodb/presto/issues/5544

Moves static aggregation fields to respective tests.