### PR TITLE
Add link to Travis build to uploaded artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,8 @@ before_deploy:
   - cp -n presto-jdbc/target/presto-jdbc-*.jar /tmp/artifacts
   - cp -n presto-cli/target/presto-cli-*-executable.jar /tmp/artifacts
   - echo $TRAVIS_COMMIT > /tmp/artifacts/git-revision.txt
+  - echo "<script>location='https://travis-ci.org/${TRAVIS_REPO_SLUG}/builds/${TRAVIS_BUILD_ID}'</script>"
+    > /tmp/artifacts/travis_build.html
   - ls -lah /tmp/artifacts
 
 deploy:


### PR DESCRIPTION
This adds even more traceability to uploaded artifacts. Sample [here](http://teradata-presto.s3.amazonaws.com/index.html?prefix=travis_build_artifacts/Teradata/presto/travis_build_link_in_artifacts/2998.4/) (click 'travis_build.html').