### PR TITLE
Window matcher rework

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowFunctionDefinition.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowFunctionDefinition.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator;
 import com.facebook.presto.operator.window.WindowFunctionSupplier;
 import com.facebook.presto.spi.function.WindowFunction;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,27 +31,23 @@ public class WindowFunctionDefinition
 
     public static WindowFunctionDefinition window(WindowFunctionSupplier functionSupplier, Type type, List<Integer> inputs)
     {
-        requireNonNull(functionSupplier, "functionSupplier is null");
-        requireNonNull(type, "type is null");
-        requireNonNull(inputs, "inputs is null");
-
         return new WindowFunctionDefinition(functionSupplier, type, inputs);
     }
 
     public static WindowFunctionDefinition window(WindowFunctionSupplier functionSupplier, Type type, Integer... inputs)
     {
-        requireNonNull(functionSupplier, "functionSupplier is null");
-        requireNonNull(type, "type is null");
-        requireNonNull(inputs, "inputs is null");
-
         return window(functionSupplier, type, Arrays.asList(inputs));
     }
 
     WindowFunctionDefinition(WindowFunctionSupplier functionSupplier, Type type, List<Integer> argumentChannels)
     {
+        requireNonNull(functionSupplier, "functionSupplier is null");
+        requireNonNull(type, "type is null");
+        requireNonNull(argumentChannels, "inputs is null");
+
         this.functionSupplier = functionSupplier;
         this.type = type;
-        this.argumentChannels = argumentChannels;
+        this.argumentChannels = ImmutableList.copyOf(argumentChannels);
     }
 
     public Type getType()

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowFunctionDefinition.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowFunctionDefinition.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.operator.window.FrameInfo;
 import com.facebook.presto.operator.window.WindowFunctionSupplier;
 import com.facebook.presto.spi.function.WindowFunction;
 import com.facebook.presto.spi.type.Type;
@@ -27,27 +28,35 @@ public class WindowFunctionDefinition
 {
     private final WindowFunctionSupplier functionSupplier;
     private final Type type;
+    private final FrameInfo frameInfo;
     private final List<Integer> argumentChannels;
 
-    public static WindowFunctionDefinition window(WindowFunctionSupplier functionSupplier, Type type, List<Integer> inputs)
+    public static WindowFunctionDefinition window(WindowFunctionSupplier functionSupplier, Type type, FrameInfo frameInfo, List<Integer> inputs)
     {
-        return new WindowFunctionDefinition(functionSupplier, type, inputs);
+        return new WindowFunctionDefinition(functionSupplier, type, frameInfo, inputs);
     }
 
-    public static WindowFunctionDefinition window(WindowFunctionSupplier functionSupplier, Type type, Integer... inputs)
+    public static WindowFunctionDefinition window(WindowFunctionSupplier functionSupplier, Type type, FrameInfo frameInfo, Integer... inputs)
     {
-        return window(functionSupplier, type, Arrays.asList(inputs));
+        return window(functionSupplier, type, frameInfo, Arrays.asList(inputs));
     }
 
-    WindowFunctionDefinition(WindowFunctionSupplier functionSupplier, Type type, List<Integer> argumentChannels)
+    WindowFunctionDefinition(WindowFunctionSupplier functionSupplier, Type type, FrameInfo frameInfo, List<Integer> argumentChannels)
     {
         requireNonNull(functionSupplier, "functionSupplier is null");
         requireNonNull(type, "type is null");
+        requireNonNull(frameInfo, "frameInfo is null");
         requireNonNull(argumentChannels, "inputs is null");
 
         this.functionSupplier = functionSupplier;
         this.type = type;
+        this.frameInfo = frameInfo;
         this.argumentChannels = ImmutableList.copyOf(argumentChannels);
+    }
+
+    public FrameInfo getFrameInfo()
+    {
+        return frameInfo;
     }
 
     public Type getType()

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/FrameInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/FrameInfo.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.window;
 import com.facebook.presto.sql.tree.FrameBound;
 import com.facebook.presto.sql.tree.WindowFrame;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -66,6 +67,32 @@ public class FrameInfo
     public int getEndChannel()
     {
         return endChannel;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(type, startType, startChannel, endType, endChannel);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        FrameInfo other = (FrameInfo) obj;
+
+        return Objects.equals(this.type, other.type) &&
+                Objects.equals(this.startType, other.startType) &&
+                Objects.equals(this.startChannel, other.startChannel) &&
+                Objects.equals(this.endType, other.endType) &&
+                Objects.equals(this.endChannel, other.endChannel);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/FramedWindowFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/FramedWindowFunction.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.window;
+
+import com.facebook.presto.spi.function.WindowFunction;
+
+import static java.util.Objects.requireNonNull;
+
+public final class FramedWindowFunction
+{
+    private final WindowFunction function;
+    private final FrameInfo frame;
+
+    public FramedWindowFunction(WindowFunction windowFunction, FrameInfo frameInfo)
+    {
+        this.function = requireNonNull(windowFunction, "windowFunction is null");
+        this.frame = requireNonNull(frameInfo, "frameInfo is null");
+    }
+
+    public WindowFunction getFunction()
+    {
+        return function;
+    }
+
+    public FrameInfo getFrame()
+    {
+        return frame;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/WindowPartition.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/WindowPartition.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.window;
 import com.facebook.presto.operator.PagesHashStrategy;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.spi.PageBuilder;
-import com.facebook.presto.spi.function.WindowFunction;
 import com.facebook.presto.spi.function.WindowIndex;
 import com.facebook.presto.sql.tree.FrameBound;
 import com.google.common.primitives.Ints;
@@ -30,6 +29,7 @@ import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_FOLLOWING;
 import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
 import static com.facebook.presto.sql.tree.WindowFrame.Type.RANGE;
 import static com.facebook.presto.util.Failures.checkCondition;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 public final class WindowPartition
@@ -39,7 +39,7 @@ public final class WindowPartition
     private final int partitionEnd;
 
     private final int[] outputChannels;
-    private final List<WindowFunction> windowFunctions;
+    private final List<FramedWindowFunction> windowFunctions;
     private final FrameInfo frameInfo;
     private final PagesHashStrategy peerGroupHashStrategy;
 
@@ -54,8 +54,7 @@ public final class WindowPartition
             int partitionStart,
             int partitionEnd,
             int[] outputChannels,
-            List<WindowFunction> windowFunctions,
-            FrameInfo frameInfo,
+            List<FramedWindowFunction> windowFunctions,
             PagesHashStrategy peerGroupHashStrategy)
     {
         this.pagesIndex = pagesIndex;
@@ -63,17 +62,24 @@ public final class WindowPartition
         this.partitionEnd = partitionEnd;
         this.outputChannels = outputChannels;
         this.windowFunctions = windowFunctions;
-        this.frameInfo = frameInfo;
+        this.frameInfo = assertSingleFrame(windowFunctions); // TODO remove this when multiple Frames are handled correctly
         this.peerGroupHashStrategy = peerGroupHashStrategy;
 
         // reset functions for new partition
         WindowIndex windowIndex = new PagesWindowIndex(pagesIndex, partitionStart, partitionEnd);
-        for (WindowFunction windowFunction : windowFunctions) {
-            windowFunction.reset(windowIndex);
+        for (FramedWindowFunction framedWindowFunction : windowFunctions) {
+            framedWindowFunction.getFunction().reset(windowIndex);
         }
 
         currentPosition = partitionStart;
         updatePeerGroup();
+    }
+
+    private static FrameInfo assertSingleFrame(List<FramedWindowFunction> windows)
+    {
+        checkArgument(windows.stream().map(framedFunction -> framedFunction.getFrame()).distinct().count() == 1,
+                "All window functions have to share the same frame. Distinct frames in single operator are not yet supported.");
+        return windows.iterator().next().getFrame();
     }
 
     public int getPartitionEnd()
@@ -103,12 +109,10 @@ public final class WindowPartition
             updatePeerGroup();
         }
 
-        // compute window frame
         updateFrame();
 
-        // process window functions
-        for (WindowFunction function : windowFunctions) {
-            function.processRow(
+        for (FramedWindowFunction framedFunction : windowFunctions) {
+            framedFunction.getFunction().processRow(
                     pageBuilder.getBlockBuilder(channel),
                     peerGroupStart - partitionStart,
                     peerGroupEnd - partitionStart - 1,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -686,14 +686,15 @@ public class LocalExecutionPlanner
 
             ImmutableList.Builder<WindowFunctionDefinition> windowFunctionsBuilder = ImmutableList.builder();
             ImmutableList.Builder<Symbol> windowFunctionOutputSymbolsBuilder = ImmutableList.builder();
-            for (Map.Entry<Symbol, FunctionCall> entry : node.getWindowFunctions().entrySet()) {
+            for (Map.Entry<Symbol, WindowNode.Function> entry : node.getWindowFunctions().entrySet()) {
+                FunctionCall functionCall = entry.getValue().getFunctionCall();
+                Signature signature = entry.getValue().getSignature();
                 ImmutableList.Builder<Integer> arguments = ImmutableList.builder();
-                for (Expression argument : entry.getValue().getArguments()) {
+                for (Expression argument : functionCall.getArguments()) {
                     Symbol argumentSymbol = Symbol.from(argument);
                     arguments.add(source.getLayout().get(argumentSymbol));
                 }
                 Symbol symbol = entry.getKey();
-                Signature signature = node.getSignatures().get(symbol);
                 WindowFunctionSupplier windowFunctionSupplier = metadata.getFunctionRegistry().getWindowFunctionImplementation(signature);
                 Type type = metadata.getType(signature.getReturnType());
                 windowFunctionsBuilder.add(window(windowFunctionSupplier, type, arguments.build()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -680,7 +680,7 @@ public class LocalExecutionPlanner
                 Optional<Integer> frameStartChannel = Optional.empty();
                 Optional<Integer> frameEndChannel = Optional.empty();
 
-                Frame frame = node.getFrames().get(entry.getValue());
+                Frame frame = entry.getValue().getFrame();
                 if (frame.getStartValue().isPresent()) {
                     frameStartChannel = Optional.of(source.getLayout().get(frame.getStartValue().get()));
                 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -669,16 +669,6 @@ public class LocalExecutionPlanner
                     .map(symbol -> node.getOrderings().get(symbol))
                     .collect(toImmutableList());
 
-            Optional<Integer> frameStartChannel = Optional.empty();
-            Optional<Integer> frameEndChannel = Optional.empty();
-            Frame frame = node.getFrame();
-            if (frame.getStartValue().isPresent()) {
-                frameStartChannel = Optional.of(source.getLayout().get(frame.getStartValue().get()));
-            }
-            if (frame.getEndValue().isPresent()) {
-                frameEndChannel = Optional.of(source.getLayout().get(frame.getEndValue().get()));
-            }
-
             ImmutableList.Builder<Integer> outputChannels = ImmutableList.builder();
             for (int i = 0; i < source.getTypes().size(); i++) {
                 outputChannels.add(i);
@@ -687,6 +677,19 @@ public class LocalExecutionPlanner
             ImmutableList.Builder<WindowFunctionDefinition> windowFunctionsBuilder = ImmutableList.builder();
             ImmutableList.Builder<Symbol> windowFunctionOutputSymbolsBuilder = ImmutableList.builder();
             for (Map.Entry<Symbol, WindowNode.Function> entry : node.getWindowFunctions().entrySet()) {
+                Optional<Integer> frameStartChannel = Optional.empty();
+                Optional<Integer> frameEndChannel = Optional.empty();
+
+                Frame frame = node.getFrames().get(entry.getValue());
+                if (frame.getStartValue().isPresent()) {
+                    frameStartChannel = Optional.of(source.getLayout().get(frame.getStartValue().get()));
+                }
+                if (frame.getEndValue().isPresent()) {
+                    frameEndChannel = Optional.of(source.getLayout().get(frame.getEndValue().get()));
+                }
+
+                FrameInfo frameInfo = new FrameInfo(frame.getType(), frame.getStartType(), frameStartChannel, frame.getEndType(), frameEndChannel);
+
                 FunctionCall functionCall = entry.getValue().getFunctionCall();
                 Signature signature = entry.getValue().getSignature();
                 ImmutableList.Builder<Integer> arguments = ImmutableList.builder();
@@ -697,12 +700,11 @@ public class LocalExecutionPlanner
                 Symbol symbol = entry.getKey();
                 WindowFunctionSupplier windowFunctionSupplier = metadata.getFunctionRegistry().getWindowFunctionImplementation(signature);
                 Type type = metadata.getType(signature.getReturnType());
-                windowFunctionsBuilder.add(window(windowFunctionSupplier, type, arguments.build()));
+                windowFunctionsBuilder.add(window(windowFunctionSupplier, type, frameInfo, arguments.build()));
                 windowFunctionOutputSymbolsBuilder.add(symbol);
             }
 
             List<Symbol> windowFunctionOutputSymbols = windowFunctionOutputSymbolsBuilder.build();
-            List<WindowFunctionDefinition> windowFunctions = windowFunctionsBuilder.build();
 
             // compute the layout of the output from the window operator
             ImmutableMap.Builder<Symbol, Integer> outputMappings = ImmutableMap.builder();
@@ -722,13 +724,12 @@ public class LocalExecutionPlanner
                     node.getId(),
                     source.getTypes(),
                     outputChannels.build(),
-                    windowFunctions,
+                    windowFunctionsBuilder.build(),
                     partitionChannels,
                     preGroupedChannels,
                     sortChannels,
                     sortOrder,
                     node.getPreSortedOrderPrefix(),
-                    new FrameInfo(frame.getType(), frame.getStartType(), frameStartChannel, frame.getEndType(), frameEndChannel),
                     10_000);
 
             return new PhysicalOperation(operatorFactory, outputMappings.build(), source);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
@@ -576,8 +576,9 @@ public class PlanPrinter
             print(indent, "- Window[%s] => [%s]", Joiner.on(", ").join(args), formatOutputs(node.getOutputSymbols()));
             printStats(indent + 2, node.getId());
 
-            for (Map.Entry<Symbol, FunctionCall> entry : node.getWindowFunctions().entrySet()) {
-                print(indent + 2, "%s := %s(%s)", entry.getKey(), entry.getValue().getName(), Joiner.on(", ").join(entry.getValue().getArguments()));
+            for (Map.Entry<Symbol, WindowNode.Function> entry : node.getWindowFunctions().entrySet()) {
+                FunctionCall call = entry.getValue().getFunctionCall();
+                print(indent + 2, "%s := %s(%s)", entry.getKey(), call.getName(), Joiner.on(", ").join(call.getArguments()));
             }
             return processChildren(node, indent + 1);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -590,8 +590,6 @@ class QueryPlanner
 
             TranslationMap outputTranslations = subPlan.copyTranslations();
 
-            ImmutableMap.Builder<Symbol, WindowNode.Function> functionBuilder = ImmutableMap.builder();
-
             // Rewrite function call in terms of pre-projected inputs
             Expression parametersReplaced = ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(analysis.getParameters(), analysis), windowFunction);
             outputTranslations.addIntermediateMapping(windowFunction, parametersReplaced);
@@ -605,7 +603,7 @@ class QueryPlanner
             }
             outputTranslations.put(parametersReplaced, newSymbol);
 
-            functionBuilder.put(newSymbol, new WindowNode.Function((FunctionCall) rewritten, analysis.getFunctionSignature(windowFunction)));
+            WindowNode.Function function = new WindowNode.Function((FunctionCall) rewritten, analysis.getFunctionSignature(windowFunction));
 
             List<Symbol> sourceSymbols = subPlan.getRoot().getOutputSymbols();
             ImmutableList.Builder<Symbol> orderBySymbols = ImmutableList.builder();
@@ -619,9 +617,9 @@ class QueryPlanner
                             new WindowNode.Specification(
                                     partitionBySymbols.build(),
                                     orderBySymbols.build(),
-                                    orderings,
-                                    frame),
-                            functionBuilder.build(),
+                                    orderings),
+                            ImmutableMap.of(newSymbol, function),
+                            ImmutableMap.of(function, frame),
                             Optional.empty(),
                             ImmutableSet.of(),
                             0),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -603,7 +603,8 @@ class QueryPlanner
             }
             outputTranslations.put(parametersReplaced, newSymbol);
 
-            WindowNode.Function function = new WindowNode.Function((FunctionCall) rewritten, analysis.getFunctionSignature(windowFunction));
+            WindowNode.Function function = new WindowNode.Function(
+                    (FunctionCall) rewritten, analysis.getFunctionSignature(windowFunction), frame);
 
             List<Symbol> sourceSymbols = subPlan.getRoot().getOutputSymbols();
             ImmutableList.Builder<Symbol> orderBySymbols = ImmutableList.builder();
@@ -619,7 +620,6 @@ class QueryPlanner
                                     orderBySymbols.build(),
                                     orderings),
                             ImmutableMap.of(newSymbol, function),
-                            ImmutableMap.of(function, frame),
                             Optional.empty(),
                             ImmutableSet.of(),
                             0),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -590,8 +590,7 @@ class QueryPlanner
 
             TranslationMap outputTranslations = subPlan.copyTranslations();
 
-            ImmutableMap.Builder<Symbol, FunctionCall> assignments = ImmutableMap.builder();
-            Map<Symbol, Signature> signatures = new HashMap<>();
+            ImmutableMap.Builder<Symbol, WindowNode.Function> functionBuilder = ImmutableMap.builder();
 
             // Rewrite function call in terms of pre-projected inputs
             Expression parametersReplaced = ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(analysis.getParameters(), analysis), windowFunction);
@@ -604,10 +603,9 @@ class QueryPlanner
             if (rewritten instanceof Cast) {
                 rewritten = ((Cast) rewritten).getExpression();
             }
-            assignments.put(newSymbol, (FunctionCall) rewritten);
             outputTranslations.put(parametersReplaced, newSymbol);
 
-            signatures.put(newSymbol, analysis.getFunctionSignature(windowFunction));
+            functionBuilder.put(newSymbol, new WindowNode.Function((FunctionCall) rewritten, analysis.getFunctionSignature(windowFunction)));
 
             List<Symbol> sourceSymbols = subPlan.getRoot().getOutputSymbols();
             ImmutableList.Builder<Symbol> orderBySymbols = ImmutableList.builder();
@@ -623,8 +621,7 @@ class QueryPlanner
                                     orderBySymbols.build(),
                                     orderings,
                                     frame),
-                            assignments.build(),
-                            signatures,
+                            functionBuilder.build(),
                             Optional.empty(),
                             ImmutableSet.of(),
                             0),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -385,7 +385,6 @@ public class AddLocalExchanges
                     child.getNode(),
                     node.getSpecification(),
                     node.getWindowFunctions(),
-                    node.getSignatures(),
                     node.getHashSymbol(),
                     prePartitionedInputs,
                     preSortedOrderPrefix);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -385,7 +385,6 @@ public class AddLocalExchanges
                     child.getNode(),
                     node.getSpecification(),
                     node.getWindowFunctions(),
-                    node.getFrames(),
                     node.getHashSymbol(),
                     prePartitionedInputs,
                     preSortedOrderPrefix);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -385,6 +385,7 @@ public class AddLocalExchanges
                     child.getNode(),
                     node.getSpecification(),
                     node.getWindowFunctions(),
+                    node.getFrames(),
                     node.getHashSymbol(),
                     prePartitionedInputs,
                     preSortedOrderPrefix);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -426,6 +426,7 @@ public class HashGenerationOptimizer
                             child.getNode(),
                             node.getSpecification(),
                             node.getWindowFunctions(),
+                            node.getFrames(),
                             Optional.of(hashSymbol),
                             node.getPrePartitionedInputs(),
                             node.getPreSortedOrderPrefix()),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -426,7 +426,6 @@ public class HashGenerationOptimizer
                             child.getNode(),
                             node.getSpecification(),
                             node.getWindowFunctions(),
-                            node.getSignatures(),
                             Optional.of(hashSymbol),
                             node.getPrePartitionedInputs(),
                             node.getPreSortedOrderPrefix()),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -426,7 +426,6 @@ public class HashGenerationOptimizer
                             child.getNode(),
                             node.getSpecification(),
                             node.getWindowFunctions(),
-                            node.getFrames(),
                             Optional.of(hashSymbol),
                             node.getPrePartitionedInputs(),
                             node.getPreSortedOrderPrefix()),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -339,7 +339,7 @@ public class IndexJoinOptimizer
             // Only RANGE frame type currently supported for aggregation functions because it guarantees the
             // same value for each peer group.
             // ROWS frame type requires the ordering to be fully deterministic (e.g. deterministically sorted on all columns)
-            if (node.getFrame().getType() != WindowFrame.Type.RANGE) {
+            if (node.getFrames().values().stream().map(WindowNode.Frame::getType).anyMatch(type -> type != WindowFrame.Type.RANGE)) { // TODO: extract frames of type RANGE and allow optimization on them
                 return node;
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -37,7 +37,6 @@ import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.sql.tree.WindowFrame;
 import com.google.common.base.Functions;
@@ -327,7 +326,7 @@ public class IndexJoinOptimizer
         public PlanNode visitWindow(WindowNode node, RewriteContext<Context> context)
         {
             if (!node.getWindowFunctions().values().stream()
-                    .map(FunctionCall::getName)
+                    .map(function -> function.getFunctionCall().getName())
                     .allMatch(metadata.getFunctionRegistry()::isAggregationFunction)) {
                 return node;
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -339,7 +339,7 @@ public class IndexJoinOptimizer
             // Only RANGE frame type currently supported for aggregation functions because it guarantees the
             // same value for each peer group.
             // ROWS frame type requires the ordering to be fully deterministic (e.g. deterministically sorted on all columns)
-            if (node.getFrames().values().stream().map(WindowNode.Frame::getType).anyMatch(type -> type != WindowFrame.Type.RANGE)) { // TODO: extract frames of type RANGE and allow optimization on them
+            if (node.getFrames().stream().map(WindowNode.Frame::getType).anyMatch(type -> type != WindowFrame.Type.RANGE)) { // TODO: extract frames of type RANGE and allow optimization on them
                 return node;
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeIdenticalWindows.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeIdenticalWindows.java
@@ -21,15 +21,16 @@ import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.planner.plan.WindowNode;
-import com.facebook.presto.sql.planner.plan.WindowNode.Specification;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Merge together the functions in WindowNodes that have identical WindowNode.Specifications.
@@ -77,13 +78,13 @@ public class MergeIdenticalWindows
     }
 
     private static class Rewriter
-            extends SimplePlanRewriter<Multimap<Specification, WindowNode>>
+            extends SimplePlanRewriter<Multimap<SpecificationAndFrame, WindowNode>>
     {
         @Override
-        protected PlanNode visitPlan(PlanNode node, RewriteContext<Multimap<Specification, WindowNode>> context)
+        protected PlanNode visitPlan(PlanNode node, RewriteContext<Multimap<SpecificationAndFrame, WindowNode>> context)
         {
             PlanNode newNode = context.defaultRewrite(node, ImmutableListMultimap.of());
-            for (Specification specification : context.get().keySet()) {
+            for (SpecificationAndFrame specification : context.get().keySet()) {
                 Collection<WindowNode> windows = context.get().get(specification);
                 newNode = collapseWindows(newNode, specification, windows);
             }
@@ -93,33 +94,83 @@ public class MergeIdenticalWindows
         @Override
         public PlanNode visitWindow(
                 WindowNode node,
-                RewriteContext<Multimap<Specification, WindowNode>> context)
+                RewriteContext<Multimap<SpecificationAndFrame, WindowNode>> context)
         {
             checkState(!node.getHashSymbol().isPresent(), "MergeIdenticalWindows should be run before HashGenerationOptimizer");
             checkState(node.getPrePartitionedInputs().isEmpty() && node.getPreSortedOrderPrefix() == 0, "MergeIdenticalWindows should be run before AddExchanges");
+            checkState(node.getFrames().values().size() == 1, "More than one frame per WindowNode is not yet supported");
+
+            SpecificationAndFrame specificationAndFrame = new SpecificationAndFrame(node.getSpecification(), node.getFrames().values().iterator().next());
 
             return context.rewrite(
                     node.getSource(),
-                    ImmutableListMultimap.<Specification, WindowNode>builder()
-                            .put(node.getSpecification(), node) // Add the current window first so that it gets precedence in iteration order
+                    ImmutableListMultimap.<SpecificationAndFrame, WindowNode>builder()
+                            .put(specificationAndFrame, node) // Add the current window first so that it gets precedence in iteration order
                             .putAll(context.get())
                             .build());
         }
 
-        private static WindowNode collapseWindows(PlanNode source, Specification specification, Collection<WindowNode> windows)
+        private static WindowNode collapseWindows(PlanNode source, SpecificationAndFrame specification, Collection<WindowNode> windows)
         {
             WindowNode canonical = windows.iterator().next();
+            WindowNode.Frame frame = canonical.getFrames().values().iterator().next(); // asserted in #visitWindow already
             return new WindowNode(
                     canonical.getId(),
                     source,
-                    specification,
+                    specification.getSpecification(),
                     windows.stream()
                             .map(WindowNode::getWindowFunctions)
                             .flatMap(map -> map.entrySet().stream())
                             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
+                    windows.stream()
+                            .map(WindowNode::getWindowFunctions)
+                            .flatMap(map -> map.entrySet().stream())
+                            .collect(Collectors.toMap(Map.Entry::getValue, ignore -> frame)),
                     canonical.getHashSymbol(),
                     canonical.getPrePartitionedInputs(),
                     canonical.getPreSortedOrderPrefix());
+        }
+    }
+
+    private static final class SpecificationAndFrame
+    {
+        private final WindowNode.Specification specification;
+        private final WindowNode.Frame frame;
+
+        SpecificationAndFrame(WindowNode.Specification specification, WindowNode.Frame frame)
+        {
+            this.specification = requireNonNull(specification, "specification is null");
+            this.frame = requireNonNull(frame, "frame is null");
+        }
+
+        public WindowNode.Specification getSpecification()
+        {
+            return specification;
+        }
+
+        public WindowNode.Frame getFrame()
+        {
+            return frame;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(specification, frame);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            SpecificationAndFrame other = (SpecificationAndFrame) obj;
+            return Objects.equals(this.specification, other.specification) &&
+                    Objects.equals(this.frame, other.frame);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeIdenticalWindows.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeIdenticalWindows.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -98,9 +99,9 @@ public class MergeIdenticalWindows
         {
             checkState(!node.getHashSymbol().isPresent(), "MergeIdenticalWindows should be run before HashGenerationOptimizer");
             checkState(node.getPrePartitionedInputs().isEmpty() && node.getPreSortedOrderPrefix() == 0, "MergeIdenticalWindows should be run before AddExchanges");
-            checkState(node.getFrames().values().size() == 1, "More than one frame per WindowNode is not yet supported");
+            checkState(identicalFrames(node));
 
-            SpecificationAndFrame specificationAndFrame = new SpecificationAndFrame(node.getSpecification(), node.getFrames().values().iterator().next());
+            SpecificationAndFrame specificationAndFrame = new SpecificationAndFrame(node.getSpecification(), node.getFrames().iterator().next());
 
             return context.rewrite(
                     node.getSource(),
@@ -110,10 +111,23 @@ public class MergeIdenticalWindows
                             .build());
         }
 
+        private static boolean identicalFrames(WindowNode node)
+        {
+            Iterator<WindowNode.Function> functions = node.getWindowFunctions().values().iterator();
+            WindowNode.Frame canonical = functions.next().getFrame();
+
+            while (functions.hasNext()) {
+                if (!canonical.equals(functions.next().getFrame())) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         private static WindowNode collapseWindows(PlanNode source, SpecificationAndFrame specification, Collection<WindowNode> windows)
         {
             WindowNode canonical = windows.iterator().next();
-            WindowNode.Frame frame = canonical.getFrames().values().iterator().next(); // asserted in #visitWindow already
             return new WindowNode(
                     canonical.getId(),
                     source,
@@ -122,10 +136,6 @@ public class MergeIdenticalWindows
                             .map(WindowNode::getWindowFunctions)
                             .flatMap(map -> map.entrySet().stream())
                             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
-                    windows.stream()
-                            .map(WindowNode::getWindowFunctions)
-                            .flatMap(map -> map.entrySet().stream())
-                            .collect(Collectors.toMap(Map.Entry::getValue, ignore -> frame)),
                     canonical.getHashSymbol(),
                     canonical.getPrePartitionedInputs(),
                     canonical.getPreSortedOrderPrefix());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeIdenticalWindows.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeIdenticalWindows.java
@@ -117,10 +117,6 @@ public class MergeIdenticalWindows
                             .map(WindowNode::getWindowFunctions)
                             .flatMap(map -> map.entrySet().stream())
                             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
-                    windows.stream()
-                            .map(WindowNode::getSignatures)
-                            .flatMap(map -> map.entrySet().stream())
-                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
                     canonical.getHashSymbol(),
                     canonical.getPrePartitionedInputs(),
                     canonical.getPreSortedOrderPrefix());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -330,7 +330,7 @@ public class PruneUnreferencedOutputs
                     .addAll(node.getPartitionBy())
                     .addAll(node.getOrderBy());
 
-            for (WindowNode.Frame frame : node.getFrames().values()) {
+            for (WindowNode.Frame frame : node.getFrames()) {
                 if (frame.getStartValue().isPresent()) {
                     expectedInputs.add(frame.getStartValue().get());
                 }
@@ -346,12 +346,13 @@ public class PruneUnreferencedOutputs
             ImmutableMap.Builder<Symbol, WindowNode.Function> functionsBuilder = ImmutableMap.builder();
             for (Map.Entry<Symbol, WindowNode.Function> entry : node.getWindowFunctions().entrySet()) {
                 Symbol symbol = entry.getKey();
+                WindowNode.Function function = entry.getValue();
 
                 if (context.get().contains(symbol)) {
-                    FunctionCall call = entry.getValue().getFunctionCall();
+                    FunctionCall call = function.getFunctionCall();
                     expectedInputs.addAll(DependencyExtractor.extractUnique(call));
 
-                    functionsBuilder.put(symbol, new WindowNode.Function(call, entry.getValue().getSignature()));
+                    functionsBuilder.put(symbol, entry.getValue());
                 }
             }
 
@@ -368,7 +369,6 @@ public class PruneUnreferencedOutputs
                     source,
                     node.getSpecification(),
                     functions,
-                    node.getFrames(),
                     node.getHashSymbol(),
                     node.getPrePartitionedInputs(),
                     node.getPreSortedOrderPrefix());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -341,23 +341,21 @@ public class PruneUnreferencedOutputs
                 expectedInputs.add(node.getHashSymbol().get());
             }
 
-            ImmutableMap.Builder<Symbol, Signature> functionsBuilder = ImmutableMap.builder();
-            ImmutableMap.Builder<Symbol, FunctionCall> functionCallsBuilder = ImmutableMap.builder();
-            for (Map.Entry<Symbol, FunctionCall> entry : node.getWindowFunctions().entrySet()) {
+            ImmutableMap.Builder<Symbol, WindowNode.Function> functionsBuilder = ImmutableMap.builder();
+            for (Map.Entry<Symbol, WindowNode.Function> entry : node.getWindowFunctions().entrySet()) {
                 Symbol symbol = entry.getKey();
 
                 if (context.get().contains(symbol)) {
-                    FunctionCall call = entry.getValue();
+                    FunctionCall call = entry.getValue().getFunctionCall();
                     expectedInputs.addAll(DependencyExtractor.extractUnique(call));
 
-                    functionCallsBuilder.put(symbol, call);
-                    functionsBuilder.put(symbol, node.getSignatures().get(symbol));
+                    functionsBuilder.put(symbol, new WindowNode.Function(call, entry.getValue().getSignature()));
                 }
             }
 
             PlanNode source = context.rewrite(node.getSource(), expectedInputs.build());
 
-            Map<Symbol, Signature> functions = functionsBuilder.build();
+            Map<Symbol, WindowNode.Function> functions = functionsBuilder.build();
 
             if (functions.size() == 0) {
                 return source;
@@ -367,7 +365,6 @@ public class PruneUnreferencedOutputs
                     node.getId(),
                     source,
                     node.getSpecification(),
-                    functionCallsBuilder.build(),
                     functions,
                     node.getHashSymbol(),
                     node.getPrePartitionedInputs(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -330,11 +330,13 @@ public class PruneUnreferencedOutputs
                     .addAll(node.getPartitionBy())
                     .addAll(node.getOrderBy());
 
-            if (node.getFrame().getStartValue().isPresent()) {
-                expectedInputs.add(node.getFrame().getStartValue().get());
-            }
-            if (node.getFrame().getEndValue().isPresent()) {
-                expectedInputs.add(node.getFrame().getEndValue().get());
+            for (WindowNode.Frame frame : node.getFrames().values()) {
+                if (frame.getStartValue().isPresent()) {
+                    expectedInputs.add(frame.getStartValue().get());
+                }
+                if (frame.getEndValue().isPresent()) {
+                    expectedInputs.add(frame.getEndValue().get());
+                }
             }
 
             if (node.getHashSymbol().isPresent()) {
@@ -366,6 +368,7 @@ public class PruneUnreferencedOutputs
                     source,
                     node.getSpecification(),
                     functions,
+                    node.getFrames(),
                     node.getHashSymbol(),
                     node.getPrePartitionedInputs(),
                     node.getPreSortedOrderPrefix());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -202,13 +202,14 @@ public class UnaliasSymbolReferences
         {
             PlanNode source = context.rewrite(node.getSource());
 
-            ImmutableMap.Builder<Symbol, Signature> functionInfos = ImmutableMap.builder();
-            ImmutableMap.Builder<Symbol, FunctionCall> functionCalls = ImmutableMap.builder();
-            for (Map.Entry<Symbol, FunctionCall> entry : node.getWindowFunctions().entrySet()) {
+            ImmutableMap.Builder<Symbol, WindowNode.Function> functions = ImmutableMap.builder();
+            for (Map.Entry<Symbol, WindowNode.Function> entry : node.getWindowFunctions().entrySet()) {
                 Symbol symbol = entry.getKey();
                 Symbol canonical = canonicalize(symbol);
-                functionCalls.put(canonical, (FunctionCall) canonicalize(entry.getValue()));
-                functionInfos.put(canonical, node.getSignatures().get(symbol));
+
+                FunctionCall functionCall = entry.getValue().getFunctionCall();
+                Signature signature = entry.getValue().getSignature();
+                functions.put(canonical, new WindowNode.Function((FunctionCall) canonicalize(functionCall), signature));
             }
 
             ImmutableMap.Builder<Symbol, SortOrder> orderings = ImmutableMap.builder();
@@ -229,8 +230,7 @@ public class UnaliasSymbolReferences
                             canonicalizeAndDistinct(node.getOrderBy()),
                             orderings.build(),
                             frame),
-                    functionCalls.build(),
-                    functionInfos.build(),
+                    functions.build(),
                     canonicalize(node.getHashSymbol()),
                     canonicalize(node.getPrePartitionedInputs()),
                     node.getPreSortedOrderPrefix());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -271,7 +271,7 @@ public class WindowFilterPushDown
                 return false;
             }
             Symbol rowNumberSymbol = getOnlyElement(node.getWindowFunctions().entrySet()).getKey();
-            return isRowNumberSignature(node.getSignatures().get(rowNumberSymbol));
+            return isRowNumberSignature(node.getWindowFunctions().get(rowNumberSymbol).getSignature());
         }
 
         private static boolean isRowNumberSignature(Signature signature)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -51,6 +51,7 @@ import static com.facebook.presto.sql.planner.DomainTranslator.ExtractionResult;
 import static com.facebook.presto.sql.planner.DomainTranslator.fromPredicate;
 import static com.facebook.presto.sql.planner.DomainTranslator.toPredicate;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Objects.requireNonNull;
@@ -99,6 +100,7 @@ public class WindowFilterPushDown
         @Override
         public PlanNode visitWindow(WindowNode node, RewriteContext<Void> context)
         {
+            checkState(node.getWindowFunctions().size() == 1, "WindowFilterPushdown requires that WindowNodes contain exactly one window function");
             PlanNode rewrittenSource = context.rewrite(node.getSource());
 
             if (canReplaceWithRowNumber(node)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
@@ -191,7 +191,6 @@ public class ChildReplacer
                 Iterables.getOnlyElement(newChildren),
                 node.getSpecification(),
                 node.getWindowFunctions(),
-                node.getFrames(),
                 node.getHashSymbol(),
                 node.getPrePartitionedInputs(),
                 node.getPreSortedOrderPrefix());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
@@ -191,6 +191,7 @@ public class ChildReplacer
                 Iterables.getOnlyElement(newChildren),
                 node.getSpecification(),
                 node.getWindowFunctions(),
+                node.getFrames(),
                 node.getHashSymbol(),
                 node.getPrePartitionedInputs(),
                 node.getPreSortedOrderPrefix());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
@@ -191,7 +191,6 @@ public class ChildReplacer
                 Iterables.getOnlyElement(newChildren),
                 node.getSpecification(),
                 node.getWindowFunctions(),
-                node.getSignatures(),
                 node.getHashSymbol(),
                 node.getPrePartitionedInputs(),
                 node.getPreSortedOrderPrefix());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.tree.WindowFrame;
 import com.facebook.presto.util.ImmutableCollectors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -213,9 +214,20 @@ public class WindowNode
 
             Specification other = (Specification) obj;
 
+            // Changing this? Go change WindowMatcher.matches too.
             return Objects.equals(this.partitionBy, other.partitionBy) &&
                     Objects.equals(this.orderBy, other.orderBy) &&
                     Objects.equals(this.orderings, other.orderings);
+        }
+
+        @Override
+        public String toString()
+        {
+            return MoreObjects.toStringHelper(this)
+                    .add("partitionBy", this.partitionBy)
+                    .add("orderBy", this.orderBy)
+                    .add("orderings", this.orderings)
+                    .toString();
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
@@ -22,7 +22,6 @@ import com.facebook.presto.sql.tree.WindowFrame;
 import com.facebook.presto.util.ImmutableCollectors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -35,6 +34,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.concat;
 import static java.util.Objects.requireNonNull;
@@ -223,7 +223,7 @@ public class WindowNode
         @Override
         public String toString()
         {
-            return MoreObjects.toStringHelper(this)
+            return toStringHelper(this)
                     .add("partitionBy", this.partitionBy)
                     .add("orderBy", this.orderBy)
                     .add("orderings", this.orderings)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/TypeValidator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/TypeValidator.java
@@ -96,8 +96,7 @@ public final class TypeValidator
         {
             visitPlan(node, context);
 
-            checkFunctionSignature(node.getSignatures());
-            checkFunctionCall(node.getWindowFunctions());
+            checkWindowFunctions(node.getWindowFunctions());
 
             return null;
         }
@@ -138,21 +137,42 @@ public final class TypeValidator
             return null;
         }
 
+        private void checkWindowFunctions(Map<Symbol, WindowNode.Function> functions)
+        {
+            for (Map.Entry<Symbol, WindowNode.Function> entry : functions.entrySet()) {
+                Signature signature = entry.getValue().getSignature();
+                FunctionCall call = entry.getValue().getFunctionCall();
+
+                checkSignature(entry.getKey(), signature);
+                checkCall(entry.getKey(), call);
+            }
+        }
+
+        private void checkSignature(Symbol symbol, Signature signature)
+        {
+            TypeSignature expectedTypeSignature = types.get(symbol).getTypeSignature();
+            TypeSignature actualTypeSignature = signature.getReturnType();
+            verifyTypeSignature(symbol, expectedTypeSignature, actualTypeSignature);
+        }
+
+        private void checkCall(Symbol symbol, FunctionCall call)
+        {
+            Type expectedType = types.get(symbol);
+            Type actualType = getExpressionTypes(session, metadata, sqlParser, types, call, emptyList() /*parameters already replaced */).get(call);
+            verifyTypeSignature(symbol, expectedType.getTypeSignature(), actualType.getTypeSignature());
+        }
+
         private void checkFunctionSignature(Map<Symbol, Signature> functions)
         {
             for (Map.Entry<Symbol, Signature> entry : functions.entrySet()) {
-                TypeSignature expectedTypeSignature = types.get(entry.getKey()).getTypeSignature();
-                TypeSignature actualTypeSignature = entry.getValue().getReturnType();
-                verifyTypeSignature(entry.getKey(), expectedTypeSignature, actualTypeSignature);
+                checkSignature(entry.getKey(), entry.getValue());
             }
         }
 
         private void checkFunctionCall(Map<Symbol, FunctionCall> functionCalls)
         {
             for (Map.Entry<Symbol, FunctionCall> entry : functionCalls.entrySet()) {
-                Type expectedType = types.get(entry.getKey());
-                Type actualType = getExpressionTypes(session, metadata, sqlParser, types, entry.getValue(), emptyList() /*parameters already replaced */).get(entry.getValue());
-                verifyTypeSignature(entry.getKey(), expectedType.getTypeSignature(), actualType.getTypeSignature());
+                checkCall(entry.getKey(), entry.getValue());
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -167,11 +167,13 @@ public final class ValidateDependenciesChecker
             checkDependencies(inputs, node.getOrderBy(), "Invalid node. Order by symbols (%s) not in source plan output (%s)", node.getOrderBy(), node.getSource().getOutputSymbols());
 
             ImmutableList.Builder<Symbol> bounds = ImmutableList.builder();
-            if (node.getFrame().getStartValue().isPresent()) {
-                bounds.add(node.getFrame().getStartValue().get());
-            }
-            if (node.getFrame().getEndValue().isPresent()) {
-                bounds.add(node.getFrame().getEndValue().get());
+            for (WindowNode.Frame frame : node.getFrames().values()) {
+                if (frame.getStartValue().isPresent()) {
+                    bounds.add(frame.getStartValue().get());
+                }
+                if (frame.getEndValue().isPresent()) {
+                    bounds.add(frame.getEndValue().get());
+                }
             }
             checkDependencies(inputs, bounds.build(), "Invalid node. Frame bounds (%s) not in source plan output (%s)", bounds.build(), node.getSource().getOutputSymbols());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -175,8 +175,8 @@ public final class ValidateDependenciesChecker
             }
             checkDependencies(inputs, bounds.build(), "Invalid node. Frame bounds (%s) not in source plan output (%s)", bounds.build(), node.getSource().getOutputSymbols());
 
-            for (FunctionCall call : node.getWindowFunctions().values()) {
-                Set<Symbol> dependencies = DependencyExtractor.extractUnique(call);
+            for (WindowNode.Function function : node.getWindowFunctions().values()) {
+                Set<Symbol> dependencies = DependencyExtractor.extractUnique(function.getFunctionCall());
                 checkDependencies(inputs, dependencies, "Invalid node. Window function dependencies (%s) not in source plan output (%s)", dependencies, node.getSource().getOutputSymbols());
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -167,7 +167,7 @@ public final class ValidateDependenciesChecker
             checkDependencies(inputs, node.getOrderBy(), "Invalid node. Order by symbols (%s) not in source plan output (%s)", node.getOrderBy(), node.getSource().getOutputSymbols());
 
             ImmutableList.Builder<Symbol> bounds = ImmutableList.builder();
-            for (WindowNode.Frame frame : node.getFrames().values()) {
+            for (WindowNode.Frame frame : node.getFrames()) {
                 if (frame.getStartValue().isPresent()) {
                     bounds.add(frame.getStartValue().get());
                 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
@@ -61,28 +61,30 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 @Test(singleThreaded = true)
 public class TestWindowOperator
 {
+    private static final FrameInfo UNBOUNDED_FRAME = new FrameInfo(RANGE, UNBOUNDED_PRECEDING, Optional.empty(), UNBOUNDED_FOLLOWING, Optional.empty());
+
     private static final List<WindowFunctionDefinition> ROW_NUMBER = ImmutableList.of(
-            window(new ReflectionWindowFunctionSupplier<>("row_number", BIGINT, ImmutableList.<Type>of(), RowNumberFunction.class), BIGINT)
+            window(new ReflectionWindowFunctionSupplier<>("row_number", BIGINT, ImmutableList.<Type>of(), RowNumberFunction.class), BIGINT, UNBOUNDED_FRAME)
     );
 
     private static final List<WindowFunctionDefinition> FIRST_VALUE = ImmutableList.of(
-            window(new ReflectionWindowFunctionSupplier<>("first_value", VARCHAR, ImmutableList.<Type>of(VARCHAR), FirstValueFunction.class), VARCHAR, 1)
+            window(new ReflectionWindowFunctionSupplier<>("first_value", VARCHAR, ImmutableList.<Type>of(VARCHAR), FirstValueFunction.class), VARCHAR, UNBOUNDED_FRAME, 1)
     );
 
     private static final List<WindowFunctionDefinition> LAST_VALUE = ImmutableList.of(
-            window(new ReflectionWindowFunctionSupplier<>("last_value", VARCHAR, ImmutableList.<Type>of(VARCHAR), LastValueFunction.class), VARCHAR, 1)
+            window(new ReflectionWindowFunctionSupplier<>("last_value", VARCHAR, ImmutableList.<Type>of(VARCHAR), LastValueFunction.class), VARCHAR, UNBOUNDED_FRAME, 1)
     );
 
     private static final List<WindowFunctionDefinition> NTH_VALUE = ImmutableList.of(
-            window(new ReflectionWindowFunctionSupplier<>("nth_value", VARCHAR, ImmutableList.of(VARCHAR, BIGINT), NthValueFunction.class), VARCHAR, 1, 3)
+            window(new ReflectionWindowFunctionSupplier<>("nth_value", VARCHAR, ImmutableList.of(VARCHAR, BIGINT), NthValueFunction.class), VARCHAR, UNBOUNDED_FRAME, 1, 3)
     );
 
     private static final List<WindowFunctionDefinition> LAG = ImmutableList.of(
-            window(new ReflectionWindowFunctionSupplier<>("lag", VARCHAR, ImmutableList.of(VARCHAR, BIGINT, VARCHAR), LagFunction.class), VARCHAR, 1, 3, 4)
+            window(new ReflectionWindowFunctionSupplier<>("lag", VARCHAR, ImmutableList.of(VARCHAR, BIGINT, VARCHAR), LagFunction.class), VARCHAR, UNBOUNDED_FRAME, 1, 3, 4)
     );
 
     private static final List<WindowFunctionDefinition> LEAD = ImmutableList.of(
-            window(new ReflectionWindowFunctionSupplier<>("lead", VARCHAR, ImmutableList.of(VARCHAR, BIGINT, VARCHAR), LeadFunction.class), VARCHAR, 1, 3, 4)
+            window(new ReflectionWindowFunctionSupplier<>("lead", VARCHAR, ImmutableList.of(VARCHAR, BIGINT, VARCHAR), LeadFunction.class), VARCHAR, UNBOUNDED_FRAME, 1, 3, 4)
     );
 
     private ExecutorService executor;
@@ -662,7 +664,6 @@ public class TestWindowOperator
                 sortChannels,
                 sortOrder,
                 preSortedChannelPrefix,
-                new FrameInfo(RANGE, UNBOUNDED_PRECEDING, Optional.empty(), UNBOUNDED_FOLLOWING, Optional.empty()),
                 10);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -39,13 +39,11 @@ import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
-import com.facebook.presto.sql.tree.FrameBound;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GenericLiteral;
 import com.facebook.presto.sql.tree.IsNullPredicate;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.WindowFrame;
 import com.facebook.presto.type.UnknownType;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
@@ -286,10 +284,8 @@ public class TestEffectivePredicateExtractor
                 new WindowNode.Specification(
                         ImmutableList.of(A),
                         ImmutableList.of(A),
-                        ImmutableMap.of(A, SortOrder.ASC_NULLS_LAST),
-                        new WindowNode.Frame(WindowFrame.Type.RANGE,
-                                FrameBound.Type.UNBOUNDED_PRECEDING, Optional.empty(),
-                                FrameBound.Type.CURRENT_ROW, Optional.empty())),
+                        ImmutableMap.of(A, SortOrder.ASC_NULLS_LAST)),
+                ImmutableMap.of(),
                 ImmutableMap.of(),
                 Optional.empty(),
                 ImmutableSet.of(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -290,8 +290,7 @@ public class TestEffectivePredicateExtractor
                         new WindowNode.Frame(WindowFrame.Type.RANGE,
                                 FrameBound.Type.UNBOUNDED_PRECEDING, Optional.empty(),
                                 FrameBound.Type.CURRENT_ROW, Optional.empty())),
-                ImmutableMap.<Symbol, FunctionCall>of(),
-                ImmutableMap.<Symbol, Signature>of(),
+                ImmutableMap.of(),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -286,7 +286,6 @@ public class TestEffectivePredicateExtractor
                         ImmutableList.of(A),
                         ImmutableMap.of(A, SortOrder.ASC_NULLS_LAST)),
                 ImmutableMap.of(),
-                ImmutableMap.of(),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.symbolStem;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
@@ -76,9 +77,9 @@ public class TestLogicalPlanner
                 anyTree(
                         join(INNER, ImmutableList.of(aliasPair("O", "L")),
                                 any(
-                                        tableScan("orders").withSymbol("orderkey", "O")),
+                                        tableScan("orders").withSymbol(symbolStem("orderkey"), "O")),
                                 anyTree(
-                                        tableScan("lineitem").withSymbol("orderkey", "L")))));
+                                        tableScan("lineitem").withSymbol(symbolStem("orderkey"), "L")))));
     }
 
     @Test
@@ -88,11 +89,11 @@ public class TestLogicalPlanner
                 anyTree(
                         join(INNER, ImmutableList.of(aliasPair("X", "Y")),
                                 project(
-                                        tableScan("orders").withSymbol("orderkey", "X")),
+                                        tableScan("orders").withSymbol(symbolStem("orderkey"), "X")),
                                 project(
                                         node(EnforceSingleRowNode.class,
                                                 anyTree(
-                                                        tableScan("lineitem").withSymbol("orderkey", "Y")))))));
+                                                        tableScan("lineitem").withSymbol(symbolStem("orderkey"), "Y")))))));
 
         assertPlan("SELECT * FROM orders WHERE orderkey IN (SELECT orderkey FROM lineitem WHERE linenumber % 4 = 0)",
                 anyTree(
@@ -100,9 +101,9 @@ public class TestLogicalPlanner
                                 project(
                                         semiJoin("X", "Y", "S",
                                                 anyTree(
-                                                        tableScan("orders").withSymbol("orderkey", "X")),
+                                                        tableScan("orders").withSymbol(symbolStem("orderkey"), "X")),
                                                 anyTree(
-                                                        tableScan("lineitem").withSymbol("orderkey", "Y")))))));
+                                                        tableScan("lineitem").withSymbol(symbolStem("orderkey"), "Y")))))));
 
         assertPlan("SELECT * FROM orders WHERE orderkey NOT IN (SELECT orderkey FROM lineitem WHERE linenumber < 0)",
                 anyTree(
@@ -110,9 +111,9 @@ public class TestLogicalPlanner
                                 project(
                                         semiJoin("X", "Y", "S",
                                                 anyTree(
-                                                        tableScan("orders").withSymbol("orderkey", "X")),
+                                                        tableScan("orders").withSymbol(symbolStem("orderkey"), "X")),
                                                 anyTree(
-                                                        tableScan("lineitem").withSymbol("orderkey", "Y")))))));
+                                                        tableScan("lineitem").withSymbol(symbolStem("orderkey"), "Y")))))));
     }
 
     @Test
@@ -180,7 +181,7 @@ public class TestLogicalPlanner
                 anyTree(
                         filter("3 = X",
                                 apply(ImmutableList.of("X"),
-                                        tableScan("orders").withSymbol("orderkey", "X"),
+                                        tableScan("orders").withSymbol(symbolStem("orderkey"), "X"),
                                         node(EnforceSingleRowNode.class,
                                                 project(
                                                         node(ValuesNode.class)
@@ -195,10 +196,10 @@ public class TestLogicalPlanner
                         filter("3 IN (C)",
                                 apply(ImmutableList.of("C", "O"),
                                         project(
-                                                tableScan("orders").withSymbol("orderkey", "O").withSymbol("custkey", "C")),
+                                                tableScan("orders").withSymbol(symbolStem("orderkey"), "O").withSymbol(symbolStem("custkey"), "C")),
                                         anyTree(
                                                 apply(ImmutableList.of("L"),
-                                                        tableScan("lineitem").withSymbol("orderkey", "L"),
+                                                        tableScan("lineitem").withSymbol(symbolStem("orderkey"), "L"),
                                                         node(EnforceSingleRowNode.class,
                                                                 project(
                                                                         node(ValuesNode.class)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -150,7 +150,6 @@ public class TestTypeValidator
                         ImmutableList.of(DOUBLE.getTypeSignature()),
                         false);
         FunctionCall functionCall = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference()));
-        WindowNode.Function function = new WindowNode.Function(functionCall, signature);
 
         WindowNode.Frame frame = new WindowNode.Frame(
                 WindowFrame.Type.RANGE,
@@ -158,6 +157,9 @@ public class TestTypeValidator
                 Optional.empty(),
                 FrameBound.Type.UNBOUNDED_FOLLOWING,
                 Optional.empty());
+
+        WindowNode.Function function = new WindowNode.Function(functionCall, signature, frame);
+
         WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of());
 
         PlanNode node = new WindowNode(
@@ -165,7 +167,6 @@ public class TestTypeValidator
                 baseTableScan,
                 specification,
                 ImmutableMap.of(windowSymbol, function),
-                ImmutableMap.of(function, frame),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);
@@ -315,7 +316,6 @@ public class TestTypeValidator
                         ImmutableList.of(DOUBLE.getTypeSignature()),
                         false);
         FunctionCall functionCall = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnA.toSymbolReference())); // should be columnC
-        WindowNode.Function function = new WindowNode.Function(functionCall, signature);
 
         WindowNode.Frame frame = new WindowNode.Frame(
                 WindowFrame.Type.RANGE,
@@ -323,6 +323,9 @@ public class TestTypeValidator
                 Optional.empty(),
                 FrameBound.Type.UNBOUNDED_FOLLOWING,
                 Optional.empty());
+
+        WindowNode.Function function = new WindowNode.Function(functionCall, signature, frame);
+
         WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of());
 
         PlanNode node = new WindowNode(
@@ -330,7 +333,6 @@ public class TestTypeValidator
                 baseTableScan,
                 specification,
                 ImmutableMap.of(windowSymbol, function),
-                ImmutableMap.of(function, frame),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);
@@ -352,13 +354,16 @@ public class TestTypeValidator
                         ImmutableList.of(DOUBLE.getTypeSignature()),
                         false);
         FunctionCall functionCall = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference()));
-        WindowNode.Function function = new WindowNode.Function(functionCall, signature);
+
         WindowNode.Frame frame = new WindowNode.Frame(
                 WindowFrame.Type.RANGE,
                 FrameBound.Type.UNBOUNDED_PRECEDING,
                 Optional.empty(),
                 FrameBound.Type.UNBOUNDED_FOLLOWING,
                 Optional.empty());
+
+        WindowNode.Function function = new WindowNode.Function(functionCall, signature, frame);
+
         WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of());
 
         PlanNode node = new WindowNode(
@@ -366,7 +371,6 @@ public class TestTypeValidator
                 baseTableScan,
                 specification,
                 ImmutableMap.of(windowSymbol, function),
-                ImmutableMap.of(function, frame),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -149,20 +149,23 @@ public class TestTypeValidator
                         DOUBLE.getTypeSignature(),
                         ImmutableList.of(DOUBLE.getTypeSignature()),
                         false);
-        FunctionCall function = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference()));
+        FunctionCall functionCall = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference()));
+        WindowNode.Function function = new WindowNode.Function(functionCall, signature);
+
         WindowNode.Frame frame = new WindowNode.Frame(
                 WindowFrame.Type.RANGE,
                 FrameBound.Type.UNBOUNDED_PRECEDING,
                 Optional.empty(),
                 FrameBound.Type.UNBOUNDED_FOLLOWING,
                 Optional.empty());
-        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of(), frame);
+        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of());
 
         PlanNode node = new WindowNode(
                 newId(),
                 baseTableScan,
                 specification,
-                ImmutableMap.of(windowSymbol, new WindowNode.Function(function, signature)),
+                ImmutableMap.of(windowSymbol, function),
+                ImmutableMap.of(function, frame),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);
@@ -311,20 +314,23 @@ public class TestTypeValidator
                         DOUBLE.getTypeSignature(),
                         ImmutableList.of(DOUBLE.getTypeSignature()),
                         false);
-        FunctionCall function = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnA.toSymbolReference())); // should be columnC
+        FunctionCall functionCall = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnA.toSymbolReference())); // should be columnC
+        WindowNode.Function function = new WindowNode.Function(functionCall, signature);
+
         WindowNode.Frame frame = new WindowNode.Frame(
                 WindowFrame.Type.RANGE,
                 FrameBound.Type.UNBOUNDED_PRECEDING,
                 Optional.empty(),
                 FrameBound.Type.UNBOUNDED_FOLLOWING,
                 Optional.empty());
-        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of(), frame);
+        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of());
 
         PlanNode node = new WindowNode(
                 newId(),
                 baseTableScan,
                 specification,
-                ImmutableMap.of(windowSymbol, new WindowNode.Function(function, signature)),
+                ImmutableMap.of(windowSymbol, function),
+                ImmutableMap.of(function, frame),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);
@@ -345,20 +351,22 @@ public class TestTypeValidator
                         BIGINT.getTypeSignature(), // should be DOUBLE
                         ImmutableList.of(DOUBLE.getTypeSignature()),
                         false);
-        FunctionCall function = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference()));
+        FunctionCall functionCall = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference()));
+        WindowNode.Function function = new WindowNode.Function(functionCall, signature);
         WindowNode.Frame frame = new WindowNode.Frame(
                 WindowFrame.Type.RANGE,
                 FrameBound.Type.UNBOUNDED_PRECEDING,
                 Optional.empty(),
                 FrameBound.Type.UNBOUNDED_FOLLOWING,
                 Optional.empty());
-        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of(), frame);
+        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of());
 
         PlanNode node = new WindowNode(
                 newId(),
                 baseTableScan,
                 specification,
-                ImmutableMap.of(windowSymbol, new WindowNode.Function(function, signature)),
+                ImmutableMap.of(windowSymbol, function),
+                ImmutableMap.of(function, frame),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -141,16 +141,15 @@ public class TestTypeValidator
             throws Exception
     {
         Symbol windowSymbol = symbolAllocator.newSymbol("sum", DOUBLE);
-        Map<Symbol, Signature> signatures = ImmutableMap.of(
-                windowSymbol, new Signature(
+        Signature signature = new Signature(
                         "sum",
                         FunctionKind.WINDOW,
                         ImmutableList.of(),
                         ImmutableList.of(),
                         DOUBLE.getTypeSignature(),
                         ImmutableList.of(DOUBLE.getTypeSignature()),
-                        false));
-        Map<Symbol, FunctionCall> functions = ImmutableMap.of(windowSymbol, new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())));
+                        false);
+        FunctionCall function = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference()));
         WindowNode.Frame frame = new WindowNode.Frame(
                 WindowFrame.Type.RANGE,
                 FrameBound.Type.UNBOUNDED_PRECEDING,
@@ -163,8 +162,7 @@ public class TestTypeValidator
                 newId(),
                 baseTableScan,
                 specification,
-                functions,
-                signatures,
+                ImmutableMap.of(windowSymbol, new WindowNode.Function(function, signature)),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);
@@ -305,16 +303,15 @@ public class TestTypeValidator
             throws Exception
     {
         Symbol windowSymbol = symbolAllocator.newSymbol("sum", DOUBLE);
-        Map<Symbol, Signature> signatures = ImmutableMap.of(
-                windowSymbol, new Signature(
+        Signature signature = new Signature(
                         "sum",
                         FunctionKind.WINDOW,
                         ImmutableList.of(),
                         ImmutableList.of(),
                         DOUBLE.getTypeSignature(),
                         ImmutableList.of(DOUBLE.getTypeSignature()),
-                        false));
-        Map<Symbol, FunctionCall> functions = ImmutableMap.of(windowSymbol, new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnA.toSymbolReference()))); // shoud be columnC
+                        false);
+        FunctionCall function = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnA.toSymbolReference())); // should be columnC
         WindowNode.Frame frame = new WindowNode.Frame(
                 WindowFrame.Type.RANGE,
                 FrameBound.Type.UNBOUNDED_PRECEDING,
@@ -327,8 +324,7 @@ public class TestTypeValidator
                 newId(),
                 baseTableScan,
                 specification,
-                functions,
-                signatures,
+                ImmutableMap.of(windowSymbol, new WindowNode.Function(function, signature)),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);
@@ -341,16 +337,15 @@ public class TestTypeValidator
             throws Exception
     {
         Symbol windowSymbol = symbolAllocator.newSymbol("sum", DOUBLE);
-        Map<Symbol, Signature> signatures = ImmutableMap.of(
-                windowSymbol, new Signature(
+        Signature signature = new Signature(
                         "sum",
                         FunctionKind.WINDOW,
                         ImmutableList.of(),
                         ImmutableList.of(),
                         BIGINT.getTypeSignature(), // should be DOUBLE
                         ImmutableList.of(DOUBLE.getTypeSignature()),
-                        false));
-        Map<Symbol, FunctionCall> functions = ImmutableMap.of(windowSymbol, new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())));
+                        false);
+        FunctionCall function = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference()));
         WindowNode.Frame frame = new WindowNode.Frame(
                 WindowFrame.Type.RANGE,
                 FrameBound.Type.UNBOUNDED_PRECEDING,
@@ -363,8 +358,7 @@ public class TestTypeValidator
                 newId(),
                 baseTableScan,
                 specification,
-                functions,
-                signatures,
+                ImmutableMap.of(windowSymbol, new WindowNode.Function(function, signature)),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -326,12 +326,26 @@ public final class PlanMatchPattern
         @Override
         public boolean equals(Object o)
         {
+            // Inconsistent with hashCode. See below.
             return stemEquals(o, Symbol.class, Symbol::getName);
         }
 
         @Override
         public int hashCode()
         {
+            /*
+             * hashCode() and equals() are inconsistent with each other. In theory, we'd like to
+             * throw UnsupportedOperationException here. We can't, however because creating a
+             * WindowNode.Specification with more than one Ordering requires being able to put
+             * Symbols in a hash table.
+             *
+             * It turns out that this being inconsistent with equals ends up not mattering. We
+             * can't meaningfully do an equals comparison on the hash tables representing the
+             * expected Orderings and the actual Orderings because that would require knowing
+             * the mangled symbols in the expected value a priori. Instead, we do an equals
+             * comparison that relies solely on equals() returning true for mangled and
+             * non-mangled symbols
+             */
             return stem.hashCode();
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -151,9 +151,9 @@ public final class PlanMatchPattern
         return states.build();
     }
 
-    public PlanMatchPattern withSymbol(String pattern, String alias)
+    public PlanMatchPattern withSymbol(Symbol expectedSymbol, String alias)
     {
-        return with(new SymbolMatcher(pattern, alias));
+        return with(new SymbolMatcher(expectedSymbol, alias));
     }
 
     public PlanMatchPattern with(Matcher matcher)
@@ -344,6 +344,12 @@ public final class PlanMatchPattern
         public String getOtherName(Symbol other)
         {
             return other.getName();
+        }
+
+        @Override
+        public SymbolReference toSymbolReference()
+        {
+            return new SymbolReferenceStem(stem);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -173,11 +173,12 @@ public final class PlanMatchPattern
         return sourcePatterns.isEmpty();
     }
 
-    public static FunctionCall functionCall(String name, Window window, boolean distinct, SymbolReference... args)
-    {
-        return new FunctionCall(QualifiedName.of(name), Optional.of(window), distinct, Arrays.asList(args));
-    }
-
+    /*
+     * Caveat Emptor: FunctionCall's come from the parser, and represent what
+     * the user has typed. As such, they don't contain a WindowFrame if one
+     * isn't specified in the SQL. In this case, the correct value to pass is
+     * Optional.empty()
+     */
     public static FunctionCall functionCall(String name, Optional<WindowFrame> frame, SymbolReference... args)
     {
         return new RelaxedEqualityFunctionCall(QualifiedName.of(name), Arrays.asList(args), frame);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -268,12 +268,12 @@ public final class PlanMatchPattern
         }
     }
 
-    public static class SymbolStem extends Symbol
+    private static class SymbolStem extends Symbol
         implements Stem<Symbol>
     {
         private final String stem;
 
-        public SymbolStem(String stem)
+        private SymbolStem(String stem)
         {
             super(stem + "_*");
             this.stem = requireNonNull(stem);
@@ -314,9 +314,9 @@ public final class PlanMatchPattern
         return new SymbolReferenceStem(stem);
     }
 
-    public static class AnySymbolReference extends SymbolReference
+    private static class AnySymbolReference extends SymbolReference
     {
-        public AnySymbolReference()
+        private AnySymbolReference()
         {
             super("*");
         }
@@ -342,12 +342,12 @@ public final class PlanMatchPattern
         }
     }
 
-    public static class SymbolReferenceStem extends SymbolReference
+    private static class SymbolReferenceStem extends SymbolReference
             implements Stem<SymbolReference>
     {
         private final String stem;
 
-        public SymbolReferenceStem(String stem)
+        private SymbolReferenceStem(String stem)
         {
             super(stem + "_*");
             this.stem = requireNonNull(stem);
@@ -389,7 +389,7 @@ public final class PlanMatchPattern
          */
         Optional<WindowFrame> frame;
 
-        RelaxedEqualityFunctionCall(QualifiedName name, List<Expression> arguments, Optional<WindowFrame> frame)
+        private RelaxedEqualityFunctionCall(QualifiedName name, List<Expression> arguments, Optional<WindowFrame> frame)
         {
             super(name, arguments);
             this.frame = requireNonNull(frame);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -281,7 +281,7 @@ public final class PlanMatchPattern
         @Override
         public boolean equals(Object o)
         {
-            return this.stemEquals(o, Symbol.class, Symbol::getName);
+            return stemEquals(o, Symbol.class, Symbol::getName);
         }
 
         @Override
@@ -349,7 +349,7 @@ public final class PlanMatchPattern
         @Override
         public boolean equals(Object o)
         {
-            return this.stemEquals(o, SymbolReference.class, SymbolReference::getName);
+            return stemEquals(o, SymbolReference.class, SymbolReference::getName);
         }
 
         @Override
@@ -379,7 +379,7 @@ public final class PlanMatchPattern
         RelaxedEqualityFunctionCall(QualifiedName name, List<Expression> arguments, Optional<WindowFrame> frame)
         {
             super(name, arguments);
-            this.frame = frame;
+            this.frame = requireNonNull(frame);
         }
 
         @Override
@@ -388,23 +388,28 @@ public final class PlanMatchPattern
             if (this == obj) {
                 return true;
             }
+
             if (obj == null || obj.getClass() != FunctionCall.class) {
                 return false;
             }
+
             FunctionCall o = (FunctionCall) obj;
+
+            /*
+             * A FunctionCall representing a window function must have a
+             * window. If not, there's a failure somewhere upstream.
+             */
+            checkState(o.getWindow().isPresent());
+
             return Objects.equals(getName(), o.getName()) &&
                     Objects.equals(getArguments(), o.getArguments()) &&
-                    /*
-                     * No isPresent check - it's an error if the FunctionCall
-                     * doesn't have a Window here, and a stack trace is more
-                     * informative than a test failure.
-                     */
                     Objects.equals(frame, o.getWindow().get().getFrame());
         }
 
         @Override
         public int hashCode()
         {
+            // This is a test object. We shouldn't put it in a hash table.
             throw new UnsupportedOperationException();
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -241,11 +241,12 @@ public final class PlanMatchPattern
         return new SymbolStem(stem);
     }
 
-    private interface Stem
+    private interface Stem<T>
     {
         String getStem();
+        String getOtherName(T other);
 
-        default <T> boolean stemEquals(Object o, Class<T> clazz, Function<T, String> getName)
+        default boolean stemEquals(Object o, Class<T> clazz, Function<T, String> getName)
         {
             if (this == o) {
                 return true;
@@ -260,7 +261,7 @@ public final class PlanMatchPattern
             }
 
             T other = clazz.cast(o);
-            String name = getName.apply(other);
+            String name = getOtherName(other);
             int endIndex = name.lastIndexOf('_');
             String otherStem = endIndex == -1 ? name : name.substring(0, endIndex);
             return getStem().equals(otherStem);
@@ -268,7 +269,7 @@ public final class PlanMatchPattern
     }
 
     public static class SymbolStem extends Symbol
-        implements Stem
+        implements Stem<Symbol>
     {
         private final String stem;
 
@@ -294,6 +295,12 @@ public final class PlanMatchPattern
         public String getStem()
         {
             return stem;
+        }
+
+        @Override
+        public String getOtherName(Symbol other)
+        {
+            return other.getName();
         }
     }
 
@@ -336,7 +343,7 @@ public final class PlanMatchPattern
     }
 
     public static class SymbolReferenceStem extends SymbolReference
-            implements Stem
+            implements Stem<SymbolReference>
     {
         private final String stem;
 
@@ -362,6 +369,12 @@ public final class PlanMatchPattern
         public String getStem()
         {
             return stem;
+        }
+
+        @Override
+        public String getOtherName(SymbolReference other)
+        {
+            return other.getName();
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -30,7 +30,6 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SymbolReference;
-import com.facebook.presto.sql.tree.Window;
 import com.facebook.presto.sql.tree.WindowFrame;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolMatcher.java
@@ -19,19 +19,17 @@ import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.google.common.base.MoreObjects;
 
-import java.util.regex.Pattern;
-
 import static com.google.common.base.Preconditions.checkState;
 
 final class SymbolMatcher
         implements Matcher
 {
-    private final Pattern pattern;
+    private final Symbol expectedSymbol;
     private final String alias;
 
-    SymbolMatcher(String pattern, String alias)
+    SymbolMatcher(Symbol expectedSymbol, String alias)
     {
-        this.pattern = Pattern.compile(pattern);
+        this.expectedSymbol = expectedSymbol;
         this.alias = alias;
     }
 
@@ -40,8 +38,8 @@ final class SymbolMatcher
     {
         Symbol symbol = null;
         for (Symbol outputSymbol : node.getOutputSymbols()) {
-            if (pattern.matcher(outputSymbol.getName()).find()) {
-                checkState(symbol == null, "%s symbol was found multiple times in %s", pattern, node.getOutputSymbols());
+            if (expectedSymbol.equals(outputSymbol)) {
+                checkState(symbol == null, "%s symbol was found multiple times in %s", expectedSymbol.getName(), node.getOutputSymbols());
                 symbol = outputSymbol;
             }
         }
@@ -57,7 +55,7 @@ final class SymbolMatcher
     {
         return MoreObjects.toStringHelper(this)
                 .add("alias", alias)
-                .add("pattern", pattern)
+                .add("name", expectedSymbol)
                 .toString();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
@@ -24,9 +24,9 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 
 final class WindowMatcher
         implements Matcher
@@ -46,17 +46,15 @@ final class WindowMatcher
         }
 
         WindowNode windowNode = (WindowNode) node;
-        List<FunctionCall> actualCalls = windowNode.getWindowFunctions().values().stream()
+        LinkedList<FunctionCall> actualCalls = windowNode.getWindowFunctions().values().stream()
                 .map(WindowNode.Function::getFunctionCall)
-                .collect(toList());
+                .collect(Collectors.toCollection(LinkedList::new));
 
         if (actualCalls.size() != functionCalls.size()) {
             return false;
         }
 
-        LinkedList<FunctionCall> expectedCalls = new LinkedList<>(functionCalls);
-
-        for (FunctionCall expectedCall : expectedCalls) {
+        for (FunctionCall expectedCall : functionCalls) {
             if (!actualCalls.remove(expectedCall)) {
                 // Found an expectedCall not in expectedCalls.
                 return false;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
@@ -46,7 +46,9 @@ final class WindowMatcher
         }
 
         WindowNode windowNode = (WindowNode) node;
-        List<FunctionCall> actualCalls = windowNode.getWindowFunctions().values().stream().map(function -> function.getFunctionCall()).collect(toList());
+        List<FunctionCall> actualCalls = windowNode.getWindowFunctions().values().stream()
+                .map(WindowNode.Function::getFunctionCall)
+                .collect(toList());
 
         if (actualCalls.size() != functionCalls.size()) {
             return false;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
@@ -22,11 +22,11 @@ import com.facebook.presto.sql.tree.FunctionCall;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 final class WindowMatcher
         implements Matcher
@@ -46,24 +46,23 @@ final class WindowMatcher
         }
 
         WindowNode windowNode = (WindowNode) node;
-        Collection<FunctionCall> actualCalls = windowNode.getWindowFunctions().values();
+        List<FunctionCall> actualCalls = windowNode.getWindowFunctions().values().stream().map(function -> function.getFunctionCall()).collect(toList());
 
         if (actualCalls.size() != functionCalls.size()) {
             return false;
         }
 
         LinkedList<FunctionCall> expectedCalls = new LinkedList<>(functionCalls);
-        LinkedList<FunctionCall> actualCopy = new LinkedList<>(actualCalls);
 
         for (FunctionCall expectedCall : expectedCalls) {
-            if (!actualCopy.remove(expectedCall)) {
+            if (!actualCalls.remove(expectedCall)) {
                 // Found an expectedCall not in expectedCalls.
                 return false;
             }
         }
 
         // expectedCalls was missing something in actualCalls.
-        return actualCopy.isEmpty();
+        return actualCalls.isEmpty();
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
@@ -16,6 +16,8 @@ package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.FunctionCall;
@@ -24,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
@@ -31,11 +34,73 @@ import static java.util.Objects.requireNonNull;
 final class WindowMatcher
         implements Matcher
 {
+    private final WindowNode.Specification specification;
     private final List<FunctionCall> functionCalls;
 
-    WindowMatcher(List<FunctionCall> functionCalls)
+    WindowMatcher(WindowNode.Specification specification, List<FunctionCall> functionCalls)
     {
+        this.specification = specification;
         this.functionCalls = ImmutableList.copyOf(requireNonNull(functionCalls, "functionCalls is null"));
+    }
+
+    private static boolean sameIshSpecification(
+            WindowNode.Specification expected,
+            WindowNode.Specification actual)
+    {
+        if (!expected.getPartitionBy().equals(actual.getPartitionBy()) ||
+                !expected.getOrderBy().equals(actual.getOrderBy())) {
+            return false;
+        }
+
+        Map<Symbol, SortOrder> expectedOrderings = expected.getOrderings();
+        Map<Symbol, SortOrder> actualOrderings = actual.getOrderings();
+
+        if (expectedOrderings.size() != actualOrderings.size()) {
+            return false;
+        }
+
+        /*
+         * Ooof. Sad story time.
+         *
+         * Symbols in the plan get decorated with a number if the same symbol is used twice. E.g. if two parts
+         * of a query both refer to a column foo, you'll end up with symbols foo and foo_32 (for example).
+         *
+         * When we verify the orderings in a plan, the orderings take the form of a Map<Symbol, SortOrder>.
+         * Unfortunately, we have no way of knowing a priori what the number affixed to the symbol name, and
+         * even if we did, we'd be relying on implementation details of the SymbolAllocator.
+         *
+         * What's further unfortunate is that we can't just extend Symbol with something that compares equal
+         * to a Symbol with a name that has a unique id affixed. This is because we end up going through
+         * Map.equals, and if you dig deep enough you end up finding that the hashCodes would have to match too.
+         * Since we can't change how Symbol.hashCode is implemented (and wouldn't want to!), we're back to
+         * needing to know the unknowable.
+         *
+         * Another approach to making to WindowNode.Specifications compare with .equals() that doesn't work
+         * is extending Map to do the comparison in a way that doesn't rely on hashCode. That doesn't work
+         * because WindowNode.Specification copies the members of the map you pass to its constructor.
+         *
+         * Instead, we implement the comparison here in a way that doesn't rely on hashCode. This is brittle
+         * because if somebody adds another field to Specification that's included in a equals comparison,
+         * this need to be updated too.
+         */
+        actualEntries:
+        for (Map.Entry<Symbol, SortOrder> actualEntry : actualOrderings.entrySet()) {
+            Symbol actualKey = actualEntry.getKey();
+            for (Map.Entry<Symbol, SortOrder> expectedEntry : expectedOrderings.entrySet()) {
+                Symbol expectedKey = expectedEntry.getKey();
+                if (expectedKey.equals(actualKey)) {
+                    if (expectedEntry.getValue().equals(actualEntry.getValue())) {
+                        continue actualEntries;
+                    }
+                    else {
+                        return false;
+                    }
+                }
+            }
+            return false;
+        }
+
+        return true;
     }
 
     @Override
@@ -46,6 +111,11 @@ final class WindowMatcher
         }
 
         WindowNode windowNode = (WindowNode) node;
+
+        if (!sameIshSpecification(specification, windowNode.getSpecification())) {
+            return false;
+        }
+
         LinkedList<FunctionCall> actualCalls = windowNode.getWindowFunctions().values().stream()
                 .map(WindowNode.Function::getFunctionCall)
                 .collect(Collectors.toCollection(LinkedList::new));
@@ -69,6 +139,7 @@ final class WindowMatcher
     public String toString()
     {
         return MoreObjects.toStringHelper(this)
+                .add("specification", specification)
                 .add("functionCalls", functionCalls)
                 .toString();
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
@@ -43,7 +43,7 @@ final class WindowMatcher
         this.functionCalls = ImmutableList.copyOf(requireNonNull(functionCalls, "functionCalls is null"));
     }
 
-    private static boolean sameIshSpecification(
+    private static boolean samePartitionAndOrder(
             WindowNode.Specification expected,
             WindowNode.Specification actual)
     {
@@ -85,10 +85,10 @@ final class WindowMatcher
          */
         actualEntries:
         for (Map.Entry<Symbol, SortOrder> actualEntry : actualOrderings.entrySet()) {
-            Symbol actualKey = actualEntry.getKey();
+            Symbol actualSymbol = actualEntry.getKey();
             for (Map.Entry<Symbol, SortOrder> expectedEntry : expectedOrderings.entrySet()) {
-                Symbol expectedKey = expectedEntry.getKey();
-                if (expectedKey.equals(actualKey)) {
+                Symbol expectedSymbol = expectedEntry.getKey();
+                if (expectedSymbol.equals(actualSymbol)) {
                     if (expectedEntry.getValue().equals(actualEntry.getValue())) {
                         continue actualEntries;
                     }
@@ -112,7 +112,7 @@ final class WindowMatcher
 
         WindowNode windowNode = (WindowNode) node;
 
-        if (!sameIshSpecification(specification, windowNode.getSpecification())) {
+        if (!samePartitionAndOrder(specification, windowNode.getSpecification())) {
             return false;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeIdenticalWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeIdenticalWindows.java
@@ -190,6 +190,108 @@ public class TestMergeIdenticalWindows
     }
 
     @Test
+    public void testIdenticalWindowSpecificationsDefaultFrame()
+    {
+        Window windowC = new Window(
+                ImmutableList.of(new SymbolReference("suppkey")),
+                ImmutableList.of(new SortItem(new SymbolReference("orderkey"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
+                Optional.empty());
+
+        Window windowD = new Window(
+                ImmutableList.of(new SymbolReference("orderkey")),
+                ImmutableList.of(new SortItem(new SymbolReference("shipdate"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
+                Optional.empty());
+
+        @Language("SQL") String sql = "select " +
+                "sum(quantity) over (partition by suppkey order by orderkey), " +
+                "sum(quantity) over (partition by orderkey order by shipdate), " +
+                "sum(discount) over (partition by suppkey order by orderkey) " +
+                "from lineitem";
+
+        assertUnitPlan(sql,
+                anyTree(
+                        window(ImmutableList.of(
+                                functionCall("sum", windowD, false, "quantity")),
+                                window(ImmutableList.of(
+                                        functionCall("sum", windowC, false, "quantity"),
+                                        functionCall("sum", windowC, false, "discount")),
+                                        anyNot(WindowNode.class)))));
+    }
+
+    @Test
+    public void testNotMergeDifferentFrames()
+    {
+        WindowFrame frameC = new WindowFrame(
+                WindowFrame.Type.ROWS,
+                new FrameBound(FrameBound.Type.UNBOUNDED_PRECEDING),
+                Optional.of(new FrameBound(FrameBound.Type.CURRENT_ROW)));
+
+        Window windowC = new Window(
+                ImmutableList.of(new SymbolReference("suppkey")),
+                ImmutableList.of(new SortItem(new SymbolReference("orderkey"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
+                Optional.of(frameC));
+
+        WindowFrame frameD = new WindowFrame(
+                WindowFrame.Type.ROWS,
+                new FrameBound(FrameBound.Type.CURRENT_ROW),
+                Optional.of(new FrameBound(FrameBound.Type.UNBOUNDED_FOLLOWING)));
+
+        Window windowD = new Window(
+                ImmutableList.of(new SymbolReference("suppkey")),
+                ImmutableList.of(new SortItem(new SymbolReference("orderkey"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
+                Optional.of(frameD));
+
+        @Language("SQL") String sql = "select " +
+                "sum(quantity) over (partition by suppkey order by orderkey rows between unbounded preceding and current row) sum_quantity_C, " +
+                "avg(quantity) over (partition by suppkey order by orderkey rows between current row and unbounded following) avg_quantity_D, " +
+                "sum(discount) over (partition by suppkey order by orderkey rows between unbounded preceding and current row) sum_discount_C " +
+                "from lineitem";
+
+        assertUnitPlan(sql,
+                anyTree(
+                        window(ImmutableList.of(
+                                functionCall("avg", windowD, false, "quantity")),
+                                window(ImmutableList.of(
+                                        functionCall("sum", windowC, false, "discount"),
+                                        functionCall("sum", windowC, false, "quantity")),
+                                        any()))));
+    }
+
+    @Test
+    public void testNotMergeDifferentFramesWithDefault()
+    {
+        Window windowC = new Window(
+                ImmutableList.of(new SymbolReference("suppkey")),
+                ImmutableList.of(new SortItem(new SymbolReference("orderkey"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
+                Optional.empty());
+
+        WindowFrame frameD = new WindowFrame(
+                WindowFrame.Type.ROWS,
+                new FrameBound(FrameBound.Type.CURRENT_ROW),
+                Optional.of(new FrameBound(FrameBound.Type.UNBOUNDED_FOLLOWING)));
+
+        Window windowD = new Window(
+                ImmutableList.of(new SymbolReference("suppkey")),
+                ImmutableList.of(new SortItem(new SymbolReference("orderkey"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
+                Optional.of(frameD));
+
+        @Language("SQL") String sql = "select " +
+                "sum(quantity) over (partition by suppkey order by orderkey) sum_quantity_C, " +
+                "avg(quantity) over (partition by suppkey order by orderkey rows between current row and unbounded following) avg_quantity_D, " +
+                "sum(discount) over (partition by suppkey order by orderkey) sum_discount_C " +
+                "from lineitem";
+
+        assertUnitPlan(sql,
+                anyTree(
+                        window(ImmutableList.of(
+                                functionCall("avg", windowD, false, "quantity")),
+                                window(ImmutableList.of(
+                                        functionCall("sum", windowC, false, "discount"),
+                                        functionCall("sum", windowC, false, "quantity")),
+                                        any()))));
+    }
+
+    @Test
     public void testNotMergeAcrossJoinBranches()
     {
         @Language("SQL") String sql = "with foo as (" +

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.server.SliceDeserializer;
+import com.facebook.presto.server.SliceSerializer;
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.sql.Serialization;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FrameBound;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.WindowFrame;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.json.ObjectMapperProvider;
+import io.airlift.slice.Slice;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+
+public class TestWindowNode
+{
+    private SymbolAllocator symbolAllocator;
+    private ValuesNode sourceNode;
+    private Symbol columnA;
+    private Symbol columnB;
+    private Symbol columnC;
+
+    private final ObjectMapper objectMapper;
+
+    TestWindowNode()
+    {
+        // dependencies copied from ServerMainModule.java to avoid depending on whole ServerMainModule here
+        SqlParser sqlParser = new SqlParser();
+        ObjectMapperProvider provider = new ObjectMapperProvider();
+        provider.setJsonSerializers(ImmutableMap.of(
+                Slice.class, new SliceSerializer(),
+                Expression.class, new Serialization.ExpressionSerializer()));
+        provider.setJsonDeserializers(ImmutableMap.of(
+                Slice.class, new SliceDeserializer(),
+                Expression.class, new Serialization.ExpressionDeserializer(sqlParser),
+                FunctionCall.class, new Serialization.FunctionCallDeserializer(sqlParser)));
+        objectMapper = provider.get();
+    }
+
+    @BeforeMethod
+    public void setUp()
+    {
+        symbolAllocator = new SymbolAllocator();
+        columnA = symbolAllocator.newSymbol("a", BIGINT);
+        columnB = symbolAllocator.newSymbol("b", BIGINT);
+        columnC = symbolAllocator.newSymbol("c", BIGINT);
+
+        sourceNode = new ValuesNode(
+                newId(),
+                ImmutableList.of(columnA, columnB, columnC),
+                ImmutableList.of());
+    }
+
+    @Test
+    public void testSerializationRoundtrip()
+            throws Exception
+    {
+        Symbol windowSymbol = symbolAllocator.newSymbol("sum", BIGINT);
+        Signature signature = new Signature(
+                "sum",
+                FunctionKind.WINDOW,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                BIGINT.getTypeSignature(),
+                ImmutableList.of(BIGINT.getTypeSignature()),
+                false);
+        FunctionCall functionCall = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference()));
+        WindowNode.Function windowFunction = new WindowNode.Function(functionCall, signature);
+        WindowNode.Frame frame = new WindowNode.Frame(
+                WindowFrame.Type.RANGE,
+                FrameBound.Type.UNBOUNDED_PRECEDING,
+                Optional.empty(),
+                FrameBound.Type.UNBOUNDED_FOLLOWING,
+                Optional.empty());
+
+        PlanNodeId id = newId();
+        WindowNode.Specification specification = new WindowNode.Specification(
+                ImmutableList.of(columnA),
+                ImmutableList.of(columnB),
+                ImmutableMap.of(columnB, SortOrder.ASC_NULLS_FIRST));
+        Map<Symbol, WindowNode.Function> functions = ImmutableMap.of(windowSymbol, windowFunction);
+        Map<WindowNode.Function, WindowNode.Frame> frames = ImmutableMap.of(windowFunction, frame);
+        Optional<Symbol> hashSymbol = Optional.of(columnB);
+        Set<Symbol> prePartitionedInputs = ImmutableSet.of(columnA);
+        WindowNode windowNode = new WindowNode(
+                id,
+                sourceNode,
+                specification,
+                functions,
+                frames,
+                hashSymbol,
+                prePartitionedInputs,
+                0);
+
+        String json = objectMapper.writeValueAsString(windowNode);
+
+        WindowNode actualNode = objectMapper.readValue(json, WindowNode.class);
+
+        assertEquals(actualNode.getId(), windowNode.getId());
+        assertEquals(actualNode.getSpecification(), windowNode.getSpecification());
+        assertEquals(actualNode.getWindowFunctions(), windowNode.getWindowFunctions());
+        assertEquals(actualNode.getFrames(), windowNode.getFrames());
+        assertEquals(actualNode.getHashSymbol(), windowNode.getHashSymbol());
+        assertEquals(actualNode.getPrePartitionedInputs(), windowNode.getPrePartitionedInputs());
+        assertEquals(actualNode.getPreSortedOrderPrefix(), windowNode.getPreSortedOrderPrefix());
+    }
+
+    private static PlanNodeId newId()
+    {
+        return new PlanNodeId(UUID.randomUUID().toString());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
@@ -97,7 +97,6 @@ public class TestWindowNode
                 ImmutableList.of(BIGINT.getTypeSignature()),
                 false);
         FunctionCall functionCall = new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference()));
-        WindowNode.Function windowFunction = new WindowNode.Function(functionCall, signature);
         WindowNode.Frame frame = new WindowNode.Frame(
                 WindowFrame.Type.RANGE,
                 FrameBound.Type.UNBOUNDED_PRECEDING,
@@ -110,8 +109,7 @@ public class TestWindowNode
                 ImmutableList.of(columnA),
                 ImmutableList.of(columnB),
                 ImmutableMap.of(columnB, SortOrder.ASC_NULLS_FIRST));
-        Map<Symbol, WindowNode.Function> functions = ImmutableMap.of(windowSymbol, windowFunction);
-        Map<WindowNode.Function, WindowNode.Frame> frames = ImmutableMap.of(windowFunction, frame);
+        Map<Symbol, WindowNode.Function> functions = ImmutableMap.of(windowSymbol, new WindowNode.Function(functionCall, signature, frame));
         Optional<Symbol> hashSymbol = Optional.of(columnB);
         Set<Symbol> prePartitionedInputs = ImmutableSet.of(columnA);
         WindowNode windowNode = new WindowNode(
@@ -119,7 +117,6 @@ public class TestWindowNode
                 sourceNode,
                 specification,
                 functions,
-                frames,
                 hashSymbol,
                 prePartitionedInputs,
                 0);


### PR DESCRIPTION
Per offline discussion with @martint, pending the arrival of the new optimizer, unit tests should be asserting some things about WindowNodes against the WindowNode.Specification, and somethings against the WindowFunctions contained in the WindowNodes.

This updates the implementation of the matching code to do be consistent with that, and should make it harder to get false positives.