### PR TITLE
Support long prepared statements

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
@@ -16,6 +16,7 @@ package com.facebook.presto.benchmark.driver;
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.client.StatementStats;
 import com.google.common.base.Throwables;
@@ -61,6 +62,7 @@ public class BenchmarkQueryRunner
     private final HttpClient httpClient;
     private final List<URI> nodes;
     private final JsonCodec<QueryResults> queryResultsCodec;
+    private final JsonCodec<QuerySubmission> querySubmissionCodec;
 
     private int failures;
 
@@ -78,6 +80,7 @@ public class BenchmarkQueryRunner
         this.debug = debug;
 
         this.queryResultsCodec = jsonCodec(QueryResults.class);
+        this.querySubmissionCodec = jsonCodec(QuerySubmission.class);
 
         requireNonNull(socksProxy, "socksProxy is null");
         HttpClientConfig httpClientConfig = new HttpClientConfig();
@@ -149,7 +152,7 @@ public class BenchmarkQueryRunner
         failures = 0;
         while (true) {
             // start query
-            StatementClient client = new StatementClient(httpClient, queryResultsCodec, session, "show schemas");
+            StatementClient client = new StatementClient(httpClient, queryResultsCodec, querySubmissionCodec, session, "show schemas");
 
             // read query output
             ImmutableList.Builder<String> schemas = ImmutableList.builder();
@@ -190,7 +193,7 @@ public class BenchmarkQueryRunner
     private StatementStats execute(ClientSession session, String name, String query)
     {
         // start query
-        StatementClient client = new StatementClient(httpClient, queryResultsCodec, session, query);
+        StatementClient client = new StatementClient(httpClient, queryResultsCodec, querySubmissionCodec, session, query);
 
         // read query output
         while (client.isValid() && client.advance()) {

--- a/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
@@ -15,6 +15,7 @@ package com.facebook.presto.cli;
 
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.client.StatementClient;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
@@ -41,10 +42,12 @@ public class QueryRunner
     private final JsonCodec<QueryResults> queryResultsCodec;
     private final AtomicReference<ClientSession> session;
     private final HttpClient httpClient;
+    private final JsonCodec<QuerySubmission> querySubmissionCodec;
 
     public QueryRunner(
             ClientSession session,
             JsonCodec<QueryResults> queryResultsCodec,
+            JsonCodec<QuerySubmission> querySubmissionCodec,
             Optional<HostAndPort> socksProxy,
             Optional<String> keystorePath,
             Optional<String> keystorePassword,
@@ -59,6 +62,7 @@ public class QueryRunner
     {
         this.session = new AtomicReference<>(requireNonNull(session, "session is null"));
         this.queryResultsCodec = requireNonNull(queryResultsCodec, "queryResultsCodec is null");
+        this.querySubmissionCodec = requireNonNull(querySubmissionCodec, "querySubmissionCodec is null");
         this.httpClient = new JettyHttpClient(
                 getHttpClientConfig(
                         socksProxy,
@@ -91,7 +95,7 @@ public class QueryRunner
 
     public StatementClient startInternalQuery(String query)
     {
-        return new StatementClient(httpClient, queryResultsCodec, session.get(), query);
+        return new StatementClient(httpClient, queryResultsCodec, querySubmissionCodec, session.get(), query);
     }
 
     @Override
@@ -117,6 +121,7 @@ public class QueryRunner
         return new QueryRunner(
                 session,
                 jsonCodec(QueryResults.class),
+                jsonCodec(QuerySubmission.class),
                 socksProxy,
                 keystorePath,
                 keystorePassword,

--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -39,6 +39,7 @@ public final class PrestoHeaders
     public static final String PRESTO_PAGE_TOKEN = "X-Presto-Page-Sequence-Id";
     public static final String PRESTO_PAGE_NEXT_TOKEN = "X-Presto-Page-End-Sequence-Id";
     public static final String PRESTO_BUFFER_COMPLETE = "X-Presto-Buffer-Complete";
+    public static final String PRESTO_PREPARED_STATEMENT_IN_BODY = "X-Presto-Prepared-Statement-In-Body";
 
     private PrestoHeaders() {}
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
@@ -20,6 +20,8 @@ import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -76,6 +78,8 @@ public class QueryResults
     private final QueryError error;
     private final String updateType;
     private final Long updateCount;
+    private final Map<String, String> addedPreparedStatements;
+    private final Set<String> deallocatedPreparedStatements;
 
     @JsonCreator
     public QueryResults(
@@ -88,9 +92,11 @@ public class QueryResults
             @JsonProperty("stats") StatementStats stats,
             @JsonProperty("error") QueryError error,
             @JsonProperty("updateType") String updateType,
-            @JsonProperty("updateCount") Long updateCount)
+            @JsonProperty("updateCount") Long updateCount,
+            @JsonProperty("addedPreparedStatements") Map<String, String> addedPreparedStatements,
+            @JsonProperty("deallocatedPreparedStatements") Set<String> deallocatedPreparedStatements)
     {
-        this(id, infoUri, partialCancelUri, nextUri, columns, fixData(columns, data), stats, error, updateType, updateCount);
+        this(id, infoUri, partialCancelUri, nextUri, columns, fixData(columns, data), stats, error, updateType, updateCount, addedPreparedStatements, deallocatedPreparedStatements);
     }
 
     public QueryResults(
@@ -103,7 +109,9 @@ public class QueryResults
             StatementStats stats,
             QueryError error,
             String updateType,
-            Long updateCount)
+            Long updateCount,
+            Map<String, String> addedPreparedStatements,
+            Set<String> deallocatedPreparedStatements)
     {
         this.id = requireNonNull(id, "id is null");
         this.infoUri = requireNonNull(infoUri, "infoUri is null");
@@ -115,6 +123,10 @@ public class QueryResults
         this.error = error;
         this.updateType = updateType;
         this.updateCount = updateCount;
+        requireNonNull(addedPreparedStatements, "addedPreparedStatements is null");
+        this.addedPreparedStatements = ImmutableMap.copyOf(addedPreparedStatements);
+        requireNonNull(deallocatedPreparedStatements, "deallocatedPreparedStatements is null");
+        this.deallocatedPreparedStatements = ImmutableSet.copyOf(deallocatedPreparedStatements);
     }
 
     @NotNull
@@ -187,6 +199,20 @@ public class QueryResults
         return updateCount;
     }
 
+    @NotNull
+    @JsonProperty
+    public Map<String, String> getAddedPreparedStatements()
+    {
+        return addedPreparedStatements;
+    }
+
+    @NotNull
+    @JsonProperty
+    public Set<String> getDeallocatedPreparedStatements()
+    {
+        return deallocatedPreparedStatements;
+    }
+
     @Override
     public String toString()
     {
@@ -201,6 +227,8 @@ public class QueryResults
                 .add("error", error)
                 .add("updateType", updateType)
                 .add("updateCount", updateCount)
+                .add("addedPreparedStatements", addedPreparedStatements)
+                .add("deallocatedPreparedStatements", deallocatedPreparedStatements)
                 .toString();
     }
 

--- a/presto-client/src/main/java/com/facebook/presto/client/QuerySubmission.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QuerySubmission.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * For use with /v1/statement when you send prepared statements via that
+ */
+@Immutable
+public class QuerySubmission
+{
+    private final String query;
+    private final Map<String, String> preparedStatements;
+
+    @JsonCreator
+    public QuerySubmission(
+            @JsonProperty("query") String query,
+            @JsonProperty("preparedStatements") Map<String, String> preparedStatements)
+    {
+        this.query = requireNonNull(query, "query is null");
+        this.preparedStatements = requireNonNull(preparedStatements, "preparedStatements is null");
+    }
+
+    @JsonProperty
+    public String getQuery()
+    {
+        return query;
+    }
+
+    @JsonProperty
+    public Map<String, String> getPreparedStatements()
+    {
+        return preparedStatements;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("query", query)
+                .add("preparedStatements", preparedStatements)
+                .toString();
+    }
+}

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -44,10 +44,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_ADDED_PREPARE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLEAR_SESSION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLEAR_TRANSACTION_ID;
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_DEALLOCATED_PREPARE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT_IN_BODY;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_SESSION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_STARTED_TRANSACTION_ID;
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -249,6 +248,7 @@ public class StatementClient
     {
         builder.setHeader(PrestoHeaders.PRESTO_USER, user);
         builder.setHeader(USER_AGENT, USER_AGENT_VALUE)
+                .setHeader(PRESTO_PREPARED_STATEMENT_IN_BODY, "true")
                 .setUri(nextUri);
 
         return builder;
@@ -323,17 +323,6 @@ public class StatementClient
             resetSessionProperties.add(clearSession);
         }
 
-        for (String entry : response.getHeaders(PRESTO_ADDED_PREPARE)) {
-            List<String> keyValue = SESSION_HEADER_SPLITTER.splitToList(entry);
-            if (keyValue.size() != 2) {
-                continue;
-            }
-            addedPreparedStatements.put(urlDecode(keyValue.get(0)), urlDecode(keyValue.get(1)));
-        }
-        for (String entry : response.getHeaders(PRESTO_DEALLOCATED_PREPARE)) {
-            deallocatedPreparedStatements.add(urlDecode(entry));
-        }
-
         String startedTransactionId = response.getHeader(PRESTO_STARTED_TRANSACTION_ID);
         if (startedTransactionId != null) {
             this.startedtransactionId.set(startedTransactionId);
@@ -342,7 +331,12 @@ public class StatementClient
             clearTransactionId.set(true);
         }
 
-        currentResults.set(response.getValue());
+        QueryResults queryResults = response.getValue();
+
+        this.addedPreparedStatements.putAll(queryResults.getAddedPreparedStatements());
+        this.deallocatedPreparedStatements.addAll(queryResults.getDeallocatedPreparedStatements());
+
+        currentResults.set(queryResults);
     }
 
     private RuntimeException requestFailedException(String task, Request request, JsonResponse<QueryResults> response)

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -58,14 +58,14 @@ import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonRespo
 import static io.airlift.http.client.HttpStatus.Family;
 import static io.airlift.http.client.HttpStatus.familyForStatusCode;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
 import static io.airlift.http.client.Request.Builder.prepareDelete;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.Request.Builder.preparePost;
-import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static io.airlift.http.client.StatusResponseHandler.StatusResponse;
 import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static io.airlift.json.JsonCodec.jsonCodec;
 import static java.lang.String.format;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -96,11 +96,18 @@ public class StatementClient
     private final TimeZoneKey timeZone;
     private final long requestTimeoutNanos;
     private final String user;
+    private final JsonCodec<QuerySubmission> querySubmissionCodec;
 
     public StatementClient(HttpClient httpClient, JsonCodec<QueryResults> queryResultsCodec, ClientSession session, String query)
     {
+        this(httpClient, queryResultsCodec, jsonCodec(QuerySubmission.class), session, query);
+    }
+
+    public StatementClient(HttpClient httpClient, JsonCodec<QueryResults> queryResultsCodec, JsonCodec<QuerySubmission> querySubmissionCodec, ClientSession session, String query)
+    {
         requireNonNull(httpClient, "httpClient is null");
         requireNonNull(queryResultsCodec, "queryResultsCodec is null");
+        requireNonNull(querySubmissionCodec, "querySubmissionCodec is null");
         requireNonNull(session, "session is null");
         requireNonNull(query, "query is null");
 
@@ -111,6 +118,7 @@ public class StatementClient
         this.query = query;
         this.requestTimeoutNanos = session.getClientRequestTimeout().roundTo(NANOSECONDS);
         this.user = session.getUser();
+        this.querySubmissionCodec = querySubmissionCodec;
 
         Request request = buildQueryRequest(session, query);
         JsonResponse<QueryResults> response = httpClient.execute(request, responseHandler);
@@ -125,7 +133,8 @@ public class StatementClient
     private Request buildQueryRequest(ClientSession session, String query)
     {
         Request.Builder builder = prepareRequest(preparePost(), uriBuilderFrom(session.getServer()).replacePath("/v1/statement").build())
-                .setBodyGenerator(createStaticBodyGenerator(query, UTF_8));
+                .setBodyGenerator(jsonBodyGenerator(querySubmissionCodec, new QuerySubmission(query, session.getPreparedStatements())));
+        builder.setHeader(PrestoHeaders.PRESTO_PREPARED_STATEMENT_IN_BODY, "true");
 
         if (session.getSource() != null) {
             builder.setHeader(PrestoHeaders.PRESTO_SOURCE, session.getSource());
@@ -147,11 +156,6 @@ public class StatementClient
         Map<String, String> property = session.getProperties();
         for (Entry<String, String> entry : property.entrySet()) {
             builder.addHeader(PrestoHeaders.PRESTO_SESSION, entry.getKey() + "=" + entry.getValue());
-        }
-
-        Map<String, String> statements = session.getPreparedStatements();
-        for (Entry<String, String> entry : statements.entrySet()) {
-            builder.addHeader(PrestoHeaders.PRESTO_PREPARED_STATEMENT, urlEncode(entry.getKey()) + "=" + urlEncode(entry.getValue()));
         }
 
         builder.setHeader(PrestoHeaders.PRESTO_TRANSACTION_ID, session.getTransactionId() == null ? "NONE" : session.getTransactionId());

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/QueryExecutor.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/QueryExecutor.java
@@ -15,6 +15,7 @@ package com.facebook.presto.jdbc;
 
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.client.StatementClient;
 import com.google.common.collect.ImmutableSet;
@@ -49,17 +50,19 @@ class QueryExecutor
     private final JsonCodec<QueryResults> queryInfoCodec;
     private final JsonCodec<ServerInfo> serverInfoCodec;
     private final HttpClient httpClient;
+    private final JsonCodec<QuerySubmission> querySubmissionCodec;
 
-    private QueryExecutor(JsonCodec<QueryResults> queryResultsCodec, JsonCodec<ServerInfo> serverInfoCodec, HttpClient httpClient)
+    private QueryExecutor(JsonCodec<QueryResults> queryResultsCodec, JsonCodec<ServerInfo> serverInfoCodec, JsonCodec<QuerySubmission> querySubmissionCodec, HttpClient httpClient)
     {
         this.queryInfoCodec = requireNonNull(queryResultsCodec, "queryResultsCodec is null");
         this.serverInfoCodec = requireNonNull(serverInfoCodec, "serverInfoCodec is null");
+        this.querySubmissionCodec = requireNonNull(querySubmissionCodec, "querySubmissionCodec is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
     }
 
     public StatementClient startQuery(ClientSession session, String query)
     {
-        return new StatementClient(httpClient, queryInfoCodec, session, query);
+        return new StatementClient(httpClient, queryInfoCodec, querySubmissionCodec, session, query);
     }
 
     @Override
@@ -95,7 +98,7 @@ class QueryExecutor
 
     static QueryExecutor create(HttpClient httpClient)
     {
-        return new QueryExecutor(jsonCodec(QueryResults.class), jsonCodec(ServerInfo.class), httpClient);
+        return new QueryExecutor(jsonCodec(QueryResults.class), jsonCodec(ServerInfo.class), jsonCodec(QuerySubmission.class), httpClient);
     }
 
     @Nullable

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
@@ -19,6 +19,8 @@ import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.StatementStats;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HttpHeaders;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.HttpStatus;
@@ -78,7 +80,9 @@ public class TestProgressMonitor
                 new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
                 null,
                 null,
-                null);
+                null,
+                ImmutableMap.of(),
+                ImmutableSet.of());
 
         return QUERY_RESULTS_CODEC.toJson(queryResults);
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.server;
 
 import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.execution.AddColumnTask;
 import com.facebook.presto.execution.CallTask;
 import com.facebook.presto.execution.CommitTask;
@@ -139,6 +140,7 @@ public class CoordinatorModule
         jsonCodecBinder(binder).bindJsonCodec(QueryInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(TaskInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(QueryResults.class);
+        jsonCodecBinder(binder).bindJsonCodec(QuerySubmission.class);
         jaxrsBinder(binder).bind(StatementResource.class);
 
         // query execution visualizer

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionFactory.java
@@ -85,7 +85,7 @@ final class HttpRequestSessionFactory
     private final boolean clientTransactionSupport;
     private final String clientInfo;
 
-    public HttpRequestSessionFactory(HttpServletRequest servletRequest)
+    public HttpRequestSessionFactory(HttpServletRequest servletRequest, Map<String, String> additionalPreparedStatements)
             throws WebApplicationException
     {
         catalog = trimEmptyToNull(servletRequest.getHeader(PRESTO_CATALOG));
@@ -137,6 +137,7 @@ final class HttpRequestSessionFactory
                 .collect(toImmutableMap(Entry::getKey, entry -> ImmutableMap.copyOf(entry.getValue())));
 
         preparedStatements = parsePreparedStatementsHeaders(servletRequest);
+        preparedStatements.putAll(additionalPreparedStatements);
 
         String transactionIdHeader = servletRequest.getHeader(PRESTO_TRANSACTION_ID);
         clientTransactionSupport = transactionIdHeader != null;

--- a/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
@@ -187,7 +187,7 @@ public class StatementResource
                 blockEncodingSerde);
         queries.put(query.getQueryId(), query);
 
-        return getQueryResults(query, Optional.empty(), uriInfo, new Duration(1, MILLISECONDS));
+        return getQueryResults(query, Optional.empty(), uriInfo, new Duration(1, MILLISECONDS), servletRequest);
     }
 
     /**
@@ -212,7 +212,8 @@ public class StatementResource
             @PathParam("queryId") QueryId queryId,
             @PathParam("token") long token,
             @QueryParam("maxWait") Duration maxWait,
-            @Context UriInfo uriInfo)
+            @Context UriInfo uriInfo,
+            @Context HttpServletRequest servletRequest)
             throws InterruptedException
     {
         Query query = queries.get(queryId);
@@ -221,10 +222,10 @@ public class StatementResource
         }
 
         Duration wait = WAIT_ORDERING.min(MAX_WAIT_TIME, maxWait);
-        return getQueryResults(query, Optional.of(token), uriInfo, wait);
+        return getQueryResults(query, Optional.of(token), uriInfo, wait, servletRequest);
     }
 
-    private static Response getQueryResults(Query query, Optional<Long> token, UriInfo uriInfo, Duration wait)
+    private static Response getQueryResults(Query query, Optional<Long> token, UriInfo uriInfo, Duration wait, HttpServletRequest servletRequest)
             throws InterruptedException
     {
         QueryResults queryResults;
@@ -245,16 +246,18 @@ public class StatementResource
         query.getResetSessionProperties()
                 .forEach(name -> response.header(PRESTO_CLEAR_SESSION, name));
 
-        // add added prepare statements
-        for (Entry<String, String> entry : query.getAddedPreparedStatements().entrySet()) {
-            String encodedKey = urlEncode(entry.getKey());
-            String encodedValue = urlEncode(entry.getValue());
-            response.header(PRESTO_ADDED_PREPARE, encodedKey + '=' + encodedValue);
-        }
+        if (servletRequest.getHeader(PRESTO_PREPARED_STATEMENT_IN_BODY) == null) {
+            // add added prepare statements
+            for (Entry<String, String> entry : query.getAddedPreparedStatements().entrySet()) {
+                String encodedKey = urlEncode(entry.getKey());
+                String encodedValue = urlEncode(entry.getValue());
+                response.header(PRESTO_ADDED_PREPARE, encodedKey + '=' + encodedValue);
+            }
 
-        // add deallocated prepare statements
-        for (String name : query.getDeallocatedPreparedStatements()) {
-            response.header(PRESTO_DEALLOCATED_PREPARE, urlEncode(name));
+            // add deallocated prepare statements
+            for (String name : query.getDeallocatedPreparedStatements()) {
+                response.header(PRESTO_DEALLOCATED_PREPARE, urlEncode(name));
+            }
         }
 
         // add new transaction ID
@@ -502,7 +505,9 @@ public class StatementResource
                     toStatementStats(queryInfo),
                     toQueryError(queryInfo),
                     queryInfo.getUpdateType(),
-                    updateCount);
+                    updateCount,
+                    addedPreparedStatements,
+                    deallocatedPreparedStatements);
 
             // cache the last results
             if (lastResult != null && lastResult.getNextUri() != null) {

--- a/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
@@ -20,6 +20,7 @@ import com.facebook.presto.client.Column;
 import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.client.StageStats;
 import com.facebook.presto.client.StatementStats;
 import com.facebook.presto.execution.QueryInfo;
@@ -48,10 +49,12 @@ import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.transaction.TransactionId;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
+import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -98,6 +101,7 @@ import static com.facebook.presto.client.PrestoHeaders.PRESTO_ADDED_PREPARE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLEAR_SESSION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLEAR_TRANSACTION_ID;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_DEALLOCATED_PREPARE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT_IN_BODY;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_SESSION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_STARTED_TRANSACTION_ID;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -129,18 +133,21 @@ public class StatementResource
 
     private final ConcurrentMap<QueryId, Query> queries = new ConcurrentHashMap<>();
     private final ScheduledExecutorService queryPurger = newSingleThreadScheduledExecutor(threadsNamed("query-purger"));
+    private final JsonCodec<QuerySubmission> querySubmissionCodec;
 
     @Inject
     public StatementResource(
             QueryManager queryManager,
             SessionPropertyManager sessionPropertyManager,
             ExchangeClientSupplier exchangeClientSupplier,
-            BlockEncodingSerde blockEncodingSerde)
+            BlockEncodingSerde blockEncodingSerde,
+            JsonCodec<QuerySubmission> querySubmissionCodec)
     {
         this.queryManager = requireNonNull(queryManager, "queryManager is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.exchangeClientSupplier = requireNonNull(exchangeClientSupplier, "exchangeClientSupplier is null");
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
+        this.querySubmissionCodec = requireNonNull(querySubmissionCodec, "querySubmissionCodec is null");
 
         queryPurger.scheduleWithFixedDelay(new PurgeQueriesRunnable(queries, queryManager), 200, 200, MILLISECONDS);
     }
@@ -167,12 +174,13 @@ public class StatementResource
                     .build());
         }
 
-        SessionSupplier sessionSupplier = new HttpRequestSessionFactory(servletRequest);
+        QuerySubmission querySubmission = parseStringToQuerySubmission(servletRequest, statement, querySubmissionCodec);
+        SessionSupplier sessionSupplier = new HttpRequestSessionFactory(servletRequest, querySubmission.getPreparedStatements());
 
         ExchangeClient exchangeClient = exchangeClientSupplier.get(deltaMemoryInBytes -> { });
         Query query = new Query(
                 sessionSupplier,
-                statement,
+                querySubmission.getQuery(),
                 queryManager,
                 sessionPropertyManager,
                 exchangeClient,
@@ -180,6 +188,21 @@ public class StatementResource
         queries.put(query.getQueryId(), query);
 
         return getQueryResults(query, Optional.empty(), uriInfo, new Duration(1, MILLISECONDS));
+    }
+
+    /**
+     * The query can be sent from the client either in plaintext or via a Jackson-serialized JSON representation of
+     * a QuerySubmission object, which includes prepared statements in the body of the HTTP request as well as
+     * the query.
+     */
+    private static QuerySubmission parseStringToQuerySubmission(HttpServletRequest servletRequest, String statement, JsonCodec<QuerySubmission> querySubmissionCodec)
+    {
+        if (servletRequest.getHeader(PRESTO_PREPARED_STATEMENT_IN_BODY) != null) {
+            return querySubmissionCodec.fromJson(statement);
+        }
+        else {
+            return new QuerySubmission(statement, ImmutableMap.of());
+        }
     }
 
     @GET

--- a/presto-main/src/test/java/com/facebook/presto/server/TestHttpRequestSessionFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestHttpRequestSessionFactory.java
@@ -34,6 +34,7 @@ import static com.facebook.presto.client.PrestoHeaders.PRESTO_CATALOG;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLIENT_INFO;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_LANGUAGE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT_IN_BODY;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SCHEMA;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SESSION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SOURCE;
@@ -64,7 +65,7 @@ public class TestHttpRequestSessionFactory
                         .build(),
                 "testRemote");
 
-        HttpRequestSessionFactory sessionFactory = new HttpRequestSessionFactory(request);
+        HttpRequestSessionFactory sessionFactory = new HttpRequestSessionFactory(request, ImmutableMap.of());
         Session session = sessionFactory.createSession(
                 new QueryId("test_query_id"),
                 createTestTransactionManager(),
@@ -101,7 +102,7 @@ public class TestHttpRequestSessionFactory
                         .put(PRESTO_TIME_ZONE, "unknown_timezone")
                         .build(),
                 "testRemote");
-        HttpRequestSessionFactory sessionFactory = new HttpRequestSessionFactory(request);
+        HttpRequestSessionFactory sessionFactory = new HttpRequestSessionFactory(request, ImmutableMap.of());
         sessionFactory.createSession(
                 new QueryId("test_query_id"),
                 createTestTransactionManager(),
@@ -125,6 +126,43 @@ public class TestHttpRequestSessionFactory
                         .put(PRESTO_PREPARED_STATEMENT, "query1=abcdefg")
                         .build(),
                 "testRemote");
-        new HttpRequestSessionFactory(request);
+        new HttpRequestSessionFactory(request, ImmutableMap.of());
+    }
+
+    @Test
+    public void testPreparedStatementsInBody()
+    {
+        HttpServletRequest request = new MockHttpServletRequest(
+                ImmutableListMultimap.<String, String>builder()
+                        .put(PRESTO_USER, "testUser")
+                        .put(PRESTO_SOURCE, "testSource")
+                        .put(PRESTO_CATALOG, "testCatalog")
+                        .put(PRESTO_SCHEMA, "testSchema")
+                        .put(PRESTO_LANGUAGE, "zh-TW")
+                        .put(PRESTO_TIME_ZONE, "Asia/Taipei")
+                        .put(PRESTO_CLIENT_INFO, "client-info")
+                        .put(PRESTO_SESSION, QUERY_MAX_MEMORY + "=1GB")
+                        .put(PRESTO_SESSION, DISTRIBUTED_JOIN + "=true," + HASH_PARTITION_COUNT + " = 43")
+                        .put(PRESTO_PREPARED_STATEMENT, "query1=select * from foo,query2=select * from bar")
+                        .put(PRESTO_PREPARED_STATEMENT_IN_BODY, "true")
+                        .build(),
+                "testRemote");
+
+        HttpRequestSessionFactory sessionFactory = new HttpRequestSessionFactory(request, ImmutableMap.<String, String>builder()
+                .put("query3", "select * from alpha")
+                .put("query4", "select * from beta")
+                .build());
+        Session session = sessionFactory.createSession(
+                new QueryId("test_query_id"),
+                createTestTransactionManager(),
+                new AllowAllAccessControl(),
+                new SessionPropertyManager());
+
+        assertEquals(session.getPreparedStatements(), ImmutableMap.<String, String>builder()
+                .put("query1", "select * from foo")
+                .put("query2", "select * from bar")
+                .put("query3", "select * from alpha")
+                .put("query4", "select * from beta")
+                .build());
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -54,6 +54,7 @@ public final class TestGroups
     public static final String CASSANDRA = "cassandra";
     public static final String LDAP = "ldap";
     public static final String LDAP_CLI = "ldap_cli";
+    public static final String PREPARED_STATEMENTS = "prepared_statements";
 
     private TestGroups() {}
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
@@ -29,9 +29,12 @@ import java.io.File;
 import java.io.IOException;
 
 import static com.facebook.presto.tests.TestGroups.CLI;
+import static com.facebook.presto.tests.TestGroups.PREPARED_STATEMENTS;
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Strings.repeat;
 import static com.teradata.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.NATION;
 import static com.teradata.tempto.process.CliProcess.trimLines;
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -139,6 +142,36 @@ public class PrestoCliTests
 
         launchPrestoCliWithServerArgument("--file", temporayFile.getAbsolutePath());
         assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
+    }
+
+    @Test(groups = {CLI, PREPARED_STATEMENTS}, timeOut = TIMEOUT)
+    public void shouldExecuteSimplePreparedStatement()
+            throws IOException, InterruptedException
+    {
+        launchPrestoCliWithServerArgument("--execute", "prepare my_select1 from select * from hive.default.nation; execute my_select1;");
+        assertThat(trimLines(presto.readRemainingErrorLines())).contains("PREPARE");
+        assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
+    }
+
+    @Test(groups = {CLI, PREPARED_STATEMENTS}, timeOut = TIMEOUT)
+    public void shouldExecuteLongPreparedStatement()
+            throws IOException, InterruptedException
+    {
+        launchPrestoCliWithServerArgument(
+                "--execute",
+                format("prepare my_select2 from select * from hive.default.nation where n_name != '%s'; execute my_select2;", repeat("a", 65536)));
+        assertThat(trimLines(presto.readRemainingErrorLines())).contains("PREPARE");
+        assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
+    }
+
+    @Test(groups = {CLI, PREPARED_STATEMENTS}, timeOut = TIMEOUT)
+    public void shouldAddAndDeallocateLongPreparedStatement()
+            throws IOException, InterruptedException
+    {
+        launchPrestoCliWithServerArgument(
+                "--execute",
+                format("prepare my_select2 from select * from hive.default.nation where n_name != '%s'; deallocate prepare my_select2;", repeat("a", 65536)));
+        assertThat(trimLines(presto.readRemainingErrorLines())).containsExactly("PREPARE", "DEALLOCATE");
     }
 
     private void launchPrestoCliWithServerArgument(String... arguments)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -18,6 +18,7 @@ import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.Column;
 import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.metadata.MetadataUtil;
 import com.facebook.presto.metadata.QualifiedObjectName;
@@ -52,6 +53,7 @@ public abstract class AbstractTestingPrestoClient<T>
         implements Closeable
 {
     private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
+    private static final JsonCodec<QuerySubmission> QUERY_SUBMISSION_CODEC = jsonCodec(QuerySubmission.class);
 
     private final TestingPrestoServer prestoServer;
     private final Session defaultSession;
@@ -89,7 +91,7 @@ public abstract class AbstractTestingPrestoClient<T>
 
         ClientSession clientSession = toClientSession(session, prestoServer.getBaseUrl(), true, new Duration(2, TimeUnit.MINUTES));
 
-        try (StatementClient client = new StatementClient(httpClient, QUERY_RESULTS_CODEC, clientSession, sql)) {
+        try (StatementClient client = new StatementClient(httpClient, QUERY_RESULTS_CODEC, QUERY_SUBMISSION_CODEC, clientSession, sql)) {
             while (client.isValid()) {
                 QueryResults results = client.current();
 


### PR DESCRIPTION
Fixes https://github.com/prestodb/presto/issues/5759 by passing prepared statements in the HTTP request body rather than the headers, which have a limit in Jetty of 4k bytes.

Whether prepared statements are passed in the headers or the body is configurable (via an HTTP header), to allow other clients a chance to update.
