### PR TITLE
Align tpch/q19 query and its result with TPCH

### DIFF
--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q19.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q19.result
@@ -1,2 +1,2 @@
 -- delimiter: |; ignoreOrder: false; types: DECIMAL
-3020909.6530|
+3083843.057799999|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q19.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q19.sql
@@ -7,7 +7,7 @@ WHERE
   (
     p_partkey = l_partkey
     AND p_brand = 'Brand#12'
-    AND p_container IN ('SM CASE ', 'SM BOX', 'SM PACK', 'SM PKG')
+    AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
     AND l_quantity >= 1 AND l_quantity <= 1 + 10
     AND p_size BETWEEN 1 AND 5
     AND l_shipmode IN ('AIR', 'AIR REG')


### PR DESCRIPTION
This is simple fix in query and its result. It was introduced by mistake and for that reason our results were of the official TPCH standard.
After this change the TPCH verification passes on all of our results, so products tests related to TPCH are really testing the right thing now.