### PR TITLE
Fix deadlock in ContinuousTaskStatusFetcher#updateTaskStatus

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
@@ -208,7 +208,7 @@ class ContinuousTaskStatusFetcher
         }
     }
 
-    synchronized void updateTaskStatus(TaskStatus newValue)
+    void updateTaskStatus(TaskStatus newValue)
     {
         // change to new value if old value is not changed and new value has a newer version
         AtomicBoolean taskMismatch = new AtomicBoolean();


### PR DESCRIPTION
The updateTaskStatus method performs a callback while holding a lock.
The lock on this method is not needed at all.

Fixes #6196