### PR TITLE
Check number of arguments for TRY

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1170,6 +1170,7 @@ class AstBuilder
             return new CoalesceExpression(getLocation(context), visit(context.expression(), Expression.class));
         }
         if (name.toString().equalsIgnoreCase("try")) {
+            check(context.expression().size() == 1, "The 'try' function must have exactly one argument", context);
             check(!window.isPresent(), "OVER clause not valid for 'try' function", context);
             check(!distinct, "DISTINCT not valid for 'try' function", context);
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5068,6 +5068,9 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT COUNT(CAST(orderkey AS VARCHAR) || TRY(to_base(100, CAST(round(totalprice/100) AS BIGINT)))) FROM orders",
                 "SELECT SUM(CASE WHEN CAST(round(totalprice/100) AS BIGINT) BETWEEN 2 AND 36 THEN 1 ELSE 0 END) FROM orders");
+
+        // missing function argument
+        assertQueryFails("SELECT TRY()", "line 1:8: The 'try' function must have exactly one argument");
     }
 
     // no regexp specified because the JVM optimizes away exception message constructor if run enough times


### PR DESCRIPTION
/cc @raghavsethi 

```
presto:default> select try();
Exception in thread "main" java.util.NoSuchElementException
        at java.util.Collections$EmptyIterator.next(Collections.java:4189)
        at com.google.common.collect.Iterators.getOnlyElement(Iterators.java:302)
        at com.google.common.collect.Iterables.getOnlyElement(Iterables.java:289)
        at com.facebook.presto.sql.parser.AstBuilder.visitFunctionCall(AstBuilder.java:1176)
        at com.facebook.presto.sql.parser.AstBuilder.visitFunctionCall(AstBuilder.java:160)
        at com.facebook.presto.sql.parser.SqlBaseParser$FunctionCallContext.accept(SqlBaseParser.java:6837)
        at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visitChildren(AbstractParseTreeVisitor.java:70)
        at com.facebook.presto.sql.parser.SqlBaseBaseVisitor.visitValueExpressionDefault(SqlBaseBaseVisitor.java:608)
        at com.facebook.presto.sql.parser.SqlBaseParser$ValueExpressionDefaultContext.accept(SqlBaseParser.java:5964)
        at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:42)
        at com.facebook.presto.sql.parser.AstBuilder.visitPredicated(AstBuilder.java:840)
        at com.facebook.presto.sql.parser.AstBuilder.visitPredicated(AstBuilder.java:160)
```