### PR TITLE
Update to airlift 0.134

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.5.1</dep.antlr.version>
-        <dep.airlift.version>0.133</dep.airlift.version>
+        <dep.airlift.version>0.134</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.23</dep.slice.version>
         <dep.aws-sdk.version>1.9.40</dep.aws-sdk.version>


### PR DESCRIPTION
Fixes an where tools.jar needed to be available in the classpath
in order for airlift's JMX agent code to work.

Fixes #5854