### PR TITLE
Add TLS support to the presto-jdbc driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -831,6 +831,12 @@
                 <artifactId>cassandra-driver</artifactId>
                 <version>3.1.4-1</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.skife</groupId>
+                <artifactId>clocked-executor</artifactId>
+                <version>0.0.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -102,6 +102,11 @@
             <artifactId>annotations</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -140,8 +145,9 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>concurrent</artifactId>
+            <groupId>org.skife</groupId>
+            <artifactId>clocked-executor</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -142,7 +142,6 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>concurrent</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/AbstractConnectionProperty.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/AbstractConnectionProperty.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.jdbc;
+
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Predicate;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public abstract class AbstractConnectionProperty<T>
+        implements ConnectionProperty<T>
+{
+    private final String key;
+    private final Optional<String> defaultValue;
+    private final Predicate<Properties> isRequired;
+    private final Converter<T> converter;
+
+    protected AbstractConnectionProperty(
+            String key,
+            Optional<String> defaultValue,
+            Predicate<Properties> isRequired,
+            Converter<T> converter)
+    {
+        this.key = requireNonNull(key);
+        this.defaultValue = requireNonNull(defaultValue);
+        this.isRequired = requireNonNull(isRequired);
+        this.converter = requireNonNull(converter);
+    }
+
+    protected AbstractConnectionProperty(
+            String key,
+            Predicate<Properties> required,
+            Converter<T> converter)
+    {
+        this(key, Optional.empty(), required, converter);
+    }
+
+    @Override
+    public String getKey()
+    {
+        return key;
+    }
+
+    @Override
+    public Optional<String> getDefault()
+    {
+        return defaultValue;
+    }
+
+    @Override
+    public DriverPropertyInfo getDriverPropertyInfo(Properties mergedProperties)
+    {
+        String currentValue = mergedProperties.getProperty(key);
+        DriverPropertyInfo result = new DriverPropertyInfo(key, currentValue);
+        result.required = isRequired.test(mergedProperties);
+        return result;
+    }
+
+    @Override
+    public boolean isRequired(Properties properties)
+    {
+        return isRequired.test(properties);
+    }
+
+    @Override
+    public Optional<T> getValue(Properties properties)
+            throws SQLException
+    {
+        String value = properties.getProperty(key);
+        if (value == null) {
+            if (isRequired(properties)) {
+                throw new SQLException(format("Connection property '%s' is required", key));
+            }
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(converter.convert(value));
+        }
+        catch (Exception e) {
+            throw new SQLException(format("Connection property '%s' value is invalid: %s", key, value), e);
+        }
+    }
+
+    @Override
+    public void validate(Properties properties)
+            throws SQLException
+    {
+        getValue(properties);
+    }
+
+    protected static final Predicate<Properties> REQUIRED = properties -> true;
+    protected static final Predicate<Properties> NOT_REQUIRED = properties -> false;
+
+    protected static <T> Predicate<Properties> dependsKeyValue(ConnectionProperty property, T value)
+    {
+        return properties -> properties.get(property.getKey()).equals(value.toString());
+    }
+
+    private interface Converter<T>
+    {
+        T convert(String value)
+                throws Exception;
+    }
+
+    protected static final Converter<String> STRING_CONVERTER = (value) -> value;
+    protected static final Converter<Boolean> BOOLEAN_CONVERTER = (value) -> Boolean.parseBoolean(value);
+}

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.jdbc;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+import static java.lang.String.format;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+public class ConnectionProperties
+{
+    public static final ConnectionProperty<String> USER = new User();
+    public static final ConnectionProperty<String> PASSWORD = new Password();
+    public static final ConnectionProperty<Boolean> SECURE = new Secure();
+
+    private static final Set<ConnectionProperty> ALL_OF = ImmutableSet.of(
+            USER,
+            PASSWORD,
+            SECURE);
+
+    private static final Map<String, ConnectionProperty> KEY_LOOKUP = unmodifiableMap(allOf().stream()
+            .collect(toMap(ConnectionProperty::getKey, identity())));
+
+    private static final Map<String, String> DEFAULTS;
+
+    static {
+        ImmutableMap.Builder<String, String> defaults = ImmutableMap.builder();
+        for (ConnectionProperty property : ALL_OF) {
+            Optional<String> value = property.getDefault();
+
+            if (value.isPresent()) {
+                defaults.put(property.getKey(), value.get());
+            }
+        }
+        DEFAULTS = defaults.build();
+    }
+
+    private ConnectionProperties() {}
+
+    public static ConnectionProperty forKey(String propertiesKey)
+    {
+        return KEY_LOOKUP.get(propertiesKey);
+    }
+
+    public static Set<ConnectionProperty> allOf()
+    {
+        return ALL_OF;
+    }
+
+    public static Map<String, String> getDefaults()
+    {
+        return DEFAULTS;
+    }
+
+    private static class User
+            extends AbstractConnectionProperty<String>
+    {
+        private User()
+        {
+            super("user", REQUIRED, STRING_CONVERTER);
+        }
+    }
+
+    private static class Password
+            extends AbstractConnectionProperty<String>
+    {
+        private Password()
+        {
+            super("password", NOT_REQUIRED, STRING_CONVERTER);
+        }
+    }
+
+    public static final boolean SSL_DISABLED = false;
+    public static final boolean SSL_ENABLED = true;
+
+    private static class Secure
+            extends AbstractConnectionProperty<Boolean>
+    {
+        private static final Set<Boolean> allowed = ImmutableSet.of(SSL_DISABLED, SSL_ENABLED);
+
+        private Secure()
+        {
+            super("secure", Optional.of(Boolean.toString(SSL_DISABLED)), NOT_REQUIRED, BOOLEAN_CONVERTER);
+        }
+
+        @Override
+        public void validate(Properties properties)
+                throws SQLException
+        {
+            Optional<Boolean> flag = getValue(properties);
+            if (!flag.isPresent()) {
+                return;
+            }
+
+            if (!allowed.contains(flag.get())) {
+                throw new SQLException(format("The value of %s must be one of %s", getKey(), Joiner.on(", ").join(allowed)));
+            }
+        }
+    }
+}

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperty.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperty.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.jdbc;
+
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.Properties;
+
+public interface ConnectionProperty<T>
+{
+    String getKey();
+
+    Optional<String> getDefault();
+
+    DriverPropertyInfo getDriverPropertyInfo(Properties properties);
+
+    boolean isRequired(Properties properties);
+
+    Optional<T> getValue(Properties properties)
+            throws SQLException;
+
+    void validate(Properties properties)
+            throws SQLException;
+}

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperty.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperty.java
@@ -28,6 +28,8 @@ public interface ConnectionProperty<T>
 
     boolean isRequired(Properties properties);
 
+    boolean isAllowed(Properties properties);
+
     Optional<T> getValue(Properties properties)
             throws SQLException;
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/HttpClientCreator.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/HttpClientCreator.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.jdbc;
+
+import com.google.common.collect.ImmutableSet;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.HttpRequestFilter;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.http.client.jetty.JettyIoPool;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import static java.util.Objects.requireNonNull;
+
+public class HttpClientCreator
+{
+    private final String userAgent;
+    private final JettyIoPool jettyIoPool;
+    private final Map<String, BiConsumer<HttpClientConfig, String>> configSetters;
+
+    public HttpClientCreator(
+            String userAgent,
+            JettyIoPool jettyIoPool,
+            Map<String, BiConsumer<HttpClientConfig, String>> configSetters)
+    {
+        this.userAgent = requireNonNull(userAgent, "userAgent is null");
+        this.jettyIoPool = requireNonNull(jettyIoPool, "jettyIoPool is null");
+        this.configSetters = requireNonNull(configSetters, "configSetters is null");
+    }
+
+    private Set<? extends HttpRequestFilter> getFilters()
+    {
+        return ImmutableSet.of(new UserAgentRequestFilter(userAgent));
+    }
+
+    private HttpClientConfig getClientConfig(HttpClientConfig config)
+    {
+        for (Map.Entry<String, BiConsumer<HttpClientConfig, String>> entry : configSetters.entrySet()) {
+            entry.getValue().accept(config, entry.getKey());
+        }
+        return config;
+    }
+
+    public HttpClient create(HttpClientConfig config)
+    {
+        return new JettyHttpClient(getClientConfig(config), jettyIoPool, getFilters());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(userAgent, jettyIoPool, configSetters.keySet());
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj == null || !obj.getClass().equals(this.getClass())) {
+            return false;
+        }
+
+        HttpClientCreator other = (HttpClientCreator) obj;
+
+        return Objects.equals(this.userAgent, other.userAgent) &&
+                Objects.equals(jettyIoPool, other.jettyIoPool) &&
+                Objects.equals(this.configSetters.keySet(), other.configSetters.keySet());
+    }
+}

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -71,8 +71,9 @@ public class PrestoConnection
     private final Map<String, String> sessionProperties = new ConcurrentHashMap<>();
     private final AtomicReference<String> transactionId = new AtomicReference<>();
     private final QueryExecutor queryExecutor;
+    private final Runnable onClose;
 
-    PrestoConnection(PrestoDriverUri uri, String user, QueryExecutor queryExecutor)
+    PrestoConnection(PrestoConnectionConfig uri, String user, QueryExecutor queryExecutor, Runnable onClose)
             throws SQLException
     {
         requireNonNull(uri, "uri is null");
@@ -83,6 +84,8 @@ public class PrestoConnection
 
         this.user = requireNonNull(user, "user is null");
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
+        this.onClose = requireNonNull(onClose, "onClose is null");
+
         timeZoneId.set(TimeZone.getDefault().getID());
         locale.set(Locale.getDefault());
     }
@@ -162,6 +165,7 @@ public class PrestoConnection
     public void close()
             throws SQLException
     {
+        onClose.run();
         closed.set(true);
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnectionConfig.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnectionConfig.java
@@ -119,6 +119,11 @@ final class PrestoConnectionConfig
         ImmutableMap.Builder<String, BiConsumer<HttpClientConfig, String>> result = ImmutableMap.builder();
         for (String key : connectionProperties.stringPropertyNames()) {
             ConnectionProperty property = ConnectionProperties.forKey(key);
+
+            if (property == null) {
+                continue;
+            }
+
             String value = connectionProperties.getProperty(key);
 
             if (property.isRequired(connectionProperties) && value == null) {

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/QueryExecutor.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/QueryExecutor.java
@@ -17,14 +17,10 @@ import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.client.StatementClient;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
-import io.airlift.http.client.jetty.JettyHttpClient;
-import io.airlift.http.client.jetty.JettyIoPool;
-import io.airlift.http.client.jetty.JettyIoPoolConfig;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.Duration;
 
@@ -83,14 +79,11 @@ class QueryExecutor
         close();
     }
 
-    static QueryExecutor create(String userAgent)
+    static HttpClientConfig baseClientConfig()
     {
-        return create(new JettyHttpClient(
-                new HttpClientConfig()
-                        .setConnectTimeout(new Duration(10, TimeUnit.SECONDS))
-                        .setSocksProxy(getSystemSocksProxy()),
-                new JettyIoPool("presto-jdbc", new JettyIoPoolConfig()),
-                ImmutableSet.of(new UserAgentRequestFilter(userAgent))));
+        return new HttpClientConfig()
+                .setConnectTimeout(new Duration(10, TimeUnit.SECONDS))
+                .setSocksProxy(getSystemSocksProxy());
     }
 
     static QueryExecutor create(HttpClient httpClient)

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ReferenceCountingLoadingCache.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ReferenceCountingLoadingCache.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.jdbc;
+
+import com.google.common.base.Ticker;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+class ReferenceCountingLoadingCache<K, V>
+{
+    private static class Holder<V>
+    {
+        private final V value;
+        private int refcount;
+        private int cleanerCount;
+        private ScheduledFuture currentCleanup;
+
+        private Holder(V value)
+        {
+            this.value = requireNonNull(value, "value is null");
+        }
+
+        private V get()
+        {
+            return value;
+        }
+
+        private int getRefcount()
+        {
+            return refcount;
+        }
+
+        private int getCleanerCount()
+        {
+            return cleanerCount;
+        }
+
+        private int reference()
+        {
+            setCleanup(null);
+            return ++refcount;
+        }
+
+        private int dereference()
+        {
+            return --refcount;
+        }
+
+        private void setCleanup(ScheduledFuture cleanup)
+        {
+            if (currentCleanup != null && currentCleanup.cancel(false)) {
+                --cleanerCount;
+            }
+
+            checkState(cleanerCount >= 0, "Negative cleanerCount in setCleanup");
+
+            currentCleanup = cleanup;
+            if (cleanup != null) {
+                ++cleanerCount;
+            }
+        }
+
+        private void scheduleCleanup(
+                ScheduledExecutorService cleanupService,
+                Runnable cleanupTask,
+                long delay,
+                TimeUnit unit)
+        {
+            checkState(refcount == 0, "non-zero refcount in scheduleCleanup");
+            ScheduledFuture cleanup = cleanupService.schedule(cleanupTask, delay, unit);
+            setCleanup(cleanup);
+        }
+
+        private void releaseForCleaning()
+        {
+            --cleanerCount;
+            checkState(cleanerCount >= 0, "Negative cleanerCount in releaseForCleaning");
+        }
+    }
+
+    private final ScheduledExecutorService valueCleanupService;
+    private final LoadingCache<K, Holder<V>> backingCache;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    // TODO: This is probably on the long side. Maybe change to 30 seconds?
+    private static final long retentionPeriod = 2;
+    private static final TimeUnit retentionUnit = TimeUnit.MINUTES;
+
+    private ReferenceCountingLoadingCache(CacheLoader<K, V> loader, Consumer<V> disposer, Ticker ticker)
+    {
+        requireNonNull(loader, "loader is null");
+        requireNonNull(disposer, "disposer is null");
+
+        this.valueCleanupService = new ScheduledThreadPoolExecutor(1, daemonThreadsNamed("cache-cleanup-%s"));
+        this.backingCache = CacheBuilder.newBuilder()
+                .removalListener(new RemovalListener<K, Holder<V>>() {
+                    @Override
+                    public void onRemoval(RemovalNotification<K, Holder<V>> notification)
+                    {
+                        Holder<V> holder = notification.getValue();
+                        /*
+                         * The docs say that both the key and value may be
+                         * null if they've already been garbage collected.
+                         * We aren't using weak or soft keys or values, so
+                         * this shouldn't apply.
+                         */
+                        requireNonNull(holder, format("holder is null while removing key %s", notification.getKey()));
+                        checkState(holder.getRefcount() == 0, "Non-zero refcount disposing %s", notification.getKey());
+                        checkState(holder.getCleanerCount() == 0, "Non-zero refcount disposing %s", notification.getKey());
+                        disposer.accept(holder.get());
+                    }
+                })
+                .ticker(ticker)
+                .build(new CacheLoader<K, Holder<V>>() {
+                    @Override
+                    public Holder<V> load(K key)
+                            throws Exception
+                    {
+                        return new Holder<>(loader.load(key));
+                    }
+                });
+    }
+
+    public static class Builder<K, V>
+    {
+        Ticker ticker = Ticker.systemTicker();
+
+        public Builder<K, V> ticker(Ticker ticker)
+        {
+            this.ticker = requireNonNull(ticker, "ticker is null");
+            return this;
+        }
+
+        public ReferenceCountingLoadingCache<K, V> build(CacheLoader<K, V> loader, Consumer<V> disposer)
+        {
+            return new ReferenceCountingLoadingCache<K, V>(loader, disposer, ticker);
+        }
+    }
+
+    public static <K, V> Builder<K, V> builder()
+    {
+        return new Builder<>();
+    }
+
+    public void close()
+    {
+        if (closed.compareAndSet(false, true)) {
+            valueCleanupService.shutdownNow();
+            backingCache.invalidateAll();
+        }
+    }
+
+    public V acquire(K key)
+    {
+        synchronized (this) {
+            Holder<V> holder = backingCache.getUnchecked(key);
+            holder.reference();
+            return holder.get();
+        }
+    }
+
+    public void release(K key)
+    {
+        /*
+         * Access through the Map interface to avoid creating a Holder and immediately
+         * scheduling it for cleanup.
+         */
+        Holder holder = backingCache.asMap().get(key);
+        if (holder == null) {
+            return;
+        }
+
+        Runnable deferredRelease = () -> {
+            synchronized (this) {
+                holder.releaseForCleaning();
+                if (holder.getCleanerCount() ==  0 && holder.getRefcount() == 0) {
+                    backingCache.invalidate(key);
+                }
+            }
+        };
+
+        synchronized (this) {
+            if (holder.dereference() == 0) {
+                holder.scheduleCleanup(valueCleanupService, deferredRelease, retentionPeriod, retentionUnit);
+            }
+        }
+    }
+}

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
@@ -1358,11 +1358,11 @@ public class TestPrestoDriver
         }
     }
 
-    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Username property \\(user\\) must be set")
+    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Connection property 'user' is required")
     public void testUserIsRequired()
             throws Exception
     {
-        try (Connection ignored = DriverManager.getConnection("jdbc:presto://test.invalid/")) {
+        try (Connection ignored = DriverManager.getConnection(format("jdbc:presto://%s", server.getAddress()))) {
             fail("expected exception");
         }
     }

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
@@ -17,6 +17,7 @@ import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.sql.SQLException;
+import java.util.Properties;
 
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
@@ -24,13 +25,27 @@ import static org.testng.Assert.assertEquals;
 public class TestPrestoDriverUri
 {
     private static final String SERVER = "127.0.0.1:60429";
+    private static final Properties minimalProperties = new Properties();
+
+    public TestPrestoDriverUri()
+    {
+        minimalProperties.put("user", "BaltimoreJack");
+    }
+
+    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Unrecognized connection property 'ShoeSize'")
+    public void testUnrecognizedParameter()
+            throws Exception
+    {
+        String url = format("jdbc:presto://%s/hive/default?ShoeSize=13", SERVER);
+        new PrestoConnectionConfig(url, minimalProperties);
+    }
 
     @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Invalid path segments in URL: .*")
     public void testBadUrlExtraPathSegments()
             throws Exception
     {
         String url = format("jdbc:presto://%s/hive/default/bad_string", SERVER);
-        new PrestoDriverUri(url);
+        new PrestoConnectionConfig(url, minimalProperties);
     }
 
     @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Catalog name is empty: .*")
@@ -38,7 +53,7 @@ public class TestPrestoDriverUri
             throws Exception
     {
         String url = format("jdbc:presto://%s//default", SERVER);
-        new PrestoDriverUri(url);
+        new PrestoConnectionConfig(url, minimalProperties);
     }
 
     @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Catalog name is empty: .*")
@@ -46,7 +61,7 @@ public class TestPrestoDriverUri
             throws Exception
     {
         String url = format("jdbc:presto://%s//", SERVER);
-        new PrestoDriverUri(url);
+        new PrestoConnectionConfig(url, minimalProperties);
     }
 
     @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Schema name is empty: .*")
@@ -54,14 +69,14 @@ public class TestPrestoDriverUri
             throws Exception
     {
         String url = format("jdbc:presto://%s/a//", SERVER);
-        new PrestoDriverUri(url);
+        new PrestoConnectionConfig(url, minimalProperties);
     }
 
     @Test
     public void testUrlWithSsl()
             throws SQLException
     {
-        PrestoDriverUri parameters = new PrestoDriverUri("presto://some-ssl-server:443/blackhole");
+        PrestoConnectionConfig parameters = new PrestoConnectionConfig("presto://some-ssl-server:443/blackhole", minimalProperties);
 
         URI uri = parameters.getHttpUri();
         assertEquals(uri.getPort(), 443);
@@ -72,7 +87,7 @@ public class TestPrestoDriverUri
     public void testUriWithSecureMissing()
             throws SQLException
     {
-        PrestoDriverUri parameters = new PrestoDriverUri("presto://localhost:8080/blackhole");
+        PrestoConnectionConfig parameters = new PrestoConnectionConfig("presto://localhost:8080/blackhole", minimalProperties);
 
         URI uri = parameters.getHttpUri();
         assertEquals(uri.getPort(), 8080);
@@ -83,7 +98,7 @@ public class TestPrestoDriverUri
     public void testUriWithSecureTrue()
             throws SQLException
     {
-        PrestoDriverUri parameters = new PrestoDriverUri("presto://localhost:8080/blackhole?secure=true");
+        PrestoConnectionConfig parameters = new PrestoConnectionConfig("presto://localhost:8080/blackhole?secure=true", minimalProperties);
 
         URI uri = parameters.getHttpUri();
         assertEquals(uri.getPort(), 8080);
@@ -94,7 +109,7 @@ public class TestPrestoDriverUri
     public void testUriWithSecureFalse()
             throws SQLException
     {
-        PrestoDriverUri parameters = new PrestoDriverUri("presto://localhost:8080/blackhole?secure=false");
+        PrestoConnectionConfig parameters = new PrestoConnectionConfig("presto://localhost:8080/blackhole?secure=false", minimalProperties);
 
         URI uri = parameters.getHttpUri();
         assertEquals(uri.getPort(), 8080);

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
@@ -37,8 +37,10 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Properties;
 import java.util.function.Consumer;
 
+import static com.facebook.presto.jdbc.ConnectionProperties.USER;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
@@ -119,7 +121,9 @@ public class TestProgressMonitor
         HttpClient client = new TestingHttpClient(new TestingHttpClientProcessor(RESPONSES));
         QueryExecutor testQueryExecutor = QueryExecutor.create(client);
         String uri = format("prestotest://%s", SERVER_ADDRESS);
-        return new PrestoConnection(new PrestoDriverUri(uri), "test", testQueryExecutor);
+        Properties properties = new Properties();
+        properties.put(USER.getKey(), "BobPeoples");
+        return new PrestoConnection(new PrestoConnectionConfig(uri, properties), "test", testQueryExecutor, () -> { });
     }
 
     private static class TestingHttpClientProcessor

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestReferenceCountingLoadingCache.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestReferenceCountingLoadingCache.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.jdbc;
+
+import com.google.common.cache.CacheLoader;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.Duration;
+import org.skife.clocked.ClockedExecutorService;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
+
+public class TestReferenceCountingLoadingCache
+{
+    @Test
+    public void testSimpleLoad()
+    {
+        String zero = "zero";
+        SingleKeyMockCacheLoaderDisposer<Integer, String> loader = mockCacheLoaderDisposer(0, ImmutableList.of(zero));
+        TestCache<Integer, String> cache = new TestCache<>(loader, (value) -> {
+        });
+        assertSame(cache.acquire(0), zero);
+    }
+
+    @Test
+    public void testSimpleLoadRelease()
+            throws ExecutionException, InterruptedException
+    {
+        String zero = "zero";
+        SingleKeyMockCacheLoaderDisposer<Integer, String> loaderDisposer = mockCacheLoaderDisposer(0, ImmutableList.of(zero));
+        TestCache<Integer, String> cache = new TestCache<>(loaderDisposer, loaderDisposer);
+        assertSame(cache.acquire(0), zero);
+        cache.release(0);
+        cache.advanceRetention();
+        loaderDisposer.validate();
+    }
+
+    @Test
+    public void testDontLoadOnReleaseNonexistentKey()
+            throws ExecutionException, InterruptedException
+    {
+        TestCache<Integer, String> cache = new TestCache<>(
+                failLoader("Loader shouldn't have been called"),
+                failDisposer("Disposer *definitely* shouldn't have been called"));
+        cache.release(0);
+        cache.advanceRetention();
+    }
+
+    @Test
+    public void testReacquireRetainedValue()
+            throws ExecutionException, InterruptedException
+    {
+        String zero = "zero";
+        SingleKeyMockCacheLoaderDisposer<Integer, String> loaderDisposer = mockCacheLoaderDisposer(0, ImmutableList.of(zero));
+        TestCache<Integer, String> cache = new TestCache<>(loaderDisposer, loaderDisposer);
+        assertSame(cache.acquire(0), zero);
+        cache.release(0);
+
+        cache.advance(cache.getRetentionDuration().toMillis() / 2, TimeUnit.MILLISECONDS);
+
+        assertSame(cache.acquire(0), zero);
+        cache.release(0);
+
+        cache.advanceRetention();
+        loaderDisposer.validate();
+    }
+
+    @Test
+    public void testAcquireNewValueForDisposedKey()
+            throws ExecutionException, InterruptedException
+    {
+        String first = "first";
+        String second = "second";
+        SingleKeyMockCacheLoaderDisposer<Integer, String> loaderDisposer = mockCacheLoaderDisposer(0, ImmutableList.of(first, second));
+        TestCache<Integer, String> cache = new TestCache<>(loaderDisposer, loaderDisposer);
+        assertSame(cache.acquire(0), first);
+        cache.release(0);
+
+        cache.advanceRetention();
+
+        assertSame(cache.acquire(0), second);
+        cache.release(0);
+
+        cache.advanceRetention();
+
+        loaderDisposer.validate();
+    }
+
+    @Test
+    public void testMultiplyAcquiredValueNotReleased()
+            throws ExecutionException, InterruptedException
+    {
+        String first = "first";
+        SingleKeyMockCacheLoaderDisposer<Integer, String> loader = mockCacheLoaderDisposer(0, ImmutableList.of(first));
+        TestCache<Integer, String> cache = new TestCache<>(
+                loader,
+                failDisposer("Multiply acquired value shouldn't have been released"));
+        assertSame(cache.acquire(0), first);
+        assertSame(cache.acquire(0), first);
+
+        cache.release(0);
+
+        cache.advanceRetention();
+    }
+
+    @Test
+    public void testClose()
+    {
+        String first = "first";
+        SingleKeyMockCacheLoaderDisposer<Integer, String> loaderDisposer = mockCacheLoaderDisposer(0, ImmutableList.of(first));
+        TestCache<Integer, String> cache = new TestCache<>(loaderDisposer, loaderDisposer);
+        assertSame(cache.acquire(0), first);
+        cache.release(0);
+        cache.close();
+        loaderDisposer.validate();
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*closed with outstanding.*")
+    public void testCloseOutstandingObjects()
+    {
+        String first = "first";
+        SingleKeyMockCacheLoaderDisposer<Integer, String> loader = mockCacheLoaderDisposer(0, ImmutableList.of(first));
+        TestCache<Integer, String> cache = new TestCache<>(
+                loader,
+                failDisposer("Shouldn't have called dispose on unreleased object"));
+        assertSame(cache.acquire(0), first);
+        cache.close();
+    }
+
+    @Test(expectedExceptions = { IllegalStateException.class }, expectedExceptionsMessageRegExp = ".*closed cache.*")
+    public void testCloseAcquire()
+    {
+        String first = "first";
+        SingleKeyMockCacheLoaderDisposer<Integer, String> loaderDisposer = mockCacheLoaderDisposer(0, ImmutableList.of(first));
+        TestCache<Integer, String> cache = new TestCache<>(loaderDisposer, loaderDisposer);
+        assertSame(cache.acquire(0), first);
+        cache.release(0);
+        cache.close();
+        loaderDisposer.validate();
+        cache.acquire(0);
+    }
+
+    @Test(expectedExceptions = { IllegalStateException.class }, expectedExceptionsMessageRegExp = ".*closed cache.*")
+    public void testCloseRelease()
+    {
+        TestCache<Integer, String> cache = new TestCache<>(
+                failLoader("loader shouldn't have been called"),
+                failDisposer("disposer shouldn't have been called"));
+        cache.close();
+        cache.release(0);
+    }
+
+    @Test
+    public void testCloseTwice()
+    {
+        String first = "first";
+        SingleKeyMockCacheLoaderDisposer<Integer, String> loaderDisposer = mockCacheLoaderDisposer(0, ImmutableList.of(first));
+        TestCache<Integer, String> cache = new TestCache<>(loaderDisposer, loaderDisposer);
+        assertSame(cache.acquire(0), first);
+        cache.release(0);
+        cache.close();
+        loaderDisposer.validate();
+        cache.close();
+        loaderDisposer.validate();
+    }
+
+    private static class TestCache<K, V>
+    {
+        private ReferenceCountingLoadingCache<K, V> cache;
+        private ClockedExecutorService valueCleanupService;
+
+        private TestCache(
+                CacheLoader<K, V> loader,
+                Consumer<V> disposer)
+        {
+            valueCleanupService = new ClockedExecutorService();
+            cache = ReferenceCountingLoadingCache.<K, V>builder()
+                    .withCleanupService(valueCleanupService)
+                    .withRetentionDuration(new Duration(30, TimeUnit.SECONDS))
+                    .build(loader, disposer);
+        }
+
+        public void advance(long time, TimeUnit unit)
+                throws ExecutionException, InterruptedException
+        {
+            valueCleanupService.advance(time, unit).get();
+        }
+
+        public void advanceRetention()
+                throws ExecutionException, InterruptedException
+        {
+            advance(getRetentionDuration().toMillis(), TimeUnit.MILLISECONDS);
+        }
+
+        public void close()
+        {
+            cache.close();
+        }
+
+        public V acquire(K key)
+        {
+            return cache.acquire(key);
+        }
+
+        public void release(K key)
+        {
+            cache.release(key);
+        }
+
+        public Duration getRetentionDuration()
+        {
+            return cache.getRetentionDuration();
+        }
+    }
+
+    private static <K, V> SingleKeyMockCacheLoaderDisposer<K, V> mockCacheLoaderDisposer(K key, List<V> values)
+    {
+        return new SingleKeyMockCacheLoaderDisposer<>(key, values);
+    }
+
+    private static class SingleKeyMockCacheLoaderDisposer<K, V>
+            extends CacheLoader<K, V>
+            implements Consumer<V>
+    {
+        K key;
+        List<V> values;
+        int loadIndex = 0;
+        int disposeIndex = 0;
+
+        public SingleKeyMockCacheLoaderDisposer(K key, List<V> values)
+        {
+            this.key = requireNonNull(key, "key is null");
+            this.values = requireNonNull(values, "values is null");
+        }
+
+        @Override
+        public V load(K key)
+                throws Exception
+        {
+            checkState(loadIndex == disposeIndex);
+            checkState(key == this.key);
+            return values.get(loadIndex++);
+        }
+
+        @Override
+        public void accept(V v)
+        {
+            checkState(loadIndex == disposeIndex + 1);
+            ++disposeIndex;
+        }
+
+        public void validate()
+        {
+            assertEquals(disposeIndex, loadIndex);
+        }
+    }
+
+    private static <K, V> CacheLoader<K, V> failLoader(String message)
+    {
+        return new CacheLoader<K, V>()
+        {
+            public V load(K key)
+            {
+                fail(message);
+                // not reached
+                return null;
+            }
+        };
+    }
+
+    private static <V> Consumer<V> failDisposer(String message)
+    {
+        return value -> fail(message);
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/JdbcDriverUtils.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/JdbcDriverUtils.java
@@ -78,17 +78,19 @@ public class JdbcDriverUtils
 
     public static boolean usingPrestoJdbcDriver(Connection connection)
     {
-        return getClassNameForJdbcDriver(connection).equals("com.facebook.presto.jdbc.PrestoConnection");
+        return connection instanceof PrestoConnection;
     }
 
     public static boolean usingTeradataJdbcDriver(Connection connection)
     {
-        return  getClassNameForJdbcDriver(connection).startsWith("com.teradata.jdbc.");
+        String className = getClassNameForJdbcDriver(connection);
+        return className != null && className.startsWith("com.teradata.jdbc.");
     }
 
     public static boolean usingTeradataJdbc4Driver(Connection connection)
     {
-        return getClassNameForJdbcDriver(connection).startsWith("com.teradata.jdbc.jdbc4.");
+        String className = getClassNameForJdbcDriver(connection);
+        return className != null && className.startsWith("com.teradata.jdbc.jdbc4.");
     }
 
     private static String getClassNameForJdbcDriver(Connection connection)


### PR DESCRIPTION
There are two major parts of this change:
1. Allowing more than one QueryExecutor to exist in the driver at a time, and cache them.
2. Configure the HttpClient used by the QueryExecutor to use a trust store so it can establish https connections to the presto server.

Internal reviews:
https://github.com/Teradata/presto/pull/366
https://github.com/Teradata/presto/pull/391
