### PR TITLE
Remove types and bucketCount from getBucketFunction

### DIFF
--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleConnectorFactory.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleConnectorFactory.java
@@ -52,7 +52,7 @@ public class BlackHoleConnectorFactory
     public Connector create(String connectorId, Map<String, String> requiredConfig)
     {
         return new BlackHoleConnector(
-                new BlackHoleMetadata(),
+                new BlackHoleMetadata(connectorId, nodeManager),
                 new BlackHoleSplitManager(),
                 new BlackHolePageSourceProvider(),
                 new BlackHolePageSinkProvider(),

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHolePartitioningHandle.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHolePartitioningHandle.java
@@ -14,9 +14,61 @@
 package com.facebook.presto.plugin.blackhole;
 
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
+import com.facebook.presto.spi.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-public enum BlackHolePartitioningHandle
+import java.util.List;
+import java.util.Objects;
+
+public class BlackHolePartitioningHandle
         implements ConnectorPartitioningHandle
 {
-    INSTANCE
+    private final List<Type> partitionChannelTypes;
+    private final int bucketCount;
+
+    @JsonCreator
+    public BlackHolePartitioningHandle(@JsonProperty("partitionChannelTypes") List<Type> partitionChannelTypes, @JsonProperty("bucketCount") int bucketCount)
+    {
+        this.partitionChannelTypes = partitionChannelTypes;
+        this.bucketCount = bucketCount;
+    }
+
+    @JsonProperty
+    public List<Type> getPartitionChannelTypes()
+    {
+        return partitionChannelTypes;
+    }
+
+    @JsonProperty
+    public int getBucketCount()
+    {
+        return bucketCount;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BlackHolePartitioningHandle that = (BlackHolePartitioningHandle) o;
+        return bucketCount == that.bucketCount &&
+                Objects.equals(partitionChannelTypes, that.partitionChannelTypes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(partitionChannelTypes, bucketCount);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "blackhole_" + bucketCount;
+    }
 }

--- a/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleMetadata.java
+++ b/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleMetadata.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.plugin.blackhole;
 
+import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.SchemaTableName;
@@ -31,7 +32,7 @@ import static org.testng.Assert.assertTrue;
 
 public class TestBlackHoleMetadata
 {
-    private final BlackHoleMetadata metadata = new BlackHoleMetadata();
+    private final BlackHoleMetadata metadata = new BlackHoleMetadata("tesr", new InMemoryNodeManager());
     private final Map<String, Object> tableProperties = ImmutableMap.of(
             BlackHoleConnector.SPLIT_COUNT_PROPERTY, 0,
             BlackHoleConnector.PAGES_PER_SPLIT_PROPERTY, 0,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveNodePartitioningProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveNodePartitioningProvider.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableMap;
 
 import javax.inject.Inject;
@@ -57,13 +56,11 @@ public class HiveNodePartitioningProvider
     public BucketFunction getBucketFunction(
             ConnectorTransactionHandle transactionHandle,
             ConnectorSession session,
-            ConnectorPartitioningHandle partitioningHandle,
-            List<Type> partitionChannelTypes,
-            int bucketCount)
+            ConnectorPartitioningHandle partitioningHandle)
     {
         HivePartitioningHandle handle = checkType(partitioningHandle, HivePartitioningHandle.class, "partitioningHandle");
         List<HiveType> hiveTypes = handle.getHiveTypes();
-        return new HiveBucketFunction(bucketCount, hiveTypes, forceIntegralToBigint);
+        return new HiveBucketFunction(handle.getBucketCount(), hiveTypes, forceIntegralToBigint);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
@@ -78,9 +78,7 @@ public class NodePartitioningManager
             bucketFunction = partitioningProvider.getBucketFunction(
                     partitioningHandle.getTransactionHandle().orElse(null),
                     session.toConnectorSession(),
-                    partitioningHandle.getConnectorHandle(),
-                    partitionChannelTypes,
-                    bucketToPartition.get().length);
+                    partitioningHandle.getConnectorHandle());
 
             checkArgument(bucketFunction != null, "No function %s", partitioningHandle);
         }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorNodePartitioningProvider.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorNodePartitioningProvider.java
@@ -21,12 +21,10 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableMap;
 
 import javax.inject.Inject;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.ToIntFunction;
@@ -72,8 +70,11 @@ public class RaptorNodePartitioningProvider
     }
 
     @Override
-    public BucketFunction getBucketFunction(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorPartitioningHandle partitioning, List<Type> partitionChannelTypes, int bucketCount)
+    public BucketFunction getBucketFunction(ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorPartitioningHandle partitioning)
     {
-        return new RaptorBucketFunction(bucketCount);
+        RaptorPartitioningHandle handle = checkType(partitioning, RaptorPartitioningHandle.class, "partitioning");
+        return new RaptorBucketFunction(handle.getBucketToNode().size());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorNodePartitioningProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorNodePartitioningProvider.java
@@ -17,9 +17,7 @@ import com.facebook.presto.spi.BucketFunction;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.Node;
-import com.facebook.presto.spi.type.Type;
 
-import java.util.List;
 import java.util.Map;
 import java.util.function.ToIntFunction;
 
@@ -32,7 +30,5 @@ public interface ConnectorNodePartitioningProvider
     BucketFunction getBucketFunction(
             ConnectorTransactionHandle transactionHandle,
             ConnectorSession session,
-            ConnectorPartitioningHandle partitioningHandle,
-            List<Type> partitionChannelTypes,
-            int bucketCount);
+            ConnectorPartitioningHandle partitioningHandle);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeNodePartitioningProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeNodePartitioningProvider.java
@@ -21,9 +21,7 @@ import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.facebook.presto.spi.type.Type;
 
-import java.util.List;
 import java.util.Map;
 import java.util.function.ToIntFunction;
 
@@ -45,12 +43,10 @@ public final class ClassLoaderSafeNodePartitioningProvider
     public BucketFunction getBucketFunction(
             ConnectorTransactionHandle transactionHandle,
             ConnectorSession session,
-            ConnectorPartitioningHandle partitioningHandle,
-            List<Type> partitionChannelTypes,
-            int bucketCount)
+            ConnectorPartitioningHandle partitioningHandle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getBucketFunction(transactionHandle, session, partitioningHandle, partitionChannelTypes, bucketCount);
+            return delegate.getBucketFunction(transactionHandle, session, partitioningHandle);
         }
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.tests;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.RecordCursor;
@@ -77,7 +78,7 @@ public class H2QueryRunner
     public H2QueryRunner()
     {
         handle = DBI.open("jdbc:h2:mem:test" + System.nanoTime());
-        TpchMetadata tpchMetadata = new TpchMetadata("");
+        TpchMetadata tpchMetadata = new TpchMetadata("", new InMemoryNodeManager(), 1);
 
         handle.execute("CREATE TABLE orders (\n" +
                 "  orderkey BIGINT PRIMARY KEY,\n" +

--- a/presto-tests/src/main/java/com/facebook/presto/tests/tpch/IndexedTpchConnectorFactory.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/tpch/IndexedTpchConnectorFactory.java
@@ -67,7 +67,7 @@ public class IndexedTpchConnectorFactory
     public Connector create(String connectorId, Map<String, String> properties)
     {
         int splitsPerNode = getSplitsPerNode(properties);
-        TpchIndexedData indexedData = new TpchIndexedData(connectorId, indexSpec);
+        TpchIndexedData indexedData = new TpchIndexedData(connectorId, nodeManager, splitsPerNode, indexSpec);
 
         return new Connector()
         {
@@ -80,7 +80,7 @@ public class IndexedTpchConnectorFactory
             @Override
             public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle)
             {
-                return new TpchIndexMetadata(connectorId, indexedData);
+                return new TpchIndexMetadata(connectorId, nodeManager, splitsPerNode, indexedData);
             }
 
             @Override
@@ -110,7 +110,7 @@ public class IndexedTpchConnectorFactory
             @Override
             public ConnectorNodePartitioningProvider getNodePartitioningProvider()
             {
-                return new TpchNodePartitioningProvider(connectorId, nodeManager, splitsPerNode);
+                return new TpchNodePartitioningProvider(connectorId, nodeManager);
             }
         };
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/tpch/TpchIndexMetadata.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/tpch/TpchIndexMetadata.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorResolvedIndex;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.tpch.TpchMetadata;
@@ -42,9 +43,9 @@ public class TpchIndexMetadata
 {
     private final TpchIndexedData indexedData;
 
-    public TpchIndexMetadata(String connectorId, TpchIndexedData indexedData)
+    public TpchIndexMetadata(String connectorId, NodeManager nodeManager, int splitsPerNode, TpchIndexedData indexedData)
     {
-        super(connectorId);
+        super(connectorId, nodeManager, splitsPerNode);
         this.indexedData = requireNonNull(indexedData, "indexedData is null");
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/tpch/TpchIndexedData.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/tpch/TpchIndexedData.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.tests.tpch;
 
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.SchemaTableName;
@@ -50,12 +51,12 @@ class TpchIndexedData
 {
     private final Map<Set<TpchScaledColumn>, IndexedTable> indexedTables;
 
-    public TpchIndexedData(String connectorId, TpchIndexSpec tpchIndexSpec)
+    public TpchIndexedData(String connectorId, NodeManager nodeManager, int splitsPerNode, TpchIndexSpec tpchIndexSpec)
     {
         requireNonNull(connectorId, "connectorId is null");
         requireNonNull(tpchIndexSpec, "tpchIndexSpec is null");
 
-        TpchMetadata tpchMetadata = new TpchMetadata(connectorId);
+        TpchMetadata tpchMetadata = new TpchMetadata(connectorId, nodeManager, splitsPerNode);
         TpchRecordSetProvider tpchRecordSetProvider = new TpchRecordSetProvider();
 
         ImmutableMap.Builder<Set<TpchScaledColumn>, IndexedTable> indexedTablesBuilder = ImmutableMap.builder();

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchConnectorFactory.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchConnectorFactory.java
@@ -74,7 +74,7 @@ public class TpchConnectorFactory
             @Override
             public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
             {
-                return new TpchMetadata(connectorId);
+                return new TpchMetadata(connectorId, nodeManager, splitsPerNode);
             }
 
             @Override
@@ -92,7 +92,7 @@ public class TpchConnectorFactory
             @Override
             public ConnectorNodePartitioningProvider getNodePartitioningProvider()
             {
-                return new TpchNodePartitioningProvider(connectorId, nodeManager, splitsPerNode);
+                return new TpchNodePartitioningProvider(connectorId, nodeManager);
             }
         };
     }

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchPartitioningHandle.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchPartitioningHandle.java
@@ -27,14 +27,17 @@ public class TpchPartitioningHandle
 {
     private final String table;
     private final long totalRows;
+    private final int bucketCount;
 
     @JsonCreator
-    public TpchPartitioningHandle(@JsonProperty("table") String table, @JsonProperty("totalRows") long totalRows)
+    public TpchPartitioningHandle(@JsonProperty("table") String table, @JsonProperty("totalRows") long totalRows, @JsonProperty("bucketCount") int bucketCount)
     {
         this.table = requireNonNull(table, "table is null");
 
         checkArgument(totalRows > 0, "totalRows must be at least 1");
         this.totalRows = totalRows;
+        checkArgument(bucketCount > 0, "bucketCount must be at least 1");
+        this.bucketCount = bucketCount;
     }
 
     @JsonProperty
@@ -49,6 +52,12 @@ public class TpchPartitioningHandle
         return totalRows;
     }
 
+    @JsonProperty
+    public int getBucketCount()
+    {
+        return bucketCount;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -60,18 +69,19 @@ public class TpchPartitioningHandle
         }
         TpchPartitioningHandle that = (TpchPartitioningHandle) o;
         return Objects.equals(table, that.table) &&
-                totalRows == that.totalRows;
+                totalRows == that.totalRows &&
+                bucketCount == that.bucketCount;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(table, totalRows);
+        return Objects.hash(table, totalRows, bucketCount);
     }
 
     @Override
     public String toString()
     {
-        return table + ":" + totalRows;
+        return table + ":" + totalRows + ":" + bucketCount;
     }
 }

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/testing/SampledTpchConnectorFactory.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/testing/SampledTpchConnectorFactory.java
@@ -76,7 +76,7 @@ public class SampledTpchConnectorFactory
             @Override
             public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
             {
-                return new SampledTpchMetadata(connectorId);
+                return new SampledTpchMetadata(connectorId, nodeManager, splitsPerNode);
             }
 
             @Override
@@ -88,13 +88,13 @@ public class SampledTpchConnectorFactory
             @Override
             public ConnectorRecordSetProvider getRecordSetProvider()
             {
-                return new SampledTpchRecordSetProvider(connectorId, sampleWeight);
+                return new SampledTpchRecordSetProvider(connectorId, nodeManager, splitsPerNode, sampleWeight);
             }
 
             @Override
             public ConnectorNodePartitioningProvider getNodePartitioningProvider()
             {
-                return new TpchNodePartitioningProvider(connectorId, nodeManager, splitsPerNode);
+                return new TpchNodePartitioningProvider(connectorId, nodeManager);
             }
         };
     }

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/testing/SampledTpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/testing/SampledTpchMetadata.java
@@ -16,6 +16,7 @@ package com.facebook.presto.tpch.testing;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.tpch.TpchColumnHandle;
 import com.facebook.presto.tpch.TpchMetadata;
 
@@ -26,9 +27,9 @@ public class SampledTpchMetadata
 {
     public static final String SAMPLE_WEIGHT_COLUMN_NAME = "$sampleWeight";
 
-    public SampledTpchMetadata(String connectorId)
+    public SampledTpchMetadata(String connectorId, NodeManager nodeManager, int splitsPerNode)
     {
-        super(connectorId);
+        super(connectorId, nodeManager, splitsPerNode);
     }
 
     @Override

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/testing/SampledTpchRecordSetProvider.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/testing/SampledTpchRecordSetProvider.java
@@ -16,6 +16,7 @@ package com.facebook.presto.tpch.testing;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
@@ -40,9 +41,9 @@ public class SampledTpchRecordSetProvider
     private final TpchMetadata metadata;
     private final int sampleWeight;
 
-    public SampledTpchRecordSetProvider(String connectorId, int sampleWeight)
+    public SampledTpchRecordSetProvider(String connectorId, NodeManager nodeManager, int splitsPerNode, int sampleWeight)
     {
-        this.metadata = new TpchMetadata(connectorId);
+        this.metadata = new TpchMetadata(connectorId, nodeManager, splitsPerNode);
         this.sampleWeight = sampleWeight;
     }
 


### PR DESCRIPTION
These arguments are available when the PartitionHandle is created and
this simplifies the usages