### PR TITLE
Fast adapter between SliceOutput and OutputStream using Slice as buffer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.server.InputStreamSliceInputAdapter;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
@@ -31,7 +32,6 @@ import io.airlift.http.client.Response;
 import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.ResponseTooLargeException;
 import io.airlift.log.Logger;
-import io.airlift.slice.InputStreamSliceInput;
 import io.airlift.slice.SliceInput;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -584,7 +584,7 @@ public final class HttpPageBufferClient
                 long nextToken = getNextToken(response);
                 boolean complete = getComplete(response);
 
-                try (SliceInput input = new InputStreamSliceInput(response.getInputStream())) {
+                try (SliceInput input = new InputStreamSliceInputAdapter(response.getInputStream(), 128 * 1024)) {
                     List<Page> pages = ImmutableList.copyOf(readPages(blockEncodingSerde, input));
                     return createPagesResponse(taskInstanceId, token, nextToken, pages, complete);
                 }

--- a/presto-main/src/main/java/com/facebook/presto/server/InputStreamSliceInputAdapter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/InputStreamSliceInputAdapter.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import io.airlift.slice.RuntimeIOException;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.Slices;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.primitives.Ints.checkedCast;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
+
+public final class InputStreamSliceInputAdapter
+        extends SliceInput
+{
+    private static final int MINIMUM_CHUNK_SIZE = 4096;
+
+    private final InputStream inputStream;
+
+    private final byte[] buffer;
+    private final Slice slice;
+    /**
+     * Offset of buffer within stream.
+     */
+    private long bufferOffset;
+    /**
+     * Current position for reading from buffer.
+     */
+    private int bufferPosition;
+
+    private int bufferFill;
+
+    public InputStreamSliceInputAdapter(InputStream inputStream, int bufferSize)
+    {
+        checkArgument(bufferSize >= MINIMUM_CHUNK_SIZE, "minimum buffer size of " + MINIMUM_CHUNK_SIZE + " required");
+        if (inputStream == null) {
+            throw new NullPointerException("inputStream is null");
+        }
+
+        this.inputStream = inputStream;
+        this.buffer = new byte[bufferSize];
+        this.slice = Slices.wrappedBuffer(buffer);
+    }
+
+    @Override
+    public long position()
+    {
+        return checkedCast(bufferOffset + bufferPosition);
+    }
+
+    @Override
+    public void setPosition(long position)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isReadable()
+    {
+        return available() > 0;
+    }
+
+    @Override
+    public int skipBytes(int n)
+    {
+        return (int) skip(n);
+    }
+
+    @Override
+    public boolean readBoolean()
+    {
+        return readByte() != 0;
+    }
+
+    @Override
+    public byte readByte()
+    {
+        ensureAvailable(SIZE_OF_BYTE);
+        byte v = slice.getByte(bufferPosition);
+        bufferPosition += SIZE_OF_BYTE;
+        return v;
+    }
+
+    @Override
+    public int readUnsignedByte()
+    {
+        return readByte() & 0xFF;
+    }
+
+    @Override
+    public short readShort()
+    {
+        ensureAvailable(SIZE_OF_SHORT);
+        short v = slice.getShort(bufferPosition);
+        bufferPosition += SIZE_OF_SHORT;
+        return v;
+    }
+
+    @Override
+    public int readUnsignedShort()
+    {
+        return readShort() & 0xFFFF;
+    }
+
+    @Override
+    public int readInt()
+    {
+        ensureAvailable(SIZE_OF_INT);
+        int v = slice.getInt(bufferPosition);
+        bufferPosition += SIZE_OF_INT;
+        return v;
+    }
+
+    @Override
+    public long readLong()
+    {
+        ensureAvailable(SIZE_OF_LONG);
+        long v = slice.getLong(bufferPosition);
+        bufferPosition += SIZE_OF_LONG;
+        return v;
+    }
+
+    @Override
+    public float readFloat()
+    {
+        return Float.intBitsToFloat(readInt());
+    }
+
+    @Override
+    public double readDouble()
+    {
+        return Double.longBitsToDouble(readLong());
+    }
+
+    @Override
+    public int read()
+    {
+        if (available() == 0) {
+            return -1;
+        }
+
+        assert availableBytes() > 0;
+        int v = slice.getByte(bufferPosition) & 0xFF;
+        bufferPosition += SIZE_OF_BYTE;
+        return v;
+    }
+
+    @Override
+    public int read(byte[] destination, int destinationIndex, int length)
+    {
+        if (available() == 0) {
+            return -1;
+        }
+
+        assert availableBytes() > 0;
+        int batch = Math.min(availableBytes(), length);
+        slice.getBytes(bufferPosition, destination, destinationIndex, batch);
+        bufferPosition += batch;
+        return batch;
+    }
+
+    @Override
+    public long skip(long length)
+    {
+        int batch = availableBytes();
+        // is skip within the current buffer?
+        if (batch >= length) {
+            bufferPosition += length;
+            return length;
+        }
+
+        // drop current buffer
+        bufferPosition = bufferFill;
+
+        try {
+            return batch + inputStream.skip(length - batch);
+        }
+        catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    @Override
+    public int available()
+    {
+        if (bufferPosition < bufferFill) {
+            return availableBytes();
+        }
+
+        return fillBuffer();
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            inputStream.close();
+        }
+        catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    @Override
+    public void readBytes(byte[] destination, int destinationIndex, int length)
+    {
+        while (length > 0) {
+            int batch = Math.min(availableBytes(), length);
+            slice.getBytes(bufferPosition, destination, destinationIndex, batch);
+
+            bufferPosition += batch;
+            destinationIndex += batch;
+            length -= batch;
+
+            ensureAvailable(Math.min(length, MINIMUM_CHUNK_SIZE));
+        }
+    }
+
+    @Override
+    public Slice readSlice(int length)
+    {
+        if (length == 0) {
+            return Slices.EMPTY_SLICE;
+        }
+
+        Slice newSlice = Slices.allocate(length);
+        readBytes(newSlice, 0, length);
+        return newSlice;
+    }
+
+    @Override
+    public void readBytes(Slice destination, int destinationIndex, int length)
+    {
+        while (length > 0) {
+            int batch = Math.min(availableBytes(), length);
+            slice.getBytes(bufferPosition, destination, destinationIndex, batch);
+
+            bufferPosition += batch;
+            destinationIndex += batch;
+            length -= batch;
+
+            ensureAvailable(Math.min(length, MINIMUM_CHUNK_SIZE));
+        }
+    }
+
+    @Override
+    public void readBytes(OutputStream out, int length)
+            throws IOException
+    {
+        while (length > 0) {
+            int batch = Math.min(availableBytes(), length);
+            out.write(buffer, bufferPosition, batch);
+
+            bufferPosition += batch;
+            length -= batch;
+
+            ensureAvailable(Math.min(length, MINIMUM_CHUNK_SIZE));
+        }
+    }
+
+    private int availableBytes()
+    {
+        return bufferFill - bufferPosition;
+    }
+
+    private void ensureAvailable(int size)
+    {
+        if (bufferPosition + size < bufferFill) {
+            return;
+        }
+
+        if (fillBuffer() < size) {
+            throw new IndexOutOfBoundsException("End of stream");
+        }
+    }
+
+    private int fillBuffer()
+    {
+        // Keep the rest
+        int rest = bufferFill - bufferPosition;
+        // Use System.arraycopy for small copies
+        System.arraycopy(buffer, bufferPosition, buffer, 0, rest);
+
+        bufferFill = rest;
+        bufferOffset += bufferPosition;
+        bufferPosition = 0;
+        // Fill buffer with a minimum of bytes
+        while (bufferFill < MINIMUM_CHUNK_SIZE) {
+            try {
+                int bytesRead = inputStream.read(buffer, bufferFill, buffer.length - bufferFill);
+                if (bytesRead < 0) {
+                    break;
+                }
+
+                bufferFill += bytesRead;
+            }
+            catch (IOException e) {
+                throw new RuntimeIOException(e);
+            }
+        }
+
+        return bufferFill;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/OutputStreamSliceOutputAdapter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/OutputStreamSliceOutputAdapter.java
@@ -1,0 +1,360 @@
+package com.facebook.presto.server;
+
+import io.airlift.slice.RuntimeIOException;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.primitives.Ints.checkedCast;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+import static io.airlift.slice.SizeOf.SIZE_OF_FLOAT;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
+
+public final class OutputStreamSliceOutputAdapter
+        extends SliceOutput
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(OutputStreamSliceOutputAdapter.class).instanceSize();
+    /**
+     * Flag for little endian architecture.
+     */
+    private static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
+    private static final int MINIMUM_CHUNK_SIZE = 4096;
+
+    private final OutputStream outputStream;
+
+    private final Slice slice;
+    private final byte[] buffer;
+
+    /**
+     * Offset of buffer within stream.
+     */
+    private long bufferOffset;
+    /**
+     * Current position for writing in buffer.
+     */
+    private int bufferPosition;
+
+    public OutputStreamSliceOutputAdapter(OutputStream outputStream, int bufferSize)
+    {
+        checkArgument(bufferSize >= MINIMUM_CHUNK_SIZE, "minimum buffer size of " + MINIMUM_CHUNK_SIZE + " required");
+        checkNotNull(outputStream, "outputStream is null");
+
+        this.outputStream = outputStream;
+        this.buffer = new byte[bufferSize];
+        this.slice = Slices.wrappedBuffer(buffer);
+    }
+
+    @Override
+    public void flush()
+            throws IOException
+    {
+        flushBufferToOutputStream();
+        outputStream.flush();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        flushBufferToOutputStream();
+        outputStream.close();
+    }
+
+    @Override
+    public void reset()
+    {
+        throw new UnsupportedOperationException("OutputStream can not be reset");
+    }
+
+    @Override
+    public int size()
+    {
+        return checkedCast(bufferOffset + bufferPosition);
+    }
+
+    @Override
+    public int getRetainedSize()
+    {
+        return slice.getRetainedSize() + INSTANCE_SIZE;
+    }
+
+    @Override
+    public int writableBytes()
+    {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public boolean isWritable()
+    {
+        return true;
+    }
+
+    @Override
+    public void writeByte(int value)
+    {
+        ensureSize(bufferPosition + SIZE_OF_BYTE);
+        slice.setByte(bufferPosition, value);
+        bufferPosition += SIZE_OF_BYTE;
+    }
+
+    @Override
+    public void writeShort(int value)
+    {
+        ensureSize(bufferPosition + SIZE_OF_SHORT);
+        slice.setShort(bufferPosition, memoryLayoutLittleEndian((short) value));
+        bufferPosition += SIZE_OF_SHORT;
+    }
+
+    @Override
+    public void writeInt(int value)
+    {
+        ensureSize(bufferPosition + SIZE_OF_INT);
+        slice.setInt(bufferPosition, memoryLayoutLittleEndian(value));
+        bufferPosition += SIZE_OF_INT;
+    }
+
+    @Override
+    public void writeLong(long value)
+    {
+        ensureSize(bufferPosition + SIZE_OF_LONG);
+
+        slice.setLong(bufferPosition, memoryLayoutLittleEndian(value));
+        bufferPosition += SIZE_OF_LONG;
+    }
+
+    @Override
+    public void writeFloat(float value)
+    {
+        ensureSize(bufferPosition + SIZE_OF_FLOAT);
+        slice.setInt(bufferPosition, Float.floatToIntBits(value));
+        bufferPosition += SIZE_OF_FLOAT;
+    }
+
+    @Override
+    public void writeDouble(double value)
+    {
+        ensureSize(bufferPosition + SIZE_OF_DOUBLE);
+        slice.setLong(bufferPosition, Double.doubleToLongBits(value));
+        bufferPosition += SIZE_OF_DOUBLE;
+    }
+
+    @Override
+    public void writeBytes(Slice source)
+    {
+        writeBytes(source, 0, source.length());
+    }
+
+    @Override
+    public void writeBytes(Slice source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            ensureSize(bufferPosition + Math.min(MINIMUM_CHUNK_SIZE, length));
+
+            int batch = Math.min(length, slice.length() - bufferPosition);
+            slice.setBytes(bufferPosition, source, sourceIndex, batch);
+
+            sourceIndex += batch;
+            bufferPosition += batch;
+            length -= batch;
+        }
+    }
+
+    @Override
+    public void writeBytes(byte[] source)
+    {
+        writeBytes(source, 0, source.length);
+    }
+
+    @Override
+    public void writeBytes(byte[] source, int sourceIndex, int length)
+    {
+        // Write huge chunks direct to OutputStream
+        if (length >= MINIMUM_CHUNK_SIZE) {
+            flushBufferToOutputStream();
+            writeToOutputStream(source, sourceIndex, length);
+
+            bufferOffset += length;
+        }
+        else {
+            ensureSize(bufferPosition + length);
+            slice.setBytes(bufferPosition, source, sourceIndex, length);
+
+            bufferPosition += length;
+        }
+    }
+
+    @Override
+    public void writeBytes(InputStream in, int length)
+            throws IOException
+    {
+        while (length > 0) {
+            ensureSize(bufferPosition + Math.min(MINIMUM_CHUNK_SIZE, length));
+            int batch = Math.min(length, slice.length() - bufferPosition);
+
+            slice.setBytes(bufferPosition, in, batch);
+            bufferPosition += batch;
+            length -= batch;
+        }
+    }
+
+    @Override
+    public void writeZero(int length)
+    {
+        checkArgument(length >= 0, "length must be 0 or greater than 0.");
+
+        while (length > 0) {
+            ensureSize(bufferPosition + Math.min(MINIMUM_CHUNK_SIZE, length));
+            int batch = Math.min(length, slice.length() - bufferPosition);
+
+            Arrays.fill(buffer, bufferPosition, bufferPosition + batch, (byte) 0);
+            bufferPosition += batch;
+            length -= batch;
+        }
+    }
+
+    @Override
+    public SliceOutput appendLong(long value)
+    {
+        writeLong(value);
+        return this;
+    }
+
+    @Override
+    public SliceOutput appendDouble(double value)
+    {
+        writeDouble(value);
+        return this;
+    }
+
+    @Override
+    public SliceOutput appendInt(int value)
+    {
+        writeInt(value);
+        return this;
+    }
+
+    @Override
+    public SliceOutput appendShort(int value)
+    {
+        writeShort(value);
+        return this;
+    }
+
+    @Override
+    public SliceOutput appendByte(int value)
+    {
+        writeByte(value);
+        return this;
+    }
+
+    @Override
+    public SliceOutput appendBytes(byte[] source, int sourceIndex, int length)
+    {
+        writeBytes(source, sourceIndex, length);
+        return this;
+    }
+
+    @Override
+    public SliceOutput appendBytes(byte[] source)
+    {
+        writeBytes(source);
+        return this;
+    }
+
+    @Override
+    public SliceOutput appendBytes(Slice slice)
+    {
+        writeBytes(slice);
+        return this;
+    }
+
+    @Override
+    public Slice slice()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Slice getUnderlyingSlice()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString(Charset charset)
+    {
+        return toString();
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder("OutputStreamSliceOutputAdapter{");
+        builder.append("outputStream=").append(outputStream);
+        builder.append("bufferSize=").append(slice.length());
+        builder.append('}');
+        return builder.toString();
+    }
+
+    private void ensureSize(int minWritableBytes)
+    {
+        if (minWritableBytes > slice.length()) {
+            flushBufferToOutputStream();
+        }
+    }
+
+    private void flushBufferToOutputStream()
+    {
+        writeToOutputStream(buffer, 0, bufferPosition);
+        bufferOffset += bufferPosition;
+        bufferPosition = 0;
+    }
+
+    private void writeToOutputStream(byte[] source, int sourceIndex, int length)
+    {
+        try {
+            outputStream.write(source, sourceIndex, length);
+        }
+        catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    /**
+     * Ensure that the layout of the value in memory is little endian.
+     */
+    private short memoryLayoutLittleEndian(short value)
+    {
+        return LITTLE_ENDIAN ? value : Short.reverseBytes(value);
+    }
+
+    /**
+     * Ensure that the layout of the value in memory is little endian.
+     */
+    private int memoryLayoutLittleEndian(int value)
+    {
+        return LITTLE_ENDIAN ? value : Integer.reverseBytes(value);
+    }
+
+    /**
+     * Ensure that the layout of the value in memory is little endian.
+     */
+    private long memoryLayoutLittleEndian(long value)
+    {
+        return LITTLE_ENDIAN ? value : Long.reverseBytes(value);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/OutputStreamSliceOutputAdapter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/OutputStreamSliceOutputAdapter.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.facebook.presto.server;
 
 import io.airlift.slice.RuntimeIOException;
@@ -14,7 +27,6 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.primitives.Ints.checkedCast;
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
@@ -50,7 +62,9 @@ public final class OutputStreamSliceOutputAdapter
     public OutputStreamSliceOutputAdapter(OutputStream outputStream, int bufferSize)
     {
         checkArgument(bufferSize >= MINIMUM_CHUNK_SIZE, "minimum buffer size of " + MINIMUM_CHUNK_SIZE + " required");
-        checkNotNull(outputStream, "outputStream is null");
+        if (outputStream == null) {
+            throw new NullPointerException("outputStream is null");
+        }
 
         this.outputStream = outputStream;
         this.buffer = new byte[bufferSize];

--- a/presto-main/src/main/java/com/facebook/presto/server/OutputStreamSliceOutputAdapter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/OutputStreamSliceOutputAdapter.java
@@ -28,8 +28,6 @@ import java.util.Arrays;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.primitives.Ints.checkedCast;
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
-import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
-import static io.airlift.slice.SizeOf.SIZE_OF_FLOAT;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
@@ -147,17 +145,13 @@ public final class OutputStreamSliceOutputAdapter
     @Override
     public void writeFloat(float value)
     {
-        ensureWritableBytes(SIZE_OF_FLOAT);
-        slice.setInt(bufferPosition, Float.floatToIntBits(value));
-        bufferPosition += SIZE_OF_FLOAT;
+        writeInt(Float.floatToIntBits(value));
     }
 
     @Override
     public void writeDouble(double value)
     {
-        ensureWritableBytes(SIZE_OF_DOUBLE);
-        slice.setLong(bufferPosition, Double.doubleToLongBits(value));
-        bufferPosition += SIZE_OF_DOUBLE;
+        writeLong(Double.doubleToLongBits(value));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/PagesResponseWriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PagesResponseWriter.java
@@ -18,8 +18,8 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.google.common.base.Throwables;
 import com.google.common.reflect.TypeToken;
-import io.airlift.slice.OutputStreamSliceOutput;
 import io.airlift.slice.RuntimeIOException;
+import io.airlift.slice.SliceOutput;
 
 import javax.inject.Inject;
 import javax.ws.rs.Produces;
@@ -88,7 +88,9 @@ public class PagesResponseWriter
             throws IOException, WebApplicationException
     {
         try {
-            PagesSerde.writePages(blockEncodingSerde, new OutputStreamSliceOutput(output), pages);
+            SliceOutput sliceOutput = new OutputStreamSliceOutputAdapter(output, 128 * 1024);
+            PagesSerde.writePages(blockEncodingSerde, sliceOutput, pages);
+            sliceOutput.flush();
         }
         catch (RuntimeIOException e) {
             // EOF exception occurs when the client disconnects while writing data

--- a/presto-main/src/test/java/com/facebook/presto/server/TestInputStreamSliceInputAdapter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestInputStreamSliceInputAdapter.java
@@ -86,6 +86,16 @@ public class TestInputStreamSliceInputAdapter
         assertEquals(buildSliceInput(new byte[] {0, 0, 0, 0, 0, 0, -16, 127}).readDouble(), Double.POSITIVE_INFINITY);
     }
 
+    @Test
+    public void testEncodingFloat()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {-61, -11, 72, 64}).readFloat(), 3.14f);
+        assertEquals(buildSliceInput(new byte[] {0, 0, -64, 127}).readFloat(), Float.NaN);
+        assertEquals(buildSliceInput(new byte[] {0, 0, -128, -1}).readFloat(), Float.NEGATIVE_INFINITY);
+        assertEquals(buildSliceInput(new byte[] {0, 0, -128, 127}).readFloat(), Float.POSITIVE_INFINITY);
+    }
+
     private SliceInput buildSliceInput(byte[] bytes)
     {
         FastByteArrayInputStream inputStream = new FastByteArrayInputStream(bytes);

--- a/presto-main/src/test/java/com/facebook/presto/server/TestInputStreamSliceInputAdapter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestInputStreamSliceInputAdapter.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.facebook.presto.server;
 
 import io.airlift.slice.SliceInput;

--- a/presto-main/src/test/java/com/facebook/presto/server/TestInputStreamSliceInputAdapter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestInputStreamSliceInputAdapter.java
@@ -1,0 +1,94 @@
+package com.facebook.presto.server;
+
+import io.airlift.slice.SliceInput;
+import it.unimi.dsi.fastutil.io.FastByteArrayInputStream;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestInputStreamSliceInputAdapter
+{
+    @Test
+    public void testEmptyInput()
+            throws Exception
+    {
+        SliceInput input = buildSliceInput(new byte[0]);
+        assertEquals(input.position(), 0);
+    }
+
+    @Test
+    public void testEmptyRead()
+            throws Exception
+    {
+        SliceInput input = buildSliceInput(new byte[0]);
+        assertEquals(input.read(), -1);
+    }
+
+    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    public void testEmptyReadByte()
+            throws Exception
+    {
+        SliceInput input = buildSliceInput(new byte[0]);
+        input.readByte();
+    }
+
+    @Test
+    public void testEncodingBoolean()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {1}).readBoolean(), true);
+        assertEquals(buildSliceInput(new byte[] {0}).readBoolean(), false);
+    }
+
+    @Test
+    public void testEncodingByte()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {92}).readByte(), 92);
+        assertEquals(buildSliceInput(new byte[] {-100}).readByte(), -100);
+        assertEquals(buildSliceInput(new byte[] {-17}).readByte(), -17);
+    }
+
+    @Test
+    public void testEncodingShort()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {109, 92}).readShort(), 23661);
+        assertEquals(buildSliceInput(new byte[] {109, -100}).readShort(), -25491);
+        assertEquals(buildSliceInput(new byte[] {-52, -107}).readShort(), -27188);
+
+        assertEquals(buildSliceInput(new byte[] {109, -100}).readUnsignedShort(), 40045);
+        assertEquals(buildSliceInput(new byte[] {-52, -107}).readUnsignedShort(), 38348);
+    }
+
+    @Test
+    public void testEncodingInteger()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {109, 92, 75, 58}).readInt(), 978017389);
+        assertEquals(buildSliceInput(new byte[] {-16, -60, -120, -1}).readInt(), -7813904);
+    }
+
+    @Test
+    public void testEncodingLong()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {109, 92, 75, 58, 18, 120, -112, -17}).readLong(), -1184314682315678611L);
+    }
+
+    @Test
+    public void testEncodingDouble()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {31, -123, -21, 81, -72, 30, 9, 64}).readDouble(), 3.14);
+        assertEquals(buildSliceInput(new byte[] {0, 0, 0, 0, 0, 0, -8, 127}).readDouble(), Double.NaN);
+        assertEquals(buildSliceInput(new byte[] {0, 0, 0, 0, 0, 0, -16, -1}).readDouble(), Double.NEGATIVE_INFINITY);
+        assertEquals(buildSliceInput(new byte[] {0, 0, 0, 0, 0, 0, -16, 127}).readDouble(), Double.POSITIVE_INFINITY);
+    }
+
+    private SliceInput buildSliceInput(byte[] bytes)
+    {
+        FastByteArrayInputStream inputStream = new FastByteArrayInputStream(bytes);
+        return new InputStreamSliceInputAdapter(inputStream, 16 * 1024);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/TestOutputStreamSliceOutputAdapter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestOutputStreamSliceOutputAdapter.java
@@ -42,35 +42,41 @@ public class TestOutputStreamSliceOutputAdapter
     public void testEncodingByte()
             throws Exception
     {
-        assertEncoding(sliceOutput -> sliceOutput.writeByte(0x5c),
+        assertEncoding(sliceOutput -> sliceOutput.writeByte(92),
                 new byte[] {92});
-        assertEncoding(sliceOutput -> sliceOutput.writeByte(0x9c),
+        assertEncoding(sliceOutput -> sliceOutput.writeByte(156),
                 new byte[] {-100});
+        assertEncoding(sliceOutput -> sliceOutput.writeByte(-17),
+                new byte[] {-17});
     }
 
     @Test
     public void testEncodingShort()
             throws Exception
     {
-        assertEncoding(sliceOutput -> sliceOutput.writeShort(0x5c6d),
+        assertEncoding(sliceOutput -> sliceOutput.writeShort(23661),
                 new byte[] {109, 92});
-        assertEncoding(sliceOutput -> sliceOutput.writeShort(0x9c6d),
+        assertEncoding(sliceOutput -> sliceOutput.writeShort(40045),
                 new byte[] {109, -100});
+        assertEncoding(sliceOutput -> sliceOutput.writeShort(-27188),
+                new byte[] {-52, -107});
     }
 
     @Test
     public void testEncodingInteger()
             throws Exception
     {
-        assertEncoding(sliceOutput -> sliceOutput.writeInt(0x3a4b5c6d),
+        assertEncoding(sliceOutput -> sliceOutput.writeInt(978017389),
                 new byte[] {109, 92, 75, 58});
+        assertEncoding(sliceOutput -> sliceOutput.writeInt(-7813904),
+                new byte[] {-16, -60, -120, -1});
     }
 
     @Test
     public void testEncodingLong()
             throws Exception
     {
-        assertEncoding(sliceOutput -> sliceOutput.writeLong(0xef9078123a4b5c6dL),
+        assertEncoding(sliceOutput -> sliceOutput.writeLong(-1184314682315678611L),
                 new byte[] {109, 92, 75, 58, 18, 120, -112, -17});
     }
 
@@ -158,6 +164,8 @@ public class TestOutputStreamSliceOutputAdapter
         assertEncoding(operations, 8, expected);
         assertEncoding(operations, 16, expected);
         assertEncoding(operations, 511, expected);
+        assertEncoding(operations, 12000, expected);
+        assertEncoding(operations, 13000, expected);
         assertEncoding(operations, 16000, expected);
         assertEncoding(operations, 16380, expected);
         assertEncoding(operations, 16383, expected);

--- a/presto-main/src/test/java/com/facebook/presto/server/TestOutputStreamSliceOutputAdapter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestOutputStreamSliceOutputAdapter.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.facebook.presto.server;
 
 import io.airlift.slice.Slice;

--- a/presto-main/src/test/java/com/facebook/presto/server/TestOutputStreamSliceOutputAdapter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestOutputStreamSliceOutputAdapter.java
@@ -95,6 +95,20 @@ public class TestOutputStreamSliceOutputAdapter
     }
 
     @Test
+    public void testEncodingFloat()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeFloat(3.14f),
+                new byte[] {-61, -11, 72, 64});
+        assertEncoding(sliceOutput -> sliceOutput.writeFloat(Float.NaN),
+                new byte[] {0, 0, -64, 127});
+        assertEncoding(sliceOutput -> sliceOutput.writeFloat(Float.NEGATIVE_INFINITY),
+                new byte[] {0, 0, -128, -1});
+        assertEncoding(sliceOutput -> sliceOutput.writeFloat(Float.POSITIVE_INFINITY),
+                new byte[] {0, 0, -128, 127});
+    }
+
+    @Test
     public void testEncodingBytes()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/server/TestOutputStreamSliceOutputAdapter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestOutputStreamSliceOutputAdapter.java
@@ -1,0 +1,169 @@
+package com.facebook.presto.server;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestOutputStreamSliceOutputAdapter
+{
+    @Test
+    public void testEncodingBoolean()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeBoolean(true),
+                new byte[] {1});
+        assertEncoding(sliceOutput -> sliceOutput.writeBoolean(false),
+                new byte[] {0});
+    }
+
+    @Test
+    public void testEncodingByte()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeByte(0x5c),
+                new byte[] {92});
+        assertEncoding(sliceOutput -> sliceOutput.writeByte(0x9c),
+                new byte[] {-100});
+    }
+
+    @Test
+    public void testEncodingShort()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeShort(0x5c6d),
+                new byte[] {109, 92});
+        assertEncoding(sliceOutput -> sliceOutput.writeShort(0x9c6d),
+                new byte[] {109, -100});
+    }
+
+    @Test
+    public void testEncodingInteger()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeInt(0x3a4b5c6d),
+                new byte[] {109, 92, 75, 58});
+    }
+
+    @Test
+    public void testEncodingLong()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeLong(0xef9078123a4b5c6dL),
+                new byte[] {109, 92, 75, 58, 18, 120, -112, -17});
+    }
+
+    @Test
+    public void testEncodingDouble()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeDouble(3.14),
+                new byte[] {31, -123, -21, 81, -72, 30, 9, 64});
+        assertEncoding(sliceOutput -> sliceOutput.writeDouble(Double.NaN),
+                new byte[] {0, 0, 0, 0, 0, 0, -8, 127});
+        assertEncoding(sliceOutput -> sliceOutput.writeDouble(Double.NEGATIVE_INFINITY),
+                new byte[] {0, 0, 0, 0, 0, 0, -16, -1});
+        assertEncoding(sliceOutput -> sliceOutput.writeDouble(Double.POSITIVE_INFINITY),
+                new byte[] {0, 0, 0, 0, 0, 0, -16, 127});
+    }
+
+    @Test
+    public void testEncodingBytes()
+            throws Exception
+    {
+        byte[] data = new byte[18000];
+        ThreadLocalRandom.current().nextBytes(data);
+
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 0), Arrays.copyOfRange(data, 0, 0));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 3), Arrays.copyOfRange(data, 0, 3));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 370), Arrays.copyOfRange(data, 0, 370));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 4095), Arrays.copyOfRange(data, 0, 4095));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 4096), Arrays.copyOfRange(data, 0, 4096));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 12348), Arrays.copyOfRange(data, 0, 12348));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 16384), Arrays.copyOfRange(data, 0, 16384));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 18000), Arrays.copyOfRange(data, 0, 18000));
+    }
+
+    @Test
+    public void testEncodingSlice()
+            throws Exception
+    {
+        byte[] data = new byte[18000];
+        ThreadLocalRandom.current().nextBytes(data);
+        Slice slice = Slices.wrappedBuffer(data);
+
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 0), Arrays.copyOfRange(data, 0, 0));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 3), Arrays.copyOfRange(data, 0, 3));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 370), Arrays.copyOfRange(data, 0, 370));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 4095), Arrays.copyOfRange(data, 0, 4095));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 4096), Arrays.copyOfRange(data, 0, 4096));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 12348), Arrays.copyOfRange(data, 0, 12348));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 16384), Arrays.copyOfRange(data, 0, 16384));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 18000), Arrays.copyOfRange(data, 0, 18000));
+    }
+
+    @Test
+    public void testWriteZero()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(0), new byte[0]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(1), new byte[1]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(2), new byte[2]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(3), new byte[3]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(4), new byte[4]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(6), new byte[6]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(7), new byte[7]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(8), new byte[8]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(9), new byte[9]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(16), new byte[16]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(22), new byte[22]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(227), new byte[227]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(4227), new byte[4227]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(18349), new byte[18349]);
+    }
+
+    /**
+     * Asserting different offsets of operations.
+     */
+    private void assertEncoding(Consumer<SliceOutput> operations, byte... expected)
+            throws IOException
+    {
+        assertEncoding(operations, 0, expected);
+        assertEncoding(operations, 1, expected);
+        assertEncoding(operations, 2, expected);
+        assertEncoding(operations, 3, expected);
+        assertEncoding(operations, 4, expected);
+        assertEncoding(operations, 7, expected);
+        assertEncoding(operations, 8, expected);
+        assertEncoding(operations, 16, expected);
+        assertEncoding(operations, 511, expected);
+        assertEncoding(operations, 16000, expected);
+        assertEncoding(operations, 16380, expected);
+        assertEncoding(operations, 16383, expected);
+        assertEncoding(operations, 16384, expected);
+        assertEncoding(operations, 18349, expected);
+    }
+
+    private void assertEncoding(Consumer<SliceOutput> operations, int offset, byte... output)
+            throws IOException
+    {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try (SliceOutput sliceOutput = new OutputStreamSliceOutputAdapter(byteArrayOutputStream, 16384)) {
+            sliceOutput.writeZero(offset);
+            operations.accept(sliceOutput);
+            assertEquals(sliceOutput.size(), offset + output.length);
+        }
+
+        byte[] expected = new byte[offset + output.length];
+        System.arraycopy(output, 0, expected, offset, output.length);
+        assertEquals(byteArrayOutputStream.toByteArray(), expected);
+    }
+}


### PR DESCRIPTION
This PR removes the extra CPU cycles mentioned in #5684 and optimizes encoding of blocks for exchange.

@dain @electrum Could you please review. If desired, I could create another PR for `SliceInput`