### PR TITLE
Feature prune join output

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
@@ -74,7 +74,7 @@ public class HashBuildAndJoinBenchmark
         }
 
         // hash build
-        HashBuilderOperatorFactory hashBuilder = new HashBuilderOperatorFactory(2, new PlanNodeId("test"), source.getTypes(), ImmutableMap.of(), Ints.asList(0), hashChannel, false, Optional.empty(), 1_500_000, 1);
+        HashBuilderOperatorFactory hashBuilder = new HashBuilderOperatorFactory(2, new PlanNodeId("test"), source.getTypes(), ImmutableList.of(0, 1), ImmutableMap.of(), Ints.asList(0), hashChannel, false, Optional.empty(), 1_500_000, 1);
         driversBuilder.add(hashBuilder);
         DriverFactory hashBuildDriverFactory = new DriverFactory(true, false, driversBuilder.build(), OptionalInt.empty());
         Driver hashBuildDriver = hashBuildDriverFactory.createDriver(taskContext.addPipelineContext(true, false).addDriverContext());
@@ -91,7 +91,7 @@ public class HashBuildAndJoinBenchmark
             hashChannel = Optional.of(2);
         }
 
-        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceFactory(), source.getTypes(), Ints.asList(0), hashChannel);
+        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceFactory(), source.getTypes(), Ints.asList(0), hashChannel, Optional.empty());
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test"), joinOperator.getTypes()));
         DriverFactory joinDriverFactory = new DriverFactory(true, true, joinDriversBuilder.build(), OptionalInt.empty());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
@@ -91,7 +91,7 @@ public class HashBuildAndJoinBenchmark
             hashChannel = Optional.of(2);
         }
 
-        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceFactory(), source.getTypes(), Ints.asList(0), hashChannel, false);
+        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceFactory(), source.getTypes(), Ints.asList(0), hashChannel);
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test"), joinOperator.getTypes()));
         DriverFactory joinDriverFactory = new DriverFactory(true, true, joinDriversBuilder.build(), OptionalInt.empty());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
@@ -69,8 +69,7 @@ public class HashBuildBenchmark
                 hashBuilder.getLookupSourceFactory(),
                 ImmutableList.of(BIGINT),
                 Ints.asList(0),
-                Optional.empty(),
-                false);
+                Optional.empty());
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test"), joinOperator.getTypes()));
         DriverFactory joinDriverFactory = new DriverFactory(true, true, joinDriversBuilder.build(), OptionalInt.empty());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
@@ -51,6 +51,7 @@ public class HashBuildBenchmark
                 1,
                 new PlanNodeId("test"),
                 ordersTableScan.getTypes(),
+                ImmutableList.of(0, 1),
                 ImmutableMap.of(),
                 Ints.asList(0),
                 Optional.empty(),
@@ -69,6 +70,7 @@ public class HashBuildBenchmark
                 hashBuilder.getLookupSourceFactory(),
                 ImmutableList.of(BIGINT),
                 Ints.asList(0),
+                Optional.empty(),
                 Optional.empty());
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test"), joinOperator.getTypes()));

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
@@ -58,6 +58,7 @@ public class HashJoinBenchmark
                     1,
                     new PlanNodeId("test"),
                     ordersTableScan.getTypes(),
+                    ImmutableList.of(0, 1),
                     ImmutableMap.of(),
                     Ints.asList(0),
                     Optional.empty(),
@@ -76,7 +77,7 @@ public class HashJoinBenchmark
 
         OperatorFactory lineItemTableScan = createTableScanOperator(0, new PlanNodeId("test"), "lineitem", "orderkey", "quantity");
 
-        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(1, new PlanNodeId("test"), lookupSourceFactory, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty());
+        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(1, new PlanNodeId("test"), lookupSourceFactory, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty(), Optional.empty());
 
         NullOutputOperatorFactory output = new NullOutputOperatorFactory(2, new PlanNodeId("test"), joinOperator.getTypes());
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
@@ -76,7 +76,7 @@ public class HashJoinBenchmark
 
         OperatorFactory lineItemTableScan = createTableScanOperator(0, new PlanNodeId("test"), "lineitem", "orderkey", "quantity");
 
-        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(1, new PlanNodeId("test"), lookupSourceFactory, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty(), false);
+        OperatorFactory joinOperator = LookupJoinOperators.innerJoin(1, new PlanNodeId("test"), lookupSourceFactory, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty());
 
         NullOutputOperatorFactory output = new NullOutputOperatorFactory(2, new PlanNodeId("test"), joinOperator.getTypes());
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinProbe.java
@@ -18,7 +18,7 @@ import com.facebook.presto.spi.PageBuilder;
 
 public interface JoinProbe
 {
-    int getChannelCount();
+    int getOutputChannelCount();
 
     boolean advanceNextPosition();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -191,7 +191,7 @@ public class LookupJoinOperator
             probe.appendTo(pageBuilder);
 
             // write build columns
-            lookupSource.appendTo(joinPosition, pageBuilder, probe.getChannelCount());
+            lookupSource.appendTo(joinPosition, pageBuilder, probe.getOutputChannelCount());
 
             // get next join position for this row
             joinPosition = lookupSource.getNextJoinPosition(joinPosition, probe.getPosition(), probe.getPage());
@@ -222,7 +222,7 @@ public class LookupJoinOperator
             probe.appendTo(pageBuilder);
 
             // write nulls into build columns
-            int outputIndex = probe.getChannelCount();
+            int outputIndex = probe.getOutputChannelCount();
             for (int buildChannel = 0; buildChannel < lookupSource.getChannelCount(); buildChannel++) {
                 pageBuilder.getBlockBuilder(outputIndex).appendNull();
                 outputIndex++;

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
@@ -39,7 +39,9 @@ public class LookupJoinOperatorFactory
     private final int operatorId;
     private final PlanNodeId planNodeId;
     private final List<Type> probeTypes;
+    private final List<Type> probeOutputTypes;
     private final List<Type> buildTypes;
+    private final List<Type> buildOutputTypes;
     private final JoinType joinType;
     private final LookupSourceFactory lookupSourceFactory;
     private final JoinProbeFactory joinProbeFactory;
@@ -51,6 +53,7 @@ public class LookupJoinOperatorFactory
             PlanNodeId planNodeId,
             LookupSourceFactory lookupSourceFactory,
             List<Type> probeTypes,
+            List<Type> probeOutputTypes,
             JoinType joinType,
             JoinProbeFactory joinProbeFactory)
     {
@@ -58,7 +61,9 @@ public class LookupJoinOperatorFactory
         this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
         this.lookupSourceFactory = requireNonNull(lookupSourceFactory, "lookupSourceFactory is null");
         this.probeTypes = ImmutableList.copyOf(requireNonNull(probeTypes, "probeTypes is null"));
+        this.probeOutputTypes = ImmutableList.copyOf(requireNonNull(probeOutputTypes, "probeOutputTypes is null"));
         this.buildTypes = ImmutableList.copyOf(lookupSourceFactory.getTypes());
+        this.buildOutputTypes = ImmutableList.copyOf(lookupSourceFactory.getOutputTypes());
         this.joinType = requireNonNull(joinType, "joinType is null");
         this.joinProbeFactory = requireNonNull(joinProbeFactory, "joinProbeFactory is null");
 
@@ -84,7 +89,7 @@ public class LookupJoinOperatorFactory
                 // lookup source may not be finished yet, so add a listener, to free the memory
                 lookupSourceFactory.createLookupSource().addListener(lookupSourceFactory::destroy, directExecutor());
             };
-            this.outerOperatorFactory = Optional.of(new LookupOuterOperatorFactory(operatorId, planNodeId, outerPositionsFuture, probeTypes, buildTypes, onOperatorClose));
+            this.outerOperatorFactory = Optional.of(new LookupOuterOperatorFactory(operatorId, planNodeId, outerPositionsFuture, probeOutputTypes, buildOutputTypes, onOperatorClose));
         }
     }
 
@@ -94,7 +99,9 @@ public class LookupJoinOperatorFactory
         operatorId = other.operatorId;
         planNodeId = other.planNodeId;
         probeTypes = other.probeTypes;
+        probeOutputTypes = other.probeOutputTypes;
         buildTypes = other.buildTypes;
+        buildOutputTypes = other.buildOutputTypes;
         joinType = other.joinType;
         lookupSourceFactory = other.lookupSourceFactory;
         joinProbeFactory = other.joinProbeFactory;
@@ -113,8 +120,8 @@ public class LookupJoinOperatorFactory
     public List<Type> getTypes()
     {
         return ImmutableList.<Type>builder()
-                .addAll(probeTypes)
-                .addAll(buildTypes)
+                .addAll(probeOutputTypes)
+                .addAll(buildOutputTypes)
                 .build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
@@ -39,24 +39,24 @@ public class LookupJoinOperators
 
     private static final JoinProbeCompiler JOIN_PROBE_COMPILER = new JoinProbeCompiler();
 
-    public static OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public static OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, rangeList(probeTypes.size()), JoinType.INNER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.INNER);
     }
 
-    public static OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public static OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, rangeList(probeTypes.size()), JoinType.PROBE_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.PROBE_OUTER);
     }
 
-    public static OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public static OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, rangeList(probeTypes.size()), JoinType.LOOKUP_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.LOOKUP_OUTER);
     }
 
-    public static OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
+    public static OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, rangeList(probeTypes.size()), JoinType.FULL_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.FULL_OUTER);
     }
 
     private static List<Integer> rangeList(int endExclusive)

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
@@ -19,10 +19,14 @@ import com.facebook.presto.sql.planner.plan.PlanNodeId;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 
 public class LookupJoinOperators
 {
-    public enum JoinType {
+    public enum JoinType
+    {
         INNER,
         PROBE_OUTER, // the Probe is the outer side of the join
         LOOKUP_OUTER, // The LookupSource is the outer side of the join
@@ -37,21 +41,28 @@ public class LookupJoinOperators
 
     public static OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.INNER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, rangeList(probeTypes.size()), JoinType.INNER);
     }
 
     public static OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.PROBE_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, rangeList(probeTypes.size()), JoinType.PROBE_OUTER);
     }
 
     public static OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.LOOKUP_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, rangeList(probeTypes.size()), JoinType.LOOKUP_OUTER);
     }
 
     public static OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.FULL_OUTER);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, rangeList(probeTypes.size()), JoinType.FULL_OUTER);
+    }
+
+    private static List<Integer> rangeList(int endExclusive)
+    {
+        return IntStream.range(0, endExclusive)
+                .boxed()
+                .collect(toImmutableList());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
@@ -35,23 +35,23 @@ public class LookupJoinOperators
 
     private static final JoinProbeCompiler JOIN_PROBE_COMPILER = new JoinProbeCompiler();
 
-    public static OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, boolean filterFunctionPresent)
+    public static OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.INNER, filterFunctionPresent);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.INNER);
     }
 
-    public static OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, boolean filterFunctionPresent)
+    public static OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.PROBE_OUTER, filterFunctionPresent);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.PROBE_OUTER);
     }
 
-    public static OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, boolean filterFunctionPresent)
+    public static OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.LOOKUP_OUTER, filterFunctionPresent);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.LOOKUP_OUTER);
     }
 
-    public static OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, boolean filterFunctionPresent)
+    public static OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel)
     {
-        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.FULL_OUTER, filterFunctionPresent);
+        return JOIN_PROBE_COMPILER.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, JoinType.FULL_OUTER);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceFactory.java
@@ -24,6 +24,8 @@ public interface LookupSourceFactory
 {
     List<Type> getTypes();
 
+    List<Type> getOutputTypes();
+
     ListenableFuture<LookupSource> createLookupSource();
 
     Map<Symbol, Integer> getLayout();

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesHashStrategy.java
@@ -19,8 +19,7 @@ import com.facebook.presto.spi.PageBuilder;
 public interface PagesHashStrategy
 {
     /**
-     * Gets the total of the columns held in in this PagesHashStrategy.  This includes both the hashed
-     * and non-hashed columns.
+     * Gets the number of columns appended by this PagesHashStrategy.
      */
     int getChannelCount();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -40,6 +40,7 @@ public final class PartitionedLookupSourceFactory
         implements LookupSourceFactory
 {
     private final List<Type> types;
+    private final List<Type> outputTypes;
     private final Map<Symbol, Integer> layout;
     private final List<Type> hashChannelTypes;
     private final Supplier<LookupSource>[] partitions;
@@ -55,9 +56,10 @@ public final class PartitionedLookupSourceFactory
     @GuardedBy("this")
     private final List<SettableFuture<LookupSource>> lookupSourceFutures = new ArrayList<>();
 
-    public PartitionedLookupSourceFactory(List<Type> types, List<Integer> hashChannels, int partitionCount, Map<Symbol, Integer> layout, boolean outer)
+    public PartitionedLookupSourceFactory(List<Type> types, List<Type> outputTypes, List<Integer> hashChannels, int partitionCount, Map<Symbol, Integer> layout, boolean outer)
     {
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        this.outputTypes = ImmutableList.copyOf(requireNonNull(outputTypes, "outputTypes is null"));
         this.layout = ImmutableMap.copyOf(layout);
         this.partitions = (Supplier<LookupSource>[]) new Supplier<?>[partitionCount];
         this.outer = outer;
@@ -71,6 +73,12 @@ public final class PartitionedLookupSourceFactory
     public List<Type> getTypes()
     {
         return types;
+    }
+
+    @Override
+    public List<Type> getOutputTypes()
+    {
+        return outputTypes;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
@@ -31,13 +31,15 @@ public class SimplePagesHashStrategy
         implements PagesHashStrategy
 {
     private final List<Type> types;
+    private final List<Integer> outputChannels;
     private final List<List<Block>> channels;
     private final List<Integer> hashChannels;
     private final List<Block> precomputedHashChannel;
 
-    public SimplePagesHashStrategy(List<Type> types, List<List<Block>> channels, List<Integer> hashChannels, Optional<Integer> precomputedHashChannel)
+    public SimplePagesHashStrategy(List<Type> types, List<Integer> outputChannels, List<List<Block>> channels, List<Integer> hashChannels, Optional<Integer> precomputedHashChannel)
     {
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        this.outputChannels = ImmutableList.copyOf(requireNonNull(outputChannels, "outputChannels is null"));
         this.channels = ImmutableList.copyOf(requireNonNull(channels, "channels is null"));
 
         checkArgument(types.size() == channels.size(), "Expected types and channels to be the same length");
@@ -53,7 +55,7 @@ public class SimplePagesHashStrategy
     @Override
     public int getChannelCount()
     {
-        return channels.size();
+        return outputChannels.size();
     }
 
     @Override
@@ -68,9 +70,9 @@ public class SimplePagesHashStrategy
     @Override
     public void appendTo(int blockIndex, int position, PageBuilder pageBuilder, int outputChannelOffset)
     {
-        for (int i = 0; i < channels.size(); i++) {
-            Type type = types.get(i);
-            List<Block> channel = channels.get(i);
+        for (int outputIndex : outputChannels) {
+            Type type = types.get(outputIndex);
+            List<Block> channel = channels.get(outputIndex);
             Block block = channel.get(blockIndex);
             type.appendTo(block, position, pageBuilder.getBlockBuilder(outputChannelOffset));
             outputChannelOffset++;

--- a/presto-main/src/main/java/com/facebook/presto/operator/TwoChannelJoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TwoChannelJoinProbe.java
@@ -85,7 +85,7 @@ public class TwoChannelJoinProbe
     }
 
     @Override
-    public int getChannelCount()
+    public int getOutputChannelCount()
     {
         return 2;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceFactory.java
@@ -71,6 +71,12 @@ public class IndexLookupSourceFactory
     }
 
     @Override
+    public List<Type> getOutputTypes()
+    {
+        return outputTypes;
+    }
+
+    @Override
     public Map<Symbol, Integer> getLayout()
     {
         return layout;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
@@ -67,7 +67,7 @@ public class EqualityInference
             return ComparisonChain.start()
                     .compare(DependencyExtractor.extractAll(expression1).size(), DependencyExtractor.extractAll(expression2).size())
                     .compare(SubExpressionExtractor.extract(expression1).size(), SubExpressionExtractor.extract(expression2).size())
-                    .compare(expression1, expression2, Ordering.arbitrary())
+                    .compare(expression1.toString(), expression2.toString())
                     .result();
         }
     });

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1398,10 +1398,10 @@ public class LocalExecutionPlanner
             OperatorFactory lookupJoinOperatorFactory;
             switch (node.getType()) {
                 case INNER:
-                    lookupJoinOperatorFactory = LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel, false);
+                    lookupJoinOperatorFactory = LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel);
                     break;
                 case SOURCE_OUTER:
-                    lookupJoinOperatorFactory = LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel, false);
+                    lookupJoinOperatorFactory = LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel);
                     break;
                 default:
                     throw new AssertionError("Unknown type: " + node.getType());
@@ -1575,13 +1575,13 @@ public class LocalExecutionPlanner
 
             switch (node.getType()) {
                 case INNER:
-                    return LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, node.getFilter().isPresent());
+                    return LookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel);
                 case LEFT:
-                    return LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, node.getFilter().isPresent());
+                    return LookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel);
                 case RIGHT:
-                    return LookupJoinOperators.lookupOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, node.getFilter().isPresent());
+                    return LookupJoinOperators.lookupOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel);
                 case FULL:
-                    return LookupJoinOperators.fullOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, node.getFilter().isPresent());
+                    return LookupJoinOperators.fullOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel);
                 default:
                     throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -199,7 +199,6 @@ import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BRO
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
-import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.CreateHandle;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.InsertHandle;
@@ -1413,7 +1412,7 @@ public class LocalExecutionPlanner
         public PhysicalOperation visitJoin(JoinNode node, LocalExecutionPlanContext context)
         {
             List<JoinNode.EquiJoinClause> clauses = node.getCriteria();
-            if (clauses.isEmpty() && !node.getFilter().isPresent() && node.getType() == INNER) {
+            if (node.isCrossJoin()) {
                 return createNestedLoopJoin(node, context);
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -299,6 +299,10 @@ class RelationPlanner
                 leftPlanBuilder.getRoot(),
                 rightPlanBuilder.getRoot(),
                 equiClauses.build(),
+                ImmutableList.<Symbol>builder()
+                        .addAll(leftPlanBuilder.getRoot().getOutputSymbols())
+                        .addAll(rightPlanBuilder.getRoot().getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -331,6 +335,10 @@ class RelationPlanner
                     leftPlanBuilder.getRoot(),
                     rightPlanBuilder.getRoot(),
                     equiClauses.build(),
+                    ImmutableList.<Symbol>builder()
+                            .addAll(leftPlanBuilder.getRoot().getOutputSymbols())
+                            .addAll(rightPlanBuilder.getRoot().getOutputSymbols())
+                            .build(),
                     Optional.of(rewritenFilterCondition),
                     Optional.empty(),
                     Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -835,6 +835,10 @@ public class AddExchanges
                     left.getNode(),
                     right.getNode(),
                     node.getCriteria(),
+                    ImmutableList.<Symbol>builder()
+                            .addAll(left.getNode().getOutputSymbols())
+                            .addAll(right.getNode().getOutputSymbols())
+                            .build(),
                     node.getFilter(),
                     node.getLeftHashSymbol(),
                     node.getRightHashSymbol());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/EliminateCrossJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/EliminateCrossJoins.java
@@ -181,6 +181,10 @@ public class EliminateCrossJoins
                         result,
                         rightNode,
                         criteria.build(),
+                        ImmutableList.<Symbol>builder()
+                                .addAll(result.getOutputSymbols())
+                                .addAll(rightNode.getOutputSymbols())
+                                .build(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -49,6 +49,7 @@ import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.type.TypeUtils;
+import com.facebook.presto.util.ImmutableCollectors;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
@@ -80,6 +81,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Stream.concat;
 
 public class HashGenerationOptimizer
         implements PlanOptimizer
@@ -286,17 +288,7 @@ public class HashGenerationOptimizer
                 allHashSymbols.putAll(right.getHashSymbols());
                 allHashSymbols.putAll(left.getHashSymbols());
 
-                return new PlanWithProperties(
-                        new JoinNode(
-                                idAllocator.getNextId(),
-                                node.getType(),
-                                left.getNode(),
-                                right.getNode(),
-                                node.getCriteria(),
-                                node.getFilter(),
-                                Optional.empty(),
-                                Optional.empty()),
-                        allHashSymbols);
+                return buildJoinNodeWithPreferredHashes(node, left, right, allHashSymbols, parentPreference, Optional.empty(), Optional.empty());
             }
 
             // join does not pass through preferred hash symbols since they take more memory and since
@@ -320,6 +312,29 @@ public class HashGenerationOptimizer
                 allHashSymbols.putAll(right.getHashSymbols());
             }
 
+            return buildJoinNodeWithPreferredHashes(node, left, right, allHashSymbols, parentPreference, Optional.of(leftHashSymbol), Optional.of(rightHashSymbol));
+        }
+
+        private PlanWithProperties buildJoinNodeWithPreferredHashes(
+                JoinNode node,
+                PlanWithProperties left,
+                PlanWithProperties right,
+                Map<HashComputation, Symbol> allHashSymbols,
+                HashComputationSet parentPreference,
+                Optional<Symbol> leftHashSymbol,
+                Optional<Symbol> rightHashSymbol)
+        {
+            // retain only hash symbols preferred by parent nodes
+            Map<HashComputation, Symbol> hashSymbolsWithParentPreferences =
+                    allHashSymbols.entrySet()
+                            .stream()
+                            .filter(entry -> parentPreference.getHashes().contains(entry.getKey()))
+                            .collect(ImmutableCollectors.toImmutableMap(Entry::getKey, Entry::getValue));
+
+            List<Symbol> outputSymbols = concat(left.getNode().getOutputSymbols().stream(), right.getNode().getOutputSymbols().stream())
+                    .filter(symbol -> node.getOutputSymbols().contains(symbol) || hashSymbolsWithParentPreferences.values().contains(symbol))
+                    .collect(toImmutableList());
+
             return new PlanWithProperties(
                     new JoinNode(
                             idAllocator.getNextId(),
@@ -327,10 +342,11 @@ public class HashGenerationOptimizer
                             left.getNode(),
                             right.getNode(),
                             node.getCriteria(),
+                            outputSymbols,
                             node.getFilter(),
-                            Optional.of(leftHashSymbol),
-                            Optional.of(rightHashSymbol)),
-                    allHashSymbols);
+                            leftHashSymbol,
+                            rightHashSymbol),
+                    hashSymbolsWithParentPreferences);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -179,7 +179,7 @@ public class IndexJoinOptimizer
             }
 
             if (leftRewritten != node.getLeft() || rightRewritten != node.getRight()) {
-                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
             }
             return node;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
@@ -186,6 +186,10 @@ public class TransformCorrelatedScalarAggregationToJoin
                     inputWithUniqueColumns,
                     scalarAggregationSource,
                     ImmutableList.of(),
+                    ImmutableList.<Symbol>builder()
+                            .addAll(inputWithUniqueColumns.getOutputSymbols())
+                            .addAll(scalarAggregationSource.getOutputSymbols())
+                            .build(),
                     joinExpression,
                     Optional.empty(),
                     Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedScalarToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedScalarToJoin.java
@@ -59,6 +59,10 @@ public class TransformUncorrelatedScalarToJoin
                         rewrittenNode.getInput(),
                         rewrittenNode.getSubquery(),
                         ImmutableList.of(),
+                        ImmutableList.<Symbol>builder()
+                                .addAll(rewrittenNode.getInput().getOutputSymbols())
+                                .addAll(rewrittenNode.getSubquery().getOutputSymbols())
+                                .build(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -507,6 +507,7 @@ public class UnaliasSymbolReferences
             PlanNode right = context.rewrite(node.getRight());
 
             List<JoinNode.EquiJoinClause> canonicalCriteria = canonicalizeJoinCriteria(node.getCriteria());
+            List<Symbol> canonicalOutputSymbols = canonicalizeAndDistinct(node.getOutputSymbols());
             Optional<Expression> canonicalFilter = node.getFilter().map(this::canonicalize);
             Optional<Symbol> canonicalLeftHashSymbol = canonicalize(node.getLeftHashSymbol());
             Optional<Symbol> canonicalRightHashSymbol = canonicalize(node.getRightHashSymbol());
@@ -514,10 +515,11 @@ public class UnaliasSymbolReferences
             if (node.getType().equals(INNER)) {
                 canonicalCriteria.stream()
                         .filter(clause -> types.get(clause.getLeft()).equals(types.get(clause.getRight())))
+                        .filter(clause -> node.getOutputSymbols().contains(clause.getLeft()))
                         .forEach(clause -> map(clause.getRight(), clause.getLeft()));
             }
 
-            return new JoinNode(node.getId(), node.getType(), left, right, canonicalCriteria, canonicalFilter, canonicalLeftHashSymbol, canonicalRightHashSymbol);
+            return new JoinNode(node.getId(), node.getType(), left, right, canonicalCriteria, canonicalOutputSymbols, canonicalFilter, canonicalLeftHashSymbol, canonicalRightHashSymbol);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -171,10 +171,7 @@ public class JoinNode
     @JsonProperty("outputSymbols")
     public List<Symbol> getOutputSymbols()
     {
-        return ImmutableList.<Symbol>builder()
-                .addAll(left.getOutputSymbols())
-                .addAll(right.getOutputSymbols())
-                .build();
+        return outputSymbols;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -19,12 +19,14 @@ import com.facebook.presto.sql.tree.Join;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -69,6 +71,12 @@ public class JoinNode
         requireNonNull(filter, "filter is null");
         requireNonNull(leftHashSymbol, "leftHashSymbol is null");
         requireNonNull(rightHashSymbol, "rightHashSymbol is null");
+
+        Set<Symbol> inputSymbols = ImmutableSet.<Symbol>builder()
+                .addAll(left.getOutputSymbols())
+                .addAll(right.getOutputSymbols())
+                .build();
+        checkArgument(inputSymbols.containsAll(outputSymbols), "Left and right join inputs do not contain all output symbols");
 
         this.type = type;
         this.left = left;

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -194,6 +194,7 @@ public class TestPhasedExecutionSchedule
                 tableScan,
                 new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of()),
                 ImmutableList.of(),
+                tableScan.getOutputSymbols(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -208,6 +209,7 @@ public class TestPhasedExecutionSchedule
                 joinType,
                 new RemoteSourceNode(new PlanNodeId("probe_id"), probeFragment.getId(), ImmutableList.of()),
                 new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of()),
+                ImmutableList.of(),
                 ImmutableList.of(),
                 Optional.empty(),
                 Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -439,6 +439,7 @@ public class TestSourcePartitionedScheduler
                                 null),
                         new RemoteSourceNode(new PlanNodeId("remote_id"), new PlanFragmentId("plan_fragment_id"), ImmutableList.of()),
                         ImmutableList.of(),
+                        ImmutableList.of(symbol),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty()),

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -43,11 +43,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.Threads.checkNotSameThreadExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
@@ -244,6 +246,7 @@ public class BenchmarkHashBuildAndJoinOperators
                 HASH_BUILD_OPERATOR_ID,
                 TEST_PLAN_NODE_ID,
                 buildContext.getTypes(),
+                rangeList(buildContext.getTypes().size()),
                 ImmutableMap.of(),
                 buildContext.getHashChannels(),
                 buildContext.getHashChannel(),
@@ -276,7 +279,8 @@ public class BenchmarkHashBuildAndJoinOperators
                 lookupSourceFactory,
                 joinContext.getTypes(),
                 joinContext.getHashChannels(),
-                joinContext.getHashChannel());
+                joinContext.getHashChannel(),
+                Optional.of(rangeList(joinContext.getTypes().size())));
 
         DriverContext driverContext = joinContext.createTaskContext().addPipelineContext(true, true).addDriverContext();
         Operator joinOperator = joinOperatorFactory.createOperator(driverContext);
@@ -304,6 +308,13 @@ public class BenchmarkHashBuildAndJoinOperators
         }
 
         return outputPages.build();
+    }
+
+    private List<Integer> rangeList(int endExclusive)
+    {
+        return IntStream.range(0, endExclusive)
+                .boxed()
+                .collect(toImmutableList());
     }
 
     public static void main(String[] args)

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -276,8 +276,7 @@ public class BenchmarkHashBuildAndJoinOperators
                 lookupSourceFactory,
                 joinContext.getTypes(),
                 joinContext.getHashChannels(),
-                joinContext.getHashChannel(),
-                false);
+                joinContext.getHashChannel());
 
         DriverContext driverContext = joinContext.createTaskContext().addPipelineContext(true, true).addDriverContext();
         Operator joinOperator = joinOperatorFactory.createOperator(driverContext);

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -258,8 +258,8 @@ public class BenchmarkHashBuildAndJoinOperators
         }
         operator.finish();
 
-        if (!operator.isFinished()) {
-            throw new AssertionError("Expected hash build operator to be finished");
+        if (!hashBuilderOperatorFactory.getLookupSourceFactory().createLookupSource().isDone()) {
+            throw new AssertionError("Expected lookup source to be done");
         }
 
         return hashBuilderOperatorFactory.getLookupSourceFactory();

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -43,13 +43,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
-import java.util.stream.IntStream;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.Threads.checkNotSameThreadExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
@@ -89,7 +87,6 @@ public class BenchmarkHashBuildAndJoinOperators
         protected Optional<Integer> hashChannel;
         protected List<Type> types;
         protected List<Integer> hashChannels;
-        protected LookupSourceFactory lookupSourceFactory;
 
         @Setup
         public void setup()
@@ -110,8 +107,6 @@ public class BenchmarkHashBuildAndJoinOperators
             executor = newCachedThreadPool(daemonThreadsNamed("test-%s"));
 
             initializeBuildPages();
-
-            lookupSourceFactory = new BenchmarkHashBuildAndJoinOperators().benchmarkBuildHash(this);
         }
 
         public TaskContext createTaskContext()
@@ -135,11 +130,6 @@ public class BenchmarkHashBuildAndJoinOperators
         public List<Type> getTypes()
         {
             return types;
-        }
-
-        public LookupSourceFactory getLookupSourceFactory()
-        {
-            return lookupSourceFactory;
         }
 
         public List<Page> getBuildPages()
@@ -174,19 +164,51 @@ public class BenchmarkHashBuildAndJoinOperators
         @Param({"0.1", "1", "2"})
         protected double matchRate;
 
+        @Param({"bigint", "all"})
+        protected String outputColumns;
+
         protected List<Page> probePages;
+        protected List<Integer> outputChannels;
+
+        protected LookupSourceFactory lookupSourceFactory;
 
         @Override
         @Setup
         public void setup()
         {
             super.setup();
+
+            switch (outputColumns) {
+                case "varchar":
+                    outputChannels = Ints.asList(0);
+                    break;
+                case "bigint":
+                    outputChannels = Ints.asList(1);
+                    break;
+                case "all":
+                    outputChannels = Ints.asList(0, 1, 2);
+                    break;
+                default:
+                    throw new UnsupportedOperationException(format("Unknown outputColumns value [%s]", hashColumns));
+            }
+
+            lookupSourceFactory = new BenchmarkHashBuildAndJoinOperators().benchmarkBuildHash(this, outputChannels);
             initializeProbePages();
+        }
+
+        public LookupSourceFactory getLookupSourceFactory()
+        {
+            return lookupSourceFactory;
         }
 
         public List<Page> getProbePages()
         {
             return probePages;
+        }
+
+        public List<Integer> getOutputChannels()
+        {
+            return outputChannels;
         }
 
         protected void initializeProbePages()
@@ -240,13 +262,18 @@ public class BenchmarkHashBuildAndJoinOperators
     @Benchmark
     public LookupSourceFactory benchmarkBuildHash(BuildContext buildContext)
     {
+        return benchmarkBuildHash(buildContext, ImmutableList.of(0, 1, 2));
+    }
+
+    private LookupSourceFactory benchmarkBuildHash(BuildContext buildContext, List<Integer> outputChannels)
+    {
         DriverContext driverContext = buildContext.createTaskContext().addPipelineContext(true, true).addDriverContext();
 
         HashBuilderOperatorFactory hashBuilderOperatorFactory = new HashBuilderOperatorFactory(
                 HASH_BUILD_OPERATOR_ID,
                 TEST_PLAN_NODE_ID,
                 buildContext.getTypes(),
-                rangeList(buildContext.getTypes().size()),
+                outputChannels,
                 ImmutableMap.of(),
                 buildContext.getHashChannels(),
                 buildContext.getHashChannel(),
@@ -280,7 +307,7 @@ public class BenchmarkHashBuildAndJoinOperators
                 joinContext.getTypes(),
                 joinContext.getHashChannels(),
                 joinContext.getHashChannel(),
-                Optional.of(rangeList(joinContext.getTypes().size())));
+                Optional.of(joinContext.getOutputChannels()));
 
         DriverContext driverContext = joinContext.createTaskContext().addPipelineContext(true, true).addDriverContext();
         Operator joinOperator = joinOperatorFactory.createOperator(driverContext);
@@ -308,13 +335,6 @@ public class BenchmarkHashBuildAndJoinOperators
         }
 
         return outputPages.build();
-    }
-
-    private List<Integer> rangeList(int endExclusive)
-    {
-        return IntStream.range(0, endExclusive)
-                .boxed()
-                .collect(toImmutableList());
     }
 
     public static void main(String[] args)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -109,8 +109,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false
+                probePages.getHashChannel()
         );
 
         // expected
@@ -160,8 +159,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false
+                probePages.getHashChannel()
         );
 
         // expected
@@ -204,8 +202,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false
+                probePages.getHashChannel()
         );
 
         // expected
@@ -249,8 +246,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false
+                probePages.getHashChannel()
         );
 
         // expected
@@ -287,8 +283,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false);
+                probePages.getHashChannel());
 
         // expected
         // expected
@@ -340,8 +335,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                true);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -395,8 +389,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -443,8 +436,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                true);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -488,8 +480,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -536,8 +527,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                true);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -580,8 +570,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                false);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
@@ -629,8 +618,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
-                true);
+                probePages.getHashChannel());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
@@ -49,6 +50,7 @@ import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEqual
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.collect.Iterables.concat;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
@@ -109,7 +111,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel()
+                probePages.getHashChannel(),
+                Optional.empty()
         );
 
         // expected
@@ -159,7 +162,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel()
+                probePages.getHashChannel(),
+                Optional.empty()
         );
 
         // expected
@@ -202,7 +206,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel()
+                probePages.getHashChannel(),
+                Optional.empty()
         );
 
         // expected
@@ -246,7 +251,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel()
+                probePages.getHashChannel(),
+                Optional.empty()
         );
 
         // expected
@@ -283,7 +289,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         // expected
@@ -335,7 +342,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -389,7 +397,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -436,7 +445,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -480,7 +490,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -527,7 +538,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -570,7 +582,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
@@ -618,7 +631,8 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel());
+                probePages.getHashChannel(),
+                Optional.empty());
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
@@ -690,6 +704,7 @@ public class TestHashJoinOperator
                 1,
                 new PlanNodeId("build"),
                 buildPages.getTypes(),
+                rangeList(buildPages.getTypes().size()),
                 ImmutableMap.of(),
                 hashChannels,
                 buildPages.getHashChannel(),
@@ -715,6 +730,13 @@ public class TestHashJoinOperator
         }
 
         return buildOperatorFactory.getLookupSourceFactory();
+    }
+
+    private static List<Integer> rangeList(int endExclusive)
+    {
+        return IntStream.range(0, endExclusive)
+                .boxed()
+                .collect(toImmutableList());
     }
 
     private static class TestInternalJoinFilterFunction

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
@@ -48,7 +48,7 @@ public class TestJoinCompiler
     @DataProvider(name = "hashEnabledValues")
     public static Object[][] hashEnabledValuesProvider()
     {
-        return new Object[][] { { true }, { false } };
+        return new Object[][] {{true}, {false}};
     }
 
     @Test(dataProvider = "hashEnabledValues")
@@ -137,9 +137,11 @@ public class TestJoinCompiler
     {
         // compile a single channel hash strategy
         JoinCompiler joinCompiler = new JoinCompiler();
-        List<Type> types = ImmutableList.of(VARCHAR, VARCHAR, BIGINT, DOUBLE, BOOLEAN);
+        List<Type> types = ImmutableList.of(VARCHAR, VARCHAR, BIGINT, DOUBLE, BOOLEAN, VARCHAR);
         List<Type> joinTypes = ImmutableList.of(VARCHAR, BIGINT, DOUBLE, BOOLEAN);
+        List<Type> outputTypes = ImmutableList.of(VARCHAR, BIGINT, DOUBLE, BOOLEAN, VARCHAR);
         List<Integer> joinChannels = Ints.asList(1, 2, 3, 4);
+        List<Integer> outputChannels = Ints.asList(1, 2, 3, 4, 0);
 
         // crate hash strategy with a single channel blocks -- make sure there is some overlap in values
         List<Block> extraChannel = ImmutableList.of(
@@ -162,28 +164,34 @@ public class TestJoinCompiler
                 BlockAssertions.createBooleanSequenceBlock(10, 20),
                 BlockAssertions.createBooleanSequenceBlock(20, 30),
                 BlockAssertions.createBooleanSequenceBlock(15, 25));
+        List<Block> extraUnusedChannel = ImmutableList.of(
+                BlockAssertions.createBooleanSequenceBlock(10, 20),
+                BlockAssertions.createBooleanSequenceBlock(20, 30),
+                BlockAssertions.createBooleanSequenceBlock(15, 25));
 
         Optional<Integer> hashChannel = Optional.empty();
-        ImmutableList<List<Block>> channels = ImmutableList.of(extraChannel, varcharChannel, longChannel, doubleChannel, booleanChannel);
+        ImmutableList<List<Block>> channels = ImmutableList.of(extraChannel, varcharChannel, longChannel, doubleChannel, booleanChannel, extraUnusedChannel);
         List<Block> precomputedHash = ImmutableList.of();
         if (hashEnabled) {
             ImmutableList.Builder<Block> hashChannelBuilder = ImmutableList.builder();
             for (int i = 0; i < 3; i++) {
                 hashChannelBuilder.add(TypeUtils.getHashBlock(joinTypes, varcharChannel.get(i), longChannel.get(i), doubleChannel.get(i), booleanChannel.get(i)));
             }
-            hashChannel = Optional.of(5);
+            hashChannel = Optional.of(6);
             precomputedHash = hashChannelBuilder.build();
-            channels = ImmutableList.of(extraChannel, varcharChannel, longChannel, doubleChannel, booleanChannel, precomputedHash);
-            types = ImmutableList.of(VARCHAR, VARCHAR, BIGINT, DOUBLE, BOOLEAN, BIGINT);
+            channels = ImmutableList.of(extraChannel, varcharChannel, longChannel, doubleChannel, booleanChannel, extraUnusedChannel, precomputedHash);
+            types = ImmutableList.of(VARCHAR, VARCHAR, BIGINT, DOUBLE, BOOLEAN, VARCHAR, BIGINT);
+            outputTypes = ImmutableList.of(VARCHAR, BIGINT, DOUBLE, BOOLEAN, VARCHAR, BIGINT);
+            outputChannels = Ints.asList(1, 2, 3, 4, 0, 6);
         }
 
-        PagesHashStrategyFactory pagesHashStrategyFactory = joinCompiler.compilePagesHashStrategyFactory(types, joinChannels);
+        PagesHashStrategyFactory pagesHashStrategyFactory = joinCompiler.compilePagesHashStrategyFactory(types, joinChannels, Optional.of(outputChannels));
         PagesHashStrategy hashStrategy = pagesHashStrategyFactory.createPagesHashStrategy(channels, hashChannel);
         // todo add tests for filter function
-        PagesHashStrategy expectedHashStrategy = new SimplePagesHashStrategy(types, channels, joinChannels, hashChannel);
+        PagesHashStrategy expectedHashStrategy = new SimplePagesHashStrategy(types, outputChannels, channels, joinChannels, hashChannel);
 
         // verify channel count
-        assertEquals(hashStrategy.getChannelCount(), types.size());
+        assertEquals(hashStrategy.getChannelCount(), outputChannels.size());
         // verify size
         long sizeInBytes = channels.stream()
                 .flatMap(List::stream)
@@ -193,7 +201,7 @@ public class TestJoinCompiler
 
         // verify hashStrategy is consistent with equals and hash code from block
         for (int leftBlockIndex = 0; leftBlockIndex < varcharChannel.size(); leftBlockIndex++) {
-            PageBuilder pageBuilder = new PageBuilder(types);
+            PageBuilder pageBuilder = new PageBuilder(outputTypes);
 
             Block[] leftBlocks = new Block[4];
             leftBlocks[0] = varcharChannel.get(leftBlockIndex);
@@ -251,21 +259,21 @@ public class TestJoinCompiler
             // verify output block matches
             Page page = pageBuilder.build();
             if (hashEnabled) {
-                assertPageEquals(types, page, new Page(
-                        extraChannel.get(leftBlockIndex),
+                assertPageEquals(outputTypes, page, new Page(
                         varcharChannel.get(leftBlockIndex),
                         longChannel.get(leftBlockIndex),
                         doubleChannel.get(leftBlockIndex),
                         booleanChannel.get(leftBlockIndex),
+                        extraChannel.get(leftBlockIndex),
                         precomputedHash.get(leftBlockIndex)));
             }
             else {
-                assertPageEquals(types, page, new Page(
-                        extraChannel.get(leftBlockIndex),
+                assertPageEquals(outputTypes, page, new Page(
                         varcharChannel.get(leftBlockIndex),
                         longChannel.get(leftBlockIndex),
                         doubleChannel.get(leftBlockIndex),
-                        booleanChannel.get(leftBlockIndex)));
+                        booleanChannel.get(leftBlockIndex),
+                        extraChannel.get(leftBlockIndex)));
             }
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -89,12 +89,14 @@ public class TestEffectivePredicateExtractor
     private static final Symbol D = new Symbol("d");
     private static final Symbol E = new Symbol("e");
     private static final Symbol F = new Symbol("f");
+    private static final Symbol G = new Symbol("g");
     private static final Expression AE = A.toSymbolReference();
     private static final Expression BE = B.toSymbolReference();
     private static final Expression CE = C.toSymbolReference();
     private static final Expression DE = D.toSymbolReference();
     private static final Expression EE = E.toSymbolReference();
     private static final Expression FE = F.toSymbolReference();
+    private static final Expression GE = G.toSymbolReference();
 
     private static final Map<Symbol, Type> TYPES = ImmutableMap.<Symbol, Type>builder()
             .put(A, BIGINT)
@@ -443,19 +445,24 @@ public class TestEffectivePredicateExtractor
                 filter(leftScan,
                         and(
                                 lessThan(BE, AE),
-                                lessThan(CE, bigintLiteral(10)))),
+                                lessThan(CE, bigintLiteral(10)),
+                                equals(GE, bigintLiteral(10)))),
                 filter(rightScan,
                         and(
                                 equals(DE, EE),
                                 lessThan(FE, bigintLiteral(100)))),
                 criteria,
+                ImmutableList.<Symbol>builder()
+                    .addAll(leftScan.getOutputSymbols())
+                    .addAll(rightScan.getOutputSymbols())
+                    .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
 
-        // All predicates should be carried through
+        // All predicates having output symbol should be carried through
         assertEquals(normalizeConjuncts(effectivePredicate),
                 normalizeConjuncts(lessThan(BE, AE),
                         lessThan(CE, bigintLiteral(10)),
@@ -501,19 +508,24 @@ public class TestEffectivePredicateExtractor
                 filter(leftScan,
                         and(
                                 lessThan(BE, AE),
-                                lessThan(CE, bigintLiteral(10)))),
+                                lessThan(CE, bigintLiteral(10)),
+                                equals(GE, bigintLiteral(10)))),
                 filter(rightScan,
                         and(
                                 equals(DE, EE),
                                 lessThan(FE, bigintLiteral(100)))),
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(leftScan.getOutputSymbols())
+                        .addAll(rightScan.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
 
-        // All right side symbols should be checked against NULL
+        // All right side symbols having output symbols should be checked against NULL
         assertEquals(normalizeConjuncts(effectivePredicate),
                 normalizeConjuncts(lessThan(BE, AE),
                         lessThan(CE, bigintLiteral(10)),
@@ -556,9 +568,14 @@ public class TestEffectivePredicateExtractor
                 filter(leftScan,
                         and(
                                 lessThan(BE, AE),
-                                lessThan(CE, bigintLiteral(10)))),
+                                lessThan(CE, bigintLiteral(10)),
+                                equals(GE, bigintLiteral(10)))),
                 filter(rightScan, FALSE_LITERAL),
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(leftScan.getOutputSymbols())
+                        .addAll(rightScan.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -608,12 +625,17 @@ public class TestEffectivePredicateExtractor
                 filter(leftScan,
                         and(
                                 lessThan(BE, AE),
-                                lessThan(CE, bigintLiteral(10)))),
+                                lessThan(CE, bigintLiteral(10)),
+                                equals(GE, bigintLiteral(10)))),
                 filter(rightScan,
                         and(
                                 equals(DE, EE),
                                 lessThan(FE, bigintLiteral(100)))),
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(leftScan.getOutputSymbols())
+                        .addAll(rightScan.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -666,6 +688,10 @@ public class TestEffectivePredicateExtractor
                                 equals(DE, EE),
                                 lessThan(FE, bigintLiteral(100)))),
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(leftScan.getOutputSymbols())
+                        .addAll(rightScan.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -219,6 +219,22 @@ public class TestLogicalPlanner
         }
     }
 
+    @Test
+    public void testJoinOutputPruning()
+    {
+        assertPlan("SELECT nationkey FROM nation JOIN region ON nation.regionkey = region.regionkey",
+                anyTree(
+                        join(INNER, ImmutableList.of(equiJoinClause("REGIONKEY_LEFT", "REGIONKEY_RIGHT")),
+                                anyTree(
+                                        tableScan("nation", ImmutableMap.of("REGIONKEY_LEFT", "regionkey", "NATIONKEY", "nationkey"))),
+                                anyTree(
+                                        tableScan("region", ImmutableMap.of("REGIONKEY_RIGHT", "regionkey"))))
+                )
+                .withNumberOfOutputColumns(1)
+                .withOutputs(ImmutableList.of("NATIONKEY"))
+        );
+    }
+
     private void assertPlanContainsNoApplyOrJoin(String sql)
     {
         PlanNodeExtractor planNodeExtractor = new PlanNodeExtractor(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -345,6 +345,12 @@ public final class PlanMatchPattern
         return this;
     }
 
+    public PlanMatchPattern withNumberOfOutputColumns(int numberOfSymbols)
+    {
+        matchers.add(new SymbolCardinalityMatcher(numberOfSymbols));
+        return this;
+    }
+
     /*
      * This is useful if you already know the bindings for the aliases you expect to find
      * in the outputs. This is the case for symbols that are produced by a direct or indirect

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolCardinalityMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolCardinalityMatcher.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+final class SymbolCardinalityMatcher
+        implements Matcher
+{
+    private final int numberOfSymbols;
+
+    SymbolCardinalityMatcher(int numberOfSymbols)
+    {
+        this.numberOfSymbols = numberOfSymbols;
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return true;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        return new MatchResult(node.getOutputSymbols().size() == numberOfSymbols);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("numberOfSymbols", numberOfSymbols)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateCrossJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateCrossJoins.java
@@ -203,6 +203,10 @@ public class TestEliminateCrossJoins
                 left,
                 right,
                 criteria.build(),
+                ImmutableList.<Symbol>builder()
+                        .addAll(left.getOutputSymbols())
+                        .addAll(right.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());


### PR DESCRIPTION
Recreating after closing (removed branch) https://github.com/prestodb/presto/pull/6465 by mistake

FYI: @martint @dain

Partial micro benchmark results:
```
    Partial results:
    Benchmark                                             (buildHashEnabled)  (hashColumns)  (matchRate)  (outputColumns)  Mode  Cnt    Score   Error  Units
    BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true         bigint            2          varchar  avgt   60  157,080 ± 3,820  ms/op
    BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true         bigint            2           bigint  avgt   60   90,912 ± 1,954  ms/op
    BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true         bigint            2              all  avgt   60  203,645 ± 3,665  ms/op
```
`all` is a baseline. When you require just some columns the join time reduces significantly.
