### PR TITLE
Allow periods in resource group ids

### DIFF
--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestFileResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestFileResourceGroupConfigurationManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.resourceGroups;
 
 import com.facebook.presto.spi.resourceGroups.ResourceGroup;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManager;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.resourceGroups.SelectionContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import io.airlift.units.DataSize;
@@ -47,7 +48,7 @@ public class TestFileResourceGroupConfigurationManager
     public void testMissing()
     {
         ResourceGroupConfigurationManager manager = parse("resource_groups_config.json");
-        ResourceGroup missing = new TestingResourceGroup("missing");
+        ResourceGroup missing = new TestingResourceGroup(new ResourceGroupId("missing"));
         manager.configure(missing, new SelectionContext(true, "user", Optional.empty(), 1));
     }
 
@@ -55,7 +56,7 @@ public class TestFileResourceGroupConfigurationManager
     public void testConfiguration()
     {
         ResourceGroupConfigurationManager manager = parse("resource_groups_config.json");
-        ResourceGroup global = new TestingResourceGroup("global");
+        ResourceGroup global = new TestingResourceGroup(new ResourceGroupId("global"));
         manager.configure(global, new SelectionContext(true, "user", Optional.empty(), 1));
         assertEquals(global.getSoftMemoryLimit(), new DataSize(1, MEGABYTE));
         assertEquals(global.getSoftCpuLimit(), new Duration(1, HOURS));
@@ -67,7 +68,7 @@ public class TestFileResourceGroupConfigurationManager
         assertEquals(global.getSchedulingWeight(), 0);
         assertEquals(global.getJmxExport(), true);
 
-        ResourceGroup sub = new TestingResourceGroup("global.sub");
+        ResourceGroup sub = new TestingResourceGroup(new ResourceGroupId(new ResourceGroupId("global"), "sub"));
         manager.configure(sub, new SelectionContext(true, "user", Optional.empty(), 1));
         assertEquals(sub.getSoftMemoryLimit(), new DataSize(2, MEGABYTE));
         assertEquals(sub.getMaxRunningQueries(), 3);

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestResourceGroupIdTemplate.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestResourceGroupIdTemplate.java
@@ -27,7 +27,10 @@ public class TestResourceGroupIdTemplate
     public void testExpansion()
     {
         ResourceGroupIdTemplate template = new ResourceGroupIdTemplate("test.${USER}.${SOURCE}");
-        assertEquals(template.expandTemplate(new SelectionContext(true, "u", Optional.of("s"), 1)), ResourceGroupId.fromString("test.u.s"));
+        ResourceGroupId expected = new ResourceGroupId(new ResourceGroupId(new ResourceGroupId("test"), "u"), "s");
+        assertEquals(template.expandTemplate(new SelectionContext(true, "u", Optional.of("s"), 1)), expected);
+        template = new ResourceGroupIdTemplate("test.${USER}");
+        assertEquals(template.expandTemplate(new SelectionContext(true, "alice.smith", Optional.empty(), 1)), new ResourceGroupId(new ResourceGroupId("test"), "alice.smith"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestingResourceGroup.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestingResourceGroup.java
@@ -19,6 +19,8 @@ import com.facebook.presto.spi.resourceGroups.SchedulingPolicy;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
+import static java.util.Objects.requireNonNull;
+
 public class TestingResourceGroup
         implements ResourceGroup
 {
@@ -33,9 +35,9 @@ public class TestingResourceGroup
     private SchedulingPolicy policy;
     private boolean jmxExport;
 
-    public TestingResourceGroup(String id)
+    public TestingResourceGroup(ResourceGroupId id)
     {
-        this.id = ResourceGroupId.fromString(id);
+        this.id = requireNonNull(id, "id is null");
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/ResourceGroupId.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/ResourceGroupId.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -50,9 +49,6 @@ public final class ResourceGroupId
         checkArgument(!segments.isEmpty(), "Resource group id is empty");
         for (String segment : segments) {
             checkArgument(!segment.isEmpty(), "Empty segment in resource group id");
-            String id = segments.stream()
-                    .collect(joining("."));
-            checkArgument(segment.indexOf('.') < 0, "Invalid resource group id. '%s' contains a '.'", id);
         }
         this.segments = segments;
     }
@@ -73,12 +69,6 @@ public final class ResourceGroupId
             return Optional.empty();
         }
         return Optional.of(new ResourceGroupId(segments.subList(0, segments.size() - 1)));
-    }
-
-    public static ResourceGroupId fromString(String value)
-    {
-        requireNonNull(value, "value is null");
-        return new ResourceGroupId(asList(value.split("\\.")));
     }
 
     private static void checkArgument(boolean argument, String format, Object... args)

--- a/presto-spi/src/test/java/com/facebook/presto/spi/resourceGroups/TestResourceGroupId.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/resourceGroups/TestResourceGroupId.java
@@ -15,26 +15,12 @@ package com.facebook.presto.spi.resourceGroups;
 
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-
 public class TestResourceGroupId
 {
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testInvalid()
-    {
-        new ResourceGroupId("test.test");
-    }
-
     @Test
     public void testBasic()
     {
+        new ResourceGroupId("test.test");
         new ResourceGroupId(new ResourceGroupId("test"), "test");
-    }
-
-    @Test
-    public void testFromString()
-    {
-        ResourceGroupId id = new ResourceGroupId(new ResourceGroupId("test"), "test");
-        assertEquals(ResourceGroupId.fromString("test.test"), id);
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroupIntegration.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroupIntegration.java
@@ -36,7 +36,7 @@ public class TestResourceGroupIntegration
             queryRunner.execute("SELECT COUNT(*), clerk FROM orders GROUP BY clerk");
             while (true) {
                 TimeUnit.SECONDS.sleep(1);
-                ResourceGroupInfo global = queryRunner.getCoordinator().getResourceGroupManager().get().getResourceGroupInfo(ResourceGroupId.fromString("global"));
+                ResourceGroupInfo global = queryRunner.getCoordinator().getResourceGroupManager().get().getResourceGroupInfo(new ResourceGroupId("global"));
                 if (global.getSoftMemoryLimit().toBytes() > 0) {
                     break;
                 }


### PR DESCRIPTION
This does not change the parsing of resource group config files, but
allows constructs like user_group.${USER} to work with user names that
contain periods