### PR TITLE
ResourceGroup SelectionContext holds Session

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupManager.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.facebook.presto.SystemSessionProperties.getQueryPriority;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_REJECTED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -138,7 +139,7 @@ public class ResourceGroupManager
 
     private synchronized void createGroupIfNecessary(ResourceGroupId id, Session session, Executor executor)
     {
-        SelectionContext context = new SelectionContext(session.getIdentity().getPrincipal().isPresent(), session.getUser(), session.getSource());
+        SelectionContext context = new SelectionContext(session.getIdentity().getPrincipal().isPresent(), session.getUser(), session.getSource(), getQueryPriority(session));
         if (!groups.containsKey(id)) {
             ResourceGroup group;
             if (id.getParent().isPresent()) {
@@ -175,7 +176,7 @@ public class ResourceGroupManager
 
     private ResourceGroupId selectGroup(Statement statement, Session session)
     {
-        SelectionContext context = new SelectionContext(session.getIdentity().getPrincipal().isPresent(), session.getUser(), session.getSource());
+        SelectionContext context = new SelectionContext(session.getIdentity().getPrincipal().isPresent(), session.getUser(), session.getSource(), getQueryPriority(session));
         for (ResourceGroupSelector selector : selectors) {
             Optional<ResourceGroupId> group = selector.match(statement, context);
             if (group.isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/SelectionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/SelectionContext.java
@@ -22,12 +22,14 @@ public final class SelectionContext
     private final boolean authenticated;
     private final String user;
     private final Optional<String> source;
+    private final int queryPriority;
 
-    public SelectionContext(boolean authenticated, String user, Optional<String> source)
+    public SelectionContext(boolean authenticated, String user, Optional<String> source, int queryPriority)
     {
         this.authenticated = authenticated;
         this.user = requireNonNull(user, "user is null");
         this.source = requireNonNull(source, "source is null");
+        this.queryPriority = queryPriority;
     }
 
     public boolean isAuthenticated()
@@ -43,5 +45,10 @@ public final class SelectionContext
     public Optional<String> getSource()
     {
         return source;
+    }
+
+    public int getQueryPriority()
+    {
+        return queryPriority;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroupIdTemplate.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroupIdTemplate.java
@@ -25,7 +25,7 @@ public class TestResourceGroupIdTemplate
     public void testExpansion()
     {
         ResourceGroupIdTemplate template = new ResourceGroupIdTemplate("test.${USER}.${SOURCE}");
-        assertEquals(template.expandTemplate(new SelectionContext(true, "u", Optional.of("s"))), ResourceGroupId.fromString("test.u.s"));
+        assertEquals(template.expandTemplate(new SelectionContext(true, "u", Optional.of("s"), 1)), ResourceGroupId.fromString("test.u.s"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/TestFileResourceGroupConfigurationManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/TestFileResourceGroupConfigurationManager.java
@@ -77,7 +77,7 @@ public class TestFileResourceGroupConfigurationManager
     {
         ResourceGroupConfigurationManager manager = parse("resource_groups_config.json");
         ResourceGroup missing = new RootResourceGroup("missing", (group, export) -> { }, directExecutor());
-        manager.configure(missing, new SelectionContext(true, "user", Optional.empty()));
+        manager.configure(missing, new SelectionContext(true, "user", Optional.empty(), 1));
     }
 
     @Test
@@ -86,7 +86,7 @@ public class TestFileResourceGroupConfigurationManager
         ResourceGroupConfigurationManager manager = parse("resource_groups_config.json");
         AtomicBoolean exported = new AtomicBoolean();
         ResourceGroup global = new RootResourceGroup("global", (group, export) -> exported.set(export), directExecutor());
-        manager.configure(global, new SelectionContext(true, "user", Optional.empty()));
+        manager.configure(global, new SelectionContext(true, "user", Optional.empty(), 1));
         assertEquals(global.getSoftMemoryLimit(), new DataSize(1, MEGABYTE));
         assertEquals(global.getSoftCpuLimit(), new Duration(1, HOURS));
         assertEquals(global.getHardCpuLimit(), new Duration(1, DAYS));
@@ -99,7 +99,7 @@ public class TestFileResourceGroupConfigurationManager
         assertEquals(exported.get(), true);
         exported.set(false);
         ResourceGroup sub = global.getOrCreateSubGroup("sub");
-        manager.configure(sub, new SelectionContext(true, "user", Optional.empty()));
+        manager.configure(sub, new SelectionContext(true, "user", Optional.empty(), 1));
         assertEquals(sub.getSoftMemoryLimit(), new DataSize(2, MEGABYTE));
         assertEquals(sub.getMaxRunningQueries(), 3);
         assertEquals(sub.getMaxQueuedQueries(), 4);


### PR DESCRIPTION
When we extend ResourceGroup other Session values like session properties might also useful to choose right ResourceGroup. 