### PR TITLE
Update big_queries tests group

### DIFF
--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q1.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q1.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch, big_query; tables: lineitem
+-- database: presto; groups: tpch; tables: lineitem
 SELECT
   l_returnflag,
   l_linestatus,

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q10.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q10.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch, big_query; tables: customer,orders,lineitem,nation
+-- database: presto; groups: tpch; tables: customer,orders,lineitem,nation
 SELECT
   c_custkey,
   c_name,

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q12.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q12.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch, big_query; tables: orders,lineitem
+-- database: presto; groups: tpch; tables: orders,lineitem
 SELECT
   l_shipmode,
   sum(CASE

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q14.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q14.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch, big_query; tables: lineitem,part
+-- database: presto; groups: tpch; tables: lineitem,part
 SELECT 100.00 * sum(CASE
                     WHEN p_type LIKE 'PROMO%'
                       THEN l_extendedprice * (1 - l_discount)

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q18.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q18.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch, big_query; tables: customer,orders,lineitem
+-- database: presto; groups: tpch; tables: customer,orders,lineitem
 SELECT
   c_name,
   c_custkey,

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q3.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q3.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch, big_query; tables: customer,orders,lineitem
+-- database: presto; groups: tpch; tables: customer,orders,lineitem
 SELECT
   l_orderkey,
   sum(l_extendedprice * (1 - l_discount)) AS revenue,

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q7.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q7.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch, big_query; tables: supplier,lineitem,orders,customer,nation
+-- database: presto; groups: tpch; tables: supplier,lineitem,orders,customer,nation
 SELECT
   supp_nation,
   cust_nation,


### PR DESCRIPTION
Update big_queries tests group

Leave in big_query only tests which do not pass because of
the lack of resources in automation.
Previously this group contained also long running tests.
