### PR TITLE
Add example of ROW literal in docs

### DIFF
--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -162,4 +162,4 @@ ROW
     A structure made up of named fields. The fields may be of any SQL type, and are
     accessed with field reference operator ``.``
 
-    Example: ``my_column.my_field``
+    Example: ``CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))``


### PR DESCRIPTION
This makes it more consistent with the other examples