### PR TITLE
Fix incorrect equality inference during predicate pushdown

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
@@ -253,7 +253,7 @@ public class EqualityInference
     {
         return expression -> {
             expression = normalizeInPredicateToEquality(expression);
-            if (DeterminismEvaluator.isDeterministic(expression) && expression instanceof ComparisonExpression) {
+            if (expression instanceof ComparisonExpression && DeterminismEvaluator.isDeterministic(expression) && !NullabilityAnalyzer.mayReturnNullOnNonNullInput(expression)) {
                 ComparisonExpression comparison = (ComparisonExpression) expression;
                 if (comparison.getType() == ComparisonExpression.Type.EQUAL) {
                     // We should only consider equalities that have distinct left and right components

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NullabilityAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NullabilityAnalyzer.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.DefaultExpressionTraversalVisitor;
+import com.facebook.presto.sql.tree.DereferenceExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.IfExpression;
+import com.facebook.presto.sql.tree.InPredicate;
+import com.facebook.presto.sql.tree.NullIfExpression;
+import com.facebook.presto.sql.tree.SearchedCaseExpression;
+import com.facebook.presto.sql.tree.SimpleCaseExpression;
+import com.facebook.presto.sql.tree.SubscriptExpression;
+import com.facebook.presto.sql.tree.TryExpression;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Objects.requireNonNull;
+
+public final class NullabilityAnalyzer
+{
+    private NullabilityAnalyzer() {}
+
+    /**
+     * TODO: this currently produces a very conservative estimate.
+     * We need to narrow down the conditions under which certain constructs
+     * can return null (e.g., if(a, b, c) might return null for non-null a
+     * only if b or c can be null.
+     */
+    public static boolean mayReturnNullOnNonNullInput(Expression expression)
+    {
+        requireNonNull(expression, "expression is null");
+
+        AtomicBoolean result = new AtomicBoolean(false);
+        new Visitor().process(expression, result);
+        return result.get();
+    }
+
+    private static class Visitor
+            extends DefaultExpressionTraversalVisitor<Void, AtomicBoolean>
+    {
+        @Override
+        protected Void visitCast(Cast node, AtomicBoolean result)
+        {
+            result.set(node.isSafe()); // try_cast
+            return null;
+        }
+
+        @Override
+        protected Void visitNullIfExpression(NullIfExpression node, AtomicBoolean result)
+        {
+            result.set(true);
+            return null;
+        }
+
+        @Override
+        protected Void visitDereferenceExpression(DereferenceExpression node, AtomicBoolean result)
+        {
+            result.set(true);
+            return null;
+        }
+
+        @Override
+        protected Void visitInPredicate(InPredicate node, AtomicBoolean result)
+        {
+            result.set(true);
+            return null;
+        }
+
+        @Override
+        protected Void visitSearchedCaseExpression(SearchedCaseExpression node, AtomicBoolean result)
+        {
+            result.set(true);
+            return null;
+        }
+
+        @Override
+        protected Void visitSimpleCaseExpression(SimpleCaseExpression node, AtomicBoolean result)
+        {
+            result.set(true);
+            return null;
+        }
+
+        @Override
+        protected Void visitSubscriptExpression(SubscriptExpression node, AtomicBoolean result)
+        {
+            result.set(true);
+            return null;
+        }
+
+        @Override
+        protected Void visitTryExpression(TryExpression node, AtomicBoolean result)
+        {
+            result.set(true);
+            return null;
+        }
+
+        @Override
+        protected Void visitIfExpression(IfExpression node, AtomicBoolean result)
+        {
+            result.set(true);
+            return null;
+        }
+
+        @Override
+        protected Void visitFunctionCall(FunctionCall node, AtomicBoolean result)
+        {
+            // TODO: this should look at whether the return type of the function is annotated with @SqlNullable
+            result.set(true);
+            return null;
+        }
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2791,6 +2791,47 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testJoinWithExpressionsThatMayReturnNull()
+            throws Exception
+    {
+        assertQuery("" +
+                        "SELECT *\n" +
+                        "FROM (\n" +
+                        "    SELECT a, nullif(a, 1)\n" +
+                        "    FROM (VALUES 1) w(a)\n" +
+                        ") t(a,b)\n" +
+                        "JOIN (VALUES 1) u(x) ON t.a = u.x",
+                "SELECT 1, NULL, 1");
+
+        assertQuery("" +
+                        "SELECT *\n" +
+                        "FROM (\n" +
+                        "    SELECT a, contains(array[2, null], a)\n" +
+                        "    FROM (VALUES 1) w(a)\n" +
+                        ") t(a,b)\n" +
+                        "JOIN (VALUES 1) u(x) ON t.a = u.x\n",
+                "SELECT 1, NULL, 1");
+
+        assertQuery("" +
+                        "SELECT *\n" +
+                        "FROM (\n" +
+                        "    SELECT a, array[null][a]\n" +
+                        "    FROM (VALUES 1) w(a)\n" +
+                        ") t(a,b)\n" +
+                        "JOIN (VALUES 1) u(x) ON t.a = u.x",
+                "SELECT 1, NULL, 1");
+
+        assertQuery("" +
+                        "SELECT *\n" +
+                        "FROM (\n" +
+                        "    SELECT a, try(a / 0)\n" +
+                        "    FROM (VALUES 1) w(a)\n" +
+                        ") t(a,b)\n" +
+                        "JOIN (VALUES 1) u(x) ON t.a = u.x",
+                "SELECT 1, NULL, 1");
+    }
+
+    @Test
     public void testLeftFilteredJoin()
             throws Exception
     {


### PR DESCRIPTION
When one side of a join has an effective predicate expression in terms of the field
use in the join criteria (e.g., v = f(k1), with a join criteria of k1 = k2), and
that expression can produce null on non-null input (e.g., nullif, case, if, most of
the array/map functions, etc), queries can produce incorrect results.

In that scenario, predicate pushdown derives another join condition v = f(k2). Since
f() can produce null on non-null input, it's possible for some value of k1 that's
equal to k2, f(k2) is null or f(k1) is null. This will cause the join criteria to
evaluate to null instead of true.

A correct derivation, although less useful for predicate pushdown,  would be

    k1 = k2 AND ((f(k1) IS NULL AND f(k2) IS NULL) OR f(k1) = f(k2)).

This change prevents the equality inference logic from considering expressions
that may return null on non-null input.

Fixes https://github.com/prestodb/presto/issues/6332