### PR TITLE
Support multiple files per bucket and partitions without files for Hive clustered tables

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -173,7 +173,13 @@ Property Name                                      Description                  
 =======
 ``hive.multi-file-bucketing.enabled``              Enable support for multiple files per bucket for Hive        ``false``
                                                    clustered tables. See :ref:`clustered-tables`
+<<<<<<< e65d33ff45c1750c77f6c9a01d8e6acf42891dbc
 >>>>>>> Add doc for multi-file hive buckets support
+=======
+
+``hive.empty-bucketed-partitions.enabled``         Enable support for clustered tables with empty partitions.   ``false``
+                                                   See :ref:`clustered-tables`
+>>>>>>> Add doc for Hive empty buckets support
 ================================================== ============================================================ ==========
 
 Amazon S3 Configuration
@@ -433,6 +439,12 @@ It will sort filenames lexicographically. Then it will treat part of filename up
 This pattern matches naming convention of files in directory when Hive is used to inject data into table.
 
 Presto will still validate if number of file groups matches number of buckets declared for table and fail if it does not.
+
+Similarly by default empty partitions (partitions with no files) are not allowed for clustered Hive tables.
+To enable support for empty paritions you can use:
+
+ * ``hive.empty-bucketed-partitions.enabled`` config property
+ * ``empty_bucketed_partitions_enabled`` session property (using ``SET SESSION <connector_name>.empty_bucketed_partitions_enabled``)
 
 Hive Connector Limitations
 --------------------------

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -168,7 +168,12 @@ Property Name                                      Description                  
 ``security.config-file``                           Path of config file to use when ``hive.security=file``.
                                                    See :ref:`hive-file-based-authorization` for details.
 
+<<<<<<< c3a42c03b7dc3f89e1ee169705e3319d0d3a3326
 ``hive.non-managed-table-writes-enabled``          Enable writes to non-managed (external) Hive tables.         ``false``
+=======
+``hive.multi-file-bucketing.enabled``              Enable support for multiple files per bucket for Hive        ``false``
+                                                   clustered tables. See :ref:`clustered-tables`
+>>>>>>> Add doc for multi-file hive buckets support
 ================================================== ============================================================ ==========
 
 Amazon S3 Configuration
@@ -405,6 +410,29 @@ for the table. The referenced data directory is not deleted::
 Drop a schema::
 
     DROP SCHEMA hive.web
+
+
+.. _clustered-tables:
+
+Clustered Hive tables support
+-----------------------------
+
+By default Presto supports only one data file per bucket per partition for clustered tables (Hive tables declared with ``CLUSTERED BY`` clause).
+If number of files does not match number of buckets exception would be thrown.
+
+To enable support for cases where there are more than one file per bucket, when multiple INSERTs were done to a single partition of the clustered table, you can use:
+
+ * ``hive.multi-file-bucketing.enabled`` config property
+ * ``multi_file_bucketing_enabled`` session property (using ``SET SESSION <connector_name>.multi_file_bucketing_enabled``)
+
+Config property changes behaviour globally and session property can be used on per query basis.
+The default value of session property is taken from config property.
+
+If support for multiple files per bucket is enabled Presto will group the files in partition directory.
+It will sort filenames lexicographically. Then it will treat part of filename up to first underscore character as bucket key.
+This pattern matches naming convention of files in directory when Hive is used to inject data into table.
+
+Presto will still validate if number of file groups matches number of buckets declared for table and fail if it does not.
 
 Hive Connector Limitations
 --------------------------

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -109,6 +109,7 @@ public class HiveClientConfig
     private boolean hdfsImpersonationEnabled;
     private String hdfsPrestoPrincipal;
     private String hdfsPrestoKeytab;
+    private boolean multiFileBucketingEnabled = false;
 
     private boolean skipDeletionForAlter;
 
@@ -900,5 +901,18 @@ public class HiveClientConfig
     public boolean getWritesToNonManagedTablesEnabled()
     {
         return writesToNonManagedTablesEnabled;
+    }
+
+    public boolean isMultiFileBucketingEnabled()
+    {
+        return multiFileBucketingEnabled;
+    }
+
+    @Config("hive.multi-file-bucketing.enabled")
+    @ConfigDescription("Allow multiple files per bucket for clustered table")
+    public HiveClientConfig setMultiFileBucketingEnabled(boolean multiFileBucketingEnabled)
+    {
+        this.multiFileBucketingEnabled = multiFileBucketingEnabled;
+        return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -110,6 +110,7 @@ public class HiveClientConfig
     private String hdfsPrestoPrincipal;
     private String hdfsPrestoKeytab;
     private boolean multiFileBucketingEnabled = false;
+    private boolean emptyBucketedPartitionsEnabled = false;
 
     private boolean skipDeletionForAlter;
 
@@ -913,6 +914,19 @@ public class HiveClientConfig
     public HiveClientConfig setMultiFileBucketingEnabled(boolean multiFileBucketingEnabled)
     {
         this.multiFileBucketingEnabled = multiFileBucketingEnabled;
+        return this;
+    }
+
+    public boolean isEmptyBucketedPartitionsEnabled()
+    {
+        return emptyBucketedPartitionsEnabled;
+    }
+
+    @Config("hive.empty-bucketed-partitions.enabled")
+    @ConfigDescription("Allow partitions without files for clustered table")
+    public HiveClientConfig setEmptyBucketedPartitionsEnabled(boolean emptyBucketedPartitionsEnabled)
+    {
+        this.emptyBucketedPartitionsEnabled = emptyBucketedPartitionsEnabled;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -41,6 +41,7 @@ public final class HiveSessionProperties
     private static final String RCFILE_OPTIMIZED_WRITER_ENABLED = "rcfile_optimized_writer_enabled";
     private static final String RCFILE_OPTIMIZED_WRITER_VALIDATE = "rcfile_optimized_writer_validate";
     private static final String MULTI_FILE_BUCKETING_ENABLED = "multi_file_bucketing_enabled";
+    private static final String EMPTY_BUCKETED_PARTITIONS_ENABLED = "empty_bucketed_partitions_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -117,6 +118,11 @@ public final class HiveSessionProperties
                         MULTI_FILE_BUCKETING_ENABLED,
                         "Allow multiple files per bucket for clustered table",
                         config.isMultiFileBucketingEnabled(),
+                        true),
+                booleanSessionProperty(
+                        EMPTY_BUCKETED_PARTITIONS_ENABLED,
+                        "Allow partitions without files for clustered table",
+                        config.isEmptyBucketedPartitionsEnabled(),
                         true));
     }
 
@@ -193,6 +199,11 @@ public final class HiveSessionProperties
     public static boolean isMultiFileBucketingEnabled(ConnectorSession session)
     {
         return session.getProperty(MULTI_FILE_BUCKETING_ENABLED, Boolean.class);
+    }
+
+    public static boolean isEmptyBucketedPartitionsEnabled(ConnectorSession session)
+    {
+        return session.getProperty(EMPTY_BUCKETED_PARTITIONS_ENABLED, Boolean.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -40,6 +40,7 @@ public final class HiveSessionProperties
     private static final String RCFILE_OPTIMIZED_READER_ENABLED = "rcfile_optimized_reader_enabled";
     private static final String RCFILE_OPTIMIZED_WRITER_ENABLED = "rcfile_optimized_writer_enabled";
     private static final String RCFILE_OPTIMIZED_WRITER_VALIDATE = "rcfile_optimized_writer_validate";
+    private static final String MULTI_FILE_BUCKETING_ENABLED = "multi_file_bucketing_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -111,7 +112,12 @@ public final class HiveSessionProperties
                         RCFILE_OPTIMIZED_WRITER_VALIDATE,
                         "Experimental: RCFile: Validate writer files",
                         true,
-                        false));
+                        false),
+                booleanSessionProperty(
+                        MULTI_FILE_BUCKETING_ENABLED,
+                        "Allow multiple files per bucket for clustered table",
+                        config.isMultiFileBucketingEnabled(),
+                        true));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -182,6 +188,11 @@ public final class HiveSessionProperties
     public static boolean isRcfileOptimizedWriterValidate(ConnectorSession session)
     {
         return session.getProperty(RCFILE_OPTIMIZED_WRITER_VALIDATE, Boolean.class);
+    }
+
+    public static boolean isMultiFileBucketingEnabled(ConnectorSession session)
+    {
+        return session.getProperty(MULTI_FILE_BUCKETING_ENABLED, Boolean.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -92,7 +92,8 @@ public class TestHiveClientConfig
                 .setBucketWritingEnabled(true)
                 .setFileSystemMaxCacheSize(1000)
                 .setWritesToNonManagedTablesEnabled(false)
-                .setMultiFileBucketingEnabled(false));
+                .setMultiFileBucketingEnabled(false)
+                .setEmptyBucketedPartitionsEnabled(false));
     }
 
     @Test
@@ -158,6 +159,7 @@ public class TestHiveClientConfig
                 .put("hive.fs.cache.max-size", "1010")
                 .put("hive.non-managed-table-writes-enabled", "true")
                 .put("hive.multi-file-bucketing.enabled", "true")
+                .put("hive.empty-bucketed-partitions.enabled", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -219,7 +221,8 @@ public class TestHiveClientConfig
                 .setBucketWritingEnabled(false)
                 .setFileSystemMaxCacheSize(1010)
                 .setWritesToNonManagedTablesEnabled(true)
-                .setMultiFileBucketingEnabled(true);
+                .setMultiFileBucketingEnabled(true)
+                .setEmptyBucketedPartitionsEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -91,7 +91,8 @@ public class TestHiveClientConfig
                 .setBucketExecutionEnabled(true)
                 .setBucketWritingEnabled(true)
                 .setFileSystemMaxCacheSize(1000)
-                .setWritesToNonManagedTablesEnabled(false));
+                .setWritesToNonManagedTablesEnabled(false)
+                .setMultiFileBucketingEnabled(false));
     }
 
     @Test
@@ -156,6 +157,7 @@ public class TestHiveClientConfig
                 .put("hive.bucket-writing", "false")
                 .put("hive.fs.cache.max-size", "1010")
                 .put("hive.non-managed-table-writes-enabled", "true")
+                .put("hive.multi-file-bucketing.enabled", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -216,7 +218,8 @@ public class TestHiveClientConfig
                 .setBucketExecutionEnabled(false)
                 .setBucketWritingEnabled(false)
                 .setFileSystemMaxCacheSize(1010)
-                .setWritesToNonManagedTablesEnabled(true);
+                .setWritesToNonManagedTablesEnabled(true)
+                .setMultiFileBucketingEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBucketedTables.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBucketedTables.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.hive;
+
+import com.teradata.tempto.ProductTest;
+import com.teradata.tempto.Requirement;
+import com.teradata.tempto.Requirements;
+import com.teradata.tempto.RequirementsProvider;
+import com.teradata.tempto.configuration.Configuration;
+import com.teradata.tempto.fulfillment.table.MutableTableRequirement;
+import com.teradata.tempto.fulfillment.table.TableDefinitionsRepository;
+import com.teradata.tempto.fulfillment.table.hive.HiveTableDefinition;
+import com.teradata.tempto.query.QueryExecutionException;
+import org.testng.annotations.Test;
+
+import java.sql.SQLException;
+import java.util.Optional;
+
+import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
+import static com.facebook.presto.tests.TpchTableResults.PRESTO_NATION_RESULT;
+import static com.facebook.presto.tests.utils.JdbcDriverUtils.setSessionProperty;
+import static com.facebook.presto.tests.utils.QueryExecutors.onHive;
+import static com.facebook.presto.tests.utils.TableDefinitionUtils.mutableTableInstanceOf;
+import static com.teradata.tempto.assertions.QueryAssert.Row.row;
+import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static com.teradata.tempto.fulfillment.table.MutableTableRequirement.State.CREATED;
+import static com.teradata.tempto.fulfillment.table.TableRequirements.immutableTable;
+import static com.teradata.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.NATION;
+import static com.teradata.tempto.query.QueryExecutor.defaultQueryExecutor;
+import static com.teradata.tempto.query.QueryExecutor.query;
+import static java.lang.String.format;
+
+public class TestHiveBucketedTables
+        extends ProductTest
+        implements RequirementsProvider
+{
+    @TableDefinitionsRepository.RepositoryTableDefinition
+    public static final HiveTableDefinition BUCKETED_NATION = bucketTableDefinition("bucket_nation", false, false);
+    @TableDefinitionsRepository.RepositoryTableDefinition
+    public static final HiveTableDefinition BUCKETED_SORTED_NATION = bucketTableDefinition("bucket_sort_nation", true, false);
+    @TableDefinitionsRepository.RepositoryTableDefinition
+    public static final HiveTableDefinition BUCKETED_PARTITIONED_NATION = bucketTableDefinition("bucket_partition_nation", false, true);
+
+    private static HiveTableDefinition bucketTableDefinition(String tableName, boolean sorted, boolean partitioned)
+    {
+        return HiveTableDefinition.builder(tableName)
+                .setCreateTableDDLTemplate("CREATE TABLE %NAME%(" +
+                        "n_nationkey     BIGINT," +
+                        "n_name          STRING," +
+                        "n_regionkey     BIGINT," +
+                        "n_comment       STRING) " +
+                        (partitioned ? "PARTITIONED BY (part_key STRING) " : " ") +
+                        "CLUSTERED BY (n_regionkey) " +
+                        (sorted ? "SORTED BY (n_regionkey) " : " ") +
+                        "INTO 4 BUCKETS " +
+                        "ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'"
+                )
+                .setNoData()
+                .build();
+    }
+
+    @Override
+    public Requirement getRequirements(Configuration configuration)
+    {
+        return Requirements.compose(
+                MutableTableRequirement.builder(BUCKETED_NATION).withState(CREATED).build(),
+                MutableTableRequirement.builder(BUCKETED_PARTITIONED_NATION).withState(CREATED).build(),
+                MutableTableRequirement.builder(BUCKETED_SORTED_NATION).withState(CREATED).build(),
+                immutableTable(NATION));
+    }
+
+    @Test(groups = {HIVE_CONNECTOR})
+    public void testSelectStar()
+            throws SQLException
+    {
+        String tableName = mutableTableInstanceOf(BUCKETED_NATION).getNameInDatabase();
+        populateDataToHiveTable(tableName, NATION.getName(), Optional.empty());
+
+        assertThat(query(format("SELECT * FROM %s", tableName))).matches(PRESTO_NATION_RESULT);
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
+                .containsExactly(row(1));
+        assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
+                .containsExactly(row(125));
+    }
+
+    @Test(groups = {HIVE_CONNECTOR},
+            expectedExceptions = QueryExecutionException.class,
+            expectedExceptionsMessageRegExp = ".*does not match the declared bucket count.*")
+    public void testSelectAfterMultipleInsertsMultiBucketDisabled()
+            throws SQLException
+    {
+        String tableName = mutableTableInstanceOf(BUCKETED_NATION).getNameInDatabase();
+        populateDataToHiveTable(tableName, NATION.getName(), Optional.empty());
+        populateDataToHiveTable(tableName, NATION.getName(), Optional.empty());
+
+        query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName));
+    }
+
+    @Test(groups = {HIVE_CONNECTOR})
+    public void testSelectAfterMultipleInserts()
+            throws SQLException
+    {
+        String tableName = mutableTableInstanceOf(BUCKETED_NATION).getNameInDatabase();
+        populateDataToHiveTable(tableName, NATION.getName(), Optional.empty());
+        populateDataToHiveTable(tableName, NATION.getName(), Optional.empty());
+
+        enableMultiFileBucketing();
+
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
+                .containsExactly(row(2));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey = 1", tableName)))
+                .containsExactly(row(10));
+        assertThat(query(format("SELECT n_regionkey, count(*) FROM %s GROUP BY n_regionkey", tableName)))
+                .containsOnly(row(0, 10), row(1, 10), row(2, 10), row(3, 10), row(4, 10));
+        assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
+                .containsExactly(row(500));
+    }
+
+    @Test(groups = {HIVE_CONNECTOR})
+    public void testSelectAfterMultipleInsertsForSortedTable()
+            throws SQLException
+    {
+        String tableName = mutableTableInstanceOf(BUCKETED_SORTED_NATION).getNameInDatabase();
+        populateDataToHiveTable(tableName, NATION.getName(), Optional.empty());
+        populateDataToHiveTable(tableName, NATION.getName(), Optional.empty());
+
+        enableMultiFileBucketing();
+
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
+                .containsExactly(row(2));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey = 1", tableName)))
+                .containsExactly(row(10));
+        assertThat(query(format("SELECT n_regionkey, count(*) FROM %s GROUP BY n_regionkey", tableName)))
+                .containsOnly(row(0, 10), row(1, 10), row(2, 10), row(3, 10), row(4, 10));
+        assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
+                .containsExactly(row(500));
+    }
+
+    @Test(groups = {HIVE_CONNECTOR})
+    public void testSelectAfterMultipleInsertsForPartitionedTable()
+            throws SQLException
+    {
+        String tableName = mutableTableInstanceOf(BUCKETED_PARTITIONED_NATION).getNameInDatabase();
+        populateDataToHiveTable(tableName, NATION.getName(), Optional.of("part_key = 'insert_1'"));
+        populateDataToHiveTable(tableName, NATION.getName(), Optional.of("part_key = 'insert_2'"));
+        populateDataToHiveTable(tableName, NATION.getName(), Optional.of("part_key = 'insert_1'"));
+        populateDataToHiveTable(tableName, NATION.getName(), Optional.of("part_key = 'insert_2'"));
+
+        enableMultiFileBucketing();
+
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
+                .containsExactly(row(4));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey = 1", tableName)))
+                .containsExactly(row(20));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey = 1 AND part_key = 'insert_1'", tableName)))
+                .hasRowsCount(1)
+                .containsExactly(row(10));
+        assertThat(query(format("SELECT n_regionkey, count(*) FROM %s WHERE part_key = 'insert_2' GROUP BY n_regionkey", tableName)))
+                .containsOnly(row(0, 10), row(1, 10), row(2, 10), row(3, 10), row(4, 10));
+        assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
+                .containsExactly(row(2000));
+        assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey WHERE n.part_key = 'insert_1'", tableName, tableName)))
+                .containsExactly(row(1000));
+    }
+
+    private static void enableMultiFileBucketing()
+            throws SQLException
+    {
+        setSessionProperty(defaultQueryExecutor().getConnection(), "hive.multi_file_bucketing_enabled", "true");
+    }
+
+    private static void populateDataToHiveTable(String destination, String source, Optional<String> partition)
+    {
+        String queryStatement = format("INSERT INTO TABLE %s" +
+                        (partition.isPresent() ? format(" PARTITION (%s) ", partition.get()) : " ") +
+                        "SELECT * FROM %s",
+                destination, source);
+
+        onHive().executeQuery("set hive.enforce.bucketing = true");
+        onHive().executeQuery("set hive.enforce.sorting = true");
+        onHive().executeQuery(queryStatement);
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/TableDefinitionUtils.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/TableDefinitionUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.utils;
+
+import com.teradata.tempto.fulfillment.table.MutableTablesState;
+import com.teradata.tempto.fulfillment.table.TableDefinition;
+import com.teradata.tempto.fulfillment.table.TableHandle;
+import com.teradata.tempto.fulfillment.table.TableInstance;
+
+import static com.teradata.tempto.context.ThreadLocalTestContextHolder.testContext;
+import static com.teradata.tempto.fulfillment.table.TableHandle.tableHandle;
+
+public class TableDefinitionUtils
+{
+    private TableDefinitionUtils() {}
+
+    public static TableInstance mutableTableInstanceOf(TableDefinition tableDefinition)
+    {
+        if (tableDefinition.getDatabase().isPresent()) {
+            return mutableTableInstanceOf(tableDefinition, tableDefinition.getDatabase().get());
+        }
+        else {
+            return mutableTableInstanceOf(tableHandleInSchema(tableDefinition));
+        }
+    }
+
+    private static TableInstance mutableTableInstanceOf(TableDefinition tableDefinition, String database)
+    {
+        return mutableTableInstanceOf(tableHandleInSchema(tableDefinition).inDatabase(database));
+    }
+
+    private static TableInstance mutableTableInstanceOf(TableHandle tableHandle)
+    {
+        return testContext().getDependency(MutableTablesState.class).get(tableHandle);
+    }
+
+    private static TableHandle tableHandleInSchema(TableDefinition tableDefinition)
+    {
+        TableHandle tableHandle = tableHandle(tableDefinition.getName());
+        if (tableDefinition.getSchema().isPresent()) {
+            tableHandle = tableHandle.inSchema(tableDefinition.getSchema().get());
+        }
+        return tableHandle;
+    }
+}


### PR DESCRIPTION
By default Presto supports only one data file per bucket per partition for clustered tables (Hive tables declared with `CLUSTERED BY` cause).
If number of files does not match number of buckets exception would be thrown.

To enable support for cases where there are more than one file per
bucket, when multiple INSERTs were done to a single partition of the
clustered table, you can use:
- `hive.multi-file-bucketing.enabled` config property
- `multi_file_bucketing_enabled` session property

Config property changes behaviour globally and session property can be used on per query basis.
The default value of session property is taken from config property.

If support for multiple files per bucket is enabled Presto will group the files in partition directory.
It will sort filenames lexicographically. Then it will treat part of filename up to first underscore character as bucket key.
This pattern matches naming convention of files in directory when Hive is used to inject data into table.

Presto will still validate if number of file groups matches number of buckets declared for table and fail if it does not.
