### PR TITLE
Handle existing privileges for grant and revoke

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePrivilegeInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePrivilegeInfo.java
@@ -96,6 +96,13 @@ public class HivePrivilegeInfo
         return null;
     }
 
+    public boolean isContainedIn(HivePrivilegeInfo hivePrivilegeInfo)
+    {
+        return (getHivePrivilege().equals(hivePrivilegeInfo.getHivePrivilege()) &&
+                (isGrantOption() == hivePrivilegeInfo.isGrantOption() ||
+                        (!isGrantOption() && hivePrivilegeInfo.isGrantOption())));
+    }
+
     @Override
     public int hashCode()
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/ThriftHiveMetastore.java
@@ -52,6 +52,7 @@ import org.weakref.jmx.Managed;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,9 +62,14 @@ import java.util.function.Function;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static com.facebook.presto.hive.HiveUtil.PRESTO_VIEW_FLAG;
+import static com.facebook.presto.hive.metastore.HivePrivilegeInfo.HivePrivilege;
 import static com.facebook.presto.hive.metastore.HivePrivilegeInfo.HivePrivilege.OWNERSHIP;
+import static com.facebook.presto.hive.metastore.HivePrivilegeInfo.parsePrivilege;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.toGrants;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.Sets.newHashSet;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -564,9 +570,35 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public void grantTablePrivileges(String databaseName, String tableName, String grantee, Set<PrivilegeGrantInfo> privilegeGrantInfoSet)
+    public void grantTablePrivileges(String databaseName, String tableName, String grantee, Set<PrivilegeGrantInfo> requestedPrivileges)
     {
+        checkArgument(!containsAllPrivilege(requestedPrivileges), "\"ALL\" not supported in PrivilegeGrantInfo.privilege");
+
         try {
+            Set<HivePrivilegeInfo> existingPrivileges = getTablePrivileges(grantee, databaseName, tableName);
+
+            Set<PrivilegeGrantInfo> privilegesToGrant = newHashSet(requestedPrivileges);
+            for (Iterator<PrivilegeGrantInfo> iterator = privilegesToGrant.iterator(); iterator.hasNext(); ) {
+                HivePrivilegeInfo requestedPrivilege = getOnlyElement(parsePrivilege(iterator.next()));
+
+                for (HivePrivilegeInfo existingPrivilege : existingPrivileges) {
+                    if ((requestedPrivilege.isContainedIn(existingPrivilege))) {
+                        iterator.remove();
+                    }
+                    else if (existingPrivilege.isContainedIn(requestedPrivilege)) {
+                        throw new PrestoException(NOT_SUPPORTED, format(
+                                "Granting %s WITH GRANT OPTION is not supported while %s possesses %s",
+                                requestedPrivilege.getHivePrivilege().name(),
+                                grantee,
+                                requestedPrivilege.getHivePrivilege().name()));
+                    }
+              }
+            }
+
+            if (privilegesToGrant.isEmpty()) {
+                return;
+            }
+
             retry()
                     .stopOnIllegalExceptions()
                     .run("grantTablePrivileges", stats.getGrantTablePrivileges().wrap(() -> {
@@ -581,7 +613,7 @@ public class ThriftHiveMetastore
                             }
 
                             ImmutableList.Builder<HiveObjectPrivilege> privilegeBagBuilder = ImmutableList.builder();
-                            for (PrivilegeGrantInfo privilegeGrantInfo : privilegeGrantInfoSet) {
+                            for (PrivilegeGrantInfo privilegeGrantInfo : privilegesToGrant) {
                                 privilegeBagBuilder.add(
                                         new HiveObjectPrivilege(new HiveObjectRef(HiveObjectType.TABLE, databaseName, tableName, null, null),
                                                 grantee,
@@ -589,7 +621,6 @@ public class ThriftHiveMetastore
                                                 privilegeGrantInfo));
                             }
                             // TODO: Check whether the user/role exists in the hive metastore.
-                            // TODO: Check whether the user already has the given privilege.
                             metastoreClient.grantPrivileges(new PrivilegeBag(privilegeBagBuilder.build()));
                         }
                         return null;
@@ -604,9 +635,23 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public void revokeTablePrivileges(String databaseName, String tableName, String grantee, Set<PrivilegeGrantInfo> privilegeGrantInfoSet)
+    public void revokeTablePrivileges(String databaseName, String tableName, String grantee, Set<PrivilegeGrantInfo> requestedPrivileges)
     {
+        checkArgument(!containsAllPrivilege(requestedPrivileges), "\"ALL\" not supported in PrivilegeGrantInfo.privilege");
+
         try {
+            Set<HivePrivilege> existingHivePrivileges = getTablePrivileges(grantee, databaseName, tableName).stream()
+                    .map(HivePrivilegeInfo::getHivePrivilege)
+                    .collect(toSet());
+
+            Set<PrivilegeGrantInfo> privilegesToRevoke = requestedPrivileges.stream()
+                    .filter(privilegeGrantInfo -> existingHivePrivileges.contains(getOnlyElement(parsePrivilege(privilegeGrantInfo)).getHivePrivilege()))
+                    .collect(toSet());
+
+            if (privilegesToRevoke.isEmpty()) {
+                return;
+            }
+
             retry()
                     .stopOnIllegalExceptions()
                     .run("revokeTablePrivileges", stats.getRevokeTablePrivileges().wrap(() -> {
@@ -621,7 +666,7 @@ public class ThriftHiveMetastore
                             }
 
                             ImmutableList.Builder<HiveObjectPrivilege> privilegeBagBuilder = ImmutableList.builder();
-                            for (PrivilegeGrantInfo privilegeGrantInfo : privilegeGrantInfoSet) {
+                            for (PrivilegeGrantInfo privilegeGrantInfo : privilegesToRevoke) {
                                 privilegeBagBuilder.add(
                                         new HiveObjectPrivilege(
                                                 new HiveObjectRef(HiveObjectType.TABLE, databaseName, tableName, null, null),
@@ -630,7 +675,6 @@ public class ThriftHiveMetastore
                                                 privilegeGrantInfo));
                             }
                             // TODO: Check whether the user/role exists in the hive metastore.
-                            // TODO: Check whether the user possesses the given privilege before revoking.
                             metastoreClient.revokePrivileges(new PrivilegeBag(privilegeBagBuilder.build()));
                         }
                         return null;
@@ -645,6 +689,12 @@ public class ThriftHiveMetastore
             }
             throw Throwables.propagate(e);
         }
+    }
+
+    private boolean containsAllPrivilege(Set<PrivilegeGrantInfo> requestedPrivileges)
+    {
+        return requestedPrivileges.stream()
+                .anyMatch(privilege -> privilege.getPrivilege().equalsIgnoreCase("all"));
     }
 
     private Set<HivePrivilegeInfo> getPrivileges(String user, HiveObjectRef objectReference)

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.tests.hive;
 
+import com.teradata.tempto.BeforeTestWithContext;
 import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
@@ -28,6 +29,10 @@ import static java.lang.String.format;
 public class TestGrantRevoke
     extends ProductTest
 {
+    private String tableName;
+    private QueryExecutor aliceExecutor;
+    private QueryExecutor bobExecutor;
+
     /*
      * Pre-requisites for the tests in this class:
      *
@@ -37,55 +42,48 @@ public class TestGrantRevoke
      * "bob@presto" that has "jdbc_user: bob"
      * (all other values of the connection are same as that of the default "presto" connection).
     */
+
+    @BeforeTestWithContext
+    public void setup()
+    {
+        tableName = "alice_owned_table";
+        aliceExecutor = connectToPresto("alice@presto");
+        bobExecutor = connectToPresto("bob@presto");
+
+        aliceExecutor.executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
+        aliceExecutor.executeQuery(format("CREATE TABLE %s(month bigint, day bigint)", tableName));
+
+        assertAccessDeniedOnAllOperationsOnTable(bobExecutor, tableName);
+    }
+
     @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testGrantRevoke()
     {
-        String tableName = "alice_owned_table";
-        QueryExecutor queryExecutorForAlice = connectToPresto("alice@presto");
-        QueryExecutor queryExecutorForBob = connectToPresto("bob@presto");
-
-        queryExecutorForAlice.executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
-        queryExecutorForAlice.executeQuery(format("CREATE TABLE %s(month bigint, day bigint)", tableName));
-
-        assertThat(() -> queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).
-                failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
-        assertThat(() -> queryExecutorForBob.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).
-                failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
-
-        //test GRANT
-        queryExecutorForAlice.executeQuery(format("GRANT INSERT, SELECT ON %s TO bob", tableName));
-        assertThat(queryExecutorForBob.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).hasRowsCount(1);
-        assertThat(queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
-        assertThat(() -> queryExecutorForBob.executeQuery(format("DELETE FROM %s WHERE day=3", tableName))).
+        // test GRANT
+        aliceExecutor.executeQuery(format("GRANT INSERT, SELECT ON %s TO bob", tableName));
+        assertThat(bobExecutor.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).hasRowsCount(1);
+        assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
+        assertThat(() -> bobExecutor.executeQuery(format("DELETE FROM %s WHERE day=3", tableName))).
                 failsWithMessage(format("Access Denied: Cannot delete from table default.%s", tableName));
 
-        //test REVOKE
-        queryExecutorForAlice.executeQuery(format("REVOKE INSERT ON %s FROM bob", tableName));
-        assertThat(() -> queryExecutorForBob.executeQuery(format("INSERT INTO %s VALUES ('y', 5)", tableName))).
+        // test REVOKE
+        aliceExecutor.executeQuery(format("REVOKE INSERT ON %s FROM bob", tableName));
+        assertThat(() -> bobExecutor.executeQuery(format("INSERT INTO %s VALUES ('y', 5)", tableName))).
                 failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
-        assertThat(queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
+        assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
     }
 
     @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testGrantRevokeAll()
     {
-        String tableName = "alice_owned_table";
-        QueryExecutor queryExecutorForAlice = connectToPresto("alice@presto");
-        QueryExecutor queryExecutorForBob = connectToPresto("bob@presto");
+        aliceExecutor.executeQuery(format("GRANT ALL PRIVILEGES ON %s TO bob", tableName));
+        assertThat(bobExecutor.executeQuery(format("INSERT INTO %s VALUES (4, 13)", tableName))).hasRowsCount(1);
+        assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
+        bobExecutor.executeQuery(format("DELETE FROM %s", tableName));
+        assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
 
-        queryExecutorForAlice.executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
-        queryExecutorForAlice.executeQuery(format("CREATE TABLE %s(month bigint, day bigint)", tableName));
-
-        assertAccessDeniedOnAllOperationsOnTable(queryExecutorForBob, tableName);
-
-        queryExecutorForAlice.executeQuery(format("GRANT ALL PRIVILEGES ON %s TO bob", tableName));
-        assertThat(queryExecutorForBob.executeQuery(format("INSERT INTO %s VALUES (4, 13)", tableName))).hasRowsCount(1);
-        assertThat(queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
-        queryExecutorForBob.executeQuery(format("DELETE FROM %s", tableName));
-        assertThat(queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
-
-        queryExecutorForAlice.executeQuery(format("REVOKE ALL PRIVILEGES ON %s FROM bob", tableName));
-        assertAccessDeniedOnAllOperationsOnTable(queryExecutorForBob, tableName);
+        aliceExecutor.executeQuery(format("REVOKE ALL PRIVILEGES ON %s FROM bob", tableName));
+        assertAccessDeniedOnAllOperationsOnTable(bobExecutor, tableName);
     }
 
     private static void assertAccessDeniedOnAllOperationsOnTable(QueryExecutor queryExecutor, String tableName)

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -60,6 +60,8 @@ public class TestGrantRevoke
     public void testGrantRevoke()
     {
         // test GRANT
+        aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO bob WITH GRANT OPTION", tableName));
+        assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
         aliceExecutor.executeQuery(format("GRANT INSERT, SELECT ON %s TO bob", tableName));
         assertThat(bobExecutor.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).hasRowsCount(1);
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
@@ -71,6 +73,9 @@ public class TestGrantRevoke
         assertThat(() -> bobExecutor.executeQuery(format("INSERT INTO %s VALUES ('y', 5)", tableName))).
                 failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
+        aliceExecutor.executeQuery(format("REVOKE INSERT, SELECT ON %s FROM bob", tableName));
+        assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).
+                failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
     }
 
     @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})


### PR DESCRIPTION
At present, the grant and revoke code fails when trying to grant a privilege that the user already possesses or revoking a privilege that a user doesn't possess. This PR adds code for handing these cases. Also added a commit for cleaning up the existing product test. The two commits are in the following order:
1. Cleaning up the product test for grant and revoke
2. Handling existing privileges in grant and revoke statements.

Testing:
Modified the existing product test for grant/revoke.

TD internal review is here: https://github.com/Teradata/presto/pull/340

CC: @dain 