### PR TITLE
Remove docker container before product and integration tests run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
   # This section can be removed once travis get equipped with docker 1.10 and docker-compose 1.6
   - |
     if [ -v PRODUCT_TESTS ] || [ -v INTEGRATION_TESTS ]; then
+      docker rm $(presto-product-tests/conf/docker/singlenode/compose.sh ps -q hadoop-master)
       sudo apt-get update
       sudo apt-get -o "Dpkg::Options::=--force-confold" -y install docker-engine
       sudo rm /usr/local/bin/docker-compose


### PR DESCRIPTION
This is to recreate environment before tests are running.
This ensures clean environment regardless of previous runs using the same container.

The purpose of this PR is to force Travis executing cleanup because there's some corrupted state of container causing failure now (the exact same commit passes on my fork (https://travis-ci.org/maciejgrzybek/presto/builds/150155601) so it has to be a local issue on prestodb/presto Travis instances).