### PR TITLE
Make the AST the canonical source for window frame information

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -334,8 +334,8 @@ class AggregationAnalyzer
                     throw new SemanticException(MUST_BE_AGGREGATE_OR_GROUP_BY, start.get(), "Window frame start must be an aggregate expression or appear in GROUP BY clause");
                 }
             }
-            if (node.getEnd().isPresent() && node.getEnd().get().getValue().isPresent()) {
-                Expression endValue = node.getEnd().get().getValue().get();
+            if (node.getEnd().getValue().isPresent()) {
+                Expression endValue = node.getEnd().getValue().get();
                 if (!process(endValue, context)) {
                     throw new SemanticException(MUST_BE_AGGREGATE_OR_GROUP_BY, endValue, "Window frame end must be an aggregate expression or appear in GROUP BY clause");
                 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -320,9 +320,7 @@ class AggregationAnalyzer
                 }
             }
 
-            if (node.getFrame().isPresent()) {
-                process(node.getFrame().get(), context);
-            }
+            process(node.getFrame(), context);
 
             return true;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -719,8 +719,8 @@ public class ExpressionAnalyzer
                     }
                 }
 
-                if (frame.getEnd().isPresent() && frame.getEnd().get().getValue().isPresent()) {
-                    Type type = process(frame.getEnd().get().getValue().get(), context);
+                if (frame.getEnd().getValue().isPresent()) {
+                    Type type = process(frame.getEnd().getValue().get(), context);
                     if (!type.equals(INTEGER) && !type.equals(BIGINT)) {
                         throw new SemanticException(TYPE_MISMATCH, node, "Window frame end value type must be INTEGER or BIGINT (actual %s)", type);
                     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -710,21 +710,19 @@ public class ExpressionAnalyzer
                     }
                 }
 
-                if (node.getWindow().get().getFrame().isPresent()) {
-                    WindowFrame frame = node.getWindow().get().getFrame().get();
+                WindowFrame frame = node.getWindow().get().getFrame();
 
-                    if (frame.getStart().getValue().isPresent()) {
-                        Type type = process(frame.getStart().getValue().get(), context);
-                        if (!type.equals(INTEGER) && !type.equals(BIGINT)) {
-                            throw new SemanticException(TYPE_MISMATCH, node, "Window frame start value type must be INTEGER or BIGINT(actual %s)", type);
-                        }
+                if (frame.getStart().getValue().isPresent()) {
+                    Type type = process(frame.getStart().getValue().get(), context);
+                    if (!type.equals(INTEGER) && !type.equals(BIGINT)) {
+                        throw new SemanticException(TYPE_MISMATCH, node, "Window frame start value type must be INTEGER or BIGINT(actual %s)", type);
                     }
+                }
 
-                    if (frame.getEnd().isPresent() && frame.getEnd().get().getValue().isPresent()) {
-                        Type type = process(frame.getEnd().get().getValue().get(), context);
-                        if (!type.equals(INTEGER) && !type.equals(BIGINT)) {
-                            throw new SemanticException(TYPE_MISMATCH, node, "Window frame end value type must be INTEGER or BIGINT (actual %s)", type);
-                        }
+                if (frame.getEnd().isPresent() && frame.getEnd().get().getValue().isPresent()) {
+                    Type type = process(frame.getEnd().get().getValue().get(), context);
+                    if (!type.equals(INTEGER) && !type.equals(BIGINT)) {
+                        throw new SemanticException(TYPE_MISMATCH, node, "Window frame end value type must be INTEGER or BIGINT (actual %s)", type);
                     }
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1025,7 +1025,7 @@ class StatementAnalyzer
     private static void analyzeWindowFrame(WindowFrame frame)
     {
         FrameBound.Type startType = frame.getStart().getType();
-        FrameBound.Type endType = frame.getEnd().orElse(new FrameBound(CURRENT_ROW)).getType();
+        FrameBound.Type endType = frame.getEnd().getType();
 
         if (startType == UNBOUNDED_FOLLOWING) {
             throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame start cannot be UNBOUNDED FOLLOWING");

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -997,9 +997,7 @@ class StatementAnalyzer
                 nestedExtractor.process(sortItem.getSortKey(), null);
             }
 
-            if (window.getFrame().isPresent()) {
-                nestedExtractor.process(window.getFrame().get(), null);
-            }
+            nestedExtractor.process(window.getFrame(), null);
 
             if (!nestedExtractor.getWindowFunctions().isEmpty()) {
                 throw new SemanticException(NESTED_WINDOW, node, "Cannot nest window functions inside window function '%s': %s",
@@ -1011,9 +1009,7 @@ class StatementAnalyzer
                 throw new SemanticException(NOT_SUPPORTED, node, "DISTINCT in window function parameters not yet supported: %s", windowFunction);
             }
 
-            if (window.getFrame().isPresent()) {
-                analyzeWindowFrame(window.getFrame().get());
-            }
+            analyzeWindowFrame(window.getFrame());
 
             List<TypeSignature> argumentTypes = Lists.transform(windowFunction.getArguments(), expression -> analysis.getType(expression).getTypeSignature());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -500,23 +500,17 @@ class QueryPlanner
             Window window = windowFunction.getWindow().get();
 
             // Extract frame
-            WindowFrame.Type frameType = WindowFrame.Type.RANGE;
-            FrameBound.Type frameStartType = FrameBound.Type.UNBOUNDED_PRECEDING;
+            WindowFrame frame = window.getFrame();
+            WindowFrame.Type frameType = frame.getType();
+            FrameBound.Type frameStartType = frame.getStart().getType();
+            Expression frameStart = frame.getStart().getValue().orElse(null);
+
             FrameBound.Type frameEndType = FrameBound.Type.CURRENT_ROW;
-            Expression frameStart = null;
             Expression frameEnd = null;
 
-            if (window.getFrame().isPresent()) {
-                WindowFrame frame = window.getFrame().get();
-                frameType = frame.getType();
-
-                frameStartType = frame.getStart().getType();
-                frameStart = frame.getStart().getValue().orElse(null);
-
-                if (frame.getEnd().isPresent()) {
-                    frameEndType = frame.getEnd().get().getType();
-                    frameEnd = frame.getEnd().get().getValue().orElse(null);
-                }
+            if (frame.getEnd().isPresent()) {
+                frameEndType = frame.getEnd().get().getType();
+                frameEnd = frame.getEnd().get().getValue().orElse(null);
             }
 
             // Pre-project inputs
@@ -557,7 +551,7 @@ class QueryPlanner
                 frameEndSymbol = Optional.of(subPlan.translate(frameEnd));
             }
 
-            WindowNode.Frame frame = new WindowNode.Frame(frameType,
+            WindowNode.Frame rewrittenFrame = new WindowNode.Frame(frameType,
                     frameStartType, frameStartSymbol,
                     frameEndType, frameEndSymbol);
 
@@ -593,7 +587,7 @@ class QueryPlanner
                                     partitionBySymbols.build(),
                                     orderBySymbols.build(),
                                     orderings,
-                                    frame),
+                                    rewrittenFrame),
                             assignments.build(),
                             signatures,
                             Optional.empty(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -504,14 +504,8 @@ class QueryPlanner
             WindowFrame.Type frameType = frame.getType();
             FrameBound.Type frameStartType = frame.getStart().getType();
             Expression frameStart = frame.getStart().getValue().orElse(null);
-
-            FrameBound.Type frameEndType = FrameBound.Type.CURRENT_ROW;
-            Expression frameEnd = null;
-
-            if (frame.getEnd().isPresent()) {
-                frameEndType = frame.getEnd().get().getType();
-                frameEnd = frame.getEnd().get().getValue().orElse(null);
-            }
+            FrameBound.Type frameEndType = frame.getEnd().getType();
+            Expression frameEnd = frame.getEnd().getValue().orElse(null);
 
             // Pre-project inputs
             ImmutableList.Builder<Expression> inputs = ImmutableList.<Expression>builder()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeIdenticalWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeIdenticalWindows.java
@@ -70,12 +70,12 @@ public class TestMergeIdenticalWindows
         windowA = new Window(
                 ImmutableList.of(new SymbolReference("suppkey")),
                 ImmutableList.of(new SortItem(new SymbolReference("orderkey"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
-                Optional.of(frame));
+                frame);
 
         windowB = new Window(
                 ImmutableList.of(new SymbolReference("orderkey")),
                 ImmutableList.of(new SortItem(new SymbolReference("shipdate"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
-                Optional.of(frame));
+                frame);
     }
 
     /**

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeIdenticalWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeIdenticalWindows.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
 import javax.inject.Provider;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyNot;
@@ -65,7 +64,7 @@ public class TestMergeIdenticalWindows
         WindowFrame frame = new WindowFrame(
                 WindowFrame.Type.ROWS,
                 new FrameBound(FrameBound.Type.UNBOUNDED_PRECEDING),
-                Optional.of(new FrameBound(FrameBound.Type.CURRENT_ROW)));
+                new FrameBound(FrameBound.Type.CURRENT_ROW));
 
         windowA = new Window(
                 ImmutableList.of(new SymbolReference("suppkey")),

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -531,9 +531,7 @@ public final class ExpressionFormatter
             if (!node.getOrderBy().isEmpty()) {
                 parts.add("ORDER BY " + formatSortItems(node.getOrderBy(), unmangleNames));
             }
-            if (node.getFrame().isPresent()) {
-                parts.add(process(node.getFrame().get(), unmangleNames));
-            }
+            parts.add(process(node.getFrame(), unmangleNames));
 
             return '(' + Joiner.on(' ').join(parts) + ')';
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -543,15 +543,10 @@ public final class ExpressionFormatter
 
             builder.append(node.getType().toString()).append(' ');
 
-            if (node.getEnd().isPresent()) {
-                builder.append("BETWEEN ")
-                        .append(process(node.getStart(), unmangleNames))
-                        .append(" AND ")
-                        .append(process(node.getEnd().get(), unmangleNames));
-            }
-            else {
-                builder.append(process(node.getStart(), unmangleNames));
-            }
+            builder.append("BETWEEN ")
+                    .append(process(node.getStart(), unmangleNames))
+                    .append(" AND ")
+                    .append(process(node.getEnd(), unmangleNames));
 
             return builder.toString();
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1229,7 +1229,7 @@ class AstBuilder
                 getLocation(context),
                 getFrameType(context.frameType),
                 (FrameBound) visit(context.start),
-                visitOrElse(context.end, FrameBound.class, FrameBound.defaultEnd(getLocation(context))));
+                Optional.of(visitOrElse(context.end, FrameBound.class, FrameBound.defaultEnd(getLocation(context)))));
     }
 
     @Override
@@ -1363,12 +1363,12 @@ class AstBuilder
         throw new UnsupportedOperationException("not yet implemented");
     }
 
-    private <T> Optional<T> visitOrElse(ParserRuleContext context, Class<T> clazz, T other)
+    private <T> T visitOrElse(ParserRuleContext context, Class<T> clazz, T other)
     {
-        return Optional.of(Optional.ofNullable(context)
+        return Optional.ofNullable(context)
                 .map(this::visit)
                 .map(clazz::cast)
-                .orElse(other));
+                .orElse(other);
     }
 
     private <T> Optional<T> visitIfPresent(ParserRuleContext context, Class<T> clazz)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1229,7 +1229,7 @@ class AstBuilder
                 getLocation(context),
                 getFrameType(context.frameType),
                 (FrameBound) visit(context.start),
-                Optional.of(visitOrElse(context.end, FrameBound.class, FrameBound.defaultEnd(getLocation(context)))));
+                visitOrElse(context.end, FrameBound.class, FrameBound.defaultEnd(getLocation(context))));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1229,7 +1229,7 @@ class AstBuilder
                 getLocation(context),
                 getFrameType(context.frameType),
                 (FrameBound) visit(context.start),
-                visitIfPresent(context.end, FrameBound.class));
+                visitOrElse(context.end, FrameBound.class, FrameBound.defaultEnd(getLocation(context))));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1199,7 +1199,7 @@ class AstBuilder
                 getLocation(context),
                 visit(context.partition, Expression.class),
                 visit(context.sortItem(), SortItem.class),
-                visitIfPresent(context.windowFrame(), WindowFrame.class));
+                visitOrElse(context.windowFrame(), WindowFrame.class, WindowFrame.defaultFrame(getLocation(context))));
     }
 
     @Override
@@ -1361,6 +1361,14 @@ class AstBuilder
         }
 
         throw new UnsupportedOperationException("not yet implemented");
+    }
+
+    private <T> Optional<T> visitOrElse(ParserRuleContext context, Class<T> clazz, T other)
+    {
+        return Optional.of(Optional.ofNullable(context)
+                .map(this::visit)
+                .map(clazz::cast)
+                .orElse(other));
     }
 
     private <T> Optional<T> visitIfPresent(ParserRuleContext context, Class<T> clazz)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -194,9 +194,7 @@ public abstract class DefaultTraversalVisitor<R, C>
             process(sortItem.getSortKey(), context);
         }
 
-        if (node.getFrame().isPresent()) {
-            process(node.getFrame().get(), context);
-        }
+        process(node.getFrame(), context);
 
         return null;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -203,9 +203,7 @@ public abstract class DefaultTraversalVisitor<R, C>
     public R visitWindowFrame(WindowFrame node, C context)
     {
         process(node.getStart(), context);
-        if (node.getEnd().isPresent()) {
-            process(node.getEnd().get(), context);
-        }
+        process(node.getEnd(), context);
 
         return null;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -502,27 +502,25 @@ public final class ExpressionTreeRewriter<C>
 
                 WindowFrame frame = window.getFrame();
 
-                FrameBound start = frame.getStart();
-                if (start.getValue().isPresent()) {
-                    Expression value = rewrite(start.getValue().get(), context.get());
-                    if (value != start.getValue().get()) {
-                        start = new FrameBound(start.getType(), value);
+                FrameBound rewrittenStart = frame.getStart();
+                if (rewrittenStart.getValue().isPresent()) {
+                    Expression value = rewrite(rewrittenStart.getValue().get(), context.get());
+                    if (value != rewrittenStart.getValue().get()) {
+                        rewrittenStart = new FrameBound(rewrittenStart.getType(), value);
                     }
                 }
 
-                Optional<FrameBound> rewrittenEnd = frame.getEnd();
-                if (rewrittenEnd.isPresent()) {
-                    Optional<Expression> value = rewrittenEnd.get().getValue();
-                    if (value.isPresent()) {
-                        Expression rewrittenValue = rewrite(value.get(), context.get());
-                        if (rewrittenValue != value.get()) {
-                            rewrittenEnd = Optional.of(new FrameBound(rewrittenEnd.get().getType(), rewrittenValue));
-                        }
+                FrameBound rewrittenEnd = frame.getEnd();
+                Optional<Expression> value = rewrittenEnd.getValue();
+                if (value.isPresent()) {
+                    Expression rewrittenValue = rewrite(value.get(), context.get());
+                    if (rewrittenValue != value.get()) {
+                        rewrittenEnd = new FrameBound(rewrittenEnd.getType(), rewrittenValue);
                     }
                 }
 
-                if ((frame.getStart() != start) || !sameElements(frame.getEnd(), rewrittenEnd)) {
-                    frame = new WindowFrame(frame.getType(), start, rewrittenEnd);
+                if ((frame.getStart() != rewrittenStart) || frame.getEnd() != rewrittenEnd) {
+                    frame = new WindowFrame(frame.getType(), rewrittenStart, rewrittenEnd);
                 }
 
                 if (!sameElements(window.getPartitionBy(), partitionBy.build()) ||

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -500,38 +500,35 @@ public final class ExpressionTreeRewriter<C>
                     }
                 }
 
-                Optional<WindowFrame> rewrittenFrame = window.getFrame();
-                if (rewrittenFrame.isPresent()) {
-                    WindowFrame frame = rewrittenFrame.get();
+                WindowFrame frame = window.getFrame();
 
-                    FrameBound start = frame.getStart();
-                    if (start.getValue().isPresent()) {
-                        Expression value = rewrite(start.getValue().get(), context.get());
-                        if (value != start.getValue().get()) {
-                            start = new FrameBound(start.getType(), value);
+                FrameBound start = frame.getStart();
+                if (start.getValue().isPresent()) {
+                    Expression value = rewrite(start.getValue().get(), context.get());
+                    if (value != start.getValue().get()) {
+                        start = new FrameBound(start.getType(), value);
+                    }
+                }
+
+                Optional<FrameBound> rewrittenEnd = frame.getEnd();
+                if (rewrittenEnd.isPresent()) {
+                    Optional<Expression> value = rewrittenEnd.get().getValue();
+                    if (value.isPresent()) {
+                        Expression rewrittenValue = rewrite(value.get(), context.get());
+                        if (rewrittenValue != value.get()) {
+                            rewrittenEnd = Optional.of(new FrameBound(rewrittenEnd.get().getType(), rewrittenValue));
                         }
                     }
+                }
 
-                    Optional<FrameBound> rewrittenEnd = frame.getEnd();
-                    if (rewrittenEnd.isPresent()) {
-                        Optional<Expression> value = rewrittenEnd.get().getValue();
-                        if (value.isPresent()) {
-                            Expression rewrittenValue = rewrite(value.get(), context.get());
-                            if (rewrittenValue != value.get()) {
-                                rewrittenEnd = Optional.of(new FrameBound(rewrittenEnd.get().getType(), rewrittenValue));
-                            }
-                        }
-                    }
-
-                    if ((frame.getStart() != start) || !sameElements(frame.getEnd(), rewrittenEnd)) {
-                        rewrittenFrame = Optional.of(new WindowFrame(frame.getType(), start, rewrittenEnd));
-                    }
+                if ((frame.getStart() != start) || !sameElements(frame.getEnd(), rewrittenEnd)) {
+                    frame = new WindowFrame(frame.getType(), start, rewrittenEnd);
                 }
 
                 if (!sameElements(window.getPartitionBy(), partitionBy.build()) ||
                         !sameElements(window.getOrderBy(), orderBy.build()) ||
-                        !sameElements(window.getFrame(), rewrittenFrame)) {
-                    rewrittenWindow = Optional.of(new Window(partitionBy.build(), orderBy.build(), rewrittenFrame));
+                        window.getFrame() != frame) {
+                    rewrittenWindow = Optional.of(new Window(partitionBy.build(), orderBy.build(), frame));
                 }
             }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/FrameBound.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/FrameBound.java
@@ -66,6 +66,11 @@ public class FrameBound
         this.value = Optional.ofNullable(value);
     }
 
+    public static FrameBound defaultEnd(NodeLocation location)
+    {
+        return new FrameBound(Optional.of(location), Type.CURRENT_ROW);
+    }
+
     public Type getType()
     {
         return type;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/FrameBound.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/FrameBound.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class FrameBound
@@ -62,6 +63,7 @@ public class FrameBound
     private FrameBound(Optional<NodeLocation> location, Type type, Expression value)
     {
         super(location);
+        checkState(!(type == Type.CURRENT_ROW || type == Type.UNBOUNDED_PRECEDING || type == Type.UNBOUNDED_FOLLOWING) || value == null);
         this.type = requireNonNull(type, "type is null");
         this.value = Optional.ofNullable(value);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Window.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Window.java
@@ -25,19 +25,19 @@ public class Window
 {
     private final List<Expression> partitionBy;
     private final List<SortItem> orderBy;
-    private final Optional<WindowFrame> frame;
+    private final WindowFrame frame;
 
-    public Window(List<Expression> partitionBy, List<SortItem> orderBy, Optional<WindowFrame> frame)
+    public Window(List<Expression> partitionBy, List<SortItem> orderBy, WindowFrame frame)
     {
         this(Optional.empty(), partitionBy, orderBy, frame);
     }
 
-    public Window(NodeLocation location, List<Expression> partitionBy, List<SortItem> orderBy, Optional<WindowFrame> frame)
+    public Window(NodeLocation location, List<Expression> partitionBy, List<SortItem> orderBy, WindowFrame frame)
     {
         this(Optional.of(location), partitionBy, orderBy, frame);
     }
 
-    private Window(Optional<NodeLocation> location, List<Expression> partitionBy, List<SortItem> orderBy, Optional<WindowFrame> frame)
+    private Window(Optional<NodeLocation> location, List<Expression> partitionBy, List<SortItem> orderBy, WindowFrame frame)
     {
         super(location);
         this.partitionBy = requireNonNull(partitionBy, "partitionBy is null");
@@ -55,7 +55,7 @@ public class Window
         return orderBy;
     }
 
-    public Optional<WindowFrame> getFrame()
+    public WindowFrame getFrame()
     {
         return frame;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/WindowFrame.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/WindowFrame.java
@@ -29,19 +29,19 @@ public class WindowFrame
 
     private final Type type;
     private final FrameBound start;
-    private final Optional<FrameBound> end;
+    private final FrameBound end;
 
-    public WindowFrame(Type type, FrameBound start, Optional<FrameBound> end)
+    public WindowFrame(Type type, FrameBound start, FrameBound end)
     {
         this(Optional.empty(), type, start, end);
     }
 
-    public WindowFrame(NodeLocation location, Type type, FrameBound start, Optional<FrameBound> end)
+    public WindowFrame(NodeLocation location, Type type, FrameBound start, FrameBound end)
     {
         this(Optional.of(location), type, start, end);
     }
 
-    private WindowFrame(Optional<NodeLocation> location, Type type, FrameBound start, Optional<FrameBound> end)
+    private WindowFrame(Optional<NodeLocation> location, Type type, FrameBound start, FrameBound end)
     {
         super(location);
         this.type = requireNonNull(type, "type is null");
@@ -55,7 +55,7 @@ public class WindowFrame
                 nodeLocation,
                 Type.RANGE,
                 new FrameBound(nodeLocation, FrameBound.Type.UNBOUNDED_PRECEDING),
-                Optional.of(new FrameBound(nodeLocation, FrameBound.Type.CURRENT_ROW)));
+                new FrameBound(nodeLocation, FrameBound.Type.CURRENT_ROW));
     }
 
     public Type getType()
@@ -68,7 +68,7 @@ public class WindowFrame
         return start;
     }
 
-    public Optional<FrameBound> getEnd()
+    public FrameBound getEnd()
     {
         return end;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/WindowFrame.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/WindowFrame.java
@@ -49,6 +49,15 @@ public class WindowFrame
         this.end = requireNonNull(end, "end is null");
     }
 
+    public static WindowFrame defaultFrame(NodeLocation nodeLocation)
+    {
+        return new WindowFrame(
+                nodeLocation,
+                Type.RANGE,
+                new FrameBound(nodeLocation, FrameBound.Type.UNBOUNDED_PRECEDING),
+                Optional.of(new FrameBound(nodeLocation, FrameBound.Type.CURRENT_ROW)));
+    }
+
     public Type getType()
     {
         return type;


### PR DESCRIPTION
The AST currently contains empty window frames and frame end bounds when none are specified. Later the planner creates WindowNodes containing window frames (and frame end bounds) with the SQL standard defaults when the AST has empty frames (or bounds).

This has two effects:

1. the AST is not the canonical source for frame information
2. The AST and the plan are inconsistent in terms of what they contain

Ensuring that the AST contains the appropriate defaults resolves both of those and also simplifies a whole bunch of places in the analyzer and planner that currently have to handle the default window frame as a special case.
