### PR TITLE
Start jmx history thread if there are tables configured to be sampled

### DIFF
--- a/presto-jmx/pom.xml
+++ b/presto-jmx/pom.xml
@@ -55,6 +55,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>


### PR DESCRIPTION
Start the jmx history sampler thread only if the user configures some tables to be sampled.