### PR TITLE
Produce better hash for int-based and long-based types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/BigintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/BigintOperators.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.AbstractLongType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Shorts;
@@ -253,6 +254,6 @@ public final class BigintOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.BIGINT) long value)
     {
-        return value;
+        return AbstractLongType.hash(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/DateOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DateOperators.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.AbstractIntType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
 import org.joda.time.chrono.ISOChronology;
@@ -148,6 +149,6 @@ public final class DateOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.DATE) long value)
     {
-        return (int) value;
+        return AbstractIntType.hash((int) value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/IntegerOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntegerOperators.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.AbstractIntType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
@@ -236,6 +237,6 @@ public final class IntegerOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.INTEGER) long value)
     {
-        return (int) value;
+        return AbstractIntType.hash((int) value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/IntervalDayTimeOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntervalDayTimeOperators.java
@@ -16,6 +16,7 @@ package com.facebook.presto.type;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.AbstractLongType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
 
@@ -162,6 +163,6 @@ public final class IntervalDayTimeOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long value)
     {
-        return value;
+        return AbstractLongType.hash(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/IntervalYearMonthOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntervalYearMonthOperators.java
@@ -17,6 +17,7 @@ import com.facebook.presto.client.IntervalYearMonth;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.AbstractIntType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.primitives.Ints;
 import io.airlift.slice.Slice;
@@ -163,6 +164,6 @@ public final class IntervalYearMonthOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long value)
     {
-        return value;
+        return AbstractIntType.hash((int) value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/RealOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RealOperators.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.AbstractIntType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Shorts;
@@ -147,7 +148,7 @@ public final class RealOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.REAL) long value)
     {
-        return value;
+        return AbstractIntType.hash((int) value);
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/com/facebook/presto/type/SmallintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/SmallintOperators.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.SmallintType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
@@ -231,6 +232,6 @@ public final class SmallintOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.SMALLINT) long value)
     {
-        return (short) value;
+        return SmallintType.hash((short) value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/TimeOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimeOperators.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.AbstractLongType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
 
@@ -137,6 +138,6 @@ public final class TimeOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.TIME) long value)
     {
-        return value;
+        return AbstractLongType.hash(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/TimeWithTimeZoneOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimeWithTimeZoneOperators.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.AbstractLongType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
 
@@ -121,6 +122,6 @@ public final class TimeWithTimeZoneOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long value)
     {
-        return unpackMillisUtc(value);
+        return AbstractLongType.hash(unpackMillisUtc(value));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.AbstractLongType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
 import org.joda.time.chrono.ISOChronology;
@@ -159,6 +160,6 @@ public final class TimestampOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.TIMESTAMP) long value)
     {
-        return value;
+        return AbstractLongType.hash(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/TimestampWithTimeZoneOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimestampWithTimeZoneOperators.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.AbstractLongType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
 import org.joda.time.chrono.ISOChronology;
@@ -164,6 +165,6 @@ public final class TimestampWithTimeZoneOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long value)
     {
-        return unpackMillisUtc(value);
+        return AbstractLongType.hash(unpackMillisUtc(value));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/TinyintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TinyintOperators.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.TinyintType;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
 
@@ -226,6 +227,6 @@ public final class TinyintOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.TINYINT) long value)
     {
-        return (byte) value;
+        return TinyintType.hash((byte) value);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestGroupByHash.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestGroupByHash.java
@@ -176,7 +176,7 @@ public class TestGroupByHash
         }
         Page outputPage = pageBuilder.build();
         assertEquals(outputPage.getPositionCount(), 50);
-        BlockAssertions.assertBlockEquals(BIGINT, outputPage.getBlock(1), BlockAssertions.createLongSequenceBlock(0, 50));
+        BlockAssertions.assertBlockEquals(BIGINT, outputPage.getBlock(0), BlockAssertions.createLongSequenceBlock(0, 50));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -408,8 +408,8 @@ public class TestHashAggregationOperator
             MaterializedResult actual;
             if (hashEnabled) {
                 // Drop the hashChannel for all pages
-                List<Page> actualPages = dropChannel(outputPages, hashChannels);
-                List<Type> expectedTypes = without(operator.getTypes(), hashChannels);
+                List<Page> actualPages = dropChannel(outputPages, ImmutableList.of(1));
+                List<Type> expectedTypes = without(operator.getTypes(), ImmutableList.of(1));
                 actual = toMaterializedResult(operator.getOperatorContext().getSession(), expectedTypes, actualPages);
             }
             else {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
@@ -19,6 +19,8 @@ import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.IntArrayBlockBuilder;
 import io.airlift.slice.Slice;
 
+import static java.lang.Long.rotateLeft;
+
 public abstract class AbstractIntType
         extends AbstractType
         implements FixedWidthType
@@ -86,7 +88,7 @@ public abstract class AbstractIntType
     @Override
     public long hash(Block block, int position)
     {
-        return block.getInt(position, 0);
+        return hash(block.getInt(position, 0));
     }
 
     @Override
@@ -117,5 +119,11 @@ public abstract class AbstractIntType
     public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
         return new IntArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
+    }
+
+    public static long hash(int value)
+    {
+        // xxhash64 mix
+        return rotateLeft(value * 0xC2B2AE3D27D4EB4FL, 31) * 0x9E3779B185EBCA87L;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
@@ -19,6 +19,8 @@ import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.LongArrayBlockBuilder;
 import io.airlift.slice.Slice;
 
+import static java.lang.Long.rotateLeft;
+
 public abstract class AbstractLongType
         extends AbstractType
         implements FixedWidthType
@@ -86,7 +88,7 @@ public abstract class AbstractLongType
     @Override
     public long hash(Block block, int position)
     {
-        return block.getLong(position, 0);
+        return hash(block.getLong(position, 0));
     }
 
     @Override
@@ -115,5 +117,11 @@ public abstract class AbstractLongType
     public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
         return new LongArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
+    }
+
+    public static long hash(long value)
+    {
+        // xxhash64 mix
+        return rotateLeft(value * 0xC2B2AE3D27D4EB4FL, 31) * 0x9E3779B185EBCA87L;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.block.ShortArrayBlockBuilder;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static java.lang.Long.rotateLeft;
 
 public final class SmallintType
         extends AbstractType
@@ -93,7 +94,7 @@ public final class SmallintType
     @Override
     public long hash(Block block, int position)
     {
-        return block.getShort(position, 0);
+        return hash(block.getShort(position, 0));
     }
 
     @Override
@@ -147,5 +148,11 @@ public final class SmallintType
     public int hashCode()
     {
         return getClass().hashCode();
+    }
+
+    public static long hash(short value)
+    {
+        // xxhash64 mix
+        return rotateLeft(value * 0xC2B2AE3D27D4EB4FL, 31) * 0x9E3779B185EBCA87L;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeWithTimeZoneType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeWithTimeZoneType.java
@@ -47,10 +47,9 @@ public final class TimeWithTimeZoneType
         return leftValue == rightValue;
     }
 
-    @Override
     public long hash(Block block, int position)
     {
-        return unpackMillisUtc(block.getLong(position, 0));
+        return AbstractLongType.hash(unpackMillisUtc(block.getLong(position, 0)));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampWithTimeZoneType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampWithTimeZoneType.java
@@ -50,7 +50,7 @@ public final class TimestampWithTimeZoneType
     @Override
     public long hash(Block block, int position)
     {
-        return unpackMillisUtc(block.getLong(position, 0));
+        return AbstractLongType.hash(unpackMillisUtc(block.getLong(position, 0)));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.block.ByteArrayBlockBuilder;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static java.lang.Long.rotateLeft;
 
 public final class TinyintType
         extends AbstractType
@@ -93,7 +94,7 @@ public final class TinyintType
     @Override
     public long hash(Block block, int position)
     {
-        return block.getByte(position, 0);
+        return hash(block.getByte(position, 0));
     }
 
     @Override
@@ -146,5 +147,11 @@ public final class TinyintType
     public int hashCode()
     {
         return getClass().hashCode();
+    }
+
+    public static long hash(byte value)
+    {
+        // xxhash64 mix
+        return rotateLeft(value * 0xC2B2AE3D27D4EB4FL, 31) * 0x9E3779B185EBCA87L;
     }
 }


### PR DESCRIPTION
The previous implementation produces bad hashes, which can
cause downstream skew when the hashes are not combined in a
 way that scrambles the bits properly (e.g., combine hash).