### PR TITLE
Use columnValue to handle all prefilled column value

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursor.java
@@ -235,7 +235,7 @@ class ColumnarBinaryHiveRecordCursor<K>
                     slices[columnIndex] = varcharPartitionKey(columnValue, name, type);
                 }
                 else if (isCharType(type)) {
-                    slices[columnIndex] = charPartitionKey(partitionKey.getValue(), name, type);
+                    slices[columnIndex] = charPartitionKey(columnValue, name, type);
                 }
                 else if (DATE.equals(type)) {
                     longs[columnIndex] = datePartitionKey(columnValue, name);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursor.java
@@ -221,7 +221,7 @@ class ColumnarTextHiveRecordCursor<K>
                     slices[columnIndex] = varcharPartitionKey(columnValue, name, type);
                 }
                 else if (isCharType(type)) {
-                    slices[columnIndex] = charPartitionKey(partitionKey.getValue(), name, type);
+                    slices[columnIndex] = charPartitionKey(columnValue, name, type);
                 }
                 else if (DATE.equals(type)) {
                     longs[columnIndex] = datePartitionKey(columnValue, name);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
@@ -222,7 +222,7 @@ class GenericHiveRecordCursor<K, V extends Writable>
                     slices[columnIndex] = varcharPartitionKey(columnValue, name, type);
                 }
                 else if (isCharType(type)) {
-                    slices[columnIndex] = charPartitionKey(partitionKey.getValue(), name, type);
+                    slices[columnIndex] = charPartitionKey(columnValue, name, type);
                 }
                 else if (DATE.equals(type)) {
                     longs[columnIndex] = datePartitionKey(columnValue, name);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
@@ -192,7 +192,7 @@ public class OrcPageSource
                     }
                 }
                 else if (isCharType(type)) {
-                    Slice value = charPartitionKey(partitionKey.getValue(), name, type);
+                    Slice value = charPartitionKey(columnValue, name, type);
                     for (int i = 0; i < MAX_BATCH_SIZE; i++) {
                         type.writeSlice(blockBuilder, value);
                     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -208,7 +208,7 @@ class ParquetPageSource
                     }
                 }
                 else if (isCharType(type)) {
-                    Slice value = charPartitionKey(partitionKey.getValue(), name, type);
+                    Slice value = charPartitionKey(columnValue, name, type);
                     for (int i = 0; i < MAX_VECTOR_LENGTH; i++) {
                         type.writeSlice(blockBuilder, value);
                     }


### PR DESCRIPTION
`partitionKey` could be null if the current column is a hidden column,
which might cause NPE and query failure.