### PR TITLE
Add queryIds and cpuUsage to ResourceGroupInfo

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupInfo.java
@@ -13,11 +13,14 @@
  */
 package com.facebook.presto.execution.resourceGroups;
 
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 
 import java.util.List;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -30,7 +33,9 @@ public class ResourceGroupInfo
     private final int maxQueuedQueries;
     private final int runningQueries;
     private final int queuedQueries;
+    private final long cpuUsage;
     private final DataSize memoryUsage;
+    private final Set<QueryId> queryIds;
     private final List<ResourceGroupInfo> subGroups;
 
     public ResourceGroupInfo(
@@ -40,7 +45,9 @@ public class ResourceGroupInfo
             int maxQueuedQueries,
             int runningQueries,
             int queuedQueries,
+            long cpuUsage,
             DataSize memoryUsage,
+            Set<QueryId> queryIds,
             List<ResourceGroupInfo> subGroups)
     {
         this.id = id;
@@ -49,7 +56,9 @@ public class ResourceGroupInfo
         this.maxQueuedQueries = maxQueuedQueries;
         this.runningQueries = runningQueries;
         this.queuedQueries = queuedQueries;
+        this.cpuUsage = cpuUsage;
         this.memoryUsage = requireNonNull(memoryUsage, "memoryUsage is null");
+        this.queryIds = ImmutableSet.copyOf(requireNonNull(queryIds, "queryIds is null"));
         this.subGroups = ImmutableList.copyOf(requireNonNull(subGroups, "subGroups is null"));
     }
 
@@ -88,8 +97,18 @@ public class ResourceGroupInfo
         return queuedQueries;
     }
 
+    public long getCpuUsage()
+    {
+        return cpuUsage;
+    }
+
     public DataSize getMemoryUsage()
     {
         return memoryUsage;
+    }
+
+    public Set<QueryId> getQueryIds()
+    {
+        return queryIds;
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroupIntegration.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroupIntegration.java
@@ -13,16 +13,27 @@
  */
 package com.facebook.presto.execution.resourceGroups;
 
+import com.facebook.presto.execution.QueryInfo;
+import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.resourceGroups.ResourceGroupManagerPlugin;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static io.airlift.testing.Assertions.assertGreaterThan;
 import static io.airlift.testing.Assertions.assertLessThan;
 import static io.airlift.units.Duration.nanosSince;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestResourceGroupIntegration
 {
@@ -38,7 +49,7 @@ public class TestResourceGroupIntegration
             long startTime = System.nanoTime();
             while (true) {
                 SECONDS.sleep(1);
-                ResourceGroupInfo global = queryRunner.getCoordinator().getResourceGroupManager().get().getResourceGroupInfo(new ResourceGroupId("global"));
+                ResourceGroupInfo global = getResourceGroupInfo(queryRunner, new ResourceGroupId("global"));
                 if (global.getSoftMemoryLimit().toBytes() > 0) {
                     break;
                 }
@@ -47,8 +58,46 @@ public class TestResourceGroupIntegration
         }
     }
 
+    @Test
+    public void testResourceGroupInfo()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = createQueryRunner(ImmutableMap.of(), ImmutableMap.of("experimental.resource-groups-enabled", "true"))) {
+            queryRunner.installPlugin(new ResourceGroupManagerPlugin());
+            queryRunner.getCoordinator().getResourceGroupManager().get().setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_info.json")));
+
+            CompletableFuture<MaterializedResult> future = runAsync(queryRunner, "SELECT COUNT(*), clerk FROM orders GROUP BY clerk");
+            while (true) {
+                List<QueryInfo> queries = queryRunner.getCoordinator().getQueryManager().getAllQueryInfo();
+                if (!queries.isEmpty() && queries.get(0).getState().isDone()) {
+                    break;
+                }
+                if (queries.isEmpty() || !queries.get(0).getState().equals(QueryState.RUNNING)) {
+                    MILLISECONDS.sleep(1);
+                    continue;
+                }
+                ResourceGroupInfo global = getResourceGroupInfo(queryRunner, new ResourceGroupId("global"));
+                assertEquals(global.getQueryIds(), ImmutableSet.of(queries.get(0).getQueryId()));
+            }
+            ResourceGroupInfo global = getResourceGroupInfo(queryRunner, new ResourceGroupId("global"));
+            assertGreaterThan(global.getCpuUsage(), 0L);
+            future.get();
+            assertTrue(future.isDone());
+        }
+    }
+
     private String getResourceFilePath(String fileName)
     {
         return this.getClass().getClassLoader().getResource(fileName).getPath();
+    }
+
+    private static CompletableFuture<MaterializedResult> runAsync(DistributedQueryRunner queryRunner, String query)
+    {
+        return CompletableFuture.supplyAsync(() -> queryRunner.execute(query));
+    }
+
+    private static ResourceGroupInfo getResourceGroupInfo(DistributedQueryRunner queryRunner, ResourceGroupId id)
+    {
+        return queryRunner.getCoordinator().getResourceGroupManager().get().getResourceGroupInfo(id);
     }
 }

--- a/presto-tests/src/test/resources/resource_groups_info.json
+++ b/presto-tests/src/test/resources/resource_groups_info.json
@@ -1,0 +1,21 @@
+{
+  "rootGroups": [
+    {
+      "name": "global",
+      "softMemoryLimit": "50%",
+      "hardCpuLimit": "5m",
+      "softCpuLimit": "30s",
+      "maxRunning": 100,
+      "maxQueued": 1000,
+      "subGroups": [
+      ]
+    }
+  ],
+  "selectors": [
+    {
+      "group": "global"
+    }
+  ],
+  "cpuQuotaPeriod": "30s"
+}
+


### PR DESCRIPTION
I face situations that I need to figure out the following information for management and reporting. 
- What queries are running under this group
- What resource group does this query is running under
- What is current cpu-usage-millis to show and to find out how much it exceeds the soft/hard cpu limits
