### PR TITLE
Fix kafka plugin dependency scope

### DIFF
--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -112,6 +112,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- used by tests but also needed transitively -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -164,12 +171,6 @@
         <dependency>
             <groupId>com.101tec</groupId>
             <artifactId>zkclient</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>log-manager</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Before this fix queries were failing with the error below. /cc @electrum 

```
java.lang.NoClassDefFoundError: org/apache/log4j/Logger
        at kafka.utils.Logging$class.logger(Logging.scala:24)
        at kafka.consumer.SimpleConsumer.logger$lzycompute(SimpleConsumer.scala:30)
        at kafka.consumer.SimpleConsumer.logger(SimpleConsumer.scala:30)
        at kafka.utils.Logging$class.info(Logging.scala:67)
        at kafka.consumer.SimpleConsumer.info(SimpleConsumer.scala:30)
        at kafka.consumer.SimpleConsumer.liftedTree1$1(SimpleConsumer.scala:74)
        at kafka.consumer.SimpleConsumer.kafka$consumer$SimpleConsumer$$sendRequest(SimpleConsumer.scala:68)
        at kafka.consumer.SimpleConsumer.send(SimpleConsumer.scala:91)
        at kafka.javaapi.consumer.SimpleConsumer.send(SimpleConsumer.scala:68)
        at com.facebook.presto.kafka.KafkaSplitManager.getSplits(KafkaSplitManager.java:83)
        at com.facebook.presto.split.SplitManager.getSplits(SplitManager.java:45)
        at com.facebook.presto.sql.planner.DistributedExecutionPlanner$Visitor.visitTableScan(DistributedExecutionPlanner.java:112)
        at com.facebook.presto.sql.planner.DistributedExecutionPlanner$Visitor.visitTableScan(DistributedExecutionPlanner.java:92)
        at com.facebook.presto.sql.planner.plan.TableScanNode.accept(TableScanNode.java:135)
        at com.facebook.presto.sql.planner.DistributedExecutionPlanner$Visitor.visitLimit(DistributedExecutionPlanner.java:258)
        at com.facebook.presto.sql.planner.DistributedExecutionPlanner$Visitor.visitLimit(DistributedExecutionPlanner.java:92)
        at com.facebook.presto.sql.planner.plan.LimitNode.accept(LimitNode.java:86)
        at com.facebook.presto.sql.planner.DistributedExecutionPlanner.plan(DistributedExecutionPlanner.java:78)
        at com.facebook.presto.sql.planner.DistributedExecutionPlanner.plan(DistributedExecutionPlanner.java:83)
        at com.facebook.presto.execution.SqlQueryExecution.planDistribution(SqlQueryExecution.java:318)
        at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:231)
        at com.facebook.presto.execution.QueuedExecution.lambda$start$1(QueuedExecution.java:62)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
```