### PR TITLE
Varchar tests unicode + test utils

### DIFF
--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -45,6 +45,8 @@ public class MySqlClient
     {
         super(connectorId, config, "`", new Driver());
         connectionProperties.setProperty("nullCatalogMeansCurrent", "false");
+        connectionProperties.setProperty("useUnicode", "true");
+        connectionProperties.setProperty("characterEncoding", "utf8");
         if (mySqlConfig.isAutoReconnect()) {
             connectionProperties.setProperty("autoReconnect", String.valueOf(mySqlConfig.isAutoReconnect()));
             connectionProperties.setProperty("maxReconnects", String.valueOf(mySqlConfig.getMaxReconnects()));

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
@@ -15,8 +15,13 @@ package com.facebook.presto.plugin.mysql;
 
 import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.testing.MaterializedResult;
-import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.tests.AbstractTestQueries;
+import com.facebook.presto.tests.datatype.CreateAndInsertDataSetup;
+import com.facebook.presto.tests.datatype.CreateAsSelectDataSetup;
+import com.facebook.presto.tests.datatype.DataSetup;
+import com.facebook.presto.tests.datatype.DataTypeTest;
+import com.facebook.presto.tests.sql.JdbcSqlExecutor;
+import com.facebook.presto.tests.sql.PrestoSqlExecutor;
 import io.airlift.testing.mysql.TestingMySqlServer;
 import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
@@ -32,7 +37,8 @@ import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.facebook.presto.tests.datatype.DataType.stringDataType;
+import static com.facebook.presto.tests.datatype.DataType.varcharDataType;
 import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -89,83 +95,42 @@ public class TestMySqlDistributedQueries
     public void testPrestoCreatedParameterizedVarchar()
             throws Exception
     {
-        assertUpdate("CREATE TABLE presto_test_parameterized_varchar AS SELECT " +
-                "CAST('a' AS varchar(10)) text_a," +
-                "CAST('b' AS varchar(255)) text_b," +
-                "CAST('c' AS varchar(256)) text_c," +
-                "CAST('d' AS varchar(65535)) text_d," +
-                "CAST('e' AS varchar(65536)) text_e," +
-                "CAST('f' AS varchar(16777215)) text_f," +
-                "CAST('g' AS varchar(16777216)) text_g," +
-                "CAST('h' AS varchar(" + VarcharType.MAX_LENGTH + ")) text_h," +
-                "CAST('unbounded' AS varchar) text_unbounded", 1);
-        assertTrue(queryRunner.tableExists(getSession(), "presto_test_parameterized_varchar"));
-        assertTableColumnNames(
-                "presto_test_parameterized_varchar",
-                "text_a",
-                "text_b",
-                "text_c",
-                "text_d",
-                "text_e",
-                "text_f",
-                "text_g",
-                "text_h",
-                "text_unbounded");
-
-        MaterializedResult materializedRows = computeActual("SELECT * from presto_test_parameterized_varchar");
-        assertEquals(materializedRows.getTypes().get(0), createVarcharType(255));
-        assertEquals(materializedRows.getTypes().get(1), createVarcharType(255));
-        assertEquals(materializedRows.getTypes().get(2), createVarcharType(65535));
-        assertEquals(materializedRows.getTypes().get(3), createVarcharType(65535));
-        assertEquals(materializedRows.getTypes().get(4), createVarcharType(16777215));
-        assertEquals(materializedRows.getTypes().get(5), createVarcharType(16777215));
-        assertEquals(materializedRows.getTypes().get(6), createUnboundedVarcharType());
-        assertEquals(materializedRows.getTypes().get(7), createUnboundedVarcharType());
-        assertEquals(materializedRows.getTypes().get(8), createUnboundedVarcharType());
-
-        MaterializedRow row = getOnlyElement(materializedRows);
-        assertEquals(row.getField(0), "a");
-        assertEquals(row.getField(1), "b");
-        assertEquals(row.getField(2), "c");
-        assertEquals(row.getField(3), "d");
-        assertEquals(row.getField(4), "e");
-        assertEquals(row.getField(5), "f");
-        assertEquals(row.getField(6), "g");
-        assertEquals(row.getField(7), "h");
-        assertEquals(row.getField(8), "unbounded");
-        assertUpdate("DROP TABLE presto_test_parameterized_varchar");
+        DataTypeTest.create()
+                .addRoundTrip(stringDataType("varchar(10)", createVarcharType(255)), "text_a")
+                .addRoundTrip(stringDataType("varchar(255)", createVarcharType(255)), "text_b")
+                .addRoundTrip(stringDataType("varchar(256)", createVarcharType(65535)), "text_c")
+                .addRoundTrip(stringDataType("varchar(65535)", createVarcharType(65535)), "text_d")
+                .addRoundTrip(stringDataType("varchar(65536)", createVarcharType(16777215)), "text_e")
+                .addRoundTrip(stringDataType("varchar(16777215)", createVarcharType(16777215)), "text_f")
+                .addRoundTrip(stringDataType("varchar(16777216)", createUnboundedVarcharType()), "text_g")
+                .addRoundTrip(stringDataType("varchar(" + VarcharType.MAX_LENGTH + ")", createUnboundedVarcharType()), "text_h")
+                .addRoundTrip(stringDataType("varchar", createUnboundedVarcharType()), "unbounded")
+                .execute(queryRunner, prestoCreateAsSelect("presto_test_parameterized_varchar"));
     }
 
     @Test
     public void testMySqlCreatedParameterizedVarchar()
             throws Exception
     {
-        execute("CREATE TABLE tpch.mysql_test_parameterized_varchar (" +
-                "text_a tinytext, " +
-                "text_b text, " +
-                "text_c mediumtext, " +
-                "text_d longtext, " +
-                "text_e varchar(32), " +
-                "text_f varchar(20000)" +
-                ")");
-        execute("INSERT INTO tpch.mysql_test_parameterized_varchar VALUES('a', 'b', 'c', 'd', 'e', 'f')");
+        DataTypeTest.create()
+                .addRoundTrip(stringDataType("tinytext", createVarcharType(255)), "a")
+                .addRoundTrip(stringDataType("text", createVarcharType(65535)), "b")
+                .addRoundTrip(stringDataType("mediumtext", createVarcharType(16777215)), "c")
+                .addRoundTrip(stringDataType("longtext", createUnboundedVarcharType()), "d")
+                .addRoundTrip(varcharDataType(32), "e")
+                .addRoundTrip(varcharDataType(20000), "f")
+                .execute(queryRunner, mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar"));
+    }
 
-        MaterializedResult materializedRows = computeActual("SELECT * from mysql_test_parameterized_varchar");
-        assertEquals(materializedRows.getTypes().get(0), createVarcharType(255));
-        assertEquals(materializedRows.getTypes().get(1), createVarcharType(65535));
-        assertEquals(materializedRows.getTypes().get(2), createVarcharType(16777215));
-        assertEquals(materializedRows.getTypes().get(3), createUnboundedVarcharType());
-        assertEquals(materializedRows.getTypes().get(4), createVarcharType(32));
-        assertEquals(materializedRows.getTypes().get(5), createVarcharType(20000));
+    private DataSetup prestoCreateAsSelect(String tableNamePrefix)
+    {
+        return new CreateAsSelectDataSetup(new PrestoSqlExecutor(queryRunner), tableNamePrefix);
+    }
 
-        MaterializedRow row = getOnlyElement(materializedRows);
-        assertEquals(row.getField(0), "a");
-        assertEquals(row.getField(1), "b");
-        assertEquals(row.getField(2), "c");
-        assertEquals(row.getField(3), "d");
-        assertEquals(row.getField(4), "e");
-        assertEquals(row.getField(5), "f");
-        assertUpdate("DROP TABLE mysql_test_parameterized_varchar");
+    private DataSetup mysqlCreateAndInsert(String tableNamePrefix)
+    {
+        JdbcSqlExecutor mysqlUnicodeExecutor = new JdbcSqlExecutor(mysqlServer.getJdbcUrl());
+        return new CreateAndInsertDataSetup(mysqlUnicodeExecutor, tableNamePrefix);
     }
 
     @Override

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
@@ -48,6 +48,8 @@ import static org.testng.Assert.assertTrue;
 public class TestMySqlDistributedQueries
         extends AbstractTestQueries
 {
+    private static final String CHARACTER_SET_UTF8 = "CHARACTER SET utf8";
+
     private final TestingMySqlServer mysqlServer;
 
     public TestMySqlDistributedQueries()
@@ -122,6 +124,22 @@ public class TestMySqlDistributedQueries
                 .execute(queryRunner, mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar"));
     }
 
+    @Test
+    public void testMySqlCreatedParameterizedVarcharUnicode()
+            throws Exception
+    {
+        String sampleUnicodeText = "\u653b\u6bbb\u6a5f\u52d5\u968a";
+        DataTypeTest.create()
+                .addRoundTrip(stringDataType("tinytext " + CHARACTER_SET_UTF8, createVarcharType(255)), sampleUnicodeText)
+                .addRoundTrip(stringDataType("text " + CHARACTER_SET_UTF8, createVarcharType(65535)), sampleUnicodeText)
+                .addRoundTrip(stringDataType("mediumtext " + CHARACTER_SET_UTF8, createVarcharType(16777215)), sampleUnicodeText)
+                .addRoundTrip(stringDataType("longtext " + CHARACTER_SET_UTF8, createUnboundedVarcharType()), sampleUnicodeText)
+                .addRoundTrip(varcharDataType(sampleUnicodeText.length(), CHARACTER_SET_UTF8), sampleUnicodeText)
+                .addRoundTrip(varcharDataType(32, CHARACTER_SET_UTF8), sampleUnicodeText)
+                .addRoundTrip(varcharDataType(20000, CHARACTER_SET_UTF8), sampleUnicodeText)
+                .execute(queryRunner, mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar_unicode"));
+    }
+
     private DataSetup prestoCreateAsSelect(String tableNamePrefix)
     {
         return new CreateAsSelectDataSetup(new PrestoSqlExecutor(queryRunner), tableNamePrefix);
@@ -129,7 +147,7 @@ public class TestMySqlDistributedQueries
 
     private DataSetup mysqlCreateAndInsert(String tableNamePrefix)
     {
-        JdbcSqlExecutor mysqlUnicodeExecutor = new JdbcSqlExecutor(mysqlServer.getJdbcUrl());
+        JdbcSqlExecutor mysqlUnicodeExecutor = new JdbcSqlExecutor(mysqlServer.getJdbcUrl() + "&useUnicode=true&characterEncoding=utf8");
         return new CreateAndInsertDataSetup(mysqlUnicodeExecutor, tableNamePrefix);
     }
 

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -13,9 +13,12 @@
  */
 package com.facebook.presto.plugin.postgresql;
 
-import com.facebook.presto.testing.MaterializedResult;
-import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.tests.AbstractTestQueries;
+import com.facebook.presto.tests.datatype.CreateAndInsertDataSetup;
+import com.facebook.presto.tests.datatype.CreateAsSelectDataSetup;
+import com.facebook.presto.tests.datatype.DataTypeTest;
+import com.facebook.presto.tests.sql.JdbcSqlExecutor;
+import com.facebook.presto.tests.sql.PrestoSqlExecutor;
 import io.airlift.testing.postgresql.TestingPostgreSqlServer;
 import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
@@ -28,11 +31,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import static com.facebook.presto.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
-import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
-import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.facebook.presto.tests.datatype.DataType.varcharDataType;
 import static io.airlift.testing.Closeables.closeAllRuntimeException;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -88,45 +88,28 @@ public class TestPostgreSqlDistributedQueries
     public void testPrestoCreatedParameterizedVarchar()
             throws Exception
     {
-        assertUpdate("CREATE TABLE presto_test_parameterized_varchar AS SELECT " +
-                "CAST('a' AS varchar(255)) text_a," +
-                "CAST('b' AS varchar(20000)) text_b," +
-                "CAST('unbounded' AS varchar) text_unbounded", 1);
-        assertTrue(queryRunner.tableExists(getSession(), "presto_test_parameterized_varchar"));
-        assertTableColumnNames("presto_test_parameterized_varchar", "text_a", "text_b", "text_unbounded");
-
-        MaterializedResult materializedRows = computeActual("SELECT * from presto_test_parameterized_varchar");
-        assertEquals(materializedRows.getTypes().get(0), createVarcharType(255));
-        assertEquals(materializedRows.getTypes().get(1), createVarcharType(20000));
-        assertEquals(materializedRows.getTypes().get(2), createUnboundedVarcharType());
-
-        MaterializedRow row = getOnlyElement(materializedRows);
-        assertEquals(row.getField(0), "a");
-        assertEquals(row.getField(1), "b");
-        assertEquals(row.getField(2), "unbounded");
-        assertUpdate("DROP TABLE presto_test_parameterized_varchar");
+        PrestoSqlExecutor presto = new PrestoSqlExecutor(queryRunner);
+        createVarcharDataTypeTest()
+                .execute(queryRunner, new CreateAsSelectDataSetup(presto, "presto_test_parameterized_varchar"));
     }
 
     @Test
     public void testPostgreSqlCreatedParameterizedVarchar()
             throws Exception
     {
-        execute("CREATE TABLE tpch.postgresql_test_parameterized_varchar (" +
-                "text_a varchar(32), " +
-                "text_b varchar(20000), " +
-                "text_c text)");
-        execute("INSERT INTO tpch.postgresql_test_parameterized_varchar VALUES('a', 'b', 'c')");
+        JdbcSqlExecutor postgres = new JdbcSqlExecutor(postgreSqlServer.getJdbcUrl());
+        createVarcharDataTypeTest()
+                .execute(queryRunner, new CreateAndInsertDataSetup(postgres, "tpch.postgresql_test_parameterized_varchar"));
+    }
 
-        MaterializedResult materializedRows = computeActual("SELECT * from postgresql_test_parameterized_varchar");
-        assertEquals(materializedRows.getTypes().get(0), createVarcharType(32));
-        assertEquals(materializedRows.getTypes().get(1), createVarcharType(20000));
-        assertEquals(materializedRows.getTypes().get(2), createUnboundedVarcharType());
-
-        MaterializedRow row = getOnlyElement(materializedRows);
-        assertEquals(row.getField(0), "a");
-        assertEquals(row.getField(1), "b");
-        assertEquals(row.getField(2), "c");
-        assertUpdate("DROP TABLE postgresql_test_parameterized_varchar");
+    private DataTypeTest createVarcharDataTypeTest()
+    {
+        return DataTypeTest.create()
+                .addRoundTrip(varcharDataType(10), "text_a")
+                .addRoundTrip(varcharDataType(255), "text_b")
+                .addRoundTrip(varcharDataType(65535), "text_d")
+                .addRoundTrip(varcharDataType(10485760), "text_f")
+                .addRoundTrip(varcharDataType(), "unbounded");
     }
 
     private void execute(String sql)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/datatype/CreateAndInsertDataSetup.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/datatype/CreateAndInsertDataSetup.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.datatype;
+
+import com.facebook.presto.tests.sql.SqlExecutor;
+import com.facebook.presto.tests.sql.TestTable;
+import com.google.common.base.Joiner;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
+
+public class CreateAndInsertDataSetup
+        implements DataSetup
+{
+    private final SqlExecutor sqlExecutor;
+    private final String tableNamePrefix;
+
+    public CreateAndInsertDataSetup(SqlExecutor sqlExecutor, String tableNamePrefix)
+    {
+        this.sqlExecutor = sqlExecutor;
+        this.tableNamePrefix = tableNamePrefix;
+    }
+
+    @Override
+    public TestTable setupTestTable(List<DataTypeTest.Input<?>> inputs)
+    {
+        TestTable testTable = createTestTable(inputs);
+        insertRows(testTable, inputs);
+        return testTable;
+    }
+
+    private void insertRows(TestTable testTable, List<DataTypeTest.Input<?>> inputs)
+    {
+        Stream<String> literals = inputs.stream()
+                .map(DataTypeTest.Input::toLiteral);
+        String valueLiterals = Joiner.on(", ").join(literals.iterator());
+        sqlExecutor.execute(format("INSERT INTO %s VALUES(%s)", testTable.getName(), valueLiterals));
+    }
+
+    private TestTable createTestTable(List<DataTypeTest.Input<?>> inputs)
+    {
+        String ddlTemplate = "CREATE TABLE {TABLE_NAME} (\n" + columnDefinitions(inputs) + "\n)";
+        return new TestTable(sqlExecutor, tableNamePrefix, ddlTemplate);
+    }
+
+    private String columnDefinitions(List<DataTypeTest.Input<?>> inputs)
+    {
+        List<String> columnTypeDefinitions = inputs.stream()
+                .map(DataTypeTest.Input::getInsertType)
+                .collect(toList());
+        Stream<String> columnDefinitions = range(0, columnTypeDefinitions.size())
+                .mapToObj(i -> format("col_%d %s", i, columnTypeDefinitions.get(i)));
+        return Joiner.on(",\n").join(columnDefinitions.iterator());
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/datatype/CreateAsSelectDataSetup.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/datatype/CreateAsSelectDataSetup.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.datatype;
+
+import com.facebook.presto.tests.sql.SqlExecutor;
+import com.facebook.presto.tests.sql.TestTable;
+import com.google.common.base.Joiner;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
+
+public class CreateAsSelectDataSetup
+        implements DataSetup
+{
+    private final SqlExecutor sqlExecutor;
+    private final String tableNamePrefix;
+
+    public CreateAsSelectDataSetup(SqlExecutor sqlExecutor, String tableNamePrefix)
+    {
+        this.sqlExecutor = sqlExecutor;
+        this.tableNamePrefix = tableNamePrefix;
+    }
+
+    @Override
+    public TestTable setupTestTable(List<DataTypeTest.Input<?>> inputs)
+    {
+        List<String> columnValues = inputs.stream()
+                .map(this::literalInExplicitCast)
+                .collect(toList());
+        Stream<String> columnValuesWithNames = range(0, columnValues.size())
+                .mapToObj(i -> format("%s col_%d", columnValues.get(i), i));
+        String selectBody = Joiner.on(",\n").join(columnValuesWithNames.iterator());
+        String ddlTemplate = "CREATE TABLE {TABLE_NAME} AS SELECT\n" + selectBody;
+        return new TestTable(sqlExecutor, tableNamePrefix, ddlTemplate);
+    }
+
+    private String literalInExplicitCast(DataTypeTest.Input<?> input)
+    {
+        return format("CAST(%s AS %s)", input.toLiteral(), input.getInsertType());
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/datatype/DataSetup.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/datatype/DataSetup.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.datatype;
+
+import com.facebook.presto.tests.sql.TestTable;
+
+import java.util.List;
+
+public interface DataSetup
+{
+    TestTable setupTestTable(List<DataTypeTest.Input<?>> inputs);
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/datatype/DataType.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/datatype/DataType.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.datatype;
+
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarcharType;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+public class DataType<T>
+{
+    private String insertType;
+    private Type prestoResultType;
+    private Function<T, String> toLiteral;
+
+    public static DataType<String> varcharDataType(int size)
+    {
+        return varcharDataType(size, "");
+    }
+
+    public static DataType<String> varcharDataType(int size, String properties)
+    {
+        return varcharDataType(of(size), properties);
+    }
+
+    public static DataType<String> varcharDataType()
+    {
+        return varcharDataType(empty(), "");
+    }
+
+    private static DataType<String> varcharDataType(Optional<Integer> length, String properties)
+    {
+        String prefix = length.map(size -> "varchar(" + size + ")").orElse("varchar");
+        String suffix = properties.isEmpty() ? "" : " " + properties;
+        VarcharType varcharType = length.map(VarcharType::createVarcharType).orElse(createUnboundedVarcharType());
+        return stringDataType(prefix + suffix, varcharType);
+    }
+
+    public static DataType<String> stringDataType(String insertType, Type prestoResultType)
+    {
+        return dataType(insertType, prestoResultType, DataType::quote);
+    }
+
+    private static String quote(String value)
+    {
+        return "'" + value + "'";
+    }
+
+    public static <T> DataType<T> dataType(String insertType, Type prestoResultType, Function<T, String> toLiteral)
+    {
+        return new DataType<>(insertType, prestoResultType, toLiteral);
+    }
+
+    private DataType(String insertType, Type prestoResultType, Function<T, String> toLiteral)
+    {
+        this.insertType = insertType;
+        this.prestoResultType = prestoResultType;
+        this.toLiteral = toLiteral;
+    }
+
+    public String toLiteral(T inputValue)
+    {
+        return toLiteral.apply(inputValue);
+    }
+
+    public String getInsertType()
+    {
+        return insertType;
+    }
+
+    public Type getPrestoResultType()
+    {
+        return prestoResultType;
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/datatype/DataTypeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/datatype/DataTypeTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.datatype;
+
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.sql.TestTable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Collections.unmodifiableList;
+import static java.util.stream.Collectors.toList;
+import static org.testng.AssertJUnit.assertEquals;
+
+public class DataTypeTest
+{
+    private List<Input<?>> inputs = new ArrayList<>();
+
+    private DataTypeTest() {}
+
+    public static DataTypeTest create()
+    {
+        return new DataTypeTest();
+    }
+
+    public <T> DataTypeTest addRoundTrip(DataType<T> dataType, T value)
+    {
+        inputs.add(new Input<>(dataType, value));
+        return this;
+    }
+
+    public void execute(QueryRunner prestoExecutor, DataSetup dataSetup)
+    {
+        List<Type> expectedTypes = inputs.stream().map(Input::getPrestoResultType).collect(toList());
+        List<Object> expectedResults = inputs.stream().map(Input::getValue).collect(toList());
+        try (TestTable testTable = dataSetup.setupTestTable(unmodifiableList(inputs))) {
+            MaterializedResult materializedRows = prestoExecutor.execute("SELECT * from " + testTable.getName());
+            assertEquals(expectedTypes, materializedRows.getTypes());
+            MaterializedRow row = getOnlyElement(materializedRows);
+            assertEquals(expectedResults, row.getFields());
+        }
+    }
+
+    public static class Input<T>
+    {
+        private final DataType<T> dataType;
+        private final T value;
+
+        public Input(DataType<T> dataType, T value)
+        {
+            this.dataType = dataType;
+            this.value = value;
+        }
+
+        String getInsertType()
+        {
+            return dataType.getInsertType();
+        }
+
+        Type getPrestoResultType()
+        {
+            return dataType.getPrestoResultType();
+        }
+
+        Object getValue()
+        {
+            return value;
+        }
+
+        String toLiteral()
+        {
+            return dataType.toLiteral(value);
+        }
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/sql/JdbcSqlExecutor.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/sql/JdbcSqlExecutor.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.sql;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class JdbcSqlExecutor
+        implements SqlExecutor
+{
+    private final String jdbcUrl;
+
+    public JdbcSqlExecutor(String jdbcUrl)
+    {
+        this.jdbcUrl = jdbcUrl;
+    }
+
+    @Override
+    public void execute(String sql)
+    {
+        try (Connection connection = DriverManager.getConnection(jdbcUrl);
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+        catch (SQLException e) {
+            throw new RuntimeException("Error executing sql:\n" + sql, e);
+        }
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/sql/PrestoSqlExecutor.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/sql/PrestoSqlExecutor.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.sql;
+
+import com.facebook.presto.testing.QueryRunner;
+
+public class PrestoSqlExecutor
+        implements SqlExecutor
+{
+    private final QueryRunner queryRunner;
+
+    public PrestoSqlExecutor(QueryRunner queryRunner)
+    {
+        this.queryRunner = queryRunner;
+    }
+
+    @Override
+    public void execute(String sql)
+    {
+        try {
+            queryRunner.execute(queryRunner.getDefaultSession(), sql);
+        }
+        catch (Throwable e) {
+            throw new RuntimeException("Error executing sql:\n" + sql, e);
+        }
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/sql/SqlExecutor.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/sql/SqlExecutor.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.sql;
+
+public interface SqlExecutor
+{
+    void execute(String sql);
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/sql/TestTable.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/sql/TestTable.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.sql;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestTable
+        implements AutoCloseable
+{
+    private final SqlExecutor sqlExecutor;
+    private final String name;
+
+    private static final AtomicInteger instanceCounter = new AtomicInteger();
+
+    public TestTable(SqlExecutor sqlExecutor, String namePrefix, String createDdlTemplate)
+    {
+        this.sqlExecutor = sqlExecutor;
+        this.name = namePrefix + "_" + instanceCounter.incrementAndGet();
+        sqlExecutor.execute(createDdlTemplate.replace("{TABLE_NAME}", this.name));
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public void close()
+    {
+        sqlExecutor.execute("DROP TABLE " + name);
+    }
+}


### PR DESCRIPTION
This is a prerequisite of #5501 (CHAR support) that can be merged independently. It consists of:
 - tests for Unicode support in `varchar` and `varchar(x)` types in postgresql and mysql connectors
 - a minor change in mysql connector making it add `useUnicode=true` and `characterEncoding=utf8` parameters when connecting via jdbc
 - a bit of test utilities allowing for terse and readable tests of data type encoding details

The test utilities give a 4 x decrease in test code amount and a huge improvement in readability, allowing the reader to see the details that would otherwise be missed (see the screenshot below):

![testmysqldistributedqueries_java___users_arturgajowy_projects_presto_presto-mysql_src_test_java_com_facebook_presto_plugin_mysql__and_refactor_of_parsing_scalar_functions_annotations_code_by_fiedukow_ _pull_request__5377_ _prestodb_presto](https://cloud.githubusercontent.com/assets/460141/17366514/eb390f0e-598b-11e6-929a-06f91fa021f5.png)

Using the utilities, the tests are also easier to write and abstract from irrelevant details such as concrete table or column names. They even allowed for reuse of test cases for unicode support between `char` and `varchar` data types, as [can be seen in the CHAR(x) PR](https://github.com/prestodb/presto/pull/5501/commits/88ccad2c435599edf5b35542f89a88c7da11d4d5#diff-6254c015bd4ca4cba218763b531d3bb7R111).