### PR TITLE
Fix alias handling in sql formatter

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -382,8 +382,7 @@ public final class SqlFormatter
             process(node.getRelation(), indent);
 
             builder.append(' ')
-                    .append(node.getAlias());
-
+                    .append(formatName(node.getAlias()));
             appendAliasColumns(builder, node.getColumnNames());
 
             return null;

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1541,6 +1541,14 @@ public class TestSqlParser
                                         new ExistsPredicate(simpleQuery(selectList(new LongLiteral("2"))))))));
     }
 
+    @Test
+    public void testFormatter()
+    {
+        Statement parsed = SQL_PARSER.createStatement("prepare p from select * from (select * from T) \"A B\"");
+        String formatted =  formatSql(parsed, Optional.empty());
+        assertTrue(parsed.equals(SQL_PARSER.createStatement(formatted)));
+    }
+
     private static void assertCast(String type)
     {
         assertCast(type, type);


### PR DESCRIPTION
Currently the sql formatter cannot handle aliases with whitespace in them. I have seen queries like the one below from the teradata odbc driver and they fail right away.

```
presto:nyigitbasi> prepare p from select * from (select * from system.runtime.nodes) "A B C";
Query 20160921_182923_00000_sxu5w failed: Formatted query does not parse: Query{queryBody=QuerySpecification{select=Select{distinct=false, selectItems=[*]}, from=Optional[AliasedRelation{relation=TableSubquery{Query{queryBody=QuerySpecification{select=Select{distinct=false, selectItems=[*]}, from=Optional[Table{system.runtime.nodes}], where=null, groupBy=Optional.empty, having=null, orderBy=[], limit=null}, orderBy=[]}}, alias=A B C}], where=null, groupBy=Optional.empty, having=null, orderBy=[], limit=null}, orderBy=[]}
com.facebook.presto.spi.PrestoException: Formatted query does not parse: Query{queryBody=QuerySpecification{select=Select{distinct=false, selectItems=[*]}, from=Optional[AliasedRelation{relation=TableSubquery{Query{queryBody=QuerySpecification{select=Select{distinct=false, selectItems=[*]}, from=Optional[Table{system.runtime.nodes}], where=null, groupBy=Optional.empty, having=null, orderBy=[], limit=null}, orderBy=[]}}, alias=A B C}], where=null, groupBy=Optional.empty, having=null, orderBy=[], limit=null}, orderBy=[]}
        at com.facebook.presto.sql.SqlFormatterUtil.getFormattedSql(SqlFormatterUtil.java:42)
        at com.facebook.presto.execution.PrepareTask.execute(PrepareTask.java:71)
        at com.facebook.presto.execution.PrepareTask.execute(PrepareTask.java:39)
        at com.facebook.presto.execution.DataDefinitionExecution.start(DataDefinitionExecution.java:110)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
```