### PR TITLE
fix Typo in mongodb connector document in #5941 

### DIFF
--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -146,7 +146,7 @@ The required replica set name. With this option set, the MongoClient instance wi
 
 This property is optional; no default value.
 
-``mongodb.required-replica-set``
+``mongodb.cursor-batch-size``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Limits the number of elements returned in one batch. A cursor typically fetches a batch of result objects and stores them locally.


### PR DESCRIPTION
Fix Typo miss in #5941 
