### PR TITLE
Added support for SPLIT(..., '')

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -278,7 +278,7 @@ public final class StringFunctions
     @SqlType("array(varchar(x))")
     public static Block split(@SqlType("varchar(x)") Slice string, @SqlType(StandardTypes.VARCHAR) Slice delimiter)
     {
-        return split(string, delimiter, string.length() + 1);
+        return split(string, delimiter, Integer.MAX_VALUE);
     }
 
     @ScalarFunction
@@ -288,33 +288,44 @@ public final class StringFunctions
     {
         checkCondition(limit > 0, INVALID_FUNCTION_ARGUMENT, "Limit must be positive");
         checkCondition(limit <= Integer.MAX_VALUE, INVALID_FUNCTION_ARGUMENT, "Limit is too large");
-        checkCondition(delimiter.length() > 0, INVALID_FUNCTION_ARGUMENT, "The delimiter may not be the empty string");
         BlockBuilder parts = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 1, string.length());
-        // If limit is one, the last and only element is the complete string
-        if (limit == 1) {
-            VARCHAR.writeSlice(parts, string);
-            return parts.build();
-        }
 
+        // Split string into parts
         int index = 0;
-        while (index < string.length()) {
-            int splitIndex = string.indexOf(delimiter, index);
-            // Found split?
-            if (splitIndex < 0) {
-                break;
+        int partCount = 0;
+        if (delimiter.length() == 0) {
+            // Special case for empty delimiter
+            // Start result array with empty string '' unless limit is 1 (special case)
+            if (limit > 1) {
+                VARCHAR.writeString(parts, "");
+                ++partCount;
             }
-            // Add the part from current index to found split
-            VARCHAR.writeSlice(parts, string, index, splitIndex - index);
-            // Continue searching after delimiter
-            index = splitIndex + delimiter.length();
-            // Reached limit-1 parts so we can stop
-            if (parts.getPositionCount() == limit - 1) {
-                break;
+            // Add single-character parts until limit or end of string
+            while ((partCount < limit - 1) && (index < string.length())) {
+                final int cpLen = lengthOfCodePoint(string, index);
+                VARCHAR.writeSlice(parts, string, index, cpLen);
+                index += cpLen;
+                ++partCount;
             }
         }
-        // Rest of string
-        VARCHAR.writeSlice(parts, string, index, string.length() - index);
+        else {
+            // General case, use indexOf to find delimiters in string
+            while ((partCount < limit - 1) && (index < string.length())) {
+                final int splitIndex = string.indexOf(delimiter, index);
+                // Found split?
+                if (splitIndex < 0) {
+                    break;
+                }
+                // Add the part from current index to delimiter
+                VARCHAR.writeSlice(parts, string, index, splitIndex - index);
+                // Continue searching after delimiter
+                index = splitIndex + delimiter.length();
+                ++partCount;
+            }
+        }
 
+        // Rest of string, the empty string '' if tail of string matched the delimiter
+        VARCHAR.writeSlice(parts, string, index, string.length() - index);
         return parts.build();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestRegexpFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestRegexpFunctions.java
@@ -166,6 +166,7 @@ public class TestRegexpFunctions
         assertFunction("REGEXP_SPLIT('abcd', 'x')", new ArrayType(VARCHAR), ImmutableList.of("abcd"));
         assertFunction("REGEXP_SPLIT('abcd', '')", new ArrayType(VARCHAR), ImmutableList.of("", "a", "b", "c", "d", ""));
         assertFunction("REGEXP_SPLIT('', 'x')", new ArrayType(VARCHAR), ImmutableList.of(""));
+        assertFunction("REGEXP_SPLIT('', '')", new ArrayType(VARCHAR), ImmutableList.of("", ""));
 
         // test empty splits, leading & trailing empty splits, consecutive empty splits
         assertFunction("REGEXP_SPLIT('a,b,c,d', ',')", new ArrayType(VARCHAR), ImmutableList.of("a", "b", "c", "d"));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -249,7 +249,20 @@ public class TestStringFunctions
         assertFunction("SPLIT('a..b..c', '.', 3)", new ArrayType(createVarcharType(7)), ImmutableList.of("a", "", "b..c"));
         assertFunction("SPLIT('a.b..', '.', 3)", new ArrayType(createVarcharType(5)), ImmutableList.of("a", "b", "."));
 
-        assertInvalidFunction("SPLIT('a.b.c', '', 1)", "The delimiter may not be the empty string");
+        // Empty string
+        assertFunction("SPLIT('', '.')", new ArrayType(createVarcharType(0)), ImmutableList.of(""));
+        assertFunction("SPLIT('', '')", new ArrayType(createVarcharType(0)), ImmutableList.of("", ""));
+        assertFunction("SPLIT('', '', 1)", new ArrayType(createVarcharType(0)), ImmutableList.of(""));
+        assertFunction("SPLIT('', '', 2)", new ArrayType(createVarcharType(0)), ImmutableList.of("", ""));
+
+        // Empty delimiter
+        assertFunction("SPLIT('abc', '')", new ArrayType(createVarcharType(3)), ImmutableList.of("", "a", "b", "c", ""));
+        assertFunction("SPLIT('abc', '', 1)", new ArrayType(createVarcharType(3)), ImmutableList.of("abc"));
+        assertFunction("SPLIT('abc', '', 2)", new ArrayType(createVarcharType(3)), ImmutableList.of("", "abc"));
+        assertFunction("SPLIT('abc', '', 10)", new ArrayType(createVarcharType(3)), ImmutableList.of("", "a", "b", "c", ""));
+        assertFunction("SPLIT('\u8B49\u8BC1\u8A3C', '')", new ArrayType(createVarcharType(3)), ImmutableList.of("", "\u8B49", "\u8BC1", "\u8A3C", ""));
+        assertFunction("SPLIT('\u8B49\u8BC1\u8A3C', '', 2)", new ArrayType(createVarcharType(3)), ImmutableList.of("", "\u8B49\u8BC1\u8A3C"));
+
         assertInvalidFunction("SPLIT('a.b.c', '.', 0)", "Limit must be positive");
         assertInvalidFunction("SPLIT('a.b.c', '.', -1)", "Limit must be positive");
         assertInvalidFunction("SPLIT('a.b.c', '.', 2147483648)", "Limit is too large");


### PR DESCRIPTION
I started out with #5406 but found that it was not working (no support for UTF-8 for starters), so I had to put in some more effort. This new version is consistent with REGEXP_SPLIT, but we might consider changing the corner case semantics of SPLIT and REGEXP_SPLIT unless we believe there are many existing queries which rely on the current semantics. See discussion in #5290.

Fixes #5290 