### PR TITLE
Remove incorrect @NotNull annotation from Metadata

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -29,8 +29,6 @@ import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.sql.tree.QualifiedName;
 import io.airlift.slice.Slice;
 
-import javax.validation.constraints.NotNull;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -46,29 +44,23 @@ public interface Metadata
 
     boolean isAggregationFunction(QualifiedName name);
 
-    @NotNull
     List<SqlFunction> listFunctions();
 
     void addFunctions(List<? extends SqlFunction> functions);
 
     boolean schemaExists(Session session, CatalogSchemaName schema);
 
-    @NotNull
     List<String> listSchemaNames(Session session, String catalogName);
 
     /**
      * Returns a table handle for the specified table name.
      */
-    @NotNull
     Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName);
 
-    @NotNull
     List<TableLayoutResult> getLayouts(Session session, TableHandle tableHandle, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns);
 
-    @NotNull
     TableLayout getLayout(Session session, TableLayoutHandle handle);
 
-    @NotNull
     Optional<Object> getInfo(Session session, TableLayoutHandle handle);
 
     /**
@@ -76,13 +68,11 @@ public interface Metadata
      *
      * @throws RuntimeException if table handle is no longer valid
      */
-    @NotNull
     TableMetadata getTableMetadata(Session session, TableHandle tableHandle);
 
     /**
      * Get the names that match the specified table prefix (never null).
      */
-    @NotNull
     List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix);
 
     /**
@@ -90,7 +80,6 @@ public interface Metadata
      *
      * @throws RuntimeException if table handle is no longer valid
      */
-    @NotNull
     Map<String, ColumnHandle> getColumnHandles(Session session, TableHandle tableHandle);
 
     /**
@@ -98,13 +87,11 @@ public interface Metadata
      *
      * @throws RuntimeException if table or column handles are no longer valid
      */
-    @NotNull
     ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle);
 
     /**
      * Gets the metadata for all columns that match the specified table prefix.
      */
-    @NotNull
     Map<QualifiedObjectName, List<ColumnMetadata>> listTableColumns(Session session, QualifiedTablePrefix prefix);
 
     /**
@@ -125,7 +112,6 @@ public interface Metadata
     /**
      * Creates a table using the specified table metadata.
      */
-    @NotNull
     void createTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata);
 
     /**
@@ -204,7 +190,6 @@ public interface Metadata
     /**
      * Returns a connector id for the specified catalog name.
      */
-    @NotNull
     Optional<ConnectorId> getCatalogHandle(Session session, String catalogName);
 
     /**
@@ -212,25 +197,21 @@ public interface Metadata
      *
      * @return Map of catalog name to connector id
      */
-    @NotNull
     Map<String, ConnectorId> getCatalogNames(Session session);
 
     /**
      * Get the names that match the specified table prefix (never null).
      */
-    @NotNull
     List<QualifiedObjectName> listViews(Session session, QualifiedTablePrefix prefix);
 
     /**
      * Get the view definitions that match the specified table prefix (never null).
      */
-    @NotNull
     Map<QualifiedObjectName, ViewDefinition> getViews(Session session, QualifiedTablePrefix prefix);
 
     /**
      * Returns the view definition for the specified view name.
      */
-    @NotNull
     Optional<ViewDefinition> getView(Session session, QualifiedObjectName viewName);
 
     /**


### PR DESCRIPTION
None of the methods on Metadata return null, and the code was
using the validation constrint @NotNull annotation.