### PR TITLE
Add approximate most frequent aggregation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -202,6 +202,19 @@ Approximate Aggregate Functions
     for all ``value``\ s. This function is equivalent to the variant of
     :func:`numeric_histogram` that takes a ``weight``, with a per-item weight of ``1``.
 
+.. function:: approx_most_frequent(max_counts, value) -> map<[same as value], bigint>
+
+    Returns an upper bound on the counts of up ``max_counts`` of some of the most
+    frequent ``value``\ s. The algorithm periodically truncates the histogram
+    to ``buckets`` entries and overflows the truncated entries by setting the
+    lowest retained entries to a constant, rounding up.
+    If there are fewer than ``max_counts`` distinct values, the result is the exact
+    histogram of ``value``. Otherwise, the result contains upper bounds on the counts
+    of ``max_counts`` distinct ``value``\ s.
+    Furthermore, the error is less than the minimum count retained in the histogram.
+    In both cases, the sum of the returned counts is at least the number of ``value``\ s.
+
+
 Statistical Aggregate Functions
 -------------------------------
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -178,6 +178,7 @@ import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.metadata.FunctionKind.WINDOW;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.SignatureBinder.applyBoundVariables;
+import static com.facebook.presto.operator.aggregation.ApproximateMostFrequentFunction.APPROXIMATE_MOST_FREQUENT;
 import static com.facebook.presto.operator.aggregation.ArbitraryAggregationFunction.ARBITRARY_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ChecksumAggregationFunction.CHECKSUM_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.CountColumn.COUNT_COLUMN;
@@ -501,6 +502,7 @@ public class FunctionRegistry
                 .function(DECIMAL_BETWEEN_OPERATOR)
                 .function(DECIMAL_DISTINCT_FROM_OPERATOR)
                 .function(HISTOGRAM)
+                .function(APPROXIMATE_MOST_FREQUENT)
                 .function(CHECKSUM_AGGREGATION)
                 .function(IDENTITY_CAST)
                 .function(ARBITRARY_AGGREGATION)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateMostFrequentFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateMostFrequentFunction.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.ExceededMemoryLimitException;
+import com.facebook.presto.bytecode.DynamicClassLoader;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.MapType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static java.lang.String.format;
+
+/**
+ * Aggregation function that approximates the frequency of the top-K elements for Zipfian distributions.
+ * This function keeps counts for a "frequent" subset of elements and assumes all other elements
+ * once fewer than the least-frequent "frequent" element.
+ *
+ * The algorithm is based loosely on:
+ *
+ * .. code-block:: none
+ *
+ * Ahmed Metwally, Divyakant Agrawal, and Amr El Abbadi,
+ * "Efficient Computation of Frequent and Top-*k* Elements in Data Streams",
+ * https://icmi.cs.ucsb.edu/research/tech_reports/reports/2005-23.pdf
+ */
+public class ApproximateMostFrequentFunction
+        extends SqlAggregationFunction
+{
+    public static final ApproximateMostFrequentFunction APPROXIMATE_MOST_FREQUENT = new ApproximateMostFrequentFunction();
+    public static final String NAME = "approx_most_frequent";
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(ApproximateMostFrequentFunction.class, "output", ApproximateMostFrequentState.class, BlockBuilder.class);
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(ApproximateMostFrequentFunction.class, "input", Type.class, ApproximateMostFrequentState.class, long.class, Block.class, int.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(ApproximateMostFrequentFunction.class, "combine", ApproximateMostFrequentState.class, ApproximateMostFrequentState.class);
+
+    public static final int EXPECTED_SIZE_FOR_HASHING = 10;
+
+    public ApproximateMostFrequentFunction()
+    {
+        super(NAME,
+                ImmutableList.of(comparableTypeParameter("K")),
+                ImmutableList.of(),
+                parseTypeSignature("map(K,bigint)"),
+                ImmutableList.of(parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature("K")));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Count the number of times each value occurs, mixing up counts for infrequent values after max buckets";
+    }
+
+    @Override
+    public InternalAggregationFunction specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type keyType = boundVariables.getTypeVariable("K");
+        return generateAggregation(keyType, BigintType.BIGINT);
+    }
+
+    private static InternalAggregationFunction generateAggregation(Type keyType, Type valueType)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(ApproximateMostFrequentFunction.class.getClassLoader());
+        List<Type> inputTypes = ImmutableList.of(BIGINT, keyType);
+        Type outputType = new MapType(keyType, valueType);
+        AccumulatorStateSerializer<ApproximateMostFrequentState> stateSerializer = new ApproximateMostFrequentStateSerializer(keyType);
+        Type intermediateType = stateSerializer.getSerializedType();
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, outputType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                createInputParameterMetadata(keyType),
+                INPUT_FUNCTION.bindTo(keyType),
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION,
+                ApproximateMostFrequentState.class,
+                stateSerializer,
+                new ApproximateMostFrequentStateFactory(),
+                outputType);
+
+        GenericAccumulatorFactoryBinder factory = new AccumulatorCompiler().generateAccumulatorFactoryBinder(metadata, classLoader);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, factory);
+    }
+
+    private static List<ParameterMetadata> createInputParameterMetadata(Type keyType)
+    {
+        return ImmutableList.of(new ParameterMetadata(STATE),
+                new ParameterMetadata(INPUT_CHANNEL, BIGINT),
+                new ParameterMetadata(BLOCK_INPUT_CHANNEL, keyType),
+                new ParameterMetadata(BLOCK_INDEX));
+    }
+
+    public static void input(Type type, ApproximateMostFrequentState state, long buckets, Block key, int position)
+    {
+        TypedApproximateMostFrequentHistogram typedHistogram = state.get();
+        if (typedHistogram == null) {
+            checkCondition(buckets >= 2, INVALID_FUNCTION_ARGUMENT, "approx_most_frequent bucket count must be greater than one");
+            typedHistogram = new TypedApproximateMostFrequentHistogram(type, EXPECTED_SIZE_FOR_HASHING, Ints.checkedCast(buckets));
+            state.set(typedHistogram);
+        }
+
+        try {
+            typedHistogram.add(position, key, 1L);
+        }
+        catch (ExceededMemoryLimitException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("The result of histogram may not exceed %s", e.getMaxMemory()));
+        }
+    }
+
+    public static void combine(ApproximateMostFrequentState state, ApproximateMostFrequentState otherState)
+    {
+        if (state.get() != null && otherState.get() != null) {
+            TypedApproximateMostFrequentHistogram typedHistogram = state.get();
+            try {
+                typedHistogram.addAll(otherState.get());
+            }
+            catch (ExceededMemoryLimitException e) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("The result of histogram may not exceed %s", e.getMaxMemory()));
+            }
+        }
+        else if (state.get() == null) {
+            state.set(otherState.get());
+        }
+    }
+
+    public static void output(ApproximateMostFrequentState state, BlockBuilder out)
+    {
+        TypedApproximateMostFrequentHistogram typedHistogram = state.get();
+        if (typedHistogram == null) {
+            out.appendNull();
+        }
+        else {
+            typedHistogram.writeMapTo(out);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateMostFrequentState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateMostFrequentState.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+
+@AccumulatorStateMetadata(stateSerializerClass = ApproximateMostFrequentStateSerializer.class, stateFactoryClass = ApproximateMostFrequentStateFactory.class)
+public interface ApproximateMostFrequentState
+        extends AccumulatorState
+{
+    void set(TypedApproximateMostFrequentHistogram histogram);
+
+    TypedApproximateMostFrequentHistogram get();
+
+    void addMemoryUsage(long memory);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateMostFrequentStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateMostFrequentStateFactory.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.operator.aggregation.state.AbstractGroupedAccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+
+import static java.util.Objects.requireNonNull;
+
+public class ApproximateMostFrequentStateFactory
+        implements AccumulatorStateFactory<ApproximateMostFrequentState>
+{
+    @Override
+    public ApproximateMostFrequentState createSingleState()
+    {
+        return new SingleApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends ApproximateMostFrequentState> getSingleStateClass()
+    {
+        return SingleApproximateMostFrequentState.class;
+    }
+
+    @Override
+    public ApproximateMostFrequentState createGroupedState()
+    {
+        return new GroupedApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends ApproximateMostFrequentState> getGroupedStateClass()
+    {
+        return GroupedApproximateMostFrequentState.class;
+    }
+
+    public static class GroupedApproximateMostFrequentState
+            extends AbstractGroupedAccumulatorState
+            implements ApproximateMostFrequentState
+    {
+        private final ObjectBigArray<TypedApproximateMostFrequentHistogram> typedHistogram = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            typedHistogram.ensureCapacity(size);
+        }
+
+        @Override
+        public TypedApproximateMostFrequentHistogram get()
+        {
+            return typedHistogram.get(getGroupId());
+        }
+
+        @Override
+        public void set(TypedApproximateMostFrequentHistogram value)
+        {
+            requireNonNull(value, "value is null");
+
+            TypedApproximateMostFrequentHistogram previous = get();
+            if (previous != null) {
+                size -= previous.getEstimatedSize();
+            }
+
+            typedHistogram.set(getGroupId(), value);
+            size += value.getEstimatedSize();
+        }
+
+        @Override
+        public void addMemoryUsage(long memory)
+        {
+            size += memory;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + typedHistogram.sizeOf();
+        }
+    }
+
+    public static class SingleApproximateMostFrequentState
+            implements ApproximateMostFrequentState
+    {
+        private TypedApproximateMostFrequentHistogram typedHistogram;
+
+        @Override
+        public TypedApproximateMostFrequentHistogram get()
+        {
+            return typedHistogram;
+        }
+
+        @Override
+        public void set(TypedApproximateMostFrequentHistogram value)
+        {
+            typedHistogram = value;
+        }
+
+        @Override
+        public void addMemoryUsage(long memory)
+        {
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            if (typedHistogram == null) {
+                return 0;
+            }
+            return typedHistogram.getEstimatedSize();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateMostFrequentStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateMostFrequentStateSerializer.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.RowType;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+
+public class ApproximateMostFrequentStateSerializer
+        implements AccumulatorStateSerializer<ApproximateMostFrequentState>
+{
+    private final Type type;
+
+    public ApproximateMostFrequentStateSerializer(Type type)
+    {
+        this.type = type;
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return new RowType(ImmutableList.of(BIGINT, new MapType(type, BIGINT)), Optional.empty());
+    }
+
+    @Override
+    public void serialize(ApproximateMostFrequentState state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            state.get().serialize(out);
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, ApproximateMostFrequentState state)
+    {
+        if (block.isNull(index)) {
+            state.set(null);
+        }
+        else {
+            Block subBlock = (Block) getSerializedType().getObject(block, index);
+            state.set(TypedApproximateMostFrequentHistogram.deserialize(type, subBlock));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedApproximateMostFrequentHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedApproximateMostFrequentHistogram.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.array.IntBigArray;
+import com.facebook.presto.array.LongBigArray;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.MapType;
+import com.google.common.primitives.Ints;
+import io.airlift.units.DataSize;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalLimit;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.type.TypeUtils.expectedValueSize;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static it.unimi.dsi.fastutil.HashCommon.arraySize;
+import static it.unimi.dsi.fastutil.HashCommon.murmurHash3;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A histogram that periodically truncates infrequent items and overflows their counters onto other items.
+ */
+public class TypedApproximateMostFrequentHistogram
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(TypedApproximateMostFrequentHistogram.class).instanceSize();
+
+    private static final float FILL_RATIO = 0.75f;
+    private static final float COMPACT_RATIO = 0.5f;
+    private static final long FOUR_MEGABYTES = new DataSize(4, MEGABYTE).toBytes();
+
+    private final int compactLimit;
+    private final LongBigArray counts;
+
+    private int maxFill;
+    private int mask;
+
+    private final Type type;
+
+    private BlockBuilder values;
+    private IntBigArray hashPositions;
+
+    public TypedApproximateMostFrequentHistogram(Type type, int expectedSize, int compactLimit)
+    {
+        this.type = type;
+        this.compactLimit = compactLimit;
+
+        checkArgument(expectedSize > 0, "expectedSize must be greater than zero");
+
+        int hashSize = arraySize(expectedSize, FILL_RATIO);
+
+        maxFill = calculateMaxFill(hashSize);
+        mask = hashSize - 1;
+        values = this.type.createBlockBuilder(new BlockBuilderStatus(), hashSize, expectedValueSize(type, hashSize));
+        hashPositions = new IntBigArray(-1);
+        hashPositions.ensureCapacity(hashSize);
+        counts = new LongBigArray();
+        counts.ensureCapacity(hashSize);
+    }
+
+    public long getEstimatedSize()
+    {
+        return INSTANCE_SIZE +
+                values.getRetainedSizeInBytes() +
+                counts.sizeOf() +
+                hashPositions.sizeOf();
+    }
+
+    private Block getValues()
+    {
+        return values.build();
+    }
+
+    private LongBigArray getCounts()
+    {
+        return counts;
+    }
+
+    public void addAll(TypedApproximateMostFrequentHistogram other)
+    {
+        Block otherValues = other.getValues();
+        LongBigArray otherCounts = other.getCounts();
+        for (int i = 0; i < otherValues.getPositionCount(); i++) {
+            long count = otherCounts.get(i);
+            if (count > 0) {
+                add(i, otherValues, count);
+            }
+        }
+    }
+
+    public void add(int position, Block block, long count)
+    {
+        int hashPosition = getHashPosition(com.facebook.presto.type.TypeUtils.hashPosition(type, block, position), mask);
+
+        // look for an empty slot or a slot containing this key
+        while (true) {
+            if (hashPositions.get(hashPosition) == -1) {
+                break;
+            }
+
+            if (type.equalTo(block, position, values, hashPositions.get(hashPosition))) {
+                counts.add(hashPositions.get(hashPosition), count);
+                return;
+            }
+
+            // increment position and mask to handle wrap around
+            hashPosition = (hashPosition + 1) & mask;
+        }
+
+        addNewGroup(hashPosition, position, block, count);
+    }
+
+    private void addNewGroup(int hashPosition, int position, Block block, long count)
+    {
+        hashPositions.set(hashPosition, values.getPositionCount());
+        counts.set(values.getPositionCount(), count);
+        type.appendTo(block, position, values);
+
+        compactIfNeeded();
+
+        rehashIfNeeded();
+
+        if (getEstimatedSize() > FOUR_MEGABYTES) {
+            throw exceededLocalLimit(new DataSize(4, MEGABYTE));
+        }
+    }
+
+    private void rehashIfNeeded()
+    {
+        // increase capacity, if necessary
+        if (values.getPositionCount() >= maxFill) {
+            int size = maxFill * 2;
+            int hashSize = arraySize(size + 1, FILL_RATIO);
+            mask = hashSize - 1;
+            rehash();
+        }
+    }
+
+    private void rehash()
+    {
+        int hashSize = mask + 1;
+        IntBigArray newHashPositions = new IntBigArray(-1);
+        newHashPositions.ensureCapacity(hashSize);
+
+        for (int i = 0; i < values.getPositionCount(); i++) {
+            // find an empty slot for the address
+            int hashPosition = getHashPosition(com.facebook.presto.type.TypeUtils.hashPosition(type, values, i), mask);
+            while (newHashPositions.get(hashPosition) != -1) {
+                hashPosition = (hashPosition + 1) & mask;
+            }
+
+            // record the mapping
+            newHashPositions.set(hashPosition, i);
+        }
+
+        maxFill = calculateMaxFill(hashSize);
+        hashPositions = newHashPositions;
+
+        this.counts.ensureCapacity(maxFill);
+    }
+
+    /**
+     * Call {@link #compact()} if over {@link #COMPACT_RATIO} of the value/count pairs exceeds {@link #compactLimit}.
+     * This should be called after insertion to limit memory usage.
+     */
+    private void compactIfNeeded()
+    {
+        if (values.getPositionCount() * COMPACT_RATIO > compactLimit) {
+            /*
+             * Note that we don't check value.getRetainedSizeInBytes() or anything value-dependent.
+             * This is because, for variable-length types, we can't use
+             * the exact byte size, as the probability of a new value triggering a compaction is approximately:
+             * min(1, (new value/count pair size) / (pre-compaction bytes - post-compaction bytes)
+             * In particular, if a value is longer than the (pre-compaction bytes - post-compaction bytes), then it will
+             * almost always be compacted out (the triggering value is almost always compacted out).
+             */
+            compact();
+        }
+    }
+
+    /**
+     * Ensure there are no more than {@link #compactLimit} value/counts pairs.
+     * This works by evicting the smallest counts and overflowing the counts to the smallest retained counts, increasing
+     * them all to the same value (rounding up).
+     * The end result is that the estimated counts are an upper bound to the true counts.
+     * In addition, the over-estimation is less than the minimum retained count.
+     * This is because every overflow increases the minimum retained count by the most.
+     */
+    private void compact()
+    {
+        if (values.getPositionCount() <= compactLimit) {
+            return;
+        }
+
+        int truncatedNum = values.getPositionCount() - compactLimit;
+        checkState(0 < truncatedNum);
+        checkState(truncatedNum < values.getPositionCount());
+
+        int hashSize = mask + 1;
+        BlockBuilder newValues = type.createBlockBuilder(new BlockBuilderStatus(), hashSize, expectedValueSize(type, hashSize));
+
+        // Sort the counts so we know which counts to truncate.
+        long[] countsSorted = new long[values.getPositionCount()];
+        for (int i = 0; i < values.getPositionCount(); i++) {
+            countsSorted[i] = counts.get(i);
+        }
+        Arrays.sort(countsSorted);
+
+        // Redistribute truncated counts approximately to the overflowed counts:
+        // If countsCopy = [1, 1, 2, 3, 10, 15, 20] and we need to truncate the 2 counts [1, 1]...
+        long truncatedSum = 0;
+        // Number equal to max truncated. 2 in this case. Used to break ties.
+        long maxTruncated = countsSorted[truncatedNum - 1];
+        int maxTruncatedCount = 0;
+        for (int i = 0; i < truncatedNum; ++i) {
+            truncatedSum += countsSorted[i];
+            if (countsSorted[i] == maxTruncated) {
+                ++maxTruncatedCount;
+            }
+        }
+
+        // Overflow [1, 1] into the start of [2, 3, 10, 15, 20] by increasing the smallest prefix of the array to a
+        // constant, maintaining sorted order.
+        // For the example, overflow until the 10, producing [4, 4, 10, 15, 20].
+        // This is where overflowSum = sum([1, 1, 2, 3]) <= sum([4, 4]) <= 10 * 2.
+        int overflowUntil = truncatedNum;
+        long overflowSum = truncatedSum;
+        while (overflowUntil < countsSorted.length &&
+                countsSorted[overflowUntil] * (overflowUntil - truncatedNum) < overflowSum) {
+            overflowSum += countsSorted[overflowUntil++];
+        }
+        int overflowNum = overflowUntil - truncatedNum;
+        long overflowConstant = overflowNum == 0 ? 0 : (overflowSum + (overflowNum - 1)) / overflowNum;
+
+        // Copy the value/count pairs over, skipping truncated counts and "overflowing" other counts.
+        for (int oldPosition = 0; oldPosition < values.getPositionCount(); ++oldPosition) {
+            long oldCount = counts.get(oldPosition);
+
+            // Skip the truncated values
+            if (oldCount < maxTruncated
+                    // If there's a tie, break it by first-come-first-serve
+                    || (oldCount == maxTruncated && maxTruncatedCount-- > 0)) {
+                continue;
+            }
+
+            final int newPosition = newValues.getPositionCount();
+            checkState(newPosition <= oldPosition);
+            counts.set(newPosition, Math.max(overflowConstant, oldCount));
+            values.writePositionTo(oldPosition, newValues);
+            newValues.closeEntry();
+        }
+
+        values = newValues;
+        checkState(values.getPositionCount() == compactLimit);
+
+        rehash();
+    }
+
+    private static int getHashPosition(long rawHash, int mask)
+    {
+        return ((int) murmurHash3(rawHash)) & mask;
+    }
+
+    private static int calculateMaxFill(int hashSize)
+    {
+        checkArgument(hashSize > 0, "hashSize must greater than 0");
+        int maxFill = (int) Math.ceil(hashSize * FILL_RATIO);
+        if (maxFill == hashSize) {
+            maxFill--;
+        }
+        checkArgument(hashSize > maxFill, "hashSize must be larger than maxFill");
+        return maxFill;
+    }
+
+    public void writeMapTo(BlockBuilder out)
+    {
+        compact();
+
+        Block valuesBlock = values.build();
+        BlockBuilder blockBuilder = out.beginBlockEntry();
+        for (int i = 0; i < valuesBlock.getPositionCount(); i++) {
+            type.appendTo(valuesBlock, i, blockBuilder);
+            BIGINT.writeLong(blockBuilder, counts.get(i));
+        }
+        out.closeEntry();
+    }
+
+    public void serialize(BlockBuilder out)
+    {
+        BlockBuilder blockBuilder = out.beginBlockEntry();
+
+        BIGINT.writeLong(blockBuilder, compactLimit);
+        writeMapTo(blockBuilder);
+
+        out.closeEntry();
+    }
+
+    public static TypedApproximateMostFrequentHistogram deserialize(Type type, Block block)
+    {
+        requireNonNull(block, "block is null");
+        int compactLimit = Ints.checkedCast(BIGINT.getLong(block, 0));
+        final TypedApproximateMostFrequentHistogram histogram = new TypedApproximateMostFrequentHistogram(type, ApproximateMostFrequentFunction.EXPECTED_SIZE_FOR_HASHING, compactLimit);
+
+        Block mapBlock = new MapType(type, BIGINT).getObject(block, 1);
+        for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
+            histogram.add(i, mapBlock, BIGINT.getLong(mapBlock, i + 1));
+        }
+
+        return histogram;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateMostFrequent.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateMostFrequent.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.SqlTimestampWithTimeZone;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.TimeZoneKey;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.RowType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringArraysBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.operator.OperatorAssertion.toRow;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.operator.aggregation.ApproximateMostFrequentFunction.NAME;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TimeZoneKey.getTimeZoneKey;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.util.DateTimeZoneIndex.getDateTimeZone;
+import static com.facebook.presto.util.StructuralTestUtil.mapBlockOf;
+
+public class TestApproximateMostFrequent
+{
+    private static final MetadataManager metadata = MetadataManager.createTestMetadataManager();
+    private static final TimeZoneKey TIME_ZONE_KEY = getTimeZoneKey("UTC");
+    private static final DateTimeZone DATE_TIME_ZONE = getDateTimeZone(TIME_ZONE_KEY);
+
+    @Test
+    public void testSimpleHistograms()
+            throws Exception
+    {
+        MapType mapType = new MapType(VARCHAR, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.VARCHAR)));
+        assertAggregation(
+                aggregationFunction,
+                ImmutableMap.of("a", 1L, "b", 1L, "c", 1L),
+                createRLEBlock(251, 3),
+                createStringsBlock("a", "b", "c"));
+
+        mapType = new MapType(BIGINT, BIGINT);
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BIGINT)));
+        assertAggregation(
+                aggregationFunction,
+                ImmutableMap.of(100L, 1L, 200L, 1L, 300L, 1L),
+                createRLEBlock(251, 3),
+                createLongsBlock(100L, 200L, 300L));
+
+        mapType = new MapType(DOUBLE, BIGINT);
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.DOUBLE)));
+        assertAggregation(
+                aggregationFunction,
+                ImmutableMap.of(0.1, 1L, 0.3, 1L, 0.2, 1L),
+                createRLEBlock(251, 3),
+                createDoublesBlock(0.1, 0.3, 0.2));
+
+        mapType = new MapType(BOOLEAN, BIGINT);
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BOOLEAN)));
+        assertAggregation(
+                aggregationFunction,
+                ImmutableMap.of(true, 1L, false, 1L),
+                createRLEBlock(251, 2),
+                createBooleansBlock(true, false));
+    }
+
+    @Test
+    public void testDuplicateKeysValues()
+            throws Exception
+    {
+        MapType mapType = new MapType(VARCHAR, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.VARCHAR)));
+        assertAggregation(
+                aggregationFunction,
+                ImmutableMap.of("a", 2L, "b", 1L),
+                createRLEBlock(251, 3),
+                createStringsBlock("a", "b", "a"));
+
+        mapType = new MapType(TIMESTAMP_WITH_TIME_ZONE, BIGINT);
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE)));
+        long timestampWithTimeZone1 = packDateTimeWithZone(new DateTime(1970, 1, 1, 0, 0, 0, 0, DATE_TIME_ZONE).getMillis(), TIME_ZONE_KEY);
+        long timestampWithTimeZone2 = packDateTimeWithZone(new DateTime(2015, 1, 1, 0, 0, 0, 0, DATE_TIME_ZONE).getMillis(), TIME_ZONE_KEY);
+        assertAggregation(
+                aggregationFunction,
+                ImmutableMap.of(new SqlTimestampWithTimeZone(timestampWithTimeZone1), 2L, new SqlTimestampWithTimeZone(timestampWithTimeZone2), 1L),
+                createRLEBlock(251, 3),
+                createLongsBlock(timestampWithTimeZone1, timestampWithTimeZone1, timestampWithTimeZone2));
+    }
+
+    @Test
+    public void testWithNulls()
+            throws Exception
+    {
+        MapType mapType = new MapType(BIGINT, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BIGINT)));
+        assertAggregation(
+                aggregationFunction,
+                ImmutableMap.of(1L, 1L, 2L, 1L),
+                createRLEBlock(251, 3),
+                createLongsBlock(2L, null, 1L));
+
+        mapType = new MapType(BIGINT, BIGINT);
+        aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BIGINT)));
+        assertAggregation(
+                aggregationFunction,
+                null,
+                createRLEBlock(251, 1),
+                createLongsBlock((Long) null));
+        //noinspection RedundantArrayCreation
+        assertAggregation(
+                aggregationFunction,
+                null,
+                createRLEBlock(251, 0),
+                createLongsBlock(new Long[0]));
+    }
+
+    @Test
+    public void testArrayHistograms()
+            throws Exception
+    {
+        ArrayType arrayType = new ArrayType(VARCHAR);
+        MapType mapType = new MapType(arrayType, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), arrayType.getTypeSignature()));
+
+        assertAggregation(
+                aggregationFunction,
+                ImmutableMap.of(ImmutableList.of("a", "b", "c"), 1L, ImmutableList.of("d", "e", "f"), 1L, ImmutableList.of("c", "b", "a"), 1L),
+                createRLEBlock(251, 3),
+                createStringArraysBlock(ImmutableList.of(ImmutableList.of("a", "b", "c"), ImmutableList.of("d", "e", "f"), ImmutableList.of("c", "b", "a"))));
+    }
+
+    @Test
+    public void testMapHistograms()
+            throws Exception
+    {
+        MapType innerMapType = new MapType(VARCHAR, VARCHAR);
+        MapType mapType = new MapType(innerMapType, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), innerMapType.getTypeSignature()));
+
+        BlockBuilder builder = innerMapType.createBlockBuilder(new BlockBuilderStatus(), 3);
+        innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("a", "b")));
+        innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("c", "d")));
+        innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("e", "f")));
+
+        assertAggregation(
+                aggregationFunction,
+                ImmutableMap.of(ImmutableMap.of("a", "b"), 1L, ImmutableMap.of("c", "d"), 1L, ImmutableMap.of("e", "f"), 1L),
+                createRLEBlock(251, 3),
+                builder.build());
+    }
+
+    @Test
+    public void testRowHistograms()
+            throws Exception
+    {
+        RowType innerRowType = new RowType(ImmutableList.of(BIGINT, DOUBLE), Optional.of(ImmutableList.of("f1", "f2")));
+        MapType mapType = new MapType(innerRowType, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), innerRowType.getTypeSignature()));
+
+        BlockBuilder builder = innerRowType.createBlockBuilder(new BlockBuilderStatus(), 3);
+        innerRowType.writeObject(builder, toRow(ImmutableList.of(BIGINT, DOUBLE), 1L, 1.0));
+        innerRowType.writeObject(builder, toRow(ImmutableList.of(BIGINT, DOUBLE), 2L, 2.0));
+        innerRowType.writeObject(builder, toRow(ImmutableList.of(BIGINT, DOUBLE), 3L, 3.0));
+
+        assertAggregation(
+                aggregationFunction,
+                ImmutableMap.of(ImmutableList.of(1L, 1.0), 1L, ImmutableList.of(2L, 2.0), 1L, ImmutableList.of(3L, 3.0), 1L),
+                createRLEBlock(251, 3),
+                builder.build());
+    }
+
+    @Test
+    public void testLargerHistograms()
+            throws Exception
+    {
+        MapType mapType = new MapType(VARCHAR, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.VARCHAR)));
+        assertAggregation(
+                aggregationFunction,
+                // the d=1 and e=2 buckets are truncated and overflow onto the b=10 and c=12 buckets
+                // This result means a appeared at least 13 times and b and c appeared at least once each.
+                ImmutableMap.of("a", 25L, "b", 13L, "c", 13L),
+                createRLEBlock(3, 25 + 10 + 12 + 1 + 2),
+                createStringsBlock("a", "b", "c", "d", "e", "e", "c", "a", "a", "a", "b", "a", "a", "a", "a", "b", "a", "a", "a", "a", "b", "a", "a", "a", "a", "b", "a", "a", "a", "a", "b", "a", "c", "c", "b", "a", "c", "c", "b", "a", "c", "c", "b", "a", "c", "c", "b", "a", "c", "c"));
+    }
+
+    @Test
+    public void testHighCardinality()
+            throws Exception
+    {
+        MapType mapType = new MapType(VARCHAR, BIGINT);
+        InternalAggregationFunction aggregationFunction = metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature(NAME, AGGREGATE, mapType.getTypeSignature(), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.VARCHAR)));
+        assertAggregation(
+                aggregationFunction,
+                // The 6 cdefgh overflow onto the 2 ab buckets, resulting in 9+ of each of a and b
+                // Due to extra compactions, the result is actually 10 each
+                // Note that this result merely means that:
+                // - a and b appeared 1-10 times
+                // - there are up to 20 values.
+                // - nothing appeared more than 10 times
+                ImmutableMap.of("a", 10L, "b", 10L),
+                createRLEBlock(2, 6 * (2 + 1)),
+                // c [ab] d [ab] e [ab] f [ab] g [ab] h [ab]
+                createStringsBlock("c", "a", "b", "d", "a", "b", "e", "a", "b", "f", "a", "b", "g", "a", "b", "h", "a", "b"));
+    }
+}


### PR DESCRIPTION
(Moved from https://github.com/prestodb/presto/pull/4120)

This PR adds a truncated histogram aggregation that computes an approximate histogram of values. It's a hybrid of `histogram` and `numeric_histogram`.

The truncated histogram aggregation can be used to get an upper and lower bound for how many times each value appears in a column, for up to `buckets` values:
- For less than `buckets` distinct values, it'll return the same result as `histogram(value)`.
- For skewed distributions, you can get tight bounds for most permutations of the distribution.
- For unskewed distributions, the bounds will be very loose. (for example, `SELECT approx_most_frequent(251, user_id) FROM users`).
- I think, if any value appears more than `1 / buckets` of the time, it will be reported.

In addition, just like `histogram`, if the memory usage exceeds 4 MB, the query will fail. However, this generally happens only when the bucket count is set too high. I've also decreased the hash table load factor from 90% to 75% because it gives me 1.8x throughput (rows/cpu sec) in my tests.

Original issue: https://github.com/facebook/presto/issues/4094
Copied from: https://github.com/facebook/presto/pull/4119/

Text from issue:

> I'm looking for an efficient way to get an (approximate) histogram of the frequent values for each column of a table. These columns are generally high-cardinality, but often skewed. Currently, I'm running a sequence of queries like:
> 
> ```
> SELECT col_x, count(*) AS c
>     FROM my_table
>     GROUP BY col_x
>     ORDER BY c DESC
>     LIMIT 250;
> ```
> 
> This is pretty slow when there are a lot of columns. I've tried running the queries together (using UNION ALL) and such, but it doesn't seem to avoid scanning the table multiple times. I'm looking for a faster way to approximate this result. I've looked at `TABLESAMPLE SYSTEM`, but it seems to omit data in a predictable way because of how my tables are laid out.
> 
> I've noticed there is the `histogram(value)` and `numeric_histogram(bucket_limit, value)` aggregations. Are there any plans for an approximate variant of my SQL query?
> 
> If not, would a patch be welcome? I'm thinking the signature would be:
> `approx_most_frequent(bucket_limit, value)`. The algorithm would be a variant of Space-Saving [1], which computes frequent elements in constant space and linear time in input size. It returns tight error bounds for skewed data. In the limit, as `bucket_limit => infinity`, it degrades to `histogram`.
> The implementation would be similar to that of `numeric_histogram`: Periodically, the smallest counters are merged.
> 
> [1] Ahmed Metwally, Divyakant Agrawal, and Amr El Abbadi,
>         "Efficient Computation of Frequent and Top-_k_ Elements in Data Streams",
>         https://icmi.cs.ucsb.edu/research/tech_reports/reports/2005-23.pdf
