### PR TITLE
Window matcher rework fb

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.concat;
 import static java.util.Objects.requireNonNull;
@@ -213,9 +214,20 @@ public class WindowNode
 
             Specification other = (Specification) obj;
 
+            // Changing this? Go change WindowMatcher.matches too.
             return Objects.equals(this.partitionBy, other.partitionBy) &&
                     Objects.equals(this.orderBy, other.orderBy) &&
                     Objects.equals(this.orderings, other.orderings);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("partitionBy", this.partitionBy)
+                    .add("orderBy", this.orderBy)
+                    .add("orderings", this.orderings)
+                    .toString();
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -45,6 +45,7 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.symbolStem;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
@@ -77,9 +78,9 @@ public class TestLogicalPlanner
                 anyTree(
                         join(INNER, ImmutableList.of(aliasPair("O", "L")),
                                 any(
-                                        tableScan("orders").withSymbol("orderkey", "O")),
+                                        tableScan("orders").withSymbol(symbolStem("orderkey"), "O")),
                                 anyTree(
-                                        tableScan("lineitem").withSymbol("orderkey", "L")))));
+                                        tableScan("lineitem").withSymbol(symbolStem("orderkey"), "L")))));
     }
 
     @Test
@@ -89,11 +90,11 @@ public class TestLogicalPlanner
                 anyTree(
                         join(INNER, ImmutableList.of(aliasPair("X", "Y")),
                                 project(
-                                        tableScan("orders").withSymbol("orderkey", "X")),
+                                        tableScan("orders").withSymbol(symbolStem("orderkey"), "X")),
                                 project(
                                         node(EnforceSingleRowNode.class,
                                                 anyTree(
-                                                        tableScan("lineitem").withSymbol("orderkey", "Y")))))));
+                                                        tableScan("lineitem").withSymbol(symbolStem("orderkey"), "Y")))))));
 
         assertPlan("SELECT * FROM orders WHERE orderkey IN (SELECT orderkey FROM lineitem WHERE linenumber % 4 = 0)",
                 anyTree(
@@ -101,9 +102,9 @@ public class TestLogicalPlanner
                                 project(
                                         semiJoin("X", "Y", "S",
                                                 anyTree(
-                                                        tableScan("orders").withSymbol("orderkey", "X")),
+                                                        tableScan("orders").withSymbol(symbolStem("orderkey"), "X")),
                                                 anyTree(
-                                                        tableScan("lineitem").withSymbol("orderkey", "Y")))))));
+                                                        tableScan("lineitem").withSymbol(symbolStem("orderkey"), "Y")))))));
 
         assertPlan("SELECT * FROM orders WHERE orderkey NOT IN (SELECT orderkey FROM lineitem WHERE linenumber < 0)",
                 anyTree(
@@ -111,9 +112,9 @@ public class TestLogicalPlanner
                                 project(
                                         semiJoin("X", "Y", "S",
                                                 anyTree(
-                                                        tableScan("orders").withSymbol("orderkey", "X")),
+                                                        tableScan("orders").withSymbol(symbolStem("orderkey"), "X")),
                                                 anyTree(
-                                                        tableScan("lineitem").withSymbol("orderkey", "Y")))))));
+                                                        tableScan("lineitem").withSymbol(symbolStem("orderkey"), "Y")))))));
     }
 
     @Test
@@ -194,7 +195,7 @@ public class TestLogicalPlanner
                 anyTree(
                         filter("3 = X",
                                 apply(ImmutableList.of("X"),
-                                        tableScan("orders").withSymbol("orderkey", "X"),
+                                        tableScan("orders").withSymbol(symbolStem("orderkey"), "X"),
                                         node(EnforceSingleRowNode.class,
                                                 project(
                                                         node(ValuesNode.class)
@@ -209,10 +210,10 @@ public class TestLogicalPlanner
                         filter("3 IN (C)",
                                 apply(ImmutableList.of("C", "O"),
                                         project(
-                                                tableScan("orders").withSymbol("orderkey", "O").withSymbol("custkey", "C")),
+                                                tableScan("orders").withSymbol(symbolStem("orderkey"), "O").withSymbol(symbolStem("custkey"), "C")),
                                         anyTree(
                                                 apply(ImmutableList.of("L"),
-                                                        tableScan("lineitem").withSymbol("orderkey", "L"),
+                                                        tableScan("lineitem").withSymbol(symbolStem("orderkey"), "L"),
                                                         node(EnforceSingleRowNode.class,
                                                                 project(
                                                                         node(ValuesNode.class)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -29,15 +30,17 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SymbolReference;
-import com.facebook.presto.sql.tree.Window;
+import com.facebook.presto.sql.tree.WindowFrame;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkState;
@@ -86,9 +89,9 @@ public final class PlanMatchPattern
         return node(TableScanNode.class).with(new TableScanMatcher(expectedTableName, constraint));
     }
 
-    public static PlanMatchPattern window(List<FunctionCall> functionCalls, PlanMatchPattern source)
+    public static PlanMatchPattern window(WindowNode.Specification specification, List<FunctionCall> functionCalls, PlanMatchPattern source)
     {
-        return node(WindowNode.class, source).with(new WindowMatcher(functionCalls));
+        return any(source).with(new WindowMatcher(specification, functionCalls));
     }
 
     public static PlanMatchPattern project(PlanMatchPattern source)
@@ -169,29 +172,15 @@ public final class PlanMatchPattern
         return sourcePatterns.isEmpty();
     }
 
-    private static List<Expression> toExpressionList(String... args)
+    /*
+     * Caveat Emptor: FunctionCall's come from the parser, and represent what
+     * the user has typed. As such, they don't contain a WindowFrame if one
+     * isn't specified in the SQL. In this case, the correct value to pass is
+     * Optional.empty()
+     */
+    public static FunctionCall functionCall(String name, Optional<WindowFrame> frame, SymbolReference... args)
     {
-        ImmutableList.Builder<Expression> builder = ImmutableList.builder();
-        for (String arg : args) {
-            if (arg.equals("*")) {
-                builder.add(new PlanMatchPattern.AnySymbolReference());
-            }
-            else {
-                builder.add(new SymbolReference(arg));
-            }
-        }
-
-        return builder.build();
-    }
-
-    public static FunctionCall functionCall(String name, Window window, boolean distinct, String... args)
-    {
-        return new FunctionCall(QualifiedName.of(name), Optional.of(window), distinct, toExpressionList(args));
-    }
-
-    public static FunctionCall functionCall(String name, String... args)
-    {
-        return new RelaxedEqualityFunctionCall(QualifiedName.of(name), toExpressionList(args));
+        return new RelaxedEqualityFunctionCall(QualifiedName.of(name), Arrays.asList(args), frame);
     }
 
     @Override
@@ -247,10 +236,144 @@ public final class PlanMatchPattern
         return Strings.repeat("    ", indent);
     }
 
-    private static class AnySymbolReference
-            extends SymbolReference
+    public static SymbolStem symbolStem(String stem)
     {
-        AnySymbolReference()
+        return new SymbolStem(stem);
+    }
+
+    /*
+     * All comments below about Symbols apply to SymbolReferences as well.
+     *
+     * This is the result of a compromise to satisfy as many of the following
+     * constraints as possible:
+     *
+     * 1) Many objects we want to compare in plans already define equals
+     * methods. We should use these to the greatest degree possible in the
+     * various Matchers, because there's no test-specific code that can get
+     * out of date.
+     * 2) Many of said objects contain either Symbols.
+     * 3) Symbols in the final Plan may be decorated by the SymbolAllocator to
+     * make them unique as needed.
+     * 4) There's no way to know a-priori what the decorated name of a Symbol
+     * will be in the plan. Even if we could, future changes to the planner
+     * might change the name of the Symbols in the plan, rendering the expected
+     * values in tests that depended on them out of date.
+     *
+     * The solution to writing expected plans that match actual plans and are
+     * as self-maintaining as possible is to extend Symbol so that the
+     * following returns true:
+     *   expectedSymbol.equals(actualDecoratedSymbol)
+     *
+     * This ensures that we can construct expected objects containing Symbols
+     * and use their built-in equals() methods to compare them to the actual
+     * objects in the plan.
+     *
+     * To actually implement this, we need to handle comparing the equality
+     * comparison between e.g. column_name and column_name_829. This is done by
+     * treating column_name as a stem and making sure that everything prior to
+     * the last underscore in column_name_829 is the same as the stem.
+     *
+     * This basically reverses the transformation SymbolAllocator does to
+     * create the unique column_name_829 Symbol name in the first place.
+     *
+     * A different approach to this that is problematic is to have a
+     * TestSymbolAllocator that keeps track of the reverse mappings in a Map
+     * having entries such as "column_name_927" -> "column_name". The issue
+     * with this is that constructing the expected plan for a query would have
+     * to depend on the actual plan, which is what actually has the
+     * SymbolAllocator. Having the expected value for a test depend on the
+     * actual value seems fishy.
+     */
+    private interface Stem<T>
+    {
+        String getStem();
+        String getOtherName(T other);
+
+        default boolean stemEquals(Object o, Class<T> clazz, Function<T, String> getName)
+        {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null) {
+                return false;
+            }
+
+            if (!clazz.equals(o.getClass())) {
+                return false;
+            }
+
+            T other = clazz.cast(o);
+            String name = getOtherName(other);
+            int endIndex = name.lastIndexOf('_');
+            String otherStem = endIndex == -1 ? name : name.substring(0, endIndex);
+            return getStem().equals(otherStem);
+        }
+    }
+
+    private static class SymbolStem extends Symbol
+        implements Stem<Symbol>
+    {
+        private final String stem;
+
+        private SymbolStem(String stem)
+        {
+            super(stem + "_*");
+            this.stem = requireNonNull(stem);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            // Inconsistent with hashCode. See below.
+            return stemEquals(o, Symbol.class, Symbol::getName);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            /*
+             * hashCode() and equals() are inconsistent with each other. In theory, we'd like to
+             * throw UnsupportedOperationException here. We can't, however because creating a
+             * WindowNode.Specification with more than one Ordering requires being able to put
+             * Symbols in a hash table.
+             *
+             * It turns out that this being inconsistent with equals ends up not mattering. We
+             * can't meaningfully do an equals comparison on the hash tables representing the
+             * expected Orderings and the actual Orderings because that would require knowing
+             * the mangled symbols in the expected value a priori. Instead, we do an equals
+             * comparison that relies solely on equals() returning true for mangled and
+             * non-mangled symbols
+             */
+            return stem.hashCode();
+        }
+
+        @Override
+        public String getStem()
+        {
+            return stem;
+        }
+
+        @Override
+        public String getOtherName(Symbol other)
+        {
+            return other.getName();
+        }
+    }
+
+    public static SymbolReference anySymbolReference()
+    {
+        return new AnySymbolReference();
+    }
+
+    public static SymbolReference symbolReferenceStem(String stem)
+    {
+        return new SymbolReferenceStem(stem);
+    }
+
+    private static class AnySymbolReference extends SymbolReference
+    {
+        private AnySymbolReference()
         {
             super("*");
         }
@@ -262,7 +385,7 @@ public final class PlanMatchPattern
                 return true;
             }
 
-            if (o == null || !SymbolReference.class.isInstance(o)) {
+            if (o == null || !SymbolReference.class.equals(o.getClass())) {
                 return false;
             }
 
@@ -276,12 +399,57 @@ public final class PlanMatchPattern
         }
     }
 
-    private static class RelaxedEqualityFunctionCall
-            extends FunctionCall
+    private static class SymbolReferenceStem extends SymbolReference
+            implements Stem<SymbolReference>
     {
-        RelaxedEqualityFunctionCall(QualifiedName name, List<Expression> arguments)
+        private final String stem;
+
+        private SymbolReferenceStem(String stem)
+        {
+            super(stem + "_*");
+            this.stem = requireNonNull(stem);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            return stemEquals(o, SymbolReference.class, SymbolReference::getName);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getStem()
+        {
+            return stem;
+        }
+
+        @Override
+        public String getOtherName(SymbolReference other)
+        {
+            return other.getName();
+        }
+    }
+
+    private static class RelaxedEqualityFunctionCall extends FunctionCall
+    {
+        /*
+         * FunctionCalls for window functions must have a Window. By the time
+         * the we've gone through the optimizers, everything but the Frame
+         * has a corresponding entry in the WindowNode. Since the WindowNode
+         * has had default entries filled in, we only need to compare the
+         * window frame with the one in the FunctionCall in equals.
+         */
+        Optional<WindowFrame> frame;
+
+        private RelaxedEqualityFunctionCall(QualifiedName name, List<Expression> arguments, Optional<WindowFrame> frame)
         {
             super(name, arguments);
+            this.frame = requireNonNull(frame);
         }
 
         @Override
@@ -290,18 +458,29 @@ public final class PlanMatchPattern
             if (this == obj) {
                 return true;
             }
+
             if (obj == null || obj.getClass() != FunctionCall.class) {
                 return false;
             }
+
             FunctionCall o = (FunctionCall) obj;
+
+            /*
+             * A FunctionCall representing a window function must have a
+             * window. If not, there's a failure somewhere upstream.
+             */
+            checkState(o.getWindow().isPresent());
+
             return Objects.equals(getName(), o.getName()) &&
-                    Objects.equals(getArguments(), o.getArguments());
+                    Objects.equals(getArguments(), o.getArguments()) &&
+                    Objects.equals(frame, o.getWindow().get().getFrame());
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(getName(), getArguments());
+            // This is a test object. We shouldn't put it in a hash table.
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolMatcher.java
@@ -18,20 +18,18 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 
-import java.util.regex.Pattern;
-
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 
 final class SymbolMatcher
         implements Matcher
 {
-    private final Pattern pattern;
+    private final Symbol expectedSymbol;
     private final String alias;
 
-    SymbolMatcher(String pattern, String alias)
+    SymbolMatcher(Symbol expectedSymbol, String alias)
     {
-        this.pattern = Pattern.compile(pattern);
+        this.expectedSymbol = expectedSymbol;
         this.alias = alias;
     }
 
@@ -40,8 +38,8 @@ final class SymbolMatcher
     {
         Symbol symbol = null;
         for (Symbol outputSymbol : node.getOutputSymbols()) {
-            if (pattern.matcher(outputSymbol.getName()).find()) {
-                checkState(symbol == null, "%s symbol was found multiple times in %s", pattern, node.getOutputSymbols());
+            if (expectedSymbol.equals(outputSymbol)) {
+                checkState(symbol == null, "%s symbol was found multiple times in %s", expectedSymbol.getName(), node.getOutputSymbols());
                 symbol = outputSymbol;
             }
         }
@@ -57,7 +55,7 @@ final class SymbolMatcher
     {
         return toStringHelper(this)
                 .add("alias", alias)
-                .add("pattern", pattern)
+                .add("name", expectedSymbol)
                 .toString();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
@@ -16,26 +16,91 @@ package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.google.common.collect.ImmutableList;
 
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 final class WindowMatcher
         implements Matcher
 {
+    private final WindowNode.Specification specification;
     private final List<FunctionCall> functionCalls;
 
-    WindowMatcher(List<FunctionCall> functionCalls)
+    WindowMatcher(WindowNode.Specification specification, List<FunctionCall> functionCalls)
     {
+        this.specification = specification;
         this.functionCalls = ImmutableList.copyOf(requireNonNull(functionCalls, "functionCalls is null"));
+    }
+
+    private static boolean samePartitionAndOrder(
+            WindowNode.Specification expected,
+            WindowNode.Specification actual)
+    {
+        if (!expected.getPartitionBy().equals(actual.getPartitionBy()) ||
+                !expected.getOrderBy().equals(actual.getOrderBy())) {
+            return false;
+        }
+
+        Map<Symbol, SortOrder> expectedOrderings = expected.getOrderings();
+        Map<Symbol, SortOrder> actualOrderings = actual.getOrderings();
+
+        if (expectedOrderings.size() != actualOrderings.size()) {
+            return false;
+        }
+
+        /*
+         * Ooof. Sad story time.
+         *
+         * Symbols in the plan get decorated with a number if the same symbol is used twice. E.g. if two parts
+         * of a query both refer to a column foo, you'll end up with symbols foo and foo_32 (for example).
+         *
+         * When we verify the orderings in a plan, the orderings take the form of a Map<Symbol, SortOrder>.
+         * Unfortunately, we have no way of knowing a priori what the number affixed to the symbol name, and
+         * even if we did, we'd be relying on implementation details of the SymbolAllocator.
+         *
+         * What's further unfortunate is that we can't just extend Symbol with something that compares equal
+         * to a Symbol with a name that has a unique id affixed. This is because we end up going through
+         * Map.equals, and if you dig deep enough you end up finding that the hashCodes would have to match too.
+         * Since we can't change how Symbol.hashCode is implemented (and wouldn't want to!), we're back to
+         * needing to know the unknowable.
+         *
+         * Another approach to making to WindowNode.Specifications compare with .equals() that doesn't work
+         * is extending Map to do the comparison in a way that doesn't rely on hashCode. That doesn't work
+         * because WindowNode.Specification copies the members of the map you pass to its constructor.
+         *
+         * Instead, we implement the comparison here in a way that doesn't rely on hashCode. This is brittle
+         * because if somebody adds another field to Specification that's included in a equals comparison,
+         * this need to be updated too.
+         */
+        Comparator<Map.Entry<Symbol, SortOrder>> entryComparator =
+                (Map.Entry<Symbol, SortOrder> x, Map.Entry<Symbol, SortOrder> y) -> x.getKey().compareTo(y.getKey());
+
+        List<Map.Entry<Symbol, SortOrder>> actualEntries = actualOrderings
+                .entrySet()
+                .stream()
+                .sorted(entryComparator)
+                .collect(toImmutableList());
+
+        List<Map.Entry<Symbol, SortOrder>> expectedEntries = expectedOrderings
+                .entrySet()
+                .stream()
+                .sorted(entryComparator)
+                .collect(toImmutableList());
+
+        return expectedEntries.equals(actualEntries);
     }
 
     @Override
@@ -46,6 +111,11 @@ final class WindowMatcher
         }
 
         WindowNode windowNode = (WindowNode) node;
+
+        if (!samePartitionAndOrder(specification, windowNode.getSpecification())) {
+            return false;
+        }
+
         LinkedList<FunctionCall> actualCalls = windowNode.getWindowFunctions().values().stream()
                 .map(WindowNode.Function::getFunctionCall)
                 .collect(Collectors.toCollection(LinkedList::new));
@@ -69,6 +139,7 @@ final class WindowMatcher
     public String toString()
     {
         return toStringHelper(this)
+                .add("specification", specification)
                 .add("functionCalls", functionCalls)
                 .toString();
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeIdenticalWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeIdenticalWindows.java
@@ -13,16 +13,16 @@
  */
 package com.facebook.presto.sql.planner.optimizations;
 
+import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.assertions.PlanAssert;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.FrameBound;
-import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.SymbolReference;
-import com.facebook.presto.sql.tree.Window;
 import com.facebook.presto.sql.tree.WindowFrame;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.tpch.TpchConnectorFactory;
@@ -36,22 +36,36 @@ import java.util.Optional;
 
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyNot;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anySymbolReference;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.symbolReferenceStem;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.symbolStem;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.window;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 
 public class TestMergeIdenticalWindows
 {
     private final LocalQueryRunner queryRunner;
-    private final Window windowA;
-    private final Window windowB;
+
+    private final Symbol suppkey;
+    private final Symbol orderkey;
+    private final Symbol shipdate;
+
+    private final SymbolReference quantityReference;
+    private final SymbolReference discountReference;
+
+    private final Optional<WindowFrame> commonFrame;
+    private final Optional<WindowFrame> defaultFrame;
+
+    private final WindowNode.Specification specificationA;
+    private final WindowNode.Specification specificationB;
 
     public TestMergeIdenticalWindows()
     {
-        this.queryRunner = new LocalQueryRunner(testSessionBuilder()
+        queryRunner = new LocalQueryRunner(testSessionBuilder()
                 .setCatalog("local")
                 .setSchema("tiny")
                 .build());
@@ -60,20 +74,29 @@ public class TestMergeIdenticalWindows
                 new TpchConnectorFactory(1),
                 ImmutableMap.<String, String>of());
 
-        WindowFrame frame = new WindowFrame(
+        commonFrame = Optional.of(new WindowFrame(
                 WindowFrame.Type.ROWS,
                 new FrameBound(FrameBound.Type.UNBOUNDED_PRECEDING),
-                Optional.of(new FrameBound(FrameBound.Type.CURRENT_ROW)));
+                Optional.of(new FrameBound(FrameBound.Type.CURRENT_ROW))));
 
-        windowA = new Window(
-                ImmutableList.of(new SymbolReference("suppkey")),
-                ImmutableList.of(new SortItem(new SymbolReference("orderkey"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
-                Optional.of(frame));
+        defaultFrame = Optional.empty();
 
-        windowB = new Window(
-                ImmutableList.of(new SymbolReference("orderkey")),
-                ImmutableList.of(new SortItem(new SymbolReference("shipdate"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
-                Optional.of(frame));
+        suppkey = new Symbol("suppkey");
+        orderkey = new Symbol("orderkey");
+        shipdate = new Symbol("shipdate");
+
+        quantityReference = new SymbolReference("quantity");
+        discountReference = new SymbolReference("discount");
+
+        specificationA = new WindowNode.Specification(
+                ImmutableList.of(suppkey),
+                ImmutableList.of(orderkey),
+                ImmutableMap.of(orderkey, SortOrder.ASC_NULLS_LAST));
+
+        specificationB = new WindowNode.Specification(
+                ImmutableList.of(orderkey),
+                ImmutableList.of(shipdate),
+                ImmutableMap.of(shipdate, SortOrder.ASC_NULLS_LAST));
     }
 
     /**
@@ -113,12 +136,14 @@ public class TestMergeIdenticalWindows
 
         PlanMatchPattern pattern =
                 anyTree(
-                        window(ImmutableList.of(
-                                functionCall("sum", windowB, false, "quantity")),
+                        window(specificationB,
+                                ImmutableList.of(
+                                functionCall("sum", commonFrame, quantityReference)),
                                 anyTree(
-                                        window(ImmutableList.of(
-                                                functionCall("sum", windowA, false, "quantity"),
-                                                functionCall("sum", windowA, false, "discount")),
+                                        window(specificationA,
+                                                ImmutableList.of(
+                                                functionCall("sum", commonFrame, quantityReference),
+                                                functionCall("sum", commonFrame, discountReference)),
                                                 anyNot(WindowNode.class,
                                                         anyTree())))));
 
@@ -140,11 +165,13 @@ public class TestMergeIdenticalWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(ImmutableList.of(
-                                functionCall("sum", windowB, false, "quantity")),
-                                window(ImmutableList.of(
-                                        functionCall("sum", windowA, false, "quantity"),
-                                        functionCall("sum", windowA, false, "discount")),
+                        window(specificationB,
+                                ImmutableList.of(
+                                functionCall("sum", commonFrame, quantityReference)),
+                                window(specificationA,
+                                        ImmutableList.of(
+                                        functionCall("sum", commonFrame, quantityReference),
+                                        functionCall("sum", commonFrame, discountReference)),
                                         anyNot(WindowNode.class)))));
     }
 
@@ -159,11 +186,14 @@ public class TestMergeIdenticalWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(ImmutableList.of(functionCall("sum", windowA, false, "discount")),
-                                window(ImmutableList.of(functionCall("lag", windowB, false, "quantity", "*", "*")),
+                        window(specificationA,
+                                ImmutableList.of(functionCall("sum", commonFrame, discountReference)),
+                                window(specificationB,
+                                        ImmutableList.of(functionCall("lag", commonFrame, quantityReference, anySymbolReference(), anySymbolReference())),
                                         project(
-                                                window(ImmutableList.of(
-                                                        functionCall("sum", windowA, false, "quantity")),
+                                                window(specificationA,
+                                                        ImmutableList.of(
+                                                        functionCall("sum", commonFrame, quantityReference)),
                                                         any()))))));
     }
 
@@ -178,27 +208,29 @@ public class TestMergeIdenticalWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(ImmutableList.of(
-                                functionCall("sum", windowA, false, "discount"),
-                                functionCall("lag", windowA, false, "quantity", "*", "*")),
+                        window(specificationA,
+                                ImmutableList.of(
+                                functionCall("sum", commonFrame, discountReference),
+                                functionCall("lag", commonFrame, quantityReference, anySymbolReference(), anySymbolReference())),
                                 project(
-                                        window(ImmutableList.of(
-                                                functionCall("sum", windowA, false, "quantity")),
+                                        window(specificationA,
+                                                ImmutableList.of(
+                                                functionCall("sum", commonFrame, quantityReference)),
                                                 any())))));
     }
 
     @Test
     public void testIdenticalWindowSpecificationsDefaultFrame()
     {
-        Window windowC = new Window(
-                ImmutableList.of(new SymbolReference("suppkey")),
-                ImmutableList.of(new SortItem(new SymbolReference("orderkey"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
-                Optional.empty());
+        WindowNode.Specification specificationC = new WindowNode.Specification(
+                ImmutableList.of(suppkey),
+                ImmutableList.of(orderkey),
+                ImmutableMap.of(orderkey, SortOrder.ASC_NULLS_LAST));
 
-        Window windowD = new Window(
-                ImmutableList.of(new SymbolReference("orderkey")),
-                ImmutableList.of(new SortItem(new SymbolReference("shipdate"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
-                Optional.empty());
+        WindowNode.Specification specificationD = new WindowNode.Specification(
+                ImmutableList.of(orderkey),
+                ImmutableList.of(shipdate),
+                ImmutableMap.of(shipdate, SortOrder.ASC_NULLS_LAST));
 
         @Language("SQL") String sql = "select " +
                 "sum(quantity) over (partition by suppkey order by orderkey), " +
@@ -208,36 +240,38 @@ public class TestMergeIdenticalWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(ImmutableList.of(
-                                functionCall("sum", windowD, false, "quantity")),
-                                window(ImmutableList.of(
-                                        functionCall("sum", windowC, false, "quantity"),
-                                        functionCall("sum", windowC, false, "discount")),
+                        window(specificationD,
+                                ImmutableList.of(
+                                functionCall("sum", defaultFrame, quantityReference)),
+                                window(specificationC,
+                                        ImmutableList.of(
+                                        functionCall("sum", defaultFrame, quantityReference),
+                                        functionCall("sum", defaultFrame, discountReference)),
                                         anyNot(WindowNode.class)))));
     }
 
     @Test
     public void testNotMergeDifferentFrames()
     {
-        WindowFrame frameC = new WindowFrame(
+        Optional<WindowFrame> frameC = Optional.of(new WindowFrame(
                 WindowFrame.Type.ROWS,
                 new FrameBound(FrameBound.Type.UNBOUNDED_PRECEDING),
-                Optional.of(new FrameBound(FrameBound.Type.CURRENT_ROW)));
+                Optional.of(new FrameBound(FrameBound.Type.CURRENT_ROW))));
 
-        Window windowC = new Window(
-                ImmutableList.of(new SymbolReference("suppkey")),
-                ImmutableList.of(new SortItem(new SymbolReference("orderkey"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
-                Optional.of(frameC));
+        WindowNode.Specification specificationC = new WindowNode.Specification(
+                ImmutableList.of(suppkey),
+                ImmutableList.of(orderkey),
+                ImmutableMap.of(orderkey, SortOrder.ASC_NULLS_LAST));
 
-        WindowFrame frameD = new WindowFrame(
+        Optional<WindowFrame> frameD = Optional.of(new WindowFrame(
                 WindowFrame.Type.ROWS,
                 new FrameBound(FrameBound.Type.CURRENT_ROW),
-                Optional.of(new FrameBound(FrameBound.Type.UNBOUNDED_FOLLOWING)));
+                Optional.of(new FrameBound(FrameBound.Type.UNBOUNDED_FOLLOWING))));
 
-        Window windowD = new Window(
-                ImmutableList.of(new SymbolReference("suppkey")),
-                ImmutableList.of(new SortItem(new SymbolReference("orderkey"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
-                Optional.of(frameD));
+        WindowNode.Specification specificationD = new WindowNode.Specification(
+                ImmutableList.of(suppkey),
+                ImmutableList.of(orderkey),
+                ImmutableMap.of(orderkey, SortOrder.ASC_NULLS_LAST));
 
         @Language("SQL") String sql = "select " +
                 "sum(quantity) over (partition by suppkey order by orderkey rows between unbounded preceding and current row) sum_quantity_C, " +
@@ -247,31 +281,33 @@ public class TestMergeIdenticalWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(ImmutableList.of(
-                                functionCall("avg", windowD, false, "quantity")),
-                                window(ImmutableList.of(
-                                        functionCall("sum", windowC, false, "discount"),
-                                        functionCall("sum", windowC, false, "quantity")),
+                        window(specificationD,
+                                ImmutableList.of(
+                                functionCall("avg", frameD, quantityReference)),
+                                window(specificationC,
+                                        ImmutableList.of(
+                                        functionCall("sum", frameC, discountReference),
+                                        functionCall("sum", frameC, quantityReference)),
                                         any()))));
     }
 
     @Test
     public void testNotMergeDifferentFramesWithDefault()
     {
-        Window windowC = new Window(
-                ImmutableList.of(new SymbolReference("suppkey")),
-                ImmutableList.of(new SortItem(new SymbolReference("orderkey"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
-                Optional.empty());
+        WindowNode.Specification specificationC = new WindowNode.Specification(
+                ImmutableList.of(suppkey),
+                ImmutableList.of(orderkey),
+                ImmutableMap.of(orderkey, SortOrder.ASC_NULLS_LAST));
 
-        WindowFrame frameD = new WindowFrame(
+        Optional<WindowFrame> frameD = Optional.of(new WindowFrame(
                 WindowFrame.Type.ROWS,
                 new FrameBound(FrameBound.Type.CURRENT_ROW),
-                Optional.of(new FrameBound(FrameBound.Type.UNBOUNDED_FOLLOWING)));
+                Optional.of(new FrameBound(FrameBound.Type.UNBOUNDED_FOLLOWING))));
 
-        Window windowD = new Window(
-                ImmutableList.of(new SymbolReference("suppkey")),
-                ImmutableList.of(new SortItem(new SymbolReference("orderkey"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
-                Optional.of(frameD));
+        WindowNode.Specification specificationD = new WindowNode.Specification(
+                ImmutableList.of(suppkey),
+                ImmutableList.of(orderkey),
+                ImmutableMap.of(orderkey, SortOrder.ASC_NULLS_LAST));
 
         @Language("SQL") String sql = "select " +
                 "sum(quantity) over (partition by suppkey order by orderkey) sum_quantity_C, " +
@@ -281,11 +317,13 @@ public class TestMergeIdenticalWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(ImmutableList.of(
-                                functionCall("avg", windowD, false, "quantity")),
-                                window(ImmutableList.of(
-                                        functionCall("sum", windowC, false, "discount"),
-                                        functionCall("sum", windowC, false, "quantity")),
+                        window(specificationD,
+                                ImmutableList.of(
+                                functionCall("avg", frameD, quantityReference)),
+                                window(specificationC,
+                                        ImmutableList.of(
+                                        functionCall("sum", defaultFrame, discountReference),
+                                        functionCall("sum", defaultFrame, quantityReference)),
                                         any()))));
     }
 
@@ -295,25 +333,34 @@ public class TestMergeIdenticalWindows
         @Language("SQL") String sql = "with foo as (" +
                 "select " +
                 "suppkey, orderkey, partkey, " +
-                "sum(discount) over (partition by orderkey order by shipdate rows between UNBOUNDED preceding and CURRENT ROW) a " +
+                "sum(discount) over (partition by orderkey order by shipdate, quantity desc rows between UNBOUNDED preceding and CURRENT ROW) a " +
                 "from lineitem where (partkey = 272 or partkey = 273) and suppkey > 50 " +
                 "), " +
                 "bar as ( " +
                 "select " +
                 "suppkey, orderkey, partkey, " +
-                "avg(quantity) over (partition by orderkey order by shipdate rows between UNBOUNDED preceding and CURRENT ROW) b " +
+                "avg(quantity) over (partition by orderkey order by shipdate, quantity desc rows between UNBOUNDED preceding and CURRENT ROW) b " +
                 "from lineitem where (partkey = 272 or partkey = 273) and suppkey > 50 " +
                 ")" +
                 "select * from foo, bar where foo.a = bar.b";
+
+        Symbol orderkey = symbolStem("orderkey");
+        Symbol shipdate = symbolStem("shipdate");
+        Symbol quantity = symbolStem("quantity");
+
+        WindowNode.Specification specificationC = new WindowNode.Specification(
+                ImmutableList.of(orderkey),
+                ImmutableList.of(shipdate, quantity),
+                ImmutableMap.of(shipdate, SortOrder.ASC_NULLS_LAST, quantity, SortOrder.DESC_NULLS_LAST));
 
         assertUnitPlan(sql,
                 anyTree(
                         join(JoinNode.Type.INNER, ImmutableList.of(),
                                 any(
-                                        window(ImmutableList.of(functionCall("sum", "*")),
+                                        window(specificationC, ImmutableList.of(functionCall("sum", commonFrame, symbolReferenceStem("discount"))),
                                                 anyTree())),
                                 any(
-                                        window(ImmutableList.of(functionCall("avg", "*")),
+                                        window(specificationC, ImmutableList.of(functionCall("avg", commonFrame, symbolReferenceStem("quantity"))),
                                                 anyTree())))));
     }
 


### PR DESCRIPTION
Per offline discussion with @martint, pending the arrival of the new optimizer, unit tests should be asserting some things about WindowNodes against the WindowNode.Specification, and somethings against the WindowFunctions contained in the WindowNodes.

This updates the implementation of the matching code to do be consistent with that, and should make it harder to get false positives.

I have irretrievably screwed up the history on our internal PR, but if you'd like to look over the comments, it's here: https://github.com/Teradata/presto/pull/326. Apologies; won't do that again :-/
