### PR TITLE
Set the user agent suffix to use for s3 calls

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -135,6 +135,7 @@ public class PrestoS3FileSystem
     public static final String S3_ENCRYPTION_MATERIALS_PROVIDER = "presto.s3.encryption-materials-provider";
     public static final String S3_SSE_ENABLED = "presto.s3.sse.enabled";
     public static final String S3_CREDENTIALS_PROVIDER = "presto.s3.credentials-provider";
+    public static final String S3_USER_AGENT = "presto";
 
     private static final DataSize BLOCK_SIZE = new DataSize(32, MEGABYTE);
     private static final DataSize MAX_SKIP_SIZE = new DataSize(1, MEGABYTE);
@@ -185,7 +186,8 @@ public class PrestoS3FileSystem
                 .withProtocol(sslEnabled ? Protocol.HTTPS : Protocol.HTTP)
                 .withConnectionTimeout(Ints.checkedCast(connectTimeout.toMillis()))
                 .withSocketTimeout(Ints.checkedCast(socketTimeout.toMillis()))
-                .withMaxConnections(maxConnections);
+                .withMaxConnections(maxConnections)
+                .withUserAgentSuffix(S3_USER_AGENT);
 
         this.s3 = createAmazonS3Client(uri, conf, configuration);
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestPrestoS3FileSystem.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
@@ -23,7 +24,6 @@ import com.amazonaws.services.s3.model.EncryptionMaterials;
 import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
 import com.facebook.presto.hive.PrestoS3FileSystem.UnrecoverableS3OperationException;
 import com.google.common.base.StandardSystemProperty;
-import com.google.common.base.Throwables;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -39,12 +39,14 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.hive.PrestoS3FileSystem.S3_CREDENTIALS_PROVIDER;
 import static com.facebook.presto.hive.PrestoS3FileSystem.S3_ENCRYPTION_MATERIALS_PROVIDER;
 import static com.facebook.presto.hive.PrestoS3FileSystem.S3_MAX_BACKOFF_TIME;
 import static com.facebook.presto.hive.PrestoS3FileSystem.S3_MAX_CLIENT_RETRIES;
 import static com.facebook.presto.hive.PrestoS3FileSystem.S3_MAX_RETRY_TIME;
+import static com.facebook.presto.hive.PrestoS3FileSystem.S3_USER_AGENT;
 import static com.facebook.presto.hive.PrestoS3FileSystem.S3_USE_INSTANCE_CREDENTIALS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.testing.Assertions.assertInstanceOf;
@@ -347,6 +349,22 @@ public class TestPrestoS3FileSystem
         }
     }
 
+    @Test
+    public void testDefaultS3ClientConfiguration()
+            throws Exception
+    {
+        HiveClientConfig defaults = new HiveClientConfig();
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI("s3n://test-bucket/"), new Configuration());
+            ClientConfiguration clientConfiguration = getFieldValue(fs.getS3Client(), "clientConfiguration", ClientConfiguration.class);
+            assertEquals(clientConfiguration.getMaxErrorRetry(), defaults.getS3MaxErrorRetries());
+            assertEquals(clientConfiguration.getConnectionTimeout(), defaults.getS3ConnectTimeout().toMillis());
+            assertEquals(clientConfiguration.getSocketTimeout(), defaults.getS3SocketTimeout().toMillis());
+            assertEquals(clientConfiguration.getMaxConnections(), defaults.getS3MaxConnections());
+            assertEquals(clientConfiguration.getUserAgentSuffix(), S3_USER_AGENT);
+        }
+    }
+
     private static AWSCredentialsProvider getAwsCredentialsProvider(PrestoS3FileSystem fs)
     {
         return getFieldValue(fs.getS3Client(), "awsCredentialsProvider", AWSCredentialsProvider.class);
@@ -355,14 +373,24 @@ public class TestPrestoS3FileSystem
     @SuppressWarnings("unchecked")
     private static <T> T getFieldValue(Object instance, String name, Class<T> type)
     {
+        Optional<T> value = doGetFieldValue(instance, instance.getClass(), name, type);
+        if (value.isPresent()) {
+            return value.get();
+        }
+        value = doGetFieldValue(instance, instance.getClass().getSuperclass(), name, type);
+        return value.orElseThrow(() -> new RuntimeException("Field cannot be found: " + name));
+    }
+
+    private static <T> Optional<T> doGetFieldValue(Object instance, Class<?> clazz, String name, Class<T> type)
+    {
         try {
-            Field field = instance.getClass().getDeclaredField(name);
+            Field field = clazz.getDeclaredField(name);
             checkArgument(field.getType() == type, "expected %s but found %s", type, field.getType());
             field.setAccessible(true);
-            return (T) field.get(instance);
+            return Optional.of((T) field.get(instance));
         }
         catch (ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
The S3 client now supports prefixing/suffixing the user agent http header used in the s3 calls, which can be useful for debugging (knowing what client made a particular s3 call is useful). For now this PR sets only the suffix to `presto`, so the user agent http header looks something like:

```
aws-sdk-java/1.11.30 Mac_OS_X/10.11.3 Java_HotSpot(TM)_64-Bit_Server_VM/25.91-b14/1.8.0_91, presto
``` 

One question is, do we want to make this suffix configurable? The only case I can think of where it may help to configure this suffix is when a user has multiple presto clusters and the user wants to differentiate the s3 calls originating from each cluster.