### PR TITLE
Create Raptor staging and storage directories on startup

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/FileStorageService.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/FileStorageService.java
@@ -63,8 +63,8 @@ public class FileStorageService
             throws IOException
     {
         deleteDirectory(baseStagingDir);
-        createParents(baseStagingDir);
-        createParents(baseStorageDir);
+        createParents(new File(baseStagingDir, "."));
+        createParents(new File(baseStorageDir, "."));
     }
 
     @Override

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestFileStorageService.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestFileStorageService.java
@@ -81,8 +81,8 @@ public class TestFileStorageService
         File staging = new File(temporary, "staging");
         File storage = new File(temporary, "storage");
 
-        assertTrue(staging.mkdir());
-        assertTrue(storage.mkdir());
+        assertDirectory(staging);
+        assertDirectory(storage);
 
         File file = store.getStagingFile(randomUUID());
         store.createParents(file);


### PR DESCRIPTION
This fixes the free space check for new installations.