### PR TITLE
Feature prune join output

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
@@ -75,7 +75,7 @@ public class HashBuildAndJoinBenchmark
         }
 
         // hash build
-        HashBuilderOperatorFactory hashBuilder = new HashBuilderOperatorFactory(2, new PlanNodeId("test"), source.getTypes(), ImmutableMap.of(), Ints.asList(0), hashChannel, false, Optional.empty(), 1_500_000, 1);
+        HashBuilderOperatorFactory hashBuilder = new HashBuilderOperatorFactory(2, new PlanNodeId("test"), source.getTypes(), ImmutableList.of(0, 1), ImmutableMap.of(), Ints.asList(0), hashChannel, false, Optional.empty(), 1_500_000, 1);
         driversBuilder.add(hashBuilder);
         DriverFactory hashBuildDriverFactory = new DriverFactory(true, false, driversBuilder.build(), OptionalInt.empty());
         Driver hashBuildDriver = hashBuildDriverFactory.createDriver(taskContext.addPipelineContext(true, false).addDriverContext());
@@ -92,7 +92,7 @@ public class HashBuildAndJoinBenchmark
             hashChannel = Optional.of(2);
         }
 
-        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceFactory(), source.getTypes(), Ints.asList(0), hashChannel);
+        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceFactory(), source.getTypes(), Ints.asList(0), hashChannel, Optional.empty());
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test"), joinOperator.getTypes()));
         DriverFactory joinDriverFactory = new DriverFactory(true, true, joinDriversBuilder.build(), OptionalInt.empty());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
@@ -92,7 +92,7 @@ public class HashBuildAndJoinBenchmark
             hashChannel = Optional.of(2);
         }
 
-        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceFactory(), source.getTypes(), Ints.asList(0), hashChannel, false);
+        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceFactory(), source.getTypes(), Ints.asList(0), hashChannel);
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test"), joinOperator.getTypes()));
         DriverFactory joinDriverFactory = new DriverFactory(true, true, joinDriversBuilder.build(), OptionalInt.empty());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
@@ -69,8 +69,7 @@ public class HashBuildBenchmark
                 hashBuilder.getLookupSourceFactory(),
                 ImmutableList.of(BIGINT),
                 Ints.asList(0),
-                Optional.empty(),
-                false);
+                Optional.empty());
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test"), joinOperator.getTypes()));
         DriverFactory joinDriverFactory = new DriverFactory(true, true, joinDriversBuilder.build(), OptionalInt.empty());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
@@ -51,6 +51,7 @@ public class HashBuildBenchmark
                 1,
                 new PlanNodeId("test"),
                 ordersTableScan.getTypes(),
+                ImmutableList.of(0, 1),
                 ImmutableMap.of(),
                 Ints.asList(0),
                 Optional.empty(),
@@ -69,6 +70,7 @@ public class HashBuildBenchmark
                 hashBuilder.getLookupSourceFactory(),
                 ImmutableList.of(BIGINT),
                 Ints.asList(0),
+                Optional.empty(),
                 Optional.empty());
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test"), joinOperator.getTypes()));

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
@@ -58,6 +58,7 @@ public class HashJoinBenchmark
                     1,
                     new PlanNodeId("test"),
                     ordersTableScan.getTypes(),
+                    ImmutableList.of(0, 1),
                     ImmutableMap.of(),
                     Ints.asList(0),
                     Optional.empty(),
@@ -76,7 +77,7 @@ public class HashJoinBenchmark
 
         OperatorFactory lineItemTableScan = createTableScanOperator(0, new PlanNodeId("test"), "lineitem", "orderkey", "quantity");
 
-        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(1, new PlanNodeId("test"), lookupSourceFactory, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty());
+        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(1, new PlanNodeId("test"), lookupSourceFactory, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty(), Optional.empty());
 
         NullOutputOperatorFactory output = new NullOutputOperatorFactory(2, new PlanNodeId("test"), joinOperator.getTypes());
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
@@ -76,7 +76,7 @@ public class HashJoinBenchmark
 
         OperatorFactory lineItemTableScan = createTableScanOperator(0, new PlanNodeId("test"), "lineitem", "orderkey", "quantity");
 
-        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(1, new PlanNodeId("test"), lookupSourceFactory, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty(), false);
+        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(1, new PlanNodeId("test"), lookupSourceFactory, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty());
 
         NullOutputOperatorFactory output = new NullOutputOperatorFactory(2, new PlanNodeId("test"), joinOperator.getTypes());
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinProbe.java
@@ -18,7 +18,7 @@ import com.facebook.presto.spi.PageBuilder;
 
 public interface JoinProbe
 {
-    int getChannelCount();
+    int getOutputChannelCount();
 
     boolean advanceNextPosition();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -191,7 +191,7 @@ public class LookupJoinOperator
             probe.appendTo(pageBuilder);
 
             // write build columns
-            lookupSource.appendTo(joinPosition, pageBuilder, probe.getChannelCount());
+            lookupSource.appendTo(joinPosition, pageBuilder, probe.getOutputChannelCount());
 
             // get next join position for this row
             joinPosition = lookupSource.getNextJoinPosition(joinPosition, probe.getPosition(), probe.getPage());
@@ -222,7 +222,7 @@ public class LookupJoinOperator
             probe.appendTo(pageBuilder);
 
             // write nulls into build columns
-            int outputIndex = probe.getChannelCount();
+            int outputIndex = probe.getOutputChannelCount();
             for (int buildChannel = 0; buildChannel < lookupSource.getChannelCount(); buildChannel++) {
                 pageBuilder.getBlockBuilder(outputIndex).appendNull();
                 outputIndex++;

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
@@ -39,7 +39,9 @@ public class LookupJoinOperatorFactory
     private final int operatorId;
     private final PlanNodeId planNodeId;
     private final List<Type> probeTypes;
+    private final List<Type> probeOutputTypes;
     private final List<Type> buildTypes;
+    private final List<Type> buildOutputTypes;
     private final JoinType joinType;
     private final LookupSourceFactory lookupSourceFactory;
     private final JoinProbeFactory joinProbeFactory;
@@ -51,6 +53,7 @@ public class LookupJoinOperatorFactory
             PlanNodeId planNodeId,
             LookupSourceFactory lookupSourceFactory,
             List<Type> probeTypes,
+            List<Type> probeOutputTypes,
             JoinType joinType,
             JoinProbeFactory joinProbeFactory)
     {
@@ -58,7 +61,9 @@ public class LookupJoinOperatorFactory
         this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
         this.lookupSourceFactory = requireNonNull(lookupSourceFactory, "lookupSourceFactory is null");
         this.probeTypes = ImmutableList.copyOf(requireNonNull(probeTypes, "probeTypes is null"));
+        this.probeOutputTypes = ImmutableList.copyOf(requireNonNull(probeOutputTypes, "probeOutputTypes is null"));
         this.buildTypes = ImmutableList.copyOf(lookupSourceFactory.getTypes());
+        this.buildOutputTypes = ImmutableList.copyOf(lookupSourceFactory.getOutputTypes());
         this.joinType = requireNonNull(joinType, "joinType is null");
         this.joinProbeFactory = requireNonNull(joinProbeFactory, "joinProbeFactory is null");
 
@@ -84,7 +89,7 @@ public class LookupJoinOperatorFactory
                 // lookup source may not be finished yet, so add a listener, to free the memory
                 lookupSourceFactory.createLookupSource().addListener(lookupSourceFactory::destroy, directExecutor());
             };
-            this.outerOperatorFactory = Optional.of(new LookupOuterOperatorFactory(operatorId, planNodeId, outerPositionsFuture, probeTypes, buildTypes, onOperatorClose));
+            this.outerOperatorFactory = Optional.of(new LookupOuterOperatorFactory(operatorId, planNodeId, outerPositionsFuture, probeOutputTypes, buildOutputTypes, onOperatorClose));
         }
     }
 
@@ -94,7 +99,9 @@ public class LookupJoinOperatorFactory
         operatorId = other.operatorId;
         planNodeId = other.planNodeId;
         probeTypes = other.probeTypes;
+        probeOutputTypes = other.probeOutputTypes;
         buildTypes = other.buildTypes;
+        buildOutputTypes = other.buildOutputTypes;
         joinType = other.joinType;
         lookupSourceFactory = other.lookupSourceFactory;
         joinProbeFactory = other.joinProbeFactory;
@@ -113,8 +120,8 @@ public class LookupJoinOperatorFactory
     public List<Type> getTypes()
     {
         return ImmutableList.<Type>builder()
-                .addAll(probeTypes)
-                .addAll(buildTypes)
+                .addAll(probeOutputTypes)
+                .addAll(buildOutputTypes)
                 .build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
@@ -35,23 +35,23 @@ public class LookupJoinOperators
 
     private static final JoinProbeCompiler JOIN_PROBE_COMPILER = new JoinProbeCompiler();
 
-    public static OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, boolean filterFunctionPresent)
+    public static OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.INNER, filterFunctionPresent);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.INNER);
     }
 
-    public static OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, boolean filterFunctionPresent)
+    public static OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.PROBE_OUTER, filterFunctionPresent);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.PROBE_OUTER);
     }
 
-    public static OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, boolean filterFunctionPresent)
+    public static OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.LOOKUP_OUTER, filterFunctionPresent);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.LOOKUP_OUTER);
     }
 
-    public static OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, boolean filterFunctionPresent)
+    public static OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.FULL_OUTER, filterFunctionPresent);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.FULL_OUTER);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
@@ -37,21 +37,21 @@ public class LookupJoinOperators
 
     public static OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.INNER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, Optional.empty(), JoinType.INNER);
     }
 
     public static OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.PROBE_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, Optional.empty(), JoinType.PROBE_OUTER);
     }
 
     public static OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.LOOKUP_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, Optional.empty(), JoinType.LOOKUP_OUTER);
     }
 
     public static OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.FULL_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, Optional.empty(), JoinType.FULL_OUTER);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
@@ -35,23 +35,23 @@ public class LookupJoinOperators
 
     private static final JoinProbeCompiler JOIN_PROBE_COMPILER = new JoinProbeCompiler();
 
-    public static OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public static OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, Optional.empty(), JoinType.INNER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels, JoinType.INNER);
     }
 
-    public static OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public static OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, Optional.empty(), JoinType.PROBE_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels, JoinType.PROBE_OUTER);
     }
 
-    public static OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public static OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, Optional.empty(), JoinType.LOOKUP_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels, JoinType.LOOKUP_OUTER);
     }
 
-    public static OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public static OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, Optional.empty(), JoinType.FULL_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels, JoinType.FULL_OUTER);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceFactory.java
@@ -24,6 +24,8 @@ public interface LookupSourceFactory
 {
     List<Type> getTypes();
 
+    List<Type> getOutputTypes();
+
     ListenableFuture<LookupSource> createLookupSource();
 
     Map<Symbol, Integer> getLayout();

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -35,6 +35,7 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.operator.SyntheticAddress.decodePosition;
 import static com.facebook.presto.operator.SyntheticAddress.decodeSliceIndex;
@@ -307,13 +308,18 @@ public class PagesIndex
 
     public Supplier<LookupSource> createLookupSourceSupplier(Session session, List<Integer> joinChannels)
     {
-        return createLookupSourceSupplier(session, joinChannels, Optional.empty(), Optional.empty());
+        return createLookupSourceSupplier(session, joinChannels, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public PagesHashStrategy createPagesHashStrategy(List<Integer> joinChannels, Optional<Integer> hashChannel)
     {
+        return createPagesHashStrategy(joinChannels, hashChannel, Optional.empty());
+    }
+
+    public PagesHashStrategy createPagesHashStrategy(List<Integer> joinChannels, Optional<Integer> hashChannel, Optional<List<Integer>> outputChannels)
+    {
         try {
-            return joinCompiler.compilePagesHashStrategyFactory(types, joinChannels)
+            return joinCompiler.compilePagesHashStrategyFactory(types, joinChannels, outputChannels)
                     .createPagesHashStrategy(ImmutableList.copyOf(channels), hashChannel);
         }
         catch (Exception e) {
@@ -321,7 +327,7 @@ public class PagesIndex
         }
 
         // if compilation fails, use interpreter
-        return new SimplePagesHashStrategy(types, ImmutableList.<List<Block>>copyOf(channels), joinChannels, hashChannel);
+        return new SimplePagesHashStrategy(types, outputChannels.orElse(rangeList(types.size())), ImmutableList.<List<Block>>copyOf(channels), joinChannels, hashChannel);
     }
 
     public Supplier<LookupSource> createLookupSourceSupplier(
@@ -330,6 +336,16 @@ public class PagesIndex
             Optional<Integer> hashChannel,
             Optional<JoinFilterFunctionFactory> filterFunctionFactory)
     {
+        return createLookupSourceSupplier(session, joinChannels, hashChannel, filterFunctionFactory, Optional.empty());
+    }
+
+    public Supplier<LookupSource> createLookupSourceSupplier(
+            Session session,
+            List<Integer> joinChannels,
+            Optional<Integer> hashChannel,
+            Optional<JoinFilterFunctionFactory> filterFunctionFactory,
+            Optional<List<Integer>> outputChannels)
+    {
         List<List<Block>> channels = ImmutableList.copyOf(this.channels);
         if (!joinChannels.isEmpty()) {
             // todo compiled implementation of lookup join does not support when we are joining with empty join channels.
@@ -337,7 +353,7 @@ public class PagesIndex
             //        OUTER joins into NestedLoopsJoin and remove "type == INNER" condition in LocalExecutionPlanner.visitJoin()
 
             try {
-                LookupSourceSupplierFactory lookupSourceFactory = joinCompiler.compileLookupSourceFactory(types, joinChannels);
+                LookupSourceSupplierFactory lookupSourceFactory = joinCompiler.compileLookupSourceFactory(types, joinChannels, outputChannels);
                 return lookupSourceFactory.createLookupSourceSupplier(
                         session.toConnectorSession(),
                         valueAddresses,
@@ -353,6 +369,7 @@ public class PagesIndex
         // if compilation fails
         PagesHashStrategy hashStrategy = new SimplePagesHashStrategy(
                 types,
+                outputChannels.orElse(rangeList(types.size())),
                 channels,
                 joinChannels,
                 hashChannel);
@@ -363,6 +380,13 @@ public class PagesIndex
                 valueAddresses,
                 channels,
                 filterFunctionFactory);
+    }
+
+    private List<Integer> rangeList(int endExclusive)
+    {
+        return IntStream.range(0, endExclusive)
+                .boxed()
+                .collect(toImmutableList());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -40,6 +40,7 @@ public final class PartitionedLookupSourceFactory
         implements LookupSourceFactory
 {
     private final List<Type> types;
+    private final List<Type> outputTypes;
     private final Map<Symbol, Integer> layout;
     private final List<Type> hashChannelTypes;
     private final Supplier<LookupSource>[] partitions;
@@ -55,9 +56,10 @@ public final class PartitionedLookupSourceFactory
     @GuardedBy("this")
     private final List<SettableFuture<LookupSource>> lookupSourceFutures = new ArrayList<>();
 
-    public PartitionedLookupSourceFactory(List<Type> types, List<Integer> hashChannels, int partitionCount, Map<Symbol, Integer> layout, boolean outer)
+    public PartitionedLookupSourceFactory(List<Type> types, List<Type> outputTypes, List<Integer> hashChannels, int partitionCount, Map<Symbol, Integer> layout, boolean outer)
     {
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        this.outputTypes = ImmutableList.copyOf(requireNonNull(outputTypes, "outputTypes is null"));
         this.layout = ImmutableMap.copyOf(layout);
         this.partitions = (Supplier<LookupSource>[]) new Supplier<?>[partitionCount];
         this.outer = outer;
@@ -71,6 +73,12 @@ public final class PartitionedLookupSourceFactory
     public List<Type> getTypes()
     {
         return types;
+    }
+
+    @Override
+    public List<Type> getOutputTypes()
+    {
+        return outputTypes;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
@@ -31,13 +31,15 @@ public class SimplePagesHashStrategy
         implements PagesHashStrategy
 {
     private final List<Type> types;
+    private final List<Integer> outputChannels;
     private final List<List<Block>> channels;
     private final List<Integer> hashChannels;
     private final List<Block> precomputedHashChannel;
 
-    public SimplePagesHashStrategy(List<Type> types, List<List<Block>> channels, List<Integer> hashChannels, Optional<Integer> precomputedHashChannel)
+    public SimplePagesHashStrategy(List<Type> types, List<Integer> outputChannels, List<List<Block>> channels, List<Integer> hashChannels, Optional<Integer> precomputedHashChannel)
     {
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        this.outputChannels = ImmutableList.copyOf(requireNonNull(outputChannels, "outputChannels is null"));
         this.channels = ImmutableList.copyOf(requireNonNull(channels, "channels is null"));
 
         checkArgument(types.size() == channels.size(), "Expected types and channels to be the same length");
@@ -53,7 +55,7 @@ public class SimplePagesHashStrategy
     @Override
     public int getChannelCount()
     {
-        return channels.size();
+        return outputChannels.size();
     }
 
     @Override
@@ -68,12 +70,12 @@ public class SimplePagesHashStrategy
     @Override
     public void appendTo(int blockIndex, int position, PageBuilder pageBuilder, int outputChannelOffset)
     {
-        for (int i = 0; i < channels.size(); i++) {
-            Type type = types.get(i);
-            List<Block> channel = channels.get(i);
+        int pageBuilderOutputChannel = 0;
+        for (int outputIndex : outputChannels) {
+            Type type = types.get(outputIndex);
+            List<Block> channel = channels.get(outputIndex);
             Block block = channel.get(blockIndex);
-            type.appendTo(block, position, pageBuilder.getBlockBuilder(outputChannelOffset));
-            outputChannelOffset++;
+            type.appendTo(block, position, pageBuilder.getBlockBuilder(outputChannelOffset + (pageBuilderOutputChannel++)));
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/TwoChannelJoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TwoChannelJoinProbe.java
@@ -85,7 +85,7 @@ public class TwoChannelJoinProbe
     }
 
     @Override
-    public int getChannelCount()
+    public int getOutputChannelCount()
     {
         return 2;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceFactory.java
@@ -71,6 +71,12 @@ public class IndexLookupSourceFactory
     }
 
     @Override
+    public List<Type> getOutputTypes()
+    {
+        return outputTypes;
+    }
+
+    @Override
     public Map<Symbol, Integer> getLayout()
     {
         return layout;

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.bytecode.Access.FINAL;
 import static com.facebook.presto.bytecode.Access.PRIVATE;
@@ -68,6 +69,7 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.consta
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantLong;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newInstance;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 
 public class JoinProbeCompiler
 {
@@ -78,7 +80,7 @@ public class JoinProbeCompiler
                 public HashJoinOperatorFactoryFactory load(JoinOperatorCacheKey key)
                         throws Exception
                 {
-                    return internalCompileJoinOperatorFactory(key.getTypes(), key.getProbeChannels(), key.getProbeHashChannel());
+                    return internalCompileJoinOperatorFactory(key.getTypes(), key.getProbeOutputChannels(), key.getProbeChannels(), key.getProbeHashChannel());
                 }
             });
 
@@ -88,10 +90,18 @@ public class JoinProbeCompiler
             List<? extends Type> probeTypes,
             List<Integer> probeJoinChannel,
             Optional<Integer> probeHashChannel,
+            Optional<List<Integer>> probeOutputChannels,
             JoinType joinType)
     {
         try {
-            HashJoinOperatorFactoryFactory operatorFactoryFactory = joinProbeFactories.get(new JoinOperatorCacheKey(probeTypes, probeJoinChannel, probeHashChannel, joinType));
+            HashJoinOperatorFactoryFactory operatorFactoryFactory = joinProbeFactories.get(new JoinOperatorCacheKey(
+                    probeTypes,
+                    probeOutputChannels.orElse(IntStream.range(0, probeTypes.size())
+                            .boxed()
+                            .collect(toImmutableList())),
+                    probeJoinChannel,
+                    probeHashChannel,
+                    joinType));
             return operatorFactoryFactory.createHashJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, joinType);
         }
         catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
@@ -99,9 +109,10 @@ public class JoinProbeCompiler
         }
     }
 
-    public HashJoinOperatorFactoryFactory internalCompileJoinOperatorFactory(List<Type> types, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    @VisibleForTesting
+    public HashJoinOperatorFactoryFactory internalCompileJoinOperatorFactory(List<Type> types, List<Integer> probeOutputChannels, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        Class<? extends JoinProbe> joinProbeClass = compileJoinProbe(types, probeJoinChannel, probeHashChannel);
+        Class<? extends JoinProbe> joinProbeClass = compileJoinProbe(types, probeOutputChannels, probeJoinChannel, probeHashChannel);
 
         ClassDefinition classDefinition = new ClassDefinition(
                 a(PUBLIC, FINAL),
@@ -128,7 +139,7 @@ public class JoinProbeCompiler
         JoinProbeFactory joinProbeFactory;
         if (probeJoinChannel.isEmpty()) {
             // see comment in PagesIndex#createLookupSource
-            joinProbeFactory = new SimpleJoinProbe.SimpleJoinProbeFactory(types, probeJoinChannel, probeHashChannel);
+            joinProbeFactory = new SimpleJoinProbe.SimpleJoinProbeFactory(types, probeOutputChannels, probeJoinChannel, probeHashChannel);
         }
         else {
             Class<? extends JoinProbeFactory> joinProbeFactoryClass = defineClass(classDefinition, JoinProbeFactory.class, classLoader);
@@ -150,12 +161,12 @@ public class JoinProbeCompiler
     }
 
     @VisibleForTesting
-    public JoinProbeFactory internalCompileJoinProbe(List<Type> types, List<Integer> probeChannels, Optional<Integer> probeHashChannel)
+    public JoinProbeFactory internalCompileJoinProbe(List<Type> types, List<Integer> probeOutputChannels, List<Integer> probeChannels, Optional<Integer> probeHashChannel)
     {
-        return new ReflectionJoinProbeFactory(compileJoinProbe(types, probeChannels, probeHashChannel));
+        return new ReflectionJoinProbeFactory(compileJoinProbe(types, probeOutputChannels, probeChannels, probeHashChannel));
     }
 
-    private Class<? extends JoinProbe> compileJoinProbe(List<Type> types, List<Integer> probeChannels, Optional<Integer> probeHashChannel)
+    private Class<? extends JoinProbe> compileJoinProbe(List<Type> types, List<Integer> probeOutputChannels, List<Integer> probeChannels, Optional<Integer> probeHashChannel)
     {
         CallSiteBinder callSiteBinder = new CallSiteBinder();
 
@@ -185,8 +196,8 @@ public class JoinProbeCompiler
         FieldDefinition probeHashBlockField = classDefinition.declareField(a(PRIVATE, FINAL), "probeHashBlock", Block.class);
 
         generateConstructor(classDefinition, probeChannels, probeHashChannel, lookupSourceField, blockFields, probeBlockFields, probeBlocksArrayField, probePageField, pageField, probeHashBlockField, positionField, positionCountField);
-        generateGetChannelCountMethod(classDefinition, blockFields.size());
-        generateAppendToMethod(classDefinition, callSiteBinder, types, blockFields, positionField);
+        generateGetChannelCountMethod(classDefinition, probeOutputChannels.size());
+        generateAppendToMethod(classDefinition, callSiteBinder, types, probeOutputChannels, blockFields, positionField);
         generateAdvanceNextPosition(classDefinition, positionField, positionCountField);
         generateGetCurrentJoinPosition(classDefinition, callSiteBinder, lookupSourceField, probePageField, pageField, probeHashChannel, probeHashBlockField, positionField);
         generateCurrentRowContainsNull(classDefinition, probeBlockFields, positionField);
@@ -281,7 +292,7 @@ public class JoinProbeCompiler
     {
         classDefinition.declareMethod(
                 a(PUBLIC),
-                "getChannelCount",
+                "getOutputChannelCount",
                 type(int.class))
                 .getBody()
                 .push(channelCount)
@@ -291,7 +302,9 @@ public class JoinProbeCompiler
     private void generateAppendToMethod(
             ClassDefinition classDefinition,
             CallSiteBinder callSiteBinder,
-            List<Type> types, List<FieldDefinition> blockFields,
+            List<Type> types,
+            List<Integer> probeOutputChannels,
+            List<FieldDefinition> blockFields,
             FieldDefinition positionField)
     {
         Parameter pageBuilder = arg("pageBuilder", PageBuilder.class);
@@ -302,14 +315,15 @@ public class JoinProbeCompiler
                 pageBuilder);
 
         Variable thisVariable = method.getThis();
-        for (int index = 0; index < blockFields.size(); index++) {
-            Type type = types.get(index);
+        int pageBuilderOutputChannel = 0;
+        for (int outputChannel : probeOutputChannels) {
+            Type type = types.get(outputChannel);
             method.getBody()
-                    .comment("%s.appendTo(block_%s, position, pageBuilder.getBlockBuilder(%s));", type.getClass(), index, index)
+                    .comment("%s.appendTo(block_%s, position, pageBuilder.getBlockBuilder(%s));", type.getClass(), outputChannel, pageBuilderOutputChannel)
                     .append(constantType(callSiteBinder, type).invoke("appendTo", void.class,
-                            thisVariable.getField(blockFields.get(index)),
+                            thisVariable.getField(blockFields.get(outputChannel)),
                             thisVariable.getField(positionField),
-                            pageBuilder.invoke("getBlockBuilder", BlockBuilder.class, constantInt(index))));
+                            pageBuilder.invoke("getBlockBuilder", BlockBuilder.class, constantInt(pageBuilderOutputChannel++))));
         }
         method.getBody()
                 .ret();
@@ -470,17 +484,20 @@ public class JoinProbeCompiler
     private static final class JoinOperatorCacheKey
     {
         private final List<Type> types;
+        private final List<Integer> probeOutputChannels;
         private final List<Integer> probeChannels;
         private final JoinType joinType;
         private final Optional<Integer> probeHashChannel;
 
         private JoinOperatorCacheKey(List<? extends Type> types,
+                List<Integer> probeOutputChannels,
                 List<Integer> probeChannels,
                 Optional<Integer> probeHashChannel,
                 JoinType joinType)
         {
             this.probeHashChannel = probeHashChannel;
             this.types = ImmutableList.copyOf(types);
+            this.probeOutputChannels = ImmutableList.copyOf(probeOutputChannels);
             this.probeChannels = ImmutableList.copyOf(probeChannels);
             this.joinType = joinType;
         }
@@ -488,6 +505,11 @@ public class JoinProbeCompiler
         private List<Type> getTypes()
         {
             return types;
+        }
+
+        private List<Integer> getProbeOutputChannels()
+        {
+            return probeOutputChannels;
         }
 
         private List<Integer> getProbeChannels()
@@ -503,7 +525,7 @@ public class JoinProbeCompiler
         @Override
         public int hashCode()
         {
-            return Objects.hash(types, probeChannels, joinType);
+            return Objects.hash(types, probeOutputChannels, probeChannels, joinType);
         }
 
         @Override
@@ -517,6 +539,7 @@ public class JoinProbeCompiler
             }
             JoinOperatorCacheKey other = (JoinOperatorCacheKey) obj;
             return Objects.equals(this.types, other.types) &&
+                    Objects.equals(this.probeOutputChannels, other.probeOutputChannels) &&
                     Objects.equals(this.probeChannels, other.probeChannels) &&
                     Objects.equals(this.probeHashChannel, other.probeHashChannel) &&
                     Objects.equals(this.joinType, other.joinType);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1388,10 +1388,10 @@ public class LocalExecutionPlanner
             OperatorFactory lookupJoinOperatorFactory;
             switch (node.getType()) {
                 case INNER:
-                    lookupJoinOperatorFactory = LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel, false);
+                    lookupJoinOperatorFactory = LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel);
                     break;
                 case SOURCE_OUTER:
-                    lookupJoinOperatorFactory = LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel, false);
+                    lookupJoinOperatorFactory = LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel);
                     break;
                 default:
                     throw new AssertionError("Unknown type: " + node.getType());
@@ -1566,13 +1566,13 @@ public class LocalExecutionPlanner
 
             switch (node.getType()) {
                 case INNER:
-                    return LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, node.getFilter().isPresent());
+                    return LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel);
                 case LEFT:
-                    return LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, node.getFilter().isPresent());
+                    return LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel);
                 case RIGHT:
-                    return LookupJoinOperators.lookupOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, node.getFilter().isPresent());
+                    return LookupJoinOperators.lookupOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel);
                 case FULL:
-                    return LookupJoinOperators.fullOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, node.getFilter().isPresent());
+                    return LookupJoinOperators.fullOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel);
                 default:
                     throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1388,10 +1388,10 @@ public class LocalExecutionPlanner
             OperatorFactory lookupJoinOperatorFactory;
             switch (node.getType()) {
                 case INNER:
-                    lookupJoinOperatorFactory = LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel);
+                    lookupJoinOperatorFactory = LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel, Optional.empty());
                     break;
                 case SOURCE_OUTER:
-                    lookupJoinOperatorFactory = LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel);
+                    lookupJoinOperatorFactory = LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel, Optional.empty());
                     break;
                 default:
                     throw new AssertionError("Unknown type: " + node.getType());
@@ -1495,6 +1495,10 @@ public class LocalExecutionPlanner
         {
             LocalExecutionPlanContext buildContext = context.createSubContext();
             PhysicalOperation buildSource = buildNode.accept(this, buildContext);
+            List<Symbol> buildOutputSymbols = node.getOutputSymbols().stream()
+                    .filter(symbol -> node.getRight().getOutputSymbols().contains(symbol))
+                    .collect(toImmutableList());
+            List<Integer> buildOutputChannels = ImmutableList.copyOf(getChannelsForSymbols(buildOutputSymbols, buildSource.getLayout()));
             List<Integer> buildChannels = ImmutableList.copyOf(getChannelsForSymbols(buildSymbols, buildSource.getLayout()));
             Optional<Integer> buildHashChannel = buildHashSymbol.map(channelGetter(buildSource));
 
@@ -1505,6 +1509,7 @@ public class LocalExecutionPlanner
                     buildContext.getNextOperatorId(),
                     node.getId(),
                     buildSource.getTypes(),
+                    buildOutputChannels,
                     buildSource.getLayout(),
                     buildChannels,
                     buildHashChannel,
@@ -1561,18 +1566,22 @@ public class LocalExecutionPlanner
                 LocalExecutionPlanContext context)
         {
             List<Type> probeTypes = probeSource.getTypes();
+            List<Symbol> probeOutputSymbols = node.getOutputSymbols().stream()
+                    .filter(symbol -> node.getLeft().getOutputSymbols().contains(symbol))
+                    .collect(toImmutableList());
+            List<Integer> probeOutputChannels = ImmutableList.copyOf(getChannelsForSymbols(probeOutputSymbols, probeSource.getLayout()));
             List<Integer> probeJoinChannels = ImmutableList.copyOf(getChannelsForSymbols(probeSymbols, probeSource.getLayout()));
             Optional<Integer> probeHashChannel = probeHashSymbol.map(channelGetter(probeSource));
 
             switch (node.getType()) {
                 case INNER:
-                    return LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel);
+                    return LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels));
                 case LEFT:
-                    return LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel);
+                    return LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels));
                 case RIGHT:
-                    return LookupJoinOperators.lookupOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel);
+                    return LookupJoinOperators.lookupOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels));
                 case FULL:
-                    return LookupJoinOperators.fullOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel);
+                    return LookupJoinOperators.fullOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels));
                 default:
                     throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -277,6 +277,10 @@ class RelationPlanner
                 leftPlanBuilder.getRoot(),
                 rightPlanBuilder.getRoot(),
                 equiClauses.build(),
+                ImmutableList.<Symbol>builder()
+                        .addAll(leftPlanBuilder.getRoot().getOutputSymbols())
+                        .addAll(rightPlanBuilder.getRoot().getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -309,6 +313,10 @@ class RelationPlanner
                     leftPlanBuilder.getRoot(),
                     rightPlanBuilder.getRoot(),
                     equiClauses.build(),
+                    ImmutableList.<Symbol>builder()
+                            .addAll(leftPlanBuilder.getRoot().getOutputSymbols())
+                            .addAll(rightPlanBuilder.getRoot().getOutputSymbols())
+                            .build(),
                     Optional.of(rewritenFilterCondition),
                     Optional.empty(),
                     Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -833,6 +833,10 @@ public class AddExchanges
                     left.getNode(),
                     right.getNode(),
                     node.getCriteria(),
+                    ImmutableList.<Symbol>builder()
+                            .addAll(left.getNode().getOutputSymbols())
+                            .addAll(right.getNode().getOutputSymbols())
+                            .build(),
                     node.getFilter(),
                     node.getLeftHashSymbol(),
                     node.getRightHashSymbol());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -179,7 +179,7 @@ public class IndexJoinOptimizer
             }
 
             if (leftRewritten != node.getLeft() || rightRewritten != node.getRight()) {
-                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
             }
             return node;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -400,7 +400,12 @@ public class PredicatePushDown
                 leftSource = new ProjectNode(idAllocator.getNextId(), leftSource, leftProjections.build());
                 rightSource = new ProjectNode(idAllocator.getNextId(), rightSource, rightProjections.build());
 
-                output = new JoinNode(node.getId(), node.getType(), leftSource, rightSource, joinConditionBuilder.build(), newJoinFilter, node.getLeftHashSymbol(), node.getRightHashSymbol());
+                List<Symbol> outputSymbols = ImmutableList.<Symbol>builder()
+                        .addAll(leftSource.getOutputSymbols())
+                        .addAll(rightSource.getOutputSymbols())
+                        .build();
+
+                output = new JoinNode(node.getId(), node.getType(), leftSource, rightSource, joinConditionBuilder.build(), outputSymbols, newJoinFilter, node.getLeftHashSymbol(), node.getRightHashSymbol());
             }
             if (!postJoinPredicate.equals(BooleanLiteral.TRUE_LITERAL)) {
                 output = new FilterNode(idAllocator.getNextId(), output, postJoinPredicate);
@@ -696,11 +701,11 @@ public class PredicatePushDown
                     return node;
                 }
                 if (canConvertToLeftJoin && canConvertToRightJoin) {
-                    return new JoinNode(node.getId(), INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+                    return new JoinNode(node.getId(), INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
                 }
                 else {
                     return new JoinNode(node.getId(), canConvertToLeftJoin ? LEFT : RIGHT,
-                            node.getLeft(), node.getRight(), node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+                            node.getLeft(), node.getRight(), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
                 }
             }
 
@@ -708,7 +713,7 @@ public class PredicatePushDown
                     node.getType() == JoinNode.Type.RIGHT && !canConvertOuterToInner(node.getLeft().getOutputSymbols(), inheritedPredicate)) {
                 return node;
             }
-            return new JoinNode(node.getId(), JoinNode.Type.INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+            return new JoinNode(node.getId(), JoinNode.Type.INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
         }
 
         private boolean canConvertOuterToInner(List<Symbol> innerSymbolsForOuterJoin, Expression inheritedPredicate)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -74,6 +74,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static com.google.common.base.Preconditions.checkState;
@@ -197,7 +198,23 @@ public class PruneUnreferencedOutputs
             PlanNode left = context.rewrite(node.getLeft(), leftInputs);
             PlanNode right = context.rewrite(node.getRight(), rightInputs);
 
-            return new JoinNode(node.getId(), node.getType(), left, right, node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+            List<Symbol> outputSymbols;
+            if (node.getCriteria().isEmpty() && !node.getFilter().isPresent() && node.getType() == INNER) {
+                // do not prune nested joins output since it is not supported
+                outputSymbols = ImmutableList.<Symbol>builder()
+                        .addAll(left.getOutputSymbols())
+                        .addAll(right.getOutputSymbols())
+                        .build();
+            }
+            else {
+                Set<Symbol> seenSymbol = new HashSet<>();
+                outputSymbols = node.getOutputSymbols().stream()
+                        .filter(symbol -> context.get().contains(symbol))
+                        .filter(seenSymbol::add)
+                        .collect(toImmutableList());
+            }
+
+            return new JoinNode(node.getId(), node.getType(), left, right, node.getCriteria(), outputSymbols, node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
@@ -186,6 +186,10 @@ public class TransformCorrelatedScalarAggregationToJoin
                     inputWithUniqueColumns,
                     scalarAggregationSource,
                     ImmutableList.of(),
+                    ImmutableList.<Symbol>builder()
+                            .addAll(inputWithUniqueColumns.getOutputSymbols())
+                            .addAll(scalarAggregationSource.getOutputSymbols())
+                            .build(),
                     joinExpression,
                     Optional.empty(),
                     Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedScalarToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedScalarToJoin.java
@@ -60,6 +60,10 @@ public class TransformUncorrelatedScalarToJoin
                         rewrittenNode.getInput(),
                         rewrittenNode.getSubquery(),
                         ImmutableList.of(),
+                        ImmutableList.<Symbol>builder()
+                                .addAll(rewrittenNode.getInput().getOutputSymbols())
+                                .addAll(rewrittenNode.getSubquery().getOutputSymbols())
+                                .build(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -470,7 +470,16 @@ public class UnaliasSymbolReferences
             PlanNode left = context.rewrite(node.getLeft());
             PlanNode right = context.rewrite(node.getRight());
 
-            return new JoinNode(node.getId(), node.getType(), left, right, canonicalizeJoinCriteria(node.getCriteria()), node.getFilter().map(this::canonicalize), canonicalize(node.getLeftHashSymbol()), canonicalize(node.getRightHashSymbol()));
+            return new JoinNode(
+                    node.getId(),
+                    node.getType(),
+                    left,
+                    right,
+                    canonicalizeJoinCriteria(node.getCriteria()),
+                    canonicalize(node.getOutputSymbols()),
+                    node.getFilter().map(this::canonicalize),
+                    canonicalize(node.getLeftHashSymbol()),
+                    canonicalize(node.getRightHashSymbol()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
@@ -134,7 +134,7 @@ public class ChildReplacer
     public PlanNode visitJoin(JoinNode node, List<PlanNode> newChildren)
     {
         checkArgument(newChildren.size() == 2, "expected newChildren to contain 2 nodes");
-        return new JoinNode(node.getId(), node.getType(), newChildren.get(0), newChildren.get(1), node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+        return new JoinNode(node.getId(), node.getType(), newChildren.get(0), newChildren.get(1), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -165,10 +165,7 @@ public class JoinNode
     @JsonProperty("outputSymbols")
     public List<Symbol> getOutputSymbols()
     {
-        return ImmutableList.<Symbol>builder()
-                .addAll(left.getOutputSymbols())
-                .addAll(right.getOutputSymbols())
-                .build();
+        return outputSymbols;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -36,6 +36,7 @@ public class JoinNode
     private final PlanNode left;
     private final PlanNode right;
     private final List<EquiJoinClause> criteria;
+    private final List<Symbol> outputSymbols;
     private final Optional<Expression> filter;
     private final Optional<Symbol> leftHashSymbol;
     private final Optional<Symbol> rightHashSymbol;
@@ -46,6 +47,7 @@ public class JoinNode
             @JsonProperty("left") PlanNode left,
             @JsonProperty("right") PlanNode right,
             @JsonProperty("criteria") List<EquiJoinClause> criteria,
+            @JsonProperty("outputSymbols") List<Symbol> outputSymbols,
             @JsonProperty("filter") Optional<Expression> filter,
             @JsonProperty("leftHashSymbol") Optional<Symbol> leftHashSymbol,
             @JsonProperty("rightHashSymbol") Optional<Symbol> rightHashSymbol)
@@ -55,6 +57,7 @@ public class JoinNode
         requireNonNull(left, "left is null");
         requireNonNull(right, "right is null");
         requireNonNull(criteria, "criteria is null");
+        requireNonNull(outputSymbols, "outputSymbols is null");
         requireNonNull(filter, "filter is null");
         requireNonNull(leftHashSymbol, "leftHashSymbol is null");
         requireNonNull(rightHashSymbol, "rightHashSymbol is null");
@@ -63,6 +66,7 @@ public class JoinNode
         this.left = left;
         this.right = right;
         this.criteria = ImmutableList.copyOf(criteria);
+        this.outputSymbols = ImmutableList.copyOf(outputSymbols);
         this.filter = filter;
         this.leftHashSymbol = leftHashSymbol;
         this.rightHashSymbol = rightHashSymbol;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -64,12 +64,16 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static com.facebook.presto.sql.planner.optimizations.IndexJoinOptimizer.IndexKeyTracer;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Ensures that all dependencies (i.e., symbols in expressions) for a plan node are provided by its source nodes
@@ -337,6 +341,10 @@ public final class ValidateDependenciesChecker
 
             Set<Symbol> leftInputs = createInputs(node.getLeft(), boundSymbols);
             Set<Symbol> rightInputs = createInputs(node.getRight(), boundSymbols);
+            Set<Symbol> allInputs = ImmutableSet.<Symbol>builder()
+                    .addAll(leftInputs)
+                    .addAll(rightInputs)
+                    .build();
 
             for (JoinNode.EquiJoinClause clause : node.getCriteria()) {
                 checkArgument(leftInputs.contains(clause.getLeft()), "Symbol from join clause (%s) not in left source (%s)", clause.getLeft(), node.getLeft().getOutputSymbols());
@@ -345,16 +353,34 @@ public final class ValidateDependenciesChecker
 
             node.getFilter().ifPresent(predicate -> {
                 Set<Symbol> predicateSymbols = DependencyExtractor.extractUnique(predicate);
-                Set<Symbol> allInputs = ImmutableSet.<Symbol>builder()
-                        .addAll(leftInputs)
-                        .addAll(rightInputs)
-                        .build();
                 checkArgument(
                         allInputs.containsAll(predicateSymbols),
                         "Symbol from filter (%s) not in sources (%s)",
-                        allInputs,
-                        predicateSymbols);
+                        predicateSymbols,
+                        allInputs);
             });
+
+            checkDependencies(allInputs, node.getOutputSymbols(), "Symbol from join output (%s) not in sources (%s)", node.getOutputSymbols(), allInputs);
+
+            List<Integer> rightSymbolIndexes = node.getRight().getOutputSymbols().stream()
+                    .filter(symbol -> node.getOutputSymbols().contains(symbol))
+                    .map(symbol -> node.getOutputSymbols().indexOf(symbol))
+                    .collect(toImmutableList());
+
+            boolean allLeftBeforeRight = node.getLeft().getOutputSymbols().stream()
+                    .filter(symbol -> node.getOutputSymbols().contains(symbol))
+                    .map(symbol -> node.getOutputSymbols().indexOf(symbol))
+                    .allMatch(leftIndex -> rightSymbolIndexes.stream()
+                            .allMatch(rightIndex -> rightIndex > leftIndex));
+            checkState(allLeftBeforeRight, "Not all left output symbols are before right output symbols");
+
+            if (node.getCriteria().isEmpty() && !node.getFilter().isPresent() && node.getType() == INNER) {
+                List<Symbol> allInputsOrdered = ImmutableList.<Symbol>builder()
+                        .addAll(node.getLeft().getOutputSymbols())
+                        .addAll(node.getRight().getOutputSymbols())
+                        .build();
+                checkState(allInputsOrdered.equals(node.getOutputSymbols()), "Outputs symbols (%s) for cross join do not match ordered input symbols (%s)", node.getOutputSymbols(), allInputsOrdered);
+            }
 
             return null;
         }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -195,6 +195,7 @@ public class TestPhasedExecutionSchedule
                 tableScan,
                 new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of()),
                 ImmutableList.of(),
+                tableScan.getOutputSymbols(),
                 Optional.<Expression>empty(),
                 Optional.<Symbol>empty(),
                 Optional.<Symbol>empty());
@@ -209,6 +210,7 @@ public class TestPhasedExecutionSchedule
                 joinType,
                 new RemoteSourceNode(new PlanNodeId("probe_id"), probeFragment.getId(), ImmutableList.of()),
                 new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of()),
+                ImmutableList.of(),
                 ImmutableList.of(),
                 Optional.empty(),
                 Optional.<Symbol>empty(),

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -440,6 +440,7 @@ public class TestSourcePartitionedScheduler
                                 null),
                         new RemoteSourceNode(new PlanNodeId("remote_id"), new PlanFragmentId("plan_fragment_id"), ImmutableList.of()),
                         ImmutableList.of(),
+                        ImmutableList.of(symbol),
                         Optional.empty(),
                         Optional.<Symbol>empty(),
                         Optional.<Symbol>empty()),

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -43,13 +43,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
-import java.util.stream.IntStream;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.Threads.checkNotSameThreadExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
@@ -89,7 +87,6 @@ public class BenchmarkHashBuildAndJoinOperators
         protected Optional<Integer> hashChannel;
         protected List<Type> types;
         protected List<Integer> hashChannels;
-        protected LookupSourceFactory lookupSourceFactory;
 
         @Setup
         public void setup()
@@ -110,8 +107,6 @@ public class BenchmarkHashBuildAndJoinOperators
             executor = newCachedThreadPool(daemonThreadsNamed("test-%s"));
 
             initializeBuildPages();
-
-            lookupSourceFactory = new BenchmarkHashBuildAndJoinOperators().benchmarkBuildHash(this);
         }
 
         public TaskContext createTaskContext()
@@ -135,11 +130,6 @@ public class BenchmarkHashBuildAndJoinOperators
         public List<Type> getTypes()
         {
             return types;
-        }
-
-        public LookupSourceFactory getLookupSourceFactory()
-        {
-            return lookupSourceFactory;
         }
 
         public List<Page> getBuildPages()
@@ -174,18 +164,50 @@ public class BenchmarkHashBuildAndJoinOperators
         @Param({"0.1", "1", "2"})
         protected double matchRate;
 
+        @Param({"bigint", "all"})
+        protected String outputColumns;
+
         protected List<Page> probePages;
+        protected List<Integer> outputChannels;
+
+        protected LookupSourceFactory lookupSourceFactory;
 
         @Setup
         public void setup()
         {
             super.setup();
+
+            switch (outputColumns) {
+                case "varchar":
+                    outputChannels = Ints.asList(0);
+                    break;
+                case "bigint":
+                    outputChannels = Ints.asList(1);
+                    break;
+                case "all":
+                    outputChannels = Ints.asList(0, 1, 2);
+                    break;
+                default:
+                    throw new UnsupportedOperationException(format("Unknown outputColumns value [%s]", hashColumns));
+            }
+
+            lookupSourceFactory = new BenchmarkHashBuildAndJoinOperators().benchmarkBuildHash(this, outputChannels);
             initializeProbePages();
+        }
+
+        public LookupSourceFactory getLookupSourceFactory()
+        {
+            return lookupSourceFactory;
         }
 
         public List<Page> getProbePages()
         {
             return probePages;
+        }
+
+        public List<Integer> getOutputChannels()
+        {
+            return outputChannels;
         }
 
         protected void initializeProbePages()
@@ -239,13 +261,18 @@ public class BenchmarkHashBuildAndJoinOperators
     @Benchmark
     public LookupSourceFactory benchmarkBuildHash(BuildContext buildContext)
     {
+        return benchmarkBuildHash(buildContext, ImmutableList.of(0, 1, 2));
+    }
+
+    private LookupSourceFactory benchmarkBuildHash(BuildContext buildContext, List<Integer> outputChannels)
+    {
         DriverContext driverContext = buildContext.createTaskContext().addPipelineContext(true, true).addDriverContext();
 
         HashBuilderOperatorFactory hashBuilderOperatorFactory = new HashBuilderOperatorFactory(
                 HASH_BUILD_OPERATOR_ID,
                 TEST_PLAN_NODE_ID,
                 buildContext.getTypes(),
-                rangeList(buildContext.getTypes().size()),
+                outputChannels,
                 ImmutableMap.of(),
                 buildContext.getHashChannels(),
                 buildContext.getHashChannel(),
@@ -279,7 +306,7 @@ public class BenchmarkHashBuildAndJoinOperators
                 joinContext.getTypes(),
                 joinContext.getHashChannels(),
                 joinContext.getHashChannel(),
-                Optional.of(rangeList(joinContext.getTypes().size())));
+                Optional.of(joinContext.getOutputChannels()));
 
         DriverContext driverContext = joinContext.createTaskContext().addPipelineContext(true, true).addDriverContext();
         Operator joinOperator = joinOperatorFactory.createOperator(driverContext);
@@ -307,13 +334,6 @@ public class BenchmarkHashBuildAndJoinOperators
         }
 
         return outputPages.build();
-    }
-
-    private List<Integer> rangeList(int endExclusive)
-    {
-        return IntStream.range(0, endExclusive)
-                .boxed()
-                .collect(toImmutableList());
     }
 
     public static void main(String[] args)

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -275,8 +275,7 @@ public class BenchmarkHashBuildAndJoinOperators
                 lookupSourceFactory,
                 joinContext.getTypes(),
                 joinContext.getHashChannels(),
-                joinContext.getHashChannel(),
-                false);
+                joinContext.getHashChannel());
 
         DriverContext driverContext = joinContext.createTaskContext().addPipelineContext(true, true).addDriverContext();
         Operator joinOperator = joinOperatorFactory.createOperator(driverContext);

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -43,11 +43,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.Threads.checkNotSameThreadExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
@@ -243,6 +245,7 @@ public class BenchmarkHashBuildAndJoinOperators
                 HASH_BUILD_OPERATOR_ID,
                 TEST_PLAN_NODE_ID,
                 buildContext.getTypes(),
+                rangeList(buildContext.getTypes().size()),
                 ImmutableMap.of(),
                 buildContext.getHashChannels(),
                 buildContext.getHashChannel(),
@@ -275,7 +278,8 @@ public class BenchmarkHashBuildAndJoinOperators
                 lookupSourceFactory,
                 joinContext.getTypes(),
                 joinContext.getHashChannels(),
-                joinContext.getHashChannel());
+                joinContext.getHashChannel(),
+                Optional.of(rangeList(joinContext.getTypes().size())));
 
         DriverContext driverContext = joinContext.createTaskContext().addPipelineContext(true, true).addDriverContext();
         Operator joinOperator = joinOperatorFactory.createOperator(driverContext);
@@ -303,6 +307,13 @@ public class BenchmarkHashBuildAndJoinOperators
         }
 
         return outputPages.build();
+    }
+
+    private List<Integer> rangeList(int endExclusive)
+    {
+        return IntStream.range(0, endExclusive)
+                .boxed()
+                .collect(toImmutableList());
     }
 
     public static void main(String[] args)

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -257,8 +257,8 @@ public class BenchmarkHashBuildAndJoinOperators
         }
         operator.finish();
 
-        if (!operator.isFinished()) {
-            throw new AssertionError("Expected hash build operator to be finished");
+        if (!hashBuilderOperatorFactory.getLookupSourceFactory().createLookupSource().isDone()) {
+            throw new AssertionError("Expected lookup source to be done");
         }
 
         return hashBuilderOperatorFactory.getLookupSourceFactory();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -109,8 +109,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false
+                probePages.getHashChannel()
         );
 
         // expected
@@ -160,8 +159,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false
+                probePages.getHashChannel()
         );
 
         // expected
@@ -204,8 +202,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false
+                probePages.getHashChannel()
         );
 
         // expected
@@ -249,8 +246,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false
+                probePages.getHashChannel()
         );
 
         // expected
@@ -287,8 +283,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false);
+                probePages.getHashChannel());
 
         // expected
         // expected
@@ -340,8 +335,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                true);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -395,8 +389,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -443,8 +436,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                true);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -488,8 +480,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -536,8 +527,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                true);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -580,8 +570,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
@@ -629,8 +618,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                true);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
@@ -49,6 +50,7 @@ import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEqual
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.collect.Iterables.concat;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
@@ -109,7 +111,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel()
+                probePages.getHashChannel(),
+                Optional.empty()
         );
 
         // expected
@@ -159,7 +162,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel()
+                probePages.getHashChannel(),
+                Optional.empty()
         );
 
         // expected
@@ -202,7 +206,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel()
+                probePages.getHashChannel(),
+                Optional.empty()
         );
 
         // expected
@@ -246,7 +251,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel()
+                probePages.getHashChannel(),
+                Optional.empty()
         );
 
         // expected
@@ -283,7 +289,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         // expected
@@ -335,7 +342,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -389,7 +397,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -436,7 +445,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -480,7 +490,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -527,7 +538,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -570,7 +582,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
@@ -618,7 +631,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
@@ -690,6 +704,7 @@ public class TestHashJoinOperator
                 1,
                 new PlanNodeId("build"),
                 buildPages.getTypes(),
+                rangeList(buildPages.getTypes().size()),
                 ImmutableMap.of(),
                 hashChannels,
                 buildPages.getHashChannel(),
@@ -715,6 +730,13 @@ public class TestHashJoinOperator
         }
 
         return buildOperatorFactory.getLookupSourceFactory();
+    }
+
+    private static List<Integer> rangeList(int endExclusive)
+    {
+        return IntStream.range(0, endExclusive)
+                .boxed()
+                .collect(toImmutableList());
     }
 
     private static class TestInternalJoinFilterFunction

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
@@ -180,7 +180,7 @@ public class TestJoinCompiler
         PagesHashStrategyFactory pagesHashStrategyFactory = joinCompiler.compilePagesHashStrategyFactory(types, joinChannels);
         PagesHashStrategy hashStrategy = pagesHashStrategyFactory.createPagesHashStrategy(channels, hashChannel);
         // todo add tests for filter function
-        PagesHashStrategy expectedHashStrategy = new SimplePagesHashStrategy(types, channels, joinChannels, hashChannel);
+        PagesHashStrategy expectedHashStrategy = new SimplePagesHashStrategy(types, ImmutableList.of(0, 1, 2, 3, 4, 5), channels, joinChannels, hashChannel);
 
         // verify channel count
         assertEquals(hashStrategy.getChannelCount(), types.size());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -447,6 +447,10 @@ public class TestEffectivePredicateExtractor
                                 equals(DE, EE),
                                 lessThan(FE, bigintLiteral(100)))),
                 criteria,
+                ImmutableList.<Symbol>builder()
+                    .addAll(leftScan.getOutputSymbols())
+                    .addAll(rightScan.getOutputSymbols())
+                    .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -505,6 +509,10 @@ public class TestEffectivePredicateExtractor
                                 equals(DE, EE),
                                 lessThan(FE, bigintLiteral(100)))),
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(leftScan.getOutputSymbols())
+                        .addAll(rightScan.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -557,6 +565,10 @@ public class TestEffectivePredicateExtractor
                                 lessThan(CE, bigintLiteral(10)))),
                 filter(rightScan, FALSE_LITERAL),
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(leftScan.getOutputSymbols())
+                        .addAll(rightScan.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -612,6 +624,10 @@ public class TestEffectivePredicateExtractor
                                 equals(DE, EE),
                                 lessThan(FE, bigintLiteral(100)))),
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(leftScan.getOutputSymbols())
+                        .addAll(rightScan.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -664,6 +680,10 @@ public class TestEffectivePredicateExtractor
                                 equals(DE, EE),
                                 lessThan(FE, bigintLiteral(100)))),
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(leftScan.getOutputSymbols())
+                        .addAll(rightScan.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());


### PR DESCRIPTION
FYI: @martint @dain 

Partial micro benchmark results:

```
    Partial results:
    Benchmark                                             (buildHashEnabled)  (hashColumns)  (matchRate)  (outputColumns)  Mode  Cnt    Score   Error  Units
    BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true         bigint            2          varchar  avgt   60  157,080 ± 3,820  ms/op
    BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true         bigint            2           bigint  avgt   60   90,912 ± 1,954  ms/op
    BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true         bigint            2              all  avgt   60  203,645 ± 3,665  ms/op
```

`all` is a baseline. When you require just some columns the join time reduces significantly.
