### PR TITLE
fix bigint array distinct function bug when inputs contains multi null

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayDistinctFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayDistinctFunction.java
@@ -81,11 +81,14 @@ public final class ArrayDistinctFunction
         LongSet set = new LongOpenHashSet(array.getPositionCount());
         BlockBuilder distinctElementBlockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), array.getPositionCount());
         for (int i = 0; i < array.getPositionCount(); i++) {
-            if (!containsNull && array.isNull(i)) {
-                containsNull = true;
-                distinctElementBlockBuilder.appendNull();
+            if (array.isNull(i)) {
+                if (!containsNull) {
+                    containsNull = true;
+                    distinctElementBlockBuilder.appendNull();
+                }
                 continue;
             }
+
             long value = BIGINT.getLong(array, i);
             if (set.add(value)) {
                 BIGINT.writeLong(distinctElementBlockBuilder, value);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -505,6 +505,7 @@ public class TestArrayOperators
             throws Exception
     {
         assertFunction("ARRAY_DISTINCT(ARRAY [])", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("ARRAY_DISTINCT(ARRAY [cast(5 as bigint), NULL, cast(12 as bigint), NULL])", new ArrayType(BIGINT), asList(5L, null, 12L));
 
         // Order matters here. Result should be stable.
         assertFunction("ARRAY_DISTINCT(ARRAY [2, 3, 4, 3, 1, 2, 3])", new ArrayType(INTEGER), ImmutableList.of(2, 3, 4, 1));


### PR DESCRIPTION
bigint array distinct function has bug when inputs contains multi null.
```
presto:default> select array_distinct(ARRAY [cast(5 as bigint), NULL, cast(12 as bigint), NULL]);
      _col0
------------------
 [5, null, 12, 0]
(1 row)

Query 20160716_052744_00003_4vf7i, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0:00 [0 rows, 0B] [0 rows/s, 0B/s]
```