### PR TITLE
Add product test for GRANT and REVOKE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - |
     if [ -v PRODUCT_TESTS ]; then
       presto-product-tests/bin/run_on_docker.sh singlenode -x quarantine,big_query,storage_formats,mysql_connector,postgresql_connector,profile_specific_tests
-      presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation
+      presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation,authorization
     fi
   - |
     if [ -v INTEGRATION_TESTS ]; then

--- a/presto-product-tests/conf/docker/common/kerberos.yml
+++ b/presto-product-tests/conf/docker/common/kerberos.yml
@@ -3,7 +3,7 @@ services:
 
   hadoop-kerberos:
     # cdh5-hive-kerberized contains keytabs and the `krb5.conf` within
-    image: 'teradatalabs/cdh5-hive-kerberized:3'
+    image: 'teradatalabs/cdh5-hive-kerberized:4'
     env_file:
       - ../../../target/classes/presto.env
     volumes:

--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -9,7 +9,7 @@ services:
       - ../../../../:/docker/volumes/presto
 
   hadoop-base:
-    image: 'teradatalabs/cdh5-hive:2'
+    image: 'teradatalabs/cdh5-hive:4'
     env_file:
       - ../../../target/classes/presto.env
     volumes:

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
@@ -23,3 +23,6 @@ hive.hdfs.authentication.type=KERBEROS
 hive.hdfs.impersonation.enabled=true
 hive.hdfs.presto.principal=hdfs/hadoop-master@LABS.TERADATA.COM
 hive.hdfs.presto.keytab=/etc/hadoop/conf/hdfs.keytab
+
+#required for testGrantRevoke() product test
+hive.security=sql-standard

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
@@ -16,7 +16,7 @@ databases:
 
   presto:
     host: presto-master
-    jdbc_user: jdbc_presto_user
+    jdbc_user: hive
     cli_server_address: https://${databases.presto.host}:7778
     cli_authentication: true
     cli_kerberos_principal: presto-client/presto-master@LABS.TERADATA.COM
@@ -26,7 +26,7 @@ databases:
     cli_keystore: /etc/presto/conf/keystore.jks
     cli_keystore_password: password
     cli_kerberos_use_canonical_hostname: false
-    configured_hdfs_user: hdfs
+    configured_hdfs_user: hive
 
   mysql:
     jdbc_driver_class: com.mysql.jdbc.Driver

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -46,6 +46,7 @@ public final class TestGroups
     public static final String PROFILE_SPECIFIC_TESTS = "profile_specific_tests";
     public static final String HDFS_IMPERSONATION = "hdfs_impersonation";
     public static final String HDFS_NO_IMPERSONATION = "hdfs_no_impersonation";
+    public static final String AUTHORIZATION = "authorization";
 
     private TestGroups() {}
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
@@ -88,6 +88,10 @@ public class PrestoCliTests
     @Named("databases.presto.cli_kerberos_use_canonical_hostname")
     private boolean kerberosUseCanonicalHostname;
 
+    @Inject
+    @Named("databases.presto.jdbc_user")
+    private String jdbcUser;
+
     private PrestoCliProcess presto;
 
     public PrestoCliTests()
@@ -164,7 +168,12 @@ public class PrestoCliTests
             throws IOException, InterruptedException
     {
         if (!authentication) {
-            launchPrestoCli(ImmutableList.<String>builder().add("--server", serverAddress).add(arguments).build());
+            ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
+            prestoClientOptions.add(
+                    "--server", serverAddress,
+                    "--user", jdbcUser);
+            prestoClientOptions.add(arguments);
+            launchPrestoCli(prestoClientOptions.build());
         }
         else {
             requireNonNull(kerberosPrincipal, "databases.presto.cli_kerberos_principal is null");
@@ -177,6 +186,7 @@ public class PrestoCliTests
             ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
             prestoClientOptions.add(
                     "--server", serverAddress,
+                    "--user", jdbcUser,
                     "--enable-authentication",
                     "--krb5-principal", kerberosPrincipal,
                     "--krb5-keytab-path", kerberosKeytab,

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.tests.hive;
+
+import com.teradata.tempto.ProductTest;
+import com.teradata.tempto.query.QueryExecutor;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.tests.TestGroups.AUTHORIZATION;
+import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
+import static com.facebook.presto.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static com.facebook.presto.tests.utils.QueryExecutors.connectToPresto;
+import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static java.lang.String.format;
+
+public class TestGrantRevoke
+    extends ProductTest
+{
+    /*
+     * Pre-requisites for the tests in this class:
+     *
+     * (1) hive.properties file should have this property set: hive.security=sql-standard
+     * (2) tempto-configuration.yaml file should have definitions for two connections to Presto server:
+     * "alice@presto" that has "jdbc_user: alice" and
+     * "bob@presto" that has "jdbc_user: bob"
+     * (all other values of the connection are same as that of the default "presto" connection).
+    */
+    @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
+    public void testGrantRevoke()
+    {
+        String tableName = "alice_owned_table";
+        QueryExecutor queryExecutorForAlice = connectToPresto("alice@presto");
+        QueryExecutor queryExecutorForBob = connectToPresto("bob@presto");
+
+        queryExecutorForAlice.executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
+        queryExecutorForAlice.executeQuery(format("CREATE TABLE %s(month bigint, day bigint)", tableName));
+
+        assertThat(() -> queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).
+                failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertThat(() -> queryExecutorForBob.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).
+                failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
+
+        //test GRANT
+        queryExecutorForAlice.executeQuery(format("GRANT INSERT, SELECT ON %s TO bob", tableName));
+        assertThat(queryExecutorForBob.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).hasRowsCount(1);
+        assertThat(queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
+        assertThat(() -> queryExecutorForBob.executeQuery(format("DELETE FROM %s WHERE day=3", tableName))).
+                failsWithMessage(format("Access Denied: Cannot delete from table default.%s", tableName));
+
+        //test REVOKE
+        queryExecutorForAlice.executeQuery(format("REVOKE INSERT ON %s FROM bob", tableName));
+        assertThat(() -> queryExecutorForBob.executeQuery(format("INSERT INTO %s VALUES ('y', 5)", tableName))).
+                failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
+        assertThat(queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
+    }
+
+    @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
+    public void testGrantRevokeAll()
+    {
+        String tableName = "alice_owned_table";
+        QueryExecutor queryExecutorForAlice = connectToPresto("alice@presto");
+        QueryExecutor queryExecutorForBob = connectToPresto("bob@presto");
+
+        queryExecutorForAlice.executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
+        queryExecutorForAlice.executeQuery(format("CREATE TABLE %s(month bigint, day bigint)", tableName));
+
+        assertAccessDeniedOnAllOperationsOnTable(queryExecutorForBob, tableName);
+
+        queryExecutorForAlice.executeQuery(format("GRANT ALL PRIVILEGES ON %s TO bob", tableName));
+        assertThat(queryExecutorForBob.executeQuery(format("INSERT INTO %s VALUES (4, 13)", tableName))).hasRowsCount(1);
+        assertThat(queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
+        queryExecutorForBob.executeQuery(format("DELETE FROM %s", tableName));
+        assertThat(queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
+
+        queryExecutorForAlice.executeQuery(format("REVOKE ALL PRIVILEGES ON %s FROM bob", tableName));
+        assertAccessDeniedOnAllOperationsOnTable(queryExecutorForBob, tableName);
+    }
+
+    private static void assertAccessDeniedOnAllOperationsOnTable(QueryExecutor queryExecutor, String tableName)
+    {
+        assertThat(() -> queryExecutor.executeQuery(format("SELECT * FROM %s", tableName))).
+                failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertThat(() -> queryExecutor.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).
+                failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
+        assertThat(() -> queryExecutor.executeQuery(format("DELETE FROM %s WHERE day=3", tableName))).
+                failsWithMessage(format("Access Denied: Cannot delete from table default.%s", tableName));
+    }
+
+    //TODO: test PUBLIC: This will require adding users such as alice and bob to the hive metastore
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/QueryExecutors.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/QueryExecutors.java
@@ -24,5 +24,10 @@ public class QueryExecutors
         return testContext().getDependency(QueryExecutor.class, "presto");
     }
 
+    public static QueryExecutor connectToPresto(String prestoConfig)
+    {
+        return testContext().getDependency(QueryExecutor.class, prestoConfig);
+    }
+
     private QueryExecutors() {}
 }

--- a/presto-product-tests/src/main/resources/tempto-configuration.yaml
+++ b/presto-product-tests/src/main/resources/tempto-configuration.yaml
@@ -32,6 +32,24 @@ databases:
     jdbc_password: na
     jdbc_pooling: false
 
+  alice@presto:
+    host: localhost
+    server_address: ${databases.presto.host}:8080
+    jdbc_driver_class: ${databases.presto.jdbc_driver_class}
+    jdbc_url: jdbc:presto://${databases.presto.server_address}/hive/${databases.hive.schema}
+    jdbc_user: alice
+    jdbc_password: na
+    jdbc_pooling: false
+
+  bob@presto:
+    host: localhost
+    server_address: ${databases.presto.host}:8080
+    jdbc_driver_class: ${databases.presto.jdbc_driver_class}
+    jdbc_url: jdbc:presto://${databases.presto.server_address}/hive/${databases.hive.schema}
+    jdbc_user: bob
+    jdbc_password: na
+    jdbc_pooling: false
+
 tests:
   hdfs:
     path: /product-test


### PR DESCRIPTION
The product test for `GRANT` and `REVOKE` will be run under a single profile, namely `singlenode-kerberos-hdfs-impersonation`. 

Running the product test requires one to set `hive.security=sql-standard` in hive.properties file. Setting this property turns on SQL Standard authorization for Hive connector. If we make this as a system-wide change, this will result in all product tests being run with SQL Standard authorization turned on. That would imply that we no longer are running the tests with the default system configuration (since by default, Hive connector configuration is `hive.security=allow-all`).

To avoid this, we are restricting this test to run under a single profile.