### PR TITLE
At time zone with qualified name

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -818,9 +818,12 @@ public class ExpressionAnalyzer
         protected Type visitAtTimeZone(AtTimeZone node, StackableAstVisitorContext<AnalysisContext> context)
         {
             Type valueType = process(node.getValue(), context);
-            process(node.getTimeZone(), context);
             if (!valueType.equals(TIME_WITH_TIME_ZONE) && !valueType.equals(TIMESTAMP_WITH_TIME_ZONE) && !valueType.equals(TIME) && !valueType.equals(TIMESTAMP)) {
                 throw new SemanticException(TYPE_MISMATCH, node.getValue(), "Type of value must be a time or timestamp with or without time zone (actual %s)", valueType);
+            }
+            Type zoneType = process(node.getTimeZone(), context);
+            if (!zoneType.equals(INTERVAL_DAY_TIME) && !(zoneType instanceof VarcharType)) {
+              throw new SemanticException(TYPE_MISMATCH, node.getTimeZone(), "Type of time zone must be VARCHAR or INTERVAL (actual %s)", zoneType);
             }
             Type resultType = valueType;
             if (valueType.equals(TIME)) {

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -296,6 +296,7 @@ primaryExpression
 timeZoneSpecifier
     : TIME ZONE interval  #timeZoneInterval
     | TIME ZONE STRING    #timeZoneString
+    | TIME ZONE qualifiedName #timeZoneQualifiedName
     ;
 
 comparisonOperator

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1000,6 +1000,22 @@ class AstBuilder
         return new StringLiteral(getLocation(context), unquote(context.STRING().getText()));
     }
 
+    @Override
+    public Node visitTimeZoneQualifiedName(SqlBaseParser.TimeZoneQualifiedNameContext context)
+    {
+        QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
+        List<String> parts = qualifiedName.getParts();
+        int partsCount = parts.size();
+        if (partsCount == 1) {
+            return new QualifiedNameReference(getLocation(context), qualifiedName);
+        }
+        Expression base = new QualifiedNameReference(QualifiedName.of(parts.get(0)));
+        for (int i = 1; i < partsCount - 1; i++) {
+            base = new DereferenceExpression(base, parts.get(i));
+        }
+        return new DereferenceExpression(getLocation(context), base, parts.get(partsCount - 1));
+    }
+
     // ********************* primary expressions **********************
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AtTimeZone.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AtTimeZone.java
@@ -16,7 +16,6 @@ package com.facebook.presto.sql.tree;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class AtTimeZone
@@ -38,7 +37,6 @@ public class AtTimeZone
     private AtTimeZone(Optional<NodeLocation> location, Expression value, Expression timeZone)
     {
         super(location);
-        checkArgument(timeZone instanceof IntervalLiteral || timeZone instanceof StringLiteral, "timeZone must be IntervalLiteral or StringLiteral");
         this.value = requireNonNull(value, "value is null");
         this.timeZone = requireNonNull(timeZone, "timeZone is null");
     }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1399,6 +1399,16 @@ public class TestSqlParser
     @Test
     public void testAtTimeZone()
     {
+        assertStatement("SELECT timestamp '2012-10-31 01:00 UTC' AT TIME ZONE t.zone from t",
+            simpleQuery(
+                selectList(new AtTimeZone(new TimestampLiteral("2012-10-31 01:00 UTC"), new DereferenceExpression(new QualifiedNameReference(QualifiedName.of("t")), "zone"))),
+                table(QualifiedName.of("t"))));
+
+        assertStatement("SELECT timestamp '2012-10-31 01:00 UTC' AT TIME ZONE zn from t",
+            simpleQuery(
+                selectList(new AtTimeZone(new TimestampLiteral("2012-10-31 01:00 UTC"), new QualifiedNameReference(QualifiedName.of("zn")))),
+                table(QualifiedName.of("t"))));
+
         assertStatement("SELECT timestamp '2012-10-31 01:00 UTC' AT TIME ZONE 'America/Los_Angeles'",
                 new Query(
                         Optional.empty(),

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4764,6 +4764,15 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT TIMESTAMP '2012-10-31 01:00' AT TIME ZONE 'America/Los_Angeles' AT TIME ZONE 'Asia/Shanghai'", "SELECT TIMESTAMP '2012-10-30 18:00:00.000 America/Los_Angeles'");
         assertQuery("SELECT min(x) AT TIME ZONE 'America/Los_Angeles' AT TIME ZONE 'UTC' FROM (values TIMESTAMP '1970-01-01 00:01:00+00:00', TIMESTAMP '1970-01-01 08:01:00+08:00', TIMESTAMP '1969-12-31 16:01:00-08:00') t(x)",
                 "values TIMESTAMP '1969-12-31 16:01:00-08:00'");
+
+        assertQuery("SELECT ts AT TIME ZONE z FROM (values (TIMESTAMP '1970-01-01 00:01:00+00:00', 'America/Los_Angeles')) t(ts, z)",
+                "values TIMESTAMP '1969-12-31 16:01:00-08:00'");
+        assertQuery("SELECT ts AT TIME ZONE t.z FROM (values (TIMESTAMP '1970-01-01 08:01:00+08:00', 'America/Los_Angeles')) t(ts, z)",
+                "values TIMESTAMP '1969-12-31 16:01:00-08:00'");
+        assertQuery("SELECT a.col0 AT TIME ZONE a.col1 FROM (VALUES ROW (CAST(ROW(TIMESTAMP '1969-12-31 16:01:00-08:00', 'America/Los_Angeles') AS ROW(col0 timestamp with time zone, col1 varchar)))) AS t (a)",
+                "values TIMESTAMP '1969-12-31 16:01:00-08:00'");
+        assertQuery("SELECT a.col0.col0 AT TIME ZONE a.col0.col1 FROM (VALUES ROW (CAST(ROW(ROW(TIMESTAMP '1969-12-31 16:01:00-08:00', 'America/Los_Angeles')) AS ROW(col0 ROW(col0 timestamp with time zone, col1 varchar))))) AS t (a)",
+                "values TIMESTAMP '1969-12-31 16:01:00-08:00'");
     }
 
     @Test


### PR DESCRIPTION
Currently AT TIME ZONE accepts interval and string only. For us, the time zone is stored in a table. This patch is to support AT TIME ZONE with a qualified name.  @electrum @dain @cberner, could you please take a look? Thanks.