### PR TITLE
Fix incorrect equality inference during predicate pushdown

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NullabilityAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NullabilityAnalyzer.java
@@ -55,7 +55,8 @@ public final class NullabilityAnalyzer
         @Override
         protected Void visitCast(Cast node, AtomicBoolean result)
         {
-            result.set(node.isSafe()); // try_cast
+            // try_cast and cast(JSON 'null' AS ...) can return null
+            result.set(true);
             return null;
         }
 


### PR DESCRIPTION
CAST(JSON 'null' AS ...) will also return null