### PR TITLE
Send serialized PrestoException as response

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -47,6 +47,7 @@ import com.facebook.presto.split.RecordPageSourceProvider;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.log.Logger;
@@ -303,6 +304,12 @@ public class ConnectorManager
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(factory.getClass().getClassLoader())) {
             return factory.create(connectorId.getCatalogName(), properties, context);
         }
+    }
+
+    @VisibleForTesting
+    public AccessControlManager getAccessControlManager()
+    {
+        return accessControlManager;
     }
 
     private static class MaterializedConnector

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -154,6 +154,13 @@ public class AccessControlManager
         log.info("-- Loaded system access control %s --", name);
     }
 
+    @VisibleForTesting
+    public void resetSystemAccessControl()
+    {
+        checkState(systemAccessControlLoading.get(), "System access control can be reset only after it was set");
+        this.systemAccessControl.set(new InitializingSystemAccessControl());
+    }
+
     @Override
     public void checkCanSetUser(Principal principal, String userName)
     {

--- a/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
@@ -39,6 +39,7 @@ import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.StandardTypes;
@@ -168,13 +169,32 @@ public class StatementResource
     {
         assertRequest(!isNullOrEmpty(statement), "SQL statement is empty");
 
-        Session session = createSessionForRequest(servletRequest, transactionManager, accessControl, sessionPropertyManager, queryIdGenerator.createNextQueryId());
+        Session session;
+
+        try {
+            session = createSessionForRequest(servletRequest, transactionManager, accessControl, sessionPropertyManager, queryIdGenerator.createNextQueryId());
+        }
+        catch (PrestoException e) {
+            return responseFromPrestoException(e);
+        }
 
         ExchangeClient exchangeClient = exchangeClientSupplier.get(deltaMemoryInBytes -> { });
         Query query = new Query(session, statement, queryManager, exchangeClient);
         queries.put(query.getQueryId(), query);
 
         return getQueryResults(query, Optional.empty(), uriInfo, new Duration(1, MILLISECONDS));
+    }
+
+    private static Response responseFromPrestoException(PrestoException e)
+    {
+        QueryError error = new QueryError(e.getMessage(),
+                null,
+                e.getErrorCode().getCode(),
+                e.getErrorCode().getName(),
+                e.getErrorCode().getType().toString(),
+                null,
+                toFailure(e).toFailureInfo());
+        return Response.serverError().entity(error).build();
     }
 
     @GET

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -299,6 +299,11 @@ public class TestingPrestoServer
         return queryManager;
     }
 
+    public AccessControlManager getAccessConnectorManager()
+    {
+        return connectorManager.getAccessControlManager();
+    }
+
     public ConnectorId createCatalog(String catalogName, String connectorName)
     {
         return createCatalog(catalogName, connectorName, ImmutableMap.of());


### PR DESCRIPTION
This change allows server to send serialized version of PrestoException
(message, serialized stack trace, error code) in order to allow clients
to handle error in better way.

The answer is still human readable and contains more informations in more
structured way allowing to better understand the problem even when encountering
plain text JSON answer.

This is single commit extracted from https://github.com/prestodb/presto/pull/5445 as requested by @electrum.
