### PR TITLE
Remove owner from ConnectorTableMetadata

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -319,7 +319,6 @@ public class BaseJdbcClient
                     table,
                     columnNames.build(),
                     columnTypes.build(),
-                    tableMetadata.getOwner(),
                     temporaryName,
                     connectionUrl,
                     fromProperties(connectionProperties));

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcOutputTableHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcOutputTableHandle.java
@@ -39,7 +39,6 @@ public class JdbcOutputTableHandle
     private final String tableName;
     private final List<String> columnNames;
     private final List<Type> columnTypes;
-    private final String tableOwner;
     private final String temporaryTableName;
     private final String connectionUrl;
     private final Map<String, String> connectionProperties;
@@ -52,7 +51,6 @@ public class JdbcOutputTableHandle
             @JsonProperty("tableName") String tableName,
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("columnTypes") List<Type> columnTypes,
-            @JsonProperty("tableOwner") String tableOwner,
             @JsonProperty("temporaryTableName") String temporaryTableName,
             @JsonProperty("connectionUrl") String connectionUrl,
             @JsonProperty("connectionProperties") Map<String, String> connectionProperties)
@@ -61,7 +59,6 @@ public class JdbcOutputTableHandle
         this.catalogName = catalogName;
         this.schemaName = schemaName;
         this.tableName = requireNonNull(tableName, "tableName is null");
-        this.tableOwner = requireNonNull(tableOwner, "tableOwner is null");
         this.temporaryTableName = requireNonNull(temporaryTableName, "temporaryTableName is null");
         this.connectionUrl = requireNonNull(connectionUrl, "connectionUrl is null");
         this.connectionProperties = ImmutableMap.copyOf(requireNonNull(connectionProperties, "connectionProperties is null"));
@@ -112,12 +109,6 @@ public class JdbcOutputTableHandle
     }
 
     @JsonProperty
-    public String getTableOwner()
-    {
-        return tableOwner;
-    }
-
-    @JsonProperty
     public String getTemporaryTableName()
     {
         return temporaryTableName;
@@ -151,7 +142,6 @@ public class JdbcOutputTableHandle
                 tableName,
                 columnNames,
                 columnTypes,
-                tableOwner,
                 temporaryTableName,
                 connectionUrl,
                 connectionProperties);
@@ -173,7 +163,6 @@ public class JdbcOutputTableHandle
                 Objects.equals(this.tableName, other.tableName) &&
                 Objects.equals(this.columnNames, other.columnNames) &&
                 Objects.equals(this.columnTypes, other.columnTypes) &&
-                Objects.equals(this.tableOwner, other.tableOwner) &&
                 Objects.equals(this.temporaryTableName, other.temporaryTableName) &&
                 Objects.equals(this.connectionUrl, other.connectionUrl) &&
                 Objects.equals(this.connectionProperties, other.connectionProperties);

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcOutputTableHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcOutputTableHandle.java
@@ -34,7 +34,6 @@ public class TestJdbcOutputTableHandle
                 "table",
                 ImmutableList.of("abc", "xyz"),
                 ImmutableList.<Type>of(VARCHAR, VARCHAR),
-                "test",
                 "tmp_table",
                 "jdbc:junk",
                 ImmutableMap.of("user", "test"));

--- a/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleMetadata.java
+++ b/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleMetadata.java
@@ -47,11 +47,7 @@ public class TestBlackHoleMetadata
 
         ConnectorOutputTableHandle table = metadata.beginCreateTable(
                 SESSION,
-                new ConnectorTableMetadata(
-                        schemaTableName,
-                        ImmutableList.of(),
-                        tableProperties,
-                        null),
+                new ConnectorTableMetadata(schemaTableName, ImmutableList.of(), tableProperties),
                 Optional.empty());
 
         assertThatNoTableIsCreated();

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
@@ -53,7 +53,6 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.PERMISSION_DENIED;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -270,8 +269,6 @@ public class CassandraMetadata
     @Override
     public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
     {
-        checkArgument(!isNullOrEmpty(tableMetadata.getOwner()), "Table owner is null or empty");
-
         ImmutableList.Builder<String> columnNames = ImmutableList.builder();
         ImmutableList.Builder<Type> columnTypes = ImmutableList.builder();
         ImmutableList.Builder<ExtraColumnMetadata> columnExtra = ImmutableList.builder();
@@ -315,8 +312,7 @@ public class CassandraMetadata
                 tableName,
                 columnNames.build(),
                 columnTypes.build(),
-                tableMetadata.isSampled(),
-                tableMetadata.getOwner());
+                tableMetadata.isSampled());
     }
 
     @Override

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraOutputTableHandle.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraOutputTableHandle.java
@@ -33,7 +33,6 @@ public class CassandraOutputTableHandle
     private final List<String> columnNames;
     private final List<Type> columnTypes;
     private final boolean sampled;
-    private final String tableOwner;
 
     @JsonCreator
     public CassandraOutputTableHandle(
@@ -42,14 +41,12 @@ public class CassandraOutputTableHandle
             @JsonProperty("tableName") String tableName,
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("columnTypes") List<Type> columnTypes,
-            @JsonProperty("sampled") boolean sampled,
-            @JsonProperty("tableOwner") String tableOwner)
+            @JsonProperty("sampled") boolean sampled)
     {
         this.sampled = sampled;
         this.connectorId = requireNonNull(connectorId, "clientId is null");
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
-        this.tableOwner = requireNonNull(tableOwner, "tableOwner is null");
 
         requireNonNull(columnNames, "columnNames is null");
         requireNonNull(columnTypes, "columnTypes is null");
@@ -92,12 +89,6 @@ public class CassandraOutputTableHandle
     public boolean isSampled()
     {
         return sampled;
-    }
-
-    @JsonProperty
-    public String getTableOwner()
-    {
-        return tableOwner;
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1313,7 +1313,7 @@ public abstract class AbstractTestHiveClient
             ConnectorMetadata metadata = newMetadata();
 
             // begin creating the table
-            ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(temporaryCreateRollbackTable, CREATE_TABLE_COLUMNS, createTableProperties(RCBINARY), session.getUser());
+            ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(temporaryCreateRollbackTable, CREATE_TABLE_COLUMNS, createTableProperties(RCBINARY));
 
             ConnectorOutputTableHandle outputHandle = metadata.beginCreateTable(session, tableMetadata, Optional.empty());
 
@@ -1456,7 +1456,7 @@ public abstract class AbstractTestHiveClient
             try {
                 ConnectorSession session = newSession();
                 List<ColumnMetadata> columns = ImmutableList.of(new ColumnMetadata("dummy", HYPER_LOG_LOG));
-                ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(invalidTable, columns, createTableProperties(storageFormat), session.getUser());
+                ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(invalidTable, columns, createTableProperties(storageFormat));
                 newMetadata().beginCreateTable(session, tableMetadata, Optional.empty());
                 fail("create table with unsupported type should fail for storage format " + storageFormat);
             }
@@ -1472,7 +1472,7 @@ public abstract class AbstractTestHiveClient
         ConnectorMetadata metadata = newMetadata();
 
         List<ColumnMetadata> columns = ImmutableList.of(new ColumnMetadata("dummy", createUnboundedVarcharType()));
-        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName, columns, createTableProperties(TEXTFILE), session.getUser());
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName, columns, createTableProperties(TEXTFILE));
         ConnectorOutputTableHandle handle = metadata.beginCreateTable(session, tableMetadata, Optional.empty());
         metadata.finishCreateTable(session, handle, ImmutableList.of());
     }
@@ -1540,7 +1540,7 @@ public abstract class AbstractTestHiveClient
                 .add(new ColumnMetadata("sales", BIGINT))
                 .build();
 
-        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName, columns, createTableProperties(RCBINARY), session.getUser(), true);
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName, columns, createTableProperties(RCBINARY), true);
         ConnectorOutputTableHandle outputHandle = metadata.beginCreateTable(session, tableMetadata, Optional.empty());
 
         // write the records
@@ -1575,8 +1575,6 @@ public abstract class AbstractTestHiveClient
 
         // verify the metadata
         tableMetadata = metadata.getTableMetadata(session, getTableHandle(metadata, tableName));
-        assertEquals(tableMetadata.getOwner(), session.getUser());
-
         Map<String, ColumnMetadata> columnMap = uniqueIndex(tableMetadata.getColumns(), ColumnMetadata::getName);
         assertEquals(columnMap.size(), 1);
 
@@ -1618,7 +1616,7 @@ public abstract class AbstractTestHiveClient
         ConnectorMetadata metadata = newMetadata();
 
         // begin creating the table
-        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName, CREATE_TABLE_COLUMNS, createTableProperties(storageFormat), session.getUser());
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName, CREATE_TABLE_COLUMNS, createTableProperties(storageFormat));
 
         ConnectorOutputTableHandle outputHandle = metadata.beginCreateTable(session, tableMetadata, Optional.empty());
 
@@ -1641,7 +1639,6 @@ public abstract class AbstractTestHiveClient
 
         // verify the metadata
         tableMetadata = metadata.getTableMetadata(session, getTableHandle(metadata, tableName));
-        assertEquals(tableMetadata.getOwner(), session.getUser());
         assertEquals(tableMetadata.getColumns(), CREATE_TABLE_COLUMNS);
 
         // verify the data
@@ -1659,7 +1656,7 @@ public abstract class AbstractTestHiveClient
                 .filter(column -> column.getName().equals("ds"))
                 .map(ColumnMetadata::getName)
                 .collect(toList());
-        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName, createTableColumns, createTableProperties(storageFormat, partitionedBy), session.getUser());
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName, createTableColumns, createTableProperties(storageFormat, partitionedBy));
 
         metadata.createTable(session, tableMetadata);
 
@@ -1668,7 +1665,6 @@ public abstract class AbstractTestHiveClient
 
         // verify the metadata
         tableMetadata = metadata.getTableMetadata(session, getTableHandle(metadata, tableName));
-        assertEquals(tableMetadata.getOwner(), session.getUser());
 
         List<ColumnMetadata> expectedColumns = createTableColumns.stream()
                 .map(column -> new ColumnMetadata(
@@ -1719,7 +1715,6 @@ public abstract class AbstractTestHiveClient
 
             // verify the metadata
             ConnectorTableMetadata tableMetadata = metadata.getTableMetadata(session, getTableHandle(metadata, tableName));
-            assertEquals(tableMetadata.getOwner(), session.getUser());
             assertEquals(tableMetadata.getColumns(), CREATE_TABLE_COLUMNS);
 
             // verify the data

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -324,7 +324,7 @@ public abstract class AbstractTestHiveClientS3
                 .add(new ColumnMetadata("id", BIGINT))
                 .build();
 
-        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName, columns, createTableProperties(storageFormat), tableOwner);
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName, columns, createTableProperties(storageFormat));
         HiveOutputTableHandle outputHandle = metadata.beginCreateTable(SESSION, tableMetadata, Optional.empty());
 
         MaterializedResult data = MaterializedResult.resultBuilder(SESSION, BIGINT)
@@ -354,7 +354,6 @@ public abstract class AbstractTestHiveClientS3
 
         // verify the metadata
         tableMetadata = metadata.getTableMetadata(SESSION, getTableHandle(metadata, tableName));
-        assertEquals(tableMetadata.getOwner(), tableOwner);
         assertEquals(tableMetadata.getColumns(), columns);
 
         // verify the data

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -90,7 +90,7 @@ public class CreateTableTask
 
         TableMetadata tableMetadata = new TableMetadata(
                 tableName.getCatalogName(),
-                new ConnectorTableMetadata(tableName.asSchemaTableName(), columns, properties, session.getUser(), false));
+                new ConnectorTableMetadata(tableName.asSchemaTableName(), columns, properties, false));
 
         metadata.createTable(session, tableName.getCatalogName(), tableMetadata);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -340,7 +340,7 @@ public class LogicalPlanner
                 session,
                 metadata);
 
-        ConnectorTableMetadata metadata = new ConnectorTableMetadata(table.asSchemaTableName(), columns, properties, owner, sampled);
+        ConnectorTableMetadata metadata = new ConnectorTableMetadata(table.asSchemaTableName(), columns, properties, sampled);
         // TODO: first argument should actually be connectorId
         return new TableMetadata(table.getCatalogName(), metadata);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorTableMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorTableMetadata.java
@@ -26,26 +26,19 @@ public class ConnectorTableMetadata
     private final SchemaTableName table;
     private final List<ColumnMetadata> columns;
     private final Map<String, Object> properties;
-    /* nullable */
-    private final String owner;
     private final boolean sampled;
 
     public ConnectorTableMetadata(SchemaTableName table, List<ColumnMetadata> columns)
     {
-        this(table, columns, emptyMap(), null);
+        this(table, columns, emptyMap());
     }
 
     public ConnectorTableMetadata(SchemaTableName table, List<ColumnMetadata> columns, Map<String, Object> properties)
     {
-        this(table, columns, properties, null);
+        this(table, columns, properties, false);
     }
 
-    public ConnectorTableMetadata(SchemaTableName table, List<ColumnMetadata> columns, Map<String, Object> properties, String owner)
-    {
-        this(table, columns, properties, owner, false);
-    }
-
-    public ConnectorTableMetadata(SchemaTableName table, List<ColumnMetadata> columns, Map<String, Object> properties, String owner, boolean sampled)
+    public ConnectorTableMetadata(SchemaTableName table, List<ColumnMetadata> columns, Map<String, Object> properties, boolean sampled)
     {
         if (table == null) {
             throw new NullPointerException("table is null or empty");
@@ -57,7 +50,6 @@ public class ConnectorTableMetadata
         this.table = table;
         this.columns = Collections.unmodifiableList(new ArrayList<>(columns));
         this.properties = Collections.unmodifiableMap(new LinkedHashMap<>(properties));
-        this.owner = owner;
         this.sampled = sampled;
     }
 
@@ -81,14 +73,6 @@ public class ConnectorTableMetadata
         return properties;
     }
 
-    /**
-     * @return table owner or null
-     */
-    public String getOwner()
-    {
-        return owner;
-    }
-
     @Override
     public String toString()
     {
@@ -96,7 +80,6 @@ public class ConnectorTableMetadata
         sb.append("table=").append(table);
         sb.append(", columns=").append(columns);
         sb.append(", properties=").append(properties);
-        sb.append(", owner=").append(owner);
         sb.append('}');
         return sb.toString();
     }


### PR DESCRIPTION
This field is only used for table creation and is not needed now that we have `ConnectorSession`.