### PR TITLE
Remove coercion from DECIMAL to REAL

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -425,8 +425,6 @@ public final class TypeRegistry
             }
             case StandardTypes.DECIMAL: {
                 switch (resultTypeBase) {
-                    case StandardTypes.REAL:
-                        return Optional.of(REAL);
                     case StandardTypes.DOUBLE:
                         return Optional.of(DOUBLE);
                     default:

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTypeRegistry.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTypeRegistry.java
@@ -140,8 +140,8 @@ public class TestTypeRegistry
 
         assertTrue(canCoerce("decimal(3,2)", "double"));
         assertTrue(canCoerce("decimal(22,1)", "double"));
-        assertTrue(canCoerce("decimal(3,2)", "real"));
-        assertTrue(canCoerce("decimal(22,1)", "real"));
+        assertFalse(canCoerce("decimal(3,2)", "real"));
+        assertFalse(canCoerce("decimal(22,1)", "real"));
 
         assertFalse(canCoerce("integer", "decimal(9,0)"));
         assertTrue(canCoerce("integer", "decimal(10,0)"));
@@ -194,7 +194,6 @@ public class TestTypeRegistry
         assertCommonSuperType("bigint", "decimal(18,0)", "decimal(19,0)");
         assertCommonSuperType("bigint", "decimal(19,0)", "decimal(19,0)");
         assertCommonSuperType("bigint", "decimal(37,1)", "decimal(37,1)");
-        assertCommonSuperType("real", "decimal(37,1)", "real");
         assertCommonSuperType("array(decimal(23,1))", "array(decimal(22,1))", "array(decimal(23,1))");
         assertCommonSuperType("array(bigint)", "array(decimal(2,1))", "array(decimal(20,1))");
 


### PR DESCRIPTION
Remove coercion from DECIMAL to REAL

Coerce DECIMAL to DOUBLE only. Currently DECIMAL can coerce to DOUBLE or
REAL. While the REAL is more specific it introduces higher precision error.
When a function accepts REAL or DOUBLE and DECIMAL given, then function
with REAL is choosen while with DOUBLE is more desired. With this patch
function with DOUBLE will be selected.
