### PR TITLE
Create query completion event after final stats are available

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -139,6 +139,12 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
+    public void addFinalQueryInfoListener(StateChangeListener<QueryInfo> stateChangeListener)
+    {
+        stateMachine.addQueryInfoStateChangeListener(stateChangeListener);
+    }
+
+    @Override
     public void fail(Throwable cause)
     {
         stateMachine.transitionToFailed(cause);

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -33,11 +33,13 @@ public class FailedQueryExecution
 {
     private final QueryInfo queryInfo;
     private final Session session;
+    private final Executor executor;
 
     public FailedQueryExecution(QueryId queryId, String query, Session session, URI self, TransactionManager transactionManager, Executor executor, Throwable cause)
     {
         requireNonNull(cause, "cause is null");
         this.session = requireNonNull(session, "session is null");
+        this.executor = requireNonNull(executor, "executor is null");
         QueryStateMachine queryStateMachine = QueryStateMachine.failed(queryId, query, session, self, transactionManager, executor, cause);
 
         queryInfo = queryStateMachine.getQueryInfo(Optional.empty());
@@ -107,13 +109,13 @@ public class FailedQueryExecution
     @Override
     public void addStateChangeListener(StateChangeListener<QueryState> stateChangeListener)
     {
-        stateChangeListener.stateChanged(QueryState.FAILED);
+        executor.execute(() -> stateChangeListener.stateChanged(QueryState.FAILED));
     }
 
     @Override
     public void addFinalQueryInfoListener(StateChangeListener<QueryInfo> stateChangeListener)
     {
-        stateChangeListener.stateChanged(queryInfo);
+        executor.execute(() -> stateChangeListener.stateChanged(queryInfo));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -111,6 +111,12 @@ public class FailedQueryExecution
     }
 
     @Override
+    public void addFinalQueryInfoListener(StateChangeListener<QueryInfo> stateChangeListener)
+    {
+        stateChangeListener.stateChanged(queryInfo);
+    }
+
+    @Override
     public void fail(Throwable cause)
     {
         // no-op

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -59,6 +59,8 @@ public interface QueryExecution
 
     void addStateChangeListener(StateChangeListener<QueryState> stateChangeListener);
 
+    void addFinalQueryInfoListener(StateChangeListener<QueryInfo> stateChangeListener);
+
     interface QueryExecutionFactory<T extends QueryExecution>
     {
         T createQueryExecution(QueryId queryId, String query, Session session, Statement statement, List<Expression> parameters);

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -257,6 +257,12 @@ public final class SqlQueryExecution
         }
     }
 
+    @Override
+    public void addFinalQueryInfoListener(StateChangeListener<QueryInfo> stateChangeListener)
+    {
+        stateMachine.addQueryInfoStateChangeListener(stateChangeListener);
+    }
+
     private PlanRoot analyzeQuery()
     {
         try {

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -328,8 +328,7 @@ public class SqlQueryManager
         QueryInfo queryInfo = queryExecution.getQueryInfo();
         queryMonitor.queryCreatedEvent(queryInfo);
 
-        queryExecution.addStateChangeListener(newValue -> {
-            if (newValue.isDone()) {
+        queryExecution.addFinalQueryInfoListener(finalQueryInfo -> {
                 try {
                     QueryInfo info = queryExecution.getQueryInfo();
                     stats.queryFinished(info);
@@ -339,7 +338,6 @@ public class SqlQueryManager
                     // execution MUST be added to the expiration queue or there will be a leak
                     expirationQueue.add(queryExecution);
                 }
-            }
         });
 
         addStatsListener(queryExecution);

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -197,6 +197,12 @@ public class MockQueryExecution
         listeners.add(stateChangeListener);
     }
 
+    @Override
+    public void addFinalQueryInfoListener(StateChangeListener<QueryInfo> stateChangeListener)
+    {
+        throw new UnsupportedOperationException();
+    }
+
     private void fireStateChange()
     {
         for (StateChangeListener<QueryState> listener : listeners) {


### PR DESCRIPTION
This is a new PR for #5804 
I accidentally closed it and github disabled the "reopen" button even though I have new commits on this branch. 