### PR TITLE
Generate long-type hash code for ArrayType and MapType

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayHashCodeOperator.java
@@ -45,11 +45,11 @@ public final class ArrayHashCodeOperator
             @TypeParameter("T") Type type,
             @SqlType("array(T)") Block block)
     {
-        int hash = 0;
+        long hash = 0;
         for (int i = 0; i < block.getPositionCount(); i++) {
             checkElementNotNull(block.isNull(i), ARRAY_NULL_ELEMENT_MSG);
             try {
-                hash = (int) CombineHashFunction.getHash(hash, (long) hashFunction.invoke(readNativeValue(type, block, i)));
+                hash = CombineHashFunction.getHash(hash, (long) hashFunction.invoke(readNativeValue(type, block, i)));
             }
             catch (Throwable t) {
                 Throwables.propagateIfInstanceOf(t, Error.class);
@@ -69,11 +69,11 @@ public final class ArrayHashCodeOperator
             @TypeParameter("T") Type type,
             @SqlType("array(T)") Block block)
     {
-        int hash = 0;
+        long hash = 0;
         for (int i = 0; i < block.getPositionCount(); i++) {
             checkElementNotNull(block.isNull(i), ARRAY_NULL_ELEMENT_MSG);
             try {
-                hash = (int) CombineHashFunction.getHash(hash, (long) hashFunction.invokeExact(type.getLong(block, i)));
+                hash = CombineHashFunction.getHash(hash, (long) hashFunction.invokeExact(type.getLong(block, i)));
             }
             catch (Throwable t) {
                 Throwables.propagateIfInstanceOf(t, Error.class);
@@ -93,11 +93,11 @@ public final class ArrayHashCodeOperator
             @TypeParameter("T") Type type,
             @SqlType("array(T)") Block block)
     {
-        int hash = 0;
+        long hash = 0;
         for (int i = 0; i < block.getPositionCount(); i++) {
             checkElementNotNull(block.isNull(i), ARRAY_NULL_ELEMENT_MSG);
             try {
-                hash = (int) CombineHashFunction.getHash(hash, (long) hashFunction.invokeExact(type.getBoolean(block, i)));
+                hash = CombineHashFunction.getHash(hash, (long) hashFunction.invokeExact(type.getBoolean(block, i)));
             }
             catch (Throwable t) {
                 Throwables.propagateIfInstanceOf(t, Error.class);
@@ -117,11 +117,11 @@ public final class ArrayHashCodeOperator
             @TypeParameter("T") Type type,
             @SqlType("array(T)") Block block)
     {
-        int hash = 0;
+        long hash = 0;
         for (int i = 0; i < block.getPositionCount(); i++) {
             checkElementNotNull(block.isNull(i), ARRAY_NULL_ELEMENT_MSG);
             try {
-                hash = (int) CombineHashFunction.getHash(hash, (long) hashFunction.invokeExact(type.getSlice(block, i)));
+                hash = CombineHashFunction.getHash(hash, (long) hashFunction.invokeExact(type.getSlice(block, i)));
             }
             catch (Throwable t) {
                 Throwables.propagateIfInstanceOf(t, Error.class);
@@ -141,11 +141,11 @@ public final class ArrayHashCodeOperator
             @TypeParameter("T") Type type,
             @SqlType("array(T)") Block block)
     {
-        int hash = 0;
+        long hash = 0;
         for (int i = 0; i < block.getPositionCount(); i++) {
             checkElementNotNull(block.isNull(i), ARRAY_NULL_ELEMENT_MSG);
             try {
-                hash = (int) CombineHashFunction.getHash(hash, (long) hashFunction.invokeExact(type.getDouble(block, i)));
+                hash = CombineHashFunction.getHash(hash, (long) hashFunction.invokeExact(type.getDouble(block, i)));
             }
             catch (Throwable t) {
                 Throwables.propagateIfInstanceOf(t, Error.class);

--- a/presto-main/src/main/java/com/facebook/presto/type/ArrayType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ArrayType.java
@@ -89,10 +89,10 @@ public class ArrayType
     public long hash(Block block, int position)
     {
         Block array = getObject(block, position);
-        int hash = 0;
+        long hash = 0;
         for (int i = 0; i < array.getPositionCount(); i++) {
             checkElementNotNull(array.isNull(i), ARRAY_NULL_ELEMENT_MSG);
-            hash = (int) CombineHashFunction.getHash(hash, elementType.hash(array, i));
+            hash = CombineHashFunction.getHash(hash, elementType.hash(array, i));
         }
         return hash;
     }

--- a/presto-main/src/main/java/com/facebook/presto/type/MapType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/MapType.java
@@ -89,7 +89,7 @@ public class MapType
     public long hash(Block block, int position)
     {
         Block mapBlock = getObject(block, position);
-        int result = 0;
+        long result = 0;
 
         for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
             result += hashPosition(keyType, mapBlock, i);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.SqlFunction;
 import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.DecimalParseResult;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.SqlDecimal;
@@ -32,6 +33,7 @@ import java.math.BigInteger;
 import java.util.List;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.metadata.FunctionRegistry.mangleOperatorName;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
@@ -63,6 +65,11 @@ public abstract class AbstractTestFunctions
     protected void assertFunction(String projection, Type expectedType, Object expected)
     {
         functionAssertions.assertFunction(projection, expectedType, expected);
+    }
+
+    protected void assertOperator(OperatorType operator, String value, Type expectedType, Object expected)
+    {
+        functionAssertions.assertFunction(format("\"%s\"(%s)", mangleOperatorName(operator), value), expectedType, expected);
     }
 
     protected void assertDecimalFunction(String statement, SqlDecimal expectedResult)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -15,6 +15,7 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.InterleavedBlockBuilder;
 import com.facebook.presto.spi.function.ScalarFunction;
@@ -31,10 +32,12 @@ import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.block.BlockSerdeUtil.writeBlock;
+import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -44,9 +47,12 @@ import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.facebook.presto.type.JsonType.JSON;
+import static com.facebook.presto.type.TypeJsonUtils.appendToBlockBuilder;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.util.StructuralTestUtil.arrayBlockOf;
 import static com.facebook.presto.util.StructuralTestUtil.mapBlockOf;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Double.doubleToLongBits;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
@@ -448,5 +454,31 @@ public class TestMapOperators
         assertFunction("CAST(MAP(ARRAY[0, 1, 2, 3], ARRAY[1,NULL, NULL, 2]) AS MAP<BIGINT, DOUBLE>)", new MapType(BIGINT, DOUBLE), expected);
 
         assertInvalidCast("CAST(MAP(ARRAY[1, 2], ARRAY[6, 9]) AS MAP<boolean, bigint>)", "duplicate keys");
+    }
+
+    @Test
+    public void testMapHashOperator()
+    {
+        assertMapHashOperator("MAP(ARRAY[1], ARRAY[2])", INTEGER, INTEGER, ImmutableList.of(1, 2));
+        assertMapHashOperator("MAP(ARRAY[1, 2147483647], ARRAY[2147483647, 2])", INTEGER, INTEGER, ImmutableList.of(1, 2147483647, 2147483647, 2));
+        assertMapHashOperator("MAP(ARRAY[8589934592], ARRAY[2])", BIGINT, INTEGER, ImmutableList.of(8589934592L, 2));
+        assertMapHashOperator("MAP(ARRAY[true], ARRAY[false])", BOOLEAN, BOOLEAN, ImmutableList.of(true, false));
+        assertMapHashOperator("MAP(ARRAY['123'], ARRAY['456'])", VARCHAR, VARCHAR, ImmutableList.of(utf8Slice("123"), utf8Slice("456")));
+    }
+
+    private void assertMapHashOperator(String inputString, Type keyType, Type valueType, List<Object> elements)
+    {
+        checkArgument(elements.size() % 2 == 0, "the size of elements should be even number");
+        MapType mapType = new MapType(keyType, valueType);
+        BlockBuilder mapArrayBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder mapBuilder = new InterleavedBlockBuilder(ImmutableList.of(keyType, valueType), new BlockBuilderStatus(), elements.size());
+        for (int i = 0; i < elements.size(); i += 2) {
+            appendToBlockBuilder(keyType, elements.get(i), mapBuilder);
+            appendToBlockBuilder(valueType, elements.get(i + 1), mapBuilder);
+        }
+        mapType.writeObject(mapArrayBuilder, mapBuilder.build());
+        long hashResult = mapType.hash(mapArrayBuilder.build(), 0);
+
+        assertOperator(HASH_CODE, inputString, BIGINT, hashResult);
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2790,6 +2790,9 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT CASE WHEN false THEN 1 IN (VALUES 2) END",
                 "SELECT NULL");
+        assertQuery(
+                "SELECT x FROM (VALUES 2) t(x) where MAP(ARRAY[8589934592], ARRAY[x]) IN (VALUES MAP(ARRAY[8589934592],ARRAY[2]))",
+                "SELECT 2");
     }
 
     @Test


### PR DESCRIPTION
This change also fixed the bug that hash operator and hash method
generate different hash codes.

Should fix #6407 