### PR TITLE
Fix memory usage stats for aggregration with no aggregators

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -80,13 +80,13 @@ public class InMemoryHashAggregationBuilder
     {
         if (aggregators.isEmpty()) {
             groupByHash.addPage(page);
-            return;
         }
+        else {
+            GroupByIdBlock groupIds = groupByHash.getGroupIds(page);
 
-        GroupByIdBlock groupIds = groupByHash.getGroupIds(page);
-
-        for (Aggregator aggregator : aggregators) {
-            aggregator.processPage(groupIds, page);
+            for (Aggregator aggregator : aggregators) {
+                aggregator.processPage(groupIds, page);
+            }
         }
         updateMemory();
     }


### PR DESCRIPTION
Fix memory usage stats for aggregration with no aggregators

When InMemoryHashAggregationBuilder had no aggregators, it did not
update memory usage (did not call updateMemory). This caused that memory
used groupByHash was not included in stats. This commit fixes that.
