### PR TITLE
 Remove unnecessary JMH dependency from presto-record-decoder

### DIFF
--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -94,19 +94,5 @@
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-core</artifactId>
-            <version>0.7.1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <version>0.7.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
It'd be nice to use the latest JMH version as of today.

ref. http://mail.openjdk.java.net/pipermail/jmh-dev/2016-September/002351.html