### PR TITLE
Pushdown join condition conjucnts to innerside based on inherited predicate (v2)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -472,6 +472,13 @@ public class PredicatePushDown
                     joinConjuncts.add(conjunct);
                 }
             }
+
+            // Push outer and join equalities into the inner side. For example:
+            // SELECT * FROM nation LEFT OUTER JOIN region ON nation.regionkey = region.regionkey and nation.name = region.name WHERE nation.name = 'blah'
+
+            EqualityInference potentialNullSymbolInferenceWithoutInnerInferred = createEqualityInference(outerOnlyInheritedEqualities, outerEffectivePredicate, joinPredicate);
+            innerPushdownConjuncts.addAll(potentialNullSymbolInferenceWithoutInnerInferred.generateEqualitiesPartitionedBy(not(in(outerSymbols))).getScopeEqualities());
+
             // TODO: we can further improve simplifying the equalities by considering other relationships from the outer side
             EqualityInference.EqualityPartition joinEqualityPartition = createEqualityInference(joinPredicate).generateEqualitiesPartitionedBy(not(in(outerSymbols)));
             innerPushdownConjuncts.addAll(joinEqualityPartition.getScopeEqualities());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.SymbolReference;
 
 import static java.lang.String.format;
@@ -87,6 +88,16 @@ final class ExpressionVerifier
         if (expectedExpression instanceof LongLiteral) {
             LongLiteral expected = (LongLiteral) expectedExpression;
             return actual.getValue() == expected.getValue();
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitStringLiteral(StringLiteral actual, Expression expectedExpression)
+    {
+        if (expectedExpression instanceof StringLiteral) {
+            StringLiteral expected = (StringLiteral) expectedExpression;
+            return actual.getValue().equals(expected.getValue());
         }
         return false;
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
@@ -27,10 +27,12 @@ import static java.util.Objects.requireNonNull;
 final class JoinMatcher
         implements Matcher
 {
+    private final JoinNode.Type joinType;
     private final List<AliasPair> equiCriteria;
 
-    JoinMatcher(List<AliasPair> equiCriteria)
+    JoinMatcher(JoinNode.Type joinType, List<AliasPair> equiCriteria)
     {
+        this.joinType = requireNonNull(joinType, "joinType is null");
         this.equiCriteria = requireNonNull(equiCriteria, "equiCriteria is null");
     }
 
@@ -39,6 +41,9 @@ final class JoinMatcher
     {
         if (node instanceof JoinNode) {
             JoinNode joinNode = (JoinNode) node;
+            if (joinNode.getType() != joinType) {
+                return false;
+            }
             if (joinNode.getCriteria().size() == equiCriteria.size()) {
                 int i = 0;
                 for (JoinNode.EquiJoinClause equiJoinClause : joinNode.getCriteria()) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -15,7 +15,9 @@ package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.tree.Expression;
@@ -24,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
@@ -60,6 +63,11 @@ public final class PlanMatchPattern
         return any().with(new TableScanMatcher(expectedTableName));
     }
 
+    public static PlanMatchPattern tableScan(String expectedTableName, Map<String, Domain> constraint)
+    {
+        return any().with(new TableScanMatcher(expectedTableName, constraint));
+    }
+
     public static PlanMatchPattern project(PlanMatchPattern... sources)
     {
         return node(ProjectNode.class, sources);
@@ -70,9 +78,9 @@ public final class PlanMatchPattern
         return any(sources).with(new SemiJoinMatcher(sourceSymbolAlias, filteringSymbolAlias, outputAlias));
     }
 
-    public static PlanMatchPattern join(List<AliasPair> expectedEquiCriteria, PlanMatchPattern... sources)
+    public static PlanMatchPattern join(JoinNode.Type joinType, List<AliasPair> expectedEquiCriteria, PlanMatchPattern... sources)
     {
-        return any(sources).with(new JoinMatcher(expectedEquiCriteria));
+        return any(sources).with(new JoinMatcher(joinType,  expectedEquiCriteria));
     }
 
     public static AliasPair aliasPair(String left, String right)


### PR DESCRIPTION

Add equality conjuncts to inner side based on join condition and outer side symbol equalities from inherited predicate and outer side predicate
This is needed to handle queries like:

```sql
SELECT * FROM nation LEFT OUTER JOIN region ON nation.regionkey = region.regionkey and nation.name = region.name WHERE nation.name = 'blah'
```

Without that region.name = 'blah' was not pushed to inner side