### PR TITLE
[WIP] Add a more complete jsonpath implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -775,6 +775,22 @@
                 <version>2.1.7</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.jayway.jsonpath</groupId>
+                <artifactId>json-path</artifactId>
+                <version>2.2.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>net.minidev</groupId>
+                        <artifactId>json-smart</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -257,6 +257,11 @@
             <artifactId>jgrapht-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/JsonFunctionsBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/JsonFunctionsBenchmark.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import io.airlift.slice.Slice;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.io.IOException;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@State(Thread)
+@OutputTimeUnit(NANOSECONDS)
+@BenchmarkMode(AverageTime)
+@Fork(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class JsonFunctionsBenchmark
+{
+    @Benchmark
+    public void benchmarkJsonExtract(Blackhole blackhole, JsonBenchmarksData data)
+    {
+        blackhole.consume(JsonFunctions.jsonExtract(data.getInputJson(), data.getJsonPath()));
+    }
+
+    @Benchmark
+    public void benchmarkJsonExtract_v2(Blackhole blackhole, JsonBenchmarksData data)
+            throws IOException
+    {
+        blackhole.consume(JsonFunctions.jsonExtract_v2(data.getInputJson(), data.getJsonPathAsSlice()));
+    }
+
+    @State(Thread)
+    public static class JsonBenchmarksData
+    {
+        private static final String JSON = "{\"store\": {\"book\": [{\"category\": \"reference\",\"author\": \"Nigel Rees\",\"title\": \"Sayings of the Century\",\"price\": 8.95}, " +
+                "{\"category\": \"fiction\",\"author\": \"Evelyn Waugh\",\"title\": \"Sword of Honour\",\"price\": 12.99}," +
+                " {\"category\": \"fiction\",\"author\": \"Herman Melville\",\"title\": \"Moby Dick\",\"isbn\": \"0-553-21311-3\",\"price\": 8.99}, " +
+                "{\"category\": \"fiction\",\"author\": \"J. R. R. Tolkien\",\"title\": \"The Lord of the Rings\",\"isbn\": \"0-395-19395-8\",\"price\": 22.99}]," +
+                "\"object\": {\"inner_object\": {\"array\": [{\"inner_array\": [{\"x\": \"y\"}]}]}}}}";
+
+        @Param({"$.store.book.doesnt_exist",
+                "$.store.book[3].author",
+                "$.store.book",
+                "$[\"store\"][\"book\"][0]",
+                "$.store.object.inner_object.array[0].inner_array[0].x"
+        })
+        private String jsonPathString;
+
+        public JsonPath getJsonPath()
+        {
+            return new JsonPath(jsonPathString);
+        }
+
+        public Slice getJsonPathAsSlice()
+        {
+            return utf8Slice(jsonPathString);
+        }
+
+        public Slice getInputJson()
+        {
+            return utf8Slice(JSON);
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + JsonFunctionsBenchmark.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}


### PR DESCRIPTION
This WIP PR adds a new jsonpath implementation using the [Jayway jsonpath library](https://github.com/jayway/JsonPath), which is a more complete jsonpath implementation than the current one. Overall, this new implementation performs better than the current one (with the `JsonFunctionsBenchmark` benchmark, please see results below), and it provides similar semantics (there are some minor differences, please see below). \cc @erichwang @electrum 

As a side note I also ran some experiments with alibaba's fastjson library, but it has more compatibility issues with the current implementation, and a larger number of json extract tests failed with it.
#### Some open issues/questions:
- Do you guys think whether this can be a valuable addition to Presto?
- There are some minor differences in semantics. I added comments to the failing tests to explain why they fail (those tests are excluded to run on the new implementation).
- If there is an interest in this, how do we want to roll this out? Do we want to have a switch to enable the new implementation? Or do we want to have a new name for the new implementation? etc. etc.

Results of the `JsonFunctionsBenchmark`:

```
Benchmark                                                                            (jsonPathString)  Mode  Cnt      Score      Error  Units
JsonFunctionsBenchmark.benchmarkJsonExtract                                 $.store.book.doesnt_exist  avgt   10  22322.857 ± 3136.774  ns/op
JsonFunctionsBenchmark.benchmarkJsonExtract                                    $.store.book[3].author  avgt   10  22262.583 ± 1681.218  ns/op
JsonFunctionsBenchmark.benchmarkJsonExtract                                              $.store.book  avgt   10  18362.310 ± 1088.162  ns/op
JsonFunctionsBenchmark.benchmarkJsonExtract                                     $["store"]["book"][0]  avgt   10  15984.752 ±  645.070  ns/op
JsonFunctionsBenchmark.benchmarkJsonExtract     $.store.object.inner_object.array[0].inner_array[0].x  avgt   10  40877.901 ± 2934.833  ns/op
JsonFunctionsBenchmark.benchmarkJsonExtract_v2                                 $.store.book[3].author  avgt   10   8341.491 ±  380.807  ns/op
JsonFunctionsBenchmark.benchmarkJsonExtract_v2                                           $.store.book  avgt   10  10107.459 ±  639.077  ns/op
JsonFunctionsBenchmark.benchmarkJsonExtract_v2                                  $["store"]["book"][0]  avgt   10   8383.035 ±  309.814  ns/op
JsonFunctionsBenchmark.benchmarkJsonExtract_v2  $.store.object.inner_object.array[0].inner_array[0].x  avgt   10   8449.030 ±  300.686  ns/op
```
