### PR TITLE
Remove memory usage discount for non-partial-output aggregations

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
@@ -90,6 +90,7 @@ public class AggregationOperator
     }
 
     private final OperatorContext operatorContext;
+    private final Step step;
     private final List<Type> types;
     private final List<Aggregator> aggregates;
 
@@ -99,7 +100,7 @@ public class AggregationOperator
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
 
-        requireNonNull(step, "step is null");
+        this.step = requireNonNull(step, "step is null");
         requireNonNull(accumulatorFactories, "accumulatorFactories is null");
 
         this.types = toTypes(step, accumulatorFactories);
@@ -155,7 +156,9 @@ public class AggregationOperator
             aggregate.processPage(page);
             memorySize += aggregate.getEstimatedSize();
         }
-        memorySize -= operatorContext.getOperatorPreAllocatedMemory().toBytes();
+        if (step.isOutputPartial()) {
+            memorySize -= operatorContext.getOperatorPreAllocatedMemory().toBytes();
+        }
         operatorContext.setMemoryReservation(Math.max(0, memorySize));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -97,11 +97,8 @@ public class InMemoryHashAggregationBuilder
         for (Aggregator aggregator : aggregators) {
             memorySize += aggregator.getEstimatedSize();
         }
-        memorySize -= operatorContext.getOperatorPreAllocatedMemory().toBytes();
-        if (memorySize < 0) {
-            memorySize = 0;
-        }
         if (partial) {
+            memorySize = Math.max(0, memorySize - operatorContext.getOperatorPreAllocatedMemory().toBytes());
             full = !operatorContext.trySetMemoryReservation(memorySize);
         }
         else {


### PR DESCRIPTION
This discount interactives with task_concurrency in an unintuitive way.
The long term plan is to use system memory tracking instead of memory
usage discount for partial-output aggregations.