### PR TITLE
Feature fast decimal ineq

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalCasts.java
@@ -59,6 +59,9 @@ import static com.facebook.presto.spi.type.StandardTypes.SMALLINT;
 import static com.facebook.presto.spi.type.StandardTypes.TINYINT;
 import static com.facebook.presto.spi.type.StandardTypes.VARCHAR;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.multiply;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.overflows;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static com.facebook.presto.util.Types.checkType;
 import static java.lang.Float.floatToRawIntBits;
@@ -161,7 +164,7 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static Slice booleanToLongDecimal(boolean value, long precision, long scale, long tenToScale)
     {
-        return encodeUnscaledValue(BigInteger.valueOf(value ? tenToScale : 0L));
+        return unscaledDecimal(value ? tenToScale : 0L);
     }
 
     @UsedByGeneratedCode
@@ -207,11 +210,16 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static Slice bigintToLongDecimal(long value, long precision, long scale, long tenToScale)
     {
-        BigInteger decimalBigInteger = BigInteger.valueOf(value).multiply(BigInteger.valueOf(tenToScale));
-        if (overflows(decimalBigInteger, (int) precision)) {
+        try {
+            Slice decimal = multiply(unscaledDecimal(value), unscaledDecimal(tenToScale));
+            if (overflows(decimal, (int) precision)) {
+                throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast BIGINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            }
+            return decimal;
+        }
+        catch (ArithmeticException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast BIGINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
-        return encodeUnscaledValue(decimalBigInteger);
     }
 
     @UsedByGeneratedCode
@@ -262,11 +270,16 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static Slice integerToLongDecimal(long value, long precision, long scale, long tenToScale)
     {
-        BigInteger decimalBigInteger = BigInteger.valueOf(value).multiply(BigInteger.valueOf(tenToScale));
-        if (overflows(decimalBigInteger, (int) precision)) {
+        try {
+            Slice decimal = multiply(unscaledDecimal(value), unscaledDecimal(tenToScale));
+            if (overflows(decimal, (int) precision)) {
+                throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast INTEGER '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            }
+            return decimal;
+        }
+        catch (ArithmeticException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast INTEGER '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
-        return encodeUnscaledValue(decimalBigInteger);
     }
 
     @UsedByGeneratedCode
@@ -317,11 +330,16 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static Slice smallintToLongDecimal(long value, long precision, long scale, long tenToScale)
     {
-        BigInteger decimalBigInteger = BigInteger.valueOf(value).multiply(BigInteger.valueOf(tenToScale));
-        if (overflows(decimalBigInteger, (int) precision)) {
+        try {
+            Slice decimal = multiply(unscaledDecimal(value), unscaledDecimal(tenToScale));
+            if (overflows(decimal, (int) precision)) {
+                throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast SMALLINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            }
+            return decimal;
+        }
+        catch (ArithmeticException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast SMALLINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
-        return encodeUnscaledValue(decimalBigInteger);
     }
 
     @UsedByGeneratedCode
@@ -372,11 +390,16 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static Slice tinyintToLongDecimal(long value, long precision, long scale, long tenToScale)
     {
-        BigInteger decimalBigInteger = BigInteger.valueOf(value).multiply(BigInteger.valueOf(tenToScale));
-        if (overflows(decimalBigInteger, (int) precision)) {
+        try {
+            Slice decimal = multiply(unscaledDecimal(value), unscaledDecimal(tenToScale));
+            if (overflows(decimal, (int) precision)) {
+                throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast TINYINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            }
+            return decimal;
+        }
+        catch (ArithmeticException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast TINYINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
-        return encodeUnscaledValue(decimalBigInteger);
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalInequalityOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalInequalityOperators.java
@@ -21,7 +21,6 @@ import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.metadata.SqlScalarFunctionBuilder.SpecializeContext;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.OperatorType;
-import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -30,7 +29,6 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
-import java.math.BigInteger;
 import java.util.List;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
@@ -44,10 +42,12 @@ import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUA
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
-import static com.facebook.presto.spi.type.Decimals.bigIntegerTenToNth;
 import static com.facebook.presto.spi.type.Decimals.longTenToNth;
 import static com.facebook.presto.spi.type.StandardTypes.BOOLEAN;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.compare;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.rescale;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.lang.Integer.max;
 
@@ -157,9 +157,7 @@ public class DecimalInequalityOperators
     {
         long aScale = context.getLiteral("a_scale");
         long bScale = context.getLiteral("b_scale");
-        BigInteger aRescale = bigIntegerTenToNth(rescaleFactor(aScale, bScale));
-        BigInteger bRescale = bigIntegerTenToNth(rescaleFactor(bScale, aScale));
-        return ImmutableList.of(aRescale, bRescale);
+        return ImmutableList.of(aScale, bScale);
     }
 
     private static int rescaleFactor(long fromScale, long toScale)
@@ -174,35 +172,35 @@ public class DecimalInequalityOperators
     }
 
     @UsedByGeneratedCode
-    public static boolean opShortShortLongRescale(long a, long b, BigInteger aRescale, BigInteger bRescale, MethodHandle getResultMethodHandle)
+    public static boolean opShortShortLongRescale(long a, long b, long aScale, long bScale, MethodHandle getResultMethodHandle)
     {
-        BigInteger left = BigInteger.valueOf(a).multiply(aRescale);
-        BigInteger right = BigInteger.valueOf(b).multiply(bRescale);
-        return invokeGetResult(getResultMethodHandle, left.compareTo(right));
+        Slice left = rescale(unscaledDecimal(a), rescaleFactor(aScale, bScale));
+        Slice right = rescale(unscaledDecimal(b), rescaleFactor(bScale, aScale));
+        return invokeGetResult(getResultMethodHandle, compare(left, right));
     }
 
     @UsedByGeneratedCode
-    public static boolean opShortLong(long a, Slice b, BigInteger aRescale, BigInteger bRescale, MethodHandle getResultMethodHandle)
+    public static boolean opShortLong(long a, Slice b, long aScale, long bScale, MethodHandle getResultMethodHandle)
     {
-        BigInteger left = BigInteger.valueOf(a).multiply(aRescale);
-        BigInteger right = Decimals.decodeUnscaledValue(b).multiply(bRescale);
-        return invokeGetResult(getResultMethodHandle, left.compareTo(right));
+        Slice left = rescale(unscaledDecimal(a), rescaleFactor(aScale, bScale));
+        Slice right = rescale(b, rescaleFactor(bScale, aScale));
+        return invokeGetResult(getResultMethodHandle, compare(left, right));
     }
 
     @UsedByGeneratedCode
-    public static boolean opLongShort(Slice a, long b, BigInteger aRescale, BigInteger bRescale, MethodHandle getResultMethodHandle)
+    public static boolean opLongShort(Slice a, long b, long aScale, long bScale, MethodHandle getResultMethodHandle)
     {
-        BigInteger left = Decimals.decodeUnscaledValue(a).multiply(aRescale);
-        BigInteger right = BigInteger.valueOf(b).multiply(bRescale);
-        return invokeGetResult(getResultMethodHandle, left.compareTo(right));
+        Slice left = rescale(a, rescaleFactor(aScale, bScale));
+        Slice right = rescale(unscaledDecimal(b), rescaleFactor(bScale, aScale));
+        return invokeGetResult(getResultMethodHandle, compare(left, right));
     }
 
     @UsedByGeneratedCode
-    public static boolean opLongLong(Slice a, Slice b, BigInteger aRescale, BigInteger bRescale, MethodHandle getResultMethodHandle)
+    public static boolean opLongLong(Slice a, Slice b, long aScale, long bScale, MethodHandle getResultMethodHandle)
     {
-        BigInteger left = Decimals.decodeUnscaledValue(a).multiply(aRescale);
-        BigInteger right = Decimals.decodeUnscaledValue(b).multiply(bRescale);
-        return invokeGetResult(getResultMethodHandle, left.compareTo(right));
+        Slice left = rescale(a, rescaleFactor(aScale, bScale));
+        Slice right = rescale(b, rescaleFactor(bScale, aScale));
+        return invokeGetResult(getResultMethodHandle, compare(left, right));
     }
 
     private static boolean invokeGetResult(MethodHandle getResultMethodHandle, int comparisonResult)

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalOperators.java
@@ -28,7 +28,6 @@ import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
-import io.airlift.slice.XxHash64;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -47,6 +46,7 @@ import static com.facebook.presto.spi.type.Decimals.bigIntegerTenToNth;
 import static com.facebook.presto.spi.type.Decimals.checkOverflow;
 import static com.facebook.presto.spi.type.Decimals.longTenToNth;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.hash;
 import static java.lang.Integer.max;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
@@ -613,7 +613,7 @@ public final class DecimalOperators
         @SqlType("bigint")
         public static long hashCode(@SqlType("decimal(p, s)") Slice value)
         {
-            return XxHash64.hash(value);
+            return hash(value);
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/SequencePageBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/SequencePageBuilder.java
@@ -16,6 +16,7 @@ package com.facebook.presto;
 import com.facebook.presto.block.BlockAssertions;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
 
@@ -24,6 +25,8 @@ import java.util.List;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isLongDecimal;
+import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
@@ -67,6 +70,12 @@ public final class SequencePageBuilder
             }
             else if (type.equals(TIMESTAMP)) {
                 blocks[i] = BlockAssertions.createTimestampSequenceBlock(initialValue, initialValue + length);
+            }
+            else if (isShortDecimal(type)) {
+                blocks[i] = BlockAssertions.createShortDecimalSequenceBlock(initialValue, initialValue + length, (DecimalType) type);
+            }
+            else if (isLongDecimal(type)) {
+                blocks[i] = BlockAssertions.createLongDecimalSequenceBlock(initialValue, initialValue + length, (DecimalType) type);
             }
             else {
                 throw new IllegalStateException("Unsupported type " + type);

--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.type.ArrayType;
 import io.airlift.slice.Slice;
@@ -30,6 +31,7 @@ import java.util.List;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.encodeUnscaledValue;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -424,6 +426,28 @@ public final class BlockAssertions
 
         for (int i = start; i < end; i++) {
             TIMESTAMP.writeLong(builder, i);
+        }
+
+        return builder.build();
+    }
+
+    public static Block createShortDecimalSequenceBlock(int start, int end, DecimalType type)
+    {
+        BlockBuilder builder = type.createFixedSizeBlockBuilder(end - start);
+
+        for (int i = start; i < end; ++i) {
+            type.writeLong(builder, i);
+        }
+
+        return builder.build();
+    }
+
+    public static Block createLongDecimalSequenceBlock(int start, int end, DecimalType type)
+    {
+        BlockBuilder builder = type.createFixedSizeBlockBuilder(end - start);
+
+        for (int i = start; i < end; ++i) {
+            type.writeSlice(builder, encodeUnscaledValue(i));
         }
 
         return builder.build();

--- a/presto-main/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.operator.PageProcessor;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.ExpressionCompiler;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolToInputRewriter;
+import com.facebook.presto.sql.relational.RowExpression;
+import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.google.common.collect.ImmutableList;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.metadata.FunctionKind.SCALAR;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.operator.scalar.FunctionAssertions.createExpression;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypesFromInput;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.stream.Collectors.toMap;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(3)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class BenchmarkDecimalOperators
+{
+    private static final int PAGE_SIZE = 30000;
+
+    private static final DecimalType SHORT_DECIMAL_TYPE = DecimalType.createDecimalType(10, 0);
+    private static final DecimalType LONG_DECIMAL_TYPE = DecimalType.createDecimalType(20, 0);
+
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final Metadata METADATA = createTestMetadataManager();
+
+    @State(Thread)
+    public static class InequalityBenchmarkState
+            extends BaseState
+    {
+        @Param({"d1 < d2",
+                "d1 < d2 AND d1 < d3 AND d1 < d4 AND d2 < d3 AND d2 < d4 AND d3 < d4",
+                "s1 < s2",
+                "s1 < s2 AND s1 < s3 AND s1 < s4 AND s2 < s3 AND s2 < s4 AND s3 < s4",
+                "l1 < l2",
+                "l1 < l2 AND l1 < l3 AND l1 < l4 AND l2 < l3 AND l2 < l4 AND l3 < l4"})
+        private String expression;
+
+        @Setup
+        public void setup()
+        {
+            addSymbol("d1", DOUBLE);
+            addSymbol("d2", DOUBLE);
+            addSymbol("d3", DOUBLE);
+            addSymbol("d4", DOUBLE);
+
+            addSymbol("s1", SHORT_DECIMAL_TYPE);
+            addSymbol("s2", SHORT_DECIMAL_TYPE);
+            addSymbol("s3", SHORT_DECIMAL_TYPE);
+            addSymbol("s4", SHORT_DECIMAL_TYPE);
+
+            addSymbol("l1", LONG_DECIMAL_TYPE);
+            addSymbol("l2", LONG_DECIMAL_TYPE);
+            addSymbol("l3", LONG_DECIMAL_TYPE);
+            addSymbol("l4", LONG_DECIMAL_TYPE);
+
+            generateInputPage(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+            generateProcessor(expression);
+            generatePageBuilder(BOOLEAN);
+        }
+    }
+
+    @Benchmark
+    public Page inequalityBenchmark(InequalityBenchmarkState state)
+    {
+        return execute(state);
+    }
+
+    private Page execute(BaseState state)
+    {
+        Page inputPage = state.getInputPage();
+        PageBuilder pageBuilder = state.getPageBuilder();
+        PageProcessor processor = state.getProcessor();
+
+        pageBuilder.reset();
+        checkState(processor.process(null, inputPage, 0, inputPage.getPositionCount(), pageBuilder) == PAGE_SIZE);
+        return pageBuilder.build();
+    }
+
+    private static class BaseState
+    {
+        private final Map<Symbol, Type> symbolTypes = new HashMap<>();
+        private final Map<Symbol, Integer> sourceLayout = new HashMap<>();
+        private final List<Type> types = new LinkedList<>();
+
+        private Page inputPage;
+        private PageBuilder pageBuilder;
+        private PageProcessor processor;
+
+        public Page getInputPage()
+        {
+            return inputPage;
+        }
+
+        public PageBuilder getPageBuilder()
+        {
+            return pageBuilder;
+        }
+
+        public PageProcessor getProcessor()
+        {
+            return processor;
+        }
+
+        protected void addSymbol(String name, Type type)
+        {
+            Symbol symbol = new Symbol(name);
+            symbolTypes.put(symbol, type);
+            sourceLayout.put(symbol, types.size());
+            types.add(type);
+        }
+
+        protected void generateInputPage(int... initialValues)
+        {
+            RowPagesBuilder buildPagesBuilder = rowPagesBuilder(types);
+            buildPagesBuilder.addSequencePage(PAGE_SIZE, initialValues);
+            inputPage = getOnlyElement(buildPagesBuilder.build());
+        }
+
+        protected void generatePageBuilder(Type type)
+        {
+            pageBuilder = new PageBuilder(ImmutableList.of(type));
+        }
+
+        protected void generateProcessor(String expression)
+        {
+            processor = new ExpressionCompiler(createTestMetadataManager()).compilePageProcessor(rowExpression("true"), ImmutableList.of(rowExpression(expression))).get();
+        }
+
+        private RowExpression rowExpression(String expression)
+        {
+            SymbolToInputRewriter symbolToInputRewriter = new SymbolToInputRewriter(sourceLayout);
+            Expression inputReferenceExpression = ExpressionTreeRewriter.rewriteWith(symbolToInputRewriter, createExpression(expression, METADATA, symbolTypes));
+
+            Map<Integer, Type> types = sourceLayout.entrySet().stream()
+                    .collect(toMap(Map.Entry::getValue, entry -> symbolTypes.get(entry.getKey())));
+
+            IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, METADATA, SQL_PARSER, types, inputReferenceExpression);
+            return SqlToRowExpressionTranslator.translate(inputReferenceExpression, SCALAR, expressionTypes, METADATA.getFunctionRegistry(), METADATA.getTypeManager(), TEST_SESSION, true);
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkDecimalOperators.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestLongDecimalType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestLongDecimalType.java
@@ -29,6 +29,7 @@ import java.math.BigInteger;
 import static com.facebook.presto.spi.type.Decimals.encodeScaledValue;
 import static com.facebook.presto.spi.type.Decimals.encodeUnscaledValue;
 import static com.facebook.presto.spi.type.Decimals.writeBigDecimal;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToBigInteger;
 import static org.testng.Assert.assertEquals;
 
 public class TestLongDecimalType
@@ -85,6 +86,6 @@ public class TestLongDecimalType
 
     private static BigDecimal toBigDecimal(Slice valueSlice, int scale)
     {
-        return new BigDecimal(new BigInteger(valueSlice.getBytes()), scale);
+        return new BigDecimal(unscaledDecimalToBigInteger(valueSlice), scale);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DecimalType.java
@@ -25,7 +25,8 @@ import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static java.util.Collections.unmodifiableList;
 
 public abstract class DecimalType
-        extends AbstractFixedWidthType
+        extends AbstractType
+        implements FixedWidthType
 {
     public static final int DEFAULT_SCALE = 0;
     public static final int DEFAULT_PRECISION = MAX_PRECISION;
@@ -53,9 +54,9 @@ public abstract class DecimalType
     private final int precision;
     private final int scale;
 
-    DecimalType(int precision, int scale, Class<?> javaType, int fixedSize)
+    DecimalType(int precision, int scale, Class<?> javaType)
     {
-        super(new TypeSignature(StandardTypes.DECIMAL, buildTypeParameters(precision, scale)), javaType, fixedSize);
+        super(new TypeSignature(StandardTypes.DECIMAL, buildTypeParameters(precision, scale)), javaType);
         this.precision = precision;
         this.scale = scale;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/Decimals.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/Decimals.java
@@ -16,7 +16,6 @@ package com.facebook.presto.spi.type;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.BlockBuilder;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -25,8 +24,10 @@ import java.util.regex.Pattern;
 
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
-import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToBigInteger;
 import static java.lang.Math.abs;
+import static java.lang.Math.min;
 import static java.lang.Math.pow;
 import static java.lang.Math.round;
 import static java.lang.String.format;
@@ -35,8 +36,6 @@ import static java.math.BigInteger.TEN;
 public class Decimals
 {
     private Decimals() {}
-
-    public static final int SIZE_OF_LONG_DECIMAL = 2 * SIZE_OF_LONG;
 
     public static final int MAX_PRECISION = 38;
     public static final int MAX_SHORT_PRECISION = 17;
@@ -51,11 +50,13 @@ public class Decimals
     private static final int POWERS_OF_TEN_TABLE_LENGTH = 100;
     private static final long[] LONG_POWERS_OF_TEN = new long[POWERS_OF_TEN_TABLE_LENGTH];
     private static final BigInteger[] BIG_INTEGER_POWERS_OF_TEN = new BigInteger[POWERS_OF_TEN_TABLE_LENGTH];
+    private static final Slice[] UNSCALED_DECIMAL_POWERS_OF_TEN = new Slice[POWERS_OF_TEN_TABLE_LENGTH];
 
     static {
         for (int i = 0; i < LONG_POWERS_OF_TEN.length; ++i) {
             LONG_POWERS_OF_TEN[i] = round(pow(10, i));
             BIG_INTEGER_POWERS_OF_TEN[i] = TEN.pow(i);
+            UNSCALED_DECIMAL_POWERS_OF_TEN[i] = unscaledDecimal(TEN.pow(min(i, MAX_PRECISION - 1)));
         }
     }
 
@@ -67,6 +68,11 @@ public class Decimals
     public static BigInteger bigIntegerTenToNth(int n)
     {
         return BIG_INTEGER_POWERS_OF_TEN[n];
+    }
+
+    public static Slice unscaledDecimalTenToNth(int n)
+    {
+        return UNSCALED_DECIMAL_POWERS_OF_TEN[n];
     }
 
     public static DecimalParseResult parse(String stringValue)
@@ -129,28 +135,12 @@ public class Decimals
 
     public static Slice encodeUnscaledValue(BigInteger unscaledValue)
     {
-        Slice result = Slices.allocate(SIZE_OF_LONG_DECIMAL);
-        byte[] bytes = unscaledValue.toByteArray();
-        if (unscaledValue.signum() < 0) {
-            // need to fill with 0xff for negative values as we
-            // represent value in two's-complement representation.
-            result.fill((byte) 0xff);
-        }
-        result.setBytes(SIZE_OF_LONG_DECIMAL - bytes.length, bytes);
-        return result;
+        return unscaledDecimal(unscaledValue);
     }
 
     public static Slice encodeUnscaledValue(long unscaledValue)
     {
-        // we just fill top 8 bytes with unscaled value from long
-        // the bottom 8 bytes are filled with 0 for positive values and 0xff for negative ones
-        // conforming two's-complement representation.
-        Slice result = Slices.allocate(SIZE_OF_LONG_DECIMAL);
-        if (unscaledValue < 0) {
-            result.setLong(0, -1L); // fill bottom 8 bytes with 0xff
-        }
-        result.setLong(SIZE_OF_LONG, Long.reverseBytes(unscaledValue));
-        return result;
+        return unscaledDecimal(unscaledValue);
     }
 
     public static Slice encodeScaledValue(BigDecimal value)
@@ -160,7 +150,7 @@ public class Decimals
 
     public static BigInteger decodeUnscaledValue(Slice valueSlice)
     {
-        return new BigInteger(valueSlice.getBytes());
+        return unscaledDecimalToBigInteger(valueSlice);
     }
 
     public static String toString(long unscaledValue, int scale)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
@@ -17,6 +17,8 @@ package com.facebook.presto.spi.type;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
 import io.airlift.slice.Slice;
 
 import static com.facebook.presto.spi.type.Decimals.MAX_PRECISION;
@@ -30,8 +32,35 @@ final class LongDecimalType
 {
     LongDecimalType(int precision, int scale)
     {
-        super(precision, scale, Slice.class, UNSCALED_DECIMAL_128_SLICE_LENGTH);
+        super(precision, scale, Slice.class);
         validatePrecisionScale(precision, scale, MAX_PRECISION);
+    }
+
+    @Override
+    public final int getFixedSize()
+    {
+        return UNSCALED_DECIMAL_128_SLICE_LENGTH;
+    }
+
+    @Override
+    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        return new FixedWidthBlockBuilder(
+                getFixedSize(),
+                blockBuilderStatus,
+                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / getFixedSize()));
+    }
+
+    @Override
+    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return createBlockBuilder(blockBuilderStatus, expectedEntries, getFixedSize());
+    }
+
+    @Override
+    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        return new FixedWidthBlockBuilder(getFixedSize(), positionCount);
     }
 
     @Override
@@ -90,5 +119,11 @@ final class LongDecimalType
     public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
     {
         blockBuilder.writeBytes(value, offset, length).closeEntry();
+    }
+
+    @Override
+    public final Slice getSlice(Block block, int position)
+    {
+        return block.getSlice(position, 0, getFixedSize());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
@@ -20,17 +20,17 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import io.airlift.slice.Slice;
 
 import static com.facebook.presto.spi.type.Decimals.MAX_PRECISION;
-import static com.facebook.presto.spi.type.Decimals.SIZE_OF_LONG_DECIMAL;
 import static com.facebook.presto.spi.type.Decimals.decodeUnscaledValue;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.UNSCALED_DECIMAL_128_SLICE_LENGTH;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.compare;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 
 final class LongDecimalType
         extends DecimalType
 {
-    private static final int SIGN_BIT_MASK = 0x80;
-
     LongDecimalType(int precision, int scale)
     {
-        super(precision, scale, Slice.class, SIZE_OF_LONG_DECIMAL);
+        super(precision, scale, Slice.class, UNSCALED_DECIMAL_128_SLICE_LENGTH);
         validatePrecisionScale(precision, scale, MAX_PRECISION);
     }
 
@@ -47,26 +47,25 @@ final class LongDecimalType
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        return leftBlock.equals(leftPosition, 0, rightBlock, rightPosition, 0, getFixedSize());
+        return compareTo(leftBlock, leftPosition, rightBlock, rightPosition) == 0;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return block.hash(position, 0, getFixedSize());
+        long lo = block.getLong(position, 0);
+        long hi = block.getLong(position, SIZE_OF_LONG);
+        return UnscaledDecimal128Arithmetic.hash(lo, hi);
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        byte left = leftBlock.getByte(leftPosition, 0);
-        byte right = rightBlock.getByte(rightPosition, 0);
-        if ((left & SIGN_BIT_MASK) != (right & SIGN_BIT_MASK)) {
-            // difference in signs of compared values
-            return Byte.compare(left, right);
-        }
-        // sign matches - we compare bytes lexicographically
-        return leftBlock.compareTo(leftPosition, 0, getFixedSize(), rightBlock, rightPosition, 0, getFixedSize());
+        long leftLo = leftBlock.getLong(leftPosition, 0);
+        long leftHi = leftBlock.getLong(leftPosition, SIZE_OF_LONG);
+        long rightLo = rightBlock.getLong(rightPosition, 0);
+        long rightHi = rightBlock.getLong(rightPosition, SIZE_OF_LONG);
+        return compare(leftLo, leftHi, rightLo, rightHi);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -17,6 +17,8 @@ package com.facebook.presto.spi.type;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.LongArrayBlockBuilder;
 
 import java.math.BigInteger;
 
@@ -28,8 +30,34 @@ final class ShortDecimalType
 {
     ShortDecimalType(int precision, int scale)
     {
-        super(precision, scale, long.class, SIZE_OF_LONG);
+        super(precision, scale, long.class);
         validatePrecisionScale(precision, scale, MAX_SHORT_PRECISION);
+    }
+
+    @Override
+    public int getFixedSize()
+    {
+        return SIZE_OF_LONG;
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        return new LongArrayBlockBuilder(
+                blockBuilderStatus,
+                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / getFixedSize()));
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return createBlockBuilder(blockBuilderStatus, expectedEntries, getFixedSize());
+    }
+
+    @Override
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        return new LongArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/UnscaledDecimal128Arithmetic.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/UnscaledDecimal128Arithmetic.java
@@ -1,0 +1,571 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.airlift.slice.XxHash64;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.math.BigInteger;
+
+import static com.facebook.presto.spi.type.Decimals.MAX_PRECISION;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+
+/**
+ * 128 bit unscaled decimal arithmetic.
+ * <p>
+ * Based on: https://github.com/apache/hive/blob/master/common/src/java/org/apache/hadoop/hive/common/type/UnsignedInt128.java
+ * and https://github.com/apache/hive/blob/master/common/src/java/org/apache/hadoop/hive/common/type/Decimal128.java
+ */
+public final class UnscaledDecimal128Arithmetic
+{
+    public static final int UNSCALED_DECIMAL_128_SLICE_LENGTH = 2 * SIZE_OF_LONG;
+
+    private static final Slice[] POWERS_OF_TEN = new Slice[MAX_PRECISION - 1];
+
+    private static final int SIGN_LONG_INDEX = 1;
+    private static final int SIGN_INT_INDEX = 3;
+    private static final long SIGN_LONG_MASK = 1L << 63;
+    private static final int SIGN_INT_MASK = 1 << 31;
+    private static final int SIGN_BYTE_MASK = 1 << 7;
+    private static final int NUMBER_OF_INTS = 4;
+    private static final int NUMBER_OF_LONGS = 2;
+    private static final int INT_MASK = 0xFFFFFFFF;
+    private static final long LONG_MASK = 0xFFFFFFFFL;
+
+    /**
+     * 5^13 fits in 2^31.
+     */
+    private static final int MAX_POWER_FIVE_INT = 13;
+    /**
+     * 5^x. All unsigned values.
+     */
+    private static final int[] POWER_FIVES_INT = new int[MAX_POWER_FIVE_INT + 1];
+
+    private static final Unsafe unsafe;
+
+    static {
+        try {
+            // fetch theUnsafe object
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            unsafe = (Unsafe) field.get(null);
+            if (unsafe == null) {
+                throw new RuntimeException("Unsafe access not available");
+            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        for (int i = 0; i < POWERS_OF_TEN.length; ++i) {
+            POWERS_OF_TEN[i] = unscaledDecimal(BigInteger.TEN.pow(i));
+        }
+
+        for (int i = 0; i < POWER_FIVES_INT.length; ++i) {
+            POWER_FIVES_INT[i] = BigInteger.valueOf(5).pow(i).intValue();
+        }
+    }
+
+    public static Slice unscaledDecimal()
+    {
+        return Slices.allocate(UNSCALED_DECIMAL_128_SLICE_LENGTH);
+    }
+
+    public static Slice unscaledDecimal(Slice decimal)
+    {
+        return Slices.copyOf(decimal);
+    }
+
+    public static Slice unscaledDecimal(String unscaledValue)
+    {
+        return unscaledDecimal(new BigInteger(unscaledValue));
+    }
+
+    public static Slice unscaledDecimal(BigInteger unscaledValue)
+    {
+        byte[] bytes = unscaledValue.abs().toByteArray();
+
+        if (bytes.length > UNSCALED_DECIMAL_128_SLICE_LENGTH
+                || (bytes.length == UNSCALED_DECIMAL_128_SLICE_LENGTH && (bytes[0] & SIGN_BYTE_MASK) != 0)) {
+            throwOverflowException();
+        }
+
+        // convert to little-endian order
+        reverse(bytes);
+
+        Slice decimal = Slices.allocate(UNSCALED_DECIMAL_128_SLICE_LENGTH);
+        decimal.setBytes(0, bytes);
+        if (unscaledValue.signum() < 0) {
+            setNegative(decimal, true);
+        }
+
+        throwIfOverflows(decimal);
+
+        return decimal;
+    }
+
+    public static Slice unscaledDecimal(long unscaledValue)
+    {
+        long[] longs = new long[NUMBER_OF_LONGS];
+        if (unscaledValue < 0) {
+            longs[0] = -unscaledValue;
+            longs[1] = SIGN_LONG_MASK;
+        }
+        else {
+            longs[0] = unscaledValue;
+        }
+        return Slices.wrappedLongArray(longs);
+    }
+
+    public static BigInteger unscaledDecimalToBigInteger(Slice decimal)
+    {
+        byte[] bytes = decimal.getBytes(0, UNSCALED_DECIMAL_128_SLICE_LENGTH);
+        // convert to big-endian order
+        reverse(bytes);
+        bytes[0] &= ~SIGN_BYTE_MASK;
+        return new BigInteger(isNegative(decimal) ? -1 : 1, bytes);
+    }
+
+    public static long unscaledDecimalToUnscaledLong(Slice decimal)
+    {
+        long lo = getLong(decimal, 0);
+        long hi = getLong(decimal, 1);
+        boolean negative = isNegative(decimal);
+
+        if (hi != 0 || ((lo > Long.MIN_VALUE || !negative) && lo < 0)) {
+            throwOverflowException();
+        }
+
+        return negative ? -lo : lo;
+    }
+
+    public static void copyUnscaledDecimal(Slice from, Slice to)
+    {
+        setRawLong(to, 0, getRawLong(from, 0));
+        setRawLong(to, 1, getRawLong(from, 1));
+    }
+
+    public static Slice rescale(Slice decimal, int rescaleFactor)
+    {
+        if (rescaleFactor == 0) {
+            return decimal;
+        }
+        else if (rescaleFactor > 0) {
+            return multiply(decimal, POWERS_OF_TEN[rescaleFactor]);
+        }
+        else {
+            Slice result = unscaledDecimal();
+            scaleDownFive(decimal, -rescaleFactor, result);
+            shiftRightRoundUp(result, -rescaleFactor, result);
+            return result;
+        }
+    }
+
+    public static Slice multiply(Slice left, Slice right)
+    {
+        Slice result = unscaledDecimal();
+        multiply(left, right, result);
+        return result;
+    }
+
+    public static void multiply(Slice left, Slice right, Slice result)
+    {
+        int l0 = getInt(left, 0);
+        int l1 = getInt(left, 1);
+        int l2 = getInt(left, 2);
+        int l3 = getInt(left, 3);
+
+        int r0 = getInt(right, 0);
+        int r1 = getInt(right, 1);
+        int r2 = getInt(right, 2);
+        int r3 = getInt(right, 3);
+
+        // the combinations below definitely result in overflow
+        if ((r3 != 0 && (l3 | l2 | l1) != 0)
+                || (r2 != 0 && (l3 | l2) != 0)
+                || (r1 != 0 && l3 != 0)) {
+            throwOverflowException();
+        }
+
+        long product;
+
+        product = (r0 & LONG_MASK) * (l0 & LONG_MASK);
+        int z0 = (int) product;
+
+        product = (r0 & LONG_MASK) * (l1 & LONG_MASK)
+                + (r1 & LONG_MASK) * (l0 & LONG_MASK)
+                + (product >> 32);
+        int z1 = (int) product;
+
+        product = (r0 & LONG_MASK) * (l2 & LONG_MASK)
+                + (r1 & LONG_MASK) * (l1 & LONG_MASK)
+                + (r2 & LONG_MASK) * (l0 & LONG_MASK)
+                + (product >> 32);
+        int z2 = (int) product;
+
+        product = (r0 & LONG_MASK) * (l3 & LONG_MASK)
+                + (r1 & LONG_MASK) * (l2 & LONG_MASK)
+                + (r2 & LONG_MASK) * (l1 & LONG_MASK)
+                + (r3 & LONG_MASK) * (l0 & LONG_MASK)
+                + (product >> 32);
+        int z3 = (int) product;
+        if ((product >>> 32) != 0) {
+            throwOverflowException();
+        }
+
+        boolean negative = isNegative(left) ^ isNegative(right);
+        pack(result, z0, z1, z2, z3, negative);
+
+        throwIfOverflows(z0, z1, z2, z3);
+    }
+
+    public static boolean overflows(Slice value, int precision)
+    {
+        return precision < MAX_PRECISION && compareUnsigned(value, POWERS_OF_TEN[precision]) >= 0;
+    }
+
+    public static int compare(Slice left, Slice right)
+    {
+        boolean leftStrictlyNegative = isStrictlyNegative(left);
+        boolean rightNegative = isNegative(right);
+
+        if (leftStrictlyNegative != rightNegative) {
+            return leftStrictlyNegative ? -1 : 1;
+        }
+        else {
+            return compareUnsigned(left, right) * (leftStrictlyNegative ? -1 : 1);
+        }
+    }
+
+    public static int compare(long leftRawLo, long leftRawHi, long rightRawLo, long rightRawHi)
+    {
+        boolean leftStrictlyNegative = isStrictlyNegative(leftRawLo, leftRawHi);
+        boolean rightNegative = isNegative(rightRawLo, rightRawHi);
+
+        if (leftStrictlyNegative != rightNegative) {
+            return leftStrictlyNegative ? -1 : 1;
+        }
+        else {
+            return compareUnsigned(leftRawLo, leftRawHi, rightRawLo, rightRawHi) * (leftStrictlyNegative ? -1 : 1);
+        }
+    }
+
+    public static int compareUnsigned(Slice left, Slice right)
+    {
+        long leftHi = getLong(left, 1);
+        long rightHi = getLong(right, 1);
+        if (leftHi != rightHi) {
+            return Long.compareUnsigned(leftHi, rightHi);
+        }
+
+        long leftLo = getLong(left, 0);
+        long rightLo = getLong(right, 0);
+        if (leftLo != rightLo) {
+            return Long.compareUnsigned(leftLo, rightLo);
+        }
+
+        return 0;
+    }
+
+    public static int compareUnsigned(long leftRawLo, long leftRawHi, long rightRawLo, long rightRawHi)
+    {
+        long leftHi = unpackUnsignedLong(leftRawHi);
+        long rightHi = unpackUnsignedLong(rightRawHi);
+        if (leftHi != rightHi) {
+            return Long.compareUnsigned(leftHi, rightHi);
+        }
+
+        if (leftRawLo != rightRawLo) {
+            return Long.compareUnsigned(leftRawLo, rightRawLo);
+        }
+
+        return 0;
+    }
+
+    public static void negate(Slice decimal)
+    {
+        setNegative(decimal, !isNegative(decimal));
+    }
+
+    public static boolean isStrictlyNegative(Slice decimal)
+    {
+        return isNegative(decimal) && (getLong(decimal, 0) != 0 || getLong(decimal, 1) != 0);
+    }
+
+    public static boolean isStrictlyNegative(long rawLo, long rawHi)
+    {
+        return isNegative(rawLo, rawHi) && (rawLo != 0 || unpackUnsignedLong(rawHi) != 0);
+    }
+
+    public static boolean isNegative(Slice decimal)
+    {
+        return (getRawInt(decimal, SIGN_INT_INDEX) & SIGN_INT_MASK) != 0;
+    }
+
+    public static boolean isNegative(long rawLo, long rawHi)
+    {
+        return (rawHi & SIGN_LONG_MASK) != 0;
+    }
+
+    public static long hash(Slice decimal)
+    {
+        return hash(getRawLong(decimal, 0), getRawLong(decimal, 1));
+    }
+
+    public static long hash(long rawLo, long rawHi)
+    {
+        return XxHash64.hash(rawLo) ^ XxHash64.hash(unpackUnsignedLong(rawHi));
+    }
+
+    private static void scaleDownFive(Slice decimal, int fiveScale, Slice result)
+    {
+        while (true) {
+            int powerFive = Math.min(fiveScale, MAX_POWER_FIVE_INT);
+            fiveScale -= powerFive;
+
+            int divisor = POWER_FIVES_INT[powerFive];
+            divide(decimal, divisor, result);
+
+            if (fiveScale == 0) {
+                return;
+            }
+        }
+    }
+
+    private static void shiftRightRoundUp(Slice decimal, int rightShifts, Slice result)
+    {
+        shiftRight(decimal, rightShifts, true, result);
+    }
+
+    // visible for testing
+    static void shiftRight(Slice decimal, int rightShifts, boolean roundUp, Slice result)
+    {
+        if (rightShifts == 0) {
+            copyUnscaledDecimal(decimal, result);
+        }
+        else {
+            final int wordShifts = rightShifts / 32;
+            final int bitShiftsInWord = rightShifts % 32;
+            final int shiftRestore = 32 - bitShiftsInWord;
+
+            // check this because "123 << 32" will be 123.
+            final boolean noRestore = bitShiftsInWord == 0;
+
+            // check round-ups before settings values to result.
+            // be aware that result could be the same object as z.
+            boolean roundCarry;
+            if (bitShiftsInWord == 0) {
+                roundCarry = roundUp && getInt(decimal, wordShifts - 1) < 0;
+            }
+            else {
+                roundCarry = roundUp && (getInt(decimal, wordShifts) & (1 << (bitShiftsInWord - 1))) != 0;
+            }
+
+            // Store negative before settings values to result.
+            boolean negative = isNegative(decimal);
+
+            for (int i = 0; i < NUMBER_OF_INTS; ++i) {
+                int val = 0;
+                if (!noRestore && i + wordShifts + 1 < NUMBER_OF_INTS) {
+                    val = getInt(decimal, i + wordShifts + 1) << shiftRestore;
+                }
+                if (i + wordShifts < NUMBER_OF_INTS) {
+                    val |= (getInt(decimal, i + wordShifts) >>> bitShiftsInWord);
+                }
+
+                if (roundCarry) {
+                    if (val != INT_MASK) {
+                        setRawInt(result, i, val + 1);
+                        roundCarry = false;
+                    }
+                    else {
+                        setRawInt(result, i, 0);
+                    }
+                }
+                else {
+                    setRawInt(result, i, val);
+                }
+            }
+
+            setNegative(result, negative);
+        }
+    }
+
+    // visible for testing
+    static void divide(Slice decimal, int divisor, Slice result)
+    {
+        long remainder = (getInt(decimal, 3) & LONG_MASK);
+        int z3 = (int) (remainder / divisor);
+        remainder %= divisor;
+
+        remainder = (getInt(decimal, 2) & LONG_MASK) + (remainder << 32);
+        int z2 = (int) (remainder / divisor);
+        remainder %= divisor;
+
+        remainder = (getInt(decimal, 1) & LONG_MASK) + (remainder << 32);
+        int z1 = (int) (remainder / divisor);
+        remainder %= divisor;
+
+        remainder = (getInt(decimal, 0) & LONG_MASK) + (remainder << 32);
+        int z0 = (int) (remainder / divisor);
+
+        pack(result, z0, z1, z2, z3, isNegative(decimal));
+    }
+
+    private static void setNegative(Slice decimal, boolean negative)
+    {
+        setNegative(decimal, getInt(decimal, SIGN_INT_INDEX), negative);
+    }
+
+    private static void setNegative(Slice decimal, int v3, boolean negative)
+    {
+        setRawInt(decimal, SIGN_INT_INDEX, v3 | (negative ? SIGN_INT_MASK : 0));
+    }
+
+    private static void pack(Slice decimal, int v0, int v1, int v2, int v3, boolean negative)
+    {
+        setRawInt(decimal, 0, v0);
+        setRawInt(decimal, 1, v1);
+        setRawInt(decimal, 2, v2);
+        setNegative(decimal, v3, negative);
+    }
+
+    private static void throwIfOverflows(int v0, int v1, int v2, int v3)
+    {
+        if (exceedsOrEqualTenToThirtyEight(v0, v1, v2, v3)) {
+            throwOverflowException();
+        }
+    }
+
+    private static void throwIfOverflows(Slice decimal)
+    {
+        if (exceedsOrEqualTenToThirtyEight(decimal)) {
+            throwOverflowException();
+        }
+    }
+
+    private static boolean exceedsOrEqualTenToThirtyEight(int v0, int v1, int v2, int v3)
+    {
+        // 10**38=
+        // v0=0(0),v1=160047680(98a22400),v2=1518781562(5a86c47a),v3=1262177448(4b3b4ca8)
+
+        if (v3 >= 0 && v3 < 0x4b3b4ca8) {
+            return false;
+        }
+        else if (v3 > 0x4b3b4ca8) {
+            return true;
+        }
+
+        if (v2 >= 0 && v2 < 0x5a86c47a) {
+            return false;
+        }
+        else if (v2 > 0x5a86c47a) {
+            return true;
+        }
+
+        return v1 < 0 || v1 >= 0x098a2240;
+    }
+
+    private static boolean exceedsOrEqualTenToThirtyEight(Slice decimal)
+    {
+        // 10**38=
+        // v0=0(0),v1=160047680(98a22400),v2=1518781562(5a86c47a),v3=1262177448(4b3b4ca8)
+
+        int v3 = getInt(decimal, 3);
+        if (v3 >= 0 && v3 < 0x4b3b4ca8) {
+            return false;
+        }
+        else if (v3 > 0x4b3b4ca8) {
+            return true;
+        }
+
+        int v2 = getInt(decimal, 2);
+        if (v2 >= 0 && v2 < 0x5a86c47a) {
+            return false;
+        }
+        else if (v2 > 0x5a86c47a) {
+            return true;
+        }
+
+        int v1 = getInt(decimal, 1);
+        return v1 < 0 || v1 >= 0x098a2240;
+    }
+
+    private static void throwOverflowException()
+    {
+        throw new ArithmeticException("Decimal overflow");
+    }
+
+    /* Based on: it.unimi.dsi.fastutil.bytes.ByteArrays.reverse; */
+    private static byte[] reverse(final byte[] a)
+    {
+        final int length = a.length;
+        for (int i = length / 2; i-- != 0; ) {
+            final byte t = a[length - i - 1];
+            a[length - i - 1] = a[i];
+            a[i] = t;
+        }
+
+        return a;
+    }
+
+    private static int getInt(Slice decimal, int index)
+    {
+        int value = getRawInt(decimal, index);
+        if (index == SIGN_INT_INDEX) {
+            value &= ~SIGN_INT_MASK;
+        }
+        return value;
+    }
+
+    private static long getLong(Slice decimal, int index)
+    {
+        long value = getRawLong(decimal, index);
+        if (index == SIGN_LONG_INDEX) {
+            return unpackUnsignedLong(value);
+        }
+        return value;
+    }
+
+    private static long unpackUnsignedLong(long value)
+    {
+        return value & ~SIGN_LONG_MASK;
+    }
+
+    private static int getRawInt(Slice decimal, int index)
+    {
+        return unsafe.getInt(decimal.getBase(), decimal.getAddress() + SIZE_OF_INT * index);
+    }
+
+    private static void setRawInt(Slice decimal, int index, int value)
+    {
+        unsafe.putInt(decimal.getBase(), decimal.getAddress() + SIZE_OF_INT * index, value);
+    }
+
+    private static long getRawLong(Slice decimal, int index)
+    {
+        return unsafe.getLong(decimal.getBase(), decimal.getAddress() + SIZE_OF_LONG * index);
+    }
+
+    private static void setRawLong(Slice decimal, int index, long value)
+    {
+        unsafe.putLong(decimal.getBase(), decimal.getAddress() + SIZE_OF_LONG * index, value);
+    }
+
+    private UnscaledDecimal128Arithmetic() {}
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestUnscaledDecimal128Arithmetic.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestUnscaledDecimal128Arithmetic.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
+
+import java.math.BigInteger;
+
+import static com.facebook.presto.spi.type.Decimals.MAX_DECIMAL_UNSCALED_VALUE;
+import static com.facebook.presto.spi.type.Decimals.MIN_DECIMAL_UNSCALED_VALUE;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.compare;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.divide;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.hash;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.isNegative;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.multiply;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.negate;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.overflows;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.rescale;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.shiftRight;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToBigInteger;
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToUnscaledLong;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestUnscaledDecimal128Arithmetic
+{
+    private static final Slice MAX_DECIMAL = unscaledDecimal(MAX_DECIMAL_UNSCALED_VALUE);
+    private static final Slice MIN_DECIMAL = unscaledDecimal(MIN_DECIMAL_UNSCALED_VALUE);
+
+    @Test
+    public void testUnscaledBigIntegerToDecimal()
+    {
+        assertconvertsUnscaledBigIntegerToDecimal(MAX_DECIMAL_UNSCALED_VALUE);
+        assertconvertsUnscaledBigIntegerToDecimal(MIN_DECIMAL_UNSCALED_VALUE);
+        assertconvertsUnscaledBigIntegerToDecimal(BigInteger.ZERO);
+        assertconvertsUnscaledBigIntegerToDecimal(BigInteger.ONE);
+        assertconvertsUnscaledBigIntegerToDecimal(BigInteger.ONE.negate());
+    }
+
+    @Test
+    public void testUnscaledBigIntegerToDecimalOverflow()
+    {
+        assertUnscaledBigIntegerToDecimalOverflows(MAX_DECIMAL_UNSCALED_VALUE.add(BigInteger.ONE));
+        assertUnscaledBigIntegerToDecimalOverflows(MIN_DECIMAL_UNSCALED_VALUE.subtract(BigInteger.ONE));
+    }
+
+    @Test
+    public void testUnscaledLongToDecimal()
+    {
+        assertConvertsUnscaledLongToDecimal(0);
+        assertConvertsUnscaledLongToDecimal(1);
+        assertConvertsUnscaledLongToDecimal(-1);
+        assertConvertsUnscaledLongToDecimal(Long.MAX_VALUE);
+        assertConvertsUnscaledLongToDecimal(Long.MIN_VALUE);
+    }
+
+    @Test
+    public void testDecimalToUnscaledLongOverflow()
+    {
+        assertDecimalToUnscaledLongOverflows(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE));
+        assertDecimalToUnscaledLongOverflows(BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE));
+        assertDecimalToUnscaledLongOverflows(MAX_DECIMAL_UNSCALED_VALUE);
+        assertDecimalToUnscaledLongOverflows(MIN_DECIMAL_UNSCALED_VALUE);
+    }
+
+    @Test
+    public void testRescale()
+    {
+        assertEquals(rescale(unscaledDecimal(10), 0), unscaledDecimal(10L));
+        assertEquals(rescale(unscaledDecimal(15), -1), unscaledDecimal(2));
+        assertEquals(rescale(unscaledDecimal(15), 1), unscaledDecimal(150));
+        assertEquals(rescale(unscaledDecimal(-14), -1), unscaledDecimal(-1));
+        assertEquals(rescale(unscaledDecimal(-14), 1), unscaledDecimal(-140));
+        assertEquals(rescale(unscaledDecimal(0), 1), unscaledDecimal(0));
+        assertEquals(rescale(unscaledDecimal(5), -1), unscaledDecimal(1));
+        assertEquals(rescale(unscaledDecimal(10), 10), unscaledDecimal(100000000000L));
+        assertEquals(rescale(MAX_DECIMAL, -1), unscaledDecimal(MAX_DECIMAL_UNSCALED_VALUE.divide(BigInteger.TEN).add(BigInteger.ONE)));
+        assertEquals(rescale(MIN_DECIMAL, -10), unscaledDecimal(MIN_DECIMAL_UNSCALED_VALUE.divide(BigInteger.valueOf(10000000000L)).subtract(BigInteger.ONE)));
+    }
+
+    @Test
+    public void testMultiply()
+    {
+        assertEquals(multiply(unscaledDecimal(0), MAX_DECIMAL), unscaledDecimal(0));
+        assertEquals(multiply(unscaledDecimal(1), MAX_DECIMAL), MAX_DECIMAL);
+        assertEquals(multiply(unscaledDecimal(1), MIN_DECIMAL), MIN_DECIMAL);
+        assertEquals(multiply(unscaledDecimal(-1), MAX_DECIMAL), MIN_DECIMAL);
+        assertEquals(multiply(unscaledDecimal(-1), MIN_DECIMAL), MAX_DECIMAL);
+
+        assertEquals(multiply(unscaledDecimal(Integer.MAX_VALUE), unscaledDecimal(Integer.MIN_VALUE)), unscaledDecimal((long) Integer.MAX_VALUE * Integer.MIN_VALUE));
+        assertEquals(multiply(unscaledDecimal("99999999999999"), unscaledDecimal("-1000000000000000000000000")), unscaledDecimal("-99999999999999000000000000000000000000"));
+    }
+
+    @Test
+    public void testMultiplyOverflow()
+    {
+        assertMultiplyOverflows(unscaledDecimal("99999999999999"), unscaledDecimal("-10000000000000000000000000"));
+        assertMultiplyOverflows(MAX_DECIMAL, unscaledDecimal("10"));
+    }
+
+    @Test
+    public void testShiftRight()
+    {
+        assertShiftRight(unscaledDecimal(0), 0, true, unscaledDecimal(0));
+        assertShiftRight(unscaledDecimal(0), 33, true, unscaledDecimal(0));
+
+        assertShiftRight(unscaledDecimal(1), 1, true, unscaledDecimal(1));
+        assertShiftRight(unscaledDecimal(-4), 1, true, unscaledDecimal(-2));
+
+        assertShiftRight(unscaledDecimal(1L << 32), 32, true, unscaledDecimal(1));
+        assertShiftRight(unscaledDecimal(1L << 31), 32, true, unscaledDecimal(1));
+        assertShiftRight(unscaledDecimal(1L << 31), 32, false, unscaledDecimal(0));
+        assertShiftRight(unscaledDecimal(3L << 33), 34, true, unscaledDecimal(2));
+        assertShiftRight(unscaledDecimal(3L << 33), 34, false, unscaledDecimal(1));
+        assertShiftRight(unscaledDecimal(BigInteger.valueOf(0x7FFFFFFFFFFFFFFFL).multiply(BigInteger.valueOf(2))), 32, true, unscaledDecimal(1L << 32));
+        assertShiftRight(unscaledDecimal(BigInteger.valueOf(-0x3FFFFFFFFFFFFFFFL).multiply(BigInteger.valueOf(2))), 32, true, unscaledDecimal(-1L << 31));
+
+        assertShiftRight(MAX_DECIMAL, 1, true, unscaledDecimal(MAX_DECIMAL_UNSCALED_VALUE.shiftRight(1).add(BigInteger.ONE)));
+        assertShiftRight(MIN_DECIMAL, 1, true, unscaledDecimal(MAX_DECIMAL_UNSCALED_VALUE.shiftRight(1).add(BigInteger.ONE).negate()));
+        assertShiftRight(MAX_DECIMAL, 66, true, unscaledDecimal(MAX_DECIMAL_UNSCALED_VALUE.shiftRight(66).add(BigInteger.ONE)));
+    }
+
+    @Test
+    public void testDivideCheckRound()
+    {
+        assertDivide(unscaledDecimal(0), 10, unscaledDecimal(0));
+        assertDivide(unscaledDecimal(5), 10, unscaledDecimal(0));
+        assertDivide(unscaledDecimal(-5), 10, negateConstructive(unscaledDecimal(0)));
+
+        assertDivide(unscaledDecimal(99), 10, unscaledDecimal(9));
+        assertDivide(unscaledDecimal(95), 10, unscaledDecimal(9));
+        assertDivide(unscaledDecimal(91), 10, unscaledDecimal(9));
+
+        assertDivide(unscaledDecimal("1000000000000000000000000"), 10, unscaledDecimal("100000000000000000000000"));
+        assertDivide(unscaledDecimal("-1000000000000000000000000"), 3, unscaledDecimal("-333333333333333333333333"));
+        assertDivide(unscaledDecimal("-1000000000000000000000000"), 9, unscaledDecimal("-111111111111111111111111"));
+    }
+
+    @Test
+    public void testOverflows()
+    {
+        assertTrue(overflows(unscaledDecimal("100"), 2));
+        assertTrue(overflows(unscaledDecimal("-100"), 2));
+        assertFalse(overflows(unscaledDecimal("99"), 2));
+        assertFalse(overflows(unscaledDecimal("-99"), 2));
+    }
+
+    @Test
+    public void testCompare()
+    {
+        assertCompare(unscaledDecimal(0), unscaledDecimal(0), 0);
+        assertCompare(negateConstructive(unscaledDecimal(0)), unscaledDecimal(0), 0);
+
+        assertCompare(unscaledDecimal(0), unscaledDecimal(10), -1);
+        assertCompare(unscaledDecimal(10), unscaledDecimal(0), 1);
+        assertCompare(negateConstructive(unscaledDecimal(0)), unscaledDecimal(10), -1);
+        assertCompare(unscaledDecimal(10), negateConstructive(unscaledDecimal(0)), 1);
+
+        assertCompare(negateConstructive(unscaledDecimal(0)), MAX_DECIMAL, -1);
+        assertCompare(MAX_DECIMAL, negateConstructive(unscaledDecimal(0)), 1);
+
+        assertCompare(unscaledDecimal(-10), unscaledDecimal(-11), 1);
+        assertCompare(unscaledDecimal(-11), unscaledDecimal(-11), 0);
+        assertCompare(unscaledDecimal(-12), unscaledDecimal(-11), -1);
+
+        assertCompare(unscaledDecimal(10), unscaledDecimal(11), -1);
+        assertCompare(unscaledDecimal(11), unscaledDecimal(11), 0);
+        assertCompare(unscaledDecimal(12), unscaledDecimal(11), 1);
+    }
+
+    @Test
+    public void testNegate()
+    {
+        assertEquals(negateConstructive(negateConstructive(MIN_DECIMAL)), MIN_DECIMAL);
+        assertEquals(negateConstructive(MIN_DECIMAL), MAX_DECIMAL);
+        assertEquals(negateConstructive(MIN_DECIMAL), MAX_DECIMAL);
+
+        assertEquals(negateConstructive(unscaledDecimal(1)), unscaledDecimal(-1));
+        assertEquals(negateConstructive(unscaledDecimal(-1)), unscaledDecimal(1));
+        assertEquals(negateConstructive(negateConstructive(unscaledDecimal(0))), unscaledDecimal(0));
+    }
+
+    @Test
+    public void testIsNegative()
+    {
+        assertEquals(isNegative(MIN_DECIMAL), true);
+        assertEquals(isNegative(MAX_DECIMAL), false);
+        assertEquals(isNegative(unscaledDecimal(0)), false);
+    }
+
+    @Test
+    public void testHash()
+    {
+        assertEquals(hash(unscaledDecimal(0)), hash(negateConstructive(unscaledDecimal(0))));
+        assertNotEquals(hash(unscaledDecimal(0)), unscaledDecimal(1));
+    }
+
+    private static void assertUnscaledBigIntegerToDecimalOverflows(BigInteger value)
+    {
+        try {
+            unscaledDecimal(value);
+            fail();
+        }
+        catch (ArithmeticException ignored) {
+        }
+    }
+
+    private static void assertDecimalToUnscaledLongOverflows(BigInteger value)
+    {
+        Slice decimal = unscaledDecimal(value);
+        try {
+            unscaledDecimalToUnscaledLong(decimal);
+            fail();
+        }
+        catch (ArithmeticException ignored) {
+        }
+    }
+
+    private static void assertMultiplyOverflows(Slice left, Slice right)
+    {
+        try {
+            multiply(left, right);
+            fail();
+        }
+        catch (ArithmeticException ignored) {
+        }
+    }
+
+    private static void assertCompare(Slice left, Slice right, int expectedResult)
+    {
+        assertEquals(compare(left, right), expectedResult);
+        assertEquals(compare(left.getLong(0), left.getLong(SIZE_OF_LONG), right.getLong(0), right.getLong(SIZE_OF_LONG)), expectedResult);
+    }
+
+    private static void assertconvertsUnscaledBigIntegerToDecimal(BigInteger value)
+    {
+        assertEquals(unscaledDecimalToBigInteger(unscaledDecimal(value)), value);
+    }
+
+    private static void assertConvertsUnscaledLongToDecimal(long value)
+    {
+        assertEquals(unscaledDecimalToUnscaledLong(unscaledDecimal(value)), value);
+        assertEquals(unscaledDecimal(value), unscaledDecimal(BigInteger.valueOf(value)));
+    }
+
+    private static void assertShiftRight(Slice decimal, int rightShifts, boolean roundUp, Slice expectedResult)
+    {
+        Slice result = unscaledDecimal();
+        shiftRight(decimal, rightShifts, roundUp, result);
+        assertEquals(result, expectedResult);
+    }
+
+    private static void assertDivide(Slice decimal, int divisor, Slice expectedResult)
+    {
+        Slice result = unscaledDecimal();
+        divide(decimal, divisor, result);
+        assertEquals(result, expectedResult);
+    }
+
+    private static Slice negateConstructive(Slice slice)
+    {
+        Slice copy = unscaledDecimal(slice);
+        negate(copy);
+        return copy;
+    }
+}


### PR DESCRIPTION
Initial work into long decimals fast performance. FYI: @martint @cberner. It also includes patch from @fmeiser (thx!). Benchmarks before improvements:

```
# Run complete. Total time: 00:03:48

Benchmark                                                                                           (expression)   Mode  Cnt   Score   Error   Units
BenchmarkDecimalInequalityOperators.execute                                                              d1 < d2  thrpt   30  10,795 ± 0,579  ops/ms
BenchmarkDecimalInequalityOperators.execute  d1 < d2 AND d1 < d3 AND d1 < d4 AND d2 < d3 AND d2 < d4 AND d3 < d4  thrpt   30   4,046 ± 0,184  ops/ms
BenchmarkDecimalInequalityOperators.execute                                                              s1 < s2  thrpt   30   6,776 ± 0,429  ops/ms
BenchmarkDecimalInequalityOperators.execute  s1 < s2 AND s1 < s3 AND s1 < s4 AND s2 < s3 AND s2 < s4 AND s3 < s4  thrpt   30   1,670 ± 0,081  ops/ms
BenchmarkDecimalInequalityOperators.execute                                                              l1 < l2  thrpt   30   0,590 ± 0,033  ops/ms
BenchmarkDecimalInequalityOperators.execute  l1 < l2 AND l1 < l3 AND l1 < l4 AND l2 < l3 AND l2 < l4 AND l3 < l4  thrpt   30   0,092 ± 0,003  ops/ms
```

after:


```
# Run complete. Total time: 00:03:48

Benchmark                                                                                           (expression)   Mode  Cnt   Score   Error   Units
BenchmarkDecimalInequalityOperators.execute                                                              d1 < d2  thrpt   30  10,874 ± 0,469  ops/ms
BenchmarkDecimalInequalityOperators.execute  d1 < d2 AND d1 < d3 AND d1 < d4 AND d2 < d3 AND d2 < d4 AND d3 < d4  thrpt   30   4,351 ± 0,210  ops/ms
BenchmarkDecimalInequalityOperators.execute                                                              s1 < s2  thrpt   30  11,392 ± 0,431  ops/ms
BenchmarkDecimalInequalityOperators.execute  s1 < s2 AND s1 < s3 AND s1 < s4 AND s2 < s3 AND s2 < s4 AND s3 < s4  thrpt   30   4,462 ± 0,191  ops/ms
BenchmarkDecimalInequalityOperators.execute                                                              l1 < l2  thrpt   30   4,392 ± 0,343  ops/ms
BenchmarkDecimalInequalityOperators.execute  l1 < l2 AND l1 < l3 AND l1 < l4 AND l2 < l3 AND l2 < l4 AND l3 < l4  thrpt   30   0,821 ± 0,041  ops/ms
```