### PR TITLE
Do not optimize expression with correlated symbols

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.DependencyExtractor;
 import com.facebook.presto.sql.planner.DomainTranslator;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.LookupSymbolResolver;
@@ -124,6 +125,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 public class AddExchanges
@@ -141,31 +143,39 @@ public class AddExchanges
     @Override
     public PlanNode optimize(PlanNode plan, Session session, Map<Symbol, Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
     {
-        PlanWithProperties result = plan.accept(new Rewriter(idAllocator, symbolAllocator, session), new Context(PreferredProperties.any(), false));
+        Context context = new Context(PreferredProperties.any(), false, ImmutableList.of());
+        PlanWithProperties result = plan.accept(new Rewriter(idAllocator, symbolAllocator, session), context);
         return result.getNode();
     }
 
     private static class Context
     {
-        private PreferredProperties preferredProperties;
+        private final PreferredProperties preferredProperties;
         // For delete queries, the TableScan node that corresponds to the table being deleted on must be collocated with the Delete node.
         // Care must be taken so that Exchange node is not introduced between the two. For now, only SemiJoin may introduce it.
-        private boolean downstreamIsDelete;
+        private final boolean downstreamIsDelete;
+        private final List<Symbol> correlations;
 
-        Context(PreferredProperties preferredProperties, boolean downstreamIsDelete)
+        Context(PreferredProperties preferredProperties, boolean downstreamIsDelete, List<Symbol> correlations)
         {
             this.preferredProperties = preferredProperties;
             this.downstreamIsDelete = downstreamIsDelete;
+            this.correlations = ImmutableList.copyOf(requireNonNull(correlations, "correlations is null"));
         }
 
         Context withPreferredProperties(PreferredProperties preferredProperties)
         {
-            return new Context(preferredProperties, downstreamIsDelete);
+            return new Context(preferredProperties, downstreamIsDelete, correlations);
         }
 
         Context withHashPartitionedSemiJoinBanned(boolean hashPartitionedSemiJoinBanned)
         {
-            return new Context(preferredProperties, hashPartitionedSemiJoinBanned);
+            return new Context(preferredProperties, hashPartitionedSemiJoinBanned, correlations);
+        }
+
+        Context withCorrelations(List<Symbol> correlations)
+        {
+            return new Context(preferredProperties, downstreamIsDelete, correlations);
         }
 
         PreferredProperties getPreferredProperties()
@@ -176,6 +186,11 @@ public class AddExchanges
         boolean isDownstreamIsDelete()
         {
             return downstreamIsDelete;
+        }
+
+        List<Symbol> getCorrelations()
+        {
+            return correlations;
         }
     }
 
@@ -569,7 +584,7 @@ public class AddExchanges
             // Layouts will be returned in order of the connector's preference
             List<TableLayoutResult> layouts = metadata.getLayouts(
                     session, node.getTable(),
-                    new Constraint<>(simplifiedConstraint, bindings -> !shouldPrune(constraint, node.getAssignments(), bindings)),
+                    new Constraint<>(simplifiedConstraint, bindings -> !shouldPrune(constraint, node.getAssignments(), bindings, context.getCorrelations())),
                     Optional.of(node.getOutputSymbols().stream()
                             .map(node.getAssignments()::get)
                             .collect(toImmutableSet())));
@@ -640,7 +655,7 @@ public class AddExchanges
             return possiblePlans.get(0);
         }
 
-        private boolean shouldPrune(Expression predicate, Map<Symbol, ColumnHandle> assignments, Map<ColumnHandle, NullableValue> bindings)
+        private boolean shouldPrune(Expression predicate, Map<Symbol, ColumnHandle> assignments, Map<ColumnHandle, NullableValue> bindings, List<Symbol> correlations)
         {
             List<Expression> conjuncts = extractConjuncts(predicate);
             IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(
@@ -655,6 +670,10 @@ public class AddExchanges
 
             // If any conjuncts evaluate to FALSE or null, then the whole predicate will never be true and so the partition should be pruned
             for (Expression expression : conjuncts) {
+                if (DependencyExtractor.extractUnique(expression).stream().anyMatch(correlations::contains)) {
+                    // expression contains correlated symbol with outer query
+                    continue;
+                }
                 ExpressionInterpreter optimizer = ExpressionInterpreter.expressionOptimizer(expression, metadata, session, expressionTypes);
                 Object optimized = optimizer.optimize(inputs);
                 if (Boolean.FALSE.equals(optimized) || optimized == null || optimized instanceof NullLiteral) {
@@ -1137,7 +1156,7 @@ public class AddExchanges
         public PlanWithProperties visitApply(ApplyNode node, Context context)
         {
             PlanWithProperties input = node.getInput().accept(this, context);
-            PlanWithProperties subquery = node.getSubquery().accept(this, context);
+            PlanWithProperties subquery = node.getSubquery().accept(this, context.withCorrelations(node.getCorrelation()));
 
             ApplyNode rewritten = new ApplyNode(
                     node.getId(),


### PR DESCRIPTION
Do not optimize expression with correlated symbols

Do not optimize expressions which contains symbols to the outer query.

Fixes #6215
