### PR TITLE
Native implementation of aggregate functions for FLOAT

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -35,6 +35,7 @@ import com.facebook.presto.operator.aggregation.CountAggregation;
 import com.facebook.presto.operator.aggregation.CountIfAggregation;
 import com.facebook.presto.operator.aggregation.CovarianceAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
+import com.facebook.presto.operator.aggregation.FloatAverageAggregation;
 import com.facebook.presto.operator.aggregation.FloatSumAggregation;
 import com.facebook.presto.operator.aggregation.GeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
@@ -358,6 +359,7 @@ public class FunctionRegistry
                 .aggregate(FloatSumAggregation.class)
                 .aggregate(LongSumAggregation.class)
                 .aggregate(AverageAggregations.class)
+                .aggregate(FloatAverageAggregation.class)
                 .aggregate(GeometricMeanAggregations.class)
                 .aggregate(ApproximateCountDistinctAggregations.class)
                 .aggregate(MergeHyperLogLogAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -41,6 +41,7 @@ import com.facebook.presto.operator.aggregation.FloatAverageAggregation;
 import com.facebook.presto.operator.aggregation.FloatCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.FloatGeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.FloatHistogramAggregation;
+import com.facebook.presto.operator.aggregation.FloatRegressionAggregation;
 import com.facebook.presto.operator.aggregation.FloatSumAggregation;
 import com.facebook.presto.operator.aggregation.GeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
@@ -373,6 +374,7 @@ public class FunctionRegistry
                 .aggregate(DoubleCovarianceAggregation.class)
                 .aggregate(FloatCovarianceAggregation.class)
                 .aggregate(DoubleRegressionAggregation.class)
+                .aggregate(FloatRegressionAggregation.class)
                 .aggregate(CorrelationAggregation.class)
                 .scalars(SequenceFunction.class)
                 .scalars(StringFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -20,6 +20,8 @@ import com.facebook.presto.operator.aggregation.ApproximateCountColumnAggregatio
 import com.facebook.presto.operator.aggregation.ApproximateCountDistinctAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateDoublePercentileAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateDoublePercentileArrayAggregations;
+import com.facebook.presto.operator.aggregation.ApproximateFloatPercentileAggregations;
+import com.facebook.presto.operator.aggregation.ApproximateFloatPercentileArrayAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateLongPercentileAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateLongPercentileArrayAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateSetAggregation;
@@ -346,6 +348,8 @@ public class FunctionRegistry
                 .aggregate(ApproximateLongPercentileArrayAggregations.class)
                 .aggregate(ApproximateDoublePercentileAggregations.class)
                 .aggregate(ApproximateDoublePercentileArrayAggregations.class)
+                .aggregate(ApproximateFloatPercentileAggregations.class)
+                .aggregate(ApproximateFloatPercentileArrayAggregations.class)
                 .aggregate(CountIfAggregation.class)
                 .aggregate(BooleanAndAggregation.class)
                 .aggregate(BooleanOrAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -36,6 +36,7 @@ import com.facebook.presto.operator.aggregation.CountIfAggregation;
 import com.facebook.presto.operator.aggregation.CovarianceAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
 import com.facebook.presto.operator.aggregation.FloatAverageAggregation;
+import com.facebook.presto.operator.aggregation.FloatGeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.FloatSumAggregation;
 import com.facebook.presto.operator.aggregation.GeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
@@ -361,6 +362,7 @@ public class FunctionRegistry
                 .aggregate(AverageAggregations.class)
                 .aggregate(FloatAverageAggregation.class)
                 .aggregate(GeometricMeanAggregations.class)
+                .aggregate(FloatGeometricMeanAggregations.class)
                 .aggregate(ApproximateCountDistinctAggregations.class)
                 .aggregate(MergeHyperLogLogAggregation.class)
                 .aggregate(ApproximateSetAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -35,6 +35,7 @@ import com.facebook.presto.operator.aggregation.CountAggregation;
 import com.facebook.presto.operator.aggregation.CountIfAggregation;
 import com.facebook.presto.operator.aggregation.CovarianceAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
+import com.facebook.presto.operator.aggregation.FloatSumAggregation;
 import com.facebook.presto.operator.aggregation.GeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.operator.aggregation.LongSumAggregation;
@@ -354,6 +355,7 @@ public class FunctionRegistry
                 .aggregate(BooleanAndAggregation.class)
                 .aggregate(BooleanOrAggregation.class)
                 .aggregate(DoubleSumAggregation.class)
+                .aggregate(FloatSumAggregation.class)
                 .aggregate(LongSumAggregation.class)
                 .aggregate(AverageAggregations.class)
                 .aggregate(GeometricMeanAggregations.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -38,6 +38,7 @@ import com.facebook.presto.operator.aggregation.DoubleHistogramAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
 import com.facebook.presto.operator.aggregation.FloatAverageAggregation;
 import com.facebook.presto.operator.aggregation.FloatGeometricMeanAggregations;
+import com.facebook.presto.operator.aggregation.FloatHistogramAggregation;
 import com.facebook.presto.operator.aggregation.FloatSumAggregation;
 import com.facebook.presto.operator.aggregation.GeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
@@ -367,6 +368,7 @@ public class FunctionRegistry
                 .aggregate(MergeHyperLogLogAggregation.class)
                 .aggregate(ApproximateSetAggregation.class)
                 .aggregate(DoubleHistogramAggregation.class)
+                .aggregate(FloatHistogramAggregation.class)
                 .aggregate(CovarianceAggregation.class)
                 .aggregate(RegressionAggregation.class)
                 .aggregate(CorrelationAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -38,6 +38,7 @@ import com.facebook.presto.operator.aggregation.DoubleHistogramAggregation;
 import com.facebook.presto.operator.aggregation.DoubleRegressionAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
 import com.facebook.presto.operator.aggregation.FloatAverageAggregation;
+import com.facebook.presto.operator.aggregation.FloatCorrelationAggregation;
 import com.facebook.presto.operator.aggregation.FloatCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.FloatGeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.FloatHistogramAggregation;
@@ -376,6 +377,7 @@ public class FunctionRegistry
                 .aggregate(DoubleRegressionAggregation.class)
                 .aggregate(FloatRegressionAggregation.class)
                 .aggregate(DoubleCorrelationAggregation.class)
+                .aggregate(FloatCorrelationAggregation.class)
                 .scalars(SequenceFunction.class)
                 .scalars(StringFunctions.class)
                 .scalars(VarbinaryFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -30,9 +30,9 @@ import com.facebook.presto.operator.aggregation.ArrayAggregationFunction;
 import com.facebook.presto.operator.aggregation.AverageAggregations;
 import com.facebook.presto.operator.aggregation.BooleanAndAggregation;
 import com.facebook.presto.operator.aggregation.BooleanOrAggregation;
-import com.facebook.presto.operator.aggregation.CorrelationAggregation;
 import com.facebook.presto.operator.aggregation.CountAggregation;
 import com.facebook.presto.operator.aggregation.CountIfAggregation;
+import com.facebook.presto.operator.aggregation.DoubleCorrelationAggregation;
 import com.facebook.presto.operator.aggregation.DoubleCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.DoubleHistogramAggregation;
 import com.facebook.presto.operator.aggregation.DoubleRegressionAggregation;
@@ -375,7 +375,7 @@ public class FunctionRegistry
                 .aggregate(FloatCovarianceAggregation.class)
                 .aggregate(DoubleRegressionAggregation.class)
                 .aggregate(FloatRegressionAggregation.class)
-                .aggregate(CorrelationAggregation.class)
+                .aggregate(DoubleCorrelationAggregation.class)
                 .scalars(SequenceFunction.class)
                 .scalars(StringFunctions.class)
                 .scalars(VarbinaryFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -34,6 +34,7 @@ import com.facebook.presto.operator.aggregation.CorrelationAggregation;
 import com.facebook.presto.operator.aggregation.CountAggregation;
 import com.facebook.presto.operator.aggregation.CountIfAggregation;
 import com.facebook.presto.operator.aggregation.CovarianceAggregation;
+import com.facebook.presto.operator.aggregation.DoubleHistogramAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
 import com.facebook.presto.operator.aggregation.FloatAverageAggregation;
 import com.facebook.presto.operator.aggregation.FloatGeometricMeanAggregations;
@@ -42,7 +43,6 @@ import com.facebook.presto.operator.aggregation.GeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.operator.aggregation.LongSumAggregation;
 import com.facebook.presto.operator.aggregation.MergeHyperLogLogAggregation;
-import com.facebook.presto.operator.aggregation.NumericHistogramAggregation;
 import com.facebook.presto.operator.aggregation.RegressionAggregation;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
 import com.facebook.presto.operator.scalar.ArrayCardinalityFunction;
@@ -366,7 +366,7 @@ public class FunctionRegistry
                 .aggregate(ApproximateCountDistinctAggregations.class)
                 .aggregate(MergeHyperLogLogAggregation.class)
                 .aggregate(ApproximateSetAggregation.class)
-                .aggregate(NumericHistogramAggregation.class)
+                .aggregate(DoubleHistogramAggregation.class)
                 .aggregate(CovarianceAggregation.class)
                 .aggregate(RegressionAggregation.class)
                 .aggregate(CorrelationAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -35,6 +35,7 @@ import com.facebook.presto.operator.aggregation.CountAggregation;
 import com.facebook.presto.operator.aggregation.CountIfAggregation;
 import com.facebook.presto.operator.aggregation.DoubleCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.DoubleHistogramAggregation;
+import com.facebook.presto.operator.aggregation.DoubleRegressionAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
 import com.facebook.presto.operator.aggregation.FloatAverageAggregation;
 import com.facebook.presto.operator.aggregation.FloatCovarianceAggregation;
@@ -45,7 +46,6 @@ import com.facebook.presto.operator.aggregation.GeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.operator.aggregation.LongSumAggregation;
 import com.facebook.presto.operator.aggregation.MergeHyperLogLogAggregation;
-import com.facebook.presto.operator.aggregation.RegressionAggregation;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
 import com.facebook.presto.operator.scalar.ArrayCardinalityFunction;
 import com.facebook.presto.operator.scalar.ArrayConcatFunction;
@@ -372,7 +372,7 @@ public class FunctionRegistry
                 .aggregate(FloatHistogramAggregation.class)
                 .aggregate(DoubleCovarianceAggregation.class)
                 .aggregate(FloatCovarianceAggregation.class)
-                .aggregate(RegressionAggregation.class)
+                .aggregate(DoubleRegressionAggregation.class)
                 .aggregate(CorrelationAggregation.class)
                 .scalars(SequenceFunction.class)
                 .scalars(StringFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -33,7 +33,7 @@ import com.facebook.presto.operator.aggregation.BooleanOrAggregation;
 import com.facebook.presto.operator.aggregation.CorrelationAggregation;
 import com.facebook.presto.operator.aggregation.CountAggregation;
 import com.facebook.presto.operator.aggregation.CountIfAggregation;
-import com.facebook.presto.operator.aggregation.CovarianceAggregation;
+import com.facebook.presto.operator.aggregation.DoubleCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.DoubleHistogramAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
 import com.facebook.presto.operator.aggregation.FloatAverageAggregation;
@@ -369,7 +369,7 @@ public class FunctionRegistry
                 .aggregate(ApproximateSetAggregation.class)
                 .aggregate(DoubleHistogramAggregation.class)
                 .aggregate(FloatHistogramAggregation.class)
-                .aggregate(CovarianceAggregation.class)
+                .aggregate(DoubleCovarianceAggregation.class)
                 .aggregate(RegressionAggregation.class)
                 .aggregate(CorrelationAggregation.class)
                 .scalars(SequenceFunction.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -37,6 +37,7 @@ import com.facebook.presto.operator.aggregation.DoubleCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.DoubleHistogramAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
 import com.facebook.presto.operator.aggregation.FloatAverageAggregation;
+import com.facebook.presto.operator.aggregation.FloatCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.FloatGeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.FloatHistogramAggregation;
 import com.facebook.presto.operator.aggregation.FloatSumAggregation;
@@ -370,6 +371,7 @@ public class FunctionRegistry
                 .aggregate(DoubleHistogramAggregation.class)
                 .aggregate(FloatHistogramAggregation.class)
                 .aggregate(DoubleCovarianceAggregation.class)
+                .aggregate(FloatCovarianceAggregation.class)
                 .aggregate(RegressionAggregation.class)
                 .aggregate(CorrelationAggregation.class)
                 .scalars(SequenceFunction.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
@@ -73,6 +73,26 @@ public final class AggregationUtils
         state.setSumXSquare(state.getSumXSquare() + x * x);
     }
 
+    public static double getRegressionSlope(RegressionState state)
+    {
+        // Math comes from ISO9075-2:2011(E) 10.9 General Rules 7 c xii
+        double dividend = state.getCount() * state.getSumXY() - state.getSumX() * state.getSumY();
+        double divisor = state.getCount() * state.getSumXSquare() - state.getSumX() * state.getSumX();
+
+        // divisor deliberately not checked for zero because the result can be Infty or NaN even if it is not zero
+        return dividend / divisor;
+    }
+
+    public static double getRegressionIntercept(RegressionState state)
+    {
+        // Math comes from ISO9075-2:2011(E) 10.9 General Rules 7 c xiii
+        double dividend = state.getSumY() * state.getSumXSquare() - state.getSumX() * state.getSumXY();
+        double divisor = state.getCount() * state.getSumXSquare() - state.getSumX() * state.getSumX();
+
+        // divisor deliberately not checked for zero because the result can be Infty or NaN even if it is not zero
+        return dividend / divisor;
+    }
+
     public static void mergeVarianceState(VarianceState state, VarianceState otherState)
     {
         long count = otherState.getCount();

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
@@ -50,6 +50,16 @@ public final class AggregationUtils
         state.setSumY(state.getSumY() + y);
     }
 
+    public static double getCovarianceSample(CovarianceState state)
+    {
+        return (state.getSumXY() - state.getSumX() * state.getSumY() / state.getCount()) / (state.getCount() - 1);
+    }
+
+    public static double getCovariancePopulation(CovarianceState state)
+    {
+        return (state.getSumXY() - state.getSumX() * state.getSumY() / state.getCount()) / state.getCount();
+    }
+
     public static void updateCorrelationState(CorrelationState state, double x, double y)
     {
         updateCovarianceState(state, x, y);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
@@ -67,6 +67,18 @@ public final class AggregationUtils
         state.setSumYSquare(state.getSumYSquare() + y * y);
     }
 
+    public static double getCorrelation(CorrelationState state)
+    {
+        // Math comes from ISO9075-2:2011(E) 10.9 General Rules 7 c x
+        double dividend = state.getCount() * state.getSumXY() - state.getSumX() * state.getSumY();
+        dividend = dividend * dividend;
+        double divisor1 = state.getCount() * state.getSumXSquare() - state.getSumX() * state.getSumX();
+        double divisor2 = state.getCount() * state.getSumYSquare() - state.getSumY() * state.getSumY();
+
+        // divisor1 and divisor2 deliberately not checked for zero because the result can be Infty or NaN even if they are both not zero
+        return dividend / divisor1 / divisor2; // When the left expression yields a finite value, dividend / (divisor1 * divisor2) can yield Infty or NaN.
+    }
+
     public static void updateRegressionState(RegressionState state, double x, double y)
     {
         updateCovarianceState(state, x, y);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileAggregations.java
@@ -19,8 +19,8 @@ import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlType;
 import io.airlift.stats.QuantileDigest;
 
-import static com.facebook.presto.operator.aggregation.LongDoubleConverterUtil.doubleToSortableLong;
-import static com.facebook.presto.operator.aggregation.LongDoubleConverterUtil.sortableLongToDouble;
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.doubleToSortableLong;
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.sortableLongToDouble;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.util.Failures.checkCondition;

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
@@ -22,8 +22,8 @@ import io.airlift.stats.QuantileDigest;
 
 import java.util.List;
 
-import static com.facebook.presto.operator.aggregation.LongDoubleConverterUtil.doubleToSortableLong;
-import static com.facebook.presto.operator.aggregation.LongDoubleConverterUtil.sortableLongToDouble;
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.doubleToSortableLong;
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.sortableLongToDouble;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 
 @AggregationFunction("approx_percentile")

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateFloatPercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateFloatPercentileAggregations.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.DigestAndPercentileState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+import io.airlift.stats.QuantileDigest;
+
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.floatToSortableInt;
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.sortableIntToFloat;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+
+@AggregationFunction("approx_percentile")
+public class ApproximateFloatPercentileAggregations
+{
+    private ApproximateFloatPercentileAggregations() {}
+
+    @InputFunction
+    public static void input(DigestAndPercentileState state, @SqlType(StandardTypes.FLOAT) long value, @SqlType(StandardTypes.DOUBLE) double percentile)
+    {
+        ApproximateLongPercentileAggregations.input(state, floatToSortableInt(intBitsToFloat((int) value)), percentile);
+    }
+
+    @InputFunction
+    public static void weightedInput(DigestAndPercentileState state, @SqlType(StandardTypes.FLOAT) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile)
+    {
+        ApproximateLongPercentileAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentile);
+    }
+
+    @InputFunction
+    public static void weightedInput(DigestAndPercentileState state, @SqlType(StandardTypes.FLOAT) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        ApproximateLongPercentileAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentile, accuracy);
+    }
+
+    @CombineFunction
+    public static void combine(DigestAndPercentileState state, DigestAndPercentileState otherState)
+    {
+        ApproximateLongPercentileAggregations.combine(state, otherState);
+    }
+
+    @OutputFunction(StandardTypes.FLOAT)
+    public static void output(DigestAndPercentileState state, BlockBuilder out)
+    {
+        QuantileDigest digest = state.getDigest();
+        double percentile = state.getPercentile();
+        if (digest == null || digest.getCount() == 0.0) {
+            out.appendNull();
+        }
+        else {
+            checkState(percentile != -1.0, "Percentile is missing");
+            checkCondition(0 <= percentile && percentile <= 1, INVALID_FUNCTION_ARGUMENT, "Percentile must be between 0 and 1");
+            FLOAT.writeLong(out, floatToRawIntBits(sortableIntToFloat((int) digest.getQuantile(percentile))));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateFloatPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateFloatPercentileArrayAggregations.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.DigestAndPercentileArrayState;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+import io.airlift.stats.QuantileDigest;
+
+import java.util.List;
+
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.floatToSortableInt;
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.sortableIntToFloat;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+
+@AggregationFunction("approx_percentile")
+public class ApproximateFloatPercentileArrayAggregations
+{
+    private ApproximateFloatPercentileArrayAggregations() {}
+
+    @InputFunction
+    public static void input(DigestAndPercentileArrayState state, @SqlType(StandardTypes.FLOAT) long value, @SqlType("array(double)") Block percentilesArrayBlock)
+    {
+        ApproximateLongPercentileArrayAggregations.input(state, floatToSortableInt(intBitsToFloat((int) value)), percentilesArrayBlock);
+    }
+
+    @InputFunction
+    public static void weightedInput(DigestAndPercentileArrayState state, @SqlType(StandardTypes.FLOAT) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType("array(double)") Block percentilesArrayBlock)
+    {
+        ApproximateLongPercentileArrayAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentilesArrayBlock);
+    }
+
+    @CombineFunction
+    public static void combine(DigestAndPercentileArrayState state, DigestAndPercentileArrayState otherState)
+    {
+        ApproximateLongPercentileArrayAggregations.combine(state, otherState);
+    }
+
+    @OutputFunction("array(float)")
+    public static void output(DigestAndPercentileArrayState state, BlockBuilder out)
+    {
+        QuantileDigest digest = state.getDigest();
+        List<Double> percentiles = state.getPercentiles();
+
+        if (percentiles == null || digest == null) {
+            out.appendNull();
+            return;
+        }
+
+        BlockBuilder blockBuilder = out.beginBlockEntry();
+
+        for (int i = 0; i < percentiles.size(); i++) {
+            Double percentile = percentiles.get(i);
+            FLOAT.writeLong(blockBuilder, floatToRawIntBits(sortableIntToFloat((int) digest.getQuantile(percentile))));
+        }
+
+        out.closeEntry();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CovarianceAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CovarianceAggregation.java
@@ -18,6 +18,8 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlType;
 
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getCovariancePopulation;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getCovarianceSample;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.mergeCovarianceState;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.updateCovarianceState;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -47,7 +49,7 @@ public class CovarianceAggregation
             out.appendNull();
         }
         else {
-            double result = (state.getSumXY() - state.getSumX() * state.getSumY() / state.getCount()) / (state.getCount() - 1);
+            double result = getCovarianceSample(state);
             DOUBLE.writeDouble(out, result);
         }
     }
@@ -60,7 +62,7 @@ public class CovarianceAggregation
             out.appendNull();
         }
         else {
-            double result = (state.getSumXY() - state.getSumX() * state.getSumY() / state.getCount()) / state.getCount();
+            double result = getCovariancePopulation(state);
             DOUBLE.writeDouble(out, result);
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleCorrelationAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleCorrelationAggregation.java
@@ -23,9 +23,9 @@ import static com.facebook.presto.operator.aggregation.AggregationUtils.updateCo
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 
 @AggregationFunction("corr")
-public class CorrelationAggregation
+public class DoubleCorrelationAggregation
 {
-    private CorrelationAggregation() {}
+    private DoubleCorrelationAggregation() {}
 
     @InputFunction
     public static void input(CorrelationState state, @SqlType(StandardTypes.DOUBLE) double dependentValue, @SqlType(StandardTypes.DOUBLE) double independentValue)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleCovarianceAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleCovarianceAggregation.java
@@ -25,9 +25,9 @@ import static com.facebook.presto.operator.aggregation.AggregationUtils.updateCo
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 
 @AggregationFunction("")
-public class CovarianceAggregation
+public class DoubleCovarianceAggregation
 {
-    private CovarianceAggregation() {}
+    private DoubleCovarianceAggregation() {}
 
     @InputFunction
     public static void input(CovarianceState state, @SqlType(StandardTypes.DOUBLE) double dependentValue, @SqlType(StandardTypes.DOUBLE) double independentValue)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleHistogramAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleHistogramAggregation.java
@@ -15,7 +15,7 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.operator.aggregation.state.AccumulatorState;
 import com.facebook.presto.operator.aggregation.state.AccumulatorStateMetadata;
-import com.facebook.presto.operator.aggregation.state.NumericHistogramStateSerializer;
+import com.facebook.presto.operator.aggregation.state.DoubleHistogramStateSerializer;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -33,15 +33,15 @@ import static com.facebook.presto.spi.type.StandardTypes.DOUBLE;
 import static com.facebook.presto.util.Failures.checkCondition;
 
 @AggregationFunction("numeric_histogram")
-public final class NumericHistogramAggregation
+public final class DoubleHistogramAggregation
 {
     public static final int ENTRY_BUFFER_SIZE = 100;
 
-    private NumericHistogramAggregation()
+    private DoubleHistogramAggregation()
     {
     }
 
-    @AccumulatorStateMetadata(stateSerializerClass = NumericHistogramStateSerializer.class, stateFactoryClass = NumericHistogramStateFactory.class)
+    @AccumulatorStateMetadata(stateSerializerClass = DoubleHistogramStateSerializer.class, stateFactoryClass = NumericHistogramStateFactory.class)
     public interface State
             extends AccumulatorState
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleRegressionAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleRegressionAggregation.java
@@ -18,6 +18,8 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlType;
 
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionIntercept;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSlope;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.mergeRegressionState;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.updateRegressionState;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -43,12 +45,7 @@ public class DoubleRegressionAggregation
     @OutputFunction(StandardTypes.DOUBLE)
     public static void regrSlope(RegressionState state, BlockBuilder out)
     {
-        // Math comes from ISO9075-2:2011(E) 10.9 General Rules 7 c xii
-        double dividend = state.getCount() * state.getSumXY() - state.getSumX() * state.getSumY();
-        double divisor = state.getCount() * state.getSumXSquare() - state.getSumX() * state.getSumX();
-
-        // divisor deliberately not checked for zero because the result can be Infty or NaN even if it is not zero
-        double result = dividend / divisor;
+        double result = getRegressionSlope(state);
         if (Double.isFinite(result)) {
             DOUBLE.writeDouble(out, result);
         }
@@ -61,12 +58,7 @@ public class DoubleRegressionAggregation
     @OutputFunction(StandardTypes.DOUBLE)
     public static void regrIntercept(RegressionState state, BlockBuilder out)
     {
-        // Math comes from ISO9075-2:2011(E) 10.9 General Rules 7 c xiii
-        double dividend = state.getSumY() * state.getSumXSquare() - state.getSumX() * state.getSumXY();
-        double divisor = state.getCount() * state.getSumXSquare() - state.getSumX() * state.getSumX();
-
-        // divisor deliberately not checked for zero because the result can be Infty or NaN even if it is not zero
-        double result = dividend / divisor;
+        double result = getRegressionIntercept(state);
         if (Double.isFinite(result)) {
             DOUBLE.writeDouble(out, result);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleRegressionAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleRegressionAggregation.java
@@ -23,9 +23,9 @@ import static com.facebook.presto.operator.aggregation.AggregationUtils.updateRe
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 
 @AggregationFunction("") // Names are on output methods
-public class RegressionAggregation
+public class DoubleRegressionAggregation
 {
-    private RegressionAggregation() {}
+    private DoubleRegressionAggregation() {}
 
     @InputFunction
     public static void input(RegressionState state, @SqlType(StandardTypes.DOUBLE) double dependentValue, @SqlType(StandardTypes.DOUBLE) double independentValue)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatAverageAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatAverageAggregation.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.LongAndDoubleState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+
+@AggregationFunction("avg")
+public final class FloatAverageAggregation
+{
+    private FloatAverageAggregation() {}
+
+    @InputFunction
+    public static void input(LongAndDoubleState state, @SqlType(StandardTypes.FLOAT) long value)
+    {
+        state.setLong(state.getLong() + 1);
+        state.setDouble(state.getDouble() + intBitsToFloat((int) value));
+    }
+
+    @CombineFunction
+    public static void combine(LongAndDoubleState state, LongAndDoubleState otherState)
+    {
+        state.setLong(state.getLong() + otherState.getLong());
+        state.setDouble(state.getDouble() + otherState.getDouble());
+    }
+
+    @OutputFunction(StandardTypes.FLOAT)
+    public static void output(LongAndDoubleState state, BlockBuilder out)
+    {
+        long count = state.getLong();
+        if (count == 0) {
+            out.appendNull();
+        }
+        else {
+            double average = state.getDouble() / count;
+            FLOAT.writeLong(out, floatToRawIntBits((float) average));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatCorrelationAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatCorrelationAggregation.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.CorrelationState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getCorrelation;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+
+@AggregationFunction("corr")
+public class FloatCorrelationAggregation
+{
+    private FloatCorrelationAggregation() {}
+
+    @InputFunction
+    public static void input(CorrelationState state, @SqlType(StandardTypes.FLOAT) long dependentValue, @SqlType(StandardTypes.FLOAT) long independentValue)
+    {
+        DoubleCorrelationAggregation.input(state, intBitsToFloat((int) dependentValue), intBitsToFloat((int) independentValue));
+    }
+
+    @CombineFunction
+    public static void combine(CorrelationState state, CorrelationState otherState)
+    {
+        DoubleCorrelationAggregation.combine(state, otherState);
+    }
+
+    @OutputFunction(StandardTypes.FLOAT)
+    public static void corr(CorrelationState state, BlockBuilder out)
+    {
+        double result = getCorrelation(state);
+        if (Double.isFinite(result)) {
+            long resultBits = floatToRawIntBits((float) Math.sqrt(result)); // sqrt cannot turn finite value to non-finite value
+            FLOAT.writeLong(out, resultBits);
+        }
+        else {
+            out.appendNull();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatCovarianceAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatCovarianceAggregation.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.CovarianceState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getCovariancePopulation;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getCovarianceSample;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static java.lang.Float.intBitsToFloat;
+
+@AggregationFunction("")
+public class FloatCovarianceAggregation
+{
+    private FloatCovarianceAggregation() {}
+
+    @InputFunction
+    public static void input(CovarianceState state, @SqlType(StandardTypes.FLOAT) long dependentValue, @SqlType(StandardTypes.FLOAT) long independentValue)
+    {
+        DoubleCovarianceAggregation.input(state, intBitsToFloat((int) dependentValue), intBitsToFloat((int) independentValue));
+    }
+
+    @CombineFunction
+    public static void combine(CovarianceState state, CovarianceState otherState)
+    {
+        DoubleCovarianceAggregation.combine(state, otherState);
+    }
+
+    @AggregationFunction("covar_samp")
+    @OutputFunction(StandardTypes.FLOAT)
+    public static void covarSamp(CovarianceState state, BlockBuilder out)
+    {
+        if (state.getCount() <= 1) {
+            out.appendNull();
+        }
+        else {
+            double result = getCovarianceSample(state);
+            FLOAT.writeLong(out, Float.floatToRawIntBits((float) result));
+        }
+    }
+
+    @AggregationFunction("covar_pop")
+    @OutputFunction(StandardTypes.FLOAT)
+    public static void covarPop(CovarianceState state, BlockBuilder out)
+    {
+        if (state.getCount() == 0) {
+            out.appendNull();
+        }
+        else {
+            double result = getCovariancePopulation(state);
+            FLOAT.writeLong(out, Float.floatToRawIntBits((float) result));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatGeometricMeanAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatGeometricMeanAggregations.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.LongAndDoubleState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+
+@AggregationFunction("geometric_mean")
+public final class FloatGeometricMeanAggregations
+{
+    private FloatGeometricMeanAggregations() {}
+
+    @InputFunction
+    public static void input(LongAndDoubleState state, @SqlType(StandardTypes.FLOAT) long value)
+    {
+        state.setLong(state.getLong() + 1);
+        state.setDouble(state.getDouble() + Math.log(intBitsToFloat((int) value)));
+    }
+
+    @CombineFunction
+    public static void combine(LongAndDoubleState state, LongAndDoubleState otherState)
+    {
+        state.setLong(state.getLong() + otherState.getLong());
+        state.setDouble(state.getDouble() + otherState.getDouble());
+    }
+
+    @OutputFunction(StandardTypes.FLOAT)
+    public static void output(LongAndDoubleState state, BlockBuilder out)
+    {
+        long count = state.getLong();
+        if (count == 0) {
+            out.appendNull();
+        }
+        else {
+            FLOAT.writeLong(out, floatToRawIntBits((float) Math.exp(state.getDouble() / count)));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatHistogramAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatHistogramAggregation.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.FloatType;
+import com.facebook.presto.type.SqlType;
+
+import java.util.Map;
+
+import static com.facebook.presto.spi.type.StandardTypes.BIGINT;
+import static com.facebook.presto.spi.type.StandardTypes.DOUBLE;
+import static com.facebook.presto.spi.type.StandardTypes.FLOAT;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+
+@AggregationFunction("numeric_histogram")
+public class FloatHistogramAggregation
+{
+    private FloatHistogramAggregation()
+    {
+    }
+
+    @InputFunction
+    public static void add(DoubleHistogramAggregation.State state, @SqlType(BIGINT) long buckets, @SqlType(FLOAT) long value, @SqlType(DOUBLE) double weight)
+    {
+        DoubleHistogramAggregation.add(state, buckets, intBitsToFloat((int) value), weight);
+    }
+
+    @InputFunction
+    public static void add(DoubleHistogramAggregation.State state, @SqlType(BIGINT) long buckets, @SqlType(FLOAT) long value)
+    {
+        add(state, buckets, value, 1);
+    }
+
+    @CombineFunction
+    public static void merge(DoubleHistogramAggregation.State state, DoubleHistogramAggregation.State other)
+    {
+        DoubleHistogramAggregation.merge(state, other);
+    }
+
+    @OutputFunction("map(float,float)")
+    public static void output(DoubleHistogramAggregation.State state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            Map<Double, Double> value = state.get().getBuckets();
+            BlockBuilder blockBuilder = FloatType.FLOAT.createBlockBuilder(new BlockBuilderStatus(), value.size() * 2);
+            for (Map.Entry<Double, Double> entry : value.entrySet()) {
+                FloatType.FLOAT.writeLong(blockBuilder, floatToRawIntBits(entry.getKey().floatValue()));
+                FloatType.FLOAT.writeLong(blockBuilder, floatToRawIntBits(entry.getValue().floatValue()));
+            }
+            Block block = blockBuilder.build();
+            out.writeObject(block);
+            out.closeEntry();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatRegressionAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatRegressionAggregation.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.RegressionState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionIntercept;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSlope;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+
+@AggregationFunction("")
+public class FloatRegressionAggregation
+{
+    private FloatRegressionAggregation() {}
+
+    @InputFunction
+    public static void input(RegressionState state, @SqlType(StandardTypes.FLOAT) long dependentValue, @SqlType(StandardTypes.FLOAT) long independentValue)
+    {
+        DoubleRegressionAggregation.input(state, intBitsToFloat((int) dependentValue), intBitsToFloat((int) independentValue));
+    }
+
+    @CombineFunction
+    public static void combine(RegressionState state, RegressionState otherState)
+    {
+        DoubleRegressionAggregation.combine(state, otherState);
+    }
+
+    @AggregationFunction("regr_slope")
+    @OutputFunction(StandardTypes.FLOAT)
+    public static void regrSlope(RegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionSlope(state);
+        if (Double.isFinite(result)) {
+            FLOAT.writeLong(out, floatToRawIntBits((float) result));
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_intercept")
+    @OutputFunction(StandardTypes.FLOAT)
+    public static void regrIntercept(RegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionIntercept(state);
+        if (Double.isFinite(result)) {
+            FLOAT.writeLong(out, floatToRawIntBits((float) result));
+        }
+        else {
+            out.appendNull();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatSumAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatSumAggregation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.NullableDoubleState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.FloatType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+
+import static com.facebook.presto.testing.AggregationTestUtils.generateInternalAggregationFunction;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+
+@AggregationFunction("sum")
+public final class FloatSumAggregation
+{
+    public static final InternalAggregationFunction FLOAT_SUM = generateInternalAggregationFunction(FloatSumAggregation.class);
+
+    private FloatSumAggregation() {}
+
+    @InputFunction
+    public static void sum(NullableDoubleState state, @SqlType(StandardTypes.FLOAT) long value)
+    {
+        state.setNull(false);
+        state.setDouble(state.getDouble() + intBitsToFloat((int) value));
+    }
+
+    @CombineFunction
+    public static void combine(NullableDoubleState state, NullableDoubleState otherState)
+    {
+        if (state.isNull()) {
+            if (otherState.isNull()) {
+                return;
+            }
+            state.setNull(false);
+            state.setDouble(otherState.getDouble());
+            return;
+        }
+
+        if (!otherState.isNull()) {
+            state.setDouble(state.getDouble() + otherState.getDouble());
+        }
+    }
+
+    @OutputFunction(StandardTypes.FLOAT)
+    public static void output(NullableDoubleState state, BlockBuilder out)
+    {
+        if (state.isNull()) {
+            out.appendNull();
+        }
+        else {
+            FloatType.FLOAT.writeLong(out, floatToRawIntBits((float) state.getDouble()));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatingPointBitsConverterUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatingPointBitsConverterUtil.java
@@ -23,7 +23,7 @@ final class FloatingPointBitsConverterUtil
      */
     public static long doubleToSortableLong(double value)
     {
-        long bits = Double.doubleToRawLongBits(value);
+        long bits = Double.doubleToLongBits(value);
         return bits ^ (bits >> 63) & Long.MAX_VALUE;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatingPointBitsConverterUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatingPointBitsConverterUtil.java
@@ -37,4 +37,26 @@ final class FloatingPointBitsConverterUtil
         value = value ^ (value >> 63) & Long.MAX_VALUE;
         return Double.longBitsToDouble(value);
     }
+
+    /**
+     * Converts a float value to a sortable int.
+     *
+     * @see #doubleToSortableLong(double)
+     */
+    public static int floatToSortableInt(float value)
+    {
+        int bits = Float.floatToIntBits(value);
+        return bits ^ (bits >> 31) & Integer.MAX_VALUE;
+    }
+
+    /**
+     * Coverts a sortable int to float.
+     *
+     * @see #sortableLongToDouble(long)
+     */
+    public static float sortableIntToFloat(int value)
+    {
+        value = value ^ (value >> 31)  & Integer.MAX_VALUE;
+        return Float.intBitsToFloat(value);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatingPointBitsConverterUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatingPointBitsConverterUtil.java
@@ -21,10 +21,10 @@ final class FloatingPointBitsConverterUtil
      * Converts a double value to a sortable long. The value is converted by getting their IEEE 754
      * floating-point bit layout. Some bits are swapped to be able to compare the result as long.
      */
-    public static double sortableLongToDouble(long value)
+    public static long doubleToSortableLong(double value)
     {
-        value = value ^ (value >> 63) & Long.MAX_VALUE;
-        return Double.longBitsToDouble(value);
+        long bits = Double.doubleToRawLongBits(value);
+        return bits ^ (bits >> 63) & Long.MAX_VALUE;
     }
 
     /**
@@ -32,9 +32,9 @@ final class FloatingPointBitsConverterUtil
      *
      * @see #sortableLongToDouble(long)
      */
-    public static long doubleToSortableLong(double value)
+    public static double sortableLongToDouble(long value)
     {
-        long bits = Double.doubleToRawLongBits(value);
-        return bits ^ (bits >> 63) & Long.MAX_VALUE;
+        value = value ^ (value >> 63) & Long.MAX_VALUE;
+        return Double.longBitsToDouble(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatingPointBitsConverterUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatingPointBitsConverterUtil.java
@@ -13,9 +13,9 @@
  */
 package com.facebook.presto.operator.aggregation;
 
-final class LongDoubleConverterUtil
+final class FloatingPointBitsConverterUtil
 {
-    private LongDoubleConverterUtil() {}
+    private FloatingPointBitsConverterUtil() {}
 
     /**
      * Converts a double value to a sortable long. The value is converted by getting their IEEE 754

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/NumericHistogramStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/NumericHistogramStateFactory.java
@@ -20,35 +20,35 @@ import com.facebook.presto.util.array.ObjectBigArray;
 import static java.util.Objects.requireNonNull;
 
 public class NumericHistogramStateFactory
-        implements AccumulatorStateFactory<NumericHistogramAggregation.State>
+        implements AccumulatorStateFactory<DoubleHistogramAggregation.State>
 {
     @Override
-    public NumericHistogramAggregation.State createSingleState()
+    public DoubleHistogramAggregation.State createSingleState()
     {
         return new SingleState();
     }
 
     @Override
-    public Class<? extends NumericHistogramAggregation.State> getSingleStateClass()
+    public Class<? extends DoubleHistogramAggregation.State> getSingleStateClass()
     {
         return SingleState.class;
     }
 
     @Override
-    public NumericHistogramAggregation.State createGroupedState()
+    public DoubleHistogramAggregation.State createGroupedState()
     {
         return new GroupedState();
     }
 
     @Override
-    public Class<? extends NumericHistogramAggregation.State> getGroupedStateClass()
+    public Class<? extends DoubleHistogramAggregation.State> getGroupedStateClass()
     {
         return GroupedState.class;
     }
 
     public static class GroupedState
             extends AbstractGroupedAccumulatorState
-            implements NumericHistogramAggregation.State
+            implements DoubleHistogramAggregation.State
     {
         private final ObjectBigArray<NumericHistogram> histograms = new ObjectBigArray<>();
         private long size;
@@ -87,7 +87,7 @@ public class NumericHistogramStateFactory
     }
 
     public static class SingleState
-            implements NumericHistogramAggregation.State
+            implements DoubleHistogramAggregation.State
     {
         private NumericHistogram histogram;
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DoubleHistogramStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DoubleHistogramStateSerializer.java
@@ -13,16 +13,16 @@
  */
 package com.facebook.presto.operator.aggregation.state;
 
+import com.facebook.presto.operator.aggregation.DoubleHistogramAggregation;
 import com.facebook.presto.operator.aggregation.NumericHistogram;
-import com.facebook.presto.operator.aggregation.NumericHistogramAggregation;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 
-public class NumericHistogramStateSerializer
-        implements AccumulatorStateSerializer<NumericHistogramAggregation.State>
+public class DoubleHistogramStateSerializer
+        implements AccumulatorStateSerializer<DoubleHistogramAggregation.State>
 {
     @Override
     public Type getSerializedType()
@@ -31,7 +31,7 @@ public class NumericHistogramStateSerializer
     }
 
     @Override
-    public void serialize(NumericHistogramAggregation.State state, BlockBuilder out)
+    public void serialize(DoubleHistogramAggregation.State state, BlockBuilder out)
     {
         if (state.get() == null) {
             out.appendNull();
@@ -42,10 +42,10 @@ public class NumericHistogramStateSerializer
     }
 
     @Override
-    public void deserialize(Block block, int index, NumericHistogramAggregation.State state)
+    public void deserialize(Block block, int index, DoubleHistogramAggregation.State state)
     {
         if (!block.isNull(index)) {
-            state.set(new NumericHistogram(VARBINARY.getSlice(block, index), NumericHistogramAggregation.ENTRY_BUFFER_SIZE));
+            state.set(new NumericHistogram(VARBINARY.getSlice(block, index), DoubleHistogramAggregation.ENTRY_BUFFER_SIZE));
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/SequencePageBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/SequencePageBuilder.java
@@ -25,6 +25,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 
@@ -48,6 +49,9 @@ public final class SequencePageBuilder
 
             if (type.equals(BIGINT)) {
                 blocks[i] = BlockAssertions.createLongSequenceBlock(initialValue, initialValue + length);
+            }
+            else if (type.equals(FLOAT)) {
+                blocks[i] = BlockAssertions.createFloatSequenceBlock(initialValue, initialValue + length);
             }
             else if (type.equals(DOUBLE)) {
                 blocks[i] = BlockAssertions.createDoubleSequenceBlock(initialValue, initialValue + length);

--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -31,6 +31,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
@@ -39,6 +40,7 @@ import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.wrappedIntArray;
+import static java.lang.Float.floatToRawIntBits;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
 
@@ -317,6 +319,38 @@ public final class BlockAssertions
 
         for (int i = start; i < end; i++) {
             BOOLEAN.writeBoolean(builder, i % 2 == 0);
+        }
+
+        return builder.build();
+    }
+
+    public static Block createFloatsBlock(Float... values)
+    {
+        requireNonNull(values, "varargs 'values' is null");
+
+        return createFloatsBlock(Arrays.asList(values));
+    }
+
+    private static Block createFloatsBlock(Iterable<Float> values)
+    {
+        BlockBuilder builder = FLOAT.createBlockBuilder(new BlockBuilderStatus(), 100);
+        for (Float value : values) {
+            if (value == null) {
+                builder.appendNull();
+            }
+            else {
+                FLOAT.writeLong(builder, floatToRawIntBits(value));
+            }
+        }
+        return builder.build();
+    }
+
+    public static Block createFloatSequenceBlock(int start, int end)
+    {
+        BlockBuilder builder = FLOAT.createFixedSizeBlockBuilder(end - start);
+
+        for (int i = start; i < end; i++) {
+            FLOAT.writeLong(builder, floatToRawIntBits((float) i));
         }
 
         return builder.build();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
@@ -35,8 +35,10 @@ import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
+import static com.facebook.presto.operator.aggregation.FloatSumAggregation.FLOAT_SUM;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
@@ -86,8 +88,8 @@ public class TestAggregationOperator
                 new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.VARCHAR)));
         InternalAggregationFunction maxVarcharColumn = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
                 new Signature("max", AGGREGATE, parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR)));
-        List<Page> input = rowPagesBuilder(VARCHAR, BIGINT, VARCHAR, BIGINT, DOUBLE, VARCHAR)
-                .addSequencePage(100, 0, 0, 300, 500, 500, 500)
+        List<Page> input = rowPagesBuilder(VARCHAR, BIGINT, VARCHAR, BIGINT, FLOAT, DOUBLE, VARCHAR)
+                .addSequencePage(100, 0, 0, 300, 500, 400, 500, 500)
                 .build();
 
         OperatorFactory operatorFactory = new AggregationOperatorFactory(
@@ -100,12 +102,13 @@ public class TestAggregationOperator
                         maxVarcharColumn.bind(ImmutableList.of(2), Optional.empty(), Optional.empty(), 1.0),
                         countVarcharColumn.bind(ImmutableList.of(0), Optional.empty(), Optional.empty(), 1.0),
                         LONG_SUM.bind(ImmutableList.of(3), Optional.empty(), Optional.empty(), 1.0),
-                        DOUBLE_SUM.bind(ImmutableList.of(4), Optional.empty(), Optional.empty(), 1.0),
-                        maxVarcharColumn.bind(ImmutableList.of(5), Optional.empty(), Optional.empty(), 1.0)));
+                        FLOAT_SUM.bind(ImmutableList.of(4), Optional.empty(), Optional.empty(), 1.0),
+                        DOUBLE_SUM.bind(ImmutableList.of(5), Optional.empty(), Optional.empty(), 1.0),
+                        maxVarcharColumn.bind(ImmutableList.of(6), Optional.empty(), Optional.empty(), 1.0)));
         Operator operator = operatorFactory.createOperator(driverContext);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, BIGINT, DOUBLE, VARCHAR, BIGINT, BIGINT, DOUBLE, VARCHAR)
-                .row(100L, 4950L, 49.5, "399", 100L, 54950L, 54950.0, "599")
+                .row(100L, 4950L, 49.5, "399", 100L, 54950L, 44950.0f, 54950.0, "599")
                 .build();
 
         assertOperatorEquals(operator, input, expected);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFloatAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFloatAverageAggregation.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.aggregation.AbstractTestAggregationFunction;
+import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createFloatsBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static java.lang.Float.floatToRawIntBits;
+
+@Test(singleThreaded = true)
+public class TestFloatAverageAggregation
+        extends AbstractTestAggregationFunction
+{
+    private InternalAggregationFunction avgFunction;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        MetadataManager metadata = MetadataManager.createTestMetadataManager();
+        avgFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("avg", FunctionKind.AGGREGATE, parseTypeSignature(StandardTypes.FLOAT), parseTypeSignature(StandardTypes.FLOAT)));
+    }
+
+    @Test
+    public void averageOfNullIsNull()
+    {
+        assertAggregation(avgFunction,
+                1.0,
+                null,
+                createFloatsBlock(null, null));
+    }
+
+    @Test
+    public void averageOfSingleValueEqualsThatValue()
+    {
+        assertAggregation(avgFunction,
+                1.0,
+                1.23f,
+                createFloatsBlock(1.23f));
+    }
+
+    @Test
+    public void averageOfTwoMaxFloatsEqualsMaxFloat()
+    {
+        assertAggregation(avgFunction,
+                1.0,
+                Float.MAX_VALUE,
+                createFloatsBlock(Float.MAX_VALUE, Float.MAX_VALUE));
+    }
+
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = FLOAT.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            FLOAT.writeLong(blockBuilder, floatToRawIntBits((float) i));
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "avg";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.FLOAT);
+    }
+
+    @Override
+    public Object getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        float sum = 0;
+        for (int i = start; i < start + length; i++) {
+            sum += i;
+        }
+        return sum / length;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
@@ -33,8 +33,6 @@ import java.util.stream.IntStream;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
-import static com.facebook.presto.util.Numbers.isFloatingNumber;
-import static com.facebook.presto.util.Numbers.isNan;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -171,10 +169,11 @@ public final class AggregationTestUtils
         BiConsumer<Object, Object> equalAssertion = (actual, expected) -> {
             assertEquals(actual, expected);
         };
-        if (isFloatingNumber(expectedValue) && !isNan(expectedValue)) {
-            equalAssertion = (actual, expected) -> {
-                assertEquals((double) actual, (double) expected, 1e-10);
-            };
+        if (expectedValue instanceof Double && !expectedValue.equals(Double.NaN)) {
+            equalAssertion = (actual, expected) -> assertEquals((double) actual, (double) expected, 1e-10);
+        }
+        if (expectedValue instanceof Float && !expectedValue.equals(Float.NaN)) {
+            equalAssertion = (actual, expected) -> assertEquals((float) actual, (float) expected, 1e-10f);
         }
 
         // This assertAggregation does not try to split up the page to test the correctness of combine function.

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
@@ -24,6 +24,8 @@ import org.testng.annotations.Test;
 
 import static com.facebook.presto.block.BlockAssertions.createDoubleSequenceBlock;
 import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createFloatSequenceBlock;
+import static com.facebook.presto.block.BlockAssertions.createFloatsBlock;
 import static com.facebook.presto.block.BlockAssertions.createLongRepeatBlock;
 import static com.facebook.presto.block.BlockAssertions.createLongSequenceBlock;
 import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
@@ -31,6 +33,7 @@ import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 
 public class TestApproximatePercentileAggregation
@@ -60,6 +63,23 @@ public class TestApproximatePercentileAggregation
             new Signature("approx_percentile", AGGREGATE, parseTypeSignature("array(bigint)"), BIGINT.getTypeSignature(), parseTypeSignature("array(double)")));
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, parseTypeSignature("array(bigint)"), BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), parseTypeSignature("array(double)")));
+
+    private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("approx_percentile", AGGREGATE, FLOAT.getTypeSignature(),
+                    ImmutableList.of(FLOAT.getTypeSignature(), DOUBLE.getTypeSignature())));
+    private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("approx_percentile", AGGREGATE, FLOAT.getTypeSignature(),
+                    ImmutableList.of(FLOAT.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature())));
+    private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("approx_percentile", AGGREGATE, FLOAT.getTypeSignature(),
+                    ImmutableList.of(FLOAT.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature())));
+
+    private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("approx_percentile", AGGREGATE, new ArrayType(FLOAT).getTypeSignature(),
+                    ImmutableList.of(FLOAT.getTypeSignature(), new ArrayType(DOUBLE).getTypeSignature())));
+    private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("approx_percentile", AGGREGATE, new ArrayType(FLOAT).getTypeSignature(),
+                    ImmutableList.of(FLOAT.getTypeSignature(), BIGINT.getTypeSignature(), new ArrayType(DOUBLE).getTypeSignature())));
 
     @Test
     public void testLongPartialStep()
@@ -198,6 +218,163 @@ public class TestApproximatePercentileAggregation
                 1.0,
                 ImmutableList.of(1L, 2L),
                 createLongsBlock(1L, 2L, 3L),
+                createLongsBlock(4L, 2L, 1L),
+                createRLEBlock(ImmutableList.of(0.5, 0.8),  3));
+    }
+
+    @Test
+    public void testFloatPartialStep()
+            throws Exception
+    {
+        // regular approx_percentile
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION,
+                1.0,
+                null,
+                createFloatsBlock(null, null),
+                createRLEBlock(0.5, 2));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION,
+                1.0,
+                1.0f,
+                createFloatsBlock(null, 1.0f),
+                createRLEBlock(0.5, 2));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION,
+                1.0,
+                2.0f,
+                createFloatsBlock(null, 1.0f, 2.0f, 3.0f),
+                createRLEBlock(0.5, 4));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION,
+                1.0,
+                1.0f,
+                createFloatsBlock(-1.0f, 1.0f),
+                createRLEBlock(0.5, 2));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION,
+                1.0,
+                -1.0f,
+                createFloatsBlock(-2.0f, 3.0f, -1.0f),
+                createRLEBlock(0.5, 3));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION,
+                1.0,
+                2.0f,
+                createFloatsBlock(1.0f, 2.0f, 3.0f),
+                createRLEBlock(0.5, 3));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION,
+                1.0,
+                3.0f,
+                createFloatsBlock(1.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 3.0f, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
+                createRLEBlock(0.5, 21));
+
+        // array of approx_percentile
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                null,
+                createFloatsBlock(null, null),
+                createRLEBlock(ImmutableList.of(0.5),  2));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                null,
+                createFloatsBlock(null, null),
+                createRLEBlock(ImmutableList.of(0.5, 0.5),  2));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1.0f, 1.0f),
+                createFloatsBlock(null, 1.0f),
+                createRLEBlock(ImmutableList.of(0.5, 0.5),  2));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1.0f, 2.0f, 3.0f),
+                createFloatsBlock(null, 1.0f, 2.0f, 3.0f),
+                createRLEBlock(ImmutableList.of(0.2, 0.5, 0.8),  4));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(2.0f, 3.0f),
+                createFloatsBlock(1.0f, 2.0f, 3.0f),
+                createRLEBlock(ImmutableList.of(0.5, 0.99),  3));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1.0f, 3.0f),
+                createFloatsBlock(1.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 3.0f, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
+                createRLEBlock(ImmutableList.of(0.01, 0.5),  21));
+
+        // weighted approx_percentile
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
+                1.0,
+                null,
+                createFloatsBlock(null, null),
+                createLongsBlock(1L, 1L),
+                createRLEBlock(0.5, 2));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
+                1.0,
+                1.0f,
+                createFloatsBlock(null, 1.0f),
+                createLongsBlock(1L, 1L),
+                createRLEBlock(0.5, 2));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
+                1.0,
+                2.0f,
+                createFloatsBlock(null, 1.0f, 2.0f, 3.0f),
+                createLongsBlock(1L, 1L, 1L, 1L),
+                createRLEBlock(0.5, 4));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
+                1.0,
+                2.0f,
+                createFloatsBlock(1.0f, 2.0f, 3.0f),
+                createLongsBlock(1L, 1L, 1L),
+                createRLEBlock(0.5, 3));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
+                1.0,
+                3.0f,
+                createFloatsBlock(1.0f, null, 2.0f, null, 2.0f, null, 2.0f, null, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
+                createLongsBlock(1L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L),
+                createRLEBlock(0.5, 17));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY,
+                1.0,
+                9900.0f,
+                createFloatSequenceBlock(0, 10000),
+                createLongRepeatBlock(1, 10000),
+                createRLEBlock(0.99, 10000),
+                createRLEBlock(0.001, 10000));
+
+        // weighted + array of approx_percentile
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION,
+                1.0,
+                ImmutableList.of(1.0f, 2.0f),
+                createFloatsBlock(1.0f, 2.0f, 3.0f),
                 createLongsBlock(4L, 2L, 1L),
                 createRLEBlock(ImmutableList.of(0.5, 0.8),  3));
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleCorrelationAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleCorrelationAggregation.java
@@ -27,7 +27,7 @@ import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.constructDoublePrimitiveArray;
 import static com.google.common.base.Preconditions.checkArgument;
 
-public class TestCorrelationAggregation
+public class TestDoubleCorrelationAggregation
         extends AbstractTestAggregationFunction
 {
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleCovariancePopAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleCovariancePopAggregation.java
@@ -23,7 +23,7 @@ import java.util.List;
 import static com.facebook.presto.block.BlockAssertions.createDoubleSequenceBlock;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.constructDoublePrimitiveArray;
 
-public class TestCovariancePopAggregation
+public class TestDoubleCovariancePopAggregation
         extends AbstractTestAggregationFunction
 {
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleCovarianceSampAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleCovarianceSampAggregation.java
@@ -23,7 +23,7 @@ import java.util.List;
 import static com.facebook.presto.block.BlockAssertions.createDoubleSequenceBlock;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.constructDoublePrimitiveArray;
 
-public class TestCovarianceSampAggregation
+public class TestDoubleCovarianceSampAggregation
         extends AbstractTestAggregationFunction
 {
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleHistogramAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleHistogramAggregation.java
@@ -41,12 +41,12 @@ import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-public class TestNumericHistogramAggregation
+public class TestDoubleHistogramAggregation
 {
     private final AccumulatorFactory factory;
     private final Page input;
 
-    public TestNumericHistogramAggregation()
+    public TestDoubleHistogramAggregation()
     {
         TypeRegistry typeRegistry = new TypeRegistry();
         FunctionRegistry functionRegistry = new FunctionRegistry(typeRegistry, new BlockEncodingManager(typeRegistry), new FeaturesConfig().setExperimentalSyntaxEnabled(true));

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrInterceptAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrInterceptAggregation.java
@@ -25,7 +25,7 @@ import static com.facebook.presto.block.BlockAssertions.createDoubleSequenceBloc
 import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
 import static com.google.common.base.Preconditions.checkArgument;
 
-public class TestRegrSlopeAggregation
+public class TestDoubleRegrInterceptAggregation
         extends AbstractTestAggregationFunction
 {
     @Override
@@ -37,7 +37,7 @@ public class TestRegrSlopeAggregation
     @Override
     protected String getFunctionName()
     {
-        return "regr_slope";
+        return "regr_intercept";
     }
 
     @Override
@@ -56,7 +56,7 @@ public class TestRegrSlopeAggregation
         for (int i = start; i < start + length; i++) {
             regression.addData(i + 2, i);
         }
-        return regression.getSlope();
+        return regression.getIntercept();
     }
 
     @Test
@@ -72,8 +72,8 @@ public class TestRegrSlopeAggregation
         for (int i = 0; i < x.length; i++) {
             regression.addData(x[i], y[i]);
         }
-        double expected = regression.getSlope();
-        checkArgument(Double.isFinite(expected) && expected != 0.0, "Expected result is trivial");
+        double expected = regression.getIntercept();
+        checkArgument(Double.isFinite(expected) && expected != 0., "Expected result is trivial");
         testAggregation(expected, createDoublesBlock(y), createDoublesBlock(x));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrSlopeAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrSlopeAggregation.java
@@ -25,7 +25,7 @@ import static com.facebook.presto.block.BlockAssertions.createDoubleSequenceBloc
 import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
 import static com.google.common.base.Preconditions.checkArgument;
 
-public class TestRegrInterceptAggregation
+public class TestDoubleRegrSlopeAggregation
         extends AbstractTestAggregationFunction
 {
     @Override
@@ -37,7 +37,7 @@ public class TestRegrInterceptAggregation
     @Override
     protected String getFunctionName()
     {
-        return "regr_intercept";
+        return "regr_slope";
     }
 
     @Override
@@ -56,7 +56,7 @@ public class TestRegrInterceptAggregation
         for (int i = start; i < start + length; i++) {
             regression.addData(i + 2, i);
         }
-        return regression.getIntercept();
+        return regression.getSlope();
     }
 
     @Test
@@ -72,8 +72,8 @@ public class TestRegrInterceptAggregation
         for (int i = 0; i < x.length; i++) {
             regression.addData(x[i], y[i]);
         }
-        double expected = regression.getIntercept();
-        checkArgument(Double.isFinite(expected) && expected != 0., "Expected result is trivial");
+        double expected = regression.getSlope();
+        checkArgument(Double.isFinite(expected) && expected != 0.0, "Expected result is trivial");
         testAggregation(expected, createDoublesBlock(y), createDoublesBlock(x));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatCorrelationAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatCorrelationAggregation.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.correlation.PearsonsCorrelation;
+
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createFloatSequenceBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.constructDoublePrimitiveArray;
+
+public class TestFloatCorrelationAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        return new Block[] {createFloatSequenceBlock(start, start + length), createFloatSequenceBlock(start + 2, start + 2 + length)};
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "corr";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.FLOAT, StandardTypes.FLOAT);
+    }
+
+    @Override
+    public Object getExpectedValue(int start, int length)
+    {
+        if (length <= 1) {
+            return null;
+        }
+        PearsonsCorrelation corr = new PearsonsCorrelation();
+        return (float) corr.correlation(constructDoublePrimitiveArray(start + 2, length), constructDoublePrimitiveArray(start, length));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatCovariancePopAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatCovariancePopAggregation.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.correlation.Covariance;
+
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createFloatSequenceBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.constructDoublePrimitiveArray;
+
+public class TestFloatCovariancePopAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        return new Block[]{createFloatSequenceBlock(start, start + length), createFloatSequenceBlock(start + 5, start + 5 + length)};
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "covar_pop";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.FLOAT, StandardTypes.FLOAT);
+    }
+
+    @Override
+    public Object getExpectedValue(int start, int length)
+    {
+        if (length <= 0) {
+            return null;
+        }
+        else if (length == 1) {
+            return 0.f;
+        }
+        Covariance covariance = new Covariance();
+        return (float) covariance.covariance(constructDoublePrimitiveArray(start + 5, length), constructDoublePrimitiveArray(start, length), false);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatCovarianceSampAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatCovarianceSampAggregation.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.correlation.Covariance;
+
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createFloatSequenceBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.constructDoublePrimitiveArray;
+
+public class TestFloatCovarianceSampAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        return new Block[]{createFloatSequenceBlock(start, start + length), createFloatSequenceBlock(start + 5, start + 5 + length)};
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "covar_samp";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.FLOAT, StandardTypes.FLOAT);
+    }
+
+    @Override
+    public Object getExpectedValue(int start, int length)
+    {
+        if (length <= 1) {
+            return null;
+        }
+        return (float) new Covariance().covariance(constructDoublePrimitiveArray(start + 5, length), constructDoublePrimitiveArray(start, length), true);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatGeometricMeanAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatGeometricMeanAggregation.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static java.lang.Float.floatToRawIntBits;
+
+public class TestFloatGeometricMeanAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = FLOAT.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            FLOAT.writeLong(blockBuilder, floatToRawIntBits((float) i));
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double product = 1.0d;
+        for (int i = start; i < start + length; i++) {
+            product *= i;
+        }
+        return (float) Math.pow(product, 1.0d / length);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "geometric_mean";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.FLOAT);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatHistogramAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatHistogramAggregation.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.TypeRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.getFinalBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.getIntermediateBlock;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestFloatHistogramAggregation
+{
+    private final AccumulatorFactory factory;
+    private final Page input;
+
+    public TestFloatHistogramAggregation()
+    {
+        TypeRegistry typeRegistry = new TypeRegistry();
+        FunctionRegistry functionRegistry = new FunctionRegistry(typeRegistry, new BlockEncodingManager(typeRegistry), new FeaturesConfig().setExperimentalSyntaxEnabled(true));
+        InternalAggregationFunction function = functionRegistry.getAggregateFunctionImplementation(
+                new Signature("numeric_histogram",
+                        AGGREGATE,
+                        parseTypeSignature("map(float, float)"),
+                        parseTypeSignature(StandardTypes.BIGINT),
+                        parseTypeSignature(StandardTypes.FLOAT),
+                        parseTypeSignature(StandardTypes.DOUBLE)));
+        factory = function.bind(ImmutableList.of(0, 1, 2), Optional.empty(), Optional.empty(), 1.0);
+
+        input = makeInput(10);
+    }
+
+    @Test
+    public void test()
+            throws Exception
+    {
+        Accumulator singleStep = factory.createAccumulator();
+        singleStep.addInput(input);
+        Block expected = getFinalBlock(singleStep);
+
+        Accumulator partialStep = factory.createAccumulator();
+        partialStep.addInput(input);
+        Block partialBlock = getIntermediateBlock(partialStep);
+
+        Accumulator finalStep = factory.createAccumulator();
+        finalStep.addIntermediate(partialBlock);
+        Block actual = getFinalBlock(finalStep);
+
+        assertEquals(extractSingleValue(actual), extractSingleValue(expected));
+    }
+
+    @Test
+    public void testMerge()
+            throws Exception
+    {
+        Accumulator singleStep = factory.createAccumulator();
+        singleStep.addInput(input);
+        Block singleStepResult = getFinalBlock(singleStep);
+
+        Accumulator partialStep = factory.createAccumulator();
+        partialStep.addInput(input);
+        Block intermediate = getIntermediateBlock(partialStep);
+
+        Accumulator finalStep = factory.createAccumulator();
+
+        finalStep.addIntermediate(intermediate);
+        finalStep.addIntermediate(intermediate);
+        Block actual = getFinalBlock(finalStep);
+
+        Map<Float, Float> expected = Maps.transformValues(extractSingleValue(singleStepResult), value -> value * 2);
+
+        assertEquals(extractSingleValue(actual), expected);
+    }
+
+    @Test
+    public void testNull()
+            throws Exception
+    {
+        Accumulator accumulator = factory.createAccumulator();
+        Block result = getFinalBlock(accumulator);
+
+        assertTrue(result.getPositionCount() == 1);
+        assertTrue(result.isNull(0));
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testBadNumberOfBuckets()
+    {
+        Accumulator singleStep = factory.createAccumulator();
+        singleStep.addInput(makeInput(0));
+        getFinalBlock(singleStep);
+    }
+
+    private static Map<Float, Float> extractSingleValue(Block block)
+            throws IOException
+    {
+        MapType mapType = new MapType(FLOAT, FLOAT);
+        return (Map<Float, Float>) mapType.getObjectValue(null, block, 0);
+    }
+
+    private Page makeInput(int numberOfBuckets)
+    {
+        PageBuilder builder = new PageBuilder(ImmutableList.of(BIGINT, FLOAT, DOUBLE));
+
+        for (int i = 0; i < 100; i++) {
+            builder.declarePosition();
+
+            BIGINT.writeLong(builder.getBlockBuilder(0), numberOfBuckets);
+            FLOAT.writeLong(builder.getBlockBuilder(1), i); // value
+            DOUBLE.writeDouble(builder.getBlockBuilder(2), 1); // weight
+        }
+
+        return builder.build();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatRegrInterceptAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatRegrInterceptAggregation.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.regression.SimpleRegression;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createFloatSequenceBlock;
+import static com.facebook.presto.block.BlockAssertions.createFloatsBlock;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class TestFloatRegrInterceptAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        return new Block[] {createFloatSequenceBlock(start, start + length), createFloatSequenceBlock(start + 2, start + 2 + length)};
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "regr_intercept";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.FLOAT, StandardTypes.FLOAT);
+    }
+
+    @Override
+    public Object getExpectedValue(int start, int length)
+    {
+        if (length <= 1) {
+            return null;
+        }
+        SimpleRegression regression = new SimpleRegression();
+        for (int i = start; i < start + length; i++) {
+            regression.addData(i + 2, i);
+        }
+        return (float) regression.getIntercept();
+    }
+
+    @Test
+    public void testNonTrivialResult()
+    {
+        testNonTrivialAggregation(new Float[] {1.0f, 2.0f, 3.0f, 4.0f, 5.0f}, new Float[] {1.0f, 4.0f, 9.0f, 16.0f, 25.0f});
+        testNonTrivialAggregation(new Float[] {1.0f, 4.0f, 9.0f, 16.0f, 25.0f}, new Float[] {1.0f, 2.0f, 3.0f, 4.0f, 5.0f});
+    }
+
+    private void testNonTrivialAggregation(Float[] y, Float[] x)
+    {
+        SimpleRegression regression = new SimpleRegression();
+        for (int i = 0; i < x.length; i++) {
+            regression.addData(x[i], y[i]);
+        }
+        float expected = (float) regression.getIntercept();
+        checkArgument(Float.isFinite(expected) && expected != 0.f, "Expected result is trivial");
+        testAggregation(expected, createFloatsBlock(y), createFloatsBlock(x));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatRegrSlopeAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatRegrSlopeAggregation.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.stat.regression.SimpleRegression;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createFloatSequenceBlock;
+import static com.facebook.presto.block.BlockAssertions.createFloatsBlock;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class TestFloatRegrSlopeAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        return new Block[] {createFloatSequenceBlock(start, start + length), createFloatSequenceBlock(start + 2, start + 2 + length)};
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "regr_slope";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.FLOAT, StandardTypes.FLOAT);
+    }
+
+    @Override
+    public Object getExpectedValue(int start, int length)
+    {
+        if (length <= 1) {
+            return null;
+        }
+        SimpleRegression regression = new SimpleRegression();
+        for (int i = start; i < start + length; i++) {
+            regression.addData(i + 2, i);
+        }
+        return (float) regression.getSlope();
+    }
+
+    @Test
+    public void testNonTrivialResult()
+    {
+        testNonTrivialAggregation(new Float[] {1.0f, 2.0f, 3.0f, 4.0f, 5.0f}, new Float[] {1.0f, 4.0f, 9.0f, 16.0f, 25.0f});
+        testNonTrivialAggregation(new Float[] {1.0f, 4.0f, 9.0f, 16.0f, 25.0f}, new Float[] {1.0f, 2.0f, 3.0f, 4.0f, 5.0f});
+    }
+
+    private void testNonTrivialAggregation(Float[] y, Float[] x)
+    {
+        SimpleRegression regression = new SimpleRegression();
+        for (int i = 0; i < x.length; i++) {
+            regression.addData(x[i], y[i]);
+        }
+        float expected = (float) regression.getSlope();
+        checkArgument(Float.isFinite(expected) && expected != 0.0f, "Expected result is trivial");
+        testAggregation(expected, createFloatsBlock(y), createFloatsBlock(x));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatSumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestFloatSumAggregation.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
+import static java.lang.Float.floatToRawIntBits;
+
+public class TestFloatSumAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = FLOAT.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            FLOAT.writeLong(blockBuilder, floatToRawIntBits((float) i));
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "sum";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.FLOAT);
+    }
+
+    @Override
+    public Object getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        float sum = 0;
+        for (int i = start; i < start + length; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4777,13 +4777,16 @@ public abstract class AbstractTestQueries
         });
 
         assertTrue(functions.containsKey("avg"), "Expected function names " + functions + " to contain 'avg'");
-        assertEquals(functions.get("avg").asList().size(), 2);
+        assertEquals(functions.get("avg").asList().size(), 3);
         assertEquals(functions.get("avg").asList().get(0).getField(1), "double");
         assertEquals(functions.get("avg").asList().get(0).getField(2), "bigint");
         assertEquals(functions.get("avg").asList().get(0).getField(3), "aggregate");
         assertEquals(functions.get("avg").asList().get(1).getField(1), "double");
         assertEquals(functions.get("avg").asList().get(1).getField(2), "double");
-        assertEquals(functions.get("avg").asList().get(0).getField(3), "aggregate");
+        assertEquals(functions.get("avg").asList().get(1).getField(3), "aggregate");
+        assertEquals(functions.get("avg").asList().get(2).getField(1), "float");
+        assertEquals(functions.get("avg").asList().get(2).getField(2), "float");
+        assertEquals(functions.get("avg").asList().get(2).getField(3), "aggregate");
 
         assertTrue(functions.containsKey("abs"), "Expected function names " + functions + " to contain 'abs'");
         assertEquals(functions.get("abs").asList().get(0).getField(3), "scalar");


### PR DESCRIPTION
It is to avoid confusion when coercions to DOUBLE are used and e.g. sum(float) = double.
E.g. when single value is given to sum(float) it would return double value which would not equal input when coercions are used.
Small commits added for review convenience, thus commit-by-commit approach is preferred.

Internal TD review: https://github.com/Teradata/presto/pull/242

CC: @cberner 