### PR TITLE
Make shard cleanup query more efficient

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/H2ShardDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/H2ShardDao.java
@@ -36,8 +36,8 @@ public interface H2ShardDao
 
     @SqlUpdate("DELETE FROM transactions\n" +
             "WHERE end_time < :maxEndTime\n" +
-            "  AND successful IS NOT NULL\n" +
+            "  AND successful IN (TRUE, FALSE)\n" +
             "  AND transaction_id NOT IN (SELECT transaction_id FROM created_shards)\n" +
             "LIMIT " + CLEANUP_TRANSACTIONS_BATCH_SIZE)
-    void deleteOldCompletedTransactions(@Bind("maxEndTime") Timestamp maxEndTime);
+    int deleteOldCompletedTransactions(@Bind("maxEndTime") Timestamp maxEndTime);
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MySqlShardDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MySqlShardDao.java
@@ -44,9 +44,9 @@ public interface MySqlShardDao
     // 'order by' is needed in this statement in order to make it compatible with statement-based replication
     @SqlUpdate("DELETE FROM transactions\n" +
             "WHERE end_time < :maxEndTime\n" +
-            "  AND successful IS NOT NULL\n" +
+            "  AND successful IN (TRUE, FALSE)\n" +
             "  AND transaction_id NOT IN (SELECT transaction_id FROM created_shards)\n" +
-            "ORDER BY transaction_id\n" +
+            "ORDER BY end_time, transaction_id\n" +
             "LIMIT " + CLEANUP_TRANSACTIONS_BATCH_SIZE)
-    void deleteOldCompletedTransactions(@Bind("maxEndTime") Timestamp maxEndTime);
+    int deleteOldCompletedTransactions(@Bind("maxEndTime") Timestamp maxEndTime);
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardDao.java
@@ -34,7 +34,7 @@ import java.util.UUID;
 public interface ShardDao
 {
     int CLEANABLE_SHARDS_BATCH_SIZE = 1000;
-    int CLEANUP_TRANSACTIONS_BATCH_SIZE = 1_000_000;
+    int CLEANUP_TRANSACTIONS_BATCH_SIZE = 10_000;
 
     @SqlUpdate("INSERT INTO nodes (node_identifier) VALUES (:nodeIdentifier)")
     @GetGeneratedKeys
@@ -206,5 +206,5 @@ public interface ShardDao
             @Bind("bucketNumber") int bucketNumber,
             @Bind("nodeId") int nodeId);
 
-    void deleteOldCompletedTransactions(@Bind("maxEndTime") Timestamp maxEndTime);
+    int deleteOldCompletedTransactions(@Bind("maxEndTime") Timestamp maxEndTime);
 }


### PR DESCRIPTION
Note, that you need an index on (end_time, transaction_id) for
"transactions" table.