### PR TITLE
Do not exit from nested bash

### DIFF
--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -1,17 +1,23 @@
 # docker-compose has a limited understanding of relative paths and interprets them relative to
 # compose-file location. We can't guarantee the shape of the paths coming from env variables,
 # so we canonicalize them.
-function canonical_path() {
+function export_canonical_path() {
     # make the path start with '/' or './'. Otherwise the result for 'foo.txt' is an absolute path.
-    local PATH=$([[ $1 = /* ]] && echo "$1" || echo "./${1#./}")
+    local PATH_REFERENCE=$1
+    # when ref=var; var=value; then ${!ref} returns value 
+    local PATH=${!PATH_REFERENCE}
+    if [[ ${PATH} != /* ]] ; then
+      PATH=./${PATH}
+    fi
     if [[ -d $PATH ]]; then
-        (cd $PATH && pwd)
+        PATH=$(cd $PATH && pwd)
     elif [[ -f $PATH ]]; then
-        echo "$(cd ${PATH%/*} && pwd)/${PATH##*/}"
+        PATH=$(echo "$(cd ${PATH%/*} && pwd)/${PATH##*/}")
     else
         echo "Invalid path: [$PATH]. Working directory is [$(pwd)]."
         exit 1
     fi
+    export $PATH_REFERENCE=$PATH
 }
 
 source ${BASH_SOURCE%/*}/../../../bin/locations.sh
@@ -27,18 +33,18 @@ if [[ -z ${PRESTO_SERVER_DIR} ]]; then
     source "${PRODUCT_TESTS_ROOT}/target/classes/presto.env"
     PRESTO_SERVER_DIR="${PROJECT_ROOT}/presto-server/target/presto-server-${PRESTO_VERSION}/"
 fi
-export PRESTO_SERVER_DIR=$(canonical_path ${PRESTO_SERVER_DIR})
+export_canonical_path PRESTO_SERVER_DIR
 
 if [[ -z ${PRESTO_CLI_JAR} ]]; then
     source "${PRODUCT_TESTS_ROOT}/target/classes/presto.env"
     PRESTO_CLI_JAR="${PROJECT_ROOT}/presto-cli/target/presto-cli-${PRESTO_VERSION}-executable.jar"
 fi
-export PRESTO_CLI_JAR=$(canonical_path ${PRESTO_CLI_JAR})
+export_canonical_path PRESTO_CLI_JAR
 
 if [[ -z ${PRODUCT_TESTS_JAR} ]]; then
     source "${PRODUCT_TESTS_ROOT}/target/classes/presto.env"
     PRODUCT_TESTS_JAR="${PRODUCT_TESTS_ROOT}/target/presto-product-tests-${PRESTO_VERSION}-executable.jar"
 fi
-export PRODUCT_TESTS_JAR=$(canonical_path ${PRODUCT_TESTS_JAR})
+export_canonical_path PRODUCT_TESTS_JAR
 
 export HIVE_PROXY_PORT=${HIVE_PROXY_PORT:-1180}

--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -3,13 +3,13 @@
 # so we canonicalize them.
 function canonical_path() {
     # make the path start with '/' or './'. Otherwise the result for 'foo.txt' is an absolute path.
-    local PATH=`[[ $1 = /* ]] && echo "$1" || echo "./${1#./}"`
+    local PATH=$([[ $1 = /* ]] && echo "$1" || echo "./${1#./}")
     if [[ -d $PATH ]]; then
         (cd $PATH && pwd)
     elif [[ -f $PATH ]]; then
-        echo "`cd ${PATH%/*} && pwd`/${PATH##*/}"
+        echo "$(cd ${PATH%/*} && pwd)/${PATH##*/}"
     else
-        echo "Invalid path: [$PATH]. Working directory is [`pwd`]."
+        echo "Invalid path: [$PATH]. Working directory is [$(pwd)]."
         exit 1
     fi
 }


### PR DESCRIPTION
Do not exit from nested bash

When an exit is called from a function called withing $(...) it exits
only the nested bash. In order to fix that function was called within
the same bash.

Fixes #6240.
