### PR TITLE
Allow type mismatch between table and partition schema

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/CoercionPolicy.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/CoercionPolicy.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+public interface CoercionPolicy
+{
+    boolean canCoerce(HiveType fromType, HiveType toType);
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -73,6 +73,7 @@ public class HiveClientModule
     {
         binder.bind(HiveConnectorId.class).toInstance(new HiveConnectorId(connectorId));
         binder.bind(TypeTranslator.class).toInstance(new HiveTypeTranslator());
+        binder.bind(CoercionPolicy.class).to(HiveCoercionPolicy.class).in(Scopes.SINGLETON);
 
         binder.bind(HdfsConfigurationUpdater.class).in(Scopes.SINGLETON);
         binder.bind(HdfsConfiguration.class).to(HiveHdfsConfiguration.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionPolicy.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionPolicy.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.inject.Inject;
+
+import static com.facebook.presto.hive.HiveType.HIVE_BYTE;
+import static com.facebook.presto.hive.HiveType.HIVE_DOUBLE;
+import static com.facebook.presto.hive.HiveType.HIVE_FLOAT;
+import static com.facebook.presto.hive.HiveType.HIVE_INT;
+import static com.facebook.presto.hive.HiveType.HIVE_LONG;
+import static com.facebook.presto.hive.HiveType.HIVE_SHORT;
+import static java.util.Objects.requireNonNull;
+
+public class HiveCoercionPolicy
+        implements CoercionPolicy
+{
+    private final TypeManager typeManager;
+
+    @Inject
+    public HiveCoercionPolicy(TypeManager typeManager)
+    {
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    @Override
+    public boolean canCoerce(HiveType fromHiveType, HiveType toHiveType)
+    {
+        Type fromType = typeManager.getType(fromHiveType.getTypeSignature());
+        Type toType = typeManager.getType(toHiveType.getTypeSignature());
+        if (fromType instanceof VarcharType) {
+            return toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG);
+        }
+        if (toType instanceof VarcharType) {
+            return fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG);
+        }
+        if (fromHiveType.equals(HIVE_BYTE)) {
+            return toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG);
+        }
+        if (fromHiveType.equals(HIVE_SHORT)) {
+            return toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG);
+        }
+        if (fromHiveType.equals(HIVE_INT)) {
+            return toHiveType.equals(HIVE_LONG);
+        }
+        if (fromHiveType.equals(HIVE_FLOAT)) {
+            return toHiveType.equals(HIVE_DOUBLE);
+        }
+
+        return false;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionRecordCursor.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.HivePageSourceProvider.ColumnMapping;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.util.List;
+
+import static com.facebook.presto.hive.HiveType.HIVE_BYTE;
+import static com.facebook.presto.hive.HiveType.HIVE_DOUBLE;
+import static com.facebook.presto.hive.HiveType.HIVE_FLOAT;
+import static com.facebook.presto.hive.HiveType.HIVE_INT;
+import static com.facebook.presto.hive.HiveType.HIVE_LONG;
+import static com.facebook.presto.hive.HiveType.HIVE_SHORT;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
+import static java.util.Objects.requireNonNull;
+
+public class HiveCoercionRecordCursor
+        implements RecordCursor
+{
+    private final RecordCursor delegate;
+    private final List<ColumnMapping> columnMappings;
+    private final Coercer[] coercers;
+
+    public HiveCoercionRecordCursor(
+            List<ColumnMapping> columnMappings,
+            TypeManager typeManager,
+            RecordCursor delegate)
+    {
+        requireNonNull(columnMappings, "columns is null");
+        requireNonNull(typeManager, "typeManager is null");
+
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.columnMappings = ImmutableList.copyOf(columnMappings);
+
+        int size = columnMappings.size();
+
+        this.coercers = new Coercer[size];
+
+        for (int columnIndex = 0; columnIndex < size; columnIndex++) {
+            ColumnMapping columnMapping = columnMappings.get(columnIndex);
+
+            if (columnMapping.getCoercionFrom().isPresent()) {
+                coercers[columnIndex] = createCoercer(typeManager, columnMapping.getCoercionFrom().get(), columnMapping.getHiveColumnHandle().getHiveType());
+            }
+        }
+    }
+
+    @Override
+    public long getTotalBytes()
+    {
+        return delegate.getTotalBytes();
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return delegate.getCompletedBytes();
+    }
+
+    @Override
+    public Type getType(int field)
+    {
+        return delegate.getType(field);
+    }
+
+    @Override
+    public boolean advanceNextPosition()
+    {
+        for (int i = 0; i < columnMappings.size(); i++) {
+            if (coercers[i] != null) {
+                coercers[i].reset();
+            }
+        }
+        return delegate.advanceNextPosition();
+    }
+
+    @Override
+    public boolean getBoolean(int field)
+    {
+        if (coercers[field] == null) {
+            return delegate.getBoolean(field);
+        }
+        return coercers[field].getBoolean(delegate, field);
+    }
+
+    @Override
+    public long getLong(int field)
+    {
+        if (coercers[field] == null) {
+            return delegate.getLong(field);
+        }
+        return coercers[field].getLong(delegate, field);
+    }
+
+    @Override
+    public double getDouble(int field)
+    {
+        if (coercers[field] == null) {
+            return delegate.getDouble(field);
+        }
+        return coercers[field].getDouble(delegate, field);
+    }
+
+    @Override
+    public Slice getSlice(int field)
+    {
+        if (coercers[field] == null) {
+            return delegate.getSlice(field);
+        }
+        return coercers[field].getSlice(delegate, field);
+    }
+
+    @Override
+    public Object getObject(int field)
+    {
+        if (coercers[field] == null) {
+            return delegate.getObject(field);
+        }
+        return coercers[field].getObject(delegate, field);
+    }
+
+    @Override
+    public boolean isNull(int field)
+    {
+        if (coercers[field] == null) {
+            return delegate.isNull(field);
+        }
+        return coercers[field].isNull(delegate, field);
+    }
+
+    @Override
+    public void close()
+    {
+        delegate.close();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return delegate.getReadTimeNanos();
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return delegate.getSystemMemoryUsage();
+    }
+
+    @VisibleForTesting
+    RecordCursor getRegularColumnRecordCursor()
+    {
+        return delegate;
+    }
+
+    private abstract static class Coercer
+    {
+        private boolean isNull;
+        private boolean loaded;
+
+        private boolean booleanValue;
+        private long longValue;
+        private double doubleValue;
+        private Slice sliceValue;
+        private Object objectValue;
+
+        public void reset()
+        {
+            isNull = false;
+            loaded = false;
+        }
+
+        public boolean isNull(RecordCursor delegate, int field)
+        {
+            assureLoaded(delegate, field);
+            return isNull;
+        }
+
+        public boolean getBoolean(RecordCursor delegate, int field)
+        {
+            assureLoaded(delegate, field);
+            return booleanValue;
+        }
+
+        public long getLong(RecordCursor delegate, int field)
+        {
+            assureLoaded(delegate, field);
+            return longValue;
+        }
+
+        public double getDouble(RecordCursor delegate, int field)
+        {
+            assureLoaded(delegate, field);
+            return doubleValue;
+        }
+
+        public Slice getSlice(RecordCursor delegate, int field)
+        {
+            assureLoaded(delegate, field);
+            return sliceValue;
+        }
+
+        public Object getObject(RecordCursor delegate, int field)
+        {
+            assureLoaded(delegate, field);
+            return objectValue;
+        }
+
+        private void assureLoaded(RecordCursor delegate, int field)
+        {
+            if (!loaded) {
+                isNull = delegate.isNull(field);
+                if (!isNull) {
+                    coerce(delegate, field);
+                }
+                loaded = true;
+            }
+        }
+
+        protected abstract void coerce(RecordCursor delegate, int field);
+
+        protected void setBoolean(boolean value)
+        {
+            booleanValue = value;
+        }
+
+        protected void setLong(long value)
+        {
+            longValue = value;
+        }
+
+        protected void setDouble(double value)
+        {
+            doubleValue = value;
+        }
+
+        protected void setSlice(Slice value)
+        {
+            sliceValue = value;
+        }
+
+        protected void setObject(Object value)
+        {
+            objectValue = value;
+        }
+
+        protected void setIsNull(boolean isNull)
+        {
+            this.isNull = isNull;
+        }
+    }
+
+    private static Coercer createCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType)
+    {
+        Type fromType = typeManager.getType(fromHiveType.getTypeSignature());
+        Type toType = typeManager.getType(toHiveType.getTypeSignature());
+        if (toType instanceof VarcharType && (fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG))) {
+            return new IntegerNumberToVarcharCoercer();
+        }
+        else if (fromType instanceof VarcharType && (toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
+            return new VarcharToIntegerNumberCoercer(toHiveType);
+        }
+        else if (fromHiveType.equals(HIVE_BYTE) && toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG)) {
+            return new IntegerNumberUpscaleCoercer();
+        }
+        else if (fromHiveType.equals(HIVE_SHORT) && toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG)) {
+            return new IntegerNumberUpscaleCoercer();
+        }
+        else if (fromHiveType.equals(HIVE_INT) && toHiveType.equals(HIVE_LONG)) {
+            return new IntegerNumberUpscaleCoercer();
+        }
+        else if (fromHiveType.equals(HIVE_FLOAT) && toHiveType.equals(HIVE_DOUBLE)) {
+            return new FloatToDoubleCoercer();
+        }
+        throw new PrestoException(NOT_SUPPORTED, format("Unsupported coercion from %s to %s", fromHiveType, toHiveType));
+    }
+
+    private static class IntegerNumberUpscaleCoercer
+            extends Coercer
+    {
+        @Override
+        public void coerce(RecordCursor delegate, int field)
+        {
+            setLong(delegate.getLong(field));
+        }
+    }
+
+    private static class IntegerNumberToVarcharCoercer
+            extends Coercer
+    {
+        @Override
+        public void coerce(RecordCursor delegate, int field)
+        {
+            setSlice(utf8Slice(valueOf(delegate.getLong(field))));
+        }
+    }
+
+    private static class FloatToDoubleCoercer
+            extends Coercer
+    {
+        @Override
+        protected void coerce(RecordCursor delegate, int field)
+        {
+            setDouble(intBitsToFloat((int) delegate.getLong(field)));
+        }
+    }
+
+    private static class VarcharToIntegerNumberCoercer
+            extends Coercer
+    {
+        private final long maxValue;
+        private final long minValue;
+
+        public VarcharToIntegerNumberCoercer(HiveType type)
+        {
+            if (type.equals(HIVE_BYTE)) {
+                minValue = Byte.MIN_VALUE;
+                maxValue = Byte.MAX_VALUE;
+            }
+            else if (type.equals(HIVE_SHORT)) {
+                minValue = Short.MIN_VALUE;
+                maxValue = Short.MAX_VALUE;
+            }
+            else if (type.equals(HIVE_INT)) {
+                minValue = Integer.MIN_VALUE;
+                maxValue = Integer.MAX_VALUE;
+            }
+            else if (type.equals(HIVE_LONG)) {
+                minValue = Long.MIN_VALUE;
+                maxValue = Long.MAX_VALUE;
+            }
+            else {
+                throw new PrestoException(NOT_SUPPORTED, format("Could not create Coercer from varchar to %s", type));
+            }
+        }
+
+        @Override
+        public void coerce(RecordCursor delegate, int field)
+        {
+            try {
+                long value = Long.parseLong(delegate.getSlice(field).toStringUtf8());
+                if (minValue <= value && value <= maxValue) {
+                    setLong(value);
+                }
+                else {
+                    setIsNull(true);
+                }
+            }
+            catch (NumberFormatException e) {
+                setIsNull(true);
+            }
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
@@ -18,17 +18,29 @@ import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.LazyBlock;
+import com.facebook.presto.spi.block.LazyBlockLoader;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.base.Throwables;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Function;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
+import static com.facebook.presto.hive.HiveType.HIVE_BYTE;
+import static com.facebook.presto.hive.HiveType.HIVE_DOUBLE;
+import static com.facebook.presto.hive.HiveType.HIVE_FLOAT;
+import static com.facebook.presto.hive.HiveType.HIVE_INT;
+import static com.facebook.presto.hive.HiveType.HIVE_LONG;
+import static com.facebook.presto.hive.HiveType.HIVE_SHORT;
 import static com.facebook.presto.hive.HiveUtil.bigintPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.booleanPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.charPartitionKey;
@@ -56,7 +68,10 @@ import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.intBitsToFloat;
 import static java.lang.String.format;
+import static java.lang.String.valueOf;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
@@ -65,7 +80,8 @@ public class HivePageSource
 {
     private List<ColumnMapping> columnMappings;
     private final Object[] prefilledValues;
-    private Type[] types;
+    private final Type[] types;
+    private final Function<Block, Block>[] coercers;
 
     private final ConnectorPageSource delegate;
 
@@ -86,6 +102,7 @@ public class HivePageSource
 
         prefilledValues = new Object[size];
         types = new Type[size];
+        coercers = new Function[size];
 
         for (int columnIndex = 0; columnIndex < size; columnIndex++) {
             ColumnMapping columnMapping = columnMappings.get(columnIndex);
@@ -94,6 +111,10 @@ public class HivePageSource
             String name = column.getName();
             Type type = typeManager.getType(column.getTypeSignature());
             types[columnIndex] = type;
+
+            if (columnMapping.getCoercionFrom().isPresent()) {
+                coercers[columnIndex] = createCoercer(typeManager, columnMapping.getCoercionFrom().get(), columnMapping.getHiveColumnHandle().getHiveType());
+            }
 
             if (columnMapping.isPrefilled()) {
                 String columnValue = columnMapping.getPrefilledValue();
@@ -186,11 +207,15 @@ public class HivePageSource
             }
             int batchSize = dataPage.getPositionCount();
             for (int fieldId = 0; fieldId < blocks.length; fieldId++) {
-                if (columnMappings.get(fieldId).isPrefilled()) {
+                ColumnMapping columnMapping = columnMappings.get(fieldId);
+                if (columnMapping.isPrefilled()) {
                     blocks[fieldId] = RunLengthEncodedBlock.create(types[fieldId], prefilledValues[fieldId], batchSize);
                 }
                 else {
-                    blocks[fieldId] = dataPage.getBlock(columnMappings.get(fieldId).getIndex());
+                    blocks[fieldId] = dataPage.getBlock(columnMapping.getIndex());
+                    if (coercers[fieldId] != null) {
+                        blocks[fieldId] = new LazyBlock(batchSize, new CoercionLazyBlockLoader(blocks[fieldId], coercers[fieldId]));
+                    }
                 }
             }
             return new Page(batchSize, blocks);
@@ -245,5 +270,191 @@ public class HivePageSource
     public ConnectorPageSource getPageSource()
     {
         return delegate;
+    }
+
+    private static Function<Block, Block> createCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType)
+    {
+        Type fromType = typeManager.getType(fromHiveType.getTypeSignature());
+        Type toType = typeManager.getType(toHiveType.getTypeSignature());
+        if (toType instanceof VarcharType && (fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG))) {
+            return new IntegerNumberToVarcharCoercer(fromType, toType);
+        }
+        else if (fromType instanceof VarcharType && (toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
+            return new VarcharToIntegerNumberCoercer(fromType, toType);
+        }
+        else if (fromHiveType.equals(HIVE_BYTE) && toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG)) {
+            return new IntegerNumberUpscaleCoercer(fromType, toType);
+        }
+        else if (fromHiveType.equals(HIVE_SHORT) && toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG)) {
+            return new IntegerNumberUpscaleCoercer(fromType, toType);
+        }
+        else if (fromHiveType.equals(HIVE_INT) && toHiveType.equals(HIVE_LONG)) {
+            return new IntegerNumberUpscaleCoercer(fromType, toType);
+        }
+        else if (fromHiveType.equals(HIVE_FLOAT) && toHiveType.equals(HIVE_DOUBLE)) {
+            return new FloatToDoubleCoercer();
+        }
+
+        throw new PrestoException(NOT_SUPPORTED, format("Unsupported coercion from %s to %s", fromHiveType, toHiveType));
+    }
+
+    private static class IntegerNumberUpscaleCoercer
+            implements Function<Block, Block>
+    {
+        private final Type fromType;
+        private final Type toType;
+
+        public IntegerNumberUpscaleCoercer(Type fromType, Type toType)
+        {
+            this.fromType = requireNonNull(fromType, "fromType is null");
+            this.toType = requireNonNull(toType, "toType is null");
+        }
+
+        @Override
+        public Block apply(Block block)
+        {
+            BlockBuilder blockBuilder = toType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount());
+            for (int i = 0; i < block.getPositionCount(); i++) {
+                if (block.isNull(i)) {
+                    blockBuilder.appendNull();
+                    continue;
+                }
+                toType.writeLong(blockBuilder, fromType.getLong(block, i));
+            }
+            return blockBuilder.build();
+        }
+    }
+
+    private static class IntegerNumberToVarcharCoercer
+            implements Function<Block, Block>
+    {
+        private final Type fromType;
+        private final Type toType;
+
+        public IntegerNumberToVarcharCoercer(Type fromType, Type toType)
+        {
+            this.fromType = requireNonNull(fromType, "fromType is null");
+            this.toType = requireNonNull(toType, "toType is null");
+        }
+
+        @Override
+        public Block apply(Block block)
+        {
+            BlockBuilder blockBuilder = toType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount());
+            for (int i = 0; i < block.getPositionCount(); i++) {
+                if (block.isNull(i)) {
+                    blockBuilder.appendNull();
+                    continue;
+                }
+                toType.writeSlice(blockBuilder, utf8Slice(valueOf(fromType.getLong(block, i))));
+            }
+            return blockBuilder.build();
+        }
+    }
+
+    private static class VarcharToIntegerNumberCoercer
+            implements Function<Block, Block>
+    {
+        private final Type fromType;
+        private final Type toType;
+
+        private final long minValue;
+        private final long maxValue;
+
+        public VarcharToIntegerNumberCoercer(Type fromType, Type toType)
+        {
+            this.fromType = requireNonNull(fromType, "fromType is null");
+            this.toType = requireNonNull(toType, "toType is null");
+
+            if (toType.equals(TINYINT)) {
+                minValue = Byte.MIN_VALUE;
+                maxValue = Byte.MAX_VALUE;
+            }
+            else if (toType.equals(SMALLINT)) {
+                minValue = Short.MIN_VALUE;
+                maxValue = Short.MAX_VALUE;
+            }
+            else if (toType.equals(INTEGER)) {
+                minValue = Integer.MIN_VALUE;
+                maxValue = Integer.MAX_VALUE;
+            }
+            else if (toType.equals(BIGINT)) {
+                minValue = Long.MIN_VALUE;
+                maxValue = Long.MAX_VALUE;
+            }
+            else {
+                throw new PrestoException(NOT_SUPPORTED, format("Could not create Coercer from from varchar to %s", toType));
+            }
+        }
+
+        @Override
+        public Block apply(Block block)
+        {
+            BlockBuilder blockBuilder = toType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount());
+            for (int i = 0; i < block.getPositionCount(); i++) {
+                if (block.isNull(i)) {
+                    blockBuilder.appendNull();
+                    continue;
+                }
+                try {
+                    long value = Long.parseLong(fromType.getSlice(block, i).toStringUtf8());
+                    if (minValue <= value && value <= maxValue) {
+                        toType.writeLong(blockBuilder, value);
+                    }
+                    else {
+                        blockBuilder.appendNull();
+                    }
+                }
+                catch (NumberFormatException e) {
+                    blockBuilder.appendNull();
+                }
+            }
+            return blockBuilder.build();
+        }
+    }
+
+    private static class FloatToDoubleCoercer
+            implements Function<Block, Block>
+    {
+        @Override
+        public Block apply(Block block)
+        {
+            BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount());
+            for (int i = 0; i < block.getPositionCount(); i++) {
+                if (block.isNull(i)) {
+                    blockBuilder.appendNull();
+                    continue;
+                }
+                DOUBLE.writeDouble(blockBuilder, intBitsToFloat((int) REAL.getLong(block, i)));
+            }
+            return blockBuilder.build();
+        }
+    }
+
+    private final class CoercionLazyBlockLoader
+            implements LazyBlockLoader<LazyBlock>
+    {
+        private final Function<Block, Block> coercer;
+        private Block block;
+
+        public CoercionLazyBlockLoader(Block block, Function<Block, Block> coercer)
+        {
+            this.block = requireNonNull(block, "block is null");
+            this.coercer = requireNonNull(coercer, "coercer is null");
+        }
+
+        @Override
+        public void load(LazyBlock lazyBlock)
+        {
+            if (block == null) {
+                return;
+            }
+
+            Block coercedBlock = coercer.apply(block);
+            lazyBlock.setBlock(coercedBlock);
+
+            // clear reference to loader to free resources, since load was successful
+            block = null;
+        }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionMetadata.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.metastore.Partition;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -23,11 +24,13 @@ public class HivePartitionMetadata
 {
     private final Optional<Partition> partition;
     private final HivePartition hivePartition;
+    private final Map<Integer, HiveType> columnCoercions;
 
-    HivePartitionMetadata(HivePartition hivePartition, Optional<Partition> partition)
+    HivePartitionMetadata(HivePartition hivePartition, Optional<Partition> partition, Map<Integer, HiveType> columnCoercions)
     {
         this.partition = requireNonNull(partition, "partition is null");
         this.hivePartition = requireNonNull(hivePartition, "hivePartition is null");
+        this.columnCoercions = requireNonNull(columnCoercions, "columnCoercions is null");
     }
 
     public HivePartition getHivePartition()
@@ -41,5 +44,10 @@ public class HivePartitionMetadata
     public Optional<Partition> getPartition()
     {
         return partition;
+    }
+
+    public Map<Integer, HiveType> getColumnCoercions()
+    {
+        return columnCoercions;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveRecordCursor.java
@@ -258,7 +258,7 @@ public class HiveRecordCursor
     }
 
     @VisibleForTesting
-    public RecordCursor getRegularColumnRecordCursor()
+    RecordCursor getRegularColumnRecordCursor()
     {
         return delegate;
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalInt;
 import java.util.Properties;
 
@@ -45,6 +46,7 @@ public class HiveSplit
     private final TupleDomain<HiveColumnHandle> effectivePredicate;
     private final OptionalInt bucketNumber;
     private final boolean forceLocalScheduling;
+    private final Map<Integer, HiveType> columnCoercions;
 
     @JsonCreator
     public HiveSplit(
@@ -60,7 +62,8 @@ public class HiveSplit
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("bucketNumber") OptionalInt bucketNumber,
             @JsonProperty("forceLocalScheduling") boolean forceLocalScheduling,
-            @JsonProperty("effectivePredicate") TupleDomain<HiveColumnHandle> effectivePredicate)
+            @JsonProperty("effectivePredicate") TupleDomain<HiveColumnHandle> effectivePredicate,
+            @JsonProperty("columnCoercions") Map<Integer, HiveType> columnCoercions)
     {
         requireNonNull(clientId, "clientId is null");
         checkArgument(start >= 0, "start must be positive");
@@ -74,6 +77,7 @@ public class HiveSplit
         requireNonNull(addresses, "addresses is null");
         requireNonNull(bucketNumber, "bucketNumber is null");
         requireNonNull(effectivePredicate, "tupleDomain is null");
+        requireNonNull(columnCoercions, "columnCoercions is null");
 
         this.clientId = clientId;
         this.database = database;
@@ -88,6 +92,7 @@ public class HiveSplit
         this.bucketNumber = bucketNumber;
         this.forceLocalScheduling = forceLocalScheduling;
         this.effectivePredicate = effectivePredicate;
+        this.columnCoercions = columnCoercions;
     }
 
     @JsonProperty
@@ -167,6 +172,12 @@ public class HiveSplit
     public boolean isForceLocalScheduling()
     {
         return forceLocalScheduling;
+    }
+
+    @JsonProperty
+    public Map<Integer, HiveType> getColumnCoercions()
+    {
+        return columnCoercions;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/HiveFileIterator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/HiveFileIterator.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive.util;
 import com.facebook.presto.hive.DirectoryLister;
 import com.facebook.presto.hive.HiveColumnHandle;
 import com.facebook.presto.hive.HivePartitionKey;
+import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.hive.NamenodeStats;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.predicate.TupleDomain;
@@ -30,6 +31,7 @@ import org.apache.hadoop.mapred.InputFormat;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
@@ -48,6 +50,7 @@ public class HiveFileIterator
     private final Properties schema;
     private final List<HivePartitionKey> partitionKeys;
     private final TupleDomain<HiveColumnHandle> effectivePredicate;
+    private final Map<Integer, HiveType> columnCoercions;
 
     private RemoteIterator<LocatedFileStatus> remoteIterator;
 
@@ -60,7 +63,8 @@ public class HiveFileIterator
             InputFormat<?, ?> inputFormat,
             Properties schema,
             List<HivePartitionKey> partitionKeys,
-            TupleDomain<HiveColumnHandle> effectivePredicate)
+            TupleDomain<HiveColumnHandle> effectivePredicate,
+            Map<Integer, HiveType> columnCoercions)
     {
         this.partitionName = requireNonNull(partitionName, "partitionName is null");
         this.inputFormat = requireNonNull(inputFormat, "inputFormat is null");
@@ -71,6 +75,7 @@ public class HiveFileIterator
         this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
         this.directoryLister = requireNonNull(directoryLister, "directoryLister is null");
         this.namenodeStats = requireNonNull(namenodeStats, "namenodeStats is null");
+        this.columnCoercions = requireNonNull(columnCoercions, "columnCoercions is null");
     }
 
     @Override
@@ -163,5 +168,10 @@ public class HiveFileIterator
     public TupleDomain<HiveColumnHandle> getEffectivePredicate()
     {
         return effectivePredicate;
+    }
+
+    public Map<Integer, HiveType> getColumnCoercions()
+    {
+        return columnCoercions;
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -190,6 +190,7 @@ public abstract class AbstractTestHiveClientS3
                 hdfsEnvironment,
                 new HadoopDirectoryLister(),
                 new BoundedExecutor(executor, hiveClientConfig.getMaxSplitIteratorThreads()),
+                new HiveCoercionPolicy(typeManager),
                 hiveClientConfig.getMaxOutstandingSplits(),
                 hiveClientConfig.getMinPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionBatchSize(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -29,6 +29,7 @@ import com.facebook.presto.type.ArrayType;
 import com.facebook.presto.type.RowType;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -576,7 +577,8 @@ public class TestHiveFileFormats
                 getColumnHandles(testColumns),
                 partitionKeys,
                 DateTimeZone.getDefault(),
-                TYPE_MANAGER);
+                TYPE_MANAGER,
+                ImmutableMap.of());
 
         RecordCursor cursor = checkType(pageSource.get(), RecordPageSource.class, "pageSource").getCursor();
 
@@ -619,7 +621,8 @@ public class TestHiveFileFormats
                 columnHandles,
                 partitionKeys,
                 DateTimeZone.getDefault(),
-                TYPE_MANAGER);
+                TYPE_MANAGER,
+                ImmutableMap.of());
 
         assertTrue(pageSource.isPresent());
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -204,7 +204,7 @@ public class TestHivePageSink
         splitProperties.setProperty(SERIALIZATION_LIB, config.getHiveStorageFormat().getSerDe());
         splitProperties.setProperty("columns", Joiner.on(',').join(getColumnHandles().stream().map(HiveColumnHandle::getName).collect(toList())));
         splitProperties.setProperty("columns.types", Joiner.on(',').join(getColumnHandles().stream().map(HiveColumnHandle::getHiveType).map(HiveType::getHiveTypeName).collect(toList())));
-        HiveSplit split = new HiveSplit(CLIENT_ID, SCHEMA_NAME, TABLE_NAME, "", "file:///" + outputFile.getAbsolutePath(), 0, outputFile.length(), splitProperties, ImmutableList.of(), ImmutableList.of(), OptionalInt.empty(), false, TupleDomain.all());
+        HiveSplit split = new HiveSplit(CLIENT_ID, SCHEMA_NAME, TABLE_NAME, "", "file:///" + outputFile.getAbsolutePath(), 0, outputFile.length(), splitProperties, ImmutableList.of(), ImmutableList.of(), OptionalInt.empty(), false, TupleDomain.all(), ImmutableMap.of());
         HivePageSourceProvider provider = new HivePageSourceProvider(config, createTestHdfsEnvironment(config), getDefaultHiveRecordCursorProvider(config), getDefaultHiveDataStreamFactories(config), TYPE_MANAGER);
         return provider.createPageSource(transaction, getSession(config), split, ImmutableList.copyOf(getColumnHandles()));
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
@@ -16,12 +16,14 @@ package com.facebook.presto.hive;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import org.testng.annotations.Test;
 
 import java.util.OptionalInt;
 import java.util.Properties;
 
+import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static org.testng.Assert.assertEquals;
 
 public class TestHiveSplit
@@ -35,7 +37,7 @@ public class TestHiveSplit
         schema.setProperty("foo", "bar");
         schema.setProperty("bar", "baz");
 
-        ImmutableList<HivePartitionKey> partitionKeys = ImmutableList.of(new HivePartitionKey("a", HiveType.HIVE_STRING, "apple"), new HivePartitionKey("b", HiveType.HIVE_LONG, "42"));
+        ImmutableList<HivePartitionKey> partitionKeys = ImmutableList.of(new HivePartitionKey("a", HIVE_STRING, "apple"), new HivePartitionKey("b", HiveType.HIVE_LONG, "42"));
         ImmutableList<HostAddress> addresses = ImmutableList.of(HostAddress.fromParts("127.0.0.1", 44), HostAddress.fromParts("127.0.0.1", 45));
         HiveSplit expected = new HiveSplit(
                 "clientId",
@@ -50,7 +52,8 @@ public class TestHiveSplit
                 addresses,
                 OptionalInt.empty(),
                 true,
-                TupleDomain.<HiveColumnHandle>all());
+                TupleDomain.<HiveColumnHandle>all(),
+                ImmutableMap.of(1, HIVE_STRING));
 
         String json = codec.toJson(expected);
         HiveSplit actual = codec.fromJson(json);
@@ -65,6 +68,7 @@ public class TestHiveSplit
         assertEquals(actual.getSchema(), expected.getSchema());
         assertEquals(actual.getPartitionKeys(), expected.getPartitionKeys());
         assertEquals(actual.getAddresses(), expected.getAddresses());
+        assertEquals(actual.getColumnCoercions(), expected.getColumnCoercions());
         assertEquals(actual.isForceLocalScheduling(), expected.isForceLocalScheduling());
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
@@ -41,6 +41,7 @@ import com.facebook.presto.type.TypeRegistry;
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import org.apache.hadoop.conf.Configuration;
@@ -397,7 +398,8 @@ public class TestOrcPageSourceMemoryTracking
                     columns,
                     partitionKeys,
                     DateTimeZone.UTC,
-                    TYPE_MANAGER)
+                    TYPE_MANAGER,
+                    ImmutableMap.of())
                     .get();
         }
 

--- a/presto-hive/src/test/sql/create-test.sql
+++ b/presto-hive/src/test/sql/create-test.sql
@@ -228,7 +228,7 @@ DROP TABLE tmp_presto_test;
 ALTER TABLE presto_test_partition_schema_change ADD PARTITION (ds='2012-12-29');
 INSERT OVERWRITE TABLE presto_test_partition_schema_change PARTITION (ds='2012-12-29')
 SELECT '123', '456' FROM presto_test_sequence;
-ALTER TABLE presto_test_partition_schema_change REPLACE COLUMNS (t_data BIGINT);
+ALTER TABLE presto_test_partition_schema_change REPLACE COLUMNS (t_data DOUBLE);
 
 INSERT OVERWRITE TABLE presto_test_partition_schema_change_non_canonical PARTITION (t_boolean='0')
 SELECT 'test' FROM presto_test_sequence LIMIT 100;

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -50,6 +50,7 @@ public final class TestGroups
     public static final String BASIC_SQL = "basic_sql";
     public static final String AUTHORIZATION = "authorization";
     public static final String POST_HIVE_1_0_1 = "post_hive_1_0_1";
+    public static final String HIVE_COERCION = "hive_coercion";
 
     private TestGroups() {}
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveCoercion.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveCoercion.java
@@ -1,0 +1,352 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.tests.hive;
+
+import com.teradata.tempto.ProductTest;
+import com.teradata.tempto.Requirement;
+import com.teradata.tempto.RequirementsProvider;
+import com.teradata.tempto.Requires;
+import com.teradata.tempto.configuration.Configuration;
+import com.teradata.tempto.fulfillment.table.MutableTableRequirement;
+import com.teradata.tempto.fulfillment.table.MutableTablesState;
+import com.teradata.tempto.fulfillment.table.TableDefinition;
+import com.teradata.tempto.fulfillment.table.TableHandle;
+import com.teradata.tempto.fulfillment.table.TableInstance;
+import com.teradata.tempto.fulfillment.table.hive.HiveTableDefinition;
+import com.teradata.tempto.query.QueryExecutor;
+import com.teradata.tempto.query.QueryResult;
+import com.teradata.tempto.query.QueryType;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Locale;
+import java.util.Optional;
+
+import static com.facebook.presto.tests.TestGroups.HIVE_COERCION;
+import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
+import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingPrestoJdbcDriver;
+import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingTeradataJdbcDriver;
+import static com.teradata.tempto.assertions.QueryAssert.Row.row;
+import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static com.teradata.tempto.context.ThreadLocalTestContextHolder.testContext;
+import static com.teradata.tempto.fulfillment.table.MutableTableRequirement.State.CREATED;
+import static com.teradata.tempto.fulfillment.table.TableHandle.tableHandle;
+import static com.teradata.tempto.query.QueryExecutor.defaultQueryExecutor;
+import static com.teradata.tempto.query.QueryExecutor.query;
+import static java.lang.String.format;
+import static java.sql.JDBCType.BIGINT;
+import static java.sql.JDBCType.DOUBLE;
+import static java.sql.JDBCType.INTEGER;
+import static java.sql.JDBCType.LONGNVARCHAR;
+import static java.sql.JDBCType.SMALLINT;
+import static java.sql.JDBCType.VARBINARY;
+
+public class TestHiveCoercion
+        extends ProductTest
+{
+    private static String tableNameFormat = "%s_hive_coercion";
+
+    public static final HiveTableDefinition HIVE_COERCION_TEXTFILE = tableDefinitionBuilder("TEXTFILE", Optional.empty(), Optional.of("DELIMITED FIELDS TERMINATED BY '|'"))
+            .setNoData()
+            .build();
+
+    public static final HiveTableDefinition HIVE_COERCION_PARQUET = parquetTableDefinitionBuilder()
+            .setNoData()
+            .build();
+
+    public static final HiveTableDefinition HIVE_COERCION_ORC = tableDefinitionBuilder("ORC", Optional.empty(), Optional.empty())
+            .setNoData()
+            .build();
+
+    public static final HiveTableDefinition HIVE_COERCION_RCTEXT = tableDefinitionBuilder("RCFILE", Optional.of("RCTEXT"), Optional.of("SERDE 'org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe'"))
+            .setNoData()
+            .build();
+
+    public static final HiveTableDefinition HIVE_COERCION_RCBINARY = tableDefinitionBuilder("RCFILE", Optional.of("RCBINARY"), Optional.of("SERDE 'org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe'"))
+            .setNoData()
+            .build();
+
+    private static HiveTableDefinition.HiveTableDefinitionBuilder tableDefinitionBuilder(String fileFormat, Optional<String> recommendTableName, Optional<String> rowFormat)
+    {
+        String tableName = format(tableNameFormat, recommendTableName.orElse(fileFormat).toLowerCase(Locale.ENGLISH));
+        return HiveTableDefinition.builder(tableName)
+                .setCreateTableDDLTemplate("" +
+                        "CREATE TABLE %NAME%(" +
+                        "    tinyint_to_smallint        TINYINT," +
+                        "    tinyint_to_int             TINYINT," +
+                        "    tinyint_to_bigint          TINYINT," +
+                        "    smallint_to_int            SMALLINT," +
+                        "    smallint_to_bigint         SMALLINT," +
+                        "    int_to_bigint              INT," +
+                        "    bigint_to_varchar          BIGINT," +
+                        "    varchar_to_integer         STRING," +
+                        "    float_to_double            FLOAT" +
+                        ") " +
+                        "PARTITIONED BY (id BIGINT) " +
+                        (rowFormat.isPresent() ? "ROW FORMAT " + rowFormat.get() + " " : " ") +
+                        "STORED AS " + fileFormat);
+    }
+
+    private static HiveTableDefinition.HiveTableDefinitionBuilder parquetTableDefinitionBuilder()
+    {
+        return HiveTableDefinition.builder("parquet_hive_coercion")
+                .setCreateTableDDLTemplate("" +
+                        "CREATE TABLE %NAME%(" +
+                        "    tinyint_to_smallint        TINYINT," +
+                        "    tinyint_to_int             TINYINT," +
+                        "    tinyint_to_bigint          TINYINT," +
+                        "    smallint_to_int            SMALLINT," +
+                        "    smallint_to_bigint         SMALLINT," +
+                        "    int_to_bigint              INT," +
+                        "    bigint_to_varchar          BIGINT," +
+                        "    varchar_to_integer         STRING," +
+                        "    float_to_double            DOUBLE" +
+                        ") " +
+                        "PARTITIONED BY (id BIGINT) " +
+                        "STORED AS PARQUET");
+    }
+
+    public static final class TextRequirements
+            implements RequirementsProvider
+    {
+        @Override
+        public Requirement getRequirements(Configuration configuration)
+        {
+            return MutableTableRequirement.builder(HIVE_COERCION_TEXTFILE).withState(CREATED).build();
+        }
+    }
+
+    public static final class OrcRequirements
+            implements RequirementsProvider
+    {
+        @Override
+        public Requirement getRequirements(Configuration configuration)
+        {
+            return MutableTableRequirement.builder(HIVE_COERCION_ORC).withState(CREATED).build();
+        }
+    }
+
+    public static final class RcTextRequirements
+            implements RequirementsProvider
+    {
+        @Override
+        public Requirement getRequirements(Configuration configuration)
+        {
+            return MutableTableRequirement.builder(HIVE_COERCION_RCTEXT).withState(CREATED).build();
+        }
+    }
+
+    public static final class RcBinaryRequirements
+            implements RequirementsProvider
+    {
+        @Override
+        public Requirement getRequirements(Configuration configuration)
+        {
+            return MutableTableRequirement.builder(HIVE_COERCION_RCBINARY).withState(CREATED).build();
+        }
+    }
+
+    public static final class ParquetRequirements
+            implements RequirementsProvider
+    {
+        @Override
+        public Requirement getRequirements(Configuration configuration)
+        {
+            return MutableTableRequirement.builder(HIVE_COERCION_PARQUET).withState(CREATED).build();
+        }
+    }
+
+    @Requires(TextRequirements.class)
+    @Test(groups = {HIVE_COERCION, HIVE_CONNECTOR})
+    public void testHiveCoercionTextFile()
+            throws SQLException
+    {
+        doTestHiveCoercion(HIVE_COERCION_TEXTFILE);
+    }
+
+    @Requires(OrcRequirements.class)
+    @Test(groups = {HIVE_COERCION, HIVE_CONNECTOR})
+    public void testHiveCoercionOrc()
+            throws SQLException
+    {
+        doTestHiveCoercion(HIVE_COERCION_ORC);
+    }
+
+    @Requires(RcTextRequirements.class)
+    @Test(groups = {HIVE_COERCION, HIVE_CONNECTOR})
+    public void testHiveCoercionRcText()
+            throws SQLException
+    {
+        doTestHiveCoercion(HIVE_COERCION_RCTEXT);
+    }
+
+    @Requires(RcBinaryRequirements.class)
+    @Test(groups = {HIVE_COERCION, HIVE_CONNECTOR})
+    public void testHiveCoercionRcBinary()
+            throws SQLException
+    {
+        doTestHiveCoercion(HIVE_COERCION_RCBINARY);
+    }
+
+    @Requires(ParquetRequirements.class)
+    @Test(groups = {HIVE_COERCION, HIVE_CONNECTOR})
+    public void testHiveCoercionParquet()
+            throws SQLException
+    {
+        doTestHiveCoercion(HIVE_COERCION_PARQUET);
+    }
+
+    private void doTestHiveCoercion(HiveTableDefinition tableDefinition)
+            throws SQLException
+    {
+        String tableName = mutableTableInstanceOf(tableDefinition).getNameInDatabase();
+
+        executeHiveQuery(format("INSERT INTO %s " +
+                "PARTITION (id=1) " +
+                "VALUES" +
+                "(-1, 2, -3, 100, -101, 2323, 12345, '-1025', 0.5)," +
+                "(1, -2, null, -100, 101, -2323, -12345, '99999999999999999999999999999', -1.5)",
+                tableName));
+
+        alterTableColumnTypes(tableName);
+        assertProperAlteredTableSchema(tableName);
+
+        QueryResult queryResult = query(format("SELECT * FROM %s", tableName));
+        assertColumnTypes(queryResult);
+        assertThat(queryResult).containsOnly(
+                row(
+                        -1,
+                        2,
+                        -3L,
+                        100,
+                        -101L,
+                        2323L,
+                        "12345",
+                        -1025,
+                        0.5,
+                        1),
+                row(
+                        1,
+                        -2,
+                        null,
+                        -100,
+                        101L,
+                        -2323L,
+                        "-12345",
+                        null,
+                        -1.5,
+                        1));
+    }
+
+    private void assertProperAlteredTableSchema(String tableName)
+    {
+        assertThat(query("SHOW COLUMNS FROM " + tableName, QueryType.SELECT).project(1, 2)).containsExactly(
+                row("tinyint_to_smallint", "smallint"),
+                row("tinyint_to_int", "integer"),
+                row("tinyint_to_bigint", "bigint"),
+                row("smallint_to_int", "integer"),
+                row("smallint_to_bigint", "bigint"),
+                row("int_to_bigint", "bigint"),
+                row("bigint_to_varchar", "varchar"),
+                row("varchar_to_integer", "integer"),
+                row("float_to_double", "double"),
+                row("id", "bigint")
+        );
+    }
+
+    private void assertColumnTypes(QueryResult queryResult)
+    {
+        Connection connection = defaultQueryExecutor().getConnection();
+        if (usingPrestoJdbcDriver(connection)) {
+            assertThat(queryResult).hasColumns(
+                    SMALLINT,
+                    INTEGER,
+                    BIGINT,
+                    INTEGER,
+                    BIGINT,
+                    BIGINT,
+                    LONGNVARCHAR,
+                    INTEGER,
+                    DOUBLE,
+                    BIGINT
+            );
+        }
+        else if (usingTeradataJdbcDriver(connection)) {
+            assertThat(queryResult).hasColumns(
+                    SMALLINT,
+                    INTEGER,
+                    BIGINT,
+                    INTEGER,
+                    BIGINT,
+                    BIGINT,
+                    VARBINARY,
+                    INTEGER,
+                    DOUBLE,
+                    BIGINT
+            );
+        }
+        else {
+            throw new IllegalStateException();
+        }
+    }
+
+    private static void alterTableColumnTypes(String tableName)
+    {
+        executeHiveQuery(format("ALTER TABLE %s CHANGE COLUMN tinyint_to_smallint tinyint_to_smallint smallint", tableName));
+        executeHiveQuery(format("ALTER TABLE %s CHANGE COLUMN tinyint_to_int tinyint_to_int int", tableName));
+        executeHiveQuery(format("ALTER TABLE %s CHANGE COLUMN tinyint_to_bigint tinyint_to_bigint bigint", tableName));
+        executeHiveQuery(format("ALTER TABLE %s CHANGE COLUMN smallint_to_int smallint_to_int int", tableName));
+        executeHiveQuery(format("ALTER TABLE %s CHANGE COLUMN smallint_to_bigint smallint_to_bigint bigint", tableName));
+        executeHiveQuery(format("ALTER TABLE %s CHANGE COLUMN int_to_bigint int_to_bigint bigint", tableName));
+        executeHiveQuery(format("ALTER TABLE %s CHANGE COLUMN bigint_to_varchar bigint_to_varchar string", tableName));
+        executeHiveQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_integer varchar_to_integer int", tableName));
+        executeHiveQuery(format("ALTER TABLE %s CHANGE COLUMN float_to_double float_to_double double", tableName));
+    }
+
+    private static TableInstance mutableTableInstanceOf(TableDefinition tableDefinition)
+    {
+        if (tableDefinition.getDatabase().isPresent()) {
+            return mutableTableInstanceOf(tableDefinition, tableDefinition.getDatabase().get());
+        }
+        else {
+            return mutableTableInstanceOf(tableHandleInSchema(tableDefinition));
+        }
+    }
+
+    private static TableInstance mutableTableInstanceOf(TableDefinition tableDefinition, String database)
+    {
+        return mutableTableInstanceOf(tableHandleInSchema(tableDefinition).inDatabase(database));
+    }
+
+    private static TableInstance mutableTableInstanceOf(TableHandle tableHandle)
+    {
+        return testContext().getDependency(MutableTablesState.class).get(tableHandle);
+    }
+
+    private static TableHandle tableHandleInSchema(TableDefinition tableDefinition)
+    {
+        TableHandle tableHandle = tableHandle(tableDefinition.getName());
+        if (tableDefinition.getSchema().isPresent()) {
+            tableHandle = tableHandle.inSchema(tableDefinition.getSchema().get());
+        }
+        return tableHandle;
+    }
+
+    private static QueryResult executeHiveQuery(String query)
+    {
+        return testContext().getDependency(QueryExecutor.class, "hive").executeQuery(query);
+    }
+}


### PR DESCRIPTION
1. The allowed coercions:
   `tinyint` -> `smallint` -> `integer` -> `bigint`
   `varchar` -> `tinyint` / `smallint` / `integer` / `bigint`
   `tinyint` / `smallint` / `integer` / `bigint` -> `varchar`
   `real` (`float`) -> `double`
2. Insertion to an existing partition with mismatch partition schema and table schema is not allowed.
