### PR TITLE
Fix resource leak in Parquet reader

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -460,13 +460,6 @@ public class ParquetHiveRecordCursor
             });
         }
         catch (Exception e) {
-            if (dataSource != null) {
-                try {
-                    dataSource.close();
-                }
-                catch (IOException ignored) {
-                }
-            }
             if (e instanceof PrestoException) {
                 throw (PrestoException) e;
             }
@@ -479,6 +472,15 @@ public class ParquetHiveRecordCursor
                 throw new PrestoException(HIVE_MISSING_DATA, message, e);
             }
             throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, message, e);
+        }
+        finally {
+            if (dataSource != null) {
+                try {
+                    dataSource.close();
+                }
+                catch (IOException ignored) {
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Commit a1425b0a7c01019b349ee0a8e30c8c4535672747 introduces a regression that I have previously fixed in #4880. This PR brings the fix back. /cc @dain  