### PR TITLE
Use columnar processing in projection operator without filter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PageProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PageProcessor.java
@@ -33,4 +33,12 @@ public interface PageProcessor
     Page processColumnar(ConnectorSession session, Page page, List<? extends Type> types);
 
     Page processColumnarDictionary(ConnectorSession session, Page page, List<? extends Type> types);
+
+    /**
+     * @return true if {@link PageProcessor} might apply filter on input pages and reduce number of rows
+     */
+    default boolean isFiltering()
+    {
+        return true;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageProcessorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageProcessorCompiler.java
@@ -68,6 +68,7 @@ import static com.facebook.presto.bytecode.Access.a;
 import static com.facebook.presto.bytecode.Parameter.arg;
 import static com.facebook.presto.bytecode.ParameterizedType.type;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.add;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantBoolean;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantFalse;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantInt;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantNull;
@@ -139,6 +140,7 @@ public class PageProcessorCompiler
 
         generateFilterPageMethod(classDefinition, filter);
         generateFilterMethod(classDefinition, callSiteBinder, cachedInstanceBinder, filter);
+        generateIsFilteringMethod(classDefinition, hasFilter);
         generateConstructor(classDefinition, cachedInstanceBinder, projections.size());
     }
 
@@ -915,6 +917,13 @@ public class PageProcessorCompiler
                 .append(projection.accept(visitor, scope))
                 .append(generateWrite(callSiteBinder, scope, wasNullVariable, projection.getType()))
                 .ret();
+        return method;
+    }
+
+    private MethodDefinition generateIsFilteringMethod(ClassDefinition classDefinition, boolean hasFilter)
+    {
+        MethodDefinition method = classDefinition.declareMethod(a(PUBLIC), "isFiltering", type(boolean.class));
+        method.getBody().append(constantBoolean(hasFilter).ret());
         return method;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPageProcessorCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPageProcessorCompiler.java
@@ -70,6 +70,7 @@ public class TestPageProcessorCompiler
         Page page = getOnlyElement(pagesBuilder.build());
 
         Page outputPage = processor.processColumnar(null, page, ImmutableList.of(BIGINT));
+        assertFalse(processor.isFiltering());
         assertEquals(outputPage.getPositionCount(), 100);
         assertEquals(page.getBlock(0), outputPage.getBlock(0));
     }
@@ -87,6 +88,7 @@ public class TestPageProcessorCompiler
         Page page = getOnlyElement(pagesBuilder.build());
 
         Page outputPage = processor.processColumnar(null, page, ImmutableList.of(BIGINT));
+        assertTrue(processor.isFiltering());
         assertEquals(outputPage.getPositionCount(), 1);
         assertNotEquals(page.getBlock(0), outputPage.getBlock(0));
     }


### PR DESCRIPTION
When there is no filter condition in `FilterAndProjectOperator` it is
optimal to use columnar version of `PageProcessor` so that for
identity expressions no data is copied. Additionally, this
optimizes memory usage when `FilterAndProjectOperator` output
is used in `InnerJoin` as build table.

FYI: @dain @martint 
