### PR TITLE
Support subqueries in non INNER join (v2)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
@@ -97,32 +97,29 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
         @Override
         public PlanNode visitFilter(FilterNode node, RewriteContext<Void> context)
         {
-            InPredicateRewriteResult inPredicateRewriteResult = rewriteInPredicates(
+            PlanNode rewrittenNode = rewriteInPredicates(
                     context.defaultRewrite(node, context.get()),
                     ImmutableList.of(node.getPredicate()));
-            inPredicateMappings.add(inPredicateRewriteResult.inPredicateMapping);
 
             return new FilterNode(
-                    inPredicateRewriteResult.node.getId(),
-                    getOnlyElement(inPredicateRewriteResult.node.getSources()),
+                    rewrittenNode.getId(),
+                    getOnlyElement(rewrittenNode.getSources()),
                     replaceInPredicates(node.getPredicate()));
         }
 
         @Override
         public PlanNode visitProject(ProjectNode node, RewriteContext<Void> context)
         {
-            InPredicateRewriteResult inPredicateRewriteResult = rewriteInPredicates(
+            PlanNode rewrittenNode = rewriteInPredicates(
                     context.defaultRewrite(node, context.get()),
                     node.getAssignments().values());
 
-            inPredicateMappings.add(inPredicateRewriteResult.inPredicateMapping);
-
-            return new ProjectNode(inPredicateRewriteResult.node.getId(),
-                    getOnlyElement(inPredicateRewriteResult.node.getSources()),
+            return new ProjectNode(rewrittenNode.getId(),
+                    getOnlyElement(rewrittenNode.getSources()),
                     replaceInPredicateInAssignments(node));
         }
 
-        private InPredicateRewriteResult rewriteInPredicates(PlanNode node, Collection<Expression> expressions)
+        private PlanNode rewriteInPredicates(PlanNode node, Collection<Expression> expressions)
         {
             List<InPredicate> inPredicates = extractApplyInPredicates(expressions);
             ImmutableMap.Builder<InPredicate, Expression> inPredicateMapping = ImmutableMap.builder();
@@ -132,19 +129,8 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
                 rewrittenNode = rewriteWith(rewriter, rewrittenNode, null);
                 inPredicateMapping.putAll(rewriter.getInPredicateMapping());
             }
-            return new InPredicateRewriteResult(rewrittenNode, inPredicateMapping.build());
-        }
-
-        private static class InPredicateRewriteResult
-        {
-            private final PlanNode node;
-            private final Map<InPredicate, Expression> inPredicateMapping;
-
-            private InPredicateRewriteResult(PlanNode node, Map<InPredicate, Expression> inPredicateMapping)
-            {
-                this.node = requireNonNull(node, "node is null");
-                this.inPredicateMapping = requireNonNull(inPredicateMapping, "inPredicateMapping is null");
-            }
+            inPredicateMappings.add(inPredicateMapping.build());
+            return rewrittenNode;
         }
 
         private Map<Symbol, Expression> replaceInPredicateInAssignments(ProjectNode node)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
@@ -99,7 +99,7 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
         {
             PlanNode rewrittenNode = rewriteInPredicates(
                     context.defaultRewrite(node, context.get()),
-                    ImmutableList.of(node.getPredicate()));
+                    node.getPredicate());
 
             return new FilterNode(
                     rewrittenNode.getId(),
@@ -117,6 +117,11 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
             return new ProjectNode(rewrittenNode.getId(),
                     getOnlyElement(rewrittenNode.getSources()),
                     replaceInPredicateInAssignments(node));
+        }
+
+        private PlanNode rewriteInPredicates(PlanNode node, Expression expressions)
+        {
+            return rewriteInPredicates(node, ImmutableList.of(expressions));
         }
 
         private PlanNode rewriteInPredicates(PlanNode node, Collection<Expression> expressions)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
@@ -108,14 +108,6 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
                     replaceInPredicates(node.getPredicate()));
         }
 
-        private Expression replaceInPredicates(Expression expression)
-        {
-            for (Map<InPredicate, Expression> inPredicateMapping : inPredicateMappings) {
-                expression = replaceExpression(expression, inPredicateMapping);
-            }
-            return expression;
-        }
-
         @Override
         public PlanNode visitProject(ProjectNode node, RewriteContext<Void> context)
         {
@@ -163,6 +155,14 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
                 assignmentsBuilder.put(symbol, replaceInPredicates(assignments.get(symbol)));
             }
             return assignmentsBuilder.build();
+        }
+
+        private Expression replaceInPredicates(Expression expression)
+        {
+            for (Map<InPredicate, Expression> inPredicateMapping : inPredicateMappings) {
+                expression = replaceExpression(expression, inPredicateMapping);
+            }
+            return expression;
         }
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -87,10 +87,10 @@ public final class QueryAssertions
 
         if (actualResults.getUpdateType().isPresent() || actualResults.getUpdateCount().isPresent()) {
             if (!actualResults.getUpdateType().isPresent()) {
-                fail("update count present without update type");
+                fail("update count present without update type for query: \n" + actual);
             }
             if (!compareUpdate) {
-                fail("update type should not be present (use assertUpdate)");
+                fail("update type should not be present (use assertUpdate) for query: \n" + actual);
             }
         }
 
@@ -99,29 +99,34 @@ public final class QueryAssertions
 
         if (compareUpdate) {
             if (!actualResults.getUpdateType().isPresent()) {
-                fail("update type not present");
+                fail("update type not present for query: \n" + actual);
             }
             if (!actualResults.getUpdateCount().isPresent()) {
-                fail("update count not present");
+                fail("update count not present for query: \n" + actual);
             }
-            assertEquals(actualRows.size(), 1);
-            assertEquals(expectedRows.size(), 1);
+            assertEquals(actualRows.size(), 1, "For query: \n " + actual + "\n:");
+            assertEquals(expectedRows.size(), 1, "For query: \n " + actual + "\n:");
             MaterializedRow row = expectedRows.get(0);
-            assertEquals(row.getFieldCount(), 1);
-            assertEquals(row.getField(0), actualResults.getUpdateCount().getAsLong());
+            assertEquals(row.getFieldCount(), 1, "For query: \n " + actual + "\n:");
+            assertEquals(row.getField(0), actualResults.getUpdateCount().getAsLong(), "For query: \n " + actual + "\n:");
         }
 
         if (ensureOrdering) {
             if (!actualRows.equals(expectedRows)) {
-                assertEquals(actualRows, expectedRows);
+                assertEquals(actualRows, expectedRows, "For query: \n " + actual + "\n:");
             }
         }
         else {
-            assertEqualsIgnoreOrder(actualRows, expectedRows);
+            assertEqualsIgnoreOrder(actualRows, expectedRows, "For query: \n " + actual);
         }
     }
 
     public static void assertEqualsIgnoreOrder(Iterable<?> actual, Iterable<?> expected)
+    {
+        assertEqualsIgnoreOrder(actual, expected, null);
+    }
+
+    public static void assertEqualsIgnoreOrder(Iterable<?> actual, Iterable<?> expected, String message)
     {
         assertNotNull(actual, "actual is null");
         assertNotNull(expected, "expected is null");
@@ -129,7 +134,8 @@ public final class QueryAssertions
         ImmutableMultiset<?> actualSet = ImmutableMultiset.copyOf(actual);
         ImmutableMultiset<?> expectedSet = ImmutableMultiset.copyOf(expected);
         if (!actualSet.equals(expectedSet)) {
-            fail(format("not equal\nActual %s rows:\n    %s\nExpected %s rows:\n    %s\n",
+            fail(format("%snot equal\nActual %s rows:\n    %s\nExpected %s rows:\n    %s\n",
+                    message == null ? "" : (message + "\n"),
                     actualSet.size(),
                     Joiner.on("\n    ").join(Iterables.limit(actualSet, 100)),
                     expectedSet.size(),

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryTemplate.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryTemplate.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.tests;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class QueryTemplate
+{
+    private final String queryTemplate;
+    private final List<Parameter> defaultParameters;
+
+    public QueryTemplate(String queryTemplate, Parameter... parameters)
+    {
+        this.queryTemplate = queryTemplate;
+        this.defaultParameters = ImmutableList.copyOf(parameters);
+    }
+
+    public String resolve(Parameter ... parameters)
+    {
+        String query = queryTemplate;
+        for (Parameter parameter : parameters) {
+            query = resolve(query, parameter.getKey(), parameter.getValue());
+        }
+        for (Parameter parameter : defaultParameters) {
+            query = resolve(query, parameter.getKey(), parameter.getValue());
+        }
+
+        return query;
+    }
+
+    private String resolve(String query, String key, String value)
+    {
+        return query.replaceAll("%" + key + "%", value);
+    }
+
+    public static final class Parameter
+    {
+        private final String key;
+        private final String value;
+
+        public Parameter(String key, String value)
+        {
+            this.key = requireNonNull(key, "key is null");
+            this.value = requireNonNull(value, "defaultValue is null");
+        }
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        public String getKey()
+        {
+            return key;
+        }
+
+        public Parameter of(String value)
+        {
+            return new Parameter(key, value);
+        }
+    }
+}


### PR DESCRIPTION
Support subqueries in non INNER join

From now subqueries can be used in join condition for non inner join.
The only lacking support is for IN predicate (semi join) which is using
references from both tables. In such case it is kind of triple side join
which is currently not possible to be executed in Presto.