### PR TITLE
Check if the value is null in truncateString

### DIFF
--- a/presto-main/src/main/resources/webapp/assets/utils.js
+++ b/presto-main/src/main/resources/webapp/assets/utils.js
@@ -117,7 +117,7 @@ function addExponentiallyWeightedToHistory (value, valuesArray) {
 // =================
 
 function truncateString(inputString, length) {
-    if (inputString.length > length) {
+    if (inputString != null && inputString.length > length) {
         return inputString.substring(0, length) + "...";
     }
 


### PR DESCRIPTION
truncateString should check if the value is null in order to prevent
exceptions. For example query-list.js passes query.session.source as
parameter and the value of it can be null. Currently, it throws an
exception and prevent the UI to be rendered if query.session.source is null