### PR TITLE
presto_typeof - presto equivalent of pg_typeof function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/conversion.rst
+++ b/presto-docs/src/main/sphinx/functions/conversion.rst
@@ -21,3 +21,10 @@ Conversion Functions
 .. function:: try_cast(value AS type) -> type
 
     Like :func:`cast`, but returns null if the cast fails.
+
+Miscellaneous
+-------------
+
+.. function:: presto_typeof(expr) -> varchar
+
+    Returns name of provided expression type.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -89,6 +89,7 @@ import com.facebook.presto.operator.scalar.MapNotEqualOperator;
 import com.facebook.presto.operator.scalar.MapToMapCast;
 import com.facebook.presto.operator.scalar.MapValues;
 import com.facebook.presto.operator.scalar.MathFunctions;
+import com.facebook.presto.operator.scalar.PrestoTypeOfFunction;
 import com.facebook.presto.operator.scalar.Re2JCastToRegexpFunction;
 import com.facebook.presto.operator.scalar.Re2JRegexpFunctions;
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
@@ -449,6 +450,7 @@ public class FunctionRegistry
                 .scalar(MapCardinalityFunction.class)
                 .scalar(MapConcatFunction.class)
                 .scalar(MapToMapCast.class)
+                .scalar(PrestoTypeOfFunction.class)
                 .functions(ZIP_FUNCTIONS)
                 .functions(ARRAY_JOIN, ARRAY_JOIN_WITH_NULL_REPLACEMENT)
                 .functions(ARRAY_TO_ARRAY_CAST, ARRAY_LESS_THAN)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/PrestoTypeOfFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/PrestoTypeOfFunction.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import javax.annotation.Nullable;
+
+import java.nio.ByteBuffer;
+
+@Description("Returns textual representation of type of expression passed as a parameter")
+@ScalarFunction("presto_typeof")
+public final class PrestoTypeOfFunction
+{
+    private PrestoTypeOfFunction() {}
+
+    @TypeParameter("T")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice typeof(
+            @TypeParameter("T") Type type,
+            @Nullable @SqlType("T") Object value)
+    {
+        return Slices.wrappedBuffer(ByteBuffer.wrap(type.getDisplayName().getBytes()));
+    }
+
+    @TypeParameter("T")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice typeof(
+            @TypeParameter("T") Type type,
+            @Nullable @SqlType("T") Long value)
+    {
+        return typeof(type, (Object) value);
+    }
+
+    @TypeParameter("T")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice typeof(
+            @TypeParameter("T") Type type,
+            @Nullable @SqlType("T") Double value)
+    {
+        return typeof(type, (Object) value);
+    }
+
+    @TypeParameter("T")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice typeof(
+            @TypeParameter("T") Type type,
+            @Nullable @SqlType("T") Boolean value)
+    {
+        return typeof(type, (Object) value);
+    }
+
+    @TypeParameter("T")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice typeof(
+            @TypeParameter("T") Type type,
+            @Nullable @SqlType("T") Void value)
+    {
+        return typeof(type, (Object) value);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPrestoTypeOfFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPrestoTypeOfFunction.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.type.VarcharType;
+import org.testng.annotations.Test;
+
+public class TestPrestoTypeOfFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testPrestoTypeOfSimpleType()
+            throws Exception
+    {
+        assertFunction("presto_typeof(CAST(1 AS BIGINT))", VarcharType.VARCHAR, "bigint");
+        assertFunction("presto_typeof(CAST(1 AS INTEGER))", VarcharType.VARCHAR, "integer");
+        assertFunction("presto_typeof(CAST(1 AS VARCHAR))", VarcharType.VARCHAR, "varchar");
+        assertFunction("presto_typeof(CAST(1 AS DOUBLE))", VarcharType.VARCHAR, "double");
+        assertFunction("presto_typeof(NULL)", VarcharType.VARCHAR, "unknown");
+    }
+
+    @Test
+    public void testPrestoTypeOfParametricType()
+            throws Exception
+    {
+        assertFunction("presto_typeof(CAST(NULL AS VARCHAR(10)))", VarcharType.VARCHAR, "varchar(10)");
+        assertFunction("presto_typeof(CAST(NULL AS DECIMAL(5,1)))", VarcharType.VARCHAR, "decimal(5,1)");
+        assertFunction("presto_typeof(CAST(NULL AS DECIMAL(1)))", VarcharType.VARCHAR, "decimal(1,0)");
+        assertFunction("presto_typeof(CAST(NULL AS DECIMAL))", VarcharType.VARCHAR, "decimal(38,0)");
+        assertFunction("presto_typeof(CAST(NULL AS ARRAY(INTEGER)))", VarcharType.VARCHAR, "array(integer)");
+        assertFunction("presto_typeof(CAST(NULL AS ARRAY(DECIMAL(5,1))))", VarcharType.VARCHAR, "array(decimal(5,1))");
+    }
+
+    @Test
+    public void testPrestoTypeOfNestedParametricType()
+            throws Exception
+    {
+        assertFunction("presto_typeof(CAST(NULL AS ARRAY(ARRAY(ARRAY(INTEGER)))))", VarcharType.VARCHAR, "array(array(array(integer)))");
+        assertFunction("presto_typeof(CAST(NULL AS ARRAY(ARRAY(ARRAY(DECIMAL(5,1))))))", VarcharType.VARCHAR, "array(array(array(decimal(5,1))))");
+    }
+
+    @Test
+    public void testPrestoTypeOfComplexExpression()
+            throws Exception
+    {
+        assertFunction("presto_typeof(CONCAT('ala','ma','kota'))", VarcharType.VARCHAR, "varchar");
+        assertFunction("presto_typeof(CONCAT(CONCAT('ala','ma','kota'), 'baz'))", VarcharType.VARCHAR, "varchar");
+        assertFunction("presto_typeof(ARRAY [CAST(1 AS INTEGER),CAST(2 AS INTEGER),CAST(3 AS INTEGER)])", VarcharType.VARCHAR, "array(integer)");
+        assertFunction("presto_typeof(sin(2))", VarcharType.VARCHAR, "double");
+        assertFunction("presto_typeof(2+sin(2)+2.3)", VarcharType.VARCHAR, "double");
+    }
+}


### PR DESCRIPTION
`presto_typeof` is meant to be used for implementing, manual testing and sql development.

The name of function uses `presto_` prefix to:
 1) Avoid possible clash of names in the future
 2) Follow `postgresql` standard for this kind of function

@dain - can you review?