### PR TITLE
Add getInt method to LongArrayBlock

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArbitraryAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArbitraryAggregation.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import static com.facebook.presto.block.BlockAssertions.createArrayBigintBlock;
 import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
 import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createIntsBlock;
 import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
 import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
@@ -176,5 +177,18 @@ public class TestArbitraryAggregation
                 1.0,
                 ImmutableList.of(23L, 45L),
                 createArrayBigintBlock(ImmutableList.of(ImmutableList.of(23L, 45L), ImmutableList.of(23L, 45L), ImmutableList.of(23L, 45L), ImmutableList.of(23L, 45L))));
+    }
+
+    @Test
+    public void testValidInt()
+            throws Exception
+    {
+        InternalAggregationFunction arrayAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary", AGGREGATE, parseTypeSignature("integer"), parseTypeSignature("integer")));
+        assertAggregation(
+                arrayAgg,
+                1.0,
+                3,
+                createIntsBlock(3, 3, null));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -100,6 +100,52 @@ public class LongArrayBlock
     }
 
     @Override
+    @Deprecated
+    // TODO: Remove when we fix intermediate types on aggregations.
+    public int getInt(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero");
+        }
+        return Math.toIntExact(values[position + arrayOffset]);
+    }
+
+    @Override
+    @Deprecated
+    // TODO: Remove when we fix intermediate types on aggregations.
+    public short getShort(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero");
+        }
+
+        short value = (short) (values[position + arrayOffset]);
+        if (value != values[position + arrayOffset]) {
+            throw new ArithmeticException("short overflow");
+        }
+        return value;
+    }
+
+    @Override
+    @Deprecated
+    // TODO: Remove when we fix intermediate types on aggregations.
+    public byte getByte(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero");
+        }
+
+        byte value = (byte) (values[position + arrayOffset]);
+        if (value != values[position + arrayOffset]) {
+            throw new ArithmeticException("byte overflow");
+        }
+        return value;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -151,6 +151,52 @@ public class LongArrayBlockBuilder
     }
 
     @Override
+    @Deprecated
+    // TODO: Remove when we fix intermediate types on aggregations.
+    public int getInt(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero");
+        }
+        return Math.toIntExact(values[position]);
+    }
+
+    @Override
+    @Deprecated
+    // TODO: Remove when we fix intermediate types on aggregations.
+    public short getShort(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero");
+        }
+
+        short value = (short) (values[position]);
+        if (value != values[position]) {
+            throw new ArithmeticException("short overflow");
+        }
+        return value;
+    }
+
+    @Override
+    @Deprecated
+    // TODO: Remove when we fix intermediate types on aggregations.
+    public byte getByte(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero");
+        }
+
+        byte value = (byte) (values[position]);
+        if (value != values[position]) {
+            throw new ArithmeticException("byte overflow");
+        }
+        return value;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(position);


### PR DESCRIPTION
Some aggregations on narrower integral types fail due to mismatches
between intermediate state and input/output state. This is a temporary
hack to get around the problem. This will be fixed by getting rid of
implicit combine functions.

@haozhun mentioned @cberner is planning to do this. This became a problem after @dain added the IntArrayBlock/LongArrayBlock performance optimizations.