### PR TITLE
Fix bug where hive.bucket-execution is not honored

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1445,7 +1445,7 @@ public class HiveMetadata
                 hiveBucketHandle.getColumns().stream()
                         .map(HiveColumnHandle::getHiveType)
                         .collect(Collectors.toList()));
-        List<String> partitionColumns = hivePartitionResult.getPartitionColumns().stream()
+        List<String> partitionColumns = hiveBucketHandle.getColumns().stream()
                 .map(HiveColumnHandle::getName)
                 .collect(Collectors.toList());
         return Optional.of(new ConnectorNewTableLayout(partitioningHandle, partitionColumns));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -83,6 +83,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public Optional<ConnectorNewTableLayout> getInsertLayout(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getInsertLayout(session, tableHandle);
+        }
+    }
+
+    @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
Before this fix,
* If bucketExecutionEnabled is true, insert into bucketed table would work
  (as if bucketExecutionWriting is enabled);
* If bucketExecutionEnabled is false, insert would either fail or create a
  corrupted partition in an existing table.