### PR TITLE
use relative URI path from nextUri with host:port based on session server URI in client

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -95,6 +95,7 @@ public class StatementClient
     private final String timeZoneId;
     private final long requestTimeoutNanos;
     private final String user;
+    private final URI server;
 
     public StatementClient(HttpClient httpClient, JsonCodec<QueryResults> queryResultsCodec, ClientSession session, String query)
     {
@@ -110,6 +111,7 @@ public class StatementClient
         this.query = query;
         this.requestTimeoutNanos = session.getClientRequestTimeout().roundTo(NANOSECONDS);
         this.user = session.getUser();
+        this.server = session.getServer();
 
         Request request = buildQueryRequest(session, query);
         JsonResponse<QueryResults> response = httpClient.execute(request, responseHandler);
@@ -123,7 +125,7 @@ public class StatementClient
 
     private Request buildQueryRequest(ClientSession session, String query)
     {
-        Request.Builder builder = prepareRequest(preparePost(), uriBuilderFrom(session.getServer()).replacePath("/v1/statement").build())
+        Request.Builder builder = prepareRequest(preparePost(), uriBuilderFrom(server).replacePath("/v1/statement").build())
                 .setBodyGenerator(createStaticBodyGenerator(query, UTF_8));
 
         if (session.getSource() != null) {
@@ -238,9 +240,8 @@ public class StatementClient
     private Request.Builder prepareRequest(Request.Builder builder, URI nextUri)
     {
         builder.setHeader(PrestoHeaders.PRESTO_USER, user);
-        builder.setHeader(USER_AGENT, USER_AGENT_VALUE)
-                .setUri(nextUri);
-
+        builder.setHeader(USER_AGENT, USER_AGENT_VALUE);
+        builder.setUri(uriBuilderFrom(server).replacePath(nextUri.getPath()).build());
         return builder;
     }
 


### PR DESCRIPTION
When connecting to a coordinator behind a proxy server using jdbc or the presto-cli the nextUri contains the private host:port of the coordinator causing subsequent requests to fail if the private address is not reachable . Using the session server URI as the known endpoint and replacing the path in requested when processing the nextUri resolves the issue.
