### PR TITLE
Add Hive bucketing warning to 0.150 release notes

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.150.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.150.rst
@@ -2,6 +2,12 @@
 Release 0.150
 =============
 
+.. warning::
+
+    The Hive bucketing changes are broken in this release. You should
+    disable them by adding ``hive.bucket-execution=false`` and
+    ``hive.bucket-writing=false`` to your Hive catalog properties.
+
 General Changes
 ---------------
 


### PR DESCRIPTION
<img width="1090" alt="screen shot 2016-07-08 at 4 41 09 pm" src="https://cloud.githubusercontent.com/assets/9230/16704355/d09c9f82-452a-11e6-855c-f6b4a07dea79.png">
