### PR TITLE
Merge filter to inner join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
@@ -425,7 +425,7 @@ public class PlanPrinter
             node.getFilter().ifPresent(expression -> joinExpressions.add(expression));
 
             // Check if the node is actually a cross join node
-            if (node.getType() == JoinNode.Type.INNER && node.getCriteria().isEmpty()) {
+            if (node.getType() == JoinNode.Type.INNER && joinExpressions.isEmpty()) {
                 print(indent, "- CrossJoin => [%s]", formatOutputs(node.getOutputSymbols()));
             }
             else {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -82,7 +82,6 @@ import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
-import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.equalTo;
@@ -622,18 +621,7 @@ public class PredicatePushDown
             rightPushDownConjuncts.addAll(allInferenceWithoutRightInferred.generateEqualitiesPartitionedBy(not(in(leftSymbols))).getScopeEqualities());
             joinConjuncts.addAll(allInference.generateEqualitiesPartitionedBy(in(leftSymbols)).getScopeStraddlingEqualities()); // scope straddling equalities get dropped in as part of the join predicate
 
-            // Since we only currently support equality in join conjuncts, factor out the non-equality conjuncts to a post-join filter
-            List<Expression> joinConjunctsList = joinConjuncts.build();
-
-            List<Expression> postJoinConjuncts = joinConjunctsList.stream()
-                    .filter(joinEqualityExpression(leftSymbols).negate())
-                    .collect(toImmutableList());
-
-            joinConjunctsList = joinConjunctsList.stream()
-                    .filter(joinEqualityExpression(leftSymbols))
-                    .collect(toImmutableList());
-
-            return new InnerJoinPushDownResult(combineConjuncts(leftPushDownConjuncts.build()), combineConjuncts(rightPushDownConjuncts.build()), combineConjuncts(joinConjunctsList), combineConjuncts(postJoinConjuncts));
+            return new InnerJoinPushDownResult(combineConjuncts(leftPushDownConjuncts.build()), combineConjuncts(rightPushDownConjuncts.build()), combineConjuncts(joinConjuncts.build()), BooleanLiteral.TRUE_LITERAL);
         }
 
         private static class InnerJoinPushDownResult

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import static com.facebook.presto.spi.predicate.Domain.singleValue;
@@ -417,13 +418,12 @@ public class TestLogicalPlanner
                                         ))))));
         assertPlan(query, anyTree(
                 project(
-                        filter(filter,
-                                join(INNER, ImmutableList.of(),
-                                        tableScan("orders").withSymbol("orderkey", columnMapping),
-                                        node(EnforceSingleRowNode.class,
-                                                node(AggregationNode.class,
-                                                        node(ValuesNode.class)).withSymbol(function, functionAlias)
-                                        ))))));
+                        join(INNER, ImmutableList.of(), Optional.of(filter),
+                                tableScan("orders").withSymbol("orderkey", columnMapping),
+                                node(EnforceSingleRowNode.class,
+                                        node(AggregationNode.class,
+                                                node(ValuesNode.class)).withSymbol(function, functionAlias)
+                                )))));
     }
 
     private static final class PlanNodeExtractor

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -232,7 +232,7 @@ public class TestLogicalPlanner
                                 anyTree(
                                         node(AggregationNode.class,
                                                 anyTree(
-                                                        join(LEFT, ImmutableList.of(),
+                                                        join(LEFT, ImmutableList.of(), Optional.of("orderkey = BIGINT '3'"),
                                                                 anyTree(
                                                                         tableScan("orders")),
                                                                 anyTree(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -107,7 +107,12 @@ public final class PlanMatchPattern
 
     public static PlanMatchPattern join(JoinNode.Type joinType, List<AliasPair> expectedEquiCriteria, PlanMatchPattern left, PlanMatchPattern right)
     {
-        return node(JoinNode.class, left, right).with(new JoinMatcher(joinType, expectedEquiCriteria));
+        return join(joinType, expectedEquiCriteria, Optional.empty(), left, right);
+    }
+
+    public static PlanMatchPattern join(JoinNode.Type joinType, List<AliasPair> expectedEquiCriteria, Optional<String> expectedFilter, PlanMatchPattern left, PlanMatchPattern right)
+    {
+        return node(JoinNode.class, left, right).with(new JoinMatcher(joinType, expectedEquiCriteria, expectedFilter.map(predicate -> new SqlParser().createExpression(predicate))));
     }
 
     public static AliasPair aliasPair(String left, String right)


### PR DESCRIPTION
This patch merges inherited predicate to `JoinNode` instead of creating separate `FilterNode` for INNER joins.
This provides huge speed up for queries where JOIN produces huge result
which is then filtered out by highly selective filter node.

Example speedup for query (which produces no rows):

``` sql
      SELECT * FROM t t1 JOIN t t2 ON t1.a = t2.a WHERE (t1.b+t2.b)*5 > 100000000
```

where table t is defined as:

``` sql
      CREATE TABLE t AS SELECT
          orderkey % 1000 as a,
          orderkey % 1000 as b,
          comment as c1,
          comment as c2,
          comment as c3,
          comment as c4
          FROM tpch.sf1.orders LIMIT 100
```

No merging:

```
     avgt   30  153.578 ± 1.424  ms/op
```

With filter merged in to join:

```
     avgt   30  15.832 ± 0.901  ms/op
```
