### PR TITLE
Store the query ID for the control and test queries in the verifier

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryResult.java
@@ -31,14 +31,16 @@ public class QueryResult
     private final Exception exception;
     private final Duration wallTime;
     private final Duration cpuTime;
+    private final String queryId;
     private final List<List<Object>> results;
 
-    public QueryResult(State state, Exception exception, Duration wallTime, Duration cpuTime, List<List<Object>> results)
+    public QueryResult(State state, Exception exception, Duration wallTime, Duration cpuTime, String queryId, List<List<Object>> results)
     {
         this.state = requireNonNull(state, "state is null");
         this.exception = exception;
         this.wallTime = wallTime;
         this.cpuTime = cpuTime;
+        this.queryId = queryId;
         this.results = (results != null) ? ImmutableList.copyOf(results) : null;
     }
 
@@ -60,6 +62,11 @@ public class QueryResult
     public Duration getCpuTime()
     {
         return cpuTime;
+    }
+
+    public String getQueryId()
+    {
+        return queryId;
     }
 
     public List<List<Object>> getResults()

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
@@ -206,12 +206,12 @@ public class Validator
 
         // query has too many rows. Consider blacklisting.
         if (controlResult.getState() == State.TOO_MANY_ROWS) {
-            testResult = new QueryResult(State.INVALID, null, null, null, ImmutableList.<List<Object>>of());
+            testResult = new QueryResult(State.INVALID, null, null, null, null, ImmutableList.<List<Object>>of());
             return false;
         }
         // query failed in the control
         if (controlResult.getState() != State.SUCCESS) {
-            testResult = new QueryResult(State.INVALID, null, null, null, ImmutableList.<List<Object>>of());
+            testResult = new QueryResult(State.INVALID, null, null, null, null, ImmutableList.<List<Object>>of());
             return true;
         }
 
@@ -239,11 +239,11 @@ public class Validator
             QueryResult queryResult = executor.apply(postqueryString);
             postQueryResults.add(queryResult);
             if (queryResult.getState() != State.SUCCESS) {
-                return new QueryResult(State.FAILED_TO_TEARDOWN, queryResult.getException(), queryResult.getWallTime(), queryResult.getCpuTime(), ImmutableList.<List<Object>>of());
+                return new QueryResult(State.FAILED_TO_TEARDOWN, queryResult.getException(), queryResult.getWallTime(), queryResult.getCpuTime(), queryResult.getQueryId(), ImmutableList.<List<Object>>of());
             }
         }
 
-        return new QueryResult(State.SUCCESS, null, null, null, ImmutableList.of());
+        return new QueryResult(State.SUCCESS, null, null, null, null, ImmutableList.of());
     }
 
     private static QueryResult setup(Query query, List<QueryResult> preQueryResults, Function<String, QueryResult> executor)
@@ -253,11 +253,11 @@ public class Validator
             QueryResult queryResult = executor.apply(prequeryString);
             preQueryResults.add(queryResult);
             if (queryResult.getState() != State.SUCCESS) {
-                return new QueryResult(State.FAILED_TO_SETUP, queryResult.getException(), queryResult.getWallTime(), queryResult.getCpuTime(), ImmutableList.<List<Object>>of());
+                return new QueryResult(State.FAILED_TO_SETUP, queryResult.getException(), queryResult.getWallTime(), queryResult.getCpuTime(), queryResult.getQueryId(), ImmutableList.<List<Object>>of());
             }
         }
 
-        return new QueryResult(State.SUCCESS, null, null, null, ImmutableList.of());
+        return new QueryResult(State.SUCCESS, null, null, null, null, ImmutableList.of());
     }
 
     private boolean checkForDeterministicAndRerunTestQueriesIfNeeded()
@@ -294,7 +294,7 @@ public class Validator
     private QueryResult executeQueryTest()
     {
         Query query = queryPair.getTest();
-        QueryResult queryResult = new QueryResult(State.INVALID, null, null, null, ImmutableList.<List<Object>>of());
+        QueryResult queryResult = new QueryResult(State.INVALID, null, null, null, null, ImmutableList.<List<Object>>of());
         try {
             // startup
             queryResult = setup(query, testPreQueryResults, testPrequery -> executeQuery(testGateway, testUsername, testPassword, queryPair.getTest(), testPrequery, testTimeout, sessionProperties));
@@ -331,7 +331,7 @@ public class Validator
     private QueryResult executeQueryControl()
     {
         Query query = queryPair.getControl();
-        QueryResult queryResult = new QueryResult(State.INVALID, null, null, null, ImmutableList.<List<Object>>of());
+        QueryResult queryResult = new QueryResult(State.INVALID, null, null, null, null, ImmutableList.<List<Object>>of());
         try {
             // startup
             queryResult = setup(query, controlPreQueryResults, controlPrequery -> executeQuery(controlGateway, controlUsername, controlPassword, queryPair.getControl(), controlPrequery, controlTimeout, sessionProperties));
@@ -402,6 +402,7 @@ public class Validator
 
     private QueryResult executeQuery(String url, String username, String password, Query query, String sql, Duration timeout, Map<String, String> sessionProperties)
     {
+        String queryId = null;
         try (Connection connection = DriverManager.getConnection(url, username, password)) {
             trySetConnectionProperties(query, connection);
             for (Map.Entry<String, String> entry : sessionProperties.entrySet()) {
@@ -437,11 +438,12 @@ public class Validator
                         throw new VerifierException("Cannot fetch query stats");
                     }
                     Duration queryCpuTime = new Duration(queryStats.getCpuTimeMillis(), TimeUnit.MILLISECONDS);
-                    return new QueryResult(State.SUCCESS, null, nanosSince(start), queryCpuTime, results);
+                    queryId = queryStats.getQueryId();
+                    return new QueryResult(State.SUCCESS, null, nanosSince(start), queryCpuTime, queryId, results);
                 }
                 catch (AssertionError e) {
                     if (e.getMessage().startsWith("unimplemented type:")) {
-                        return new QueryResult(State.INVALID, null, null, null, ImmutableList.<List<Object>>of());
+                        return new QueryResult(State.INVALID, null, null, null, queryId, ImmutableList.<List<Object>>of());
                     }
                     throw e;
                 }
@@ -449,7 +451,7 @@ public class Validator
                     throw e;
                 }
                 catch (UncheckedTimeoutException e) {
-                    return new QueryResult(State.TIMEOUT, null, null, null, ImmutableList.<List<Object>>of());
+                    return new QueryResult(State.TIMEOUT, null, null, null, queryId, ImmutableList.<List<Object>>of());
                 }
                 catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
@@ -467,10 +469,10 @@ public class Validator
                 exception = (Exception) e.getCause();
             }
             State state = isPrestoQueryInvalid(e) ? State.INVALID : State.FAILED;
-            return new QueryResult(state, exception, null, null, null);
+            return new QueryResult(state, exception, null, null, null, null);
         }
         catch (VerifierException e) {
-            return new QueryResult(State.TOO_MANY_ROWS, e, null, null, null);
+            return new QueryResult(State.TOO_MANY_ROWS, e, null, null, null, null);
         }
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Verifier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Verifier.java
@@ -215,11 +215,13 @@ public class Verifier
                 queryPair.getTest().getCatalog(),
                 queryPair.getTest().getSchema(),
                 queryPair.getTest().getQuery(),
+                test.getQueryId(),
                 optionalDurationToSeconds(test.getCpuTime()),
                 optionalDurationToSeconds(test.getWallTime()),
                 queryPair.getControl().getCatalog(),
                 queryPair.getControl().getSchema(),
                 queryPair.getControl().getQuery(),
+                control.getQueryId(),
                 optionalDurationToSeconds(control.getCpuTime()),
                 optionalDurationToSeconds(control.getWallTime()),
                 errorMessage);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/VerifierQueryEvent.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/VerifierQueryEvent.java
@@ -31,12 +31,14 @@ public class VerifierQueryEvent
     private final String testCatalog;
     private final String testSchema;
     private final String testQuery;
+    private final String testQueryId;
     private final Double testCpuTimeSecs;
     private final Double testWallTimeSecs;
 
     private final String controlCatalog;
     private final String controlSchema;
     private final String controlQuery;
+    private final String controlQueryId;
     private final Double controlCpuTimeSecs;
     private final Double controlWallTimeSecs;
 
@@ -51,11 +53,13 @@ public class VerifierQueryEvent
             String testCatalog,
             String testSchema,
             String testQuery,
+            String testQueryId,
             Double testCpuTimeSecs,
             Double testWallTimeSecs,
             String controlCatalog,
             String controlSchema,
             String controlQuery,
+            String controlQueryId,
             Double controlCpuTimeSecs,
             Double controlWallTimeSecs,
             String errorMessage)
@@ -69,12 +73,14 @@ public class VerifierQueryEvent
         this.testCatalog = testCatalog;
         this.testSchema = testSchema;
         this.testQuery = testQuery;
+        this.testQueryId = testQueryId;
         this.testCpuTimeSecs = testCpuTimeSecs;
         this.testWallTimeSecs = testWallTimeSecs;
 
         this.controlCatalog = controlCatalog;
         this.controlSchema = controlSchema;
         this.controlQuery = controlQuery;
+        this.controlQueryId = controlQueryId;
         this.controlCpuTimeSecs = controlCpuTimeSecs;
         this.controlWallTimeSecs = controlWallTimeSecs;
 
@@ -130,6 +136,12 @@ public class VerifierQueryEvent
     }
 
     @EventField
+    public String getTestQueryId()
+    {
+        return testQueryId;
+    }
+
+    @EventField
     public Double getTestCpuTimeSecs()
     {
         return testCpuTimeSecs;
@@ -157,6 +169,12 @@ public class VerifierQueryEvent
     public String getControlQuery()
     {
         return controlQuery;
+    }
+
+    @EventField
+    public String getControlQueryId()
+    {
+        return controlQueryId;
     }
 
     @EventField


### PR DESCRIPTION
Tracking and logging the ID for both the control and test query will be useful for investigating failed verifier results. In certain cases, the query ID will be unavailable because there is no `queryStats` object corresponding to the query, for example when a query fails because the Presto server cannot be reached (see `P56574912`, where `controlQueryId` is present because that query succeeded but `testQueryId` is not, because the Presto test cluster coordinator was unreachable).

I tested that this works by compiling and running the Presto verifier with my changes, and confirmed that both query IDs are stored in cases where they're available (see `P56574902`), and aren't stored in cases where they don't exist (see example with output above).