### PR TITLE
Add TypeTranslator to Hive connector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -66,6 +66,7 @@ public class HiveClientModule
     public void configure(Binder binder)
     {
         binder.bind(HiveConnectorId.class).toInstance(new HiveConnectorId(connectorId));
+        binder.bind(TypeTranslator.class).toInstance(new HiveTypeTranslator());
 
         binder.bind(HdfsConfigurationUpdater.class).in(Scopes.SINGLETON);
         binder.bind(HdfsConfiguration.class).to(HiveHdfsConfiguration.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -45,6 +45,7 @@ public class HiveMetadataFactory
     private final TableParameterCodec tableParameterCodec;
     private final JsonCodec<PartitionUpdate> partitionUpdateCodec;
     private final BoundedExecutor renameExecution;
+    private final TypeTranslator typeTranslator;
 
     @Inject
     @SuppressWarnings("deprecation")
@@ -58,7 +59,8 @@ public class HiveMetadataFactory
             TypeManager typeManager,
             LocationService locationService,
             TableParameterCodec tableParameterCodec,
-            JsonCodec<PartitionUpdate> partitionUpdateCodec)
+            JsonCodec<PartitionUpdate> partitionUpdateCodec,
+            TypeTranslator typeTranslator)
     {
         this(connectorId,
                 metastore,
@@ -75,7 +77,8 @@ public class HiveMetadataFactory
                 locationService,
                 tableParameterCodec,
                 partitionUpdateCodec,
-                executorService);
+                executorService,
+                typeTranslator);
     }
 
     public HiveMetadataFactory(
@@ -94,7 +97,8 @@ public class HiveMetadataFactory
             LocationService locationService,
             TableParameterCodec tableParameterCodec,
             JsonCodec<PartitionUpdate> partitionUpdateCodec,
-            ExecutorService executorService)
+            ExecutorService executorService,
+            TypeTranslator typeTranslator)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
 
@@ -112,6 +116,7 @@ public class HiveMetadataFactory
         this.locationService = requireNonNull(locationService, "locationService is null");
         this.tableParameterCodec = requireNonNull(tableParameterCodec, "tableParameterCodec is null");
         this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
+        this.typeTranslator = requireNonNull(typeTranslator, "typeTranslator is null");
 
         if (!allowCorruptWritesForTesting && !timeZone.equals(DateTimeZone.getDefault())) {
             log.warn("Hive writes are disabled. " +
@@ -140,6 +145,7 @@ public class HiveMetadataFactory
                 locationService,
                 tableParameterCodec,
                 partitionUpdateCodec,
-                renameExecution);
+                renameExecution,
+                typeTranslator);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.NamedTypeSignature;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.hive.common.type.HiveVarchar;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import static com.facebook.presto.hive.HiveType.HIVE_BINARY;
+import static com.facebook.presto.hive.HiveType.HIVE_BOOLEAN;
+import static com.facebook.presto.hive.HiveType.HIVE_BYTE;
+import static com.facebook.presto.hive.HiveType.HIVE_DATE;
+import static com.facebook.presto.hive.HiveType.HIVE_DOUBLE;
+import static com.facebook.presto.hive.HiveType.HIVE_INT;
+import static com.facebook.presto.hive.HiveType.HIVE_LONG;
+import static com.facebook.presto.hive.HiveType.HIVE_SHORT;
+import static com.facebook.presto.hive.HiveType.HIVE_STRING;
+import static com.facebook.presto.hive.HiveType.HIVE_TIMESTAMP;
+import static com.facebook.presto.hive.HiveUtil.isArrayType;
+import static com.facebook.presto.hive.HiveUtil.isMapType;
+import static com.facebook.presto.hive.HiveUtil.isRowType;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getListTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getMapTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getStructTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getVarcharTypeInfo;
+
+public class HiveTypeTranslator
+        implements TypeTranslator
+{
+    @Override
+    public TypeInfo translate(Type type)
+    {
+        if (BOOLEAN.equals(type)) {
+            return HIVE_BOOLEAN.getTypeInfo();
+        }
+        if (BIGINT.equals(type)) {
+            return HIVE_LONG.getTypeInfo();
+        }
+        if (INTEGER.equals(type)) {
+            return HIVE_INT.getTypeInfo();
+        }
+        if (SMALLINT.equals(type)) {
+            return HIVE_SHORT.getTypeInfo();
+        }
+        if (TINYINT.equals(type)) {
+            return HIVE_BYTE.getTypeInfo();
+        }
+        if (DOUBLE.equals(type)) {
+            return HIVE_DOUBLE.getTypeInfo();
+        }
+        if (type instanceof VarcharType) {
+            VarcharType varcharType = (VarcharType) type;
+            int varcharLength = varcharType.getLength();
+            if (varcharLength <= HiveVarchar.MAX_VARCHAR_LENGTH) {
+                return getVarcharTypeInfo(varcharLength);
+            }
+            else if (varcharLength == VarcharType.MAX_LENGTH) {
+                return HIVE_STRING.getTypeInfo();
+            }
+            else {
+                throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type: %s. Supported VARCHAR types: VARCHAR(<=%d), VARCHAR.",
+                        type, HiveVarchar.MAX_VARCHAR_LENGTH));
+            }
+        }
+        if (VARBINARY.equals(type)) {
+            return HIVE_BINARY.getTypeInfo();
+        }
+        if (DATE.equals(type)) {
+            return HIVE_DATE.getTypeInfo();
+        }
+        if (TIMESTAMP.equals(type)) {
+            return HIVE_TIMESTAMP.getTypeInfo();
+        }
+        if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            return new DecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale());
+        }
+        if (isArrayType(type)) {
+            TypeInfo elementType = translate(type.getTypeParameters().get(0));
+            return getListTypeInfo(elementType);
+        }
+        if (isMapType(type)) {
+            TypeInfo keyType = translate(type.getTypeParameters().get(0));
+            TypeInfo valueType = translate(type.getTypeParameters().get(1));
+            return getMapTypeInfo(keyType, valueType);
+        }
+        if (isRowType(type)) {
+            ImmutableList.Builder<String> fieldNames = ImmutableList.builder();
+            for (TypeSignatureParameter parameter : type.getTypeSignature().getParameters()) {
+                if (!parameter.isNamedTypeSignature()) {
+                    throw new IllegalArgumentException(format("Expected all parameters to be named type, but got %s", parameter));
+                }
+                NamedTypeSignature namedTypeSignature = parameter.getNamedTypeSignature();
+                fieldNames.add(namedTypeSignature.getName());
+            }
+            return getStructTypeInfo(
+                    fieldNames.build(),
+                    type.getTypeParameters().stream()
+                            .map(this::translate)
+                            .collect(toList()));
+        }
+        throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type: %s", type));
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/TypeTranslator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/TypeTranslator.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.type.Type;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+public interface TypeTranslator
+{
+    TypeInfo translate(Type type);
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -468,7 +468,8 @@ public abstract class AbstractTestHiveClient
                 locationService,
                 new TableParameterCodec(),
                 partitionUpdateCodec,
-                newFixedThreadPool(2));
+                newFixedThreadPool(2),
+                new HiveTypeTranslator());
         splitManager = new HiveSplitManager(
                 connectorId,
                 metastoreClient,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -164,7 +164,8 @@ public abstract class AbstractTestHiveClientS3
                 typeManager,
                 locationService,
                 new TableParameterCodec(),
-                partitionUpdateCodec);
+                partitionUpdateCodec,
+                new HiveTypeTranslator());
         splitManager = new HiveSplitManager(
                 connectorId,
                 hiveClientConfig,


### PR DESCRIPTION
The specific Hive connector could change their type-to-HiveType
conversion rules by implementing a new TypeInfoResolver.