### PR TITLE
Move access control tests out of smoke tests

### DIFF
--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
@@ -26,12 +26,4 @@ public class TestJdbcIntegrationSmokeTest
     {
         super(createJdbcQueryRunner(ORDERS));
     }
-
-    @Override
-    public void testTableSampleSystem()
-            throws Exception
-    {
-        // tablesample system doesn't work reliably with jdbc connector
-        // because it generates a single split
-    }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
@@ -34,10 +34,4 @@ public class TestJdbcIntegrationSmokeTest
         // tablesample system doesn't work reliably with jdbc connector
         // because it generates a single split
     }
-
-    @Override
-    public void testViewAccessControl()
-    {
-        // jdbc connector does not support views
-    }
 }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -36,6 +36,12 @@ public class TestCassandraDistributed
     }
 
     @Override
+    protected boolean supportsViews()
+    {
+        return false;
+    }
+
+    @Override
     public void testGroupingSetMixedExpressionAndColumn()
             throws Exception
     {
@@ -71,41 +77,6 @@ public class TestCassandraDistributed
     }
 
     @Override
-    public void testView()
-            throws Exception
-    {
-        // Cassandra connector currently does not support views
-    }
-
-    @Override
-    public void testCompatibleTypeChangeForView()
-            throws Exception
-    {
-        // Cassandra connector currently does not support views
-    }
-
-    @Override
-    public void testCompatibleTypeChangeForView2()
-            throws Exception
-    {
-        // Cassandra connector currently does not support views
-    }
-
-    @Override
-    public void testViewMetadata()
-            throws Exception
-    {
-        // Cassandra connector currently does not support views
-    }
-
-    @Test
-    public void testViewCaseSensitivity()
-            throws Exception
-    {
-        // Cassandra connector currently does not support views
-    }
-
-    @Override
     public void testInsert()
             throws Exception
     {
@@ -133,6 +104,7 @@ public class TestCassandraDistributed
         // Cassandra connector currently does not support delete
     }
 
+    @Override
     public void testShowColumns()
             throws Exception
     {

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -43,10 +43,4 @@ public class TestCassandraIntegrationSmokeTest
         queryRunner.execute(createCassandraSession(keyspace), "select * from presto_test where key='key 2'");
         queryRunner.execute(createCassandraSession(keyspace), "select * from presto_test where key='key 3'");
     }
-
-    @Override
-    public void testViewAccessControl()
-    {
-        // cassandra does not support views
-    }
 }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
@@ -44,12 +44,6 @@ public class TestKafkaIntegrationSmokeTest
         this.embeddedKafka = embeddedKafka;
     }
 
-    @Override
-    public void testViewAccessControl()
-    {
-        // kafka does not support views
-    }
-
     @AfterClass(alwaysRun = true)
     public void destroy()
             throws IOException

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -49,14 +49,6 @@ public class TestMongoIntegrationSmokeTest
         this.runner = runner;
     }
 
-    @Override
-    public void testTableSampleSystem()
-            throws Exception
-    {
-        // tablesample system doesn't work reliably with this connector
-        // because it generates a single split
-    }
-
     @Test
     public void createTableWithEveryType()
             throws Exception

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -160,12 +160,6 @@ public class TestMongoIntegrationSmokeTest
         assertNotNull(results.getMaterializedRows().get(0).getField(0));
     }
 
-    @Override
-    public void testViewAccessControl()
-    {
-        // does not support views
-    }
-
     @AfterClass(alwaysRun = true)
     public final void destroy()
     {

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -57,14 +57,6 @@ public class TestMySqlIntegrationSmokeTest
     }
 
     @Override
-    public void testTableSampleSystem()
-            throws Exception
-    {
-        // tablesample system doesn't work reliably with this connector
-        // because it generates a single split
-    }
-
-    @Override
     public void testDescribeTable()
             throws Exception
     {

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -86,12 +86,6 @@ public class TestMySqlIntegrationSmokeTest
         assertEquals(actualColumns, expectedColumns);
     }
 
-    @Override
-    public void testViewAccessControl()
-    {
-        // jdbc connector does not support views
-    }
-
     @AfterClass(alwaysRun = true)
     public final void destroy()
     {

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -47,14 +47,6 @@ public class TestPostgreSqlIntegrationSmokeTest
         this.postgreSqlServer = postgreSqlServer;
     }
 
-    @Override
-    public void testTableSampleSystem()
-            throws Exception
-    {
-        // tablesample system doesn't work reliably with this connector
-        // because it generates a single split
-    }
-
     @AfterClass(alwaysRun = true)
     public final void destroy()
             throws IOException

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -55,12 +55,6 @@ public class TestPostgreSqlIntegrationSmokeTest
         // because it generates a single split
     }
 
-    @Override
-    public void testViewAccessControl()
-    {
-        // jdbc connector does not support views
-    }
-
     @AfterClass(alwaysRun = true)
     public final void destroy()
             throws IOException

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributed.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributed.java
@@ -50,6 +50,12 @@ public class TestRedisDistributed
         closeAllRuntimeException(queryRunner, embeddedRedis);
     }
 
+    @Override
+    protected boolean supportsViews()
+    {
+        return false;
+    }
+
     //
     // Redis connector does not support table creation.
     //
@@ -67,41 +73,6 @@ public class TestRedisDistributed
     @Override
     public void testSymbolAliasing()
     {
-    }
-
-    //
-    // Redis connector does not support views.
-    //
-
-    @Override
-    public void testView()
-    {
-    }
-
-    @Override
-    public void testCompatibleTypeChangeForView()
-            throws Exception
-    {
-        // Redis connector currently does not support views
-    }
-
-    @Override
-    public void testCompatibleTypeChangeForView2()
-            throws Exception
-    {
-        // Redis connector currently does not support views
-    }
-
-    @Override
-    public void testViewMetadata()
-    {
-    }
-
-    @Test
-    public void testViewCaseSensitivity()
-            throws Exception
-    {
-        // Redis connector currently does not support views
     }
 
     //

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationSmokeTest.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationSmokeTest.java
@@ -52,12 +52,6 @@ public class TestRedisIntegrationSmokeTest
         // because it generates a single split
     }
 
-    @Override
-    public void testViewAccessControl()
-    {
-        // redis does not support views
-    }
-
     @AfterClass(alwaysRun = true)
     public void destroy()
             throws IOException

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationSmokeTest.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationSmokeTest.java
@@ -44,14 +44,6 @@ public class TestRedisIntegrationSmokeTest
         this.embeddedRedis = embeddedRedis;
     }
 
-    @Override
-    public void testTableSampleSystem()
-            throws Exception
-    {
-        // tablesample system doesn't work reliably with this connector
-        // because it generates a single split
-    }
-
     @AfterClass(alwaysRun = true)
     public void destroy()
             throws IOException

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -14,18 +14,37 @@
 package com.facebook.presto.tests;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.TestingSession;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.testing.Assertions;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.INFORMATION_SCHEMA;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.ADD_COLUMN;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.CREATE_TABLE;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.CREATE_VIEW;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.CREATE_VIEW_WITH_SELECT_TABLE;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.CREATE_VIEW_WITH_SELECT_VIEW;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.DROP_TABLE;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.RENAME_COLUMN;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.RENAME_TABLE;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_TABLE;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_VIEW;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SET_SESSION;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SET_USER;
+import static com.facebook.presto.testing.TestingAccessControlManager.privilege;
 import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
 import static com.facebook.presto.tests.QueryAssertions.assertContains;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -41,6 +60,11 @@ public abstract class AbstractTestDistributedQueries
     protected AbstractTestDistributedQueries(QueryRunner queryRunner)
     {
         super(queryRunner);
+    }
+
+    protected boolean supportsViews()
+    {
+        return true;
     }
 
     @Test
@@ -553,6 +577,8 @@ public abstract class AbstractTestDistributedQueries
     public void testView()
             throws Exception
     {
+        skipTestUnless(supportsViews());
+
         @Language("SQL") String query = "SELECT orderkey, orderstatus, totalprice / 2 half FROM orders";
 
         assertUpdate("CREATE VIEW test_view AS SELECT 123 x");
@@ -576,6 +602,8 @@ public abstract class AbstractTestDistributedQueries
     public void testViewCaseSensitivity()
             throws Exception
     {
+        skipTestUnless(supportsViews());
+
         computeActual("CREATE VIEW test_view_uppercase AS SELECT X FROM (SELECT 123 X)");
         computeActual("CREATE VIEW test_view_mixedcase AS SELECT XyZ FROM (SELECT 456 XyZ)");
         assertQuery("SELECT * FROM test_view_uppercase", "SELECT X FROM (SELECT 123 X)");
@@ -586,6 +614,8 @@ public abstract class AbstractTestDistributedQueries
     public void testCompatibleTypeChangeForView()
             throws Exception
     {
+        skipTestUnless(supportsViews());
+
         assertUpdate("CREATE TABLE test_table_1 AS SELECT 'abcdefg' a", 1);
         assertUpdate("CREATE VIEW test_view_1 AS SELECT a FROM test_table_1");
 
@@ -605,6 +635,8 @@ public abstract class AbstractTestDistributedQueries
     public void testCompatibleTypeChangeForView2()
             throws Exception
     {
+        skipTestUnless(supportsViews());
+
         assertUpdate("CREATE TABLE test_table_2 AS SELECT BIGINT '1' v", 1);
         assertUpdate("CREATE VIEW test_view_2 AS SELECT * FROM test_table_2");
 
@@ -624,6 +656,8 @@ public abstract class AbstractTestDistributedQueries
     public void testViewMetadata()
             throws Exception
     {
+        skipTestUnless(supportsViews());
+
         @Language("SQL") String query = "SELECT BIGINT '123' x, 'foo' y";
         assertUpdate("CREATE VIEW meta_test_view AS " + query);
 
@@ -744,5 +778,108 @@ public abstract class AbstractTestDistributedQueries
         assertUpdate("CREATE TABLE test_symbol_aliasing AS SELECT 1 foo_1, 2 foo_2_4", 1);
         assertQuery("SELECT foo_1, foo_2_4 FROM test_symbol_aliasing", "SELECT 1, 2");
         assertUpdate("DROP TABLE test_symbol_aliasing");
+    }
+
+    @Test
+    public void testNonQueryAccessControl()
+            throws Exception
+    {
+        skipTestUnless(supportsViews());
+
+        assertAccessDenied("SET SESSION " + QUERY_MAX_MEMORY + " = '10MB'",
+                "Cannot set system session property " + QUERY_MAX_MEMORY,
+                privilege(QUERY_MAX_MEMORY, SET_SESSION));
+
+        assertAccessDenied("CREATE TABLE foo (pk bigint)", "Cannot create table .*.foo.*", privilege("foo", CREATE_TABLE));
+        assertAccessDenied("DROP TABLE orders", "Cannot drop table .*.orders.*", privilege("orders", DROP_TABLE));
+        assertAccessDenied("ALTER TABLE orders RENAME TO foo", "Cannot rename table .*.orders.* to .*.foo.*", privilege("orders", RENAME_TABLE));
+        assertAccessDenied("ALTER TABLE orders ADD COLUMN foo bigint", "Cannot add a column to table .*.orders.*", privilege("orders", ADD_COLUMN));
+        assertAccessDenied("ALTER TABLE orders RENAME COLUMN orderkey TO foo", "Cannot rename a column in table .*.orders.*", privilege("orders", RENAME_COLUMN));
+        assertAccessDenied("CREATE VIEW foo as SELECT * FROM orders", "Cannot create view .*.foo.*", privilege("foo", CREATE_VIEW));
+        // todo add DROP VIEW test... not all connectors have view support
+
+        try {
+            assertAccessDenied("SELECT 1", "Principal .* cannot become user " + getSession().getUser() + ".*", privilege(getSession().getUser(), SET_USER));
+        }
+        catch (AssertionError e) {
+            // There is no clean exception message for authorization failure.  We simply get a 403
+            Assertions.assertContains(e.getMessage(), "statusCode=403");
+        }
+    }
+
+    @Test
+    public void testViewAccessControl()
+            throws Exception
+    {
+        skipTestUnless(supportsViews());
+
+        Session viewOwnerSession = TestingSession.testSessionBuilder()
+                .setIdentity(new Identity("test_view_access_owner", Optional.empty()))
+                .setCatalog(getSession().getCatalog().get())
+                .setSchema(getSession().getSchema().get())
+                .build();
+
+        // verify creation of view over a table requires special view creation privileges for the table
+        assertAccessDenied(
+                viewOwnerSession,
+                "CREATE VIEW test_view_access AS SELECT * FROM orders",
+                "Cannot select from table .*.orders.*",
+                privilege("orders", CREATE_VIEW_WITH_SELECT_TABLE));
+
+        // create the view
+        assertAccessAllowed(
+                viewOwnerSession,
+                "CREATE VIEW test_view_access AS SELECT * FROM orders",
+                privilege("bogus", "bogus privilege to disable security", SELECT_TABLE));
+
+        // verify selecting from a view over a table requires the view owner to have special view creation privileges for the table
+        assertAccessDenied(
+                "SELECT * FROM test_view_access",
+                "Cannot select from table .*.orders.*",
+                privilege(viewOwnerSession.getUser(), "orders", CREATE_VIEW_WITH_SELECT_TABLE));
+
+        // verify selecting from a view over a table does not require the session user to have SELECT privileges on the underlying table
+        assertAccessAllowed(
+                "SELECT * FROM test_view_access",
+                privilege(getSession().getUser(), "orders", CREATE_VIEW_WITH_SELECT_TABLE));
+        assertAccessAllowed(
+                "SELECT * FROM test_view_access",
+                privilege(getSession().getUser(), "orders", SELECT_TABLE));
+
+        Session nestedViewOwnerSession = TestingSession.testSessionBuilder()
+                .setIdentity(new Identity("test_nested_view_access_owner", Optional.empty()))
+                .setCatalog(getSession().getCatalog().get())
+                .setSchema(getSession().getSchema().get())
+                .build();
+
+        // verify creation of view over a view requires special view creation privileges for the view
+        assertAccessDenied(
+                nestedViewOwnerSession,
+                "CREATE VIEW test_nested_view_access AS SELECT * FROM test_view_access",
+                "Cannot select from view .*.test_view_access.*",
+                privilege("test_view_access", CREATE_VIEW_WITH_SELECT_VIEW));
+
+        // create the nested view
+        assertAccessAllowed(
+                nestedViewOwnerSession,
+                "CREATE VIEW test_nested_view_access AS SELECT * FROM test_view_access",
+                privilege("bogus", "bogus privilege to disable security", SELECT_TABLE));
+
+        // verify selecting from a view over a view requires the view owner of the outer view to have special view creation privileges for the inner view
+        assertAccessDenied(
+                "SELECT * FROM test_nested_view_access",
+                "Cannot select from view .*.test_view_access.*",
+                privilege(nestedViewOwnerSession.getUser(), "test_view_access", CREATE_VIEW_WITH_SELECT_VIEW));
+
+        // verify selecting from a view over a view does not require the session user to have SELECT privileges for the inner view
+        assertAccessAllowed(
+                "SELECT * FROM test_nested_view_access",
+                privilege(getSession().getUser(), "test_view_access", CREATE_VIEW_WITH_SELECT_VIEW));
+        assertAccessAllowed(
+                "SELECT * FROM test_nested_view_access",
+                privilege(getSession().getUser(), "test_view_access", SELECT_VIEW));
+
+        assertAccessAllowed(nestedViewOwnerSession, "DROP VIEW test_nested_view_access");
+        assertAccessAllowed(viewOwnerSession, "DROP VIEW test_view_access");
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -98,23 +98,6 @@ public abstract class AbstractTestIntegrationSmokeTest
     }
 
     @Test
-    public void testTableSampleSystem()
-            throws Exception
-    {
-        int total = computeActual("SELECT orderkey FROM orders").getMaterializedRows().size();
-
-        boolean sampleSizeFound = false;
-        for (int i = 0; i < 100; i++) {
-            int sampleSize = computeActual("SELECT orderkey FROM ORDERS TABLESAMPLE SYSTEM (50)").getMaterializedRows().size();
-            if (sampleSize > 0 && sampleSize < total) {
-                sampleSizeFound = true;
-                break;
-            }
-        }
-        assertTrue(sampleSizeFound, "Table sample returned unexpected number of rows");
-    }
-
-    @Test
     public void testShowSchemas()
             throws Exception
     {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -29,6 +29,7 @@ import com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilege;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
+import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 
 import java.util.List;
@@ -289,5 +290,12 @@ public abstract class AbstractTestQueryFramework
                 queryRunner.getAccessControl(),
                 sqlParser,
                 ImmutableMap.of());
+    }
+
+    protected static void skipTestUnless(boolean requirement)
+    {
+        if (!requirement) {
+            throw new SkipException("requirement not met");
+        }
     }
 }


### PR DESCRIPTION
These tests are for the engine and are not connector smoke tests.