### PR TITLE
Update S3 documentation

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -260,9 +260,10 @@ files referenced by the ``hive.config.resources`` Hive connector property.
 Tuning Properties
 ^^^^^^^^^^^^^^^^^
 
-The following tuning properties affect how many retries are attempted
-when communicating with S3. Most of these parameters affect settings
-on the ``ClientConfiguration`` object associated with the ``AmazonS3Client``.
+The following tuning properties affect the behavior of the client
+used by the Presto S3 filesystem when communicating with S3.
+Most of these parameters affect settings on the ``ClientConfiguration``
+object associated with the ``AmazonS3Client``.
 
 ===================================== =========================================================== ===============
 Property Name                         Description                                                 Default


### PR DESCRIPTION
Simple change to the s3 docs. 

Another issue is, for the `hive.s3.use-instance-credentials` property the doc says `Use the EC2 metadata service to retrieve API credentials (defaults to ``true``). This works with IAM roles in EC2.`, and I am not sure what is meant by `This works with IAM roles in EC2.` 

/cc @natesammons-nasdaq can you please clarify as you are the author of that change?
