### PR TITLE
Add field/line delimiter property in create hive table

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -109,6 +109,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil</artifactId>
         </dependency>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveOutputTableHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveOutputTableHandle.java
@@ -33,6 +33,7 @@ public class HiveOutputTableHandle
     private final List<String> partitionedBy;
     private final String tableOwner;
     private final Map<String, String> additionalTableParameters;
+    private final Map<String, String> serdeParameters;
 
     @JsonCreator
     public HiveOutputTableHandle(
@@ -48,7 +49,8 @@ public class HiveOutputTableHandle
             @JsonProperty("partitionedBy") List<String> partitionedBy,
             @JsonProperty("bucketProperty") Optional<HiveBucketProperty> bucketProperty,
             @JsonProperty("tableOwner") String tableOwner,
-            @JsonProperty("additionalTableParameters") Map<String, String> additionalTableParameters)
+            @JsonProperty("additionalTableParameters") Map<String, String> additionalTableParameters,
+            @JsonProperty("serdeParameters") Map<String, String> serdeParameters)
     {
         super(
                 clientId,
@@ -65,6 +67,7 @@ public class HiveOutputTableHandle
         this.partitionedBy = ImmutableList.copyOf(requireNonNull(partitionedBy, "partitionedBy is null"));
         this.tableOwner = requireNonNull(tableOwner, "tableOwner is null");
         this.additionalTableParameters = ImmutableMap.copyOf(requireNonNull(additionalTableParameters, "additionalTableParameters is null"));
+        this.serdeParameters = ImmutableMap.copyOf(requireNonNull(serdeParameters, "serdeParameters is null"));
     }
 
     @JsonProperty
@@ -83,5 +86,11 @@ public class HiveOutputTableHandle
     public Map<String, String> getAdditionalTableParameters()
     {
         return additionalTableParameters;
+    }
+
+    @JsonProperty
+    public Map<String, String> getSerdeParameters()
+    {
+        return serdeParameters;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import javax.inject.Inject;
 
@@ -41,6 +42,11 @@ public class HiveTableProperties
     public static final String PARTITIONED_BY_PROPERTY = "partitioned_by";
     public static final String BUCKETED_BY_PROPERTY = "bucketed_by";
     public static final String BUCKET_COUNT_PROPERTY = "bucket_count";
+    public static final String FIELD_DELIMITER_PROPERTY = "field_delimiter";
+    public static final String LINE_DELIMITER_PROPERTY = "line_delimiter";
+
+    public static final String DEFAULT_FIELD_DELIMITER = "\001";
+    public static final String DEFAULT_LINE_DELIMITER = "\n";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -84,7 +90,9 @@ public class HiveTableProperties
                                 .map(name -> ((String) name).toLowerCase(ENGLISH))
                                 .collect(Collectors.toList())),
                         value -> value),
-                integerSessionProperty(BUCKET_COUNT_PROPERTY, "Number of buckets", 0, false));
+                integerSessionProperty(BUCKET_COUNT_PROPERTY, "Number of buckets", 0, false),
+                stringSessionProperty(FIELD_DELIMITER_PROPERTY, "Field delimiter", DEFAULT_FIELD_DELIMITER, false),
+                stringSessionProperty(LINE_DELIMITER_PROPERTY, "Line delimiter", DEFAULT_LINE_DELIMITER, false));
     }
 
     public List<PropertyMetadata<?>> getTableProperties()
@@ -128,5 +136,15 @@ public class HiveTableProperties
     private static List<String> getBucketedBy(Map<String, Object> tableProperties)
     {
         return (List<String>) tableProperties.get(BUCKETED_BY_PROPERTY);
+    }
+
+    public static String getFieldDelimiterProperty(Map<String, Object> tableProperties)
+    {
+        return StringEscapeUtils.unescapeJava((String) tableProperties.get(FIELD_DELIMITER_PROPERTY));
+    }
+
+    public static String getLineDelimiterProperty(Map<String, Object> tableProperties)
+    {
+        return StringEscapeUtils.unescapeJava((String) tableProperties.get(LINE_DELIMITER_PROPERTY));
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -1554,6 +1554,39 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testCreateTableWithDelimiter()
+        throws Exception
+    {
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE %s.%s.test_table_with_delimiter (\n" +
+                        "   name varchar\n" +
+                        ")\n" +
+                        "WITH (\n" +
+                        "   field_delimiter = ',',\n" +
+                        "   format = 'TEXTFILE',\n" +
+                        "   line_delimiter = ';'\n" +
+                        ")",
+                getSession().getCatalog().get(),
+                getSession().getSchema().get());
+
+        assertUpdate(createTableSql);
+
+        MaterializedResult actual = computeActual("SHOW CREATE TABLE test_table_with_delimiter");
+        assertEquals(actual.getOnlyValue(), createTableSql);
+
+        assertUpdate("DROP TABLE test_table_with_delimiter");
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Field delimiter is only allowed when creating textfile table")
+    public void testCreateNonTextTableWithDelimiter()
+    {
+        assertUpdate("" +
+                "CREATE TABLE test_create_non_text_table_with_delimiter\n" +
+                "(grape bigint, apple varchar, orange bigint, pear varchar)\n" +
+                "WITH (field_delimiter = ',')");
+    }
+
+    @Test
     public void testPathHiddenColumn()
             throws Exception
     {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -226,6 +226,7 @@ public class TestHivePageSink
                 ImmutableList.of(),
                 Optional.empty(),
                 "test",
+                ImmutableMap.of(),
                 ImmutableMap.of());
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);
         HdfsEnvironment hdfsEnvironment = createTestHdfsEnvironment(config);


### PR DESCRIPTION
This is useful when creating a TEXTFILE table.
