### PR TITLE
Cache .m2 repo on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,16 @@ addons:
     packages:
       - oracle-java8-installer
 
+cache:
+  directories:
+    - $HOME/.m2/repository
+
 services:
   - docker
 
 before_install:
+  # This is needed until Travis #4629 is fixed (https://github.com/travis-ci/travis-ci/issues/4629)
+  - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
   # This section can be removed once travis get equipped with docker 1.10 and docker-compose 1.6
   - |
     if [ -v PRODUCT_TESTS ] || [ -v INTEGRATION_TESTS ]; then
@@ -51,6 +57,10 @@ script:
       presto-hive-hadoop2/bin/run_on_docker.sh
       ./mvnw install -DskipTests=true -B
     fi
+
+before_cache:
+  #make the cache stable between builds by removing build output
+  - rm -rf $HOME/.m2/repository/com/facebook
 
 notifications:
   slack:


### PR DESCRIPTION
This saves about 40 secs during the mvn build for a small price of 10 secs cache download (per sub-job). In terms of total execution time, the savings are c.a. 5 mins. Both results can be verified by comparing [cold cache build](https://travis-ci.org/Teradata/presto/builds/144027056) with [hot cache build](https://travis-ci.org/Teradata/presto/builds/144032369).

The cache is made stable by deleting build artifacts installed in maven repo before archiving (namely: `.m2/repository/com/facebook` dir). This ensures the archiving penalty is only paid when dependencies change and - maybe more importantly - eliminates the risk of previous builds influencing future ones. Deleting the artifacts also shrinks the cache significantly (from 1500 to 600 MB).

Proof for cache stability can be seen at the end of [hot cache build's log](https://s3.amazonaws.com/archive.travis-ci.org/jobs/144032370/log.txt):

```
[0Ktravis_fold:start:cache.2
[0Kstore build cache
travis_time:start:018b81be
[0K
travis_time:end:018b81be:start=1468281792590801202,finish=1468281792595636326,duration=4835124
[0Ktravis_time:start:24d152de
[0K[32;1mnothing changed, not updating cache[0m

travis_time:end:24d152de:start=1468281792600771039,finish=1468281793594273770,duration=993502731
[0Ktravis_fold:end:cache.2
```