### PR TITLE
Add `REAL` data type to docs

### DIFF
--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -39,6 +39,12 @@ BIGINT
     A 64-bit signed two's complement integer with a minimum value of
     ``-2^63`` and a maximum value of ``2^63 - 1``.
 
+REAL
+------
+
+    A real is a 32-bit inexact, variable-precision implementing the
+    IEEE Standard 754 for Binary Floating-Point Arithmetic.
+
 DOUBLE
 ------
 


### PR DESCRIPTION
Since this data type now exists in Presto, this adds it to the docs, it is the
same language as for `DOUBLE` but notes that it is 32 bits