### PR TITLE
Spilling to disk for aggregation v2

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -17,13 +17,18 @@ import com.facebook.presto.operator.aggregation.Accumulator;
 import com.facebook.presto.operator.aggregation.AccumulatorFactory;
 import com.facebook.presto.operator.aggregation.builder.HashAggregationBuilder;
 import com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder;
+import com.facebook.presto.operator.aggregation.builder.SpillableHashAggregationBuilder;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spiller.Spiller;
+import com.facebook.presto.spiller.SpillerFactory;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.type.TypeUtils;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 
 import java.util.Iterator;
@@ -33,11 +38,15 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder.toTypes;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.concurrent.MoreFutures.toListenableFuture;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
 
 public class HashAggregationOperator
         implements Operator
 {
+    private static final double MERGE_WITH_MEMORY_RATIO = 0.9;
+
     public static class HashAggregationOperatorFactory
             implements OperatorFactory
     {
@@ -54,6 +63,10 @@ public class HashAggregationOperator
         private final int expectedGroups;
         private final List<Type> types;
         private final DataSize maxPartialMemory;
+        private final boolean spillEnabled;
+        private final DataSize memoryLimitBeforeSpill;
+        private final DataSize memoryLimitForMergeWithMemory;
+        private final SpillerFactory spillerFactory;
 
         private boolean closed;
 
@@ -70,6 +83,86 @@ public class HashAggregationOperator
                 int expectedGroups,
                 DataSize maxPartialMemory)
         {
+            this(operatorId,
+                    planNodeId,
+                    groupByTypes,
+                    groupByChannels,
+                    globalAggregationGroupIds,
+                    step,
+                    accumulatorFactories,
+                    hashChannel,
+                    groupIdChannel,
+                    expectedGroups,
+                    maxPartialMemory,
+                    false,
+                    new DataSize(0, MEGABYTE),
+                    new DataSize(0, MEGABYTE),
+                    new SpillerFactory() {
+                        @Override
+                        public Spiller create(List<Type> types)
+                        {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public long getSpilledBytes()
+                        {
+                            return 0;
+                        }
+                    });
+        }
+
+        public HashAggregationOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                List<? extends Type> groupByTypes,
+                List<Integer> groupByChannels,
+                List<Integer> globalAggregationGroupIds,
+                Step step,
+                List<AccumulatorFactory> accumulatorFactories,
+                Optional<Integer> hashChannel,
+                Optional<Integer> groupIdChannel,
+                int expectedGroups,
+                DataSize maxPartialMemory,
+                boolean spillEnabled,
+                DataSize memoryLimitBeforeSpill,
+                SpillerFactory spillerFactory)
+        {
+            this(operatorId,
+                    planNodeId,
+                    groupByTypes,
+                    groupByChannels,
+                    globalAggregationGroupIds,
+                    step,
+                    accumulatorFactories,
+                    hashChannel,
+                    groupIdChannel,
+                    expectedGroups,
+                    maxPartialMemory,
+                    spillEnabled,
+                    memoryLimitBeforeSpill,
+                    DataSize.succinctBytes((long) (memoryLimitBeforeSpill.toBytes() * MERGE_WITH_MEMORY_RATIO)),
+                    spillerFactory);
+        }
+
+        @VisibleForTesting
+        HashAggregationOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                List<? extends Type> groupByTypes,
+                List<Integer> groupByChannels,
+                List<Integer> globalAggregationGroupIds,
+                Step step,
+                List<AccumulatorFactory> accumulatorFactories,
+                Optional<Integer> hashChannel,
+                Optional<Integer> groupIdChannel,
+                int expectedGroups,
+                DataSize maxPartialMemory,
+                boolean spillEnabled,
+                DataSize memoryLimitBeforeSpill,
+                DataSize memoryLimitForMergeWithMemory,
+                SpillerFactory spillerFactory)
+        {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.hashChannel = requireNonNull(hashChannel, "hashChannel is null");
@@ -81,6 +174,10 @@ public class HashAggregationOperator
             this.accumulatorFactories = ImmutableList.copyOf(accumulatorFactories);
             this.expectedGroups = expectedGroups;
             this.maxPartialMemory = requireNonNull(maxPartialMemory, "maxPartialMemory is null");
+            this.spillEnabled = spillEnabled;
+            this.memoryLimitBeforeSpill = requireNonNull(memoryLimitBeforeSpill, "memoryLimitBeforeSpill is null");
+            this.memoryLimitForMergeWithMemory = requireNonNull(memoryLimitForMergeWithMemory, "memoryLimitForMergeWithMemory is null");
+            this.spillerFactory = requireNonNull(spillerFactory, "spillerFactory is null");
 
             this.types = toTypes(groupByTypes, step, accumulatorFactories, hashChannel);
         }
@@ -107,7 +204,11 @@ public class HashAggregationOperator
                     hashChannel,
                     groupIdChannel,
                     expectedGroups,
-                    maxPartialMemory);
+                    maxPartialMemory,
+                    spillEnabled,
+                    memoryLimitBeforeSpill,
+                    memoryLimitForMergeWithMemory,
+                    spillerFactory);
             return hashAggregationOperator;
         }
 
@@ -131,7 +232,11 @@ public class HashAggregationOperator
                     hashChannel,
                     groupIdChannel,
                     expectedGroups,
-                    maxPartialMemory);
+                    maxPartialMemory,
+                    spillEnabled,
+                    memoryLimitBeforeSpill,
+                    memoryLimitForMergeWithMemory,
+                    spillerFactory);
         }
     }
 
@@ -145,6 +250,10 @@ public class HashAggregationOperator
     private final Optional<Integer> groupIdChannel;
     private final int expectedGroups;
     private final DataSize maxPartialMemory;
+    private final boolean spillEnabled;
+    private final DataSize memoryLimitBeforeSpill;
+    private final DataSize memoryLimitForMergeWithMemory;
+    private final SpillerFactory spillerFactory;
 
     private final List<Type> types;
 
@@ -164,7 +273,11 @@ public class HashAggregationOperator
             Optional<Integer> hashChannel,
             Optional<Integer> groupIdChannel,
             int expectedGroups,
-            DataSize maxPartialMemory)
+            DataSize maxPartialMemory,
+            boolean spillEnabled,
+            DataSize memoryLimitBeforeSpill,
+            DataSize memoryLimitForMergeWithMemory,
+            SpillerFactory spillerFactory)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         requireNonNull(step, "step is null");
@@ -181,6 +294,10 @@ public class HashAggregationOperator
         this.expectedGroups = expectedGroups;
         this.maxPartialMemory = requireNonNull(maxPartialMemory, "maxPartialMemory is null");
         this.types = toTypes(groupByTypes, step, accumulatorFactories, hashChannel);
+        this.spillEnabled = spillEnabled;
+        this.memoryLimitBeforeSpill = requireNonNull(memoryLimitBeforeSpill, "memoryLimitBeforeSpill is null");
+        this.memoryLimitForMergeWithMemory = requireNonNull(memoryLimitForMergeWithMemory, "memoryLimitForMergeWithMemory is null");
+        this.spillerFactory = requireNonNull(spillerFactory, "spillerFactory is null");
     }
 
     @Override
@@ -208,9 +325,26 @@ public class HashAggregationOperator
     }
 
     @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        if (aggregationBuilder != null) {
+            return toListenableFuture(aggregationBuilder.isBlocked());
+        }
+        return NOT_BLOCKED;
+    }
+
+    @Override
     public boolean needsInput()
     {
-        return !finishing && outputIterator == null && (aggregationBuilder == null || !aggregationBuilder.isFull());
+        if (finishing || outputIterator != null) {
+            return false;
+        }
+        else if (aggregationBuilder != null && aggregationBuilder.isFull()) {
+            return false;
+        }
+        else {
+            return true;
+        }
     }
 
     @Override
@@ -221,15 +355,30 @@ public class HashAggregationOperator
         inputProcessed = true;
 
         if (aggregationBuilder == null) {
-            aggregationBuilder = new InMemoryHashAggregationBuilder(
-                    accumulatorFactories,
-                    step,
-                    expectedGroups,
-                    groupByTypes,
-                    groupByChannels,
-                    hashChannel,
-                    operatorContext,
-                    maxPartialMemory);
+            if (step.isOutputPartial() || !spillEnabled) {
+                aggregationBuilder = new InMemoryHashAggregationBuilder(
+                        accumulatorFactories,
+                        step,
+                        expectedGroups,
+                        groupByTypes,
+                        groupByChannels,
+                        hashChannel,
+                        operatorContext,
+                        maxPartialMemory);
+            }
+            else {
+                aggregationBuilder = new SpillableHashAggregationBuilder(
+                        accumulatorFactories,
+                        step,
+                        expectedGroups,
+                        groupByTypes,
+                        groupByChannels,
+                        hashChannel,
+                        operatorContext,
+                        memoryLimitBeforeSpill,
+                        memoryLimitForMergeWithMemory,
+                        spillerFactory);
+            }
 
             // assume initial aggregationBuilder is not full
         }
@@ -237,6 +386,7 @@ public class HashAggregationOperator
             checkState(!aggregationBuilder.isFull(), "Aggregation buffer is full");
         }
         aggregationBuilder.processPage(page);
+        aggregationBuilder.updateMemory();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/MergeHashSort.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MergeHashSort.java
@@ -38,6 +38,9 @@ public class MergeHashSort
     {
     }
 
+    /**
+     * Rows with same hash value are guaranteed to be in the same result page.
+     */
     public static Iterator<Page> merge(List<Type> keyTypes, List<Type> allTypes, List<Iterator<Page>> channels)
     {
         List<Iterator<PagePosition>> channelIterators = channels.stream().map(SingleChannelPagePositions::new).collect(toList());
@@ -101,7 +104,7 @@ public class MergeHashSort
         }
     }
 
-    public static interface PagePositions extends Iterator<PagePosition>
+    public interface PagePositions extends Iterator<PagePosition>
     {
     }
 
@@ -137,7 +140,6 @@ public class MergeHashSort
 
     /**
      * This class rewrites iterator over PagePosition to iterator over Pages.
-     * Positions with same hash value are guaranteed to be in the same result page.
      */
     public static class PageRewriteIterator
             implements Iterator<Page>

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/HashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/HashAggregationBuilder.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation.builder;
 import com.facebook.presto.spi.Page;
 
 import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
 
 public interface HashAggregationBuilder
         extends AutoCloseable
@@ -25,6 +26,10 @@ public interface HashAggregationBuilder
     Iterator<Page> buildResult();
 
     boolean isFull();
+
+    CompletableFuture<?> isBlocked();
+
+    void updateMemory();
 
     @Override
     void close();

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.aggregation.builder;
 
+import com.facebook.presto.array.IntBigArray;
 import com.facebook.presto.memory.LocalMemoryContext;
 import com.facebook.presto.operator.GroupByHash;
 import com.facebook.presto.operator.GroupByIdBlock;
@@ -23,21 +24,28 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import io.airlift.units.DataSize;
+import it.unimi.dsi.fastutil.ints.AbstractIntIterator;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntIterators;
 
+import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.operator.GroupByHash.createGroupByHash;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class InMemoryHashAggregationBuilder
         implements HashAggregationBuilder
@@ -61,6 +69,28 @@ public class InMemoryHashAggregationBuilder
             OperatorContext operatorContext,
             DataSize maxPartialMemory)
     {
+        this(accumulatorFactories,
+                step,
+                expectedGroups,
+                groupByTypes,
+                groupByChannels,
+                hashChannel,
+                operatorContext,
+                maxPartialMemory,
+                Optional.empty());
+    }
+
+    public InMemoryHashAggregationBuilder(
+            List<AccumulatorFactory> accumulatorFactories,
+            AggregationNode.Step step,
+            int expectedGroups,
+            List<Type> groupByTypes,
+            List<Integer> groupByChannels,
+            Optional<Integer> hashChannel,
+            OperatorContext operatorContext,
+            DataSize maxPartialMemory,
+            Optional<Integer> overwriteIntermediateChannelOffset)
+    {
         this.groupByHash = createGroupByHash(operatorContext.getSession(), groupByTypes, Ints.toArray(groupByChannels), hashChannel, expectedGroups);
         this.operatorContext = operatorContext;
         this.partial = step.isOutputPartial();
@@ -72,7 +102,11 @@ public class InMemoryHashAggregationBuilder
         requireNonNull(accumulatorFactories, "accumulatorFactories is null");
         for (int i = 0; i < accumulatorFactories.size(); i++) {
             AccumulatorFactory accumulatorFactory = accumulatorFactories.get(i);
-            builder.add(new Aggregator(accumulatorFactory, step));
+            Optional<Integer> overwriteIntermediateChannel = Optional.empty();
+            if (overwriteIntermediateChannelOffset.isPresent()) {
+                overwriteIntermediateChannel = Optional.of(overwriteIntermediateChannelOffset.get() + i);
+            }
+            builder.add(new Aggregator(accumulatorFactory, step, overwriteIntermediateChannel));
         }
         aggregators = builder.build();
     }
@@ -95,15 +129,12 @@ public class InMemoryHashAggregationBuilder
                 aggregator.processPage(groupIds, page);
             }
         }
-        updateMemory();
     }
 
-    private void updateMemory()
+    @Override
+    public void updateMemory()
     {
-        long memorySize = groupByHash.getEstimatedSize();
-        for (Aggregator aggregator : aggregators) {
-            memorySize += aggregator.getEstimatedSize();
-        }
+        long memorySize = getSizeInMemory();
         if (partial) {
             systemMemoryContext.setBytes(memorySize);
             full = (memorySize > maxPartialMemory);
@@ -112,7 +143,6 @@ public class InMemoryHashAggregationBuilder
             operatorContext.setMemoryReservation(memorySize);
         }
     }
-
     @Override
     public boolean isFull()
     {
@@ -120,30 +150,84 @@ public class InMemoryHashAggregationBuilder
     }
 
     @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        return completedFuture(null);
+    }
+
+    public long getSizeInMemory()
+    {
+        long sizeInMemory = groupByHash.getEstimatedSize();
+        for (Aggregator aggregator : aggregators) {
+            sizeInMemory += aggregator.getEstimatedSize();
+        }
+        return sizeInMemory;
+    }
+
+    /**
+     * building hash sorted results requires memory for sorting group IDs.
+     * This method returns size of that memory requirement.
+     */
+    public long getGroupIdsSortingSize()
+    {
+        return getGroupCount() * Integer.BYTES;
+    }
+
+    public void setOutputPartial()
+    {
+        for (Aggregator aggregator : aggregators) {
+            aggregator.setOutputPartial();
+        }
+    }
+
+    public int getKeyChannels()
+    {
+        return groupByHash.getTypes().size();
+    }
+
+    public long getGroupCount()
+    {
+        return groupByHash.getGroupCount();
+    }
+
+    @Override
     public Iterator<Page> buildResult()
     {
-        List<Type> types = new ArrayList<>(groupByHash.getTypes());
-        for (Aggregator aggregator : aggregators) {
-            types.add(aggregator.getType());
-        }
+        return buildResult(consecutiveGroupIds());
+    }
 
-        final PageBuilder pageBuilder = new PageBuilder(types);
+    public Iterator<Page> buildHashSortedResult()
+    {
+        return buildResult(hashSortedGroupIds());
+    }
+
+    public List<Type> buildIntermediateTypes()
+    {
+        ArrayList<Type> types = new ArrayList<>(groupByHash.getTypes());
+        for (InMemoryHashAggregationBuilder.Aggregator aggregator : aggregators) {
+            types.add(aggregator.getIntermediateType());
+        }
+        return types;
+    }
+
+    private Iterator<Page> buildResult(IntIterator groupIds)
+    {
+        final PageBuilder pageBuilder = new PageBuilder(buildTypes());
         return new AbstractIterator<Page>()
         {
-            private final int groupCount = groupByHash.getGroupCount();
-            private int groupId;
-
             @Override
             protected Page computeNext()
             {
-                if (groupId >= groupCount) {
+                if (!groupIds.hasNext()) {
                     return endOfData();
                 }
 
                 pageBuilder.reset();
 
                 List<Type> types = groupByHash.getTypes();
-                while (!pageBuilder.isFull() && groupId < groupCount) {
+                while (!pageBuilder.isFull() && groupIds.hasNext()) {
+                    int groupId = groupIds.nextInt();
+
                     groupByHash.appendValuesTo(groupId, pageBuilder, 0);
 
                     pageBuilder.declarePosition();
@@ -152,8 +236,6 @@ public class InMemoryHashAggregationBuilder
                         BlockBuilder output = pageBuilder.getBlockBuilder(types.size() + i);
                         aggregator.evaluate(groupId, output);
                     }
-
-                    groupId++;
                 }
 
                 return pageBuilder.build();
@@ -161,17 +243,90 @@ public class InMemoryHashAggregationBuilder
         };
     }
 
+    public List<Type> buildTypes()
+    {
+        ArrayList<Type> types = new ArrayList<>(groupByHash.getTypes());
+        for (Aggregator aggregator : aggregators) {
+            types.add(aggregator.getType());
+        }
+        return types;
+    }
+
+    private IntIterator consecutiveGroupIds()
+    {
+        return IntIterators.fromTo(0, groupByHash.getGroupCount());
+    }
+
+    private IntIterator hashSortedGroupIds()
+    {
+        IntBigArray groupIds = new IntBigArray();
+        groupIds.ensureCapacity(groupByHash.getGroupCount());
+        for (int i = 0; i < groupByHash.getGroupCount(); i++) {
+            groupIds.set(i, i);
+        }
+
+        List<Integer> wrappedGroupIds = asList(groupIds, groupByHash.getGroupCount());
+        wrappedGroupIds.sort(((leftGroupId, rightGroupId) ->
+                Long.compare(groupByHash.getRawHash(leftGroupId), groupByHash.getRawHash(rightGroupId))));
+
+        return new AbstractIntIterator() {
+            private final int totalPositions = groupByHash.getGroupCount();
+            private int position = 0;
+
+            @Override
+            public boolean hasNext()
+            {
+                return position < totalPositions;
+            }
+
+            @Override
+            public int nextInt()
+            {
+                return groupIds.get(position++);
+            }
+        };
+    }
+
+    private static List<Integer> asList(IntBigArray groupIds, int size)
+    {
+        return new AbstractList<Integer>() {
+            @Override
+            public Integer get(int index)
+            {
+                return groupIds.get(index);
+            }
+
+            @Override
+            public int size()
+            {
+                return size;
+            }
+
+            @Override
+            public Integer set(int index, Integer element)
+            {
+                int oldValue = groupIds.get(index);
+                groupIds.set(index, element);
+                return oldValue;
+            }
+        };
+    }
+
     private static class Aggregator
     {
         private final GroupedAccumulator aggregation;
-        private final Step step;
+        private AggregationNode.Step step;
         private final int intermediateChannel;
 
-        private Aggregator(AccumulatorFactory accumulatorFactory, Step step)
+        private Aggregator(AccumulatorFactory accumulatorFactory, AggregationNode.Step step, Optional<Integer> overwriteIntermediateChannel)
         {
             if (step.isInputRaw()) {
                 this.intermediateChannel = -1;
                 this.aggregation = accumulatorFactory.createGroupedAccumulator();
+            }
+            else if (overwriteIntermediateChannel.isPresent()) {
+                this.intermediateChannel = overwriteIntermediateChannel.get();
+                this.aggregation = accumulatorFactory.createGroupedIntermediateAccumulator();
             }
             else {
                 checkArgument(accumulatorFactory.getInputChannels().size() == 1, "expected 1 input channel for intermediate aggregation");
@@ -215,6 +370,16 @@ public class InMemoryHashAggregationBuilder
                 aggregation.evaluateFinal(groupId, output);
             }
         }
+
+        public void setOutputPartial()
+        {
+            step = AggregationNode.Step.partialOutput(step);
+        }
+
+        public Type getIntermediateType()
+        {
+            return aggregation.getIntermediateType();
+        }
     }
 
     public static List<Type> toTypes(List<? extends Type> groupByType, Step step, List<AccumulatorFactory> factories, Optional<Integer> hashChannel)
@@ -225,7 +390,7 @@ public class InMemoryHashAggregationBuilder
             types.add(BIGINT);
         }
         for (AccumulatorFactory factory : factories) {
-            types.add(new Aggregator(factory, step).getType());
+            types.add(new Aggregator(factory, step, Optional.empty()).getType());
         }
         return types.build();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/MergingHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/MergingHashAggregationBuilder.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.builder;
+
+import com.facebook.presto.memory.LocalMemoryContext;
+import com.facebook.presto.operator.OperatorContext;
+import com.facebook.presto.operator.aggregation.AccumulatorFactory;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+public class MergingHashAggregationBuilder
+    implements Closeable
+{
+    private final List<AccumulatorFactory> accumulatorFactories;
+    private final AggregationNode.Step step;
+    private final int expectedGroups;
+    private final ImmutableList<Integer> groupByPartialChannels;
+    private final Optional<Integer> hashChannel;
+    private final OperatorContext operatorContext;
+    private final Iterator<Page> sortedPages;
+    private InMemoryHashAggregationBuilder hashAggregationBuilder;
+    private final List<Type> groupByTypes;
+    private final LocalMemoryContext systemMemoryContext;
+    private final long memorySizeBeforeSpill;
+    private final int overwriteIntermediateChannelOffset;
+
+    public MergingHashAggregationBuilder(
+            List<AccumulatorFactory> accumulatorFactories,
+            AggregationNode.Step step,
+            int expectedGroups,
+            List<Type> groupByTypes,
+            Optional<Integer> hashChannel,
+            OperatorContext operatorContext,
+            Iterator<Page> sortedPages,
+            LocalMemoryContext systemMemoryContext,
+            long memorySizeBeforeSpill,
+            int overwriteIntermediateChannelOffset)
+    {
+        ImmutableList.Builder<Integer> groupByPartialChannels = ImmutableList.builder();
+        for (int i = 0; i < groupByTypes.size(); i++) {
+            groupByPartialChannels.add(i);
+        }
+
+        this.accumulatorFactories = accumulatorFactories;
+        this.step = AggregationNode.Step.partialInput(step);
+        this.expectedGroups = expectedGroups;
+        this.groupByPartialChannels = groupByPartialChannels.build();
+        this.hashChannel = hashChannel.isPresent() ? Optional.of(groupByTypes.size()) : hashChannel;
+        this.operatorContext = operatorContext;
+        this.sortedPages = sortedPages;
+        this.groupByTypes = groupByTypes;
+        this.systemMemoryContext = systemMemoryContext;
+        this.memorySizeBeforeSpill = memorySizeBeforeSpill;
+        this.overwriteIntermediateChannelOffset = overwriteIntermediateChannelOffset;
+
+        rebuildHashAggregationBuilder();
+    }
+
+    public Iterator<Page> buildResult()
+    {
+        return new Iterator<Page>() {
+            private Iterator<Page> resultPages = Collections.emptyIterator();
+
+            @Override
+            public boolean hasNext()
+            {
+                return sortedPages.hasNext() || resultPages.hasNext();
+            }
+
+            @Override
+            public Page next()
+            {
+                if (!resultPages.hasNext()) {
+                    rebuildHashAggregationBuilder();
+                    long memorySize = 0; // ensure that at least one merged page will be processed
+
+                    // we can produce output  after every page, because sortedPages does not have
+                    // hash values that span multiple pages (guaranteed by MergeHashSort)
+                    while (sortedPages.hasNext() && !shouldProduceOutput(memorySize)) {
+                        hashAggregationBuilder.processPage(sortedPages.next());
+                        memorySize = hashAggregationBuilder.getSizeInMemory();
+                        systemMemoryContext.setBytes(memorySize);
+                    }
+                    resultPages = hashAggregationBuilder.buildResult();
+                }
+
+                return resultPages.next();
+            }
+        };
+    }
+
+    @Override
+    public void close()
+    {
+        hashAggregationBuilder.close();
+    }
+
+    private boolean shouldProduceOutput(long memorySize)
+    {
+        return (memorySizeBeforeSpill > 0 && memorySize > memorySizeBeforeSpill);
+    }
+
+    private void rebuildHashAggregationBuilder()
+    {
+        this.hashAggregationBuilder = new InMemoryHashAggregationBuilder(
+                accumulatorFactories,
+                step,
+                expectedGroups,
+                groupByTypes,
+                groupByPartialChannels,
+                hashChannel,
+                operatorContext,
+                DataSize.succinctBytes(0),
+                Optional.of(overwriteIntermediateChannelOffset));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.builder;
+
+import com.facebook.presto.memory.AbstractAggregatedMemoryContext;
+import com.facebook.presto.memory.LocalMemoryContext;
+import com.facebook.presto.operator.MergeHashSort;
+import com.facebook.presto.operator.OperatorContext;
+import com.facebook.presto.operator.aggregation.AccumulatorFactory;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spiller.Spiller;
+import com.facebook.presto.spiller.SpillerFactory;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static java.lang.Math.max;
+
+public class SpillableHashAggregationBuilder
+    implements HashAggregationBuilder
+{
+    private InMemoryHashAggregationBuilder hashAggregationBuilder;
+    private final SpillerFactory spillerFactory;
+    private final List<AccumulatorFactory> accumulatorFactories;
+    private final AggregationNode.Step step;
+    private final int expectedGroups;
+    private final List<Type> groupByTypes;
+    private final List<Integer> groupByChannels;
+    private final Optional<Integer> hashChannel;
+    private final OperatorContext operatorContext;
+    private final long memorySizeBeforeSpill;
+    private final long memoryLimitForMergeWithMemory;
+    private Optional<Spiller> spiller = Optional.empty();
+    private Optional<MergingHashAggregationBuilder> merger = Optional.empty();
+    private CompletableFuture<?> spillInProgress = CompletableFuture.completedFuture(null);
+    private final LocalMemoryContext aggregationMemoryContext;
+    private final LocalMemoryContext spillMemoryContext;
+
+    public SpillableHashAggregationBuilder(
+            List<AccumulatorFactory> accumulatorFactories,
+            AggregationNode.Step step,
+            int expectedGroups,
+            List<Type> groupByTypes,
+            List<Integer> groupByChannels,
+            Optional<Integer> hashChannel,
+            OperatorContext operatorContext,
+            DataSize memoryLimitBeforeSpill,
+            DataSize memoryLimitForMergeWithMemory,
+            SpillerFactory spillerFactory)
+    {
+        this.accumulatorFactories = accumulatorFactories;
+        this.step = step;
+        this.expectedGroups = expectedGroups;
+        this.groupByTypes = groupByTypes;
+        this.groupByChannels = groupByChannels;
+        this.hashChannel = hashChannel;
+        this.operatorContext = operatorContext;
+        this.memorySizeBeforeSpill = memoryLimitBeforeSpill.toBytes();
+        this.memoryLimitForMergeWithMemory = memoryLimitForMergeWithMemory.toBytes();
+        this.spillerFactory = spillerFactory;
+
+        AbstractAggregatedMemoryContext systemMemoryContext = operatorContext.getSystemMemoryContext();
+        this.aggregationMemoryContext = systemMemoryContext.newLocalMemoryContext();
+        this.spillMemoryContext = systemMemoryContext.newLocalMemoryContext();
+
+        rebuildHashAggregationBuilder();
+    }
+
+    @Override
+    public void processPage(Page page)
+    {
+        checkState(hasPreviousSpillCompletedSuccessfully(), "Previous spill hasn't yet finished");
+
+        hashAggregationBuilder.processPage(page);
+
+        if (shouldSpill(getSizeInMemory())) {
+            spillToDisk();
+        }
+    }
+
+    @Override
+    public void updateMemory()
+    {
+        aggregationMemoryContext.setBytes(getSizeInMemory());
+
+        if (spillInProgress.isDone()) {
+            spillMemoryContext.setBytes(0L);
+        }
+    }
+
+    public long getSizeInMemory()
+    {
+        // TODO: we could skip memory reservation for hashAggregationBuilder.getGroupIdsSortingSize()
+        // if before building result from hashAggregationBuilder we would convert it to "read only" version.
+        // Read only version of GroupByHash from hashAggregationBuilder could be compacted by dropping
+        // most of it's field, freeing up some memory that could be used for sorting.
+        return hashAggregationBuilder.getSizeInMemory() + hashAggregationBuilder.getGroupIdsSortingSize();
+    }
+
+    @Override
+    public boolean isFull()
+    {
+        return false;
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        return spillInProgress;
+    }
+
+    private boolean hasPreviousSpillCompletedSuccessfully()
+    {
+        if (isBlocked().isDone()) {
+            // check for exception from previous spill for early failure
+            getFutureValue(spillInProgress);
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+    private boolean shouldSpill(long memorySize)
+    {
+        return (memorySizeBeforeSpill > 0 && memorySize > memorySizeBeforeSpill);
+    }
+
+    private boolean shouldMergeWithMemory(long memorySize)
+    {
+        return memorySize < memoryLimitForMergeWithMemory;
+    }
+
+    @Override
+    public Iterator<Page> buildResult()
+    {
+        checkState(hasPreviousSpillCompletedSuccessfully(), "Previous spill hasn't yet finished");
+
+        if (!spiller.isPresent()) {
+            return hashAggregationBuilder.buildResult();
+        }
+
+        try {
+            if (shouldMergeWithMemory(getSizeInMemory())) {
+                return mergeFromDiskAndMemory();
+            }
+            else {
+                spillToDisk().get();
+                return mergeFromDisk();
+            }
+        }
+        catch (InterruptedException | ExecutionException e) {
+            Thread.currentThread().interrupt();
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        if (merger.isPresent()) {
+            merger.get().close();
+        }
+        if (spiller.isPresent()) {
+            spiller.get().close();
+        }
+    }
+
+    private CompletableFuture<?> spillToDisk()
+    {
+        checkState(hasPreviousSpillCompletedSuccessfully(), "Previous spill hasn't yet finished");
+        hashAggregationBuilder.setOutputPartial();
+
+        if (!spiller.isPresent()) {
+            spiller = Optional.of(spillerFactory.create(hashAggregationBuilder.buildTypes()));
+        }
+        long spillMemoryUsage = getSizeInMemory();
+
+        // start spilling process with current content of the hashAggregationBuilder builder...
+        spillInProgress = spiller.get().spill(hashAggregationBuilder.buildHashSortedResult());
+        // ... and immediately create new hashAggregationBuilder so effectively memory ownership
+        // over hashAggregationBuilder is transferred from this thread to a spilling thread
+        rebuildHashAggregationBuilder();
+
+        // First decrease memory usage of aggregation context...
+        aggregationMemoryContext.setBytes(getSizeInMemory());
+        // And then transfer this memory to spill context
+        // TODO: is there an easy way to do this atomically?
+        spillMemoryContext.setBytes(spillMemoryUsage);
+
+        return spillInProgress;
+    }
+
+    private Iterator<Page> mergeFromDiskAndMemory()
+    {
+        checkState(spiller.isPresent());
+
+        hashAggregationBuilder.setOutputPartial();
+
+        Iterator<Page> mergedSpilledPages = MergeHashSort.merge(
+                groupByTypes,
+                hashAggregationBuilder.buildIntermediateTypes(),
+                ImmutableList.<Iterator<Page>>builder()
+                        .addAll(spiller.get().getSpills())
+                        .add(hashAggregationBuilder.buildHashSortedResult())
+                        .build());
+
+        return mergeSortedPages(mergedSpilledPages, max(memorySizeBeforeSpill - memoryLimitForMergeWithMemory, 1L));
+    }
+
+    private Iterator<Page> mergeFromDisk()
+    {
+        checkState(spiller.isPresent());
+
+        Iterator<Page> mergedSpilledPages = MergeHashSort.merge(
+                groupByTypes,
+                hashAggregationBuilder.buildIntermediateTypes(),
+                spiller.get().getSpills());
+
+        return mergeSortedPages(mergedSpilledPages, memorySizeBeforeSpill);
+    }
+
+    private Iterator<Page> mergeSortedPages(Iterator<Page> sortedPages, long memorySizeBeforeSpill)
+    {
+        merger = Optional.of(new MergingHashAggregationBuilder(
+                accumulatorFactories,
+                step,
+                expectedGroups,
+                groupByTypes,
+                hashChannel,
+                operatorContext,
+                sortedPages,
+                operatorContext.getSystemMemoryContext().newLocalMemoryContext(),
+                memorySizeBeforeSpill,
+                hashAggregationBuilder.getKeyChannels()));
+
+        return merger.get().buildResult();
+    }
+
+    private void rebuildHashAggregationBuilder()
+    {
+        this.hashAggregationBuilder = new InMemoryHashAggregationBuilder(
+                accumulatorFactories,
+                step,
+                expectedGroups,
+                groupByTypes,
+                groupByChannels,
+                hashChannel,
+                operatorContext,
+                DataSize.succinctBytes(0));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -398,6 +398,7 @@ public class ServerMainModule
 
         // Spiller
         binder.bind(SpillerFactory.class).to(BinarySpillerFactory.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(SpillerFactory.class).withGeneratedName();
     }
 
     @Provides

--- a/presto-main/src/main/java/com/facebook/presto/spiller/BinarySpillerFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/BinarySpillerFactory.java
@@ -31,7 +31,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 
 public class BinarySpillerFactory
-        implements SpillerFactory
+        extends SpillerFactoryWithStats
 {
     public static final String SPILLER_THREAD_NAME_PREFIX = "binary-spiller";
 
@@ -65,6 +65,6 @@ public class BinarySpillerFactory
     @Override
     public Spiller create(List<Type> types)
     {
-        return new BinaryFileSpiller(blockEncodingSerde, executor, spillPath);
+        return new BinaryFileSpiller(blockEncodingSerde, executor, spillPath, spilledBytes);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/spiller/SpillerFactoryWithStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/SpillerFactoryWithStats.java
@@ -11,18 +11,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.facebook.presto.spiller;
 
-import com.facebook.presto.spi.type.Type;
 import org.weakref.jmx.Managed;
 
-import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
-public interface SpillerFactory
+public abstract class SpillerFactoryWithStats
+        implements SpillerFactory
 {
-    Spiller create(List<Type> types);
+    protected final AtomicLong spilledBytes = new AtomicLong();
 
+    @Override
     @Managed
-    long getSpilledBytes();
+    public long getSpilledBytes()
+    {
+        return spilledBytes.get();
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -174,8 +174,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.SystemSessionProperties.getOperatorMemoryLimitBeforeSpill;
 import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
 import static com.facebook.presto.SystemSessionProperties.getTaskWriterCount;
+import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.operator.DistinctLimitOperator.DistinctLimitOperatorFactory;
 import static com.facebook.presto.operator.NestedLoopBuildOperator.NestedLoopBuildOperatorFactory;
@@ -887,7 +889,10 @@ public class LocalExecutionPlanner
                 return planGlobalAggregation(context.getNextOperatorId(), node, source);
             }
 
-            return planGroupByAggregation(node, source, context.getNextOperatorId());
+            boolean spillEnabled = isSpillEnabled(context.getSession());
+            DataSize memoryLimitBeforeSpill = getOperatorMemoryLimitBeforeSpill(context.getSession());
+
+            return planGroupByAggregation(node, source, context.getNextOperatorId(), spillEnabled, memoryLimitBeforeSpill);
         }
 
         @Override
@@ -1847,7 +1852,12 @@ public class LocalExecutionPlanner
             return new PhysicalOperation(operatorFactory, outputMappings.build(), source);
         }
 
-        private PhysicalOperation planGroupByAggregation(AggregationNode node, PhysicalOperation source, int operatorId)
+        private PhysicalOperation planGroupByAggregation(
+                AggregationNode node,
+                PhysicalOperation source,
+                int operatorId,
+                boolean spillEnabled,
+                DataSize memoryLimitBeforeSpill)
         {
             List<Symbol> groupBySymbols = node.getGroupingKeys();
 
@@ -1909,7 +1919,10 @@ public class LocalExecutionPlanner
                     hashChannel,
                     node.getGroupIdSymbol().map(mappings::get),
                     10_000,
-                    maxPartialAggregationMemorySize);
+                    maxPartialAggregationMemorySize,
+                    spillEnabled,
+                    memoryLimitBeforeSpill,
+                    spillerFactory);
 
             return new PhysicalOperation(operatorFactory, mappings, source);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
@@ -72,6 +72,26 @@ public class AggregationNode
         {
             return outputPartial;
         }
+
+        public static Step partialOutput(Step step)
+        {
+            if (step.isInputRaw()) {
+                return Step.PARTIAL;
+            }
+            else {
+                return Step.INTERMEDIATE;
+            }
+        }
+
+        public static Step partialInput(Step step)
+        {
+            if (step.isOutputPartial()) {
+                return Step.INTERMEDIATE;
+            }
+            else {
+                return Step.FINAL;
+            }
+        }
     }
 
     @JsonCreator

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalBinarySpilledQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalBinarySpilledQueries.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableMap;
+
+import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+
+public class TestLocalBinarySpilledQueries
+        extends AbstractTestQueries
+{
+    public TestLocalBinarySpilledQueries()
+    {
+        super(createLocalQueryRunner());
+    }
+
+    private static LocalQueryRunner createLocalQueryRunner()
+    {
+        Session defaultSession = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema(TINY_SCHEMA_NAME)
+                .setSystemProperty(SystemSessionProperties.SPILL_ENABLED, "true")
+                .setSystemProperty(SystemSessionProperties.OPERATOR_MEMORY_LIMIT_BEFORE_SPILL, "1B") //spill constantly
+                .build();
+
+        LocalQueryRunner localQueryRunner = new LocalQueryRunner(defaultSession);
+
+        // add the tpch catalog
+        // local queries run directly against the generator
+        localQueryRunner.createCatalog(
+                defaultSession.getCatalog().get(),
+                new TpchConnectorFactory(1),
+                ImmutableMap.<String, String>of());
+
+        localQueryRunner.getMetadata().addFunctions(CUSTOM_FUNCTIONS);
+
+        SessionPropertyManager sessionPropertyManager = localQueryRunner.getMetadata().getSessionPropertyManager();
+        sessionPropertyManager.addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);
+        sessionPropertyManager.addConnectorSessionProperties(new ConnectorId(TESTING_CATALOG), TEST_CATALOG_PROPERTIES);
+
+        return localQueryRunner;
+    }
+}


### PR DESCRIPTION
Supersedes https://github.com/prestodb/presto/pull/5142. Notable changes:
- reordered commits
- removed `max-entries-before-spill` property
