### PR TITLE
Desugar the expressions before evaluating the constant values

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5327,6 +5327,9 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT TIMESTAMP '2012-10-31 01:00' AT TIME ZONE 'America/Los_Angeles' AT TIME ZONE 'Asia/Shanghai'", "SELECT TIMESTAMP '2012-10-30 18:00:00.000 America/Los_Angeles'");
         assertQuery("SELECT min(x) AT TIME ZONE 'America/Los_Angeles' AT TIME ZONE 'UTC' FROM (values TIMESTAMP '1970-01-01 00:01:00+00:00', TIMESTAMP '1970-01-01 08:01:00+08:00', TIMESTAMP '1969-12-31 16:01:00-08:00') t(x)",
                 "values TIMESTAMP '1969-12-31 16:01:00-08:00'");
+
+        // with AT TIME ZONE in VALUES
+        assertQuery("SELECT * from (VALUES TIMESTAMP '2012-10-31 01:00' AT TIME ZONE 'Asia/Oral')", "SELECT TIMESTAMP '2012-10-30 18:00:00.000 America/Los_Angeles'");
     }
 
     @Test


### PR DESCRIPTION
ValuesNode is trying to evaluate its expressions to be constant values
with ExpressionInterpreter before DesugaringOptimizer has been run,
while ExpressionInterpreter is not aware of AT TIME ZONE. And this will
cause query failure when using AT TIME ZONE in VALUES.

This change will ensure desugaring has been done when evaluating
expressions to be constant values.
