### PR TITLE
Revert integration tests optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
       presto-hive-hadoop2/bin/run_on_docker.sh
   - |
     test ! -v INTEGRATION_TESTS ||
-      ./mvnw install -DskipTests -B
+      ./mvnw install -DskipTests -B -T C1
   - |
     # Build presto-server-rpm for later artifact upload
     test ! -v DEPLOY_S3_ACCESS_KEY || test ! -v PRODUCT_TESTS ||

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,9 @@ before_install:
   # This is needed until Travis #4629 is fixed (https://github.com/travis-ci/travis-ci/issues/4629)
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
 
+install: ./mvnw install -DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1 -pl '!presto-docs,!presto-server-rpm'
+
 script:
-  - |
-    test -v INTEGRATION_TESTS ||
-      ./mvnw install -DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1 -pl '!presto-docs,!presto-server-rpm'
-  - |
-    test ! -v INTEGRATION_TESTS ||
-      ./mvnw install -DskipTests -B -T C1
   - |
     test ! -v TEST_MODULES ||
       ./mvnw test $MAVEN_SKIP_CHECKS_AND_DOCS -B -pl $TEST_MODULES
@@ -52,6 +48,9 @@ script:
   - |
     test ! -v INTEGRATION_TESTS ||
       presto-hive-hadoop2/bin/run_on_docker.sh
+  - |
+    test ! -v INTEGRATION_TESTS ||
+      ./mvnw install -DskipTests -B
   - |
     # Build presto-server-rpm for later artifact upload
     test ! -v DEPLOY_S3_ACCESS_KEY || test ! -v PRODUCT_TESTS ||


### PR DESCRIPTION
When building RPM before the integration tests, build hits the disk space limit,
and the tables for the integration tests couldn't be provisioned.