### PR TITLE
Fix product tests after introducing DECIMAL to TPCH tables

### DIFF
--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q19.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q19.result
@@ -1,2 +1,2 @@
--- delimiter: |; ignoreOrder: false; types: DECIMAL 
-3083843.0578|
+-- delimiter: |; ignoreOrder: false; types: DECIMAL
+3020909.6530|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q2.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q2.result
@@ -1,4 +1,4 @@
--- delimiter: |; ignoreOrder: false; types: DOUBLE|LONGNVARCHAR|LONGNVARCHAR|BIGINT|LONGNVARCHAR|LONGNVARCHAR|LONGNVARCHAR|LONGNVARCHAR
+-- delimiter: |; ignoreOrder: false; types: DECIMAL|LONGNVARCHAR|LONGNVARCHAR|BIGINT|LONGNVARCHAR|LONGNVARCHAR|LONGNVARCHAR|LONGNVARCHAR
 9938.53000000000|Supplier#000005359|UNITED KINGDOM|185358|Manufacturer#4|QKuHYh,vZGiwu2FWEJoLDx04|33-429-790-6131|uriously regular requests hag|
 9937.84000000000|Supplier#000005969|ROMANIA|108438|Manufacturer#1|ANDENSOSmk,miq23Xfb5RWt6dvUcvt6Qa|29-520-692-3537|efully express instructions. regular requests against the slyly fin|
 9936.22000000000|Supplier#000005250|UNITED KINGDOM|249|Manufacturer#4|B3rqp0xbSEim4Mpy2RH J|33-320-228-2957|etect about the furiously final accounts. slyly ironic pinto beans sleep inside the furiously|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q22.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q22.result
@@ -1,4 +1,4 @@
--- delimiter: |; ignoreOrder: false; types: LONGNVARCHAR|BIGINT|DOUBLE
+-- delimiter: |; ignoreOrder: false; types: LONGNVARCHAR|BIGINT|DECIMAL
 13|888|6737713.99|
 17|861|6460573.72|
 18|964|7236687.40|


### PR DESCRIPTION
With Tempto version 1.14 introduced to Presto some TPCH tables got DECIMAL columns instead of DOUBLE.
Tests need to be updated.

https://github.com/prestodb/tempto/commit/4d190191d92c61349a0dcaaa49a9c818e3f7c68b introduced (release 1.13 of Tempto) DECIMAL to product tests schema for TPCH tables in Tempto.
https://github.com/prestodb/presto/commit/f624f512764908a81de5acd21c3531b6baa2b6c9 changed version 1.12 -> 1.14 of Tempto for Presto.
https://github.com/prestodb/presto/commit/7378415710b6221b5717c278b62d5835029e8adb unquarantined affected tests.