### PR TITLE
Tableau - javascript fix to https connection to http Presto server

### DIFF
--- a/presto-main/src/main/resources/webapp/tableau/presto-client.js
+++ b/presto-main/src/main/resources/webapp/tableau/presto-client.js
@@ -17,6 +17,8 @@ function StatementClient(connectionData, headerCallback, dataCallback, errorCall
     this.currentResults = null;
     this.valid = true;
 
+    this.isHttps = window.location.protocol === "https:"
+
     if (!(connectionData.sessionParameters === undefined)) {
         var parameterMap = JSON.parse(connectionData.sessionParameters);
         for (var name in parameterMap) {
@@ -72,7 +74,7 @@ StatementClient.prototype.advance = function(lastRecordNumber) {
     var statementClient = this;
     $.ajax({
         type: "GET",
-        url: this.currentResults.nextUri,
+        url: this.isHttps ? this.currentResults.nextUri.replace(/^http:/, 'https:') : this.currentResults.nextUri,
         headers: this.headers,
         dataType: 'json',
         // FIXME having problems when async: true


### PR DESCRIPTION
In our environment the client connects to a proxy via https which proxies to presto via http.

Without configuring Presto server with SSL and require all users to access via https, when https requests go to an http Presto server, the server responds with nextUri specified in http which causes jquery to be blocked and hangs the page from loading.

This change uses javascript to detect mode, and if it's https it will modify returned nextUri from http to https.
