### PR TITLE
Revert change to the default value of task info refresh interval

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -50,7 +50,7 @@ public class TaskManagerConfig
     private Duration infoMaxAge = new Duration(15, TimeUnit.MINUTES);
 
     private Duration statusRefreshMaxWait = new Duration(1, TimeUnit.SECONDS);
-    private Duration infoUpdateInterval = new Duration(1, TimeUnit.SECONDS);
+    private Duration infoUpdateInterval = new Duration(200, TimeUnit.MILLISECONDS);
 
     private int writerCount = 1;
     private int taskConcurrency = 1;

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -35,7 +35,7 @@ public class TestTaskManagerConfig
                 .setInitialSplitsPerNode(Runtime.getRuntime().availableProcessors() * 2)
                 .setSplitConcurrencyAdjustmentInterval(new Duration(100, TimeUnit.MILLISECONDS))
                 .setStatusRefreshMaxWait(new Duration(1, TimeUnit.SECONDS))
-                .setInfoUpdateInterval(new Duration(1, TimeUnit.SECONDS))
+                .setInfoUpdateInterval(new Duration(200, TimeUnit.MILLISECONDS))
                 .setVerboseStats(false)
                 .setTaskCpuTimerEnabled(true)
                 .setMaxWorkerThreads(Runtime.getRuntime().availableProcessors() * 2)


### PR DESCRIPTION
This can add up to 1 second latency to the wall time of queries.
Reset this to the previous value of 200ms until we can decouple query
stats from query completion.