### PR TITLE
Change default socks proxy port for product tests

### DIFF
--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -410,11 +410,22 @@ been downloaded:
 
 ## Known issues
 
+### Port 1180 already allocated
+
 If you see the error
 ```
-ERROR: for hadoop-master  Cannot start service hadoop-master: driver failed programming external connectivity on endpoint common_hadoop-master_1 Error starting userland proxy: Bind for 0.0.0.0:1080 failed: port is already allocated
+ERROR: for hadoop-master  Cannot start service hadoop-master: driver failed programming external connectivity on endpoint common_hadoop-master_1 Error starting userland proxy: Bind for 0.0.0.0:1180 failed: port is already allocated
 ```
-You most likely have some application listening on port 1080 on either docker-machine or on your local machine if you are running docker natively.
-You can override the default socks proxy port (1080) used by dockerized Hive deployment in product tests using the
-`HIVE_PROXY_PORT` environment variable, e.g. `export HIVE_PROXY_PORT=1180`. This will run all of the dockerized tests using the custom port for the socks proxy.
-When you change the default socks proxy port (1080), you have to modify the property `hive.metastore.thrift.client.socks-proxy=hadoop-master:1080` in `conf/presto/etc/catalog/hive.properties`.
+You most likely have some application listening on port `1180` on either
+docker-machine or on your local machine if you are running docker natively.
+You can override the default socks proxy port (`1180`) used by dockerized
+Hive deployment in product tests using the `HIVE_PROXY_PORT` environment
+variable, e.g. `export HIVE_PROXY_PORT=5555`. This will run all of the
+dockerized tests using the custom port for the socks proxy.
+
+When you change the default socks proxy port (`1180`), you have to modify
+the property `hive.metastore.thrift.client.socks-proxy=hadoop-master:1180`
+in `conf/presto/etc/catalog/hive.properties`.
+
+Note that `1080` is the standard port for socks proxy, but we use `1180` by
+default in order to leave the standard port available for other applications.

--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -41,4 +41,4 @@ if [[ -z ${PRODUCT_TESTS_JAR} ]]; then
 fi
 export PRODUCT_TESTS_JAR=$(canonical_path ${PRODUCT_TESTS_JAR})
 
-export HIVE_PROXY_PORT=${HIVE_PROXY_PORT:-1080}
+export HIVE_PROXY_PORT=${HIVE_PROXY_PORT:-1180}

--- a/presto-product-tests/conf/presto/etc/catalog/hive.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/hive.properties
@@ -7,7 +7,7 @@
 
 connector.name=hive-cdh5
 hive.metastore.uri=thrift://hadoop-master:9083
-hive.metastore.thrift.client.socks-proxy=hadoop-master:1080
+hive.metastore.thrift.client.socks-proxy=hadoop-master:1180
 hive.allow-add-column=true
 hive.allow-rename-column=true
 hive.allow-drop-table=true

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-hdfs-impersonation/hive.properties
@@ -7,7 +7,7 @@
 
 connector.name=hive-cdh5
 hive.metastore.uri=thrift://hadoop-master:9083
-hive.metastore.thrift.client.socks-proxy=hadoop-master:1080
+hive.metastore.thrift.client.socks-proxy=hadoop-master:1180
 hive.allow-drop-table=true
 hive.allow-add-column=true
 hive.allow-rename-table=true

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
@@ -7,7 +7,7 @@
 
 connector.name=hive-cdh5
 hive.metastore.uri=thrift://hadoop-master:9083
-hive.metastore.thrift.client.socks-proxy=hadoop-master:1080
+hive.metastore.thrift.client.socks-proxy=hadoop-master:1180
 hive.metastore-cache-ttl=0s
 
 hive.metastore.authentication.type=KERBEROS

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties
@@ -7,7 +7,7 @@
 
 connector.name=hive-cdh5
 hive.metastore.uri=thrift://hadoop-master:9083
-hive.metastore.thrift.client.socks-proxy=hadoop-master:1080
+hive.metastore.thrift.client.socks-proxy=hadoop-master:1180
 hive.allow-drop-table=true
 hive.allow-rename-table=true
 hive.metastore-cache-ttl=0s


### PR DESCRIPTION
Use 1180 instead of 1080 to avoid conflicts with the standard port.