### PR TITLE
Re-enable product tests for PostgreSQL and MySQL connectors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
   - |
     test ! -v PRODUCT_TESTS ||
       presto-product-tests/bin/run_on_docker.sh \
-        multinode -x quarantine,big_query,storage_formats,mysql_connector,postgresql_connector,profile_specific_tests
+        multinode -x quarantine,big_query,storage_formats,profile_specific_tests
   - |
     test ! -v PRODUCT_TESTS ||
       presto-product-tests/bin/run_on_docker.sh \


### PR DESCRIPTION
I don't know the reason why they weren't run in the first place, but they seem to pass on CI:
https://travis-ci.org/ArturGajowy/presto/builds/148048657

The tests add like 8 secs to the build, so they don't affect build performance.