### PR TITLE
Upload artifacts to s3 if credentials and bucket are configured

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
       sudo mv docker-compose /usr/local/bin
     fi
 
-install: ./mvnw install -DskipTests=true $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1 -pl '!presto-docs,!presto-server-rpm'
+install: ./mvnw install -DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1 -pl '!presto-docs,!presto-server-rpm'
 
 script:
   - |
@@ -59,12 +59,38 @@ script:
       presto-hive-hadoop2/bin/run_on_docker.sh
   - |
     test ! -v INTEGRATION_TESTS ||
-      ./mvnw install -DskipTests=true -B
+      ./mvnw install -DskipTests -B
+  - |
+    # Build presto-server-rpm for later artifact upload
+    test ! -v DEPLOY_S3_ACCESS_KEY || test ! -v PRODUCT_TESTS ||
+       ./mvnw install -DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1 -pl presto-server-rpm
 
 before_cache:
-  #make the cache stable between builds by removing build output
+  # Make the cache stable between builds by removing build output
   - rm -rf $HOME/.m2/repository/com/facebook
 
 notifications:
   slack:
     secure: V5eyoGShxFoCcYJcp858vf/T6gC9KeMxL0C1EElcpZRcKBrIVZzvhek3HLHxZOxlghqnvNVsyDtU3u5orkEaAXeXj5c2dN+4XBsAB9oeN5MtQ0Z3VLAhZDqKIW1LzcXrq4DpzM0PkGhjfjum/P94/qFYk0UckPtB6a341AuYRo8=
+
+before_deploy:
+  - mkdir /tmp/artifacts
+  - cp -n presto-server/target/presto-server-*.tar.gz /tmp/artifacts
+  - cp -n presto-server-rpm/target/presto-server-rpm-*.x86_64.rpm /tmp/artifacts
+  - cp -n presto-product-tests/target/presto-product-tests-*-executable.jar /tmp/artifacts
+  - cp -n presto-jdbc/target/presto-jdbc-*.jar /tmp/artifacts
+  - cp -n presto-cli/target/presto-cli-*-executable.jar /tmp/artifacts
+  - ls -lah /tmp/artifacts
+
+deploy:
+  on:
+    all_branches: true
+    condition: -v DEPLOY_S3_ACCESS_KEY && -v PRODUCT_TESTS
+  provider: s3
+  access_key_id: ${DEPLOY_S3_ACCESS_KEY}
+  secret_access_key: ${DEPLOY_S3_SECRET_KEY}
+  bucket: ${DEPLOY_S3_BUCKET}
+  skip_cleanup: true
+  local-dir: /tmp/artifacts
+  upload-dir: travis_build_artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_JOB_NUMBER}
+  acl: public_read


### PR DESCRIPTION
To enable artifact upload for your fork, set the following
environment variables in your repository settings @ Travis:
 - `DEPLOY_S3_SECRET_KEY_ID` - AWS access key id
 - `DEPLOY_S3_SECRET_KEY` - AWS access key
 - `DEPLOY_S3_BUCKET` - target S3 bucket

The change does not impact Travis waiting time, even for
forks uploading the artifacts, because:
 - the artifact upload is piggybacked on the shortest job,
namely the product tests run,
 - `presto-server-rpm` (needed for artifacts upload)
is built only if s3 credentials are defined.