### PR TITLE
Fix handling of null for try_cast

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeUtils.java
@@ -195,10 +195,12 @@ public final class BytecodeUtils
                     block.append(ifWasNullPopAndGoto(scope, end, unboxedReturnType, Lists.reverse(stackTypes)));
                 }
                 else {
-                    block.append(boxPrimitiveIfNecessary(scope, type));
                     if (function.getNullFlags().get(realParameterIndex)) {
                         block.append(scope.getVariable("wasNull"));
                         currentParameterIndex++;
+                    }
+                    else {
+                        block.append(boxPrimitiveIfNecessary(scope, type));
                     }
                     block.append(scope.getVariable("wasNull").set(constantFalse()));
                 }
@@ -251,6 +253,7 @@ public final class BytecodeUtils
 
     public static BytecodeNode boxPrimitiveIfNecessary(Scope scope, Class<?> type)
     {
+        checkArgument(!type.isPrimitive(), "cannot box into primitive type");
         if (!Primitives.isWrapperType(type)) {
             return NOP;
         }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4493,6 +4493,9 @@ public abstract class AbstractTestQueries
 
         assertQuery("SELECT coalesce(try_cast('foo' AS BIGINT), 456) FROM orders", "SELECT 456 FROM orders");
         assertQuery("SELECT coalesce(try_cast(clerk AS BIGINT), 456) FROM orders", "SELECT 456 FROM orders");
+
+        assertQuery("SELECT CAST(x AS BIGINT) FROM (VALUES 1, 2, 3, NULL) t (x)", "VALUES 1, 2, 3, NULL");
+        assertQuery("SELECT try_cast(x AS BIGINT) FROM (VALUES 1, 2, 3, NULL) t (x)", "VALUES 1, 2, 3, NULL");
     }
 
     @Test


### PR DESCRIPTION
For cast source types such as integers or booleans that use a Java
primitive type, null input values were incorrectly converted to the
default value for the type (zero or false) before casting.