### PR TITLE
Fix ClassCastException when planning window node with coercions

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3797,6 +3797,19 @@ public abstract class AbstractTestQueries
                 .build();
 
         assertEquals(actual, expected);
+
+        actual = computeActual("" +
+                "SELECT (MAX(x.a) OVER () - x.a) * 100.0 / MAX(x.a) OVER ()\n" +
+                "FROM (VALUES 1, 2, 3, 4) x(a)");
+
+        expected = resultBuilder(getSession(), DOUBLE)
+                .row(75.0)
+                .row(50.0)
+                .row(25.0)
+                .row(0.0)
+                .build();
+
+        assertEquals(actual, expected);
     }
 
     @Test


### PR DESCRIPTION
If the output of the window function has to be coerced, it's
wrapped with a Cast node. The code wasn't accounting for that
and was blindly pulling out the child of the Cast node, which
might be a SymbolReference if the function had already been
translated.

Fixes https://github.com/prestodb/presto/issues/6278