### PR TITLE
Fix verifier write shadowing to deal with LIMIT queries

### DIFF
--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/TestShadowing.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/TestShadowing.java
@@ -66,7 +66,7 @@ public class TestShadowing
     {
         handle.execute("CREATE TABLE \"my_test_table\" (column1 BIGINT, column2 DOUBLE)");
         SqlParser parser = new SqlParser();
-        Query query = new Query(CATALOG, SCHEMA, ImmutableList.of(), "CREATE TABLE my_test_table AS SELECT 1 column1, CAST(2.0 AS DOUBLE) column2", ImmutableList.of(), null, null, ImmutableMap.of());
+        Query query = new Query(CATALOG, SCHEMA, ImmutableList.of(), "CREATE TABLE my_test_table AS SELECT 1 column1, CAST(2.0 AS DOUBLE) column2 LIMIT 1", ImmutableList.of(), null, null, ImmutableMap.of());
         QueryRewriter rewriter = new QueryRewriter(parser, URL, QualifiedName.of("tmp_"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), 1, new Duration(10, SECONDS));
         Query rewrittenQuery = rewriter.shadowQuery(query);
         assertEquals(rewrittenQuery.getPreQueries().size(), 1);


### PR DESCRIPTION
The verifier introduces a LIMIT 0 while determining column
types. However, if the query being shadowed already has a LIMIT
clause, then parsing fails. This removes the limit from the query
before introducing the zero limit.