### PR TITLE
Swallow exception on cleanup to expose the underlying cause of failure

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/AlterTableTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/AlterTableTests.java
@@ -14,8 +14,11 @@
 package com.facebook.presto.tests;
 
 import com.facebook.presto.tests.ImmutableTpchTablesRequirements.ImmutableNationTable;
+import com.teradata.tempto.AfterTestWithContext;
+import com.teradata.tempto.BeforeTestWithContext;
 import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.Requires;
+import io.airlift.log.Logger;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.tests.TestGroups.ALTER_TABLE;
@@ -30,73 +33,67 @@ import static java.lang.String.format;
 public class AlterTableTests
         extends ProductTest
 {
+    private static final String TABLE_NAME = "table_name";
+    private static final String RENAMED_TABLE_NAME = "renamed_table_name";
+
+    @BeforeTestWithContext
+    @AfterTestWithContext
+    public void dropTestTables()
+    {
+        try {
+            query(format("DROP TABLE IF EXISTS %s", TABLE_NAME));
+            query(format("DROP TABLE IF EXISTS %s", RENAMED_TABLE_NAME));
+        }
+        catch (Exception e) {
+            Logger.get(getClass()).warn(e, "failed to drop table");
+        }
+    }
+
     @Test(groups = {ALTER_TABLE, SMOKE})
     public void renameTable()
     {
-        String tableName = "to_be_renamed";
-        String renamedTableName = "renamed_table_name";
+        query(format("CREATE TABLE %s AS SELECT * FROM nation", TABLE_NAME));
 
-        query(format("DROP TABLE IF EXISTS %s", tableName));
-        query(format("DROP TABLE IF EXISTS %s", renamedTableName));
+        assertThat(query(format("ALTER TABLE %s RENAME TO %s", TABLE_NAME, RENAMED_TABLE_NAME), UPDATE))
+                .hasRowsCount(1);
 
-        try {
-            query(format("CREATE TABLE %s AS SELECT * FROM nation", tableName));
+        assertThat(query(format("SELECT * FROM %s", RENAMED_TABLE_NAME)))
+                .hasRowsCount(25);
 
-            assertThat(query(format("ALTER TABLE %s RENAME TO %s", tableName, renamedTableName), UPDATE))
-                    .hasRowsCount(1);
-
-            assertThat(query(format("SELECT * FROM %s", renamedTableName)))
-                    .hasRowsCount(25);
-
-            // rename back to original name
-            assertThat(query(format("ALTER TABLE %s RENAME TO %s", renamedTableName, tableName), UPDATE))
-                    .hasRowsCount(1);
-        }
-        finally {
-            query(format("DROP TABLE %s", tableName));
-        }
+        // rename back to original name
+        assertThat(query(format("ALTER TABLE %s RENAME TO %s", RENAMED_TABLE_NAME, TABLE_NAME), UPDATE))
+                .hasRowsCount(1);
     }
 
     @Test(groups = {ALTER_TABLE, SMOKE})
     public void renameColumn()
     {
-        String tableName = "tableName";
-        try {
-            query(format("CREATE TABLE %s AS SELECT * FROM nation", tableName));
-            assertThat(query(format("ALTER TABLE %s RENAME COLUMN n_nationkey TO nationkey", tableName), UPDATE))
-                    .hasRowsCount(1);
-            assertThat(query(format("SELECT count(nationkey) FROM %s", tableName)))
-                    .containsExactly(row(25));
-            assertThat(() -> query(format("ALTER TABLE %s RENAME COLUMN nationkey TO nATIoNkEy", tableName)))
-                    .failsWithMessage("Column 'nationkey' already exists");
-            assertThat(() -> query(format("ALTER TABLE %s RENAME COLUMN nationkey TO n_regionkeY", tableName)))
-                    .failsWithMessage("Column 'n_regionkey' already exists");
+        query(format("CREATE TABLE %s AS SELECT * FROM nation", TABLE_NAME));
 
-            assertThat(query(format("ALTER TABLE %s RENAME COLUMN nationkey TO n_nationkey", tableName)));
-        }
-        finally {
-            query(format("DROP TABLE %s", tableName));
-        }
+        assertThat(query(format("ALTER TABLE %s RENAME COLUMN n_nationkey TO nationkey", TABLE_NAME), UPDATE))
+                .hasRowsCount(1);
+        assertThat(query(format("SELECT count(nationkey) FROM %s", TABLE_NAME)))
+                .containsExactly(row(25));
+        assertThat(() -> query(format("ALTER TABLE %s RENAME COLUMN nationkey TO nATIoNkEy", TABLE_NAME)))
+                .failsWithMessage("Column 'nationkey' already exists");
+        assertThat(() -> query(format("ALTER TABLE %s RENAME COLUMN nationkey TO n_regionkeY", TABLE_NAME)))
+                .failsWithMessage("Column 'n_regionkey' already exists");
+
+        assertThat(query(format("ALTER TABLE %s RENAME COLUMN nationkey TO n_nationkey", TABLE_NAME)));
     }
 
     @Test(groups = {ALTER_TABLE, SMOKE})
     public void addColumn()
     {
-        String tableName = "tableName";
-        try {
-            query(format("CREATE TABLE %s AS SELECT * FROM nation", tableName));
+        query(format("CREATE TABLE %s AS SELECT * FROM nation", TABLE_NAME));
 
-            assertThat(query(format("SELECT count(1) FROM %s", tableName)))
-                    .containsExactly(row(25));
-            assertThat(query(format("ALTER TABLE %s ADD COLUMN some_new_column BIGINT", tableName)))
-                    .hasRowsCount(1);
-            assertThat(() -> query(format("ALTER TABLE %s ADD COLUMN n_nationkey BIGINT", tableName)))
-                    .failsWithMessage("Column 'n_nationkey' already exists");
-            assertThat(() -> query(format("ALTER TABLE %s ADD COLUMN n_naTioNkEy BIGINT", tableName)))
-                    .failsWithMessage("Column 'n_naTioNkEy' already exists");
-        }
-        finally {
-            query(format("DROP TABLE %s", tableName));
-        }
+        assertThat(query(format("SELECT count(1) FROM %s", TABLE_NAME)))
+                .containsExactly(row(25));
+        assertThat(query(format("ALTER TABLE %s ADD COLUMN some_new_column BIGINT", TABLE_NAME)))
+                .hasRowsCount(1);
+        assertThat(() -> query(format("ALTER TABLE %s ADD COLUMN n_nationkey BIGINT", TABLE_NAME)))
+                .failsWithMessage("Column 'n_nationkey' already exists");
+        assertThat(() -> query(format("ALTER TABLE %s ADD COLUMN n_naTioNkEy BIGINT", TABLE_NAME)))
+                .failsWithMessage("Column 'n_naTioNkEy' already exists");
     }
 }


### PR DESCRIPTION
Failure on tear down is logged and exception is swallowed. This allows propagating real cause of test failure.
Similar mechanism is used in AbstractTestHiveClient.

---

This is to address https://github.com/prestodb/presto/pull/4985#discussion_r59222727.