### PR TITLE
Add sort order in Window node in Explain output

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
@@ -567,10 +567,10 @@ public class PlanPrinter
                 args.add(format("order by (%s)", Stream.concat(
                         node.getOrderBy().stream()
                                 .limit(node.getPreSortedOrderPrefix())
-                                .map(symbol -> "<" + symbol + ">"),
+                                .map(symbol -> "<" + symbol + node.getOrderings().get(symbol) + ">"),
                         node.getOrderBy().stream()
                                 .skip(node.getPreSortedOrderPrefix())
-                                .map(Symbol::toString))
+                                .map(symbol -> symbol + " " + node.getOrderings().get(symbol)))
                         .collect(Collectors.joining(", "))));
             }
 


### PR DESCRIPTION
Currently only the ordering column is being printed
in the Explain plan output for Window nodes. It is
also desirable to know what ordering is used for each
of those columns.