### PR TITLE
Fix race condition in TestHttpPageBufferClient

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
@@ -309,8 +309,13 @@ public class TestHttpPageBufferClient
         }
         catch (BrokenBarrierException ignored) {
         }
+        try {
+            afterRequest.await(10, TimeUnit.SECONDS);
+        }
+        catch (BrokenBarrierException ignored) {
+            afterRequest.reset();
+        }
         // client.close() triggers a DELETE request, so wait for it to finish
-        afterRequest.reset();
         beforeRequest.await(10, TimeUnit.SECONDS);
         afterRequest.await(10, TimeUnit.SECONDS);
         requestComplete.await(10, TimeUnit.SECONDS);


### PR DESCRIPTION
A unit test fails when request completes before "after request handler" is called which occasianally happens.
The fix is to wait for "after handler" to complete or reset the barrier if a thread was already interrupted.