### PR TITLE
Fix query failure when referencing a field of a NULL row

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -358,6 +358,11 @@ public class ExpressionInterpreter
             }
 
             Object base = process(node.getBase(), context);
+            // if the base part is evaluated to be null, the dereference expression should also be null
+            if (base == null) {
+                return null;
+            }
+
             if (hasUnresolvedValue(base)) {
                 return new DereferenceExpression(toExpression(base, type), node.getFieldName());
             }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2646,6 +2646,16 @@ public abstract class AbstractTestQueries
     {
         assertQuery("SELECT COUNT(*) FROM lineitem LEFT JOIN orders ON lineitem.orderkey = orders.orderkey");
         assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey");
+
+        // With null base (null row value) in dereference expression
+        assertQuery(
+                "SELECT x.val FROM " +
+                        "(SELECT CAST(ROW(v) as ROW(val integer)) FROM (VALUES 1, 2, 3) t(v)) ta (x) " +
+                        "LEFT OUTER JOIN " +
+                        "(SELECT CAST(ROW(v) as ROW(val integer)) FROM (VALUES 1, 2, 3) t(v)) tb (y) " +
+                        "ON x.val=y.val " +
+                        "WHERE y.val=1",
+                "SELECT 1");
     }
 
     @Test


### PR DESCRIPTION
We try to pre-calculate the row field value if possible when planning.
Before this commit, we fail to handle the case when the row itself is
evaluated to be null, which will lead to a NullPointerException.

In this commit, the row field will be pre-calculated as a null if the
row is evaluated to be a null.