### PR TITLE
Make HashGenerationOptimizer insensitive of hash symbols order

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -25,6 +25,7 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -65,6 +66,8 @@ public class JoinNode
         this.filter = filter;
         this.leftHashSymbol = leftHashSymbol;
         this.rightHashSymbol = rightHashSymbol;
+
+        checkState(leftHashSymbol.isPresent() == rightHashSymbol.isPresent(), "Either none or both hash symbols should be provided");
     }
 
     public enum Type

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -237,6 +237,39 @@ public class TestLogicalPlanner
                                                                 ))))))));
     }
 
+    @Test
+    public void testGeneratesOneLeftHashForTwoJoinsWithShuffledSymbols()
+    {
+        assertPlan(
+                "SELECT * " +
+                        " FROM " +
+                        "  (SELECT " +
+                        "    l.suppkey," +
+                        "    l.partkey" +
+                        "   FROM" +
+                        "    lineitem l" +
+                        "   JOIN" +
+                        "    partsupp ps" +
+                        "   ON" +
+                        "    ps.suppkey = l.suppkey" +
+                        "    AND ps.partkey = l.partkey) l" +
+                        "  JOIN" +
+                        "   partsupp ps" +
+                        "  ON" +
+                        "   ps.partkey = l.partkey" +
+                        "   AND ps.suppkey = l.suppkey",
+                anyTree(node(JoinNode.class,
+                        project(
+                                node(JoinNode.class,
+                                        project(
+                                                anyTree()).withSymbol("hash", "H"),
+                                        anyTree())
+                        ).withSymbol("suppkey", "S")
+                                .withSymbol("partkey", "P")
+                                .withSymbol("hash", "H"),
+                        anyTree())));
+    }
+
     private void assertPlan(String sql, PlanMatchPattern pattern)
     {
         assertPlan(sql, LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED, pattern);


### PR DESCRIPTION
This improvement reduces number of hash computations in a plan
when hash symbols for partitions or join are the same but
with different order (e.g: Tpch Q9 query).

Example without optimization:
```
 Fragment 4 [HASH]                                                                                                                                                                                          
     Output layout: [nationkey_9, extendedprice, discount, nationkey_9, $hashvalue_121, $hashvalue_121]                                                                                                     
     Output partitioning: HASH [nationkey_9]                                                                                                                                                                
     - Project => [nationkey_9:bigint, extendedprice:double, discount:double, $hashvalue_121:bigint]                                                                                                        
             $hashvalue_121 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("nationkey_9"), 0))                                                                                                
         - InnerJoin[("suppkey_48" = "suppkey_49") AND ("nationkey_50" = "nationkey_51")] => [nationkey:bigint, suppkey:bigint, extendedprice:double, discount:double, suppkey_48:bigint, nationkey_50:bigin
             - Project => [nationkey:bigint, suppkey:bigint, extendedprice:double, discount:double, suppkey_48:bigint, nationkey_50:bigint, $hashvalue_101:bigint]                                          
                 - RemoteSource[5] => [nationkey:bigint, suppkey:bigint, extendedprice:double, discount:double, suppkey_48:bigint, nationkey_50:bigint, $hashvalue_101:bigint, $hashvalue_102:bigint]       
             - Project => [nationkey_9:bigint, suppkey_6:bigint, suppkey_49:bigint, nationkey_51:bigint, $hashvalue_117:bigint]                                                                             
                 - RemoteSource[10] => [nationkey_9:bigint, suppkey_6:bigint, suppkey_49:bigint, nationkey_51:bigint, $hashvalue_117:bigint, $hashvalue_118:bigint]                                         
                                                                                                                                                                                                            
 Fragment 5 [HASH]                                                                                                                                                                                          
     Output layout: [nationkey, suppkey, extendedprice, discount, suppkey, nationkey, $hashvalue_115, $hashvalue_116]                                                                                       
     Output partitioning: HASH [nationkey, suppkey]                                                                                                                                                         
     - Project => [extendedprice:double, $hashvalue_115:bigint, nationkey:bigint, discount:double, $hashvalue_116:bigint, suppkey:bigint]                                                                   
             $hashvalue_115 := "combine_hash"("combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("suppkey"), 0)), COALESCE("$operator$hash_code"("nationkey"), 0))                                   
             $hashvalue_116 := "combine_hash"("combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("nationkey"), 0)), COALESCE("$operator$hash_code"("suppkey"), 0))                                   
         - InnerJoin[("orderkey_46" = "orderkey_47")] => [orderkey:bigint, nationkey:bigint, orderkey_46:bigint, $hashvalue_103:bigint, orderkey_3:bigint, extendedprice:double, discount:double, suppkey:bi
             - Project => [orderkey:bigint, nationkey:bigint, orderkey_46:bigint, $hashvalue_103:bigint]                                                                                                    
                 - RemoteSource[6] => [orderkey:bigint, nationkey:bigint, orderkey_46:bigint, $hashvalue_103:bigint, $hashvalue_104:bigint]                                                                 
             - Project => [orderkey_3:bigint, extendedprice:double, discount:double, suppkey:bigint, orderkey_47:bigint, $hashvalue_112:bigint]                                                             
                 - RemoteSource[9] => [orderkey_3:bigint, extendedprice:double, discount:double, suppkey:bigint, orderkey_47:bigint, $hashvalue_112:bigint, $hashvalue_113:bigint]
```

with:
```
 Fragment 4 [HASH]                                                                                                                                                                                          
     Output layout: [nationkey, extendedprice, discount, nationkey, $hashvalue_119, $hashvalue_119]                                                                                                         
     Output partitioning: HASH [nationkey]                                                                                                                                                                  
     - Project => [extendedprice:double, nationkey:bigint, discount:double, $hashvalue_119:bigint]                                                                                                          
             $hashvalue_119 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("nationkey"), 0))                                                                                                  
         - InnerJoin[("suppkey_48" = "suppkey_49") AND ("nationkey_50" = "nationkey_51")] => [nationkey:bigint, suppkey:bigint, extendedprice:double, discount:double, suppkey_48:bigint, nationkey_50:bigin
             - Project => [nationkey:bigint, suppkey:bigint, extendedprice:double, discount:double, suppkey_48:bigint, nationkey_50:bigint, $hashvalue_101:bigint]                                          
                 - RemoteSource[5] => [nationkey:bigint, suppkey:bigint, extendedprice:double, discount:double, suppkey_48:bigint, nationkey_50:bigint, $hashvalue_101:bigint, $hashvalue_102:bigint]       
             - Project => [nationkey_9:bigint, suppkey_6:bigint, suppkey_49:bigint, nationkey_51:bigint, $hashvalue_116:bigint]                                                                             
                 - RemoteSource[10] => [nationkey_9:bigint, suppkey_6:bigint, suppkey_49:bigint, nationkey_51:bigint, $hashvalue_116:bigint, $hashvalue_117:bigint]                                         
                                                                                                                                                                                                            
 Fragment 5 [HASH]                                                                                                                                                                                          
     Output layout: [nationkey, suppkey, extendedprice, discount, suppkey, nationkey, $hashvalue_115, $hashvalue_115]                                                                                       
     Output partitioning: HASH [nationkey, suppkey]                                                                                                                                                         
     - Project => [extendedprice:double, $hashvalue_115:bigint, nationkey:bigint, discount:double, suppkey:bigint]                                                                                          
             $hashvalue_115 := "combine_hash"("combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("nationkey"), 0)), COALESCE("$operator$hash_code"("suppkey"), 0))                                   
         - InnerJoin[("orderkey_46" = "orderkey_47")] => [orderkey:bigint, nationkey:bigint, orderkey_46:bigint, $hashvalue_103:bigint, orderkey_3:bigint, extendedprice:double, discount:double, suppkey:bi
             - Project => [orderkey:bigint, nationkey:bigint, orderkey_46:bigint, $hashvalue_103:bigint]                                                                                                    
                 - RemoteSource[6] => [orderkey:bigint, nationkey:bigint, orderkey_46:bigint, $hashvalue_103:bigint, $hashvalue_104:bigint]                                                                 
             - Project => [orderkey_3:bigint, extendedprice:double, discount:double, suppkey:bigint, orderkey_47:bigint, $hashvalue_112:bigint]                                                             
                 - RemoteSource[9] => [orderkey_3:bigint, extendedprice:double, discount:double, suppkey:bigint, orderkey_47:bigint, $hashvalue_112:bigint, $hashvalue_113:bigint] 
```

This is follow up work of: https://github.com/prestodb/presto/pull/6264

FYI: @martint @kokosing 