### PR TITLE
Flushing SliceOutput in PagesResponseWriter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/PagesResponseWriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PagesResponseWriter.java
@@ -20,6 +20,7 @@ import com.google.common.base.Throwables;
 import com.google.common.reflect.TypeToken;
 import io.airlift.slice.OutputStreamSliceOutput;
 import io.airlift.slice.RuntimeIOException;
+import io.airlift.slice.SliceOutput;
 
 import javax.inject.Inject;
 import javax.ws.rs.Produces;
@@ -88,7 +89,10 @@ public class PagesResponseWriter
             throws IOException, WebApplicationException
     {
         try {
-            PagesSerde.writePages(blockEncodingSerde, new OutputStreamSliceOutput(output), pages);
+            SliceOutput sliceOutput = new OutputStreamSliceOutput(output);
+            PagesSerde.writePages(blockEncodingSerde, sliceOutput, pages);
+            // We use flush instead of close, because the underlying stream would be closed and that is not allowed.
+            sliceOutput.flush();
         }
         catch (RuntimeIOException e) {
             // EOF exception occurs when the client disconnects while writing data


### PR DESCRIPTION
Some implementations of `SliceOutput` might use a buffer. This buffer must be flushed after the pages have been written.
This PR fixes this bug and is a preparation for an optimized variant of `OutputStreamSliceOutput` (see https://github.com/airlift/slice/pull/63).