### PR TITLE
Add support for custom credentials providers to S3 filesystem

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestPrestoS3FileSystem.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.internal.StaticCredentialsProvider;
@@ -39,10 +40,12 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
 
+import static com.facebook.presto.hive.PrestoS3FileSystem.S3_CREDENTIALS_PROVIDER;
 import static com.facebook.presto.hive.PrestoS3FileSystem.S3_ENCRYPTION_MATERIALS_PROVIDER;
 import static com.facebook.presto.hive.PrestoS3FileSystem.S3_MAX_BACKOFF_TIME;
 import static com.facebook.presto.hive.PrestoS3FileSystem.S3_MAX_CLIENT_RETRIES;
 import static com.facebook.presto.hive.PrestoS3FileSystem.S3_MAX_RETRY_TIME;
+import static com.facebook.presto.hive.PrestoS3FileSystem.S3_USE_INSTANCE_CREDENTIALS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static io.airlift.testing.FileUtils.deleteRecursively;
@@ -88,7 +91,7 @@ public class TestPrestoS3FileSystem
             throws Exception
     {
         Configuration config = new Configuration();
-        config.setBoolean(PrestoS3FileSystem.S3_USE_INSTANCE_CREDENTIALS, false);
+        config.setBoolean(S3_USE_INSTANCE_CREDENTIALS, false);
 
         try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
             fs.initialize(new URI("s3n://test-bucket/"), config);
@@ -319,6 +322,32 @@ public class TestPrestoS3FileSystem
         throw new UnrecoverableS3OperationException(new Path("/tmp/test/path"), new IOException("test io exception"));
     }
 
+    @Test
+    public void testCustomCredentialsProvider()
+            throws Exception
+    {
+        Configuration config = new Configuration();
+        config.set(S3_USE_INSTANCE_CREDENTIALS, "false");
+        config.set(S3_CREDENTIALS_PROVIDER, TestCredentialsProvider.class.getName());
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI("s3n://test-bucket/"), config);
+            assertInstanceOf(getAwsCredentialsProvider(fs), TestCredentialsProvider.class);
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeException.class,
+            expectedExceptionsMessageRegExp = "Error creating an instance of.*")
+    public void testCustomCredentialsClassCannotBeFound()
+            throws Exception
+    {
+        Configuration config = new Configuration();
+        config.set(S3_USE_INSTANCE_CREDENTIALS, "false");
+        config.set(S3_CREDENTIALS_PROVIDER, "com.test.DoesntExist");
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI("s3n://test-bucket/"), config);
+        }
+    }
+
     private static AWSCredentialsProvider getAwsCredentialsProvider(PrestoS3FileSystem fs)
     {
         return getFieldValue(fs.getS3Client(), "awsCredentialsProvider", AWSCredentialsProvider.class);
@@ -364,5 +393,19 @@ public class TestPrestoS3FileSystem
         {
             return encryptionMaterials;
         }
+    }
+
+    private static class TestCredentialsProvider implements AWSCredentialsProvider
+    {
+        public TestCredentialsProvider(URI uri, Configuration conf) {}
+
+        @Override
+        public AWSCredentials getCredentials()
+        {
+            return null;
+        }
+
+        @Override
+        public void refresh() {}
     }
 }


### PR DESCRIPTION
This PR adds support for plugging in custom AWS credentials providers to the `PrestoS3FileSystem`. This feature is already available in the `s3a` filesystem (see [HADOOP-12723](https://issues.apache.org/jira/browse/HADOOP-12723)) and Amazon's Emr filesystem (see [their docs](http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-credentialsprovider.html)). 

Please see HADOOP-12723 for a description of how this change can be useful. Basically one can write a custom credentials provider to assume roles before accessing s3, or do fancy things like using bucket-specific credentials when accessing a particular s3 bucket etc.  With this PR we can close #2640 and #4914, which we needed for role support in the s3 filesystem. 

@electrum @dain let me know what you think. If this looks like a reasonable change I can add some documentation.