### PR TITLE
Null input check at javascript truncateString

### DIFF
--- a/presto-main/src/main/resources/webapp/assets/utils.js
+++ b/presto-main/src/main/resources/webapp/assets/utils.js
@@ -117,7 +117,7 @@ function addExponentiallyWeightedToHistory (value, valuesArray) {
 // =================
 
 function truncateString(inputString, length) {
-    if (inputString.length > length) {
+    if (inputString != null && inputString.length > length) {
         return inputString.substring(0, length) + "...";
     }
 


### PR DESCRIPTION
When `source` is not set from a Presto client, the web console cannot render query list due to javascript `null` reference error at `truncateString`

Another idea might be checking null reference at https://github.com/prestodb/presto/blob/master/presto-main/src/main/resources/webapp/assets/query-list.js#L169 but `truncateString` need to be safer as null value could be passed from various places