### PR TITLE
Fix product tests log output on Mac OS X

### DIFF
--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -36,7 +36,10 @@ function stop_unnecessary_hadoop_services() {
 }
 
 function run_in_application_runner_container() {
-  environment_compose run --rm -T application-runner "$@"
+  local CONTAINER_NAME=$( environment_compose run -d application-runner "$@" )
+  echo "Showing logs from $CONTAINER_NAME:"
+  docker logs -f $CONTAINER_NAME
+  return $( docker inspect --format '{{.State.ExitCode}}' $CONTAINER_NAME )
 }
 
 function check_presto() {


### PR DESCRIPTION
Previously most of the logs were not displayed.
The issue did not affect linux hosts.

Also log docker images used for product tests.