### PR TITLE
Introduce parameter in JDBC URL for secure connection

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -16,10 +16,7 @@ package com.facebook.presto.jdbc;
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.client.StatementClient;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.net.HostAndPort;
 import io.airlift.units.Duration;
 
 import java.net.URI;
@@ -41,7 +38,6 @@ import java.sql.SQLXML;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Struct;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
@@ -53,9 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Maps.fromProperties;
-import static io.airlift.http.client.HttpUriBuilder.uriBuilder;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -68,27 +62,26 @@ public class PrestoConnection
     private final AtomicReference<String> schema = new AtomicReference<>();
     private final AtomicReference<String> timeZoneId = new AtomicReference<>();
     private final AtomicReference<Locale> locale = new AtomicReference<>();
-    private final URI uri;
-    private final HostAndPort address;
+
+    private final PrestoDriverUri prestoDriverUri;
+
     private final String user;
     private final Map<String, String> clientInfo = new ConcurrentHashMap<>();
     private final Map<String, String> sessionProperties = new ConcurrentHashMap<>();
     private final AtomicReference<String> transactionId = new AtomicReference<>();
     private final QueryExecutor queryExecutor;
 
-    PrestoConnection(URI uri, String user, QueryExecutor queryExecutor)
+    PrestoConnection(PrestoDriverUri prestoDriverUri, String user, QueryExecutor queryExecutor)
             throws SQLException
     {
-        this.uri = requireNonNull(uri, "uri is null");
-        this.address = HostAndPort.fromParts(uri.getHost(), uri.getPort());
+        this.prestoDriverUri = prestoDriverUri;
+        this.schema.set(prestoDriverUri.getSchema());
+        this.catalog.set(prestoDriverUri.getCatalog());
+
         this.user = requireNonNull(user, "user is null");
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
         timeZoneId.set(TimeZone.getDefault().getID());
         locale.set(Locale.getDefault());
-
-        if (!isNullOrEmpty(uri.getPath())) {
-            setCatalogAndSchema();
-        }
     }
 
     @Override
@@ -562,7 +555,7 @@ public class PrestoConnection
 
     URI getURI()
     {
-        return uri;
+        return prestoDriverUri.getURI();
     }
 
     String getUser()
@@ -572,12 +565,12 @@ public class PrestoConnection
 
     ServerInfo getServerInfo()
     {
-        return queryExecutor.getServerInfo(getHttpUri());
+        return queryExecutor.getServerInfo(prestoDriverUri.getHttpUri());
     }
 
     StatementClient startQuery(String sql)
     {
-        URI uri = getHttpUri();
+        URI uri = prestoDriverUri.getHttpUri();
 
         String source = firstNonNull(clientInfo.get("ApplicationName"), "presto-jdbc");
 
@@ -585,8 +578,8 @@ public class PrestoConnection
                 uri,
                 user,
                 source,
-                catalog.get(),
-                schema.get(),
+                prestoDriverUri.getCatalog(),
+                prestoDriverUri.getSchema(),
                 timeZoneId.get(),
                 locale.get(),
                 ImmutableMap.copyOf(sessionProperties),
@@ -603,59 +596,6 @@ public class PrestoConnection
         if (isClosed()) {
             throw new SQLException("Connection is closed");
         }
-    }
-
-    private void setCatalogAndSchema()
-            throws SQLException
-    {
-        String path = uri.getPath();
-        if (path.equals("/")) {
-            return;
-        }
-
-        // remove first slash
-        if (!path.startsWith("/")) {
-            throw new SQLException("Path does not start with a slash: " + uri);
-        }
-        path = path.substring(1);
-
-        List<String> parts = Splitter.on("/").splitToList(path);
-
-        // remove last item due to a trailing slash
-        if (parts.get(parts.size() - 1).isEmpty()) {
-            parts = parts.subList(0, parts.size() - 1);
-        }
-
-        if (parts.size() > 2) {
-            throw new SQLException("Invalid path segments in URL: " + uri);
-        }
-
-        if (parts.get(0).isEmpty()) {
-            throw new SQLException("Catalog name is empty: " + uri);
-        }
-        catalog.set(parts.get(0));
-
-        if (parts.size() > 1) {
-            if (parts.get(1).isEmpty()) {
-                throw new SQLException("Schema name is empty: " + uri);
-            }
-            schema.set(parts.get(1));
-        }
-    }
-
-    @VisibleForTesting
-    URI getHttpUri()
-    {
-        return createHttpUri(address);
-    }
-
-    private static URI createHttpUri(HostAndPort address)
-    {
-        return uriBuilder()
-                .scheme((address.getPort() == 443) ? "https" : "http")
-                .host(address.getHostText())
-                .port(address.getPort())
-                .build();
     }
 
     private static void checkResultSet(int resultSetType, int resultSetConcurrency)

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriver.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriver.java
@@ -16,8 +16,6 @@ package com.facebook.presto.jdbc;
 import com.google.common.base.Throwables;
 
 import java.io.Closeable;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -44,7 +42,6 @@ public class PrestoDriver
 
     private static final DriverPropertyInfo[] DRIVER_PROPERTY_INFOS = {};
 
-    private static final String JDBC_URL_START = "jdbc:";
     private static final String DRIVER_URL_START = "jdbc:presto:";
 
     private static final String USER_PROPERTY = "user";
@@ -84,7 +81,7 @@ public class PrestoDriver
             throw new SQLException(format("Username property (%s) must be set", USER_PROPERTY));
         }
 
-        return new PrestoConnection(parseDriverUrl(url), user, queryExecutor);
+        return new PrestoConnection(new PrestoDriverUri(url), user, queryExecutor);
     }
 
     @Override
@@ -126,27 +123,5 @@ public class PrestoDriver
     {
         // TODO: support java.util.Logging
         throw new SQLFeatureNotSupportedException();
-    }
-
-    private static URI parseDriverUrl(String url)
-            throws SQLException
-    {
-        URI uri;
-        try {
-            uri = new URI(url.substring(JDBC_URL_START.length()));
-        }
-        catch (URISyntaxException e) {
-            throw new SQLException("Invalid JDBC URL: " + url, e);
-        }
-        if (isNullOrEmpty(uri.getHost())) {
-            throw new SQLException("No host specified: " + url);
-        }
-        if (uri.getPort() == -1) {
-            throw new SQLException("No port number specified: " + url);
-        }
-        if ((uri.getPort() < 1) || (uri.getPort() > 65535)) {
-            throw new SQLException("Invalid port number: " + url);
-        }
-        return uri;
     }
 }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.jdbc;
+
+import com.google.common.base.Splitter;
+import com.google.common.net.HostAndPort;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.airlift.http.client.HttpUriBuilder.uriBuilder;
+
+/**
+ * Container for parameters of a JDBC connection. The class is also responsible for parsing Presto JDBC URL.
+ */
+final class PrestoDriverUri
+{
+    private static final String JDBC_URL_START = "jdbc:";
+
+    private static final Splitter QUERY_SPLITTER = Splitter.on('&').omitEmptyStrings();
+    private static final Splitter ARG_SPLITTER = Splitter.on('=').limit(2);
+
+    private final HostAndPort address;
+    private final URI uri;
+
+    private String catalog;
+    private String schema;
+
+    public PrestoDriverUri(String url)
+            throws SQLException
+    {
+        this(parseDriverUrl(url));
+    }
+
+    public PrestoDriverUri(URI uri)
+            throws SQLException
+    {
+        this.uri = uri;
+        this.address = HostAndPort.fromParts(uri.getHost(), uri.getPort());
+
+        Map<String, String> params = parseParameters(uri.getQuery());
+
+        initCatalogAndSchema();
+    }
+
+    public URI getURI()
+    {
+        return uri;
+    }
+
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    public String getCatalog()
+    {
+        return catalog;
+    }
+
+    public URI getHttpUri()
+    {
+        return buildHttpUri();
+    }
+
+    private Map<String, String> parseParameters(String query)
+    {
+        Map<String, String> result = new HashMap<>();
+
+        if (query != null) {
+            Iterable<String> queryArgs = QUERY_SPLITTER.split(query);
+            for (String queryArg : queryArgs) {
+                List<String> parts = ARG_SPLITTER.splitToList(queryArg);
+                result.put(parts.get(0), parts.get(1));
+            }
+        }
+
+        return result;
+    }
+
+    private static URI parseDriverUrl(String url)
+            throws SQLException
+    {
+        URI uri;
+        try {
+            uri = new URI(url.substring(JDBC_URL_START.length()));
+        }
+        catch (URISyntaxException e) {
+            throw new SQLException("Invalid JDBC URL: " + url, e);
+        }
+        if (isNullOrEmpty(uri.getHost())) {
+            throw new SQLException("No host specified: " + url);
+        }
+        if (uri.getPort() == -1) {
+            throw new SQLException("No port number specified: " + url);
+        }
+        if ((uri.getPort() < 1) || (uri.getPort() > 65535)) {
+            throw new SQLException("Invalid port number: " + url);
+        }
+
+        return uri;
+    }
+
+    private URI buildHttpUri()
+    {
+        String scheme = (address.getPort() == 443) ? "https" : "http";
+
+        return uriBuilder()
+                .scheme(scheme)
+                .host(address.getHostText()).port(address.getPort())
+                .build();
+    }
+
+    private void initCatalogAndSchema()
+            throws SQLException
+    {
+        String path = uri.getPath();
+        if (isNullOrEmpty(uri.getPath()) || path.equals("/")) {
+            return;
+        }
+
+        // remove first slash
+        if (!path.startsWith("/")) {
+            throw new SQLException("Path does not start with a slash: " + uri);
+        }
+        path = path.substring(1);
+
+        List<String> parts = Splitter.on("/").splitToList(path);
+        // remove last item due to a trailing slash
+        if (parts.get(parts.size() - 1).isEmpty()) {
+            parts = parts.subList(0, parts.size() - 1);
+        }
+
+        if (parts.size() > 2) {
+            throw new SQLException("Invalid path segments in URL: " + uri);
+        }
+
+        if (parts.get(0).isEmpty()) {
+            throw new SQLException("Catalog name is empty: " + uri);
+        }
+        catalog = parts.get(0);
+
+        if (parts.size() > 1) {
+            if (parts.get(1).isEmpty()) {
+                throw new SQLException("Schema name is empty: " + uri);
+            }
+            schema = parts.get(1);
+        }
+    }
+}

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -42,6 +42,8 @@ final class PrestoDriverUri
     private String catalog;
     private String schema;
 
+    private final boolean useSecureConnection;
+
     public PrestoDriverUri(String url)
             throws SQLException
     {
@@ -55,6 +57,7 @@ final class PrestoDriverUri
         this.address = HostAndPort.fromParts(uri.getHost(), uri.getPort());
 
         Map<String, String> params = parseParameters(uri.getQuery());
+        useSecureConnection = Boolean.parseBoolean(params.get("secure"));
 
         initCatalogAndSchema();
     }
@@ -119,7 +122,7 @@ final class PrestoDriverUri
 
     private URI buildHttpUri()
     {
-        String scheme = (address.getPort() == 443) ? "https" : "http";
+        String scheme = (address.getPort() == 443 || useSecureConnection) ? "https" : "http";
 
         return uriBuilder()
                 .scheme(scheme)

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestDriver.java
@@ -44,7 +44,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
-import java.net.URI;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.DriverManager;
@@ -1275,18 +1274,6 @@ public class TestDriver
     }
 
     @Test
-    public void testConnectionWithSSL()
-            throws Exception
-    {
-        String url = format("jdbc:presto://some-ssl-server:443/%s", "blackhole");
-        try (PrestoConnection connection = (PrestoConnection) DriverManager.getConnection(url, "test", null)) {
-            URI uri = connection.getHttpUri();
-            assertEquals(uri.getPort(), 443);
-            assertEquals(uri.getScheme(), "https");
-        }
-    }
-
-    @Test
     public void testConnectionResourceHandling()
             throws Exception
     {
@@ -1325,46 +1312,6 @@ public class TestDriver
             throws Exception
     {
         try (Connection ignored = DriverManager.getConnection("jdbc:presto://test.invalid/")) {
-            fail("expected exception");
-        }
-    }
-
-    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Invalid path segments in URL: .*")
-    public void testBadUrlExtraPathSegments()
-            throws Exception
-    {
-        String url = format("jdbc:presto://%s/hive/default/bad_string", server.getAddress());
-        try (Connection ignored = DriverManager.getConnection(url, "test", null)) {
-            fail("expected exception");
-        }
-    }
-
-    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Catalog name is empty: .*")
-    public void testBadUrlMissingCatalog()
-            throws Exception
-    {
-        String url = format("jdbc:presto://%s//default", server.getAddress());
-        try (Connection ignored = DriverManager.getConnection(url, "test", null)) {
-            fail("expected exception");
-        }
-    }
-
-    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Catalog name is empty: .*")
-    public void testBadUrlEndsInSlashes()
-            throws Exception
-    {
-        String url = format("jdbc:presto://%s//", server.getAddress());
-        try (Connection ignored = DriverManager.getConnection(url, "test", null)) {
-            fail("expected exception");
-        }
-    }
-
-    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Schema name is empty: .*")
-    public void testBadUrlMissingSchema()
-            throws Exception
-    {
-        String url = format("jdbc:presto://%s/a//", server.getAddress());
-        try (Connection ignored = DriverManager.getConnection(url, "test", null)) {
             fail("expected exception");
         }
     }

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.jdbc;
+
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.sql.SQLException;
+
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+
+public class TestPrestoDriverUri
+{
+    private static final String SERVER = "127.0.0.1:60429";
+
+    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Invalid path segments in URL: .*")
+    public void testBadUrlExtraPathSegments()
+            throws Exception
+    {
+        String url = format("jdbc:presto://%s/hive/default/bad_string", SERVER);
+        new PrestoDriverUri(url);
+    }
+
+    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Catalog name is empty: .*")
+    public void testBadUrlMissingCatalog()
+            throws Exception
+    {
+        String url = format("jdbc:presto://%s//default", SERVER);
+        new PrestoDriverUri(url);
+    }
+
+    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Catalog name is empty: .*")
+    public void testBadUrlEndsInSlashes()
+            throws Exception
+    {
+        String url = format("jdbc:presto://%s//", SERVER);
+        new PrestoDriverUri(url);
+    }
+
+    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Schema name is empty: .*")
+    public void testBadUrlMissingSchema()
+            throws Exception
+    {
+        String url = format("jdbc:presto://%s/a//", SERVER);
+        new PrestoDriverUri(url);
+    }
+
+    @Test
+    public void testURIWithSSL()
+            throws SQLException
+    {
+        PrestoDriverUri parameters = new PrestoDriverUri(URI.create("presto://some-ssl-server:443/blackhole"));
+
+        URI uri = parameters.getHttpUri();
+        assertEquals(uri.getPort(), 443);
+        assertEquals(uri.getScheme(), "https");
+    }
+}

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
@@ -67,4 +67,37 @@ public class TestPrestoDriverUri
         assertEquals(uri.getPort(), 443);
         assertEquals(uri.getScheme(), "https");
     }
+
+    @Test
+    public void testURIWithSecureMissing()
+            throws SQLException
+    {
+        PrestoDriverUri parameters = new PrestoDriverUri(URI.create("presto://localhost:8080/blackhole"));
+
+        URI uri = parameters.getHttpUri();
+        assertEquals(uri.getPort(), 8080);
+        assertEquals(uri.getScheme(), "http");
+    }
+
+    @Test
+    public void testURIWithSecureTrue()
+            throws SQLException
+    {
+        PrestoDriverUri parameters = new PrestoDriverUri(URI.create("presto://localhost:8080/blackhole?secure=true"));
+
+        URI uri = parameters.getHttpUri();
+        assertEquals(uri.getPort(), 8080);
+        assertEquals(uri.getScheme(), "https");
+    }
+
+    @Test
+    public void testURIWithSecureFalse()
+            throws SQLException
+    {
+        PrestoDriverUri parameters = new PrestoDriverUri(URI.create("presto://localhost:8080/blackhole?secure=false"));
+
+        URI uri = parameters.getHttpUri();
+        assertEquals(uri.getPort(), 8080);
+        assertEquals(uri.getScheme(), "http");
+    }
 }

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
@@ -119,7 +119,7 @@ public class TestProgressMonitor
         HttpClient client = new TestingHttpClient(new TestingHttpClientProcessor(RESPONSES));
         QueryExecutor testQueryExecutor = QueryExecutor.create(client);
         URI uri = URI.create(format("prestotest://%s", SERVER_ADDRESS));
-        return new PrestoConnection(uri, "test", testQueryExecutor);
+        return new PrestoConnection(new PrestoDriverUri(uri), "test", testQueryExecutor);
     }
 
     private static class TestingHttpClientProcessor


### PR DESCRIPTION
In PR #5288, the secure connection has been supported with port `443`. This PR expands this with an additional parameter in the JDBC URL for all ports. The parameter `secure` and syntax of JDBC URL are similar to _MySQL Connector/J_.

Also added an abstraction of parameters for JDBC connections to support more parameters in future.
