### PR TITLE
Fail query when non-equi conjuncts exist for OUTER JOINs

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1229,12 +1229,18 @@ class StatementAnalyzer
                         // mixed references to both left and right join relation on one side of comparison operator.
                         // expression will be put in post-join condition; analyze in context of output table.
                         postJoinConjuncts.add(conjunct);
+                        if (node.getType() != Join.Type.INNER) {
+                            throw new SemanticException(NOT_SUPPORTED, node, "Non-equi joins only supported for inner join: %s", conjunct);
+                        }
                     }
                 }
                 else {
                     // non-comparison expression.
                     // expression will be put in post-join condition; analyze in context of output table.
                     postJoinConjuncts.add(conjunct);
+                    if (node.getType() != Join.Type.INNER) {
+                        throw new SemanticException(NOT_SUPPORTED, node, "Non-equi joins only supported for inner join: %s", conjunct);
+                    }
                 }
             }
             ExpressionAnalysis postJoinPredicatesConjunctsAnalysis = analyzeExpression(ExpressionUtils.combineConjuncts(postJoinConjuncts), output, context);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -346,6 +346,11 @@ class RelationPlanner
         if (node.getType() == INNER) {
             root = new FilterNode(idAllocator.getNextId(), root, postInnerJoinCriteria);
         }
+        else {
+            if (!new BooleanLiteral("TRUE").equals(postInnerJoinCriteria)) {
+                throw new SemanticException(NOT_SUPPORTED, node, "Non-equi joins only supported for inner join: %s", postInnerJoinCriteria);
+            }
+        }
 
         return new RelationPlan(root, outputDescriptor, outputSymbols, sampleWeight);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -378,9 +378,9 @@ public class TestAnalyzer
     public void testNonEquiOuterJoin()
             throws Exception
     {
-        analyze("SELECT * FROM t1 LEFT JOIN t2 ON t1.a + t2.a = 1");
-        analyze("SELECT * FROM t1 RIGHT JOIN t2 ON t1.a + t2.a = 1");
-        analyze("SELECT * FROM t1 LEFT JOIN t2 ON t1.a = t2.a OR t1.b = t2.b");
+        assertFails(NOT_SUPPORTED, "SELECT * FROM t1 LEFT JOIN t2 ON t1.a + t2.a = 1");
+        assertFails(NOT_SUPPORTED, "SELECT * FROM t1 RIGHT JOIN t2 ON t1.a + t2.a = 1");
+        assertFails(NOT_SUPPORTED, "SELECT * FROM t1 LEFT JOIN t2 ON t1.a = t2.a OR t1.b = t2.b");
     }
 
     @Test


### PR DESCRIPTION
This will be merged into hotfix-0.144, not master. This fixes regression in https://github.com/prestodb/presto/pull/3954. The fix is no longer relevant in master branch because non-equi join support for OUTER JOIN has since been added.

This commit fixes a regression in hotfix-0.144 branch where queries that contain non-equi conjuncts for OUTER JOINs were not properly rejected. Instead, such conjuncts were ignored.