### PR TITLE
Fix predicate pushdown for Parquet

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -454,8 +454,8 @@ public class ParquetHiveRecordCursor
                     }
                     else {
                         splitGroup.add(block);
-                        offsets.add(block.getStartingPos());
                     }
+                    offsets.add(block.getStartingPos());
                 }
             }
 


### PR DESCRIPTION
Fix bug in:
https://github.com/prestodb/presto/commit/bf88119adcb7891e1c05022445f43846b1e8906b

should compute offsets for each block, no matter whether predicate pushdown is enabled