### PR TITLE
Make mvn use 1 thread per core in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
       sudo mv docker-compose /usr/local/bin
     fi
 
-install: ./mvnw install -DskipTests=true $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T 2 -pl '!presto-docs,!presto-server-rpm'
+install: ./mvnw install -DskipTests=true $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1 -pl '!presto-docs,!presto-server-rpm'
 
 script:
   - |


### PR DESCRIPTION
This replaces the hardcoded '2 threads' value.

This will allow for better build times on bigger
Travis workers and will be future-proof should
our workers change number of cores.