### PR TITLE
Fix explain of cross join #6409

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
@@ -420,7 +420,14 @@ public class PlanPrinter
             }
             node.getFilter().ifPresent(expression -> joinExpressions.add(expression));
 
-            print(indent, "- %s[%s] => [%s]", node.getType().getJoinLabel(), Joiner.on(" AND ").join(joinExpressions), formatOutputs(node.getOutputSymbols()));
+            // Check if the node is actually a cross join node
+            if (node.getType() == JoinNode.Type.INNER && node.getCriteria().isEmpty()) {
+                print(indent, "- %s => [%s]", "CrossJoin", formatOutputs(node.getOutputSymbols()));
+            }
+            else {
+                print(indent, "- %s[%s] => [%s]", node.getType().getJoinLabel(), Joiner.on(" AND ").join(joinExpressions), formatOutputs(node.getOutputSymbols()));
+            }
+
             printStats(indent + 2, node.getId());
             node.getLeft().accept(this, indent + 1);
             node.getRight().accept(this, indent + 1);


### PR DESCRIPTION
This is a fix for #6409. 
After this fix, cross joins will be correctly explained as CrossJoin rather than InnerJoin.

Before the fix:
```
explain select * from (values 1, 2) a(x), (values 1, 2) b(x);
                      Query Plan                       
-------------------------------------------------------
 - Output[x, x] => [field:integer, field_1:integer]    
         x := field                                    
         x := field_1                                  
     - InnerJoin[] => [field:integer, field_1:integer] 
         - Values => [field:integer]                   
                 (1)                                   
                 (2)                                   
         - Values => [field_1:integer]                 
                 (1)                                   
                 (2)                                   
                                                       
(1 row)
```

After the fix:
```
explain select * from (values 1, 2) a(x), (values 1, 2) b(x);
                     Query Plan                      
-----------------------------------------------------
 - Output[x, x] => [field:integer, field_1:integer]  
         x := field                                  
         x := field_1                                
     - CrossJoin => [field:integer, field_1:integer] 
         - Values => [field:integer]                 
                 (1)                                 
                 (2)                                 
         - Values => [field_1:integer]               
                 (1)                                 
                 (2)                                 
                                                     
(1 row)
```
