### PR TITLE
Do not ignore null intermediate aggregation states

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
@@ -517,7 +517,7 @@ public class AccumulatorCompiler
             loopBody = new BytecodeBlock().append(ifStatement);
         }
 
-        body.append(generateBlockNonNullPositionForLoop(scope, position, loopBody))
+        body.append(generateBlockPositionForLoop(scope, position, loopBody))
                 .ret();
     }
 
@@ -611,6 +611,30 @@ public class AccumulatorCompiler
                         .invokeStatic(CompilerOperations.class, "lessThan", boolean.class, int.class, int.class))
                 .update(new BytecodeBlock().incrementVariable(positionVariable, (byte) 1))
                 .body(ifStatement));
+
+        return block;
+    }
+
+    // Generates a for-loop with a local variable named "position" defined, with the current position in the block,
+    // loopBody will be executed for both null and non-null positions in the Block
+    private static BytecodeBlock generateBlockPositionForLoop(Scope scope, Variable positionVariable, BytecodeBlock loopBody)
+    {
+        Variable rowsVariable = scope.declareVariable(int.class, "rows");
+        Variable blockVariable = scope.getVariable("block");
+
+        BytecodeBlock block = new BytecodeBlock()
+                .append(blockVariable)
+                .invokeInterface(Block.class, "getPositionCount", int.class)
+                .putVariable(rowsVariable);
+
+        block.append(new ForLoop()
+                .initialize(positionVariable.set(constantInt(0)))
+                .condition(new BytecodeBlock()
+                        .append(positionVariable)
+                        .append(rowsVariable)
+                        .invokeStatic(CompilerOperations.class, "lessThan", boolean.class, int.class, int.class))
+                .update(new BytecodeBlock().incrementVariable(positionVariable, (byte) 1))
+                .body(loopBody));
 
         return block;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountDistinctAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountDistinctAggregations.java
@@ -143,6 +143,9 @@ public final class ApproximateCountDistinctAggregations
     public static void combineState(HyperLogLogState state, HyperLogLogState otherState)
     {
         HyperLogLog input = otherState.getHyperLogLog();
+        if (input == null) {
+            return;
+        }
 
         HyperLogLog previous = state.getHyperLogLog();
         if (previous == null) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileAggregations.java
@@ -118,6 +118,9 @@ public final class ApproximateLongPercentileAggregations
     public static void combine(DigestAndPercentileState state, DigestAndPercentileState otherState)
     {
         QuantileDigest input = otherState.getDigest();
+        if (input == null) {
+            return;
+        }
 
         QuantileDigest previous = state.getDigest();
         if (previous == null) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileArrayAggregations.java
@@ -74,8 +74,11 @@ public final class ApproximateLongPercentileArrayAggregations
     public static void combine(DigestAndPercentileArrayState state, DigestAndPercentileArrayState otherState)
     {
         QuantileDigest otherDigest = otherState.getDigest();
-        QuantileDigest digest = state.getDigest();
+        if (otherDigest == null) {
+            return;
+        }
 
+        QuantileDigest digest = state.getDigest();
         if (digest == null) {
             state.setDigest(otherDigest);
             state.addMemoryUsage(otherDigest.estimatedInMemorySizeInBytes());

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateSetAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateSetAggregation.java
@@ -74,6 +74,9 @@ public final class ApproximateSetAggregation
     public static void combineState(HyperLogLogState state, HyperLogLogState otherState)
     {
         HyperLogLog input = otherState.getHyperLogLog();
+        if (input == null) {
+            return;
+        }
 
         HyperLogLog previous = state.getHyperLogLog();
         if (previous == null) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Histogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Histogram.java
@@ -134,7 +134,14 @@ public class Histogram
 
     public static void combine(HistogramState state, HistogramState otherState)
     {
-        if (state.get() != null && otherState.get() != null) {
+        if (otherState.get() == null) {
+            return;
+        }
+
+        if (state.get() == null) {
+            state.set(otherState.get());
+        }
+        else {
             TypedHistogram typedHistogram = state.get();
             long startSize = typedHistogram.getEstimatedSize();
             try {
@@ -144,9 +151,6 @@ public class Histogram
                 throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("The result of histogram may not exceed %s", e.getMaxMemory()));
             }
             state.addMemoryUsage(typedHistogram.getEstimatedSize() - startSize);
-        }
-        else if (state.get() == null) {
-            state.set(otherState.get());
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregationFunction.java
@@ -132,7 +132,14 @@ public class MapAggregationFunction
 
     public static void combine(KeyValuePairsState state, KeyValuePairsState otherState)
     {
-        if (state.get() != null && otherState.get() != null) {
+        if (otherState.get() == null) {
+            return;
+        }
+
+        if (state.get() == null) {
+            state.set(otherState.get());
+        }
+        else {
             Block keys = otherState.get().getKeys();
             Block values = otherState.get().getValues();
             KeyValuePairs pairs = state.get();
@@ -146,9 +153,6 @@ public class MapAggregationFunction
                 }
             }
             state.addMemoryUsage(pairs.estimatedInMemorySize() - startSize);
-        }
-        else if (state.get() == null) {
-            state.set(otherState.get());
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MultimapAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MultimapAggregationFunction.java
@@ -133,7 +133,14 @@ public class MultimapAggregationFunction
 
     public static void combine(KeyValuePairsState state, KeyValuePairsState otherState)
     {
-        if (state.get() != null && otherState.get() != null) {
+        if (otherState.get() == null) {
+            return;
+        }
+
+        if (state.get() == null) {
+            state.set(otherState.get());
+        }
+        else {
             Block keys = otherState.get().getKeys();
             Block values = otherState.get().getValues();
             KeyValuePairs pairs = state.get();
@@ -147,9 +154,6 @@ public class MultimapAggregationFunction
                 }
             }
             state.addMemoryUsage(pairs.estimatedInMemorySize() - startSize);
-        }
-        else if (state.get() == null) {
-            state.set(otherState.get());
         }
     }
 


### PR DESCRIPTION
`AccumulatorStateSerializer.deserialize` was only called for non-null positions
in the block. The `combine` function for aggregation function was also ignored.
This was an unintended side effect of the original AccumulatorCompiler
implementation. As a result, the `otherState` in `combine` function would be
guaranteed to not have any `null` fields if the
`AccumulatorStateSerializer.deserialize` implementation for the aggregation
function never produce such `State` objects when the input parameter to
`deserialize` is not null, which is normally true.

With this guarantee, a few aggregation functions passed all tests yet their
implementation seemed wrong. It makes reasoning about correctness very hard.
Additionally, when some guarantees exist but are not clearly defined, new
implementation are prone to depend on false guarantees. Furthermore, arguably,
there may be valid use cases for using null as the serialized form for a
special case, which should not be ignored.