### PR TITLE
Categorized error for too many dots

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUtil.java
@@ -16,6 +16,7 @@ package com.facebook.presto.metadata;
 import com.facebook.presto.Session;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.SemanticException;
@@ -28,6 +29,7 @@ import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.spi.StandardErrorCode.SYNTAX_ERROR;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.CATALOG_NOT_SPECIFIED;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.SCHEMA_NOT_SPECIFIED;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -93,7 +95,9 @@ public final class MetadataUtil
     {
         requireNonNull(session, "session is null");
         requireNonNull(name, "name is null");
-        checkArgument(name.getParts().size() <= 3, "Too many dots in table name: %s", name);
+        if (name.getParts().size() > 3) {
+            throw new PrestoException(SYNTAX_ERROR, format("Too many dots in table name: %s", name));
+        }
 
         List<String> parts = Lists.reverse(name.getParts());
         String objectName = parts.get(0);


### PR DESCRIPTION
Fixes #5596 
Query will fail when no catalog is found.

```
presto> select * from a.b.c.d;
Query 20160907_112918_00000_ygcxs failed: line 1:15: Catalog b does not exist
```
