### PR TITLE
Change Array element_at to return null when an index is not found

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayElementAtFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayElementAtFunction.java
@@ -47,7 +47,7 @@ public final class ArrayElementAtFunction
     @SqlType("E")
     public static Long longElementAt(@TypeParameter("E") Type elementType, @SqlType("array(E)") Block array, @SqlType("bigint") long index)
     {
-        if(!indexInRange(array, index)) {
+        if (!indexInRange(array, index)) {
             return null;
         }
         Integer position = checkedIndexToBlockPosition(array, index);
@@ -63,7 +63,7 @@ public final class ArrayElementAtFunction
     @SqlType("E")
     public static Boolean booleanElementAt(@TypeParameter("E") Type elementType, @SqlType("array(E)") Block array, @SqlType("bigint") long index)
     {
-        if(!indexInRange(array, index)) {
+        if (!indexInRange(array, index)) {
             return null;
         }
         Integer position = checkedIndexToBlockPosition(array, index);
@@ -79,7 +79,7 @@ public final class ArrayElementAtFunction
     @SqlType("E")
     public static Double doubleElementAt(@TypeParameter("E") Type elementType, @SqlType("array(E)") Block array, @SqlType("bigint") long index)
     {
-        if(!indexInRange(array, index)) {
+        if (!indexInRange(array, index)) {
             return null;
         }
         Integer position = checkedIndexToBlockPosition(array, index);
@@ -95,7 +95,7 @@ public final class ArrayElementAtFunction
     @SqlType("E")
     public static Slice sliceElementAt(@TypeParameter("E") Type elementType, @SqlType("array(E)") Block array, @SqlType("bigint") long index)
     {
-        if(!indexInRange(array, index)) {
+        if (!indexInRange(array, index)) {
             return null;
         }
         Integer position = checkedIndexToBlockPosition(array, index);
@@ -111,7 +111,7 @@ public final class ArrayElementAtFunction
     @SqlType("E")
     public static Block blockElementAt(@TypeParameter("E") Type elementType, @SqlType("array(E)") Block array, @SqlType("bigint") long index)
     {
-        if(!indexInRange(array, index)) {
+        if (!indexInRange(array, index)) {
             return null;
         }
         Integer position = checkedIndexToBlockPosition(array, index);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayElementAtFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayElementAtFunction.java
@@ -50,7 +50,7 @@ public final class ArrayElementAtFunction
         if (!indexInRange(array, index)) {
             return null;
         }
-        Integer position = checkedIndexToBlockPosition(array, index);
+        int position = checkedIndexToBlockPosition(array, index);
         if (array.isNull(position)) {
             return null;
         }
@@ -66,7 +66,7 @@ public final class ArrayElementAtFunction
         if (!indexInRange(array, index)) {
             return null;
         }
-        Integer position = checkedIndexToBlockPosition(array, index);
+        int position = checkedIndexToBlockPosition(array, index);
         if (array.isNull(position)) {
             return null;
         }
@@ -82,7 +82,7 @@ public final class ArrayElementAtFunction
         if (!indexInRange(array, index)) {
             return null;
         }
-        Integer position = checkedIndexToBlockPosition(array, index);
+        int position = checkedIndexToBlockPosition(array, index);
         if (array.isNull(position)) {
             return null;
         }
@@ -98,7 +98,7 @@ public final class ArrayElementAtFunction
         if (!indexInRange(array, index)) {
             return null;
         }
-        Integer position = checkedIndexToBlockPosition(array, index);
+        int position = checkedIndexToBlockPosition(array, index);
         if (array.isNull(position)) {
             return null;
         }
@@ -114,7 +114,7 @@ public final class ArrayElementAtFunction
         if (!indexInRange(array, index)) {
             return null;
         }
-        Integer position = checkedIndexToBlockPosition(array, index);
+        int position = checkedIndexToBlockPosition(array, index);
         if (array.isNull(position)) {
             return null;
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayElementAtFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayElementAtFunction.java
@@ -37,6 +37,7 @@ public final class ArrayElementAtFunction
     @SqlType("E")
     public static Void voidElementAt(@SqlType("array(E)") Block array, @SqlType("bigint") long index)
     {
+        indexInRange(array, index);
         checkedIndexToBlockPosition(array, index);
         return null;
     }
@@ -46,7 +47,10 @@ public final class ArrayElementAtFunction
     @SqlType("E")
     public static Long longElementAt(@TypeParameter("E") Type elementType, @SqlType("array(E)") Block array, @SqlType("bigint") long index)
     {
-        int position = checkedIndexToBlockPosition(array, index);
+        if(!indexInRange(array, index)) {
+            return null;
+        }
+        Integer position = checkedIndexToBlockPosition(array, index);
         if (array.isNull(position)) {
             return null;
         }
@@ -59,7 +63,10 @@ public final class ArrayElementAtFunction
     @SqlType("E")
     public static Boolean booleanElementAt(@TypeParameter("E") Type elementType, @SqlType("array(E)") Block array, @SqlType("bigint") long index)
     {
-        int position = checkedIndexToBlockPosition(array, index);
+        if(!indexInRange(array, index)) {
+            return null;
+        }
+        Integer position = checkedIndexToBlockPosition(array, index);
         if (array.isNull(position)) {
             return null;
         }
@@ -72,7 +79,10 @@ public final class ArrayElementAtFunction
     @SqlType("E")
     public static Double doubleElementAt(@TypeParameter("E") Type elementType, @SqlType("array(E)") Block array, @SqlType("bigint") long index)
     {
-        int position = checkedIndexToBlockPosition(array, index);
+        if(!indexInRange(array, index)) {
+            return null;
+        }
+        Integer position = checkedIndexToBlockPosition(array, index);
         if (array.isNull(position)) {
             return null;
         }
@@ -85,7 +95,10 @@ public final class ArrayElementAtFunction
     @SqlType("E")
     public static Slice sliceElementAt(@TypeParameter("E") Type elementType, @SqlType("array(E)") Block array, @SqlType("bigint") long index)
     {
-        int position = checkedIndexToBlockPosition(array, index);
+        if(!indexInRange(array, index)) {
+            return null;
+        }
+        Integer position = checkedIndexToBlockPosition(array, index);
         if (array.isNull(position)) {
             return null;
         }
@@ -98,7 +111,10 @@ public final class ArrayElementAtFunction
     @SqlType("E")
     public static Block blockElementAt(@TypeParameter("E") Type elementType, @SqlType("array(E)") Block array, @SqlType("bigint") long index)
     {
-        int position = checkedIndexToBlockPosition(array, index);
+        if(!indexInRange(array, index)) {
+            return null;
+        }
+        Integer position = checkedIndexToBlockPosition(array, index);
         if (array.isNull(position)) {
             return null;
         }
@@ -106,16 +122,21 @@ public final class ArrayElementAtFunction
         return (Block) elementType.getObject(array, position);
     }
 
-    private static int checkedIndexToBlockPosition(Block block, long index)
+    private static boolean indexInRange(Block block, long index)
     {
         int arrayLength = block.getPositionCount();
         if (index == 0) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "SQL array indices start at 1");
         }
-        if (Math.abs(index) > arrayLength) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Array subscript out of bounds");
+        else if (Math.abs(index) > arrayLength) {
+            return false;
         }
+        return true;
+    }
 
+    private static int checkedIndexToBlockPosition(Block block, long index)
+    {
+        int arrayLength = block.getPositionCount();
         if (index > 0) {
             return Ints.checkedCast(index - 1);
         }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -440,8 +440,8 @@ public class TestArrayOperators
 
         assertFunction("ELEMENT_AT(ARRAY [], 1)", UNKNOWN, null);
         assertFunction("ELEMENT_AT(ARRAY [], -1)", UNKNOWN, null);
-        assertFunction("ELEMENT_AT(ARRAY [1, 2, 3], 4)", UNKNOWN, null);
-        assertFunction("ELEMENT_AT(ARRAY [1, 2, 3], -4)", UNKNOWN, null);
+        assertFunction("ELEMENT_AT(ARRAY [1, 2, 3], 4)", INTEGER, null);
+        assertFunction("ELEMENT_AT(ARRAY [1, 2, 3], -4)", INTEGER, null);
         assertFunction("ELEMENT_AT(ARRAY [NULL], 1)", UNKNOWN, null);
         assertFunction("ELEMENT_AT(ARRAY [NULL], -1)", UNKNOWN, null);
         assertFunction("ELEMENT_AT(ARRAY [NULL, NULL, NULL], 3)", UNKNOWN, null);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -435,14 +435,13 @@ public class TestArrayOperators
     public void testElementAt()
             throws Exception
     {
-        String outOfBounds = "Array subscript out of bounds";
-        assertInvalidFunction("ELEMENT_AT(ARRAY [], -1)", outOfBounds);
         assertInvalidFunction("ELEMENT_AT(ARRAY [], 0)", "SQL array indices start at 1");
-        assertInvalidFunction("ELEMENT_AT(ARRAY [], 1)", outOfBounds);
         assertInvalidFunction("ELEMENT_AT(ARRAY [1, 2, 3], 0)", "SQL array indices start at 1");
-        assertInvalidFunction("ELEMENT_AT(ARRAY [1, 2, 3], 4)", outOfBounds);
-        assertInvalidFunction("ELEMENT_AT(ARRAY [1, 2, 3], -4)", outOfBounds);
 
+        assertFunction("ELEMENT_AT(ARRAY [], 1)", UNKNOWN, null);
+        assertFunction("ELEMENT_AT(ARRAY [], -1)", UNKNOWN, null);
+        assertFunction("ELEMENT_AT(ARRAY [1, 2, 3], 4)", UNKNOWN, null);
+        assertFunction("ELEMENT_AT(ARRAY [1, 2, 3], -4)", UNKNOWN, null);
         assertFunction("ELEMENT_AT(ARRAY [NULL], 1)", UNKNOWN, null);
         assertFunction("ELEMENT_AT(ARRAY [NULL], -1)", UNKNOWN, null);
         assertFunction("ELEMENT_AT(ARRAY [NULL, NULL, NULL], 3)", UNKNOWN, null);


### PR DESCRIPTION
# Overview

This PR is to resolve issue #6202. It changes the SQL `element_at` function to return `null` when an index is out of range. A `PrestoException` is still thrown when the `0` index is accessed because SQL array indexes start at `1`. This is in contrast to the `[]` operator which does not allow for out of range indexes.
# Changes
### ArrayElementAtFunction

The changes were made to [ArrayElementAtFunction](https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayElementAtFunction.java). The `checkedIndexToBlockPosition` method now returns a `-1` rather than throwing an error when an out of range index is given, which signals the function that called it to return `null`, `checkedIndexToBlockPosition` still throws an error when a `0` index is given. The behavior where a negative index can be used is maintained allowing the user to access the Nth last element with an index of -N, however if N is greater than the length of the array, the `element_at` function will return `null`.
### TestArrayOperators

The test method `testElementAt` in [TestArrayOperators](https://github.com/prestodb/presto/blob/master/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java) was also changed to reflect the new behavior of the `element_at` function. The changes remove the test cases expecting errors when out of bounds indexes were used and replace them with test cases that expect `null`  when out of bounds indexes are used.
