### PR TITLE
Make PartitionedLookupSourceSupplier closeable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceSupplier.java
@@ -22,15 +22,17 @@ import com.google.common.util.concurrent.SettableFuture;
 
 import javax.annotation.concurrent.GuardedBy;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public final class PartitionedLookupSourceSupplier
-        implements LookupSourceSupplier
+        implements LookupSourceSupplier, Closeable
 {
     private final List<Type> types;
     private final Map<Symbol, Integer> layout;
@@ -38,18 +40,10 @@ public final class PartitionedLookupSourceSupplier
     private final SettableFuture<LookupSource> lookupSourceFuture = SettableFuture.create();
     private final LookupSource[] partitions;
     private final boolean outer;
+    private final CompletableFuture<?> destroyed = new CompletableFuture<>();
 
     @GuardedBy("this")
     private int partitionsSet;
-
-    @GuardedBy("this")
-    private TaskContext taskContext;
-
-    @GuardedBy("this")
-    private long reservedMemory;
-
-    @GuardedBy("this")
-    private boolean destroyed;
 
     public PartitionedLookupSourceSupplier(List<Type> types, List<Integer> hashChannels, int partitionCount, Map<Symbol, Integer> layout, boolean outer)
     {
@@ -81,29 +75,19 @@ public final class PartitionedLookupSourceSupplier
         return lookupSourceFuture;
     }
 
-    public void setLookupSource(int partitionIndex, LookupSource lookupSource, OperatorContext operatorContext)
+    public void setLookupSource(int partitionIndex, LookupSource lookupSource)
     {
         PartitionedLookupSource partitionedLookupSource = null;
         synchronized (this) {
             requireNonNull(lookupSource, "lookupSource is null");
-            requireNonNull(operatorContext, "operatorContext is null");
 
-            if (destroyed) {
+            if (destroyed.isDone()) {
                 return;
             }
 
             checkState(partitions[partitionIndex] == null, "Partition already set");
             partitions[partitionIndex] = lookupSource;
             partitionsSet++;
-
-            // transfer lookup source memory to task context
-            long lookupSourceSizeInBytes = lookupSource.getInMemorySizeInBytes();
-            operatorContext.transferMemoryToTaskContext(lookupSourceSizeInBytes);
-            reservedMemory += lookupSourceSizeInBytes;
-
-            if (taskContext == null) {
-                taskContext = operatorContext.getDriverContext().getPipelineContext().getTaskContext();
-            }
 
             if (partitionsSet == partitions.length) {
                 partitionedLookupSource = new PartitionedLookupSource(ImmutableList.copyOf(partitions), hashChannelTypes, outer);
@@ -118,20 +102,16 @@ public final class PartitionedLookupSourceSupplier
     @Override
     public void destroy()
     {
-        TaskContext taskContext;
-        long reservedMemory;
-        synchronized (this) {
-            if (destroyed) {
-                return;
-            }
-            destroyed = true;
-            taskContext = this.taskContext;
-            reservedMemory = this.reservedMemory;
-        }
+        destroyed.complete(null);
+    }
 
-        // all references are released, free the task memory
-        if (taskContext != null) {
-            taskContext.freeMemory(reservedMemory);
-        }
+    public CompletableFuture<?> isDestroyed()
+    {
+        return destroyed;
+    }
+
+    @Override
+    public void close()
+    {
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -722,13 +722,17 @@ public class TestHashJoinOperator
                     100,
                     PARTITION_COUNT);
             PipelineContext buildPipeline = taskContext.addPipelineContext(true, true);
+
+            Driver[] buildDrivers = new Driver[PARTITION_COUNT];
             for (int i = 0; i < PARTITION_COUNT; i++) {
                 DriverContext buildDriverContext = buildPipeline.addDriverContext();
-                Driver buildDriver = new Driver(buildDriverContext,
+                buildDrivers[i] = new Driver(buildDriverContext,
                         sourceOperatorFactory.createOperator(buildDriverContext),
                         buildOperatorFactory.createOperator(buildDriverContext));
+            }
 
-                while (!buildDriver.isFinished()) {
+            while (!buildOperatorFactory.getLookupSourceSupplier().getLookupSource().isDone()) {
+                for (Driver buildDriver : buildDrivers) {
                     buildDriver.process();
                 }
             }


### PR DESCRIPTION
ParallelHashBuildOperators will wait untill theirs lookupSourceSupplier is no longer needed
and after that they will close it. This states clear ownership over lookupSourceSupplier
and prepares ground for two future changes:

1. Closing spilling resources
In previous model there had to be two operators (both HashBuilder and LookupJoin) to take care of closing `LookupSourceSupplier`. Which one should do it depended on query stage.

2. Memory revoking
Similarly as above. When there are multiple owners OR task context owns memory, there is
no single entity that could be responsible for revoking the memory reserved for LookupSourceSupplier

This is just first commit out of larger proposed change. Later, other lookupSources should be changed in similar way so that `transferMemoryToTaskContext` can be dropped all together.