### PR TITLE
Remove racy assertion

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
@@ -108,7 +108,6 @@ public class TestQueues
             waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
 
             assertEquals(queryManager.getStats().getRunningQueries(), 3);
-            assertEquals(queryManager.getStats().getCompletedQueries().getTotalCount(), 1);
         }
     }
 


### PR DESCRIPTION
Now that queries wait for their final info, they're not recorded as
completed until they're finished and their final info has been received.
This wasn't an important part of the test, so just remove it.