### PR TITLE
add json_array_extract functions to presto

### DIFF
--- a/presto-docs/src/main/sphinx/functions/json.rst
+++ b/presto-docs/src/main/sphinx/functions/json.rst
@@ -28,6 +28,20 @@ JSON Functions
         SELECT json_array_get('["a", "b", "c"]', 10); -- null
         SELECT json_array_get('["c", "b", "a"]', -10); -- null
 
+.. function:: json_array_extract(json, json_path) -> array(varchar)
+    Evaluates the `JSONPath`_-like expression ``json_path`` on ``json``
+    (a string containing JSON) and returns the array(varchar) result. The array's varchar content as a JSON string::
+
+        SELECT json_array_get('[{"book":{"id":"12"}}, {"book":{"id":"14"}}]', '$.book.id'); -- ['"12"', '"14"']
+
+    .. _JSONPath: http://goessner.net/articles/JsonPath/
+
+.. function:: json_array_extract_scalar(json, json_path) -> array(varchar)
+    Like :func:`json_array_extract`, but result array's varchar value as a string (as opposed
+    to being encoded as JSON).
+
+        SELECT json_array_extract_scalar('[{"book":{"id":"12"}}, {"book":{"id":"14"}}]', '$.book.id'); -- ['12', '14']
+
 .. function:: json_array_length(json) -> bigint
 
     Returns the array length of ``json`` (a string containing a JSON array)::

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonFunctions.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import com.facebook.presto.type.ArrayType;
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -312,5 +314,17 @@ public class TestJsonFunctions
         assertFunction("JSON '[1,2,3]' != JSON '[2,3,1]'", BOOLEAN, true);
         assertFunction("JSON '{\"p_1\": 1, \"p_2\":\"v_2\", \"p_3\":null, \"p_4\":true, \"p_5\": {\"p_1\":1}}' != " +
                 "JSON '{\"p_2\":\"v_2\", \"p_4\":true, \"p_1\": 1, \"p_3\":null, \"p_5\": {\"p_1\":1}}'", BOOLEAN, false);
+    }
+
+    @Test
+    public void testJsonArrayExtract()
+    {
+        assertFunction("json_array_extract('[{\"a\":{\"b\":\"13\"}}, {\"a\":{\"b\":\"18\"}}, {\"a\":{\"b\":\"12\"}}]', '$.a.b')", new ArrayType(VARCHAR), ImmutableList.of("\"13\"", "\"18\"", "\"12\""));
+    }
+
+    @Test
+    public void testJsonArrayExtractScalar()
+    {
+        assertFunction("json_array_extract_scalar('[{\"a\":{\"b\":\"13\"}}, {\"a\":{\"b\":\"18\"}}, {\"a\":{\"b\":\"12\"}}]', '$.a.b')", new ArrayType(VARCHAR), ImmutableList.of("13", "18", "12"));
     }
 }


### PR DESCRIPTION
add `json_array_extract` and `json_array_extract_scalar` function, unit test and description to presto.

```
presto:default> select json_array_extract(arr1, '$.book.id') from (values ('[{"book":{"id":"12"}}, {"book":{"id":"14"}}]')) t(arr1);
    _col0
--------------
 ["12", "14"]
(1 row)

Query 20160721_105423_00006_xgf26, FINISHED, 1 node
Splits: 1 total, 0 done (0.00%)
0:00 [0 rows, 0B] [0 rows/s, 0B/s]
```

```
presto:default> select json_array_extract_scalar(arr1, '$.book.id') from (values ('[{"book":{"id":"12"}}, {"book":{"id":"14"}}]')) t(arr1);
  _col0
----------
 [12, 14]
(1 row)

Query 20160721_105426_00007_xgf26, FINISHED, 1 node
Splits: 1 total, 0 done (0.00%)
0:00 [0 rows, 0B] [0 rows/s, 0B/s]
```
