### PR TITLE
Change default socks proxy port for product tests

### DIFF
--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -410,14 +410,14 @@ been downloaded:
 
 ## Known issues
 
-### Port 1080 already allocated
+### Port 1180 already allocated
 
 If you see the error
 ```
-ERROR: for hadoop-master  Cannot start service hadoop-master: driver failed programming external connectivity on endpoint common_hadoop-master_1 Error starting userland proxy: Bind for 0.0.0.0:1080 failed: port is already allocated
+ERROR: for hadoop-master  Cannot start service hadoop-master: driver failed programming external connectivity on endpoint common_hadoop-master_1 Error starting userland proxy: Bind for 0.0.0.0:1180 failed: port is already allocated
 ```
-You most likely have some application listening on port 1080 on either docker-machine or on your local machine if you are running docker natively.
-You can override the default socks proxy port (1080) used by dockerized Hive deployment in product tests using the
+You most likely have some application listening on port 1180 on either docker-machine or on your local machine if you are running docker natively.
+You can override the default socks proxy port (1180) used by dockerized Hive deployment in product tests using the
 `HIVE_PROXY_PORT` environment variable, e.g. `export HIVE_PROXY_PORT=1180`. This will run all of the dockerized tests using the custom port for the socks proxy.
-When you change the default socks proxy port (1080) and want to use Hive provided by product tests from outside docker (e.g. access it from Presto running in your IDE), you have to modify the property `hive.metastore.thrift.client.socks-proxy=hadoop-master:1080` in your `hive.properties` file accordingly.
-Presto inside docker (used while starting tests using `run_on_docker.sh`) will still use default port (1080) though.
+When you change the default socks proxy port (1180) and want to use Hive provided by product tests from outside docker (e.g. access it from Presto running in your IDE), you have to modify the property `hive.metastore.thrift.client.socks-proxy=hadoop-master:1180` in your `hive.properties` file accordingly.
+Presto inside docker (used while starting tests using `run_on_docker.sh`) will still use default port (1180) though.

--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -410,6 +410,8 @@ been downloaded:
 
 ## Known issues
 
+### Port 1080 already allocated
+
 If you see the error
 ```
 ERROR: for hadoop-master  Cannot start service hadoop-master: driver failed programming external connectivity on endpoint common_hadoop-master_1 Error starting userland proxy: Bind for 0.0.0.0:1080 failed: port is already allocated
@@ -417,4 +419,5 @@ ERROR: for hadoop-master  Cannot start service hadoop-master: driver failed prog
 You most likely have some application listening on port 1080 on either docker-machine or on your local machine if you are running docker natively.
 You can override the default socks proxy port (1080) used by dockerized Hive deployment in product tests using the
 `HIVE_PROXY_PORT` environment variable, e.g. `export HIVE_PROXY_PORT=1180`. This will run all of the dockerized tests using the custom port for the socks proxy.
-When you change the default socks proxy port (1080), you have to modify the property `hive.metastore.thrift.client.socks-proxy=hadoop-master:1080` in `conf/presto/etc/catalog/hive.properties`.
+When you change the default socks proxy port (1080) and want to use Hive provided by product tests from outside docker (e.g. access it from Presto running in your IDE), you have to modify the property `hive.metastore.thrift.client.socks-proxy=hadoop-master:1080` in your `hive.properties` file accordingly.
+Presto inside docker (used while starting tests using `run_on_docker.sh`) will still use default port (1080) though.

--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -16,7 +16,7 @@ function canonical_path() {
 
 source ${BASH_SOURCE%/*}/../../../bin/locations.sh
 
-export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-7}
+export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-10}
 export HADOOP_MASTER_IMAGE=${HADOOP_MASTER_IMAGE:-"teradatalabs/cdh5-hive:${DOCKER_IMAGES_VERSION}"}
 
 # The following variables are defined to enable running product tests with arbitrary/downloaded jars
@@ -41,4 +41,4 @@ if [[ -z ${PRODUCT_TESTS_JAR} ]]; then
 fi
 export PRODUCT_TESTS_JAR=$(canonical_path ${PRODUCT_TESTS_JAR})
 
-export HIVE_PROXY_PORT=${HIVE_PROXY_PORT:-1080}
+export HIVE_PROXY_PORT=${HIVE_PROXY_PORT:-1180}

--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -12,7 +12,7 @@ services:
     image: ${HADOOP_MASTER_IMAGE}
     hostname: hadoop-master
     ports:
-      - '${HIVE_PROXY_PORT}:1080'
+      - '${HIVE_PROXY_PORT}:1180'
       - '8020:8020'
       - '8088:8088'
       - '9083:9083'

--- a/presto-product-tests/conf/presto/etc/catalog/hive.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/hive.properties
@@ -7,7 +7,7 @@
 
 connector.name=hive-cdh5
 hive.metastore.uri=thrift://hadoop-master:9083
-hive.metastore.thrift.client.socks-proxy=hadoop-master:1080
+hive.metastore.thrift.client.socks-proxy=hadoop-master:1180
 hive.allow-add-column=true
 hive.allow-rename-column=true
 hive.allow-drop-table=true

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-hdfs-impersonation/hive.properties
@@ -7,7 +7,7 @@
 
 connector.name=hive-cdh5
 hive.metastore.uri=thrift://hadoop-master:9083
-hive.metastore.thrift.client.socks-proxy=hadoop-master:1080
+hive.metastore.thrift.client.socks-proxy=hadoop-master:1180
 hive.allow-drop-table=true
 hive.allow-add-column=true
 hive.allow-rename-table=true

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
@@ -7,7 +7,7 @@
 
 connector.name=hive-cdh5
 hive.metastore.uri=thrift://hadoop-master:9083
-hive.metastore.thrift.client.socks-proxy=hadoop-master:1080
+hive.metastore.thrift.client.socks-proxy=hadoop-master:1180
 hive.metastore-cache-ttl=0s
 
 hive.metastore.authentication.type=KERBEROS

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties
@@ -7,7 +7,7 @@
 
 connector.name=hive-cdh5
 hive.metastore.uri=thrift://hadoop-master:9083
-hive.metastore.thrift.client.socks-proxy=hadoop-master:1080
+hive.metastore.thrift.client.socks-proxy=hadoop-master:1180
 hive.allow-drop-table=true
 hive.allow-rename-table=true
 hive.metastore-cache-ttl=0s


### PR DESCRIPTION
Supersedes https://github.com/prestodb/presto/pull/6274.

---

Corresponding PR for a new docker image: https://github.com/Teradata/docker-images/pull/3