### PR TITLE
Optimize ShortDecimalType to use LongArrayBlock

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -31,6 +31,8 @@ import static com.facebook.presto.util.Failures.checkCondition;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Character.MAX_RADIX;
 import static java.lang.Character.MIN_RADIX;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
 import static java.lang.String.format;
 
 public final class MathFunctions
@@ -79,6 +81,14 @@ public final class MathFunctions
     public static double abs(@SqlType(StandardTypes.DOUBLE) double num)
     {
         return Math.abs(num);
+    }
+
+    @Description("absolute value")
+    @ScalarFunction("abs")
+    @SqlType(StandardTypes.FLOAT)
+    public static long absFloat(@SqlType(StandardTypes.FLOAT) long num)
+    {
+        return floatToRawIntBits(Math.abs(intBitsToFloat((int) num)));
     }
 
     @Description("arc cosine")
@@ -161,12 +171,29 @@ public final class MathFunctions
         return Math.ceil(num);
     }
 
+    @Description("round up to nearest integer")
+    @ScalarFunction(value = "ceiling", alias = "ceil")
+    @SqlType(StandardTypes.FLOAT)
+    public static long ceilingFloat(@SqlType(StandardTypes.FLOAT) long num)
+    {
+        return floatToRawIntBits((float) ceiling(intBitsToFloat((int) num)));
+    }
+
     @Description("round to integer by dropping digits after decimal point")
     @ScalarFunction
     @SqlType(StandardTypes.DOUBLE)
     public static double truncate(@SqlType(StandardTypes.DOUBLE) double num)
     {
         return Math.signum(num) * Math.floor(Math.abs(num));
+    }
+
+    @Description("round to integer by dropping digits after decimal point")
+    @ScalarFunction
+    @SqlType(StandardTypes.FLOAT)
+    public static long truncate(@SqlType(StandardTypes.FLOAT) long num)
+    {
+        float numInFloat = intBitsToFloat((int) num);
+        return floatToRawIntBits((float) (Math.signum(numInFloat) * Math.floor(Math.abs(numInFloat))));
     }
 
     @Description("cosine")
@@ -249,6 +276,14 @@ public final class MathFunctions
         return Math.floor(num);
     }
 
+    @Description("round down to nearest integer")
+    @ScalarFunction("floor")
+    @SqlType(StandardTypes.FLOAT)
+    public static long floorFloat(@SqlType(StandardTypes.FLOAT) long num)
+    {
+        return floatToRawIntBits((float) floor(intBitsToFloat((int) num)));
+    }
+
     @Description("natural logarithm")
     @ScalarFunction
     @SqlType(StandardTypes.DOUBLE)
@@ -319,6 +354,14 @@ public final class MathFunctions
     public static double mod(@SqlType(StandardTypes.DOUBLE) double num1, @SqlType(StandardTypes.DOUBLE) double num2)
     {
         return num1 % num2;
+    }
+
+    @Description("remainder of given quotient")
+    @ScalarFunction("mod")
+    @SqlType(StandardTypes.FLOAT)
+    public static long modFloat(@SqlType(StandardTypes.FLOAT) long num1, @SqlType(StandardTypes.FLOAT) long num2)
+    {
+        return floatToRawIntBits(intBitsToFloat((int) num1) % intBitsToFloat((int) num2));
     }
 
     @Description("the constant Pi")
@@ -462,6 +505,14 @@ public final class MathFunctions
     }
 
     @Description("round to given number of decimal places")
+    @ScalarFunction("round")
+    @SqlType(StandardTypes.FLOAT)
+    public static long roundFloat(@SqlType(StandardTypes.FLOAT) long num)
+    {
+        return roundFloat(num, 0);
+    }
+
+    @Description("round to given number of decimal places")
     @ScalarFunction
     @SqlType(StandardTypes.DOUBLE)
     public static double round(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.BIGINT) long decimals)
@@ -476,6 +527,24 @@ public final class MathFunctions
         }
 
         return Math.round(num * factor) / factor;
+    }
+
+    @Description("round to given number of decimal places")
+    @ScalarFunction("round")
+    @SqlType(StandardTypes.FLOAT)
+    public static long roundFloat(@SqlType(StandardTypes.FLOAT) long num, @SqlType(StandardTypes.BIGINT) long decimals)
+    {
+        float numInFloat = intBitsToFloat((int) num);
+        if (Float.isNaN(numInFloat) || Float.isInfinite(numInFloat)) {
+            return num;
+        }
+
+        double factor = Math.pow(10, decimals);
+        if (numInFloat < 0) {
+            return floatToRawIntBits((float) -(Math.round(-numInFloat * factor) / factor));
+        }
+
+        return floatToRawIntBits((float) (Math.round(numInFloat * factor) / factor));
     }
 
     @Description("signum")
@@ -516,6 +585,14 @@ public final class MathFunctions
     public static double sign(@SqlType(StandardTypes.DOUBLE) double num)
     {
         return Math.signum(num);
+    }
+
+    @Description("signum")
+    @ScalarFunction("sign")
+    @SqlType(StandardTypes.FLOAT)
+    public static long signFloat(@SqlType(StandardTypes.FLOAT) long num)
+    {
+        return floatToRawIntBits((Math.signum(intBitsToFloat((int) num))));
     }
 
     @Description("sine")

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -424,7 +424,8 @@ public class AddLocalExchanges
         {
             StreamPreferredProperties requiredProperties;
             StreamPreferredProperties preferredProperties;
-            if (getTaskWriterCount(session) > 1) {
+            // Force single writer when partition function exists
+            if (getTaskWriterCount(session) > 1 && !node.getPartitioningScheme().isPresent()) {
                 requiredProperties = fixedParallelism(getTaskWriterCount(session));
                 preferredProperties = fixedParallelism(getTaskWriterCount(session));
             }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestColorFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestColorFunctions.java
@@ -25,6 +25,7 @@ import static com.facebook.presto.operator.scalar.ColorFunctions.parseRgb;
 import static com.facebook.presto.operator.scalar.ColorFunctions.render;
 import static com.facebook.presto.operator.scalar.ColorFunctions.rgb;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 
 public class TestColorFunctions
@@ -130,6 +131,7 @@ public class TestColorFunctions
             throws Exception
     {
         assertEquals(render(1234.5678, color(toSlice("red"))), toSlice("\u001b[38;5;1m1234.5678\u001b[0m"));
+        assertEquals(render(1234.5678f, color(toSlice("red"))), toSlice(format("\u001b[38;5;1m%s\u001b[0m", (double) 1234.5678f)));
 
         assertEquals(render(1234.5678, color(toSlice("#f00"))), toSlice("\u001b[38;5;196m1234.5678\u001b[0m"));
         assertEquals(render(1234.5678, color(toSlice("#0f0"))), toSlice("\u001b[38;5;46m1234.5678\u001b[0m"));
@@ -141,6 +143,7 @@ public class TestColorFunctions
             throws Exception
     {
         assertEquals(color(0, 0, 255, color(toSlice("#000")), color(toSlice("#fff"))), 0x00_00_00);
+        assertEquals(color(0.0f, 0.0f, 255.0f, color(toSlice("#000")), color(toSlice("#fff"))), 0x00_00_00);
         assertEquals(color(128, 0, 255, color(toSlice("#000")), color(toSlice("#fff"))), 0x80_80_80);
         assertEquals(color(255, 0, 255, color(toSlice("#000")), color(toSlice("#fff"))), 0xFF_FF_FF);
 
@@ -153,6 +156,9 @@ public class TestColorFunctions
         assertEquals(color(0.5, color(toSlice("#000")), color(toSlice("#fff"))), 0x80_80_80);
         assertEquals(color(1.0, color(toSlice("#000")), color(toSlice("#fff"))), 0xFF_FF_FF);
         assertEquals(color(42, color(toSlice("#000")), color(toSlice("#fff"))), 0xFF_FF_FF);
+        assertEquals(color(1.0f, color(toSlice("#000")), color(toSlice("#fff"))), 0xFF_FF_FF);
+        assertEquals(color(-0.0f, color(toSlice("#000")), color(toSlice("#fff"))), 0x00_00_00);
+        assertEquals(color(0.0f, color(toSlice("#000")), color(toSlice("#fff"))), 0x00_00_00);
     }
 
     private static Slice toSlice(String string)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -21,6 +21,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RAN
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
@@ -58,6 +59,7 @@ public class TestMathFunctions
         assertFunction("abs(123.45)", DOUBLE, 123.45);
         assertFunction("abs(-123.45)", DOUBLE, 123.45);
         assertFunction("abs(CAST(NULL AS DOUBLE))", DOUBLE, null);
+        assertFunction("abs(FLOAT '-754.1985')", FLOAT, 754.1985f);
         assertInvalidFunction("abs(TINYINT'" + Byte.MIN_VALUE + "')", NUMERIC_VALUE_OUT_OF_RANGE);
         assertInvalidFunction("abs(SMALLINT'" + Short.MIN_VALUE + "')", NUMERIC_VALUE_OUT_OF_RANGE);
         assertInvalidFunction("abs(INTEGER'" + Integer.MIN_VALUE + "')", NUMERIC_VALUE_OUT_OF_RANGE);
@@ -133,6 +135,11 @@ public class TestMathFunctions
         assertFunction("ceil(123.45)", DOUBLE, 124.0);
         assertFunction("ceil(-123.45)", DOUBLE, -123.0);
         assertFunction("ceil(CAST(NULL as DOUBLE))", DOUBLE, null);
+        assertFunction("ceil(FLOAT '123.0')", FLOAT, 123.0f);
+        assertFunction("ceil(FLOAT '-123.0')", FLOAT, -123.0f);
+        assertFunction("ceil(FLOAT '123.45')", FLOAT, 124.0f);
+        assertFunction("ceil(FLOAT '-123.45')", FLOAT, -123.0f);
+
         assertFunction("ceiling(12300000000)", BIGINT, 12300000000L);
         assertFunction("ceiling(-12300000000)", BIGINT, -12300000000L);
         assertFunction("ceiling(CAST(NULL AS BIGINT))", BIGINT, null);
@@ -141,6 +148,12 @@ public class TestMathFunctions
         assertFunction("ceiling(123.45)", DOUBLE, 124.0);
         assertFunction("ceiling(-123.45)", DOUBLE, -123.0);
         assertFunction("ceiling(CAST(NULL AS DOUBLE))", DOUBLE, null);
+        assertFunction("ceiling(FLOAT '123.0')", FLOAT, 123.0f);
+        assertFunction("ceiling(FLOAT '-123.0')", FLOAT, -123.0f);
+        assertFunction("ceiling(FLOAT '123.45')", FLOAT, 124.0f);
+        assertFunction("ceiling(FLOAT '-123.45')", FLOAT, -123.0f);
+        assertFunction("ceil(CAST(NULL AS DOUBLE))", DOUBLE, null);
+        assertFunction("ceiling(CAST(NULL AS FLOAT))", FLOAT, null);
     }
 
     @Test
@@ -152,7 +165,10 @@ public class TestMathFunctions
         assertFunction("truncate(-17.18)", DOUBLE, -17.0);
         assertFunction("truncate(17.88)", DOUBLE, 17.0);
         assertFunction("truncate(-17.88)", DOUBLE, -17.0);
-        assertFunction("truncate(NULL)", DOUBLE, null);
+        assertFunction("truncate(FLOAT '17.18')", FLOAT, 17.0f);
+        assertFunction("truncate(FLOAT '-17.18')", FLOAT, -17.0f);
+        assertFunction("truncate(FLOAT '17.88')", FLOAT, 17.0f);
+        assertFunction("truncate(FLOAT '-17.88')", FLOAT, -17.0f);
         assertFunction("truncate(CAST(NULL AS DOUBLE))", DOUBLE, null);
         assertFunction("truncate(" + maxDouble + ")", DOUBLE, Double.MAX_VALUE);
         assertFunction("truncate(" + minDouble + ")", DOUBLE, -Double.MAX_VALUE);
@@ -221,7 +237,12 @@ public class TestMathFunctions
         assertFunction("floor(-123.0)", DOUBLE, -123.0);
         assertFunction("floor(123.45)", DOUBLE, 123.0);
         assertFunction("floor(-123.45)", DOUBLE, -124.0);
+        assertFunction("floor(FLOAT '123.0')", FLOAT, 123.0f);
+        assertFunction("floor(FLOAT '-123.0')", FLOAT, -123.0f);
+        assertFunction("floor(FLOAT '123.45')", FLOAT, 123.0f);
+        assertFunction("floor(FLOAT '-123.45')", FLOAT, -124.0f);
         assertFunction("floor(CAST(NULL as DOUBLE))", DOUBLE, null);
+        assertFunction("floor(CAST(NULL as FLOAT))", FLOAT, null);
     }
 
     @Test
@@ -302,6 +323,13 @@ public class TestMathFunctions
                 assertFunction("mod(" + left + ", " + right + ")", DOUBLE, left % right);
             }
         }
+
+        for (double left : doubleLefts) {
+            for (double right : doubleRights) {
+                assertFunction("mod(FLOAT '" + (float) left + "', FLOAT '" + (float) right + "')", FLOAT, (float) left % (float) right);
+            }
+        }
+
         assertFunction("mod(5.0, NULL)", DOUBLE, null);
         assertFunction("mod(NULL, 5.0)", DOUBLE, null);
     }
@@ -448,6 +476,14 @@ public class TestMathFunctions
         assertFunction("round(-3.5)", DOUBLE, -4.0);
         assertFunction("round(-3.5001)", DOUBLE, -4.0);
         assertFunction("round(-3.99)", DOUBLE, -4.0);
+        assertFunction("round(FLOAT '3.0')", FLOAT, 3.0f);
+        assertFunction("round(FLOAT '-3.0')", FLOAT, -3.0f);
+        assertFunction("round(FLOAT '3.499')", FLOAT, 3.0f);
+        assertFunction("round(FLOAT '-3.499')", FLOAT, -3.0f);
+        assertFunction("round(FLOAT '3.5')", FLOAT, 4.0f);
+        assertFunction("round(FLOAT '-3.5')", FLOAT, -4.0f);
+        assertFunction("round(FLOAT '-3.5001')", FLOAT, -4.0f);
+        assertFunction("round(FLOAT '-3.99')", FLOAT,  -4.0f);
         assertFunction("round(CAST(NULL as DOUBLE))", DOUBLE, null);
         assertFunction("round(" + GREATEST_DOUBLE_LESS_THAN_HALF + ")", DOUBLE, 0.0);
         assertFunction("round(-" + 0x1p-1 + ")", DOUBLE, -1.0); // -0.5
@@ -481,6 +517,14 @@ public class TestMathFunctions
         assertFunction("round(TINYINT '3', 1)", TINYINT, (byte) 3);
         assertFunction("round(SMALLINT '3', SMALLINT '1')", SMALLINT, (short) 3);
         assertFunction("round(SMALLINT '3', 1)", SMALLINT, (short) 3);
+        assertFunction("round(FLOAT '3.0', 0)", FLOAT, 3.0f);
+        assertFunction("round(FLOAT '-3.0', 0)", FLOAT, -3.0f);
+        assertFunction("round(FLOAT '3.499', 0)", FLOAT, 3.0f);
+        assertFunction("round(FLOAT '-3.499', 0)", FLOAT, -3.0f);
+        assertFunction("round(FLOAT '3.5', 0)", FLOAT, 4.0f);
+        assertFunction("round(FLOAT '-3.5', 0)", FLOAT, -4.0f);
+        assertFunction("round(FLOAT '-3.5001', 0)", FLOAT, -4.0f);
+        assertFunction("round(FLOAT '-3.99', 0)", FLOAT, -4.0f);
         assertFunction("round(3, 1)", INTEGER, 3);
         assertFunction("round(-3, 1)", INTEGER, -3);
         assertFunction("round(-3, BIGINT '1')", INTEGER, -3);
@@ -498,6 +542,14 @@ public class TestMathFunctions
         assertFunction("round(-3.5, 1)", DOUBLE, -3.5);
         assertFunction("round(-3.5001, 1)", DOUBLE, -3.5);
         assertFunction("round(-3.99, 1)", DOUBLE, -4.0);
+        assertFunction("round(FLOAT '3.0', 1)", FLOAT, 3.0f);
+        assertFunction("round(FLOAT '-3.0', 1)", FLOAT, -3.0f);
+        assertFunction("round(FLOAT '3.499', 1)", FLOAT, 3.5f);
+        assertFunction("round(FLOAT '-3.499', 1)", FLOAT, -3.5f);
+        assertFunction("round(FLOAT '3.5', 1)", FLOAT, 3.5f);
+        assertFunction("round(FLOAT '-3.5', 1)", FLOAT, -3.5f);
+        assertFunction("round(FLOAT '-3.5001', 1)", FLOAT, -3.5f);
+        assertFunction("round(FLOAT '-3.99', 1)", FLOAT, -4.0f);
         assertFunction("round(CAST(NULL as DOUBLE), CAST(NULL as BIGINT))", DOUBLE, null);
         assertFunction("round(-3.0, CAST(NULL as BIGINT))", DOUBLE, null);
         assertFunction("round(CAST(NULL as DOUBLE), 1)", DOUBLE, null);
@@ -541,9 +593,10 @@ public class TestMathFunctions
             assertFunction("sign(BIGINT '" + intValue + "')", BIGINT, signum.longValue());
         }
 
-        //double
+        //double and float
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("sign(" + doubleValue + ")", DOUBLE, Math.signum(doubleValue));
+            assertFunction("sign(FLOAT '" + (float) doubleValue + "')", FLOAT, Math.signum(((float) doubleValue)));
         }
 
         //returns NaN for NaN input

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/systemtables/ShardMetadataRecordCursor.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/systemtables/ShardMetadataRecordCursor.java
@@ -309,25 +309,32 @@ public class ShardMetadataRecordCursor
         Domain schemaNameDomain = domains.get(getColumnIndex(SHARD_METADATA, SCHEMA_NAME));
         Domain tableNameDomain = domains.get(getColumnIndex(SHARD_METADATA, TABLE_NAME));
 
+        List<String> values = new ArrayList<>();
         StringBuilder sql = new StringBuilder("SELECT table_id FROM tables ");
         if (schemaNameDomain != null || tableNameDomain != null) {
             sql.append("WHERE ");
             List<String> predicates = new ArrayList<>();
             if (tableNameDomain != null && tableNameDomain.isSingleValue()) {
-                predicates.add(format("table_name = '%s'", getStringValue(tableNameDomain.getSingleValue())));
+                predicates.add("table_name = ?");
+                values.add(getStringValue(tableNameDomain.getSingleValue()));
             }
             if (schemaNameDomain != null && schemaNameDomain.isSingleValue()) {
-                predicates.add(format("schema_name = '%s'", getStringValue(schemaNameDomain.getSingleValue())));
+                predicates.add("schema_name = ?");
+                values.add(getStringValue(schemaNameDomain.getSingleValue()));
             }
             sql.append(Joiner.on(" AND ").join(predicates));
         }
 
         ImmutableList.Builder<Long> tableIds = ImmutableList.builder();
         try (Connection connection = dbi.open().getConnection();
-                Statement statement = connection.createStatement();
-                ResultSet resultSet = statement.executeQuery(sql.toString())) {
-            while (resultSet.next()) {
-                tableIds.add(resultSet.getLong("table_id"));
+                PreparedStatement statement = connection.prepareStatement(sql.toString())) {
+            for (int i = 0; i < values.size(); i++) {
+                statement.setString(i + 1, values.get(i));
+            }
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    tableIds.add(resultSet.getLong("table_id"));
+                }
             }
         }
         catch (SQLException | DBIException e) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DecimalType.java
@@ -25,7 +25,8 @@ import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static java.util.Collections.unmodifiableList;
 
 public abstract class DecimalType
-        extends AbstractFixedWidthType
+        extends AbstractType
+        implements FixedWidthType
 {
     public static final int DEFAULT_SCALE = 0;
     public static final int DEFAULT_PRECISION = MAX_PRECISION;
@@ -53,9 +54,9 @@ public abstract class DecimalType
     private final int precision;
     private final int scale;
 
-    DecimalType(int precision, int scale, Class<?> javaType, int fixedSize)
+    DecimalType(int precision, int scale, Class<?> javaType)
     {
-        super(new TypeSignature(StandardTypes.DECIMAL, buildTypeParameters(precision, scale)), javaType, fixedSize);
+        super(new TypeSignature(StandardTypes.DECIMAL, buildTypeParameters(precision, scale)), javaType);
         this.precision = precision;
         this.scale = scale;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
@@ -37,13 +37,13 @@ final class LongDecimalType
     }
 
     @Override
-    public final int getFixedSize()
+    public int getFixedSize()
     {
         return SIZE_OF_LONG_DECIMAL;
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
         return new FixedWidthBlockBuilder(
                 getFixedSize(),
@@ -52,13 +52,13 @@ final class LongDecimalType
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
         return createBlockBuilder(blockBuilderStatus, expectedEntries, getFixedSize());
     }
 
     @Override
-    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
         return new FixedWidthBlockBuilder(getFixedSize(), positionCount);
     }
@@ -123,7 +123,7 @@ final class LongDecimalType
     }
 
     @Override
-    public final Slice getSlice(Block block, int position)
+    public Slice getSlice(Block block, int position)
     {
         return block.getSlice(position, 0, getFixedSize());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
@@ -17,6 +17,8 @@ package com.facebook.presto.spi.type;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
 import io.airlift.slice.Slice;
 
 import static com.facebook.presto.spi.type.Decimals.MAX_PRECISION;
@@ -30,8 +32,35 @@ final class LongDecimalType
 
     LongDecimalType(int precision, int scale)
     {
-        super(precision, scale, Slice.class, SIZE_OF_LONG_DECIMAL);
+        super(precision, scale, Slice.class);
         validatePrecisionScale(precision, scale, MAX_PRECISION);
+    }
+
+    @Override
+    public final int getFixedSize()
+    {
+        return SIZE_OF_LONG_DECIMAL;
+    }
+
+    @Override
+    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        return new FixedWidthBlockBuilder(
+                getFixedSize(),
+                blockBuilderStatus,
+                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / getFixedSize()));
+    }
+
+    @Override
+    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return createBlockBuilder(blockBuilderStatus, expectedEntries, getFixedSize());
+    }
+
+    @Override
+    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        return new FixedWidthBlockBuilder(getFixedSize(), positionCount);
     }
 
     @Override
@@ -91,5 +120,11 @@ final class LongDecimalType
     public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
     {
         blockBuilder.writeBytes(value, offset, length).closeEntry();
+    }
+
+    @Override
+    public final Slice getSlice(Block block, int position)
+    {
+        return block.getSlice(position, 0, getFixedSize());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -17,6 +17,8 @@ package com.facebook.presto.spi.type;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.LongArrayBlockBuilder;
 
 import java.math.BigInteger;
 
@@ -28,8 +30,34 @@ final class ShortDecimalType
 {
     ShortDecimalType(int precision, int scale)
     {
-        super(precision, scale, long.class, SIZE_OF_LONG);
+        super(precision, scale, long.class);
         validatePrecisionScale(precision, scale, MAX_SHORT_PRECISION);
+    }
+
+    @Override
+    public final int getFixedSize()
+    {
+        return SIZE_OF_LONG;
+    }
+
+    @Override
+    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        return new LongArrayBlockBuilder(
+                blockBuilderStatus,
+                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / getFixedSize()));
+    }
+
+    @Override
+    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return createBlockBuilder(blockBuilderStatus, expectedEntries, getFixedSize());
+    }
+
+    @Override
+    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        return new LongArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -35,13 +35,13 @@ final class ShortDecimalType
     }
 
     @Override
-    public final int getFixedSize()
+    public int getFixedSize()
     {
         return SIZE_OF_LONG;
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
         return new LongArrayBlockBuilder(
                 blockBuilderStatus,
@@ -49,13 +49,13 @@ final class ShortDecimalType
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
         return createBlockBuilder(blockBuilderStatus, expectedEntries, getFixedSize());
     }
 
     @Override
-    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
         return new LongArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
     }


### PR DESCRIPTION
Inherit DecimalType from AbstractType instead of AbstractFixedWidthType.
After this change ShortDecimalType can use faster LongArrayBlock.