### PR TITLE
Periodically cleanup old completed raptor transactions

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/H2ShardDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/H2ShardDao.java
@@ -17,9 +17,11 @@ import com.facebook.presto.raptor.util.UuidUtil.UuidArgumentFactory;
 import com.facebook.presto.raptor.util.UuidUtil.UuidMapperFactory;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterArgumentFactory;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapperFactory;
 
+import java.sql.Timestamp;
 import java.util.UUID;
 
 @RegisterArgumentFactory(UuidArgumentFactory.class)
@@ -31,4 +33,11 @@ public interface H2ShardDao
     @SqlBatch("MERGE INTO deleted_shards (shard_uuid, delete_time)\n" +
             "VALUES (:shardUuid, CURRENT_TIMESTAMP)")
     void insertDeletedShards(@Bind("shardUuid") Iterable<UUID> shardUuids);
+
+    @SqlUpdate("DELETE FROM transactions\n" +
+            "WHERE end_time < :maxEndTime\n" +
+            "  AND successful IS NOT NULL\n" +
+            "  AND transaction_id NOT IN (SELECT transaction_id FROM created_shards)\n" +
+            "LIMIT " + CLEANUP_TRANSACTIONS_BATCH_SIZE)
+    void deleteOldCompletedTransactions(@Bind("maxEndTime") Timestamp maxEndTime);
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MySqlShardDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MySqlShardDao.java
@@ -21,6 +21,7 @@ import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterArgumentFactory;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapperFactory;
 
+import java.sql.Timestamp;
 import java.util.UUID;
 
 @RegisterArgumentFactory(UuidArgumentFactory.class)
@@ -39,4 +40,13 @@ public interface MySqlShardDao
     @SqlBatch("INSERT IGNORE INTO deleted_shards (shard_uuid, delete_time)\n" +
             "VALUES (:shardUuid, CURRENT_TIMESTAMP)")
     void insertDeletedShards(@Bind("shardUuid") Iterable<UUID> shardUuids);
+
+    // 'order by' is needed in this statement in order to make it compatible with statement-based replication
+    @SqlUpdate("DELETE FROM transactions\n" +
+            "WHERE end_time < :maxEndTime\n" +
+            "  AND successful IS NOT NULL\n" +
+            "  AND transaction_id NOT IN (SELECT transaction_id FROM created_shards)\n" +
+            "ORDER BY transaction_id\n" +
+            "LIMIT " + CLEANUP_TRANSACTIONS_BATCH_SIZE)
+    void deleteOldCompletedTransactions(@Bind("maxEndTime") Timestamp maxEndTime);
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardCleanerConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardCleanerConfig.java
@@ -35,6 +35,7 @@ public class ShardCleanerConfig
     private Duration backupCleanerInterval = new Duration(5, MINUTES);
     private Duration backupCleanTime = new Duration(1, DAYS);
     private int backupDeletionThreads = 50;
+    private Duration maxCompletedTransactionAge = new Duration(1, DAYS);
 
     @NotNull
     @MinDuration("1m")
@@ -136,6 +137,22 @@ public class ShardCleanerConfig
     public ShardCleanerConfig setBackupDeletionThreads(int backupDeletionThreads)
     {
         this.backupDeletionThreads = backupDeletionThreads;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("1m")
+    @MaxDuration("30d")
+    public Duration getMaxCompletedTransactionAge()
+    {
+        return maxCompletedTransactionAge;
+    }
+
+    @Config("raptor.max-completed-transaction-age")
+    @ConfigDescription("Maximum time a record of a successful or failed transaction is kept")
+    public ShardCleanerConfig setMaxCompletedTransactionAge(Duration maxCompletedTransactionAge)
+    {
+        this.maxCompletedTransactionAge = maxCompletedTransactionAge;
         return this;
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardDao.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 public interface ShardDao
 {
     int CLEANABLE_SHARDS_BATCH_SIZE = 1000;
+    int CLEANUP_TRANSACTIONS_BATCH_SIZE = 1_000_000;
 
     @SqlUpdate("INSERT INTO nodes (node_identifier) VALUES (:nodeIdentifier)")
     @GetGeneratedKeys
@@ -204,4 +205,6 @@ public interface ShardDao
             @Bind("distributionId") long distributionId,
             @Bind("bucketNumber") int bucketNumber,
             @Bind("nodeId") int nodeId);
+
+    void deleteOldCompletedTransactions(@Bind("maxEndTime") Timestamp maxEndTime);
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardCleanerConfig.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardCleanerConfig.java
@@ -38,7 +38,8 @@ public class TestShardCleanerConfig
                 .setLocalCleanTime(new Duration(4, HOURS))
                 .setBackupCleanerInterval(new Duration(5, MINUTES))
                 .setBackupCleanTime(new Duration(1, DAYS))
-                .setBackupDeletionThreads(50));
+                .setBackupDeletionThreads(50)
+                .setMaxCompletedTransactionAge(new Duration(1, DAYS)));
     }
 
     @Test
@@ -52,6 +53,7 @@ public class TestShardCleanerConfig
                 .put("raptor.backup-cleaner-interval", "34m")
                 .put("raptor.backup-clean-time", "35m")
                 .put("raptor.backup-deletion-threads", "37")
+                .put("raptor.max-completed-transaction-age", "39m")
                 .build();
 
         ShardCleanerConfig expected = new ShardCleanerConfig()
@@ -61,7 +63,8 @@ public class TestShardCleanerConfig
                 .setLocalCleanTime(new Duration(32, MINUTES))
                 .setBackupCleanerInterval(new Duration(34, MINUTES))
                 .setBackupCleanTime(new Duration(35, MINUTES))
-                .setBackupDeletionThreads(37);
+                .setBackupDeletionThreads(37)
+                .setMaxCompletedTransactionAge(new Duration(39, MINUTES));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Cleanup process will delete records of successful transactions older than a specified threshold
and records of failed transaction older than a specified threshold and not referenced by
created shards.

Note, that an index on 'transactions' table, 'end_time' column is needed to
improve cleanup query performance.