### PR TITLE
Include a file with git commit hash in artifacts uploaded from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ before_deploy:
   - cp -n presto-product-tests/target/presto-product-tests-*-executable.jar /tmp/artifacts
   - cp -n presto-jdbc/target/presto-jdbc-*.jar /tmp/artifacts
   - cp -n presto-cli/target/presto-cli-*-executable.jar /tmp/artifacts
+  - echo $TRAVIS_COMMIT > /tmp/artifacts/git-revision.txt
   - ls -lah /tmp/artifacts
 
 deploy:


### PR DESCRIPTION
Example result here:

http://teradata-presto.s3.amazonaws.com/index.html?prefix=travis_build_artifacts/Teradata/presto/include_commit_hash_in_artifacts/2874.4/

http://teradata-presto.s3.amazonaws.com/travis_build_artifacts/Teradata/presto/include_commit_hash_in_artifacts/2874.4/git-revision.txt

Besides providing easier tracking of the revision used for build, this will help us implement nightly builds for presto that will run additional product test configurations.