### PR TITLE
Update to Slice 0.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dep.antlr.version>4.5.1</dep.antlr.version>
         <dep.airlift.version>0.138</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.slice.version>0.25</dep.slice.version>
+        <dep.slice.version>0.27</dep.slice.version>
         <dep.aws-sdk.version>1.11.30</dep.aws-sdk.version>
         <dep.tempto.version>1.14</dep.tempto.version>
 

--- a/presto-docs/src/main/sphinx/release/release-0.154.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.154.rst
@@ -11,6 +11,8 @@ General Changes
   subqueries in ``IN`` predicates to fail during planning.
 * Fix potential *"Input symbols do not match output symbols"*
   error when writing to bucketed tables.
+* Fix potential *"Requested array size exceeds VM limit"* error
+  that triggers the JVM's ``OutOfMemoryError`` handling.
 * Improve performance of window functions with identical partitioning and
   ordering but different frame specifications.
 * Add ``code-cache-collection-threshold`` config which controls when Presto


### PR DESCRIPTION
This version avoids allocating arrays that are beyond the JVM limit.