### PR TITLE
Add a session property to disable IndexJoin optimization

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -61,6 +61,7 @@ public final class SystemSessionProperties
     public static final String SPLIT_CONCURRENCY_ADJUSTMENT_INTERVAL = "split_concurrency_adjustment_interval";
     public static final String OPTIMIZE_METADATA_QUERIES = "optimize_metadata_queries";
     public static final String QUERY_PRIORITY = "query_priority";
+    public static final String INDEX_JOIN = "index_join";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -219,6 +220,11 @@ public final class SystemSessionProperties
                         COLOCATED_JOIN,
                         "Experimental: Use a colocated join when possible",
                         featuresConfig.isColocatedJoinsEnabled(),
+                        false),
+                booleanSessionProperty(
+                        INDEX_JOIN,
+                        "Use index join when possible",
+                        featuresConfig.isIndexJoinsEnabled(),
                         false));
     }
 
@@ -342,5 +348,10 @@ public final class SystemSessionProperties
     public static Duration getQueryMaxCpuTime(Session session)
     {
         return session.getProperty(QUERY_MAX_CPU_TIME, Duration.class);
+    }
+
+    public static boolean isIndexJoinsEnabled(Session session)
+    {
+        return session.getProperty(INDEX_JOIN, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -58,6 +58,8 @@ public class FeaturesConfig
     private int re2JDfaRetries = 5;
     private RegexLibrary regexLibrary = JONI;
 
+    private boolean indexJoinsEnabled = true;
+
     @NotNull
     public String getResourceGroupManager()
     {
@@ -268,5 +270,18 @@ public class FeaturesConfig
     {
         this.regexLibrary = regexLibrary;
         return this;
+    }
+
+    @Config("index-joins-enabled")
+    @ConfigDescription("Use an index join when possible")
+    public FeaturesConfig setIndexJoinsEnabled(boolean indexJoinsEnabled)
+    {
+        this.indexJoinsEnabled = indexJoinsEnabled;
+        return this;
+    }
+
+    public boolean isIndexJoinsEnabled()
+    {
+        return indexJoinsEnabled;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.facebook.presto.SystemSessionProperties.isIndexJoinsEnabled;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableMap;
@@ -105,6 +106,11 @@ public class IndexJoinOptimizer
         @Override
         public PlanNode visitJoin(JoinNode node, RewriteContext<Void> context)
         {
+            if (!isIndexJoinsEnabled(session)) {
+                // if index joins are disabled per session then skip this optimization
+                return node;
+            }
+
             PlanNode leftRewritten = context.rewrite(node.getLeft());
             PlanNode rightRewritten = context.rewrite(node.getRight());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -50,7 +50,8 @@ public class TestFeaturesConfig
                 .setRegexLibrary(JONI)
                 .setRe2JDfaStatesLimit(Integer.MAX_VALUE)
                 .setRe2JDfaRetries(5)
-                .setResourceGroupManager(FILE_BASED_RESOURCE_GROUP_MANAGER));
+                .setResourceGroupManager(FILE_BASED_RESOURCE_GROUP_MANAGER)
+                .setIndexJoinsEnabled(true));
     }
 
     @Test
@@ -74,6 +75,7 @@ public class TestFeaturesConfig
                 .put("re2j.dfa-states-limit", "42")
                 .put("re2j.dfa-retries", "42")
                 .put("resource-group-manager", "test")
+                .put("index-joins-enabled", "false")
                 .build();
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("experimental-syntax-enabled", "true")
@@ -93,6 +95,7 @@ public class TestFeaturesConfig
                 .put("re2j.dfa-states-limit", "42")
                 .put("re2j.dfa-retries", "42")
                 .put("resource-group-manager", "test")
+                .put("index-joins-enabled", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -112,7 +115,8 @@ public class TestFeaturesConfig
                 .setRegexLibrary(RE2J)
                 .setRe2JDfaStatesLimit(42)
                 .setRe2JDfaRetries(42)
-                .setResourceGroupManager("test");
+                .setResourceGroupManager("test")
+                .setIndexJoinsEnabled(false);
 
         assertFullMapping(properties, expected);
         assertDeprecatedEquivalence(FeaturesConfig.class, properties, propertiesLegacy);

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -178,5 +178,12 @@
             <artifactId>log-manager</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestIndexJoinOptimizer.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestIndexJoinOptimizer.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.assertions.PlanAssert;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.plan.IndexJoinNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tests.tpch.IndexedTpchConnectorFactory;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.AbstractTestIndexedQueries.INDEX_SPEC;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+
+/**
+ * Tests related to IndexJoinOptimizer.
+ * Note, that this class is not in presto-main because of dependency on TpchIndex
+ * which is needed for index join optimization to work.
+ */
+public class TestIndexJoinOptimizer
+{
+    private final LocalQueryRunner queryRunner;
+
+    public TestIndexJoinOptimizer()
+    {
+        this.queryRunner = new LocalQueryRunner(testSessionBuilder()
+                .setCatalog("local")
+                .setSchema(TINY_SCHEMA_NAME)
+                .build());
+
+        queryRunner.createCatalog(queryRunner.getDefaultSession().getCatalog().get(),
+                new IndexedTpchConnectorFactory(queryRunner.getNodeManager(), INDEX_SPEC, 1),
+                ImmutableMap.<String, String>of());
+    }
+
+    @Test
+    public void testIndexJoinOptimization()
+    {
+        String simpleJoinQuery = "SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey";
+        assertPlan(simpleJoinQuery,
+                anyTree(
+                        node(IndexJoinNode.class,
+                                anyTree(),
+                                anyTree())));
+    }
+
+    @Test
+    public void testIndexJoinOptimizationDisabled()
+    {
+        Session modifiedSession = queryRunner.getDefaultSession().withSystemProperty(SystemSessionProperties.INDEX_JOIN, "false");
+        String simpleJoinQuery = "SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey";
+        assertPlan(modifiedSession, simpleJoinQuery,
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(),
+                                anyTree())));
+    }
+
+    private void assertPlan(String sql, PlanMatchPattern pattern)
+    {
+        Plan actualPlan = plan(sql);
+        queryRunner.inTransaction(transactionSession -> {
+            PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), actualPlan, pattern);
+            return null;
+        });
+    }
+
+    private void assertPlan(Session session, String sql, PlanMatchPattern pattern)
+    {
+        Plan actualPlan = plan(session, sql);
+        queryRunner.inTransaction(session, transactionSession -> {
+            PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), actualPlan, pattern);
+            return null;
+        });
+    }
+
+    private Plan plan(String sql)
+    {
+        return queryRunner.inTransaction(transactionSession -> queryRunner.createPlan(transactionSession, sql));
+    }
+
+    private Plan plan(Session session, String sql)
+    {
+        return queryRunner.inTransaction(session, transactionSession -> queryRunner.createPlan(transactionSession, sql));
+    }
+}


### PR DESCRIPTION
Currently IndexJoin is greedily selected. However, distributed join can be faster
if the right side can fit in memory. So, adding an option which will control
IndexJoin rewrite per session.