### PR TITLE
Reduce required filehandles to 4048, to support the default Mac limit.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
@@ -33,7 +33,7 @@ import static java.lang.management.ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAM
 
 final class PrestoSystemRequirements
 {
-    private static final int MIN_FILE_DESCRIPTORS = 4096;
+    private static final int MIN_FILE_DESCRIPTORS = 4048;
     private static final int RECOMMENDED_FILE_DESCRIPTORS = 8192;
 
     private PrestoSystemRequirements() {}


### PR DESCRIPTION
This might be the lamest PR ever, but I was wondering if you'd consider lowering the min file descriptors a smidge. Why? Because the Mac OS default seems to be 4048 these days without jumping through [crazy hoops](http://blog.dekstroza.io/ulimit-shenanigans-on-osx-el-capitan/) (and in fact I can't seem to get that to work for non-root users). I figure those 48 filehandles isn't likely to make a practical difference in production, and this would make local development on apps that use presto a lot simpler for mac users.

ogies in advance.