### PR TITLE
Change GroupIdNode to behave more like ProjectNode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
@@ -523,7 +523,23 @@ public class PlanPrinter
         @Override
         public Void visitGroupId(GroupIdNode node, Integer indent)
         {
-            print(indent, "- GroupId%s => [%s]", node.getGroupingSets(), formatOutputs(node.getOutputSymbols()));
+            // grouping sets are easier to understand in terms of inputs
+            List<List<Symbol>> inputGroupingSetSymbols = node.getGroupingSets().stream()
+                    .map(set -> set.stream()
+                            .map(symbol -> node.getGroupingSetMappings().get(symbol))
+                            .collect(Collectors.toList()))
+                    .collect(Collectors.toList());
+
+            print(indent, "- GroupId%s => [%s]", inputGroupingSetSymbols, formatOutputs(node.getOutputSymbols()));
+            printStats(indent + 2, node.getId());
+
+            for (Map.Entry<Symbol, Symbol> mapping : node.getGroupingSetMappings().entrySet()) {
+                print(indent + 2, "%s := %s", mapping.getKey(), mapping.getValue());
+            }
+            for (Map.Entry<Symbol, Symbol> argument : node.getArgumentMappings().entrySet()) {
+                print(indent + 2, "%s := %s", argument.getKey(), argument.getValue());
+            }
+
             return processChildren(node, indent + 1);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolExtractor.java
@@ -113,7 +113,8 @@ public final class SymbolExtractor
             node.getSource().accept(this, context);
 
             builder.add(node.getGroupIdSymbol());
-            builder.addAll(node.getIdentityMappings().values());
+            builder.addAll(node.getGroupingSetMappings().keySet());
+            builder.addAll(node.getArgumentMappings().keySet());
 
             return null;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -312,15 +312,13 @@ public class AddExchanges
 
         private Function<Symbol, Optional<Symbol>> translateGroupIdSymbols(GroupIdNode node)
         {
-            Map<Symbol, Symbol> invertedMappings = ImmutableBiMap.copyOf(node.getIdentityMappings()).inverse();
-            List<Symbol> commonGroupingColumns = node.getCommonGroupingColumns();
             return symbol -> {
-                if (invertedMappings.containsKey(symbol)) {
-                    return Optional.of(invertedMappings.get(symbol));
+                if (node.getArgumentMappings().containsKey(symbol)) {
+                    return Optional.of(node.getArgumentMappings().get(symbol));
                 }
 
-                if (commonGroupingColumns.contains(symbol)) {
-                    return Optional.of(symbol);
+                if (node.getCommonGroupingColumns().contains(symbol)) {
+                    return Optional.of(node.getGroupingSetMappings().get(symbol));
                 }
 
                 return Optional.empty();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -307,23 +307,22 @@ final class StreamPropertyDerivations
         @Override
         public StreamProperties visitGroupId(GroupIdNode node, List<StreamProperties> inputProperties)
         {
-            return Iterables.getOnlyElement(inputProperties).translate(translateGroupIdSymbols(node));
-        }
-
-        private Function<Symbol, Optional<Symbol>> translateGroupIdSymbols(GroupIdNode node)
-        {
-            List<Symbol> commonGroupingColumns = node.getCommonGroupingColumns();
-            return symbol -> {
-                if (node.getIdentityMappings().containsKey(symbol)) {
-                    return Optional.of(node.getIdentityMappings().get(symbol));
+            Map<Symbol, Symbol> inputToOutputMappings = new HashMap<>();
+            for (Map.Entry<Symbol, Symbol> setMapping : node.getGroupingSetMappings().entrySet()) {
+                if (node.getCommonGroupingColumns().contains(setMapping.getKey())) {
+                    // TODO: Add support for translating a property on a single column to multiple columns
+                    // when GroupIdNode is copying a single input grouping column into multiple output grouping columns (i.e. aliases), this is basically picking one arbitrarily
+                    inputToOutputMappings.putIfAbsent(setMapping.getValue(), setMapping.getKey());
                 }
+            }
 
-                if (commonGroupingColumns.contains(symbol)) {
-                    return Optional.of(symbol);
-                }
+            // TODO: Add support for translating a property on a single column to multiple columns
+            // this is deliberately placed after the grouping columns, because preserving properties has a bigger perf impact
+            for (Map.Entry<Symbol, Symbol> argumentMapping : node.getArgumentMappings().entrySet()) {
+                inputToOutputMappings.putIfAbsent(argumentMapping.getValue(), argumentMapping.getKey());
+            }
 
-                return Optional.empty();
-            };
+            return Iterables.getOnlyElement(inputProperties).translate(column -> Optional.ofNullable(inputToOutputMappings.get(column)));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -81,7 +81,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
@@ -157,16 +156,31 @@ public class UnaliasSymbolReferences
         public PlanNode visitGroupId(GroupIdNode node, RewriteContext<Void> context)
         {
             PlanNode source = context.rewrite(node.getSource());
-            List<List<Symbol>> groupingSetsSymbols = node.getGroupingSets().stream()
-                    .map(this::canonicalize)
-                    .collect(Collectors.toList());
 
-            ImmutableMap.Builder<Symbol, Symbol> newPassthroughMap = ImmutableMap.builder();
-            for (Symbol inputSymbol : node.getIdentityMappings().keySet()) {
-                newPassthroughMap.put(canonicalize(inputSymbol), canonicalize(node.getIdentityMappings().get(inputSymbol)));
+            Map<Symbol, Symbol> newGroupingMappings = new HashMap<>();
+            ImmutableList.Builder<List<Symbol>> newGroupingSets = ImmutableList.builder();
+
+            for (List<Symbol> groupingSet : node.getGroupingSets()) {
+                ImmutableList.Builder<Symbol> newGroupingSet = ImmutableList.builder();
+                for (Symbol output : groupingSet) {
+                    newGroupingMappings.putIfAbsent(canonicalize(output), canonicalize(node.getGroupingSetMappings().get(output)));
+                    newGroupingSet.add(canonicalize(output));
+                }
+                newGroupingSets.add(newGroupingSet.build());
             }
 
-            return new GroupIdNode(node.getId(), source, groupingSetsSymbols, newPassthroughMap.build(), canonicalize(node.getGroupIdSymbol()));
+            Map<Symbol, Symbol> newArgumentMappings = new HashMap<>();
+            for (Symbol output : node.getArgumentMappings().keySet()) {
+                Symbol canonicalOutput = canonicalize(output);
+                if (newArgumentMappings.containsKey(canonicalOutput)) {
+                    map(output, canonicalOutput);
+                }
+                else {
+                    newArgumentMappings.put(canonicalOutput, canonicalize(node.getArgumentMappings().get(output)));
+                }
+            }
+
+            return new GroupIdNode(node.getId(), source, newGroupingSets.build(), newGroupingMappings, newArgumentMappings, canonicalize(node.getGroupIdSymbol()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
@@ -169,7 +169,7 @@ public class ChildReplacer
     @Override
     public PlanNode visitGroupId(GroupIdNode node, List<PlanNode> newChildren)
     {
-        return new GroupIdNode(node.getId(), Iterables.getOnlyElement(newChildren), node.getGroupingSets(), node.getIdentityMappings(), node.getGroupIdSymbol());
+        return new GroupIdNode(node.getId(), Iterables.getOnlyElement(newChildren), node.getGroupingSets(), node.getGroupingSetMappings(), node.getArgumentMappings(), node.getGroupIdSymbol());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/GroupIdNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/GroupIdNode.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -27,39 +28,53 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 @Immutable
 public class GroupIdNode
         extends PlanNode
 {
     private final PlanNode source;
+
+    // in terms of output symbols
     private final List<List<Symbol>> groupingSets;
-    private final Map<Symbol, Symbol> identityMappings;
+
+    // from output to input symbols
+    private final Map<Symbol, Symbol> groupingSetMappings;
+    private final Map<Symbol, Symbol> argumentMappings;
+
     private final Symbol groupIdSymbol;
 
     @JsonCreator
     public GroupIdNode(@JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
             @JsonProperty("groupingSets") List<List<Symbol>> groupingSets,
-            @JsonProperty("identityMappings") Map<Symbol, Symbol> identityMappings,
+            @JsonProperty("groupingSetMappings") Map<Symbol, Symbol> groupingSetMappings,
+            @JsonProperty("argumentMappings") Map<Symbol, Symbol> argumentMappings,
             @JsonProperty("groupIdSymbol") Symbol groupIdSymbol)
     {
         super(id);
         this.source = requireNonNull(source);
         this.groupingSets = ImmutableList.copyOf(requireNonNull(groupingSets));
-        this.identityMappings = ImmutableMap.copyOf(requireNonNull(identityMappings));
+        this.groupingSetMappings = ImmutableMap.copyOf(requireNonNull(groupingSetMappings));
+        this.argumentMappings = ImmutableMap.copyOf(requireNonNull(argumentMappings));
         this.groupIdSymbol = requireNonNull(groupIdSymbol);
+
+        checkArgument(Sets.intersection(groupingSetMappings.keySet(), argumentMappings.keySet()).isEmpty(), "argument outputs and grouping outputs must be a disjoint set");
     }
 
     @Override
     public List<Symbol> getOutputSymbols()
     {
         return ImmutableList.<Symbol>builder()
-                .addAll(getDistinctGroupingColumns())
-                .addAll(identityMappings.values())
+                .addAll(groupingSets.stream()
+                        .flatMap(Collection::stream)
+                        .collect(toSet()))
+                .addAll(argumentMappings.keySet())
                 .add(groupIdSymbol)
                 .build();
     }
@@ -76,14 +91,6 @@ public class GroupIdNode
         return source;
     }
 
-    public Set<Symbol> getInputSymbols()
-    {
-        return ImmutableSet.<Symbol>builder()
-                .addAll(identityMappings.keySet())
-                .addAll(getDistinctGroupingColumns())
-                .build();
-    }
-
     @JsonProperty
     public List<List<Symbol>> getGroupingSets()
     {
@@ -91,26 +98,15 @@ public class GroupIdNode
     }
 
     @JsonProperty
-    public Map<Symbol, Symbol> getIdentityMappings()
+    public Map<Symbol, Symbol> getGroupingSetMappings()
     {
-        return identityMappings;
+        return groupingSetMappings;
     }
 
-    public List<Symbol> getDistinctGroupingColumns()
+    @JsonProperty
+    public Map<Symbol, Symbol> getArgumentMappings()
     {
-        return groupingSets.stream()
-                .flatMap(Collection::stream)
-                .distinct()
-                .collect(toList());
-    }
-
-    public List<Symbol> getCommonGroupingColumns()
-    {
-        Set<Symbol> intersection = new HashSet<>(groupingSets.get(0));
-        for (int i = 1; i < getGroupingSets().size(); i++) {
-            intersection.retainAll(groupingSets.get(i));
-        }
-        return ImmutableList.copyOf(intersection);
+        return argumentMappings;
     }
 
     @JsonProperty
@@ -123,5 +119,27 @@ public class GroupIdNode
     public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
     {
         return visitor.visitGroupId(this, context);
+    }
+
+    public Set<Symbol> getInputSymbols()
+    {
+        return ImmutableSet.<Symbol>builder()
+                .addAll(argumentMappings.values())
+                .addAll(groupingSets.stream()
+                        .map(set -> set.stream()
+                                .map(groupingSetMappings::get).collect(Collectors.toList()))
+                        .flatMap(Collection::stream)
+                        .collect(toSet()))
+                .build();
+    }
+
+    // returns the common grouping columns in terms of output symbols
+    public Set<Symbol> getCommonGroupingColumns()
+    {
+        Set<Symbol> intersection = new HashSet<>(groupingSets.get(0));
+        for (int i = 1; i < groupingSets.size(); i++) {
+            intersection.retainAll(groupingSets.get(i));
+        }
+        return ImmutableSet.copyOf(intersection);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -332,11 +332,14 @@ public final class GraphvizPrinter
         @Override
         public Void visitGroupId(GroupIdNode node, Void context)
         {
-            List<String> groupingSets = node.getGroupingSets().stream()
-                    .map(groupingSet -> "(" + Joiner.on(", ").join(groupingSet) + ")")
+            // grouping sets are easier to understand in terms of inputs
+            List<String> inputGroupingSetSymbols = node.getGroupingSets().stream()
+                    .map(set -> "(" + Joiner.on(", ").join(set.stream()
+                            .map(symbol -> node.getGroupingSetMappings().get(symbol))
+                            .collect(Collectors.toList())) + ")")
                     .collect(Collectors.toList());
 
-            printNode(node, "GroupId", Joiner.on(", ").join(groupingSets), NODE_COLORS.get(NodeType.AGGREGATE));
+            printNode(node, "GroupId", Joiner.on(", ").join(inputGroupingSetSymbols), NODE_COLORS.get(NodeType.AGGREGATE));
             return node.getSource().accept(this, context);
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestGroupIdOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestGroupIdOperator.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.MaterializedResult;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -72,9 +73,7 @@ public class TestGroupIdOperator
                 new GroupIdOperatorFactory(0,
                         new PlanNodeId("test"),
                         ImmutableList.of(VARCHAR, BOOLEAN, BIGINT, BIGINT, BIGINT),
-                        ImmutableList.of(ImmutableList.of(1, 2), ImmutableList.of(3)),
-                        ImmutableList.of(1, 2, 3),
-                        ImmutableList.of(0));
+                        ImmutableList.of(ImmutableMap.of(0, 1, 1, 2, 3, 0), ImmutableMap.of(2, 3, 3, 0)));
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, BOOLEAN, BIGINT, BIGINT, BIGINT)
                 .row("400", true, null, 100L, 0L)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1517,6 +1517,19 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testGroupingSetsAliasedGroupingColumns()
+            throws Exception
+    {
+        assertQuery("SELECT lna, lnb, SUM(quantity) " +
+                        "FROM (SELECT linenumber lna, linenumber lnb, CAST(quantity AS BIGINT) quantity FROM lineitem) " +
+                        "GROUP BY GROUPING SETS ((lna, lnb), (lna), (lnb), ())",
+                "SELECT linenumber, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
+                        "SELECT linenumber, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
+                        "SELECT NULL, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
     public void testGroupingSetMixedExpressionAndColumn()
             throws Exception
     {


### PR DESCRIPTION
This fixes a correctness issue in queries with multiple grouping sets
that resolve to the same set when unaliased. All inputs to
AggregationNode are now written in terms of outputs from GroupIdNode
or ProjectNode. This requires that GroupIdNode look a lot more like
ProjectNode, except that GroupIdNode just copies columns instead of
projecting them.

Fixes #6379