### PR TITLE
Fix wrong result in TPCH-q19 product test

### DIFF
--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q19.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q19.result
@@ -1,2 +1,2 @@
 -- delimiter: |; ignoreOrder: false; types: DECIMAL
-3083843.057799999|
+3083843.0578|


### PR DESCRIPTION
This is a fixup for 63a2e0907756f46c5fed136c5eb6b5e3110ad660.

---

The problem arose because Tempto creates Lineitem table with decimal fields while tpch connector uses doubles instead.

Having discrepancy between TPCH tables in Hive (used by product tests) and those provided by TPCH connector is misleading and led to having a wrong result (human error based on results from TPCH connector).

Error is below acceptable by TPC-H spec level and is caused by the inaccuracy of DOUBLE.