### PR TITLE
Add accumulo.instance property to example in docs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/accumulo.rst
+++ b/presto-docs/src/main/sphinx/connector/accumulo.rst
@@ -53,6 +53,7 @@ replacing the ``accumulo.xxx`` properties as required:
 .. code-block:: none
 
     connector.name=accumulo
+    accumulo.instance=xxx
     accumulo.zookeepers=xxx
     accumulo.username=username
     accumulo.password=password


### PR DESCRIPTION
Missing a required property in the example that could mislead users.