### PR TITLE
Make DOCKER_IMAGES_VERSION overridable

### DIFF
--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -16,7 +16,7 @@ function canonical_path() {
 
 source ${BASH_SOURCE%/*}/../../../bin/locations.sh
 
-export DOCKER_IMAGES_VERSION=7
+export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-7}
 export HADOOP_MASTER_IMAGE=${HADOOP_MASTER_IMAGE:-"teradatalabs/cdh5-hive:${DOCKER_IMAGES_VERSION}"}
 
 # The following variables are defined to enable running product tests with arbitrary/downloaded jars


### PR DESCRIPTION
This allows for running additional product tests checking
if new versions of docker images behave as expected.