### PR TITLE
Use IntArrayList in TypedSet to avoid wasting memory

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
@@ -13,12 +13,12 @@
  */
 package com.facebook.presto.operator.aggregation;
 
-import com.facebook.presto.array.IntBigArray;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.units.DataSize;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.openjdk.jol.info.ClassLayout;
 
 import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalLimit;
@@ -32,11 +32,12 @@ import static java.util.Objects.requireNonNull;
 public class TypedSet
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(TypedSet.class).instanceSize();
+    private static final int INT_ARRAY_LIST_INSTANCE_SIZE = ClassLayout.parseClass(IntArrayList.class).instanceSize();
     private static final float FILL_RATIO = 0.75f;
     private static final long FOUR_MEGABYTES = new DataSize(4, MEGABYTE).toBytes();
 
     private final Type elementType;
-    private final IntBigArray blockPositionByHash = new IntBigArray();
+    private final IntArrayList blockPositionByHash;
     private final BlockBuilder elementBlock;
 
     private int maxFill;
@@ -55,7 +56,8 @@ public class TypedSet
         this.maxFill = calculateMaxFill(hashSize);
         this.hashMask = hashSize - 1;
 
-        blockPositionByHash.ensureCapacity(hashSize);
+        blockPositionByHash = new IntArrayList(hashSize);
+        blockPositionByHash.size(hashSize);
         for (int i = 0; i < hashSize; i++) {
             blockPositionByHash.set(i, EMPTY_SLOT);
         }
@@ -65,7 +67,7 @@ public class TypedSet
 
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + elementBlock.getRetainedSizeInBytes() + blockPositionByHash.sizeOf();
+        return INSTANCE_SIZE + INT_ARRAY_LIST_INSTANCE_SIZE + elementBlock.getRetainedSizeInBytes() + blockPositionByHash.size() * Integer.BYTES;
     }
 
     public boolean contains(Block block, int position)
@@ -147,7 +149,7 @@ public class TypedSet
         int newHashSize = arraySize(size + 1, FILL_RATIO);
         hashMask = newHashSize - 1;
         maxFill = calculateMaxFill(newHashSize);
-        blockPositionByHash.ensureCapacity(newHashSize);
+        blockPositionByHash.size(newHashSize);
         for (int i = 0; i < newHashSize; i++) {
             blockPositionByHash.set(i, EMPTY_SLOT);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
@@ -90,7 +90,7 @@ public class TypedSet
             containsNullElement = true;
         }
         else {
-            long hashPosition = getHashPositionOfElement(block, position);
+            int hashPosition = getHashPositionOfElement(block, position);
             if (blockPositionByHash.get(hashPosition) == EMPTY_SLOT) {
                 addNewElement(hashPosition, block, position);
             }
@@ -110,9 +110,9 @@ public class TypedSet
     /**
      * Get slot position of element at {@code position} of {@code block}
      */
-    private long getHashPositionOfElement(Block block, int position)
+    private int getHashPositionOfElement(Block block, int position)
     {
-        long hashPosition = getMaskedHash(hashPosition(elementType, block, position));
+        int hashPosition = getMaskedHash(hashPosition(elementType, block, position));
         while (true) {
             int blockPosition = blockPositionByHash.get(hashPosition);
             // Doesn't have this element
@@ -128,7 +128,7 @@ public class TypedSet
         }
     }
 
-    private void addNewElement(long hashPosition, Block block, int position)
+    private void addNewElement(int hashPosition, Block block, int position)
     {
         elementType.appendTo(block, position, elementBlock);
         if (elementBlock.getSizeInBytes() > FOUR_MEGABYTES) {
@@ -171,8 +171,8 @@ public class TypedSet
         return maxFill;
     }
 
-    private long getMaskedHash(long rawHash)
+    private int getMaskedHash(long rawHash)
     {
-        return rawHash & hashMask;
+        return (int) (rawHash & hashMask);
     }
 }


### PR DESCRIPTION
Fixes #6313 

Before this change, TypedSet used IntBigArray which allocates at least
8KB at initialization, while initialization of IntArrayList only
consumes no more than 256 bytes.

This change might fix the memory limit issues in map_agg and
multimap_agg.