### PR TITLE
Fix memory accounting in ParallelHashBuildOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ParallelHashBuildOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ParallelHashBuildOperator.java
@@ -197,8 +197,10 @@ public class ParallelHashBuildOperator
         checkState(!isFinished(), "Operator is already finished");
 
         index.addPage(page);
-
-        operatorContext.setMemoryReservation(page.getPositionCount());
+        if (!operatorContext.trySetMemoryReservation(index.getEstimatedSize().toBytes())) {
+            index.compact();
+        }
+        operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());
         operatorContext.recordGeneratedOutput(page.getSizeInBytes(), page.getPositionCount());
     }
 


### PR DESCRIPTION
Use same logic as for HashBuilderOperator

This bug/feature (?) was introduced in https://github.com/prestodb/presto/commit/6d27491a during rewriting `ParallelHashBuilder` into `ParallelHashBuildOperator`. Or @dain maybe I'm missing something?