### PR TITLE
Revert config option for treating Hive integrals as BIGINT

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketFunction.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketFunction.java
@@ -28,21 +28,19 @@ public class HiveBucketFunction
 {
     private final int bucketCount;
     private final List<TypeInfo> typeInfos;
-    private final boolean forceIntegralToBigint;
 
-    public HiveBucketFunction(int bucketCount, List<HiveType> hiveTypes, boolean forceIntegralToBigint)
+    public HiveBucketFunction(int bucketCount, List<HiveType> hiveTypes)
     {
         this.bucketCount = bucketCount;
         this.typeInfos = requireNonNull(hiveTypes, "hiveTypes is null").stream()
                 .map(HiveType::getTypeInfo)
                 .collect(Collectors.toList());
-        this.forceIntegralToBigint = forceIntegralToBigint;
     }
 
     @Override
     public int getBucket(Page page, int position)
     {
-        return HiveBucketing.getHiveBucket(typeInfos, page, position, bucketCount, forceIntegralToBigint);
+        return HiveBucketing.getHiveBucket(typeInfos, page, position, bucketCount);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
@@ -81,22 +81,22 @@ final class HiveBucketing
 
     private HiveBucketing() {}
 
-    public static int getHiveBucket(List<TypeInfo> types, Page page, int position, int bucketCount, boolean forceIntegralToBigint)
+    public static int getHiveBucket(List<TypeInfo> types, Page page, int position, int bucketCount)
     {
-        return (getBucketHashCode(types, page, position, forceIntegralToBigint) & Integer.MAX_VALUE) % bucketCount;
+        return (getBucketHashCode(types, page, position) & Integer.MAX_VALUE) % bucketCount;
     }
 
-    private static int getBucketHashCode(List<TypeInfo> types, Page page, int position, boolean forceIntegralToBigint)
+    private static int getBucketHashCode(List<TypeInfo> types, Page page, int position)
     {
         int result = 0;
         for (int i = 0; i < page.getChannelCount(); i++) {
-            int fieldHash = hash(types.get(i), page.getBlock(i), position, forceIntegralToBigint);
+            int fieldHash = hash(types.get(i), page.getBlock(i), position);
             result = result * 31 + fieldHash;
         }
         return result;
     }
 
-    private static int hash(TypeInfo type, Block block, int position, boolean forceIntegralToBigint)
+    private static int hash(TypeInfo type, Block block, int position)
     {
         // This function mirrors the behavior of function hashCode in
         // HIVE-12025 ba83fd7bff serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -112,7 +112,7 @@ final class HiveBucketing
             case PRIMITIVE: {
                 PrimitiveTypeInfo typeInfo = (PrimitiveTypeInfo) type;
                 PrimitiveCategory primitiveCategory = typeInfo.getPrimitiveCategory();
-                Type prestoType = requireNonNull(HiveType.getPrimitiveType(typeInfo, forceIntegralToBigint));
+                Type prestoType = requireNonNull(HiveType.getPrimitiveType(typeInfo));
                 switch (primitiveCategory) {
                     case BOOLEAN:
                         return prestoType.getBoolean(block, position) ? 1 : 0;
@@ -152,7 +152,7 @@ final class HiveBucketing
                 Block elementsBlock = block.getObject(position, Block.class);
                 int result = 0;
                 for (int i = 0; i < elementsBlock.getPositionCount(); i++) {
-                    result = result * 31 + hash(elementTypeInfo, elementsBlock, i, forceIntegralToBigint);
+                    result = result * 31 + hash(elementTypeInfo, elementsBlock, i);
                 }
                 return result;
             }
@@ -163,7 +163,7 @@ final class HiveBucketing
                 Block elementsBlock = block.getObject(position, Block.class);
                 int result = 0;
                 for (int i = 0; i < elementsBlock.getPositionCount(); i += 2) {
-                    result += hash(keyTypeInfo, elementsBlock, i, forceIntegralToBigint) ^ hash(valueTypeInfo, elementsBlock, i + 1, forceIntegralToBigint);
+                    result += hash(keyTypeInfo, elementsBlock, i) ^ hash(valueTypeInfo, elementsBlock, i + 1);
                 }
                 return result;
             }
@@ -182,14 +182,14 @@ final class HiveBucketing
         return result;
     }
 
-    public static Optional<HiveBucketHandle> getHiveBucketHandle(String connectorId, Table table, boolean forceIntegralToBigint)
+    public static Optional<HiveBucketHandle> getHiveBucketHandle(String connectorId, Table table)
     {
         Optional<HiveBucketProperty> hiveBucketProperty = table.getStorage().getBucketProperty();
         if (!hiveBucketProperty.isPresent()) {
             return Optional.empty();
         }
 
-        Map<String, HiveColumnHandle> map = getRegularColumnHandles(connectorId, table, forceIntegralToBigint).stream()
+        Map<String, HiveColumnHandle> map = getRegularColumnHandles(connectorId, table).stream()
                 .collect(Collectors.toMap(HiveColumnHandle::getName, identity()));
 
         List<HiveColumnHandle> bucketColumns = hiveBucketProperty.get().getBucketedBy().stream()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -130,7 +130,6 @@ public class HiveClientConfig
 
     private boolean bucketExecutionEnabled = true;
     private boolean bucketWritingEnabled = true;
-    private boolean forceIntegralToBigint = false;
 
     public int getMaxInitialSplits()
     {
@@ -1042,19 +1041,6 @@ public class HiveClientConfig
     public HiveClientConfig setBucketWritingEnabled(boolean bucketWritingEnabled)
     {
         this.bucketWritingEnabled = bucketWritingEnabled;
-        return this;
-    }
-
-    public boolean isForceIntegralToBigint()
-    {
-        return forceIntegralToBigint;
-    }
-
-    @Config("deprecated.hive.integral-types-as-bigint")
-    @ConfigDescription("Convert all hive integral types to BIGINT")
-    public HiveClientConfig setForceIntegralToBigint(boolean forceIntegralToBigint)
-    {
-        this.forceIntegralToBigint = forceIntegralToBigint;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
@@ -40,7 +40,7 @@ public class HiveColumnHandle
     public static final int PATH_COLUMN_INDEX = -11;
     public static final String PATH_COLUMN_NAME = "$path";
     public static final HiveType PATH_HIVE_TYPE = HIVE_STRING;
-    public static final TypeSignature PATH_TYPE_SIGNATURE = PATH_HIVE_TYPE.getTypeSignature(false);
+    public static final TypeSignature PATH_TYPE_SIGNATURE = PATH_HIVE_TYPE.getTypeSignature();
 
     private static final String UPDATE_ROW_ID_COLUMN_NAME = "$shard_row_id";
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -37,7 +37,6 @@ public class HiveMetadataFactory
     private final boolean respectTableFormat;
     private final boolean bucketExecutionEnabled;
     private final boolean bucketWritingEnabled;
-    private final boolean forceIntegralToBigint;
     private final boolean skipDeletionForAlter;
     private final HiveStorageFormat defaultStorageFormat;
     private final ExtendedHiveMetastore metastore;
@@ -79,7 +78,6 @@ public class HiveMetadataFactory
                 hiveClientConfig.isSkipDeletionForAlter(),
                 hiveClientConfig.isBucketExecutionEnabled(),
                 hiveClientConfig.isBucketWritingEnabled(),
-                hiveClientConfig.isForceIntegralToBigint(),
                 hiveClientConfig.getHiveStorageFormat(),
                 typeManager,
                 locationService,
@@ -102,7 +100,6 @@ public class HiveMetadataFactory
             boolean skipDeletionForAlter,
             boolean bucketExecutionEnabled,
             boolean bucketWritingEnabled,
-            boolean forceIntegralToBigint,
             HiveStorageFormat defaultStorageFormat,
             TypeManager typeManager,
             LocationService locationService,
@@ -119,7 +116,6 @@ public class HiveMetadataFactory
         this.skipDeletionForAlter = skipDeletionForAlter;
         this.bucketExecutionEnabled = bucketExecutionEnabled;
         this.bucketWritingEnabled = bucketWritingEnabled;
-        this.forceIntegralToBigint = forceIntegralToBigint;
         this.defaultStorageFormat = requireNonNull(defaultStorageFormat, "defaultStorageFormat is null");
 
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -159,7 +155,6 @@ public class HiveMetadataFactory
                 respectTableFormat,
                 bucketExecutionEnabled,
                 bucketWritingEnabled,
-                forceIntegralToBigint,
                 defaultStorageFormat,
                 typeManager,
                 locationService,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveNodePartitioningProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveNodePartitioningProvider.java
@@ -41,14 +41,12 @@ public class HiveNodePartitioningProvider
 {
     private final String connectorId;
     private final NodeManager nodeManager;
-    private final boolean forceIntegralToBigint;
 
     @Inject
-    public HiveNodePartitioningProvider(HiveConnectorId connectorId, HiveClientConfig hiveClientConfig, NodeManager nodeManager)
+    public HiveNodePartitioningProvider(HiveConnectorId connectorId, NodeManager nodeManager)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
-        this.forceIntegralToBigint = requireNonNull(hiveClientConfig, "hiveClientConfig is null").isForceIntegralToBigint();
     }
 
     @Override
@@ -61,7 +59,7 @@ public class HiveNodePartitioningProvider
     {
         HivePartitioningHandle handle = checkType(partitioningHandle, HivePartitioningHandle.class, "partitioningHandle");
         List<HiveType> hiveTypes = handle.getHiveTypes();
-        return new HiveBucketFunction(bucketCount, hiveTypes, forceIntegralToBigint);
+        return new HiveBucketFunction(bucketCount, hiveTypes);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
@@ -39,7 +39,6 @@ public class HivePageSinkProvider
     private final TypeManager typeManager;
     private final int maxOpenPartitions;
     private final boolean immutablePartitions;
-    private final boolean forceIntegralToBigint;
     private final boolean compressed;
     private final LocationService locationService;
     private final JsonCodec<PartitionUpdate> partitionUpdateCodec;
@@ -62,7 +61,6 @@ public class HivePageSinkProvider
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.maxOpenPartitions = config.getMaxPartitionsPerWriter();
         this.immutablePartitions = config.isImmutablePartitions();
-        this.forceIntegralToBigint = config.isForceIntegralToBigint();
         this.compressed = config.getHiveCompressionCodec() != HiveCompressionCodec.NONE;
         this.locationService = requireNonNull(locationService, "locationService is null");
         this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
@@ -101,7 +99,6 @@ public class HivePageSinkProvider
                 hdfsEnvironment,
                 maxOpenPartitions,
                 immutablePartitions,
-                forceIntegralToBigint,
                 compressed,
                 partitionUpdateCodec,
                 session);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -63,7 +63,6 @@ public class HivePartitionManager
     private final String connectorId;
     private final DateTimeZone timeZone;
     private final boolean assumeCanonicalPartitionKeys;
-    private final boolean forceIntegralToBigint;
     private final int domainCompactionThreshold;
     private final TypeManager typeManager;
 
@@ -78,7 +77,6 @@ public class HivePartitionManager
                 hiveClientConfig.getDateTimeZone(),
                 hiveClientConfig.getMaxOutstandingSplits(),
                 hiveClientConfig.isAssumeCanonicalPartitionKeys(),
-                hiveClientConfig.isForceIntegralToBigint(),
                 hiveClientConfig.getDomainCompactionThreshold());
     }
 
@@ -88,14 +86,12 @@ public class HivePartitionManager
             DateTimeZone timeZone,
             int maxOutstandingSplits,
             boolean assumeCanonicalPartitionKeys,
-            boolean forceIntegralToBigint,
             int domainCompactionThreshold)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
         this.timeZone = requireNonNull(timeZone, "timeZone is null");
         checkArgument(maxOutstandingSplits >= 1, "maxOutstandingSplits must be at least 1");
         this.assumeCanonicalPartitionKeys = assumeCanonicalPartitionKeys;
-        this.forceIntegralToBigint = forceIntegralToBigint;
         checkArgument(domainCompactionThreshold >= 1, "domainCompactionThreshold must be at least 1");
         this.domainCompactionThreshold = domainCompactionThreshold;
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -108,9 +104,9 @@ public class HivePartitionManager
 
         SchemaTableName tableName = hiveTableHandle.getSchemaTableName();
         Table table = getTable(metastore, tableName);
-        Optional<HiveBucketHandle> hiveBucketHandle = getHiveBucketHandle(connectorId, table, forceIntegralToBigint);
+        Optional<HiveBucketHandle> hiveBucketHandle = getHiveBucketHandle(connectorId, table);
 
-        List<HiveColumnHandle> partitionColumns = getPartitionKeyColumnHandles(connectorId, table, forceIntegralToBigint);
+        List<HiveColumnHandle> partitionColumns = getPartitionKeyColumnHandles(connectorId, table);
         Optional<HiveBucketing.HiveBucket> bucket = getHiveBucket(table, TupleDomain.extractFixedValues(effectivePredicate).get());
 
         TupleDomain<HiveColumnHandle> compactEffectivePredicate = toCompactTupleDomain(effectivePredicate, domainCompactionThreshold);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveType.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveType.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableList;
-import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.CharTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
@@ -110,14 +109,14 @@ public final class HiveType
         return typeInfo;
     }
 
-    public TypeSignature getTypeSignature(boolean forceIntegralToBigint)
+    public TypeSignature getTypeSignature()
     {
-        return getTypeSignature(typeInfo, forceIntegralToBigint);
+        return getTypeSignature(typeInfo);
     }
 
-    public Type getType(TypeManager typeManager, boolean forceIntegralToBigint)
+    public Type getType(TypeManager typeManager)
     {
-        return typeManager.getType(getTypeSignature(forceIntegralToBigint));
+        return typeManager.getType(getTypeSignature());
     }
 
     @Override
@@ -160,8 +159,7 @@ public final class HiveType
     {
         switch (typeInfo.getCategory()) {
             case PRIMITIVE:
-                // forceIntegralToBigint is set to false here because narrow integrals are *supported*, but are *read* as BIGINT
-                return getPrimitiveType((PrimitiveTypeInfo) typeInfo, false) != null;
+                return getPrimitiveType((PrimitiveTypeInfo) typeInfo) != null;
             case MAP:
                 MapTypeInfo mapTypeInfo = checkType(typeInfo, MapTypeInfo.class, "typeInfo");
                 return isSupportedType(mapTypeInfo.getMapKeyTypeInfo()) && isSupportedType(mapTypeInfo.getMapValueTypeInfo());
@@ -209,25 +207,25 @@ public final class HiveType
     }
 
     @Nonnull
-    private static TypeSignature getTypeSignature(TypeInfo typeInfo, boolean forceIntegralToBigint)
+    private static TypeSignature getTypeSignature(TypeInfo typeInfo)
     {
         switch (typeInfo.getCategory()) {
             case PRIMITIVE:
-                Type primitiveType = getPrimitiveType((PrimitiveTypeInfo) typeInfo, forceIntegralToBigint);
+                Type primitiveType = getPrimitiveType((PrimitiveTypeInfo) typeInfo);
                 if (primitiveType == null) {
                     break;
                 }
                 return primitiveType.getTypeSignature();
             case MAP:
                 MapTypeInfo mapTypeInfo = checkType(typeInfo, MapTypeInfo.class, "fieldInspector");
-                TypeSignature keyType = getTypeSignature(mapTypeInfo.getMapKeyTypeInfo(), forceIntegralToBigint);
-                TypeSignature valueType = getTypeSignature(mapTypeInfo.getMapValueTypeInfo(), forceIntegralToBigint);
+                TypeSignature keyType = getTypeSignature(mapTypeInfo.getMapKeyTypeInfo());
+                TypeSignature valueType = getTypeSignature(mapTypeInfo.getMapValueTypeInfo());
                 return new TypeSignature(
                         StandardTypes.MAP,
                         ImmutableList.of(TypeSignatureParameter.of(keyType), TypeSignatureParameter.of(valueType)));
             case LIST:
                 ListTypeInfo listTypeInfo = checkType(typeInfo, ListTypeInfo.class, "fieldInspector");
-                TypeSignature elementType = getTypeSignature(listTypeInfo.getListElementTypeInfo(), forceIntegralToBigint);
+                TypeSignature elementType = getTypeSignature(listTypeInfo.getListElementTypeInfo());
                 return new TypeSignature(
                         StandardTypes.ARRAY,
                         ImmutableList.of(TypeSignatureParameter.of(elementType)));
@@ -235,26 +233,15 @@ public final class HiveType
                 StructTypeInfo structTypeInfo = checkType(typeInfo, StructTypeInfo.class, "fieldInspector");
                 List<TypeSignature> fieldTypes = structTypeInfo.getAllStructFieldTypeInfos()
                         .stream()
-                        .map(type -> getTypeSignature(type, forceIntegralToBigint))
+                        .map(HiveType::getTypeSignature)
                         .collect(toList());
                 return new TypeSignature(StandardTypes.ROW, fieldTypes, structTypeInfo.getAllStructFieldNames());
         }
         throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type: %s", typeInfo));
     }
 
-    public static Type getPrimitiveType(PrimitiveTypeInfo typeInfo, boolean forceIntegralToBigint)
+    public static Type getPrimitiveType(PrimitiveTypeInfo typeInfo)
     {
-        if (forceIntegralToBigint) {
-            switch (typeInfo.getPrimitiveCategory()) {
-                case BYTE:
-                    return BIGINT;
-                case SHORT:
-                    return BIGINT;
-                case INT:
-                    return BIGINT;
-            }
-        }
-
         switch (typeInfo.getPrimitiveCategory()) {
             case BOOLEAN:
                 return BOOLEAN;
@@ -288,35 +275,5 @@ public final class HiveType
             default:
                 return null;
         }
-    }
-
-    public static boolean isForceBigintWritableType(TypeInfo typeInfo)
-    {
-        switch (typeInfo.getCategory()) {
-            case PRIMITIVE:
-                PrimitiveObjectInspector.PrimitiveCategory primitiveCategory = ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory();
-                return isForceBigintWritableType(primitiveCategory);
-            case MAP:
-                MapTypeInfo mapTypeInfo = checkType(typeInfo, MapTypeInfo.class, "typeInfo");
-                return isForceBigintWritableType(mapTypeInfo.getMapKeyTypeInfo()) && isForceBigintWritableType(mapTypeInfo.getMapValueTypeInfo());
-            case LIST:
-                ListTypeInfo listTypeInfo = checkType(typeInfo, ListTypeInfo.class, "typeInfo");
-                return isForceBigintWritableType(listTypeInfo.getListElementTypeInfo());
-            case STRUCT:
-                StructTypeInfo structTypeInfo = checkType(typeInfo, StructTypeInfo.class, "typeInfo");
-                return structTypeInfo.getAllStructFieldTypeInfos().stream().allMatch(HiveType::isForceBigintWritableType);
-        }
-        return false;
-    }
-
-    private static boolean isForceBigintWritableType(PrimitiveObjectInspector.PrimitiveCategory primitiveCategory)
-    {
-        switch (primitiveCategory) {
-            case INT:
-            case SHORT:
-            case BYTE:
-                return false;
-        }
-        return true;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -699,15 +699,15 @@ public final class HiveUtil
         return checkType(tableHandle, HiveTableHandle.class, "tableHandle").getSchemaTableName();
     }
 
-    public static List<HiveColumnHandle> hiveColumnHandles(String connectorId, Table table, boolean forceIntegralToBigint)
+    public static List<HiveColumnHandle> hiveColumnHandles(String connectorId, Table table)
     {
         ImmutableList.Builder<HiveColumnHandle> columns = ImmutableList.builder();
 
         // add the data fields first
-        columns.addAll(getRegularColumnHandles(connectorId, table, forceIntegralToBigint));
+        columns.addAll(getRegularColumnHandles(connectorId, table));
 
         // add the partition keys last (like Hive does)
-        columns.addAll(getPartitionKeyColumnHandles(connectorId, table, forceIntegralToBigint));
+        columns.addAll(getPartitionKeyColumnHandles(connectorId, table));
 
         // add hidden column
         columns.add(pathColumnHandle(connectorId));
@@ -715,7 +715,7 @@ public final class HiveUtil
         return columns.build();
     }
 
-    public static List<HiveColumnHandle> getRegularColumnHandles(String connectorId, Table table, boolean forceIntegralToBigint)
+    public static List<HiveColumnHandle> getRegularColumnHandles(String connectorId, Table table)
     {
         ImmutableList.Builder<HiveColumnHandle> columns = ImmutableList.builder();
 
@@ -724,7 +724,7 @@ public final class HiveUtil
             // ignore unsupported types rather than failing
             HiveType hiveType = field.getType();
             if (hiveType.isSupportedType()) {
-                columns.add(new HiveColumnHandle(connectorId, field.getName(), hiveType, hiveType.getTypeSignature(forceIntegralToBigint), hiveColumnIndex, REGULAR));
+                columns.add(new HiveColumnHandle(connectorId, field.getName(), hiveType, hiveType.getTypeSignature(), hiveColumnIndex, REGULAR));
             }
             hiveColumnIndex++;
         }
@@ -732,7 +732,7 @@ public final class HiveUtil
         return columns.build();
     }
 
-    public static List<HiveColumnHandle> getPartitionKeyColumnHandles(String connectorId, Table table, boolean forceIntegralToBigint)
+    public static List<HiveColumnHandle> getPartitionKeyColumnHandles(String connectorId, Table table)
     {
         ImmutableList.Builder<HiveColumnHandle> columns = ImmutableList.builder();
 
@@ -742,7 +742,7 @@ public final class HiveUtil
             if (!hiveType.isSupportedType()) {
                 throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type %s found in partition keys of table %s.%s", hiveType, table.getDatabaseName(), table.getTableName()));
             }
-            columns.add(new HiveColumnHandle(connectorId, field.getName(), hiveType, hiveType.getTypeSignature(forceIntegralToBigint), -1, PARTITION_KEY));
+            columns.add(new HiveColumnHandle(connectorId, field.getName(), hiveType, hiveType.getTypeSignature(), -1, PARTITION_KEY));
         }
 
         return columns.build();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -493,7 +493,6 @@ public abstract class AbstractTestHiveClient
                 false,
                 true,
                 true,
-                false,
                 HiveStorageFormat.RCBINARY,
                 typeManager,
                 locationService,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -487,7 +487,7 @@ public abstract class AbstractTestHiveFileFormats
             int columnIndex = testColumn.isPartitionKey() ? -1 : nextHiveColumnIndex++;
 
             HiveType hiveType = HiveType.valueOf(testColumn.getObjectInspector().getTypeName());
-            columns.add(new HiveColumnHandle("client_id", testColumn.getName(), hiveType, hiveType.getTypeSignature(false), columnIndex, testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR));
+            columns.add(new HiveColumnHandle("client_id", testColumn.getName(), hiveType, hiveType.getTypeSignature(), columnIndex, testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR));
         }
         return columns;
     }
@@ -572,7 +572,7 @@ public abstract class AbstractTestHiveFileFormats
                 TestColumn testColumn = testColumns.get(i);
 
                 Object fieldFromCursor;
-                Type type = HiveType.valueOf(testColumn.getObjectInspector().getTypeName()).getType(TYPE_MANAGER, false);
+                Type type = HiveType.valueOf(testColumn.getObjectInspector().getTypeName()).getType(TYPE_MANAGER);
                 if (cursor.isNull(i)) {
                     fieldFromCursor = null;
                 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
@@ -219,7 +219,7 @@ public class TestHiveBucketing
         ImmutableList.Builder<Block> blockListBuilder = ImmutableList.builder();
         for (int i = 0; i < hiveTypeStrings.size(); i++) {
             Object javaValue = javaValues.get(i);
-            Type type = hiveTypes.get(i).getType(typeRegistry, false);
+            Type type = hiveTypes.get(i).getType(typeRegistry);
 
             BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 3);
             // prepend 2 nulls to make sure position is respected when HiveBucketing function
@@ -230,7 +230,7 @@ public class TestHiveBucketing
             blockListBuilder.add(block);
         }
         ImmutableList<Block> blockList = blockListBuilder.build();
-        return HiveBucketing.getHiveBucket(hiveTypeInfos, new Page(blockList.toArray(new Block[blockList.size()])), 2, bucketCount, false);
+        return HiveBucketing.getHiveBucket(hiveTypeInfos, new Page(blockList.toArray(new Block[blockList.size()])), 2, bucketCount);
     }
 
     public static int getHiveBucket(List<Entry<ObjectInspector, Object>> columnBindings, int bucketCount)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -103,8 +103,7 @@ public class TestHiveClientConfig
                 .setHdfsPrestoKeytab(null)
                 .setSkipDeletionForAlter(false)
                 .setBucketExecutionEnabled(true)
-                .setBucketWritingEnabled(true)
-                .setForceIntegralToBigint(false));
+                .setBucketWritingEnabled(true));
     }
 
     @Test
@@ -179,7 +178,6 @@ public class TestHiveClientConfig
                 .put("hive.skip-deletion-for-alter", "true")
                 .put("hive.bucket-execution", "false")
                 .put("hive.bucket-writing", "false")
-                .put("deprecated.hive.integral-types-as-bigint", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -250,8 +248,7 @@ public class TestHiveClientConfig
                 .setHdfsPrestoKeytab("/tmp/presto.keytab")
                 .setSkipDeletionForAlter(true)
                 .setBucketExecutionEnabled(false)
-                .setBucketWritingEnabled(false)
-                .setForceIntegralToBigint(true);
+                .setBucketWritingEnabled(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -1528,7 +1528,7 @@ public class TestHiveIntegrationSmokeTest
     private Type canonicalizeType(Type type)
     {
         HiveType hiveType = HiveType.toHiveType(typeTranslator, type);
-        return typeManager.getType(hiveType.getTypeSignature(false));
+        return typeManager.getType(hiveType.getTypeSignature());
     }
 
     private String canonicalizeTypeName(String type)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -126,7 +126,7 @@ public class TestHivePageSink
         List<Type> columnTypes = columns.stream()
                 .map(LineItemColumn::getType)
                 .map(TestHivePageSink::getHiveType)
-                .map(hiveType -> hiveType.getType(TYPE_MANAGER, false))
+                .map(hiveType -> hiveType.getType(TYPE_MANAGER))
                 .collect(toList());
 
         PageBuilder pageBuilder = new PageBuilder(columnTypes);
@@ -243,7 +243,7 @@ public class TestHivePageSink
         for (int i = 0; i < columns.size(); i++) {
             LineItemColumn column = columns.get(i);
             HiveType hiveType = getHiveType(column.getType());
-            handles.add(new HiveColumnHandle(CLIENT_ID, column.getColumnName(), hiveType, hiveType.getTypeSignature(false), i, REGULAR));
+            handles.add(new HiveColumnHandle(CLIENT_ID, column.getColumnName(), hiveType, hiveType.getTypeSignature(), i, REGULAR));
         }
         return handles.build();
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
@@ -369,7 +369,7 @@ public class TestOrcPageSourceMemoryTracking
 
                 ObjectInspector inspector = testColumn.getObjectInspector();
                 HiveType hiveType = HiveType.valueOf(inspector.getTypeName());
-                Type type = hiveType.getType(TYPE_MANAGER, false);
+                Type type = hiveType.getType(TYPE_MANAGER);
 
                 columnsBuilder.add(new HiveColumnHandle("client_id", testColumn.getName(), hiveType, type.getTypeSignature(), columnIndex, testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR));
                 typesBuilder.add(type);


### PR DESCRIPTION
This reverts commit 05bba028b12fa2293c60440f15b4fc8499526633. This was
never turned on and intended to be reverted in the short term.