### PR TITLE
Fix incorrect effective predicate derivation for GROUP BY ()

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -100,6 +100,15 @@ public class EffectivePredicateExtractor
     @Override
     public Expression visitAggregation(AggregationNode node, Void context)
     {
+        // GROUP BY () always produces a group, regardless of whether there's any
+        // input (unlike the case where there are group by keys, which produce
+        // no output if there's no input).
+        // Therefore, we can't say anything about the effective predicate of the
+        // output of such an aggregation.
+        if (node.getGroupBy().isEmpty()) {
+            return TRUE_LITERAL;
+        }
+
         Expression underlyingPredicate = node.getSource().accept(this, context);
 
         return pullExpressionThroughSymbols(underlyingPredicate, node.getGroupBy());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -72,6 +72,7 @@ import static com.facebook.presto.sql.ExpressionUtils.and;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.or;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
+import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
@@ -165,6 +166,28 @@ public class TestEffectivePredicateExtractor
                         lessThan(BE, AE),
                         greaterThan(AE, bigintLiteral(2)),
                         equals(BE, CE)));
+    }
+
+    @Test
+    public void testGroupByEmpty()
+            throws Exception
+    {
+        PlanNode node = new AggregationNode(
+                newId(),
+                filter(baseTableScan, FALSE_LITERAL),
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableList.of(),
+                AggregationNode.Step.FINAL,
+                Optional.empty(),
+                1.0,
+                Optional.empty());
+
+        Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
+
+        assertEquals(effectivePredicate, TRUE_LITERAL);
     }
 
     @Test


### PR DESCRIPTION
It was incorrectly deriving "false" if the source expression
produces no rows. A GROUP BY () always produces one group.

Fixes https://github.com/prestodb/presto/issues/6059