### PR TITLE
Produce better hash for double type

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.AbstractLongType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.math.DoubleMath;
 import com.google.common.primitives.Ints;
@@ -232,7 +233,7 @@ public final class DoubleOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.DOUBLE) double value)
     {
-        return doubleToLongBits(value);
+        return AbstractLongType.hash(doubleToLongBits(value));
     }
 
     @ScalarOperator(SATURATED_FLOOR_CAST)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
@@ -75,7 +75,7 @@ public final class DoubleType
     @Override
     public long hash(Block block, int position)
     {
-        return block.getLong(position, 0);
+        return AbstractLongType.hash(block.getLong(position, 0));
     }
 
     @Override


### PR DESCRIPTION
The previous implementation produces bad hashes, which can
cause downstream skew when the hashes are not combined in a
 way that scrambles the bits properly (e.g., combine hash).

This is a follow up to d79494747c7a81930971140326a661a782b28fca.