### PR TITLE
Stop retrying on S3 AbortedException

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -764,7 +764,7 @@ public class PrestoS3FileSystem
                 int bytesRead = retry()
                         .maxAttempts(maxAttempts)
                         .exponentialBackoff(new Duration(1, TimeUnit.SECONDS), maxBackoffTime, maxRetryTime, 2.0)
-                        .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class)
+                        .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class, AbortedException.class)
                         .onRetry(STATS::newReadRetry)
                         .run("readStream", () -> {
                             seekStream();


### PR DESCRIPTION
With `limit` queries the split processing threads are interrupted, which results in `read` calls to throw `AbortedException`s. However, the threads keeps retrying, which are guaranteed to fail with the same exception, wasting resources. This PR fixes it.