### PR TITLE
Make port of socks proxy configurable in product tests

### DIFF
--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -407,3 +407,14 @@ been downloaded:
     # downloaded.
     presto-product-tests/conf/docker/<profile>/compose.sh pull
     ```
+
+## Known issues
+
+If you see the error
+```
+ERROR: for hadoop-master  Cannot start service hadoop-master: driver failed programming external connectivity on endpoint common_hadoop-master_1 Error starting userland proxy: Bind for 0.0.0.0:1080 failed: port is already allocated
+```
+You most likely have some application listening on port 1080 on either docker-machine or on your local machine if you are running docker natively.
+You can override the default socks proxy port (1080) used by dockerized Hive deployment in product tests using the
+`HIVE_PROXY_PORT` environment variable, e.g. `export HIVE_PROXY_PORT=1180`. This will run all of the dockerized tests using the custom port for the socks proxy.
+When you change the default socks proxy port (1080), you have to modify the property `hive.metastore.thrift.client.socks-proxy=hadoop-master:1080` in `conf/presto/etc/catalog/hive.properties`.

--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -40,3 +40,5 @@ if [[ -z ${PRODUCT_TESTS_JAR} ]]; then
     PRODUCT_TESTS_JAR="${PRODUCT_TESTS_ROOT}/target/presto-product-tests-${PRESTO_VERSION}-executable.jar"
 fi
 export PRODUCT_TESTS_JAR=$(canonical_path ${PRODUCT_TESTS_JAR})
+
+export HIVE_PROXY_PORT=${HIVE_PROXY_PORT:-1080}

--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -12,7 +12,7 @@ services:
     image: ${HADOOP_MASTER_IMAGE}
     hostname: hadoop-master
     ports:
-      - '1080:1080'
+      - '${HIVE_PROXY_PORT}:1080'
       - '8020:8020'
       - '8088:8088'
       - '9083:9083'


### PR DESCRIPTION
Fixes https://github.com/prestodb/presto/issues/6182.

---
TD internal review: https://github.com/Teradata/presto/pull/377