### PR TITLE
Remove unused sameCall method

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
@@ -66,12 +66,6 @@ final class WindowMatcher
         return actualCopy.isEmpty();
     }
 
-    private static boolean sameCall(FunctionCall left, FunctionCall right)
-    {
-        return left.getName().equals(right.getName()) &&
-                left.getArguments().equals(right.getArguments());
-    }
-
     @Override
     public String toString()
     {


### PR DESCRIPTION
This ended up being dead code in final form of the MergeIdenticalWindows change, but I missed removing it. Sorry about that.