### PR TITLE
Use code generation for joins with filter function

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinFilterFunctionVerifier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinFilterFunctionVerifier.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.Block;
+
+public interface JoinFilterFunctionVerifier
+{
+    boolean applyFilterFunction(int leftBlockIndex, int leftPosition, int rightPosition, Block[] allRightBlocks);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesHashStrategy.java
@@ -15,9 +15,6 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
-import com.facebook.presto.spi.block.Block;
-
-import java.util.Optional;
 
 public interface PagesHashStrategy
 {
@@ -91,16 +88,6 @@ public interface PagesHashStrategy
      * This method does not perform any null checks.
      */
     boolean positionEqualsPositionIgnoreNulls(int leftBlockIndex, int leftPosition, int rightBlockIndex, int rightPosition);
-
-    /**
-     * Returns filter function assigned to this PagesHashStrategy.
-     */
-    Optional<JoinFilterFunction> getFilterFunction();
-
-    /**
-     * Checks result of filter function for given row.
-     */
-    boolean applyFilterFunction(int leftBlockIndex, int leftPosition, int rightPosition, Block[] allRightBlocks);
 
     /**
      * Checks if any of the hashed columns is null

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -323,7 +323,7 @@ public class PagesIndex
 
     private Optional<JoinFilterFunctionVerifier> createJoinFilterFunctionVerifier(Optional<JoinFilterFunction> filterFunctionOptional, List<List<Block>> channels)
     {
-        return filterFunctionOptional.map(filterFunction -> new StandardJoinFilterFunctionVerifier(filterFunction, channels));
+        return filterFunctionOptional.map(filterFunction -> joinCompiler.compileJoinFilterFunctionVerifierFactory(filterFunction).createJoinFilterFunctionVerifier(filterFunction, channels));
     }
 
     public LookupSource createLookupSource(List<Integer> joinChannels, Optional<Integer> hashChannel, Optional<JoinFilterFunction> filterFunction)

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -328,13 +328,9 @@ public class PagesIndex
 
     public LookupSource createLookupSource(List<Integer> joinChannels, Optional<Integer> hashChannel, Optional<JoinFilterFunction> filterFunction)
     {
-        if (!filterFunction.isPresent() && !joinChannels.isEmpty()) {
-            // todo compiled implementation of lookup join does not support:
-            //  (1) case with join function and the case
-            //  (2) when we are joining with empty join channels.
-
-            // Ad (1) we need to add support for filter function into compiled PagesHashStrategy/JoinProbe
-            // Ad (2) this code path will trigger only for OUTER joins. To fix that we need to add support for
+        if (!joinChannels.isEmpty()) {
+            // todo compiled implementation of lookup join does not support when we are joining with empty join channels.
+            // This code path will trigger only for OUTER joins. To fix that we need to add support for
             //        OUTER joins into NestedLoopsJoin and remove "type == INNER" condition in LocalExecutionPlanner.visitJoin()
 
             try {

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
@@ -20,32 +20,25 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.type.TypeUtils;
 import com.google.common.collect.ImmutableList;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class SimplePagesHashStrategy
         implements PagesHashStrategy
 {
-    private static final Block[] EMPTY_BLOCK_ARRAY = new Block[0];
     private final List<Type> types;
     private final List<List<Block>> channels;
-    private final List<Block[]> channelArrays;
     private final List<Integer> hashChannels;
     private final List<Block> precomputedHashChannel;
-    private final Optional<JoinFilterFunction> filterFunction;
 
-    public SimplePagesHashStrategy(List<Type> types, List<List<Block>> channels, List<Integer> hashChannels, Optional<Integer> precomputedHashChannel, Optional<JoinFilterFunction> filterFunction)
+    public SimplePagesHashStrategy(List<Type> types, List<List<Block>> channels, List<Integer> hashChannels, Optional<Integer> precomputedHashChannel)
     {
-        this.filterFunction = filterFunction;
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
         this.channels = ImmutableList.copyOf(requireNonNull(channels, "channels is null"));
-        this.channelArrays = buildChannelArrays(channels);
 
         checkArgument(types.size() == channels.size(), "Expected types and channels to be the same length");
         this.hashChannels = ImmutableList.copyOf(requireNonNull(hashChannels, "hashChannels is null"));
@@ -55,24 +48,6 @@ public class SimplePagesHashStrategy
         else {
             this.precomputedHashChannel = null;
         }
-    }
-
-    private List<Block[]> buildChannelArrays(List<List<Block>> channels)
-    {
-        if (channels.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        int pagesCount = channels.get(0).size();
-        List<Block[]> channelArrays = new ArrayList<>();
-        for (int i = 0; i < pagesCount; ++i) {
-            Block[] blocks = new Block[channels.size()];
-            for (int j = 0; j < channels.size(); ++j) {
-                blocks[j] = channels.get(j).get(i);
-            }
-            channelArrays.add(blocks);
-        }
-        return channelArrays;
     }
 
     @Override
@@ -133,7 +108,6 @@ public class SimplePagesHashStrategy
     @Override
     public boolean rowEqualsRow(int leftPosition, Page leftPage, int rightPosition, Page rightPage)
     {
-        checkState(!filterFunction.isPresent(), "filterFunction not supported for rowEqualsRow");
         for (int i = 0; i < hashChannels.size(); i++) {
             int hashChannel = hashChannels.get(i);
             Type type = types.get(hashChannel);
@@ -219,28 +193,6 @@ public class SimplePagesHashStrategy
             }
         }
         return true;
-    }
-
-    @Override
-    public Optional<JoinFilterFunction> getFilterFunction()
-    {
-        return filterFunction;
-    }
-
-    @Override
-    public boolean applyFilterFunction(int leftBlockIndex, int leftPosition, int rightPosition, Block[] allRightBlocks)
-    {
-        return filterFunction.get().filter(leftPosition, getLeftBlocks(leftBlockIndex), rightPosition, allRightBlocks);
-    }
-
-    private Block[] getLeftBlocks(int leftBlockIndex)
-    {
-        if (channelArrays.isEmpty()) {
-            return EMPTY_BLOCK_ARRAY;
-        }
-        else {
-            return channelArrays.get(leftBlockIndex);
-        }
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/StandardJoinFilterFunctionVerifier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StandardJoinFilterFunctionVerifier.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.Block;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class StandardJoinFilterFunctionVerifier
+        implements JoinFilterFunctionVerifier
+{
+    private static final Block[] EMPTY_BLOCK_ARRAY = new Block[0];
+
+    private final JoinFilterFunction filterFunction;
+    private final List<Block[]> pages;
+
+    public StandardJoinFilterFunctionVerifier(JoinFilterFunction filterFunction, List<List<Block>> channels)
+    {
+        this.filterFunction = requireNonNull(filterFunction, "filterFunction can not be null");
+
+        requireNonNull(channels, "channels can not be null");
+        ImmutableList.Builder<Block[]> pagesBuilder = ImmutableList.builder();
+        if (!channels.isEmpty()) {
+            int pagesCount = channels.get(0).size();
+            for (int pageIndex = 0; pageIndex < pagesCount; ++pageIndex) {
+                Block[] blocks = new Block[channels.size()];
+                for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
+                    blocks[channelIndex] = channels.get(channelIndex).get(pageIndex);
+                }
+                pagesBuilder.add(blocks);
+            }
+        }
+        this.pages = pagesBuilder.build();
+    }
+
+    @Override
+    public boolean applyFilterFunction(int leftBlockIndex, int leftPosition, int rightPosition, Block[] allRightBlocks)
+    {
+        return filterFunction.filter(leftPosition, getLeftBlocks(leftBlockIndex), rightPosition, allRightBlocks);
+    }
+
+    private Block[] getLeftBlocks(int leftBlockIndex)
+    {
+        if (pages.isEmpty()) {
+            return EMPTY_BLOCK_ARRAY;
+        }
+        else {
+            return pages.get(leftBlockIndex);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSnapshot.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSnapshot.java
@@ -25,6 +25,8 @@ import static java.util.Objects.requireNonNull;
 public class IndexSnapshot
         implements IndexedData
 {
+    private static final Page EMPTY_PAGE = new Page(0);
+
     private final LookupSource values;
     private final LookupSource missingKeys;
 
@@ -52,7 +54,7 @@ public class IndexSnapshot
     @Override
     public long getNextJoinPosition(long currentPosition)
     {
-        return values.getNextJoinPosition(currentPosition, -1, null);
+        return values.getNextJoinPosition(currentPosition, -1, EMPTY_PAGE);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -95,6 +95,7 @@ import com.facebook.presto.sql.Serialization.ExpressionSerializer;
 import com.facebook.presto.sql.Serialization.FunctionCallDeserializer;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
+import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.CompilerConfig;
@@ -258,6 +259,7 @@ public class ServerMainModule
         newExporter(binder).export(IndexJoinLookupStats.class).withGeneratedName();
         binder.bind(AsyncHttpExecutionMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(AsyncHttpExecutionMBean.class).withGeneratedName();
+        binder.bind(JoinFilterFunctionCompiler.class).in(Scopes.SINGLETON);
 
         jsonCodecBinder(binder).bindJsonCodec(TaskStatus.class);
         jsonCodecBinder(binder).bindJsonCodec(TaskInfo.class);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/InputReferenceCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/InputReferenceCompiler.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.gen;
+
+import com.facebook.presto.bytecode.BytecodeNode;
+import com.facebook.presto.bytecode.Scope;
+import com.facebook.presto.bytecode.Variable;
+import com.facebook.presto.bytecode.control.IfStatement;
+import com.facebook.presto.bytecode.expression.BytecodeExpression;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.relational.CallExpression;
+import com.facebook.presto.sql.relational.ConstantExpression;
+import com.facebook.presto.sql.relational.InputReferenceExpression;
+import com.facebook.presto.sql.relational.RowExpressionVisitor;
+import com.google.common.primitives.Primitives;
+import io.airlift.slice.Slice;
+
+import java.util.function.BiFunction;
+
+import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
+import static java.util.Objects.requireNonNull;
+
+class InputReferenceCompiler
+        implements RowExpressionVisitor<Scope, BytecodeNode>
+{
+    private final BiFunction<Scope, Integer, BytecodeExpression> blockResolver;
+    private final BiFunction<Scope, Integer, BytecodeExpression> positionResolver;
+    private final Variable wasNullVariable;
+    private final CallSiteBinder callSiteBinder;
+
+    public InputReferenceCompiler(
+            BiFunction<Scope, Integer, BytecodeExpression> blockResolver,
+            BiFunction<Scope, Integer, BytecodeExpression> positionResolver,
+            Variable wasNullVariable,
+            CallSiteBinder callSiteBinder)
+    {
+        this.blockResolver = requireNonNull(blockResolver, "blockResolver is null");
+        this.positionResolver = requireNonNull(positionResolver, "positionResolver is null");
+        this.wasNullVariable = requireNonNull(wasNullVariable, "wasNullVariable is null");
+        this.callSiteBinder = requireNonNull(callSiteBinder, "callSiteBinder is null");
+    }
+
+    @Override
+    public BytecodeNode visitInputReference(InputReferenceExpression node, Scope scope)
+    {
+        int field = node.getField();
+        Type type = node.getType();
+
+        BytecodeExpression block = blockResolver.apply(scope, field);
+        BytecodeExpression position = positionResolver.apply(scope, field);
+
+        Class<?> javaType = type.getJavaType();
+        if (!javaType.isPrimitive() && javaType != Slice.class) {
+            javaType = Object.class;
+        }
+
+        IfStatement ifStatement = new IfStatement();
+        ifStatement.condition(block.invoke("isNull", boolean.class, position));
+
+        ifStatement.ifTrue()
+                .putVariable(wasNullVariable, true)
+                .pushJavaDefault(javaType);
+
+        String methodName = "get" + Primitives.wrap(javaType).getSimpleName();
+        ifStatement.ifFalse(constantType(callSiteBinder, type).invoke(methodName, javaType, block, position));
+
+        return ifStatement;
+    }
+
+    @Override
+    public BytecodeNode visitCall(CallExpression call, Scope scope)
+    {
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+
+    @Override
+    public BytecodeNode visitConstant(ConstantExpression literal, Scope scope)
+    {
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
@@ -28,9 +28,11 @@ import com.facebook.presto.bytecode.control.IfStatement;
 import com.facebook.presto.bytecode.expression.BytecodeExpression;
 import com.facebook.presto.bytecode.instruction.LabelNode;
 import com.facebook.presto.operator.InMemoryJoinHash;
+import com.facebook.presto.operator.JoinFilterFunction;
 import com.facebook.presto.operator.JoinFilterFunctionVerifier;
 import com.facebook.presto.operator.LookupSource;
 import com.facebook.presto.operator.PagesHashStrategy;
+import com.facebook.presto.operator.StandardJoinFilterFunctionVerifier;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
@@ -47,6 +49,7 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -84,12 +87,28 @@ public class JoinCompiler
             });
 
     private final LoadingCache<CacheKey, Class<? extends PagesHashStrategy>> hashStrategies = CacheBuilder.newBuilder().maximumSize(1000).build(
-            new CacheLoader<CacheKey, Class<? extends PagesHashStrategy>>() {
+            new CacheLoader<CacheKey, Class<? extends PagesHashStrategy>>()
+            {
                 @Override
                 public Class<? extends PagesHashStrategy> load(CacheKey key)
                         throws Exception
                 {
                     return internalCompileHashStrategy(key.getTypes(), key.getJoinChannels());
+                }
+            });
+
+    private final LoadingCache<Class<? extends JoinFilterFunction>, Class<? extends JoinFilterFunctionVerifier>> joinFilterFunctionVerifierClasses = CacheBuilder.newBuilder().maximumSize(1000).build(
+            new CacheLoader<Class<? extends JoinFilterFunction>, Class<? extends JoinFilterFunctionVerifier>>()
+            {
+                @Override
+                public Class<? extends JoinFilterFunctionVerifier> load(Class<? extends JoinFilterFunction> key)
+                        throws Exception
+                {
+                    return IsolatedClass.isolateClass(
+                            new DynamicClassLoader(getClass().getClassLoader()),
+                            JoinFilterFunctionVerifier.class,
+                            StandardJoinFilterFunctionVerifier.class
+                    );
                 }
             });
 
@@ -101,6 +120,21 @@ public class JoinCompiler
         catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
             throw Throwables.propagate(e.getCause());
         }
+    }
+
+    public JoinFilterFunctionVerifierFactory compileJoinFilterFunctionVerifierFactory(JoinFilterFunction joinFilterFunction)
+    {
+        return ((filterFunction, channels) -> {
+            try {
+                return joinFilterFunctionVerifierClasses
+                        .get(joinFilterFunction.getClass())
+                        .getConstructor(JoinFilterFunction.class, List.class)
+                        .newInstance(filterFunction, channels);
+            }
+            catch (ExecutionException | UncheckedExecutionException | ExecutionError | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                throw Throwables.propagate(e.getCause());
+            }
+        });
     }
 
     public PagesHashStrategyFactory compilePagesHashStrategyFactory(List<Type> types, List<Integer> joinChannels)
@@ -191,7 +225,7 @@ public class JoinCompiler
                 .invokeConstructor(Object.class);
 
         constructor.comment("this.size = 0")
-                    .append(thisVariable.setField(sizeField, constantLong(0L)));
+                .append(thisVariable.setField(sizeField, constantLong(0L)));
 
         constructor.comment("Set channel fields");
 
@@ -218,9 +252,9 @@ public class JoinCompiler
                     .getField(sizeField)
                     .append(
                             channel.invoke("get", Object.class, blockIndex)
-                            .cast(type(Block.class))
-                            .invoke("getRetainedSizeInBytes", int.class)
-                            .cast(long.class))
+                                    .cast(type(Block.class))
+                                    .invoke("getRetainedSizeInBytes", int.class)
+                                    .cast(long.class))
                     .longAdd()
                     .putField(sizeField);
         }
@@ -425,9 +459,9 @@ public class JoinCompiler
     private static BytecodeNode typeHashCode(BytecodeExpression type, BytecodeExpression blockRef, BytecodeExpression blockPosition)
     {
         return new IfStatement()
-            .condition(blockRef.invoke("isNull", boolean.class, blockPosition))
-            .ifTrue(constantLong(0L))
-            .ifFalse(type.invoke("hash", long.class, blockRef, blockPosition));
+                .condition(blockRef.invoke("isNull", boolean.class, blockPosition))
+                .ifTrue(constantLong(0L))
+                .ifFalse(type.invoke("hash", long.class, blockRef, blockPosition));
     }
 
     private static void generateRowEqualsRowMethod(
@@ -717,6 +751,11 @@ public class JoinCompiler
                 throw Throwables.propagate(e);
             }
         }
+    }
+
+    public interface JoinFilterFunctionVerifierFactory
+    {
+        JoinFilterFunctionVerifier createJoinFilterFunctionVerifier(JoinFilterFunction filterFunction, List<List<Block>> channels);
     }
 
     private static final class CacheKey

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
@@ -21,7 +21,6 @@ import com.facebook.presto.bytecode.FieldDefinition;
 import com.facebook.presto.bytecode.MethodDefinition;
 import com.facebook.presto.bytecode.OpCode;
 import com.facebook.presto.bytecode.Parameter;
-import com.facebook.presto.bytecode.Scope;
 import com.facebook.presto.bytecode.Variable;
 import com.facebook.presto.bytecode.control.ForLoop;
 import com.facebook.presto.bytecode.control.IfStatement;
@@ -482,7 +481,6 @@ public class JoinCompiler
                 rightPosition,
                 rightPage);
 
-        Scope compilerContext = rowEqualsRowMethod.getScope();
         for (int index = 0; index < joinChannelTypes.size(); index++) {
             BytecodeExpression type = constantType(callSiteBinder, joinChannelTypes.get(index));
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.gen;
+
+import com.facebook.presto.bytecode.BytecodeBlock;
+import com.facebook.presto.bytecode.BytecodeNode;
+import com.facebook.presto.bytecode.ClassDefinition;
+import com.facebook.presto.bytecode.MethodDefinition;
+import com.facebook.presto.bytecode.Parameter;
+import com.facebook.presto.bytecode.Scope;
+import com.facebook.presto.bytecode.Variable;
+import com.facebook.presto.bytecode.control.IfStatement;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.operator.JoinFilterFunction;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.relational.CallExpression;
+import com.facebook.presto.sql.relational.ConstantExpression;
+import com.facebook.presto.sql.relational.InputReferenceExpression;
+import com.facebook.presto.sql.relational.RowExpression;
+import com.facebook.presto.sql.relational.RowExpressionVisitor;
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Primitives;
+import com.google.inject.Inject;
+import io.airlift.slice.Slice;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.bytecode.Access.FINAL;
+import static com.facebook.presto.bytecode.Access.PUBLIC;
+import static com.facebook.presto.bytecode.Access.a;
+import static com.facebook.presto.bytecode.CompilerUtils.defineClass;
+import static com.facebook.presto.bytecode.CompilerUtils.makeClassName;
+import static com.facebook.presto.bytecode.Parameter.arg;
+import static com.facebook.presto.bytecode.ParameterizedType.type;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantFalse;
+import static com.facebook.presto.sql.gen.BytecodeUtils.invoke;
+import static com.facebook.presto.sql.gen.BytecodeUtils.loadConstant;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class JoinFilterFunctionCompiler
+{
+    private final Metadata metadata;
+
+    @Inject
+    public JoinFilterFunctionCompiler(Metadata metadata)
+    {
+        this.metadata = metadata;
+    }
+
+    private final LoadingCache<JoinFilterCacheKey, Class<? extends JoinFilterFunction>> joinFilterFunctions = CacheBuilder.newBuilder().maximumSize(1000).build(
+            new CacheLoader<JoinFilterCacheKey, Class<? extends JoinFilterFunction>>()
+            {
+                @Override
+                public Class<? extends JoinFilterFunction> load(JoinFilterCacheKey key)
+                        throws Exception
+                {
+                    return compileFilterFunctionInternal(key.getFilter(), key.getLeftBlocksSize());
+                }
+            });
+
+    public Supplier<JoinFilterFunction> compileJoinFilterFunction(RowExpression filter, int leftBlocksSize)
+    {
+        Class<? extends JoinFilterFunction> joinFilterFunction = joinFilterFunctions.getUnchecked(new JoinFilterCacheKey(filter, leftBlocksSize));
+        return () -> {
+            try {
+                return joinFilterFunction.newInstance();
+            }
+            catch (ReflectiveOperationException e) {
+                throw Throwables.propagate(e);
+            }
+        };
+    }
+
+    private Class<? extends JoinFilterFunction> compileFilterFunctionInternal(RowExpression filterExpression, int leftBlocksSize)
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                makeClassName("JoinFilterFunction"),
+                type(Object.class),
+                type(JoinFilterFunction.class));
+
+        CallSiteBinder callSiteBinder = new CallSiteBinder();
+
+        new JoinFilterFunctionCompiler(metadata).generateMethods(classDefinition, callSiteBinder, filterExpression, leftBlocksSize);
+
+        //
+        // toString method
+        //
+        generateToString(
+                classDefinition,
+                callSiteBinder,
+                toStringHelper(classDefinition.getType().getJavaClassName())
+                        .add("filter", filterExpression)
+                        .add("leftBlocksSize", leftBlocksSize)
+                        .toString());
+
+        return defineClass(classDefinition, JoinFilterFunction.class, callSiteBinder.getBindings(), getClass().getClassLoader());
+    }
+
+    private void generateMethods(ClassDefinition classDefinition, CallSiteBinder callSiteBinder, RowExpression filter, int leftBlocksSize)
+    {
+        CachedInstanceBinder cachedInstanceBinder = new CachedInstanceBinder(classDefinition, callSiteBinder);
+        generateFilterMethod(classDefinition, callSiteBinder, cachedInstanceBinder, filter, leftBlocksSize);
+        classDefinition.declareDefaultConstructor(a(PUBLIC));
+    }
+
+    private void generateFilterMethod(ClassDefinition classDefinition, CallSiteBinder callSiteBinder, CachedInstanceBinder cachedInstanceBinder, RowExpression filter, int leftBlocksSize)
+    {
+        // todo handle TRY expression
+        Map<CallExpression, MethodDefinition> tryMethodMap = ImmutableMap.of();
+
+        // int leftPosition, Block[] leftBlocks, int rightPosition, Block[] rightBlocks
+        Parameter leftPosition = arg("leftPosition", int.class);
+        Parameter leftBlocks = arg("leftBlocks", Block[].class);
+        Parameter rightPosition = arg("rightPosition", int.class);
+        Parameter rightBlocks = arg("rightBlocks", Block[].class);
+
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC),
+                "filter",
+                type(boolean.class),
+                ImmutableList.<Parameter>builder()
+                        .add(leftPosition)
+                        .add(leftBlocks)
+                        .add(rightPosition)
+                        .add(rightBlocks)
+                        .build());
+
+        method.comment("filter: %s", filter.toString());
+        BytecodeBlock body = method.getBody();
+
+        Scope scope = method.getScope();
+        Variable wasNullVariable = scope.declareVariable("wasNull", body, constantFalse());
+
+        BytecodeExpressionVisitor visitor = new BytecodeExpressionVisitor(
+                callSiteBinder,
+                cachedInstanceBinder,
+                fieldReferenceCompiler(callSiteBinder, leftPosition, leftBlocks, rightPosition, rightBlocks, leftBlocksSize, wasNullVariable),
+                metadata.getFunctionRegistry(),
+                tryMethodMap);
+
+        BytecodeNode visitorBody = filter.accept(visitor, scope);
+
+        Variable result = scope.declareVariable(boolean.class, "result");
+        body.append(visitorBody)
+                .putVariable(result)
+                .append(new IfStatement()
+                        .condition(wasNullVariable)
+                        .ifTrue(constantFalse().ret())
+                        .ifFalse(result.ret()));
+    }
+
+    private static void generateToString(ClassDefinition classDefinition, CallSiteBinder callSiteBinder, String string)
+    {
+        // bind constant via invokedynamic to avoid constant pool issues due to large strings
+        classDefinition.declareMethod(a(PUBLIC), "toString", type(String.class))
+                .getBody()
+                .append(invoke(callSiteBinder.bind(string, String.class), "toString"))
+                .retObject();
+    }
+
+    private static RowExpressionVisitor<Scope, BytecodeNode> fieldReferenceCompiler(
+            final CallSiteBinder callSiteBinder,
+            final Variable leftPosition,
+            final Variable leftBlocks,
+            final Variable rightPosition,
+            final Variable rightBlocks,
+            final int leftBlocksSize,
+            final Variable wasNullVariable)
+    {
+        return new RowExpressionVisitor<Scope, BytecodeNode>()
+        {
+            @Override
+            public BytecodeNode visitInputReference(InputReferenceExpression node, Scope scope)
+            {
+                int field = node.getField();
+                Type type = node.getType();
+
+                Class<?> javaType = type.getJavaType();
+                if (!javaType.isPrimitive() && javaType != Slice.class) {
+                    javaType = Object.class;
+                }
+
+                Variable blocksVariable;
+                Variable positionVariable;
+                if (field < leftBlocksSize) {
+                    blocksVariable = leftBlocks;
+                    positionVariable = leftPosition;
+                }
+                else {
+                    blocksVariable = rightBlocks;
+                    positionVariable = rightPosition;
+                    field -= leftBlocksSize;
+                }
+
+                IfStatement ifStatement = new IfStatement();
+                ifStatement.condition()
+                        .setDescription(format("block_%d.get%s()", field, type))
+                        .append(blocksVariable.getElement(field))
+                        .append(positionVariable)
+                        .invokeInterface(Block.class, "isNull", boolean.class, int.class);
+
+                ifStatement.ifTrue()
+                        .putVariable(wasNullVariable, true)
+                        .pushJavaDefault(javaType);
+
+                String methodName = "get" + Primitives.wrap(javaType).getSimpleName();
+
+                ifStatement.ifFalse()
+                        .append(loadConstant(callSiteBinder.bind(type, Type.class)))
+                        .append(blocksVariable.getElement(field))
+                        .append(positionVariable)
+                        .invokeInterface(Type.class, methodName, javaType, Block.class, int.class);
+
+                return ifStatement;
+            }
+
+            @Override
+            public BytecodeNode visitCall(CallExpression call, Scope scope)
+            {
+                throw new UnsupportedOperationException("only input references are supported");
+            }
+
+            @Override
+            public BytecodeNode visitConstant(ConstantExpression literal, Scope scope)
+            {
+                throw new UnsupportedOperationException("only input references are supported");
+            }
+        };
+    }
+
+    private static final class JoinFilterCacheKey
+    {
+        private final RowExpression filter;
+        private final int leftBlocksSize;
+
+        public JoinFilterCacheKey(RowExpression filter, int leftBlocksSize)
+        {
+            this.filter = requireNonNull(filter, "filter can not be null");
+            this.leftBlocksSize = leftBlocksSize;
+        }
+
+        public RowExpression getFilter()
+        {
+            return filter;
+        }
+
+        public int getLeftBlocksSize()
+        {
+            return leftBlocksSize;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            JoinFilterCacheKey that = (JoinFilterCacheKey) o;
+            return leftBlocksSize == that.leftBlocksSize &&
+                    Objects.equals(filter, that.filter);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(filter, leftBlocksSize);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("filter", filter)
+                    .add("leftBlocksSize", leftBlocksSize)
+                    .toString();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1571,7 +1571,7 @@ public class LocalExecutionPlanner
                     emptyList() /* parameters have already been replaced */);
 
             RowExpression translatedFilter = toRowExpression(rewrittenFilter, expressionTypes);
-            return joinFilterFunctionCompiler.compileJoinFilterFunction(translatedFilter, buildLayout.size()).get();
+            return joinFilterFunctionCompiler.compileJoinFilterFunction(translatedFilter, buildLayout.size()).create(session.toConnectorSession());
         }
 
         private OperatorFactory createLookupJoin(

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -95,6 +95,7 @@ import com.facebook.presto.sql.analyzer.Analyzer;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
+import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.CompilerConfig;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
@@ -194,7 +195,8 @@ public class LocalQueryRunner
     private final PageSinkManager pageSinkManager;
     private final TransactionManager transactionManager;
 
-    private final ExpressionCompiler compiler;
+    private final ExpressionCompiler expressionCompiler;
+    private final JoinFilterFunctionCompiler joinFilterFunctionCompiler;
     private final ConnectorManager connectorManager;
     private final ImmutableMap<Class<? extends Statement>, DataDefinitionTask<?>> dataDefinitionTask;
 
@@ -251,7 +253,8 @@ public class LocalQueryRunner
         this.eventListener = new TestingEventListenerManager();
         this.pageSourceManager = new PageSourceManager();
 
-        this.compiler = new ExpressionCompiler(metadata);
+        this.expressionCompiler = new ExpressionCompiler(metadata);
+        this.joinFilterFunctionCompiler = new JoinFilterFunctionCompiler(metadata);
 
         this.connectorManager = new ConnectorManager(
                 metadata,
@@ -526,7 +529,8 @@ public class LocalQueryRunner
                 nodePartitioningManager,
                 pageSinkManager,
                 null,
-                compiler,
+                expressionCompiler,
+                joinFilterFunctionCompiler,
                 new IndexJoinLookupStats(),
                 new CompilerConfig().setInterpreterEnabled(false), // make sure tests fail if compiler breaks
                 new TaskManagerConfig().setTaskConcurrency(4));

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.split.PageSinkManager;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
+import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.CompilerConfig;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
@@ -118,6 +119,7 @@ public final class TaskTestUtils
                 new PageSinkManager(),
                 new MockExchangeClientSupplier(),
                 new ExpressionCompiler(metadata),
+                new JoinFilterFunctionCompiler(metadata),
                 new IndexJoinLookupStats(),
                 new CompilerConfig(),
                 new TaskManagerConfig());

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
@@ -180,7 +180,7 @@ public class TestJoinCompiler
         PagesHashStrategyFactory pagesHashStrategyFactory = joinCompiler.compilePagesHashStrategyFactory(types, joinChannels);
         PagesHashStrategy hashStrategy = pagesHashStrategyFactory.createPagesHashStrategy(channels, hashChannel);
         // todo add tests for filter function
-        PagesHashStrategy expectedHashStrategy = new SimplePagesHashStrategy(types, channels, joinChannels, hashChannel, Optional.empty());
+        PagesHashStrategy expectedHashStrategy = new SimplePagesHashStrategy(types, channels, joinChannels, hashChannel);
 
         // verify channel count
         assertEquals(hashStrategy.getChannelCount(), types.size());

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinProbeCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinProbeCompiler.java
@@ -109,7 +109,7 @@ public class TestJoinProbeCompiler
             hashChannel = Optional.of(1);
             channels = ImmutableList.of(channel, hashChannelBuilder.build());
         }
-        LookupSource lookupSource = lookupSourceFactoryFactory.createLookupSource(addresses, channels, hashChannel);
+        LookupSource lookupSource = lookupSourceFactoryFactory.createLookupSource(addresses, channels, hashChannel, Optional.empty());
 
         JoinProbeCompiler joinProbeCompiler = new JoinProbeCompiler();
         JoinProbeFactory probeFactory = joinProbeCompiler.internalCompileJoinProbe(types, Ints.asList(0), hashChannel);

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinProbeCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinProbeCompiler.java
@@ -15,7 +15,6 @@ package com.facebook.presto.sql.gen;
 
 import com.facebook.presto.SequencePageBuilder;
 import com.facebook.presto.block.BlockAssertions;
-import com.facebook.presto.operator.DriverContext;
 import com.facebook.presto.operator.JoinProbe;
 import com.facebook.presto.operator.JoinProbeFactory;
 import com.facebook.presto.operator.LookupSource;
@@ -79,7 +78,7 @@ public class TestJoinProbeCompiler
     public void testSingleChannel(boolean hashEnabled)
             throws Exception
     {
-        DriverContext driverContext = taskContext.addPipelineContext(true, true).addDriverContext();
+        taskContext.addPipelineContext(true, true).addDriverContext();
 
         ImmutableList<Type> types = ImmutableList.<Type>of(VARCHAR);
         LookupSourceFactory lookupSourceFactoryFactory = joinCompiler.compileLookupSourceFactory(types, Ints.asList(0));

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2112,6 +2112,14 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testNonEqalityJoinWithScalarRequiringSessionParameter()
+            throws Exception
+    {
+        assertQuery("SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND from_unixtime(b) > current_timestamp",
+                "VALUES (1, 1, NULL, NULL), (1, 2, NULL, NULL)");
+    }
+
+    @Test
     public void testLeftJoinWithEmptyInnerTable()
             throws Exception
     {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2120,6 +2120,20 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testNonEqualityJoinWithTryInFilter()
+            throws Exception
+    {
+        assertQuery("SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) " +
+                "             ON a=c AND TRY(1 / (b-a) != 1000)",
+                "VALUES (1, 1, NULL, NULL), (1, 2, 1, 1), (1, 2, 1, 2)");
+
+        // use of scalar requiring session parameter within try
+        assertQuery("SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) " +
+                        "             ON a=c AND TRY(1 / (b-a) != 1000 OR from_unixtime(b) > current_timestamp)",
+                "VALUES (1, 1, NULL, NULL), (1, 2, 1, 1), (1, 2, 1, 2)");
+    }
+
+    @Test
     public void testLeftJoinWithEmptyInnerTable()
             throws Exception
     {


### PR DESCRIPTION
This PR extends the non-equality-outer-joins. It adds flow for execution joins with filter function using compiled version of PagesHashStrategy.