### PR TITLE
Allow reading ORC files with bloomfilters

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -57,6 +57,7 @@ import static com.facebook.presto.orc.checkpoint.Checkpoints.getDictionaryStream
 import static com.facebook.presto.orc.checkpoint.Checkpoints.getStreamCheckpoints;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY_V2;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.BLOOM_FILTER;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_COUNT;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
@@ -378,7 +379,7 @@ public class StripeReader
 
     private static boolean isIndexStream(Stream stream)
     {
-        return stream.getStreamKind() == ROW_INDEX || stream.getStreamKind() == DICTIONARY_COUNT;
+        return stream.getStreamKind() == ROW_INDEX || stream.getStreamKind() == DICTIONARY_COUNT || stream.getStreamKind() == BLOOM_FILTER;
     }
 
     private static boolean isDictionary(Stream stream, ColumnEncodingKind columnEncoding)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.primitives.Ints;
+import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.apache.hadoop.hive.ql.io.orc.OrcProto;
@@ -44,6 +45,7 @@ public class OrcMetadataReader
         implements MetadataReader
 {
     private static final Slice MAX_BYTE = Slices.wrappedBuffer(new byte[] { (byte) 0xFF });
+    private static final Logger log = Logger.get(OrcMetadataReader.class);
 
     @Override
     public PostScript readPostScript(byte[] data, int offset, int length)
@@ -426,6 +428,9 @@ public class OrcMetadataReader
                 return StreamKind.SECONDARY;
             case ROW_INDEX:
                 return StreamKind.ROW_INDEX;
+            case BLOOM_FILTER:
+                log.debug("ORC Bloom filter stream detected, not yet implemented, ignoring and continuing without using bloomfilter as predicate");
+                return StreamKind.BLOOM_FILTER;
             default:
                 throw new IllegalStateException(streamKind + " stream type not implemented yet");
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Stream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Stream.java
@@ -27,6 +27,7 @@ public class Stream
         DICTIONARY_COUNT,
         SECONDARY,
         ROW_INDEX,
+        BLOOM_FILTER,
         IN_DICTIONARY,
         ROW_GROUP_DICTIONARY,
         ROW_GROUP_DICTIONARY_LENGTH,


### PR DESCRIPTION
Currently it's not possible to read ORC files that have bloomfilters enabled. This patch allows that by ignoring the bloomfilter data in the footer stripes.

We are currently using the master + this PR in order to query the data successfully. Would be great to have this part of master. 

This would previously result in an exception like:
```
Query 20160826_104859_00464_2wzna failed: BLOOM_FILTER stream type not implemented yet
com.facebook.presto.spi.PrestoException: BLOOM_FILTER stream type not implemented yet
    at com.facebook.presto.hive.orc.OrcPageSource.getNextPage(OrcPageSource.java:286)
    at com.facebook.presto.operator.ScanFilterAndProjectOperator.getOutput(ScanFilterAndProjectOperator.java:231)
    at com.facebook.presto.operator.Driver.processInternal(Driver.java:378)
    at com.facebook.presto.operator.Driver.processFor(Driver.java:301)
    at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:622)
    at com.facebook.presto.execution.TaskExecutor$PrioritizedSplitRunner.process(TaskExecutor.java:529)
    at com.facebook.presto.execution.TaskExecutor$Runner.run(TaskExecutor.java:665)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalStateException: BLOOM_FILTER stream type not implemented yet
    at com.facebook.presto.orc.metadata.OrcMetadataReader.toStreamKind(OrcMetadataReader.java:430)
    at com.facebook.presto.orc.metadata.OrcMetadataReader.toStream(OrcMetadataReader.java:123)
    at com.google.common.collect.Iterators$8.transform(Iterators.java:799)
    at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:48)
    at com.google.common.collect.ImmutableCollection$Builder.addAll(ImmutableCollection.java:301)
    at com.google.common.collect.ImmutableList$Builder.addAll(ImmutableList.java:691)
    at com.google.common.collect.ImmutableList.copyOf(ImmutableList.java:275)
    at com.google.common.collect.ImmutableList.copyOf(ImmutableList.java:226)
    at com.facebook.presto.orc.metadata.OrcMetadataReader.toStream(OrcMetadataReader.java:128)
    at com.facebook.presto.orc.metadata.OrcMetadataReader.readStripeFooter(OrcMetadataReader.java:118)
    at com.facebook.presto.orc.StripeReader.readStripeFooter(StripeReader.java:325)
    at com.facebook.presto.orc.StripeReader.readStripe(StripeReader.java:102)
    at com.facebook.presto.orc.OrcRecordReader.advanceToNextStripe(OrcRecordReader.java:383)
    at com.facebook.presto.orc.OrcRecordReader.advanceToNextRowGroup(OrcRecordReader.java:340)
    at com.facebook.presto.orc.OrcRecordReader.nextBatch(OrcRecordReader.java:299)
    at com.facebook.presto.hive.orc.OrcPageSource.getNextPage(OrcPageSource.java:262)
    ... 9 more
```