### PR TITLE
Improve UnaliasSymbolReference for ExchangeNode  and JoinNode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -631,6 +631,11 @@ public class LocalQueryRunner
 
     public Plan createPlan(Session session, @Language("SQL") String sql, LogicalPlanner.Stage stage)
     {
+        return createPlan(session, sql, stage, false);
+    }
+
+    public Plan createPlan(Session session, @Language("SQL") String sql, LogicalPlanner.Stage stage, boolean distributed)
+    {
         Statement statement = unwrapExecuteStatement(sqlParser.createStatement(sql), sqlParser, session);
 
         assertFormattedSql(sqlParser, statement);
@@ -638,7 +643,7 @@ public class LocalQueryRunner
         FeaturesConfig featuresConfig = new FeaturesConfig()
                 .setDistributedIndexJoinsEnabled(false)
                 .setOptimizeHashGeneration(true);
-        PlanOptimizers planOptimizers = new PlanOptimizers(metadata, sqlParser, featuresConfig, true);
+        PlanOptimizers planOptimizers = new PlanOptimizers(metadata, sqlParser, featuresConfig, !distributed);
         return createPlan(session, sql, featuresConfig, planOptimizers.get(), stage);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -374,13 +374,23 @@ public class TestLogicalPlanner
 
     private void assertPlan(String sql, PlanMatchPattern pattern)
     {
-        assertPlan(sql, LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED, pattern);
+        assertPlan(sql, LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED, false, pattern);
+    }
+
+    private void assertDistributedPlan(String sql, PlanMatchPattern pattern)
+    {
+        assertPlan(sql, LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED, true, pattern);
     }
 
     private void assertPlan(String sql, LogicalPlanner.Stage stage, PlanMatchPattern pattern)
     {
+        assertPlan(sql, stage, false, pattern);
+    }
+
+    private void assertPlan(String sql, LogicalPlanner.Stage stage, boolean distributed, PlanMatchPattern pattern)
+    {
         queryRunner.inTransaction(transactionSession -> {
-            Plan actualPlan = queryRunner.createPlan(transactionSession, sql, stage);
+            Plan actualPlan = queryRunner.createPlan(transactionSession, sql, stage, distributed);
             PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), actualPlan, pattern);
             return null;
         });
@@ -388,13 +398,18 @@ public class TestLogicalPlanner
 
     private Plan plan(String sql)
     {
-        return plan(sql, LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED);
+        return plan(sql, LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED, false);
     }
 
     private Plan plan(String sql, LogicalPlanner.Stage stage)
     {
+        return plan(sql, stage, false);
+    }
+
+    private Plan plan(String sql, LogicalPlanner.Stage stage, boolean distributed)
+    {
         try {
-            return queryRunner.inTransaction(transactionSession -> queryRunner.createPlan(transactionSession, sql, stage));
+            return queryRunner.inTransaction(transactionSession -> queryRunner.createPlan(transactionSession, sql, stage, distributed));
         }
         catch (RuntimeException ex) {
             fail("Invalid SQL: " + sql, ex);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -19,12 +19,14 @@ import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.tpch.TpchConnectorFactory;
@@ -370,6 +372,53 @@ public class TestLogicalPlanner
         // check that outputs of the underlying query are not pruned
         PlanNode valuesNode = plan(sql).getRoot().getSources().get(0).getSources().get(0);
         assertEquals(valuesNode.getOutputSymbols().size(), 3);
+    }
+
+    public void testNoExtraSymbolsInJoinRemoteExchange()
+    {
+        assertDistributedPlan("SELECT c.custkey FROM customer c, orders o WHERE c.custkey = o.custkey AND c.name LIKE '%green%'",
+                anyTree(
+                        node(JoinNode.class,
+                                node(ExchangeNode.class,
+                                        anyTree(
+                                                node(TableScanNode.class).withExactSymbol("custkey", "C1"))
+                                ).withNumberOfOutputColumns(2)
+                                        .withExactSymbol("custkey", "C1")
+                                        .withExactSymbol("hash", "H1"),
+                                node(ExchangeNode.class,
+                                        anyTree(
+                                                node(TableScanNode.class).withExactSymbol("custkey", "C2"))
+                                ).withNumberOfOutputColumns(2)
+                                        .withExactSymbol("custkey", "C2")
+                                        .withExactSymbol("hash", "H2"))));
+    }
+
+    @Test
+    public void testNoExtraSymbolsInUnionRemoteExchange()
+    {
+        assertDistributedPlan("(SELECT custkey, custkey FROM orders) UNION ALL (SELECT orderkey, orderkey FROM orders)",
+                anyTree(
+                        node(ExchangeNode.class, anyTree(), anyTree())
+                                .withNumberOfOutputColumns(1)));
+
+        assertDistributedPlan("(SELECT custkey, orderkey, custkey, orderkey FROM orders) UNION ALL (SELECT orderkey, custkey, custkey, custkey FROM orders)",
+                anyTree(
+                        node(ExchangeNode.class, anyTree(), anyTree())
+                                .withNumberOfOutputColumns(3)));
+    }
+
+    @Test
+    public void testDoesNotAliasUnionRemoteExchangeSymbols()
+    {
+        assertDistributedPlan("(SELECT custkey, custkey FROM orders) UNION ALL (SELECT custkey, orderkey FROM orders)",
+                anyTree(
+                        node(ExchangeNode.class, anyTree(), anyTree())
+                                .withNumberOfOutputColumns(2)));
+
+        assertDistributedPlan("(SELECT custkey, orderkey, custkey FROM orders) UNION ALL (SELECT orderkey, custkey, custkey FROM orders)",
+                anyTree(
+                        node(ExchangeNode.class, anyTree(), anyTree())
+                                .withNumberOfOutputColumns(3)));
     }
 
     private void assertPlan(String sql, PlanMatchPattern pattern)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionAliases.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionAliases.java
@@ -16,9 +16,11 @@ package com.facebook.presto.sql.planner.assertions;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 
+import java.util.Collection;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -36,7 +38,7 @@ public final class ExpressionAliases
     public ExpressionAliases(ExpressionAliases expressionAliases)
     {
         requireNonNull(expressionAliases, "symbolAliases are null");
-        this.map = ArrayListMultimap.create(expressionAliases.map);
+        this.map = HashMultimap.create(expressionAliases.map);
     }
 
     public void put(String alias, Expression expression)
@@ -49,6 +51,11 @@ public final class ExpressionAliases
             checkState(!map.values().contains(expression), "Expression '%s' is already pointed by different alias than '%s', check mapping for '%s'", expression, alias, map);
             map.put(alias, expression);
         }
+    }
+
+    public Collection<Expression> get(String alias)
+    {
+        return map.get(alias(alias));
     }
 
     private String alias(String alias)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -166,6 +166,14 @@ public final class PlanMatchPattern
         return with(new SymbolMatcher(pattern, alias));
     }
 
+    /**
+     * Binds symbol that matches pattern with a given alias. Only one symbol can be bound to a given alias.
+     */
+    public PlanMatchPattern withExactSymbol(String pattern, String alias)
+    {
+        return with(new SymbolMatcher(pattern, alias, true));
+    }
+
     public PlanMatchPattern withNumberOfOutputColumns(int numberOfSymbols)
     {
         return with(new SymbolCardinalityMatcher(numberOfSymbols));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -166,6 +166,11 @@ public final class PlanMatchPattern
         return with(new SymbolMatcher(pattern, alias));
     }
 
+    public PlanMatchPattern withNumberOfOutputColumns(int numberOfSymbols)
+    {
+        return with(new SymbolCardinalityMatcher(numberOfSymbols));
+    }
+
     public PlanMatchPattern with(Matcher matcher)
     {
         matchers.add(matcher);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolCardinalityMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolCardinalityMatcher.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+final class SymbolCardinalityMatcher
+        implements Matcher
+{
+    private final int numberOfSymbols;
+
+    SymbolCardinalityMatcher(int numberOfSymbols)
+    {
+        this.numberOfSymbols = numberOfSymbols;
+    }
+
+    @Override
+    public boolean matches(PlanNode node, Session session, Metadata metadata, ExpressionAliases expressionAliases)
+    {
+        return node.getOutputSymbols().size() == numberOfSymbols;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("numberOfSymbols", numberOfSymbols)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolMatcher.java
@@ -28,11 +28,18 @@ final class SymbolMatcher
 {
     private final Pattern pattern;
     private final String alias;
+    private final boolean exact;
 
     SymbolMatcher(String pattern, String alias)
     {
+        this(pattern, alias, false);
+    }
+
+    SymbolMatcher(String pattern, String alias, boolean exact)
+    {
         this.pattern = Pattern.compile(pattern);
         this.alias = alias;
+        this.exact = exact;
     }
 
     @Override
@@ -47,7 +54,7 @@ final class SymbolMatcher
         }
         if (symbol != null) {
             expressionAliases.put(alias, symbol.toSymbolReference());
-            return true;
+            return !exact || expressionAliases.get(alias).size() == 1;
         }
         return false;
     }

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q5.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q5.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: big_query, tpch; tables: customer,orders,lineitem,supplier,nation,region
+-- database: presto; groups: tpch; tables: customer,orders,lineitem,supplier,nation,region
 SELECT
   n_name,
   sum(l_extendedprice * (1 - l_discount)) AS revenue

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q8.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q8.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch, big_query; tables: part,supplier,lineitem,orders,customer,nation
+-- database: presto; groups: tpch; tables: part,supplier,lineitem,orders,customer,nation
 SELECT
   o_year,
   sum(CASE


### PR DESCRIPTION
FYI: @martint 

Peek memory improvements (MBs, no compaction):

```
                       Q5          Q2          Q3         Q7        Q8           Q9        Q10        Q17
Optimized             397         57.9        131        212       480          617       85.5        293
No optimizations      527         85          213        282       699          885       115         397
```
