### PR TITLE
Don't deduplicate window functions in QueryPlanner

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3679,6 +3679,28 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testSameWindowFunctionsTwoCoerces()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT 12.0 * row_number() OVER ()/row_number() OVER(),\n" +
+                "row_number() OVER()\n" +
+                "FROM (SELECT * FROM orders ORDER BY orderkey LIMIT 10)\n" +
+                "ORDER BY 2 DESC\n" +
+                "LIMIT 5");
+
+        MaterializedResult expected = resultBuilder(getSession(), BIGINT, BIGINT)
+                .row(12.0, 10L)
+                .row(12.0, 9L)
+                .row(12.0, 8L)
+                .row(12.0, 7L)
+                .row(12.0, 6L)
+                .build();
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
     public void testRowNumberNoOptimization()
             throws Exception
     {


### PR DESCRIPTION
When two window functions existed in a query and one was coercing the other didn't get a symbol assigned.
E.g. in
  select 1.0*row_number() over(), row_number() over()
QueryPlanner was building plan based on one function only (because both row_number calls are identical and were deduplicated).
While building a plan the coercion was triggered for the first window function though.
It caused creating a symbol referring to an expression CAST(row_number() AS DOUBLE)
which is not reusable by second window function anymore.

Deduplication is necessary to handle case when OrderBy clause refers to window function from outputs though.

---

Closes: https://github.com/prestodb/presto/issues/5991

TD internal review: https://github.com/Teradata/presto/pull/362