### PR TITLE
Add support for DESCRIBE INPUT

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -203,7 +203,11 @@ public final class Session
 
     public String getPreparedStatementFromExecute(Execute execute)
     {
-        String name = execute.getName();
+        return getPreparedStatement(execute.getName());
+    }
+
+    public String getPreparedStatement(String name)
+    {
         String sql = preparedStatements.get(name);
         checkCondition(sql != null, NOT_FOUND, "Prepared statement not found: " + name);
         return sql;

--- a/presto-main/src/main/java/com/facebook/presto/execution/ParameterExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ParameterExtractor.java
@@ -18,31 +18,41 @@ import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Statement;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class ParameterExtractor
 {
-    private ParameterExtractor(){}
+    private ParameterExtractor() {}
 
     public static int getParameterCount(Statement statement)
     {
         ParameterExtractingVisitor parameterExtractingVisitor = new ParameterExtractingVisitor();
         parameterExtractingVisitor.process(statement, null);
-        return parameterExtractingVisitor.getParameterCount();
+        return parameterExtractingVisitor.getParameters().size();
+    }
+
+    public static List<Parameter> getParameters(Statement statement)
+    {
+        ParameterExtractingVisitor parameterExtractingVisitor = new ParameterExtractingVisitor();
+        parameterExtractingVisitor.process(statement, null);
+        return parameterExtractingVisitor.getParameters();
     }
 
     private static class ParameterExtractingVisitor
             extends DefaultTraversalVisitor<Void, Void>
     {
-        private int parameterCount = 0;
+        private final List<Parameter> parameters = new ArrayList<>();
 
-        private int getParameterCount()
+        public List<Parameter> getParameters()
         {
-            return parameterCount;
+            return parameters;
         }
 
         @Override
         public Void visitParameter(Parameter node, Void context)
         {
-            parameterCount++;
+            parameters.add(node);
             return null;
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -70,6 +70,7 @@ import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.Delete;
+import com.facebook.presto.sql.tree.DescribeInput;
 import com.facebook.presto.sql.tree.DropSchema;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
@@ -223,6 +224,7 @@ public class CoordinatorModule
         executionBinder.addBinding(CreateTableAsSelect.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(Insert.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(Delete.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
+        executionBinder.addBinding(DescribeInput.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
 
         binder.bind(DataDefinitionExecutionFactory.class).in(Scopes.SINGLETON);
         bindDataDefinitionTask(binder, executionBinder, CreateSchema.class, CreateSchemaTask.class);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -96,12 +96,16 @@ public class Analysis
 
     private Optional<Insert> insert = Optional.empty();
 
-    public Analysis(Statement root, List<Expression> parameters)
+    // for describe input and describe output
+    private final boolean isDescribe;
+
+    public Analysis(Statement root, List<Expression> parameters, boolean isDescribe)
     {
         requireNonNull(parameters);
 
         this.root = root;
         this.parameters = parameters;
+        this.isDescribe = isDescribe;
     }
 
     public Statement getStatement()
@@ -495,6 +499,11 @@ public class Analysis
     public List<Expression> getParameters()
     {
         return parameters;
+    }
+
+    public boolean isDescribe()
+    {
+        return isDescribe;
     }
 
     @Immutable

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -59,8 +59,13 @@ public class Analyzer
 
     public Analysis analyze(Statement statement)
     {
-        Statement rewrittenStatement = StatementRewrite.rewrite(session, metadata, sqlParser, queryExplainer, statement, parameters);
-        Analysis analysis = new Analysis(rewrittenStatement, parameters);
+        return analyze(statement, false);
+    }
+
+    public Analysis analyze(Statement statement, boolean isDescribe)
+    {
+        Statement rewrittenStatement = StatementRewrite.rewrite(session, metadata, sqlParser, queryExplainer, statement, parameters, accessControl, experimentalSyntaxEnabled);
+        Analysis analysis = new Analysis(rewrittenStatement, parameters, isDescribe);
         StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, accessControl, session, experimentalSyntaxEnabled);
         analyzer.process(rewrittenStatement, Scope.builder().markQueryBoundary().build());
         return analysis;

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -325,7 +325,7 @@ class StatementAnalyzer
 
         for (Expression expression : node.getProperties().values()) {
             // analyze table property value expressions which must be constant
-            createConstantAnalyzer(metadata, session, analysis.getParameters())
+            createConstantAnalyzer(metadata, session, analysis.getParameters(), analysis.isDescribe())
                     .analyze(expression, scope);
         }
         analysis.setCreateTableProperties(node.getProperties());
@@ -606,7 +606,8 @@ class StatementAnalyzer
                 sqlParser,
                 ImmutableMap.of(),
                 relation.getSamplePercentage(),
-                analysis.getParameters());
+                analysis.getParameters(),
+                analysis.isDescribe());
         ExpressionInterpreter samplePercentageEval = expressionOptimizer(relation.getSamplePercentage(), metadata, session, expressionTypes);
 
         Object samplePercentageObject = samplePercentageEval.optimize(symbol -> {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1165,7 +1165,8 @@ public class LocalExecutionPlanner
                         sqlParser,
                         ImmutableMap.<Symbol, Type>of(),
                         ImmutableList.copyOf(row),
-                        emptyList());
+                        emptyList(),
+                        false);
                 for (int i = 0; i < row.size(); i++) {
                     // evaluate the literal value
                     Object result = ExpressionInterpreter.expressionInterpreter(row.get(i), metadata, context.getSession(), expressionTypes).evaluate(0);

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.rewrite;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.analyzer.Analysis;
+import com.facebook.presto.sql.analyzer.Analyzer;
+import com.facebook.presto.sql.analyzer.QueryExplainer;
+import com.facebook.presto.sql.analyzer.SemanticException;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.DescribeInput;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.Parameter;
+import com.facebook.presto.sql.tree.Row;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.sql.tree.StringLiteral;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.execution.ParameterExtractor.getParameters;
+import static com.facebook.presto.sql.QueryUtil.aliased;
+import static com.facebook.presto.sql.QueryUtil.ascending;
+import static com.facebook.presto.sql.QueryUtil.nameReference;
+import static com.facebook.presto.sql.QueryUtil.ordering;
+import static com.facebook.presto.sql.QueryUtil.row;
+import static com.facebook.presto.sql.QueryUtil.selectList;
+import static com.facebook.presto.sql.QueryUtil.simpleQuery;
+import static com.facebook.presto.sql.QueryUtil.values;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static java.util.Objects.requireNonNull;
+
+final class DescribeInputRewrite
+        implements StatementRewrite.Rewrite
+{
+    @Override
+    public Statement rewrite(
+            Session session,
+            Metadata metadata,
+            SqlParser parser,
+            Optional<QueryExplainer> queryExplainer,
+            Statement node,
+            List<Expression> parameters,
+            AccessControl accessControl,
+            boolean experimentalSyntaxEnabled)
+    {
+        return (Statement) new Visitor(session, parser, metadata, queryExplainer, parameters, accessControl, experimentalSyntaxEnabled).process(node, null);
+    }
+
+    private static final class Visitor
+            extends AstVisitor<Node, Void>
+    {
+        private final Session session;
+        private final SqlParser parser;
+        private final Metadata metadata;
+        private final Optional<QueryExplainer> queryExplainer;
+        private final List<Expression> parameters;
+        private final AccessControl accessControl;
+        private final boolean experimentalSyntaxEnabled;
+
+        public Visitor(
+                Session session,
+                SqlParser parser,
+                Metadata metadata,
+                Optional<QueryExplainer> queryExplainer,
+                List<Expression> parameters,
+                AccessControl accessControl,
+                boolean experimentalSyntaxEnabled)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.parser = parser;
+            this.metadata = metadata;
+            this.queryExplainer = queryExplainer;
+            this.accessControl = accessControl;
+            this.parameters = parameters;
+            this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
+        }
+
+        @Override
+        protected Node visitDescribeInput(DescribeInput node, Void context)
+                throws SemanticException
+        {
+            String sqlString = session.getPreparedStatement(node.getName());
+            Statement statement = parser.createStatement(sqlString);
+
+            // create  analysis for the query we are describing.
+            Analyzer analyzer = new Analyzer(session, metadata, parser, accessControl, queryExplainer, experimentalSyntaxEnabled, parameters);
+            Analysis analysis = analyzer.analyze(statement, true);
+
+            // get all parameters in query
+            List<Parameter> parameters = getParameters(statement);
+
+            // return the positions and types of all parameters
+            Row[] rows = parameters.stream().map(parameter -> createDescribeInputRow(parameter, analysis)).toArray(Row[]::new);
+            Optional<String> limit = Optional.empty();
+            if (rows.length == 0) {
+                rows = new Row[] {row(new NullLiteral(), new NullLiteral())};
+                limit = Optional.of("0");
+            }
+
+            return simpleQuery(
+                    selectList(nameReference("Position"), nameReference("Type")),
+                    aliased(
+                            values(rows),
+                            "Parameter Input",
+                            ImmutableList.of("Position", "Type")),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    ordering(ascending("Position")),
+                    limit
+            );
+        }
+
+        private Row createDescribeInputRow(Parameter parameter, Analysis queryAnalysis)
+        {
+            Type type = queryAnalysis.getCoercion(parameter);
+            if (type == null) {
+                type = UNKNOWN;
+            }
+
+            return row(
+                    new LongLiteral(Integer.toString(parameter.getPosition())),
+                    new StringLiteral(type.getTypeSignature().getBase()));
+        }
+
+        @Override
+        protected Node visitNode(Node node, Void context)
+        {
+            return node;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ExplainRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ExplainRewrite.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.rewrite;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.parser.SqlParser;
@@ -43,7 +44,15 @@ final class ExplainRewrite
         implements StatementRewrite.Rewrite
 {
     @Override
-    public Statement rewrite(Session session, Metadata metadata, SqlParser parser, Optional<QueryExplainer> queryExplainer, Statement node, List<Expression> parameters)
+    public Statement rewrite(
+            Session session,
+            Metadata metadata,
+            SqlParser parser,
+            Optional<QueryExplainer> queryExplainer,
+            Statement node,
+            List<Expression> parameters,
+            AccessControl accessControl,
+            boolean experimentalSyntaxEnables)
     {
         return (Statement) new Visitor(session, parser, queryExplainer).process(node, null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -23,6 +23,7 @@ import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.metadata.TableLayout;
 import com.facebook.presto.metadata.TableLayoutResult;
 import com.facebook.presto.metadata.ViewDefinition;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.CatalogSchemaName;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -126,7 +127,15 @@ final class ShowQueriesRewrite
         implements StatementRewrite.Rewrite
 {
     @Override
-    public Statement rewrite(Session session, Metadata metadata, SqlParser parser, Optional<QueryExplainer> queryExplainer, Statement node, List<Expression> parameters)
+    public Statement rewrite(
+            Session session,
+            Metadata metadata,
+            SqlParser parser,
+            Optional<QueryExplainer> queryExplainer,
+            Statement node,
+            List<Expression> parameters,
+            AccessControl accessControl,
+            boolean experimentalSyntaxEnabled)
     {
         return (Statement) new Visitor(metadata, parser, session, parameters).process(node, null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/StatementRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/StatementRewrite.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.rewrite;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.Expression;
@@ -30,21 +31,38 @@ import static java.util.Objects.requireNonNull;
 public final class StatementRewrite
 {
     private static final List<Rewrite> REWRITES = ImmutableList.of(
+            new DescribeInputRewrite(),
             new ShowQueriesRewrite(),
             new ExplainRewrite());
 
     private StatementRewrite() {}
 
-    public static Statement rewrite(Session session, Metadata metadata, SqlParser parser, Optional<QueryExplainer> queryExplainer, Statement node, List<Expression> parameters)
+    public static Statement rewrite(
+            Session session,
+            Metadata metadata,
+            SqlParser parser,
+            Optional<QueryExplainer> queryExplainer,
+            Statement node,
+            List<Expression> parameters,
+            AccessControl accessControl,
+            boolean experimentalSyntaxEnabled)
     {
         for (Rewrite rewrite : REWRITES) {
-            node = requireNonNull(rewrite.rewrite(session, metadata, parser, queryExplainer, node, parameters), "Statement rewrite returned null");
+            node = requireNonNull(rewrite.rewrite(session, metadata, parser, queryExplainer, node, parameters, accessControl, experimentalSyntaxEnabled), "Statement rewrite returned null");
         }
         return node;
     }
 
     interface Rewrite
     {
-        Statement rewrite(Session session, Metadata metadata, SqlParser parser, Optional<QueryExplainer> queryExplainer, Statement node, List<Expression> parameters);
+        Statement rewrite(
+                Session session,
+                Metadata metadata,
+                SqlParser parser,
+                Optional<QueryExplainer> queryExplainer,
+                Statement node,
+                List<Expression> parameters,
+                AccessControl accessControl,
+                boolean experimentalSyntaxEnabled);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -436,7 +436,15 @@ public final class FunctionAssertions
 
         parsedExpression = rewriteQualifiedNamesToSymbolReferences(parsedExpression);
 
-        final ExpressionAnalysis analysis = analyzeExpressionsWithSymbols(TEST_SESSION, metadata, SQL_PARSER, symbolTypes, ImmutableList.of(parsedExpression), emptyList());
+        final ExpressionAnalysis analysis = analyzeExpressionsWithSymbols(
+                TEST_SESSION,
+                metadata,
+                SQL_PARSER,
+                symbolTypes,
+                ImmutableList.of(parsedExpression),
+                emptyList(),
+                false);
+
         Expression rewrittenExpression = ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
         {
             @Override

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -83,6 +83,7 @@ statement
     | PREPARE identifier FROM statement                                #prepare
     | DEALLOCATE PREPARE identifier                                    #deallocate
     | EXECUTE identifier (USING expression (',' expression)*)?         #execute
+    | DESCRIBE INPUT identifier                                        #describeInput
     ;
 
 query
@@ -435,6 +436,7 @@ nonReserved
     | GRANT | REVOKE | PRIVILEGES | PUBLIC | OPTION
     | SUBSTRING
     | SCHEMA | CASCADE | RESTRICT
+    | INPUT
     ;
 
 normalForm
@@ -604,6 +606,7 @@ CALL: 'CALL';
 PREPARE: 'PREPARE';
 DEALLOCATE: 'DEALLOCATE';
 EXECUTE: 'EXECUTE';
+INPUT: 'INPUT';
 CASCADE: 'CASCADE';
 RESTRICT: 'RESTRICT';
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -26,6 +26,7 @@ import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.Delete;
+import com.facebook.presto.sql.tree.DescribeInput;
 import com.facebook.presto.sql.tree.DropSchema;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
@@ -185,6 +186,14 @@ public final class SqlFormatter
                 builder.append(" USING ");
                 Joiner.on(", ").appendTo(builder, parameters);
             }
+            return null;
+        }
+
+        @Override
+        protected Void visitDescribeInput(DescribeInput node, Integer indent)
+        {
+            append(indent, "DESCRIBE INPUT ");
+            builder.append(node.getName());
             return null;
         }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -43,6 +43,7 @@ import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.DecimalLiteral;
 import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DereferenceExpression;
+import com.facebook.presto.sql.tree.DescribeInput;
 import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.DropSchema;
 import com.facebook.presto.sql.tree.DropTable;
@@ -383,6 +384,13 @@ class AstBuilder
     {
         String name = context.identifier().getText();
         return new Execute(getLocation(context), name, visit(context.expression(), Expression.class));
+    }
+
+    @Override
+    public Node visitDescribeInput(SqlBaseParser.DescribeInputContext context)
+    {
+        String name = context.identifier().getText();
+        return new DescribeInput(getLocation(context), name);
     }
 
     // ********************** query expressions ********************

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -97,6 +97,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitDescribeInput(DescribeInput node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitQuery(Query node, C context)
     {
         return visitStatement(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeInput.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeInput.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class DescribeInput
+        extends Statement
+{
+    private final String name;
+
+    public DescribeInput(NodeLocation location, String name)
+    {
+        this(Optional.of(location), name);
+    }
+
+    public DescribeInput(String name)
+    {
+        this(Optional.empty(), name);
+    }
+
+    private DescribeInput(Optional<NodeLocation> location, String name)
+    {
+        super(location);
+        this.name = name;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitDescribeInput(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        DescribeInput o = (DescribeInput) obj;
+        return Objects.equals(name, o.name);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .toString();
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -38,6 +38,7 @@ import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.DecimalLiteral;
 import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DereferenceExpression;
+import com.facebook.presto.sql.tree.DescribeInput;
 import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.DropSchema;
 import com.facebook.presto.sql.tree.DropTable;
@@ -1586,6 +1587,12 @@ public class TestSqlParser
                                         ComparisonExpression.Type.EQUAL,
                                         new NotExpression(new ExistsPredicate(simpleQuery(selectList(new LongLiteral("1"))))),
                                         new ExistsPredicate(simpleQuery(selectList(new LongLiteral("2"))))))));
+    }
+
+    @Test
+    public void testDescribeInput()
+    {
+        assertStatement("DESCRIBE INPUT myquery", new DescribeInput("myquery"));
     }
 
     private static void assertCast(String type)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7871,4 +7871,32 @@ public abstract class AbstractTestQueries
             assertEquals(e.getMessage(), "line 1:1: Incorrect number of parameters: expected 1 but found 0");
         }
     }
+
+    @Test
+    public void testDescribeInput()
+    {
+        Session session = getSession().withPreparedStatement("my_query", "select ? from nation where nationkey = ? and name < ?");
+        MaterializedResult actual = computeActual(session, "DESCRIBE INPUT my_query");
+        MaterializedResult expected = resultBuilder(session, BIGINT, VARCHAR)
+                .row(0, "unknown")
+                .row(1, "bigint")
+                .row(2, "varchar")
+                .build();
+        assertEqualsIgnoreOrder(actual, expected);
+    }
+
+    @Test
+    public void testDescribeInputNoParameters()
+    {
+        Session session = getSession().withPreparedStatement("my_query", "select * from nation");
+        MaterializedResult actual = computeActual(session, "DESCRIBE INPUT my_query");
+        MaterializedResult expected = resultBuilder(session, BIGINT, VARCHAR).build();
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testDescribeInputNoSuchQuery()
+    {
+        assertQueryFails("DESCRIBE INPUT my_query", "Prepared statement not found: my_query");
+    }
 }


### PR DESCRIPTION
Syntax:
DESCRIBE INPUT <statement_name>

Describes the requirements for the input parameters to a prepared
statement.  For each expected parameter, a row will be returned
containing the position of the parameter and the expected type if
it can be determined, or unknown if not.

Set operations and insert queries don't resolve types until planning, so we won't be able to get proper types for those queries.  If this is the way to go for describe input, I can file a ticket to address that after everything else goes in (it's rather complicated to change the relation coercions to happen at analysis time).