### PR TITLE
Hotfix: Add missing presto-main dependency

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -22,6 +22,12 @@
         </dependency>
 
         <dependency>
+            <!-- used by tests but also needed transitively -->
+            <groupId>org.apache.bval</groupId>
+            <artifactId>bval-jsr</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
         </dependency>
@@ -286,12 +292,6 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-parser</artifactId>
             <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.bval</groupId>
-            <artifactId>bval-jsr</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Currently there is a problem while starting presto-server with basic setup from README due to class `ApacheValidationProvider` not being found. 

This is only **hotfix** to make master running, to be investigated:
 - Is ApacheValidationProvider really required outside of test now.
 - Why product tests didn't catch that problem.