### PR TITLE
Add an alias for DOUBLE PRECISION

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/type/TestDoubleOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDoubleOperators.java
@@ -40,6 +40,9 @@ public class TestDoubleOperators
         assertFunction("DOUBLE '12.34'", DOUBLE, 12.34);
         assertFunction("DOUBLE '-17.6'", DOUBLE, -17.6);
         assertFunction("DOUBLE '+754'", DOUBLE, 754.0);
+        assertFunction("DOUBLE PRECISION '12.34'", DOUBLE, 12.34);
+        assertFunction("DOUBLE PRECISION '-17.6'", DOUBLE, -17.6);
+        assertFunction("DOUBLE PRECISION '+754'", DOUBLE, 754.0);
     }
 
     @Test
@@ -218,5 +221,7 @@ public class TestDoubleOperators
     {
         assertFunction("cast('37.7' as double)", DOUBLE, 37.7);
         assertFunction("cast('17.1' as double)", DOUBLE, 17.1);
+        assertFunction("cast('37.7' as double precision)", DOUBLE, 37.7);
+        assertFunction("cast('17.1' as double precision)", DOUBLE, 17.1);
     }
 }

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -260,6 +260,7 @@ primaryExpression
     : NULL                                                                           #nullLiteral
     | interval                                                                       #intervalLiteral
     | identifier STRING                                                              #typeConstructor
+    | DOUBLE_PRECISION STRING                                                        #typeConstructor
     | number                                                                         #numericLiteral
     | booleanValue                                                                   #booleanLiteral
     | STRING                                                                         #stringLiteral
@@ -330,6 +331,7 @@ typeParameter
 baseType
     : TIME_WITH_TIME_ZONE
     | TIMESTAMP_WITH_TIME_ZONE
+    | DOUBLE_PRECISION
     | identifier
     ;
 
@@ -665,6 +667,10 @@ TIME_WITH_TIME_ZONE
 
 TIMESTAMP_WITH_TIME_ZONE
     : 'TIMESTAMP' WS 'WITH' WS 'TIME' WS 'ZONE'
+    ;
+
+DOUBLE_PRECISION
+    : 'DOUBLE' WS 'PRECISION'
     ;
 
 fragment EXPONENT

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1278,9 +1278,14 @@ class AstBuilder
     @Override
     public Node visitTypeConstructor(SqlBaseParser.TypeConstructorContext context)
     {
-        String type = context.identifier().getText();
         String value = unquote(context.STRING().getText());
 
+        if (context.DOUBLE_PRECISION() != null) {
+            // TODO: Temporary hack that should be removed with new planner.
+            return new GenericLiteral(getLocation(context), "DOUBLE", value);
+        }
+
+        String type = context.identifier().getText();
         if (type.equalsIgnoreCase("time")) {
             return new TimeLiteral(getLocation(context), value);
         }
@@ -1293,7 +1298,6 @@ class AstBuilder
         if (type.equalsIgnoreCase("char")) {
             return new CharLiteral(getLocation(context), value);
         }
-
         return new GenericLiteral(getLocation(context), type, value);
     }
 
@@ -1613,6 +1617,10 @@ class AstBuilder
     {
         if (type.baseType() != null) {
             String signature = type.baseType().getText();
+            if (type.baseType().DOUBLE_PRECISION() != null) {
+                // TODO: Temporary hack that should be removed with new planner.
+                signature = "DOUBLE";
+            }
             if (!type.typeParameter().isEmpty()) {
                 String typeParameterSignature = type
                         .typeParameter()

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -274,6 +274,9 @@ public class TestSqlParser
         assertCast("BIGINT");
         assertCast("double");
         assertCast("DOUBLE");
+        assertCast("DOUBLE PRECISION", "DOUBLE");
+        assertCast("DOUBLE   PRECISION", "DOUBLE");
+        assertCast("double precision", "DOUBLE");
         assertCast("boolean");
         assertCast("date");
         assertCast("time");


### PR DESCRIPTION
Note that in AstBuilder we transform it to "DOUBLE". This servers two
purposes:
 1) Correctness, otherwise system doesn't find type "DOUBLE PRECISION"
 2) Avoid test error in cases of multiple space between DOUBLE and
    PRECISION tokens.

Fixes #5815 