### PR TITLE
Optimize DictionaryBlock.copyPositions()

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -18,7 +18,9 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
@@ -28,7 +30,6 @@ import static io.airlift.slice.Slices.copyOf;
 import static io.airlift.slice.Slices.wrappedIntArray;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 public class DictionaryBlock
@@ -220,18 +221,19 @@ public class DictionaryBlock
     {
         checkValidPositions(positions, positionCount);
 
-        List<Integer> distinctPositions = positions.stream().distinct().collect(toList());
-        List<Integer> currentDictionaryIndexes = distinctPositions.stream().map(this::getIndex).collect(toList());
-
-        List<Integer> positionsToCopy = currentDictionaryIndexes.stream().distinct().collect(toList());
-        Block dictionaryBlock = dictionary.copyPositions(positionsToCopy);
-
+        List<Integer> positionsToCopy = new ArrayList<>();
+        Map<Integer, Integer> oldIndexToNewIndex = new HashMap<>();
         int[] newIds = new int[positions.size()];
+
         for (int i = 0; i < positions.size(); i++) {
-            int oldIndex = currentDictionaryIndexes.get(distinctPositions.indexOf(positions.get(i)));
-            newIds[i] = positionsToCopy.indexOf(oldIndex);
+            int oldIndex = getIndex(positions.get(i));
+            if (!oldIndexToNewIndex.containsKey(oldIndex)) {
+                oldIndexToNewIndex.put(oldIndex, positionsToCopy.size());
+                positionsToCopy.add(oldIndex);
+            }
+            newIds[i] = oldIndexToNewIndex.get(oldIndex);
         }
-        return new DictionaryBlock(positions.size(), dictionaryBlock, wrappedIntArray(newIds));
+        return new DictionaryBlock(positions.size(), dictionary.copyPositions(positionsToCopy), wrappedIntArray(newIds));
     }
 
     @Override


### PR DESCRIPTION
This reduces the time complexity from O(n^2) to O(n)