### PR TITLE
Fix duplicated TRY method generation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/TryExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/TryExpressionExtractor.java
@@ -21,8 +21,10 @@ import com.facebook.presto.sql.relational.InputReferenceExpression;
 import com.facebook.presto.sql.relational.RowExpression;
 import com.facebook.presto.sql.relational.RowExpressionVisitor;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 
 import java.util.List;
+import java.util.Set;
 
 import static com.facebook.presto.sql.relational.Signatures.TRY;
 import static com.google.common.base.Preconditions.checkState;
@@ -31,7 +33,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 public class TryExpressionExtractor
         implements RowExpressionVisitor<Scope, BytecodeNode>
 {
-    private final ImmutableList.Builder<CallExpression> tryExpressions = ImmutableList.builder();
+    private final Set<CallExpression> tryExpressions = Sets.newLinkedHashSet();
 
     @Override
     public BytecodeNode visitInputReference(InputReferenceExpression node, Scope scope)
@@ -65,6 +67,6 @@ public class TryExpressionExtractor
 
     public List<CallExpression> getTryExpressionsPreOrder()
     {
-        return tryExpressions.build().reverse();
+        return ImmutableList.copyOf(tryExpressions).reverse();
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2314,6 +2314,22 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testTryPushedDownLeftJoinClause()
+            throws Exception
+    {
+        // this pushdowns TRY function to the sub filters
+        assertQuery("SELECT * FROM " +
+                        "(SELECT regionkey FROM region WHERE regionkey < 1) t1 " +
+                        "   LEFT OUTER JOIN " +
+                        "(SELECT TRY(from_base(name, 36)) AS id FROM nation WHERE name IS NOT NULL) t2 " +
+                        "     ON t1.regionkey = t2.id " +
+                        "   LEFT OUTER JOIN " +
+                        "(SELECT TRY(from_base(name, 36)) AS id FROM nation WHERE name IS NOT NULL) t3 " +
+                        "     ON t2.id = t3.id",
+                "VALUES (0, NULL, NULL)");
+    }
+
+    @Test
     public void testLeftJoinWithEmptyInnerTable()
             throws Exception
     {


### PR DESCRIPTION
At the generation of `TRY` byte code generation, there could be the same `TRY` clause under sub expressions. 

I got the following exception.

```
Error Type  INTERNAL_ERROR
Error Code  COMPILER_ERROR (65543)
Stack Trace 
com.facebook.presto.spi.PrestoException: Compiler failed and interpreter is disabled
    at com.facebook.presto.sql.planner.LocalExecutionPlanner$Visitor.visitScanFilterAndProject(LocalExecutionPlanner.java:1038)
    at com.facebook.presto.sql.planner.LocalExecutionPlanner$Visitor.visitProject(LocalExecutionPlanner.java:933)
    at com.facebook.presto.sql.planner.LocalExecutionPlanner$Visitor.visitProject(LocalExecutionPlanner.java:525)
    at com.facebook.presto.sql.planner.plan.ProjectNode.accept(ProjectNode.java:81)
    at com.facebook.presto.sql.planner.LocalExecutionPlanner$Visitor.visitScanFilterAndProject(LocalExecutionPlanner.java:973)
    at com.facebook.presto.sql.planner.LocalExecutionPlanner$Visitor.visitProject(LocalExecutionPlanner.java:933)
    at com.facebook.presto.sql.planner.LocalExecutionPlanner$Visitor.visitProject(LocalExecutionPlanner.java:525)
    at com.facebook.presto.sql.planner.plan.ProjectNode.accept(ProjectNode.java:81)
    at com.facebook.presto.sql.planner.LocalExecutionPlanner$Visitor.visitAggregation(LocalExecutionPlanner.java:864)
    at com.facebook.presto.sql.planner.LocalExecutionPlanner$Visitor.visitAggregation(LocalExecutionPlanner.java:525)
    at com.facebook.presto.sql.planner.plan.AggregationNode.accept(AggregationNode.java:189)
    at com.facebook.presto.sql.planner.LocalExecutionPlanner.plan(LocalExecutionPlanner.java:340)
    at com.facebook.presto.sql.planner.LocalExecutionPlanner.plan(LocalExecutionPlanner.java:324)
    at com.facebook.presto.execution.SqlTaskExecution.<init>(SqlTaskExecution.java:161)
    at com.facebook.presto.execution.SqlTaskExecution.createSqlTaskExecution(SqlTaskExecution.java:120)
    at com.facebook.presto.execution.SqlTaskExecutionFactory.create(SqlTaskExecutionFactory.java:74)
...
Caused by: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Multiple entries with same key: from_base(#1, 36)=public java.lang.Long filter_try_1(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.RecordCursor cursor, boolean wasNull) and from_base(#1, 36)=public java.lang.Long filter_try_0(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.RecordCursor cursor, boolean wasNull)
    at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2203)
    at com.google.common.cache.LocalCache.get(LocalCache.java:3937)
    at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3941)
    at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4824)
    at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4830)
    at com.facebook.presto.sql.gen.ExpressionCompiler.compileCursorProcessor(ExpressionCompiler.java:86)
    at com.facebook.presto.sql.planner.LocalExecutionPlanner$Visitor.visitScanFilterAndProject(LocalExecutionPlanner.java:1009)
    ... 71 more
Caused by: java.lang.IllegalArgumentException: Multiple entries with same key: from_base(#1, 36)=public java.lang.Long filter_try_1(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.RecordCursor cursor, boolean wasNull) and from_base(#1, 36)=public java.lang.Long filter_try_0(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.RecordCursor cursor, boolean wasNull)
    at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:150)
    at com.google.common.collect.RegularImmutableMap.checkNoConflictInBucket(RegularImmutableMap.java:104)
    at com.google.common.collect.RegularImmutableMap.<init>(RegularImmutableMap.java:70)
    at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:254)
    at com.facebook.presto.sql.gen.CursorProcessorCompiler.generateTryMethods(CursorProcessorCompiler.java:222)
    at com.facebook.presto.sql.gen.CursorProcessorCompiler.generateFilterMethod(CursorProcessorCompiler.java:227)
    at com.facebook.presto.sql.gen.CursorProcessorCompiler.generateMethods(CursorProcessorCompiler.java:70)
    at com.facebook.presto.sql.gen.ExpressionCompiler.compileProcessor(ExpressionCompiler.java:134)
    at com.facebook.presto.sql.gen.ExpressionCompiler.compile(ExpressionCompiler.java:114)
    at com.facebook.presto.sql.gen.ExpressionCompiler.access$300(ExpressionCompiler.java:46)
    at com.facebook.presto.sql.gen.ExpressionCompiler$2.load(ExpressionCompiler.java:68)
    at com.facebook.presto.sql.gen.ExpressionCompiler$2.load(ExpressionCompiler.java:63)
    at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3527)
    at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2319)
    at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2282)
    at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2197)
    ... 77 more
```
