### PR TITLE
Optimize ShortDecimalType to use LongArrayBlock v2

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DecimalType.java
@@ -25,7 +25,8 @@ import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static java.util.Collections.unmodifiableList;
 
 public abstract class DecimalType
-        extends AbstractFixedWidthType
+        extends AbstractType
+        implements FixedWidthType
 {
     public static final int DEFAULT_SCALE = 0;
     public static final int DEFAULT_PRECISION = MAX_PRECISION;
@@ -53,9 +54,9 @@ public abstract class DecimalType
     private final int precision;
     private final int scale;
 
-    DecimalType(int precision, int scale, Class<?> javaType, int fixedSize)
+    DecimalType(int precision, int scale, Class<?> javaType)
     {
-        super(new TypeSignature(StandardTypes.DECIMAL, buildTypeParameters(precision, scale)), javaType, fixedSize);
+        super(new TypeSignature(StandardTypes.DECIMAL, buildTypeParameters(precision, scale)), javaType);
         this.precision = precision;
         this.scale = scale;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
@@ -37,13 +37,13 @@ final class LongDecimalType
     }
 
     @Override
-    public final int getFixedSize()
+    public int getFixedSize()
     {
         return SIZE_OF_LONG_DECIMAL;
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
         return new FixedWidthBlockBuilder(
                 getFixedSize(),
@@ -52,13 +52,13 @@ final class LongDecimalType
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
         return createBlockBuilder(blockBuilderStatus, expectedEntries, getFixedSize());
     }
 
     @Override
-    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
         return new FixedWidthBlockBuilder(getFixedSize(), positionCount);
     }
@@ -123,7 +123,7 @@ final class LongDecimalType
     }
 
     @Override
-    public final Slice getSlice(Block block, int position)
+    public Slice getSlice(Block block, int position)
     {
         return block.getSlice(position, 0, getFixedSize());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
@@ -17,6 +17,8 @@ package com.facebook.presto.spi.type;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
 import io.airlift.slice.Slice;
 
 import static com.facebook.presto.spi.type.Decimals.MAX_PRECISION;
@@ -30,8 +32,35 @@ final class LongDecimalType
 
     LongDecimalType(int precision, int scale)
     {
-        super(precision, scale, Slice.class, SIZE_OF_LONG_DECIMAL);
+        super(precision, scale, Slice.class);
         validatePrecisionScale(precision, scale, MAX_PRECISION);
+    }
+
+    @Override
+    public final int getFixedSize()
+    {
+        return SIZE_OF_LONG_DECIMAL;
+    }
+
+    @Override
+    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        return new FixedWidthBlockBuilder(
+                getFixedSize(),
+                blockBuilderStatus,
+                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / getFixedSize()));
+    }
+
+    @Override
+    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return createBlockBuilder(blockBuilderStatus, expectedEntries, getFixedSize());
+    }
+
+    @Override
+    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        return new FixedWidthBlockBuilder(getFixedSize(), positionCount);
     }
 
     @Override
@@ -91,5 +120,11 @@ final class LongDecimalType
     public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
     {
         blockBuilder.writeBytes(value, offset, length).closeEntry();
+    }
+
+    @Override
+    public final Slice getSlice(Block block, int position)
+    {
+        return block.getSlice(position, 0, getFixedSize());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -17,6 +17,8 @@ package com.facebook.presto.spi.type;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.LongArrayBlockBuilder;
 
 import java.math.BigInteger;
 
@@ -28,8 +30,34 @@ final class ShortDecimalType
 {
     ShortDecimalType(int precision, int scale)
     {
-        super(precision, scale, long.class, SIZE_OF_LONG);
+        super(precision, scale, long.class);
         validatePrecisionScale(precision, scale, MAX_SHORT_PRECISION);
+    }
+
+    @Override
+    public final int getFixedSize()
+    {
+        return SIZE_OF_LONG;
+    }
+
+    @Override
+    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        return new LongArrayBlockBuilder(
+                blockBuilderStatus,
+                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / getFixedSize()));
+    }
+
+    @Override
+    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return createBlockBuilder(blockBuilderStatus, expectedEntries, getFixedSize());
+    }
+
+    @Override
+    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        return new LongArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -35,13 +35,13 @@ final class ShortDecimalType
     }
 
     @Override
-    public final int getFixedSize()
+    public int getFixedSize()
     {
         return SIZE_OF_LONG;
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
         return new LongArrayBlockBuilder(
                 blockBuilderStatus,
@@ -49,13 +49,13 @@ final class ShortDecimalType
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
         return createBlockBuilder(blockBuilderStatus, expectedEntries, getFixedSize());
     }
 
     @Override
-    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
         return new LongArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
     }


### PR DESCRIPTION
Inherit DecimalType from AbstractType instead of AbstractFixedWidthType.
After this change ShortDecimalType can use faster LongArrayBlock.