### PR TITLE
Fix Hive SQL standard permissions on table creation

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -464,9 +464,13 @@ public class HiveMetadata
 
     private static PrincipalPrivilegeSet buildInitialPrivilegeSet(String tableOwner)
     {
-        PrivilegeGrantInfo allPrivileges = new PrivilegeGrantInfo("all", 0, tableOwner, PrincipalType.USER, true);
         return new PrincipalPrivilegeSet(
-                ImmutableMap.of(tableOwner, ImmutableList.of(allPrivileges)),
+                ImmutableMap.of(tableOwner, ImmutableList.of(
+                        new PrivilegeGrantInfo("SELECT", 0, tableOwner, PrincipalType.USER, true),
+                        new PrivilegeGrantInfo("INSERT", 0, tableOwner, PrincipalType.USER, true),
+                        new PrivilegeGrantInfo("UPDATE", 0, tableOwner, PrincipalType.USER, true),
+                        new PrivilegeGrantInfo("DELETE", 0, tableOwner, PrincipalType.USER, true)
+                )),
                 ImmutableMap.of(),
                 ImmutableMap.of());
     }


### PR DESCRIPTION
 When creating a Hive table, ALL privileges are translated to SELECT, INSERT, UPDATE, DELETE privileges. When presto creates a Hive table, it sets the privilege to ALL rather than granting the underlying privileges. This is handled incorrectly when querying for authorization. Exploding the ALL privilege to its constituents solves the issue.

Example:
< current presto >
hive> SHOW GRANT USER spyne ON TABLE customer_ctas_old;
OK
default customer_ctas           spyne   USER    ALL true    1470714881000   spyne
Time taken: 0.587 seconds, Fetched: 1 row(s)

< presto with patch >
hive> SHOW GRANT USER spyne ON TABLE customer_ctas;
OK
default customer_ctas           spyne   USER    DELETE  true    1470712777000   spyne
default customer_ctas           spyne   USER    INSERT  true    1470712777000   spyne
default customer_ctas           spyne   USER    SELECT  true    1470712777000   spyne
default customer_ctas           spyne   USER    UPDATE  true    1470712777000   spyne
Time taken: 0.574 seconds, Fetched: 4 row(s)

