### PR TITLE
Fix json path tokenizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonPathTokenizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonPathTokenizer.java
@@ -145,7 +145,7 @@ public class JsonPathTokenizer
 
     private boolean tryMatch(char expected)
     {
-        if (peekCharacter() != expected) {
+        if (!hasNextCharacter() || peekCharacter() != expected) {
             return false;
         }
         index++;

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
@@ -314,6 +314,7 @@ public class TestJsonExtract
         assertInvalidExtract("", "$$", "Invalid JSON path: '$$'");
         assertInvalidExtract("", " ", "Invalid JSON path: ' '");
         assertInvalidExtract("", ".", "Invalid JSON path: '.'");
+        assertInvalidExtract("{ \"store\": { \"book\": [{ \"title\": \"title\" }] } }", "$.store.book[", "Invalid JSON path: '$.store.book['");
     }
 
     private static String doExtract(JsonExtractor<Slice> jsonExtractor, String json)


### PR DESCRIPTION
Fixes a case where the tokenizer peeks beyond the given json path
expression if the expression is not valid.

```
presto:nyigitbasi> select json_extract('{ "store": { "book": [{ "title": "title" }] } }', '$.store.book[');
Query 20160811_233913_00004_g9ip6, FAILED, 1 node
http://localhost:8080/query.html?20160811_233913_00004_g9ip6
Splits: 1 total, 0 done (0.00%)
CPU Time: 0.0s total,     0 rows/s,     0B/s, 0% active
Per Node: 0.0 parallelism,     0 rows/s,     0B/s
Parallelism: 0.0
0:00 [0 rows, 0B] [0 rows/s, 0B/s]

Query 20160811_233913_00004_g9ip6 failed: String index out of range: 13
java.lang.StringIndexOutOfBoundsException: String index out of range: 13
        at java.lang.String.charAt(String.java:658)
        at com.facebook.presto.operator.scalar.JsonPathTokenizer.peekCharacter(JsonPathTokenizer.java:162)
        at com.facebook.presto.operator.scalar.JsonPathTokenizer.tryMatch(JsonPathTokenizer.java:148)
        at com.facebook.presto.operator.scalar.JsonPathTokenizer.computeNext(JsonPathTokenizer.java:60)
        at com.facebook.presto.operator.scalar.JsonPathTokenizer.computeNext(JsonPathTokenizer.java:24)
        at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:143)
        at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:138)
        at com.google.common.collect.ImmutableCollection$Builder.addAll(ImmutableCollection.java:300)
        at com.google.common.collect.ImmutableList$Builder.addAll(ImmutableList.java:691)
        at com.google.common.collect.ImmutableList.copyOf(ImmutableList.java:275)
        at com.facebook.presto.operator.scalar.JsonExtract.generateExtractor(JsonExtract.java:152)
        at com.facebook.presto.operator.scalar.JsonExtract.generateExtractor(JsonExtract.java:147)
        at com.facebook.presto.operator.scalar.JsonPath.<init>(JsonPath.java:26)
        at com.facebook.presto.operator.scalar.JsonFunctions.castToJsonPath(JsonFunctions.java:75)
        at com_facebook_presto_$gen_PageProcessor_15.project_0(Unknown Source)
        at com_facebook_presto_$gen_PageProcessor_15.process(Unknown Source)
        at com.facebook.presto.operator.FilterAndProjectOperator.getOutput(FilterAndProjectOperator.java:111)
        at com.facebook.presto.operator.Driver.processInternal(Driver.java:378)
        at com.facebook.presto.operator.Driver.processFor(Driver.java:301)
        at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:622)
        at com.facebook.presto.execution.TaskExecutor$PrioritizedSplitRunner.process(TaskExecutor.java:529)
        at com.facebook.presto.execution.TaskExecutor$Runner.run(TaskExecutor.java:665)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
```