### PR TITLE
Fix comparison for CHAR to take into account padding

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/CharOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/CharOperators.java
@@ -30,6 +30,7 @@ import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.type.Chars.compareChars;
 
 public final class CharOperators
 {
@@ -56,7 +57,7 @@ public final class CharOperators
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean lessThan(@SqlType("char(x)") Slice left, @SqlType("char(x)") Slice right)
     {
-        return left.compareTo(right) < 0;
+        return compareChars(left, right) < 0;
     }
 
     @LiteralParameters({"x"})
@@ -64,7 +65,7 @@ public final class CharOperators
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean lessThanOrEqual(@SqlType("char(x)") Slice left, @SqlType("char(x)") Slice right)
     {
-        return left.compareTo(right) <= 0;
+        return compareChars(left, right) <= 0;
     }
 
     @LiteralParameters({"x"})
@@ -72,7 +73,7 @@ public final class CharOperators
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean greaterThan(@SqlType("char(x)") Slice left, @SqlType("char(x)") Slice right)
     {
-        return left.compareTo(right) > 0;
+        return compareChars(left, right) > 0;
     }
 
     @LiteralParameters({"x"})
@@ -80,7 +81,7 @@ public final class CharOperators
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean greaterThanOrEqual(@SqlType("char(x)") Slice left, @SqlType("char(x)") Slice right)
     {
-        return left.compareTo(right) >= 0;
+        return compareChars(left, right) >= 0;
     }
 
     @LiteralParameters({"x"})
@@ -88,7 +89,7 @@ public final class CharOperators
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean between(@SqlType("char(x)") Slice value, @SqlType("char(x)") Slice min, @SqlType("char(x)") Slice max)
     {
-        return min.compareTo(value) <= 0 && value.compareTo(max) <= 0;
+        return compareChars(min, value) <= 0 && compareChars(value, max) <= 0;
     }
 
     @LiteralParameters("x")

--- a/presto-main/src/test/java/com/facebook/presto/type/TestCharOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestCharOperators.java
@@ -29,6 +29,13 @@ public class TestCharOperators
         assertFunction("cast('foo' as char(3)) = cast('foo' as char(3))", BOOLEAN, true);
         assertFunction("cast('foo' as char(3)) = cast('bar' as char(3))", BOOLEAN, false);
         assertFunction("cast('bar' as char(3)) = cast('foo' as char(3))", BOOLEAN, false);
+
+        assertFunction("cast('a' as char(2)) = cast('a ' as char(2))", BOOLEAN, true);
+        assertFunction("cast('a ' as char(2)) = cast('a' as char(2))", BOOLEAN, true);
+
+        assertFunction("cast('a' as char(3)) = cast('a' as char(2))", BOOLEAN, false);
+        assertFunction("cast('' as char(3)) = cast('' as char(2))", BOOLEAN, false);
+        assertFunction("cast('' as char(2)) = cast('' as char(2))", BOOLEAN, true);
     }
 
     @Test
@@ -39,6 +46,9 @@ public class TestCharOperators
         assertFunction("cast('foo' as char(3)) <> cast('foo' as char(3))", BOOLEAN, false);
         assertFunction("cast('foo' as char(3)) <> cast('bar' as char(3))", BOOLEAN, true);
         assertFunction("cast('bar' as char(3)) <> cast('foo' as char(3))", BOOLEAN, true);
+
+        assertFunction("cast('a' as char(2)) <> cast('a ' as char(2))", BOOLEAN, false);
+        assertFunction("cast('a ' as char(2)) <> cast('a' as char(2))", BOOLEAN, false);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestCharOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestCharOperators.java
@@ -49,6 +49,10 @@ public class TestCharOperators
 
         assertFunction("cast('a' as char(2)) <> cast('a ' as char(2))", BOOLEAN, false);
         assertFunction("cast('a ' as char(2)) <> cast('a' as char(2))", BOOLEAN, false);
+
+        assertFunction("cast('a' as char(3)) <> cast('a' as char(2))", BOOLEAN, true);
+        assertFunction("cast('' as char(3)) <> cast('' as char(2))", BOOLEAN, true);
+        assertFunction("cast('' as char(2)) <> cast('' as char(2))", BOOLEAN, false);
     }
 
     @Test
@@ -66,6 +70,12 @@ public class TestCharOperators
         assertFunction("cast('bar' as char(3)) < cast('foo' as char(3))", BOOLEAN, true);
         assertFunction("cast('foobar' as char(6)) < cast('foobaz' as char(6))", BOOLEAN, true);
         assertFunction("cast('foob r' as char(6)) < cast('foobar' as char(6))", BOOLEAN, true);
+        assertFunction("cast('\0' as char(1)) < cast(' ' as char(1))", BOOLEAN, true);
+        assertFunction("cast('\0' as char(1)) < cast('' as char(0))", BOOLEAN, false); // length mismatch, coercion to VARCHAR applies, thus '\0' > ''
+        assertFunction("cast('abc\0' as char(4)) < cast('abc' as char(4))", BOOLEAN, true); // 'abc' is implicitly padded with spaces -> 'abc' is greater
+        assertFunction("cast('\0' as char(1)) < cast('\0 ' as char(2))", BOOLEAN, true); // length mismatch, coercion to VARCHAR applies
+        assertFunction("cast('\0' as char(2)) < cast('\0 ' as char(2))", BOOLEAN, false); // '\0' is implicitly padded with spaces -> both are equal
+        assertFunction("cast('\0 a' as char(3)) < cast('\0' as char(3))", BOOLEAN, false);
     }
 
     @Test
@@ -83,6 +93,12 @@ public class TestCharOperators
         assertFunction("cast('bar' as char(3)) <= cast('foo' as char(3))", BOOLEAN, true);
         assertFunction("cast('foobar' as char(6)) <= cast('foobaz' as char(6))", BOOLEAN, true);
         assertFunction("cast('foob r' as char(6)) <= cast('foobar' as char(6))", BOOLEAN, true);
+        assertFunction("cast('\0' as char(1)) <= cast(' ' as char(1))", BOOLEAN, true);
+        assertFunction("cast('\0' as char(1)) <= cast('' as char(0))", BOOLEAN, false); // length mismatch, coercion to VARCHAR applies, thus '\0' > ''
+        assertFunction("cast('abc\0' as char(4)) <= cast('abc' as char(4))", BOOLEAN, true); // 'abc' is implicitly padded with spaces -> 'abc' is greater
+        assertFunction("cast('\0' as char(1)) <= cast('\0 ' as char(2))", BOOLEAN, true); // length mismatch, coercion to VARCHAR applies
+        assertFunction("cast('\0' as char(2)) <= cast('\0 ' as char(2))", BOOLEAN, true); // '\0' is implicitly padded with spaces -> both are equal
+        assertFunction("cast('\0 a' as char(3)) <= cast('\0' as char(3))", BOOLEAN, false);
     }
 
     @Test
@@ -100,6 +116,12 @@ public class TestCharOperators
         assertFunction("cast('bar' as char(3)) > cast('foo' as char(3))", BOOLEAN, false);
         assertFunction("cast('foobar' as char(6)) > cast('foobaz' as char(6))", BOOLEAN, false);
         assertFunction("cast('foob r' as char(6)) > cast('foobar' as char(6))", BOOLEAN, false);
+        assertFunction("cast(' ' as char(1)) > cast('\0' as char(1))", BOOLEAN, true);
+        assertFunction("cast('' as char(0)) > cast('\0' as char(1))", BOOLEAN, false); // length mismatch, coercion to VARCHAR applies, thus '\0' > ''
+        assertFunction("cast('abc' as char(4)) > cast('abc\0' as char(4))", BOOLEAN, true); // 'abc' is implicitly padded with spaces -> 'abc' is greater
+        assertFunction("cast('\0 ' as char(2)) > cast('\0' as char(1))", BOOLEAN, true); // length mismatch, coercion to VARCHAR applies
+        assertFunction("cast('\0 ' as char(2)) > cast('\0' as char(2))", BOOLEAN, false); // '\0' is implicitly padded with spaces -> both are equal
+        assertFunction("cast('\0 a' as char(3)) > cast('\0' as char(3))", BOOLEAN, true);
     }
 
     @Test
@@ -117,6 +139,12 @@ public class TestCharOperators
         assertFunction("cast('bar' as char(3)) >= cast('foo' as char(3))", BOOLEAN, false);
         assertFunction("cast('foobar' as char(6)) >= cast('foobaz' as char(6))", BOOLEAN, false);
         assertFunction("cast('foob r' as char(6)) >= cast('foobar' as char(6))", BOOLEAN, false);
+        assertFunction("cast(' ' as char(1)) >= cast('\0' as char(1))", BOOLEAN, true);
+        assertFunction("cast('' as char(0)) >= cast('\0' as char(1))", BOOLEAN, false); // length mismatch, coercion to VARCHAR applies, thus '\0' > ''
+        assertFunction("cast('abc' as char(4)) >= cast('abc\0' as char(4))", BOOLEAN, true); // 'abc' is implicitly padded with spaces -> 'abc' is greater
+        assertFunction("cast('\0 ' as char(2)) >= cast('\0' as char(1))", BOOLEAN, true); // length mismatch, coercion to VARCHAR applies
+        assertFunction("cast('\0 ' as char(2)) >= cast('\0' as char(2))", BOOLEAN, true); // '\0' is implicitly padded with spaces -> both are equal
+        assertFunction("cast('\0 a' as char(3)) >= cast('\0' as char(3))", BOOLEAN, true);
     }
 
     @Test
@@ -137,6 +165,8 @@ public class TestCharOperators
 
         assertFunction("cast('bar' as char(3)) BETWEEN cast('bar' as char(3)) AND cast('foo' as char(3))", BOOLEAN, true);
         assertFunction("cast('bar' as char(3)) BETWEEN cast('bar' as char(3)) AND cast('bar' as char(3))", BOOLEAN, true);
+
+        assertFunction("cast('\0 a' as char(3)) BETWEEN cast('\0' as char(3)) AND cast('\0a' as char(3))", BOOLEAN, true);
 
         // length based comparison
         assertFunction("cast('bar' as char(4)) BETWEEN cast('bar' as char(3)) AND cast('bar' as char(5))", BOOLEAN, true);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
@@ -232,6 +232,8 @@ public class TestTupleDomainOrcPredicate
         assertEquals(getDomain(CHAR, 10, stringColumnStats(5L, null, "taco")), create(ValueSet.ofRanges(lessThanOrEqual(CHAR, utf8Slice("taco"))), true));
         assertEquals(getDomain(CHAR, 10, stringColumnStats(5L, "apple     ", null)), create(ValueSet.ofRanges(greaterThanOrEqual(CHAR, utf8Slice("apple"))), true));
         assertEquals(getDomain(CHAR, 10, stringColumnStats(5L, "apple", null)), create(ValueSet.ofRanges(greaterThanOrEqual(CHAR, utf8Slice("apple"))), true));
+
+        assertEquals(getDomain(CHAR, 10, stringColumnStats(10L, "\0 ", " ")), create(ValueSet.ofRanges(range(CHAR, utf8Slice("\0"), true, utf8Slice(""), true)), false));
     }
 
     private static ColumnStatistics stringColumnStats(Long numberOfValues, String minimum, String maximum)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/CharType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/CharType.java
@@ -23,6 +23,7 @@ import io.airlift.slice.Slices;
 import java.util.Objects;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.Chars.compareChars;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 
@@ -106,9 +107,10 @@ public final class CharType
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        int leftLength = leftBlock.getLength(leftPosition);
-        int rightLength = rightBlock.getLength(rightPosition);
-        return leftBlock.compareTo(leftPosition, 0, leftLength, rightBlock, rightPosition, 0, rightLength);
+        Slice leftSlice = leftBlock.getSlice(leftPosition, 0, leftBlock.getLength(leftPosition));
+        Slice rightSlice = rightBlock.getSlice(rightPosition, 0, rightBlock.getLength(rightPosition));
+
+        return compareChars(leftSlice, rightSlice);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/Chars.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/Chars.java
@@ -112,4 +112,42 @@ public final class Chars
         }
         return 0;
     }
+
+    public static int compareChars(Slice left, Slice right)
+    {
+        if (left.length() < right.length()) {
+            return compareCharsShorterToLonger(left, right);
+        }
+        else {
+            return -compareCharsShorterToLonger(right, left);
+        }
+    }
+
+    private static int compareCharsShorterToLonger(Slice shorter, Slice longer)
+    {
+        for (int i = 0; i < shorter.length(); ++i) {
+            int result = compareUnsignedBytes(shorter.getByte(i), longer.getByte(i));
+            if (result != 0) {
+                return result;
+            }
+        }
+
+        for (int i = shorter.length(); i < longer.length(); ++i) {
+            int result = compareUnsignedBytes((byte) ' ', longer.getByte(i));
+            if (result != 0) {
+                return result;
+            }
+        }
+        return 0;
+    }
+
+    private static int compareUnsignedBytes(byte thisByte, byte thatByte)
+    {
+        return unsignedByteToInt(thisByte) - unsignedByteToInt(thatByte);
+    }
+
+    private static int unsignedByteToInt(byte thisByte)
+    {
+        return thisByte & 0xFF;
+    }
 }


### PR DESCRIPTION
Previous implementation of CHAR comparison didn't work properly with control chars (e.g. '\0').

---

Internal TD review: https://github.com/Teradata/presto/pull/363
Can be relevant: https://github.com/prestodb/presto/issues/2295
