### PR TITLE
Make PredicatePushdown optimizer not create unnecessary symbols

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -378,10 +378,15 @@ public class PredicatePushDown
                         Expression leftExpression = (alignedComparison) ? equality.getLeft() : equality.getRight();
                         Expression rightExpression = (alignedComparison) ? equality.getRight() : equality.getLeft();
 
-                        Symbol leftSymbol = symbolAllocator.newSymbol(leftExpression, extractType(leftExpression));
-                        leftProjections.put(leftSymbol, leftExpression);
-                        Symbol rightSymbol = symbolAllocator.newSymbol(rightExpression, extractType(rightExpression));
-                        rightProjections.put(rightSymbol, rightExpression);
+                        Symbol leftSymbol = symbolForExpression(leftExpression);
+                        if (!node.getLeft().getOutputSymbols().contains(leftSymbol)) {
+                            leftProjections.put(leftSymbol, leftExpression);
+                        }
+
+                        Symbol rightSymbol = symbolForExpression(rightExpression);
+                        if (!node.getRight().getOutputSymbols().contains(rightSymbol)) {
+                            rightProjections.put(rightSymbol, rightExpression);
+                        }
 
                         joinConditionBuilder.add(new JoinNode.EquiJoinClause(leftSymbol, rightSymbol));
                     }
@@ -404,6 +409,15 @@ public class PredicatePushDown
                 output = new FilterNode(idAllocator.getNextId(), output, postJoinPredicate);
             }
             return output;
+        }
+
+        private Symbol symbolForExpression(Expression expression)
+        {
+            if (expression instanceof SymbolReference) {
+                return Symbol.from(expression);
+            }
+
+            return symbolAllocator.newSymbol(expression, extractType(expression));
         }
 
         private OuterJoinPushDownResult processLimitedOuterJoin(Expression inheritedPredicate, Expression outerEffectivePredicate, Expression innerEffectivePredicate, Expression joinPredicate, Collection<Symbol> outerSymbols)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -781,6 +781,19 @@ public abstract class AbstractTestDistributedQueries
     }
 
     @Test
+    public void testJoinPartitioningByExpression()
+            throws Exception
+    {
+        assertQuery("WITH t AS (" +
+                "    SELECT name, nationkey" +
+                "    FROM tpch.tiny.nation" +
+                "    GROUP BY 1, 2" +
+                " )" +
+                " SELECT count(*)" +
+                " FROM t a JOIN t b ON a.name = 'ALGERIA' AND a.nationkey = b.nationkey - 1", "SELECT 1");
+    }
+
+    @Test
     public void testNonQueryAccessControl()
             throws Exception
     {


### PR DESCRIPTION
PredicatePushdown optimizer created unnecessary symbols for join
clauses which confuses HashGenerationOptimizer (it did not recognize
that Exchange symbols and hash symbols are the same).
