### PR TITLE
Do not prune ApplyNode subquery symbols are used in join criteria

### DIFF
--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloDistributedQueries.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloDistributedQueries.java
@@ -45,14 +45,12 @@ public class TestAccumuloDistributedQueries
 
     @Override
     public void testAddColumn()
-            throws Exception
     {
         // Adding columns via SQL are not supported until adding columns with comments are supported
     }
 
     @Override
     public void testCreateTableAsSelect()
-            throws Exception
     {
         // This test is overridden due to Function "UUID" not found errors
         // Some test cases from the base class are removed
@@ -89,14 +87,12 @@ public class TestAccumuloDistributedQueries
 
     @Override
     public void testDelete()
-            throws Exception
     {
         // Deletes are not supported by the connector
     }
 
     @Override
     public void testInsert()
-            throws Exception
     {
         @Language("SQL") String query = "SELECT UUID() AS uuid, orderdate, orderkey FROM orders";
 
@@ -133,7 +129,6 @@ public class TestAccumuloDistributedQueries
 
     @Test
     public void testInsertDuplicateRows()
-            throws Exception
     {
         // This test case tests the Accumulo connectors override capabilities
         // When a row is inserted into a table where a row with the same row ID already exists,
@@ -152,7 +147,6 @@ public class TestAccumuloDistributedQueries
 
     @Override
     public void testBuildFilteredLeftJoin()
-            throws Exception
     {
         // Override because of extra UUID column in lineitem table, cannot SELECT *
         assertQuery("SELECT "
@@ -165,7 +159,6 @@ public class TestAccumuloDistributedQueries
     @Override
     @Test
     public void testJoinWithAlias()
-            throws Exception
     {
         // Override because of extra UUID column in lineitem table, cannot SELECT *
         // Cannot munge test to pass due to aliased data set 'x' containing duplicate orderkey and comment columns
@@ -173,7 +166,6 @@ public class TestAccumuloDistributedQueries
 
     @Override
     public void testProbeFilteredLeftJoin()
-            throws Exception
     {
         // Override because of extra UUID column in lineitem table, cannot SELECT *
         assertQuery("SELECT "
@@ -186,7 +178,6 @@ public class TestAccumuloDistributedQueries
     @Override
     @Test
     public void testJoinWithDuplicateRelations()
-            throws Exception
     {
         // Override because of extra UUID column in lineitem table, cannot SELECT *
         // Cannot munge test to pass due to aliased data sets 'x' containing duplicate orderkey and comment columns
@@ -194,7 +185,6 @@ public class TestAccumuloDistributedQueries
 
     @Override
     public void testLeftJoinWithEmptyInnerTable()
-            throws Exception
     {
         // Override because of extra UUID column in lineitem table, cannot SELECT *
         // Use orderkey = rand() to create an empty relation
@@ -222,7 +212,6 @@ public class TestAccumuloDistributedQueries
 
     @Override
     public void testScalarSubquery()
-            throws Exception
     {
         // Override because of extra UUID column in lineitem table, cannot SELECT *
 
@@ -313,7 +302,6 @@ public class TestAccumuloDistributedQueries
 
     @Override
     public void testShowColumns()
-            throws Exception
     {
         // Override base class because table descriptions for Accumulo connector include comments
         MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
@@ -340,7 +328,6 @@ public class TestAccumuloDistributedQueries
 
     @Test
     public void testMultiInBelowCardinality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM partsupp WHERE partkey = 1", "SELECT 4");
         assertQuery("SELECT COUNT(*) FROM partsupp WHERE partkey = 2", "SELECT 4");
@@ -349,7 +336,6 @@ public class TestAccumuloDistributedQueries
 
     @Test
     public void testSelectNullValue()
-            throws Exception
     {
         try {
             assertUpdate("CREATE TABLE test_select_null_value AS SELECT 1 a, 2 b, CAST(NULL AS BIGINT) c", 1);

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcDistributedQueries.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcDistributedQueries.java
@@ -29,7 +29,6 @@ public class TestJdbcDistributedQueries
 
     @Override
     public void testLargeIn()
-            throws Exception
     {
     }
 }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -43,70 +43,60 @@ public class TestCassandraDistributed
 
     @Override
     public void testGroupingSetMixedExpressionAndColumn()
-            throws Exception
     {
         // Cassandra does not support DATE
     }
 
     @Override
     public void testGroupingSetMixedExpressionAndOrdinal()
-            throws Exception
     {
         // Cassandra does not support DATE
     }
 
     @Override
     public void testRenameTable()
-            throws Exception
     {
         // Cassandra does not support renaming tables
     }
 
     @Override
     public void testAddColumn()
-            throws Exception
     {
         // Cassandra does not support adding columns
     }
 
     @Override
     public void testRenameColumn()
-            throws Exception
     {
         // Cassandra does not support renaming columns
     }
 
     @Override
     public void testInsert()
-            throws Exception
     {
         // Cassandra connector currently does not support insert
     }
 
     @Override
     public void testCreateTable()
-            throws Exception
     {
         // Cassandra connector currently does not support create table
     }
 
     @Override
     public void testCreateTableAsSelect()
-            throws Exception
     {
         // Cassandra connector currently does not support create table
     }
 
     @Override
     public void testDelete()
-            throws Exception
     {
         // Cassandra connector currently does not support delete
     }
 
     @Override
     public void testShowColumns()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
@@ -29,28 +29,24 @@ public class TestHiveDistributedQueries
 
     @Override
     public void testDelete()
-            throws Exception
     {
         // Hive connector currently does not support row-by-row delete
     }
 
     @Override
     public void testAddColumn()
-            throws Exception
     {
         // Hive connector currently does not support schema change
     }
 
     @Override
     public void testRenameColumn()
-            throws Exception
     {
         // Hive connector currently does not support schema change
     }
 
     @Override
     public void testRenameTable()
-            throws Exception
     {
         // Hive connector currently does not support table rename
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -504,22 +504,23 @@ public class PruneUnreferencedOutputs
             return new ProjectNode(node.getId(), rewrittenSource, assignments);
         }
 
-        private PlanNode pruneUnreferencedApplyNodes(List<Expression> removedExpressions, PlanNode rewrittenSource, Map<Symbol, Expression> assignments)
+        private PlanNode pruneUnreferencedApplyNodes(List<Expression> removedExpressions, PlanNode node, Map<Symbol, Expression> assignments)
         {
             Set<Symbol> symbolsUsedByProjection = assignments.values().stream()
                     .map(DependencyExtractor::extractUnique)
                     .flatMap(Set::stream)
                     .collect(toImmutableSet());
 
+            PlanNode rewrittenNode = node;
             for (Expression removedExpression : removedExpressions) {
                 for (Symbol symbol : DependencyExtractor.extractUnique(removedExpression)) {
                     if (!symbolsUsedByProjection.contains(symbol)) {
                         UnusedApplyRemover unusedApplyRemover = new UnusedApplyRemover(symbol.toSymbolReference());
-                        rewrittenSource = SimplePlanRewriter.rewriteWith(unusedApplyRemover, rewrittenSource, null);
+                        rewrittenNode = SimplePlanRewriter.rewriteWith(unusedApplyRemover, rewrittenNode, null);
                     }
                 }
             }
-            return rewrittenSource;
+            return rewrittenNode;
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -75,6 +75,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
@@ -751,7 +752,7 @@ public class PruneUnreferencedOutputs
         @Override
         protected PlanNode visitPlan(PlanNode node, RewriteContext<Void> context)
         {
-            if (usesSymbol(node, Symbol.from(reference))) {
+            if (usesSymbol(node, getReferenceSymbol())) {
                 return node;
             }
             return context.defaultRewrite(node);
@@ -761,6 +762,64 @@ public class PruneUnreferencedOutputs
         public PlanNode visitProject(ProjectNode node, RewriteContext<Void> context)
         {
             return visitPlan(node, context);
+        }
+
+        @Override
+        public PlanNode visitJoin(JoinNode node, RewriteContext<Void> context)
+        {
+            if (usesSymbol(node, getReferenceSymbol())) {
+                return node;
+            }
+
+            boolean usesSymbolInCriteria = node.getCriteria().stream()
+                    .flatMap(criteria -> Stream.of(criteria.getLeft(), criteria.getRight()))
+                    .anyMatch(criteriaSymbol -> criteriaSymbol.equals(getReferenceSymbol()));
+
+            if (usesSymbolInCriteria) {
+                return node;
+            }
+
+            return context.defaultRewrite(node);
+        }
+
+        @Override
+        public PlanNode visitIndexJoin(IndexJoinNode node, RewriteContext<Void> context)
+        {
+            if (usesSymbol(node, getReferenceSymbol())) {
+                return node;
+            }
+
+            boolean usesSymbolInCriteria = node.getCriteria().stream()
+                    .flatMap(criteria -> Stream.of(criteria.getProbe(), criteria.getIndex()))
+                    .anyMatch(criteriaSymbol -> criteriaSymbol.equals(getReferenceSymbol()));
+
+            if (usesSymbolInCriteria) {
+                return node;
+            }
+
+            return context.defaultRewrite(node);
+        }
+
+        private Symbol getReferenceSymbol()
+        {
+            return Symbol.from(reference);
+        }
+
+        @Override
+        public PlanNode visitSemiJoin(SemiJoinNode node, RewriteContext<Void> context)
+        {
+            if (usesSymbol(node, getReferenceSymbol())) {
+                return node;
+            }
+
+            boolean usesSymbolInCriteria = node.getSourceJoinSymbol().equals(getReferenceSymbol())
+                    && node.getFilteringSourceJoinSymbol().equals(getReferenceSymbol());
+
+            if (usesSymbolInCriteria) {
+                return node;
+            }
+
+            return context.defaultRewrite(node);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -759,10 +759,7 @@ public class PruneUnreferencedOutputs
         @Override
         public PlanNode visitProject(ProjectNode node, RewriteContext<Void> context)
         {
-            if (usesSymbol(node, Symbol.from(reference))) {
-                return node;
-            }
-            return context.defaultRewrite(node);
+            return visitPlan(node, context);
         }
 
         @Override

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
@@ -75,7 +75,6 @@ public class TestMySqlDistributedQueries
 
     @Test
     public void testDropTable()
-            throws Exception
     {
         assertUpdate("CREATE TABLE test_drop AS SELECT 123 x", 1);
         assertTrue(queryRunner.tableExists(getSession(), "test_drop"));
@@ -86,7 +85,7 @@ public class TestMySqlDistributedQueries
 
     @Test
     public void testViews()
-            throws Exception
+            throws SQLException
     {
         execute("CREATE OR REPLACE VIEW tpch.test_view AS SELECT * FROM tpch.orders");
 
@@ -97,7 +96,6 @@ public class TestMySqlDistributedQueries
 
     @Test
     public void testPrestoCreatedParameterizedVarchar()
-            throws Exception
     {
         DataTypeTest.create()
                 .addRoundTrip(stringDataType("varchar(10)", createVarcharType(255)), "text_a")
@@ -114,7 +112,6 @@ public class TestMySqlDistributedQueries
 
     @Test
     public void testMySqlCreatedParameterizedVarchar()
-            throws Exception
     {
         DataTypeTest.create()
                 .addRoundTrip(stringDataType("tinytext", createVarcharType(255)), "a")
@@ -128,7 +125,6 @@ public class TestMySqlDistributedQueries
 
     @Test
     public void testMySqlCreatedParameterizedVarcharUnicode()
-            throws Exception
     {
         String sampleUnicodeText = "\u653b\u6bbb\u6a5f\u52d5\u968a";
         DataTypeTest.create()
@@ -144,14 +140,12 @@ public class TestMySqlDistributedQueries
 
     @Test
     public void testPrestoCreatedParameterizedChar()
-            throws Exception
     {
         mysqlCharTypeTest().execute(queryRunner, prestoCreateAsSelect("mysql_test_parameterized_char"));
     }
 
     @Test
     public void testMySqlCreatedParameterizedChar()
-            throws Exception
     {
         mysqlCharTypeTest().execute(queryRunner, mysqlCreateAndInsert("tpch.mysql_test_parameterized_char"));
     }
@@ -170,7 +164,6 @@ public class TestMySqlDistributedQueries
 
     @Test
     public void testMySqlCreatedParameterizedCharUnicode()
-            throws Exception
     {
         DataTypeTest.create()
                 .addRoundTrip(charDataType(1, CHARACTER_SET_UTF8), "\u653b")
@@ -192,7 +185,6 @@ public class TestMySqlDistributedQueries
 
     @Override
     public void testShowColumns()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
 

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -67,7 +67,6 @@ public class TestPostgreSqlDistributedQueries
 
     @Override
     public void testLargeIn()
-            throws Exception
     {
         // the PostgreSQL query fails with "stack depth limit exceeded"
         // TODO: fix QueryBuilder not to generate such a large query
@@ -76,7 +75,6 @@ public class TestPostgreSqlDistributedQueries
 
     @Test
     public void testDropTable()
-            throws Exception
     {
         assertUpdate("CREATE TABLE test_drop AS SELECT 123 x", 1);
         assertTrue(queryRunner.tableExists(getSession(), "test_drop"));
@@ -98,14 +96,12 @@ public class TestPostgreSqlDistributedQueries
 
     @Test
     public void testPrestoCreatedParameterizedVarchar()
-            throws Exception
     {
         varcharDataTypeTest().execute(queryRunner, prestoCreateAsSelect("presto_test_parameterized_varchar"));
     }
 
     @Test
     public void testPostgreSqlCreatedParameterizedVarchar()
-            throws Exception
     {
         varcharDataTypeTest().execute(queryRunner, postgresCreateAndInsert("tpch.postgresql_test_parameterized_varchar"));
     }
@@ -122,28 +118,24 @@ public class TestPostgreSqlDistributedQueries
 
     @Test
     public void testPrestoCreatedParameterizedVarcharUnicode()
-            throws Exception
     {
         unicodeVarcharDateTypeTest().execute(queryRunner, prestoCreateAsSelect("postgresql_test_parameterized_varchar_unicode"));
     }
 
     @Test
     public void testPostgreSqlCreatedParameterizedVarcharUnicode()
-            throws Exception
     {
         unicodeVarcharDateTypeTest().execute(queryRunner, postgresCreateAndInsert("tpch.postgresql_test_parameterized_varchar_unicode"));
     }
 
     @Test
     public void testPrestoCreatedParameterizedCharUnicode()
-            throws Exception
     {
         unicodeDataTypeTest(DataType::charDataType).execute(queryRunner, prestoCreateAsSelect("postgresql_test_parameterized_char_unicode"));
     }
 
     @Test
     public void testPostgreSqlCreatedParameterizedCharUnicode()
-            throws Exception
     {
         unicodeDataTypeTest(DataType::charDataType).execute(queryRunner, postgresCreateAndInsert("tpch.postgresql_test_parameterized_char_unicode"));
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -69,7 +69,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testSetSession()
-            throws Exception
     {
         MaterializedResult result = computeActual("SET SESSION test_string = 'bar'");
         assertTrue((Boolean) getOnlyElement(result).getField(0));
@@ -106,7 +105,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testResetSession()
-            throws Exception
     {
         MaterializedResult result = computeActual(getSession(), "RESET SESSION test_string");
         assertTrue((Boolean) getOnlyElement(result).getField(0));
@@ -119,7 +117,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testCreateTable()
-            throws Exception
     {
         assertUpdate("CREATE TABLE test_create (a bigint, b double, c varchar)");
         assertTrue(queryRunner.tableExists(getSession(), "test_create"));
@@ -157,7 +154,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testCreateTableAsSelect()
-            throws Exception
     {
         assertUpdate("CREATE TABLE test_create_table_as_if_not_exists (a bigint, b double)");
         assertTrue(queryRunner.tableExists(getSession(), "test_create_table_as_if_not_exists"));
@@ -294,19 +290,16 @@ public abstract class AbstractTestDistributedQueries
     }
 
     protected void assertCreateTableAsSelect(String table, @Language("SQL") String query, @Language("SQL") String rowCountQuery)
-            throws Exception
     {
         assertCreateTableAsSelect(getSession(), table, query, query, rowCountQuery);
     }
 
     protected void assertCreateTableAsSelect(String table, @Language("SQL") String query, @Language("SQL") String expectedQuery, @Language("SQL") String rowCountQuery)
-            throws Exception
     {
         assertCreateTableAsSelect(getSession(), table, query, expectedQuery, rowCountQuery);
     }
 
     protected void assertCreateTableAsSelect(Session session, String table, @Language("SQL") String query, @Language("SQL") String expectedQuery, @Language("SQL") String rowCountQuery)
-            throws Exception
     {
         assertUpdate(session, "CREATE TABLE " + table + " AS " + query, rowCountQuery);
         assertQuery(session, "SELECT * FROM " + table, expectedQuery);
@@ -317,7 +310,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testRenameTable()
-            throws Exception
     {
         assertUpdate("CREATE TABLE test_rename AS SELECT 123 x", 1);
 
@@ -338,7 +330,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testRenameColumn()
-            throws Exception
     {
         assertUpdate("CREATE TABLE test_rename_column AS SELECT 123 x", 1);
 
@@ -356,7 +347,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testAddColumn()
-            throws Exception
     {
         assertUpdate("CREATE TABLE test_add_column AS SELECT 123 x", 1);
         assertUpdate("CREATE TABLE test_add_column_a AS SELECT 234 x, 111 a", 1);
@@ -396,7 +386,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testInsert()
-            throws Exception
     {
         @Language("SQL") String query = "SELECT orderdate, orderkey, totalprice FROM orders";
 
@@ -446,7 +435,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testDelete()
-            throws Exception
     {
         // delete half the table, then delete the rest
 
@@ -566,7 +554,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testDropTableIfExists()
-            throws Exception
     {
         assertFalse(queryRunner.tableExists(getSession(), "test_drop_if_exists"));
         assertUpdate("DROP TABLE IF EXISTS test_drop_if_exists");
@@ -575,7 +562,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testView()
-            throws Exception
     {
         skipTestUnless(supportsViews());
 
@@ -600,7 +586,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testViewCaseSensitivity()
-            throws Exception
     {
         skipTestUnless(supportsViews());
 
@@ -612,7 +597,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testCompatibleTypeChangeForView()
-            throws Exception
     {
         skipTestUnless(supportsViews());
 
@@ -633,7 +617,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testCompatibleTypeChangeForView2()
-            throws Exception
     {
         skipTestUnless(supportsViews());
 
@@ -654,7 +637,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testViewMetadata()
-            throws Exception
     {
         skipTestUnless(supportsViews());
 
@@ -729,14 +711,12 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testLargeQuerySuccess()
-            throws Exception
     {
         assertQuery("SELECT " + Joiner.on(" AND ").join(nCopies(500, "1 = 1")), "SELECT true");
     }
 
     @Test
     public void testShowSchemasFromOther()
-            throws Exception
     {
         MaterializedResult result = computeActual("SHOW SCHEMAS FROM tpch");
         assertTrue(result.getOnlyColumnAsSet().containsAll(ImmutableSet.of(INFORMATION_SCHEMA, "tiny", "sf1")));
@@ -744,7 +724,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testTableSampleSystem()
-            throws Exception
     {
         int total = computeActual("SELECT orderkey FROM orders").getMaterializedRows().size();
 
@@ -761,7 +740,6 @@ public abstract class AbstractTestDistributedQueries
 
     @Test
     public void testTableSampleSystemBoundaryValues()
-            throws Exception
     {
         MaterializedResult fullSample = computeActual("SELECT orderkey FROM orders TABLESAMPLE SYSTEM (100)");
         MaterializedResult emptySample = computeActual("SELECT orderkey FROM orders TABLESAMPLE SYSTEM (0)");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -137,14 +137,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testParsingError()
-            throws Exception
     {
         assertQueryFails("SELECT foo FROM", "line 1:16: no viable alternative at input.*");
     }
 
     @Test
     public void selectLargeInterval()
-            throws Exception
     {
         MaterializedResult result = computeActual("SELECT INTERVAL '30' DAY");
         assertEquals(result.getRowCount(), 1);
@@ -157,14 +155,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void selectNull()
-            throws Exception
     {
         assertQuery("SELECT NULL", "SELECT NULL FROM (SELECT * FROM ORDERS LIMIT 1)");
     }
 
     @Test
     public void testLimitIntMax()
-            throws Exception
     {
         assertQuery("SELECT orderkey from orders LIMIT " + Integer.MAX_VALUE);
         assertQuery("SELECT orderkey from orders ORDER BY orderkey LIMIT " + Integer.MAX_VALUE);
@@ -196,7 +192,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testMapSubscript()
-            throws Exception
     {
         assertQuery("select map(array[1], array['aa'])[1]", "select 'aa'");
         assertQuery("select map(array['a'], array['aa'])['a']", "select 'aa'");
@@ -206,7 +201,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testVarbinary()
-            throws Exception
     {
         assertQuery("SELECT LENGTH(x) FROM (SELECT from_base64('gw==') as x)", "SELECT 1");
         assertQuery("SELECT LENGTH(from_base64('gw=='))", "SELECT 1");
@@ -214,7 +208,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowFieldAccessor()
-            throws Exception
     {
         //Dereference only
         assertQuery("SELECT a.col0 FROM (VALUES ROW (CAST(ROW(1, 2) AS ROW(col0 integer, col1 integer)))) AS t (a)", "SELECT 1");
@@ -236,7 +229,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowFieldAccessorInAggregate()
-            throws Exception
     {
         assertQuery("SELECT a.col0, SUM(a.col1[2]), SUM(a.col2.col0), SUM(a.col2.col1) FROM " +
                         "(VALUES " +
@@ -315,7 +307,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowFieldAccessorInWindowFunction()
-            throws Exception
     {
         assertQuery("SELECT a.col0, " +
                         "SUM(a.col1[1].col1) OVER(PARTITION BY a.col2.col0), " +
@@ -342,7 +333,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowFieldAccessorInJoin()
-            throws Exception
     {
         assertQuery("" +
                         "SELECT t.a.col1, custkey, orderkey FROM " +
@@ -357,7 +347,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowCast()
-            throws Exception
     {
         assertQuery("SELECT cast(row(1, 2) as row(aa bigint, bb boolean)).aa", "SELECT 1");
         assertQuery("SELECT cast(row(1, 2) as row(aa bigint, bb boolean)).bb", "SELECT true");
@@ -369,7 +358,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testDereferenceInSubquery()
-            throws Exception
     {
         assertQuery("" +
                         "SELECT x " +
@@ -415,7 +403,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testDereferenceInFunctionCall()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(DISTINCT custkey) " +
@@ -428,7 +415,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testDereferenceInComparison()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT orders.custkey, orders.orderkey " +
@@ -438,7 +424,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testMissingRowFieldInGroupBy()
-            throws Exception
     {
         assertQueryFails(
                 "SELECT a.col0, count(*) FROM (VALUES ROW(cast(ROW(1, 1) as ROW(col0 integer, col1 integer)))) t(a)",
@@ -447,7 +432,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWhereWithRowField()
-            throws Exception
     {
         assertQuery("SELECT a.col0 FROM (VALUES ROW(CAST(ROW(1, 2) AS ROW(col0 integer, col1 integer)))) AS t (a) WHERE a.col0 > 0", "SELECT 1");
         assertQuery("SELECT SUM(a.col0) FROM (VALUES ROW(CAST(ROW(1, 2) AS ROW(col0 integer, col1 integer)))) AS t (a) WHERE a.col0 <= 0", "SELECT null");
@@ -459,7 +443,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testUnnest()
-            throws Exception
     {
         assertQuery("SELECT 1 FROM (VALUES (ARRAY[1])) AS t (a) CROSS JOIN UNNEST(a)", "SELECT 1");
         assertQuery("SELECT x[1] FROM UNNEST(ARRAY[ARRAY[1, 2, 3]]) t(x)", "SELECT 1");
@@ -521,7 +504,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testArrays()
-            throws Exception
     {
         assertQuery("SELECT a[1] FROM (SELECT ARRAY[orderkey] AS a FROM orders ORDER BY orderkey) t", "SELECT orderkey FROM orders");
         assertQuery("SELECT a[1 + cast(round(rand()) AS BIGINT)] FROM (SELECT ARRAY[orderkey, orderkey] AS a FROM orders ORDER BY orderkey) t", "SELECT orderkey FROM orders");
@@ -533,7 +515,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRows()
-            throws Exception
     {
         // Using JSON_FORMAT(CAST(_ AS JSON)) because H2 does not support ROW type
         assertQuery("SELECT JSON_FORMAT(CAST(ROW(1 + 2, CONCAT('a', 'b')) AS JSON))", "SELECT '[3,\"ab\"]'");
@@ -551,14 +532,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testMaps()
-            throws Exception
     {
         assertQuery("SELECT m[max_key] FROM (SELECT map_agg(orderkey, orderkey) m, max(orderkey) max_key FROM orders)", "SELECT max(orderkey) FROM orders");
     }
 
     @Test
     public void testValues()
-            throws Exception
     {
         assertQuery("VALUES 1, 2, 3, 4");
         assertQuery("VALUES 1, 3, 2, 4 ORDER BY 1", "SELECT * FROM (VALUES 1, 3, 2, 4) ORDER BY 1");
@@ -584,7 +563,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSpecialFloatingPointValues()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT nan(), infinity(), -infinity()");
         MaterializedRow row = getOnlyElement(actual.getMaterializedRows());
@@ -595,14 +573,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testMaxMinStringWithNulls()
-            throws Exception
     {
         assertQuery("SELECT custkey, MAX(NULLIF(orderstatus, 'O')), MIN(NULLIF(orderstatus, 'O')) FROM orders GROUP BY custkey");
     }
 
     @Test
     public void testApproxPercentile()
-            throws Exception
     {
         MaterializedResult raw = computeActual("SELECT orderstatus, orderkey, totalprice FROM ORDERS");
 
@@ -649,7 +625,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testComplexQuery()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT sum(orderkey), row_number() OVER (ORDER BY orderkey)\n" +
                 "FROM orders\n" +
@@ -670,7 +645,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWhereNull()
-            throws Exception
     {
         // This query is has this strange shape to force the compiler to leave a true on the stack
         // with the null flag set so if the filter method is not handling nulls correctly, this
@@ -680,28 +654,24 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSumOfNulls()
-            throws Exception
     {
         assertQuery("SELECT orderstatus, sum(CAST(NULL AS BIGINT)) FROM orders GROUP BY orderstatus");
     }
 
     @Test
     public void testAggregationWithSomeArgumentCasts()
-            throws Exception
     {
         assertQuery("SELECT APPROX_PERCENTILE(0.1, x), AVG(x), MIN(x) FROM (values 1, 1, 1) t(x)", "SELECT 0.1, 1.0, 1");
     }
 
     @Test
     public void testAggregationWithHaving()
-            throws Exception
     {
         assertQuery("SELECT a, count(1) FROM (VALUES 1, 2, 3, 2) t(a) GROUP BY a HAVING count(1) > 1", "SELECT 2, 2");
     }
 
     @Test
     public void testApproximateCountDistinct()
-            throws Exception
     {
         assertQuery("SELECT approx_distinct(custkey) FROM orders", "SELECT 996");
         assertQuery("SELECT approx_distinct(custkey, 0.023) FROM orders", "SELECT 996");
@@ -715,7 +685,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testApproximateCountDistinctGroupBy()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT orderstatus, approx_distinct(custkey) FROM orders GROUP BY orderstatus");
         MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
@@ -729,7 +698,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testApproximateCountDistinctGroupByWithStandardError()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT orderstatus, approx_distinct(custkey, 0.023) FROM orders GROUP BY orderstatus");
         MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
@@ -743,42 +711,36 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCountBoolean()
-            throws Exception
     {
         assertQuery("SELECT COUNT(true) FROM orders");
     }
 
     @Test
     public void testJoinWithMultiFieldGroupBy()
-            throws Exception
     {
         assertQuery("SELECT orderstatus FROM lineitem JOIN (SELECT DISTINCT orderkey, orderstatus FROM ORDERS) T on lineitem.orderkey = T.orderkey");
     }
 
     @Test
     public void testGroupByRepeatedField()
-            throws Exception
     {
         assertQuery("SELECT sum(custkey) FROM orders GROUP BY orderstatus, orderstatus");
     }
 
     @Test
     public void testGroupByRepeatedField2()
-            throws Exception
     {
         assertQuery("SELECT count(*) FROM (select orderstatus a, orderstatus b FROM orders) GROUP BY a, b");
     }
 
     @Test
     public void testGroupByMultipleFieldsWithPredicateOnAggregationArgument()
-            throws Exception
     {
         assertQuery("SELECT custkey, orderstatus, MAX(orderkey) FROM ORDERS WHERE orderkey = 1 GROUP BY custkey, orderstatus");
     }
 
     @Test
     public void testReorderOutputsOfGroupByAggregation()
-            throws Exception
     {
         assertQuery(
                 "SELECT orderstatus, a, custkey, b FROM (SELECT custkey, orderstatus, -COUNT(*) a, MAX(orderkey) b FROM ORDERS WHERE orderkey = 1 GROUP BY custkey, orderstatus) T");
@@ -786,14 +748,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupAggregationOverNestedGroupByAggregation()
-            throws Exception
     {
         assertQuery("SELECT sum(custkey), max(orderstatus), min(c) FROM (SELECT orderstatus, custkey, COUNT(*) c FROM ORDERS GROUP BY orderstatus, custkey) T");
     }
 
     @Test
     public void test15WayGroupBy()
-            throws Exception
     {
         // Among other things, this test verifies we are not getting for overflow in the distributed HashPagePartitionFunction
         assertQuery("" +
@@ -809,14 +769,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testDistinctMultipleFields()
-            throws Exception
     {
         assertQuery("SELECT DISTINCT custkey, orderstatus FROM ORDERS");
     }
 
     @Test
     public void testDistinctJoin()
-            throws Exception
     {
         assertQuery("SELECT COUNT(DISTINCT CAST(b.quantity AS BIGINT)), a.orderstatus " +
                 "FROM orders a " +
@@ -827,28 +785,24 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testArithmeticNegation()
-            throws Exception
     {
         assertQuery("SELECT -custkey FROM orders");
     }
 
     @Test
     public void testDistinct()
-            throws Exception
     {
         assertQuery("SELECT DISTINCT custkey FROM orders");
     }
 
     @Test
     public void testDistinctGroupBy()
-            throws Exception
     {
         assertQuery("SELECT COUNT(DISTINCT clerk) as count, orderdate FROM orders GROUP BY orderdate ORDER BY count, orderdate");
     }
 
     @Test
     public void testSingleDistinctOptimizer()
-            throws Exception
     {
         assertQuery("SELECT custkey, orderstatus, COUNT(DISTINCT orderkey) FROM orders GROUP BY custkey, orderstatus");
         assertQuery("SELECT custkey, orderstatus, COUNT(DISTINCT orderkey), SUM(DISTINCT orderkey) FROM orders GROUP BY custkey, orderstatus");
@@ -886,7 +840,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testDistinctHaving()
-            throws Exception
     {
         assertQuery("SELECT COUNT(DISTINCT clerk) AS count " +
                 "FROM orders " +
@@ -913,7 +866,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testDistinctWindow()
-            throws Exception
     {
         MaterializedResult actual = computeActual(
                 "SELECT RANK() OVER (PARTITION BY orderdate ORDER BY COUNT(DISTINCT clerk)) rnk " +
@@ -927,21 +879,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testDistinctWhere()
-            throws Exception
     {
         assertQuery("SELECT COUNT(DISTINCT clerk) FROM orders WHERE LENGTH(clerk) > 5");
     }
 
     @Test
     public void testMultipleDifferentDistinct()
-            throws Exception
     {
         assertQuery("SELECT COUNT(DISTINCT orderstatus), SUM(DISTINCT custkey) FROM orders");
     }
 
     @Test
     public void testMultipleDistinct()
-            throws Exception
     {
         assertQuery(
                 "SELECT COUNT(DISTINCT custkey), SUM(DISTINCT custkey) FROM orders",
@@ -950,7 +899,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testComplexDistinct()
-            throws Exception
     {
         assertQuery(
                 "SELECT COUNT(DISTINCT custkey), " +
@@ -967,7 +915,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testDistinctLimit()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT DISTINCT orderstatus, custkey " +
@@ -979,21 +926,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCountDistinct()
-            throws Exception
     {
         assertQuery("SELECT COUNT(DISTINCT custkey + 1) FROM orders", "SELECT COUNT(*) FROM (SELECT DISTINCT custkey + 1 FROM orders) t");
     }
 
     @Test
     public void testDistinctWithOrderBy()
-            throws Exception
     {
         assertQueryOrdered("SELECT DISTINCT custkey FROM orders ORDER BY custkey LIMIT 10");
     }
 
     @Test
     public void testDistinctWithOrderByNotInSelect()
-            throws Exception
     {
         assertQueryFails(
                 "SELECT DISTINCT custkey FROM orders ORDER BY orderkey LIMIT 10",
@@ -1002,70 +946,60 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testOrderByLimit()
-            throws Exception
     {
         assertQueryOrdered("SELECT custkey, orderstatus FROM ORDERS ORDER BY orderkey DESC LIMIT 10");
     }
 
     @Test
     public void testOrderByExpressionWithLimit()
-            throws Exception
     {
         assertQueryOrdered("SELECT custkey, orderstatus FROM ORDERS ORDER BY orderkey + 1 DESC LIMIT 10");
     }
 
     @Test
     public void testGroupByOrderByLimit()
-            throws Exception
     {
         assertQueryOrdered("SELECT custkey, SUM(totalprice) FROM ORDERS GROUP BY custkey ORDER BY SUM(totalprice) DESC LIMIT 10");
     }
 
     @Test
     public void testLimitZero()
-            throws Exception
     {
         assertQuery("SELECT custkey, totalprice FROM orders LIMIT 0");
     }
 
     @Test
     public void testLimitAll()
-            throws Exception
     {
         assertQuery("SELECT custkey, totalprice FROM orders LIMIT ALL", "SELECT custkey, totalprice FROM orders");
     }
 
     @Test
     public void testOrderByLimitZero()
-            throws Exception
     {
         assertQuery("SELECT custkey, totalprice FROM orders ORDER BY orderkey LIMIT 0");
     }
 
     @Test
     public void testOrderByLimitAll()
-            throws Exception
     {
         assertQuery("SELECT custkey, totalprice FROM orders ORDER BY orderkey LIMIT ALL", "SELECT custkey, totalprice FROM orders ORDER BY orderkey");
     }
 
     @Test
     public void testRepeatedAggregations()
-            throws Exception
     {
         assertQuery("SELECT SUM(orderkey), SUM(orderkey) FROM ORDERS");
     }
 
     @Test
     public void testRepeatedOutputs()
-            throws Exception
     {
         assertQuery("SELECT orderkey a, orderkey b FROM ORDERS WHERE orderstatus = 'F'");
     }
 
     @Test
     public void testRepeatedOutputs2()
-            throws Exception
     {
         // this test exposed a bug that wasn't caught by other tests that resulted in the execution engine
         // trying to read orderkey as the second field, causing a type mismatch
@@ -1074,7 +1008,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testLimit()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT orderkey FROM ORDERS LIMIT 10");
         MaterializedResult all = computeExpected("SELECT orderkey FROM ORDERS", actual.getTypes());
@@ -1085,7 +1018,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testAggregationWithLimit()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT custkey, SUM(totalprice) FROM ORDERS GROUP BY custkey LIMIT 10");
         MaterializedResult all = computeExpected("SELECT custkey, SUM(totalprice) FROM ORDERS GROUP BY custkey", actual.getTypes());
@@ -1096,7 +1028,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testLimitInInlineView()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT orderkey FROM (SELECT orderkey FROM ORDERS LIMIT 100) T LIMIT 10");
         MaterializedResult all = computeExpected("SELECT orderkey FROM ORDERS", actual.getTypes());
@@ -1107,7 +1038,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCountAll()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM ORDERS");
         assertQuery("SELECT COUNT(42) FROM ORDERS", "SELECT COUNT(*) FROM ORDERS");
@@ -1117,7 +1047,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCountColumn()
-            throws Exception
     {
         assertQuery("SELECT COUNT(orderkey) FROM ORDERS");
         assertQuery("SELECT COUNT(orderstatus) FROM ORDERS");
@@ -1130,56 +1059,48 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWildcard()
-            throws Exception
     {
         assertQuery("SELECT * FROM ORDERS");
     }
 
     @Test
     public void testMultipleWildcards()
-            throws Exception
     {
         assertQuery("SELECT *, 123, * FROM ORDERS");
     }
 
     @Test
     public void testMixedWildcards()
-            throws Exception
     {
         assertQuery("SELECT *, orders.*, orderkey FROM orders");
     }
 
     @Test
     public void testQualifiedWildcardFromAlias()
-            throws Exception
     {
         assertQuery("SELECT T.* FROM ORDERS T");
     }
 
     @Test
     public void testQualifiedWildcardFromInlineView()
-            throws Exception
     {
         assertQuery("SELECT T.* FROM (SELECT orderkey + custkey FROM ORDERS) T");
     }
 
     @Test
     public void testQualifiedWildcard()
-            throws Exception
     {
         assertQuery("SELECT ORDERS.* FROM ORDERS");
     }
 
     @Test
     public void testAverageAll()
-            throws Exception
     {
         assertQuery("SELECT AVG(totalprice) FROM ORDERS");
     }
 
     @Test
     public void testVariance()
-            throws Exception
     {
         // int64
         assertQuery("SELECT VAR_SAMP(custkey) FROM ORDERS");
@@ -1196,7 +1117,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testVariancePop()
-            throws Exception
     {
         // int64
         assertQuery("SELECT VAR_POP(custkey) FROM ORDERS");
@@ -1213,7 +1133,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testStdDev()
-            throws Exception
     {
         // int64
         assertQuery("SELECT STDDEV_SAMP(custkey) FROM ORDERS");
@@ -1230,7 +1149,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testStdDevPop()
-            throws Exception
     {
         // int64
         assertQuery("SELECT STDDEV_POP(custkey) FROM ORDERS");
@@ -1247,63 +1165,54 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCountAllWithPredicate()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM ORDERS WHERE orderstatus = 'F'");
     }
 
     @Test
     public void testGroupByArray()
-            throws Exception
     {
         assertQuery("SELECT col[1], count FROM (SELECT ARRAY[custkey] col, COUNT(*) count FROM ORDERS GROUP BY 1 ORDER BY 1)", "SELECT custkey, COUNT(*) FROM orders GROUP BY custkey ORDER BY custkey");
     }
 
     @Test
     public void testGroupByMap()
-            throws Exception
     {
         assertQuery("SELECT col[1], count FROM (SELECT MAP(ARRAY[1], ARRAY[custkey]) col, COUNT(*) count FROM ORDERS GROUP BY 1)", "SELECT custkey, COUNT(*) FROM orders GROUP BY custkey");
     }
 
     @Test
     public void testGroupByComplexMap()
-            throws Exception
     {
         assertQuery("SELECT MAP_KEYS(x)[1] FROM (VALUES MAP(ARRAY['a'], ARRAY[ARRAY[1]]), MAP(ARRAY['b'], ARRAY[ARRAY[2]])) t(x) GROUP BY x", "SELECT * FROM (VALUES 'a', 'b')");
     }
 
     @Test
     public void testGroupByRow()
-            throws Exception
     {
         assertQuery("SELECT col.col1, count FROM (SELECT cast(row(custkey, custkey) as row(col0 bigint, col1 bigint)) col, COUNT(*) count FROM ORDERS GROUP BY 1)", "SELECT custkey, COUNT(*) FROM orders GROUP BY custkey");
     }
 
     @Test
     public void testJoinCoercion()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM orders t join (SELECT * FROM orders LIMIT 1) t2 ON sin(t2.custkey) = 0");
     }
 
     @Test
     public void testJoinCoercionOnEqualityComparison()
-            throws Exception
     {
         assertQuery("SELECT o.clerk, avg(o.shippriority), COUNT(l.linenumber) FROM orders o LEFT OUTER JOIN lineitem l ON o.orderkey=l.orderkey AND o.shippriority=1 GROUP BY o.clerk");
     }
 
     @Test
     public void testGroupByNoAggregations()
-            throws Exception
     {
         assertQuery("SELECT custkey FROM ORDERS GROUP BY custkey");
     }
 
     @Test
     public void testGroupByCount()
-            throws Exception
     {
         assertQuery(
                 "SELECT orderstatus, COUNT(*) FROM ORDERS GROUP BY orderstatus",
@@ -1313,14 +1222,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupByMultipleFields()
-            throws Exception
     {
         assertQuery("SELECT custkey, orderstatus, COUNT(*) FROM ORDERS GROUP BY custkey, orderstatus");
     }
 
     @Test
     public void testGroupByWithAlias()
-            throws Exception
     {
         assertQuery(
                 "SELECT orderdate x, COUNT(*) FROM orders GROUP BY orderdate",
@@ -1330,21 +1237,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupBySum()
-            throws Exception
     {
         assertQuery("SELECT suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY suppkey");
     }
 
     @Test
     public void testGroupByRequireIntegerCoercion()
-            throws Exception
     {
         assertQuery("SELECT partkey, COUNT(DISTINCT shipdate), SUM(linenumber) FROM lineitem GROUP BY partkey");
     }
 
     @Test
     public void testGroupByEmptyGroupingSet()
-            throws Exception
     {
         assertQuery("SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY ()",
                 "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem");
@@ -1352,14 +1256,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupByWithWildcard()
-            throws Exception
     {
         assertQuery("SELECT * FROM (SELECT orderkey FROM orders) t GROUP BY orderkey");
     }
 
     @Test
     public void testSingleGroupingSet()
-            throws Exception
     {
         assertQuery(
                 "SELECT linenumber, SUM(CAST(quantity AS BIGINT)) " +
@@ -1372,7 +1274,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSets()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
                 "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
@@ -1381,7 +1282,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsNoInput()
-            throws Exception
     {
         assertQuery(
                 "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
@@ -1401,7 +1301,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsWithGlobalAggregationNoInput()
-            throws Exception
     {
         assertQuery(
                 "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
@@ -1425,7 +1324,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsWithSingleDistinct()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
                 "SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
@@ -1434,7 +1332,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsWithMultipleDistinct()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
                 "SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) FROM lineitem GROUP BY linenumber, suppkey UNION " +
@@ -1443,7 +1340,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsWithMultipleDistinctNoInput()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) " +
                         "FROM lineitem " +
@@ -1462,7 +1358,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsGrandTotalSet()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
                 "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
@@ -1471,7 +1366,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsRepeatedSetsAll()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((), (linenumber, suppkey), (), (linenumber, suppkey))",
                 "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
@@ -1482,7 +1376,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsRepeatedSetsAllNoInput()
-            throws Exception
     {
         assertQuery(
                 "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
@@ -1510,7 +1403,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsRepeatedSetsDistinct()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY DISTINCT GROUPING SETS ((), (linenumber, suppkey), (), (linenumber, suppkey))",
                 "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
@@ -1519,7 +1411,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsGrandTotalSetFirst()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((), (linenumber), (linenumber, suppkey))",
                 "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
@@ -1529,7 +1420,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsOnlyGrandTotalSet()
-            throws Exception
     {
         assertQuery("SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS (())",
                 "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem");
@@ -1537,7 +1427,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsMultipleGrandTotalSets()
-            throws Exception
     {
         assertQuery("SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((), ())",
                 "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem UNION ALL " +
@@ -1546,7 +1435,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsMultipleGrandTotalSetsNoInput()
-            throws Exception
     {
         assertQuery("SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY GROUPING SETS ((), ())",
                 "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 UNION ALL " +
@@ -1568,7 +1456,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetMixedExpressionAndColumn()
-            throws Exception
     {
         assertQuery("SELECT suppkey, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate), ROLLUP(suppkey)",
                 "SELECT suppkey, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate), suppkey UNION ALL " +
@@ -1577,7 +1464,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetMixedExpressionAndOrdinal()
-            throws Exception
     {
         assertQuery("SELECT suppkey, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY 2, ROLLUP(suppkey)",
                 "SELECT suppkey, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate), suppkey UNION ALL " +
@@ -1586,7 +1472,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetSubsetAndPartitioning()
-            throws Exception
     {
         assertQuery("SELECT COUNT_IF(x IS NULL) FROM (" +
                         "SELECT x, y, COUNT(z) FROM (SELECT CAST(lineitem.orderkey AS BIGINT) x, lineitem.linestatus y, SUM(lineitem.quantity) z FROM lineitem " +
@@ -1596,7 +1481,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetPredicatePushdown()
-            throws Exception
     {
         assertQuery("SELECT * FROM (" +
                         "SELECT COALESCE(orderpriority, 'ALL'), COALESCE(shippriority, -1) sp FROM (" +
@@ -1606,7 +1490,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsAggregateOnGroupedColumn()
-            throws Exception
     {
         assertQuery("SELECT orderpriority, COUNT(orderpriority) FROM orders GROUP BY ROLLUP (orderpriority)",
                 "SELECT orderpriority, COUNT(orderpriority) FROM orders GROUP BY orderpriority UNION " +
@@ -1615,7 +1498,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsMultipleAggregatesOnGroupedColumn()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, SUM(suppkey), COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
                 "SELECT linenumber, suppkey, SUM(suppkey), COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
@@ -1624,7 +1506,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsMultipleAggregatesOnUngroupedColumn()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, COUNT(CAST(quantity AS BIGINT)), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
                 "SELECT linenumber, suppkey, COUNT(CAST(quantity AS BIGINT)), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
@@ -1633,7 +1514,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsMultipleAggregatesWithGroupedColumns()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
                 "SELECT linenumber, suppkey, COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
@@ -1642,7 +1522,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsWithSingleDistinctAndUnion()
-            throws Exception
     {
         assertQuery("SELECT suppkey, COUNT(DISTINCT linenumber) FROM " +
                         "(SELECT * FROM lineitem WHERE linenumber%2 = 0 UNION ALL SELECT * FROM lineitem WHERE linenumber%2 = 1) " +
@@ -1653,7 +1532,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsWithSingleDistinctAndUnionGroupedArguments()
-            throws Exception
     {
         assertQuery("SELECT linenumber, COUNT(DISTINCT linenumber) FROM " +
                         "(SELECT * FROM lineitem WHERE linenumber%2 = 0 UNION ALL SELECT * FROM lineitem WHERE linenumber%2 = 1) " +
@@ -1664,7 +1542,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingSetsWithMultipleDistinctAndUnion()
-            throws Exception
     {
         assertQuery("SELECT linenumber, COUNT(DISTINCT linenumber), SUM(DISTINCT suppkey) FROM " +
                         "(SELECT * FROM lineitem WHERE linenumber%2 = 0 UNION ALL SELECT * FROM lineitem WHERE linenumber%2 = 1) " +
@@ -1675,7 +1552,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRollup()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY ROLLUP (linenumber, suppkey)",
                 "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
@@ -1685,7 +1561,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCube()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY CUBE (linenumber, suppkey)",
                 "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
@@ -1696,7 +1571,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCubeNoInput()
-            throws Exception
     {
         assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY CUBE (linenumber, suppkey)",
                 "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY linenumber, suppkey UNION ALL " +
@@ -1707,7 +1581,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingCombinationsAll()
-            throws Exception
     {
         assertQuery("SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, ROLLUP (suppkey, linenumber), CUBE (linenumber)",
                 "SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, suppkey, linenumber UNION ALL " +
@@ -1720,7 +1593,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupingCombinationsDistinct()
-            throws Exception
     {
         assertQuery("SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY DISTINCT orderkey, partkey, ROLLUP (suppkey, linenumber), CUBE (linenumber)",
                 "SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, suppkey, linenumber UNION ALL " +
@@ -1731,7 +1603,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRollupOverUnion()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT orderstatus, sum(orderkey)\n" +
@@ -1749,7 +1620,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testIntersect()
-            throws Exception
     {
         assertQuery(
                 "SELECT regionkey FROM nation WHERE nationkey < 7 " +
@@ -1795,7 +1665,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testIntersectWithAggregation()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM nation INTERSECT SELECT COUNT(regionkey) FROM nation HAVING SUM(regionkey) IS NOT NULL");
         assertQuery("SELECT SUM(nationkey), COUNT(name) FROM (SELECT nationkey,name FROM nation INTERSECT SELECT regionkey, name FROM nation) n");
@@ -1813,7 +1682,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testExcept()
-            throws Exception
     {
         assertQuery(
                 "SELECT regionkey FROM nation WHERE nationkey < 7 " +
@@ -1855,7 +1723,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testExceptWithAggregation()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM nation EXCEPT SELECT COUNT(regionkey) FROM nation where regionkey < 3 HAVING SUM(regionkey) IS NOT NULL");
         assertQuery("SELECT SUM(nationkey), COUNT(name) FROM (SELECT nationkey, name FROM nation where nationkey < 6 EXCEPT SELECT regionkey, name FROM nation) n");
@@ -1873,35 +1740,30 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCountAllWithComparison()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem WHERE tax < discount");
     }
 
     @Test
     public void testSelectWithComparison()
-            throws Exception
     {
         assertQuery("SELECT orderkey FROM lineitem WHERE tax < discount");
     }
 
     @Test
     public void testCountWithNotPredicate()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem WHERE NOT tax < discount");
     }
 
     @Test
     public void testCountWithNullPredicate()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem WHERE NULL");
     }
 
     @Test
     public void testCountWithIsNullPredicate()
-            throws Exception
     {
         assertQuery(
                 "SELECT COUNT(*) FROM orders WHERE NULLIF(orderstatus, 'F') IS NULL",
@@ -1911,7 +1773,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCountWithIsNotNullPredicate()
-            throws Exception
     {
         assertQuery(
                 "SELECT COUNT(*) FROM orders WHERE NULLIF(orderstatus, 'F') IS NOT NULL",
@@ -1921,14 +1782,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCountWithNullIfPredicate()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM orders WHERE NULLIF(orderstatus, 'F') = orderstatus ");
     }
 
     @Test
     public void testCountWithCoalescePredicate()
-            throws Exception
     {
         assertQuery(
                 "SELECT COUNT(*) FROM orders WHERE COALESCE(NULLIF(orderstatus, 'F'), 'bar') = 'bar'",
@@ -1938,91 +1797,78 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCountWithAndPredicate()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem WHERE tax < discount AND tax > 0.01 AND discount < 0.05");
     }
 
     @Test
     public void testCountWithOrPredicate()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem WHERE tax < 0.01 OR discount > 0.05");
     }
 
     @Test
     public void testCountWithInlineView()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM (SELECT orderkey FROM lineitem) x");
     }
 
     @Test
     public void testNestedCount()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM (SELECT orderkey, COUNT(*) FROM lineitem GROUP BY orderkey) x");
     }
 
     @Test
     public void testAggregationWithProjection()
-            throws Exception
     {
         assertQuery("SELECT sum(totalprice * 2) - sum(totalprice) FROM orders");
     }
 
     @Test
     public void testAggregationWithProjection2()
-            throws Exception
     {
         assertQuery("SELECT sum(totalprice * 2) + sum(totalprice * 2) FROM orders");
     }
 
     @Test
     public void testGroupByOnSupersetOfPartitioning()
-            throws Exception
     {
         assertQuery("SELECT orderdate, c, count(*) FROM (SELECT orderdate, count(*) c FROM orders GROUP BY orderdate) GROUP BY orderdate, c");
     }
 
     @Test
     public void testInlineView()
-            throws Exception
     {
         assertQuery("SELECT orderkey, custkey FROM (SELECT orderkey, custkey FROM ORDERS) U");
     }
 
     @Test
     public void testAliasedInInlineView()
-            throws Exception
     {
         assertQuery("SELECT x, y FROM (SELECT orderkey x, custkey y FROM ORDERS) U");
     }
 
     @Test
     public void testInlineViewWithProjections()
-            throws Exception
     {
         assertQuery("SELECT x + 1, y FROM (SELECT orderkey * 10 x, custkey y FROM ORDERS) u");
     }
 
     @Test
     public void testGroupByWithoutAggregation()
-            throws Exception
     {
         assertQuery("SELECT orderstatus FROM orders GROUP BY orderstatus");
     }
 
     @Test
     public void testNestedGroupByWithSameKey()
-            throws Exception
     {
         assertQuery("SELECT custkey, sum(t) FROM (SELECT custkey, count(*) t FROM orders GROUP BY custkey) GROUP BY custkey");
     }
 
     @Test
     public void testGroupByWithNulls()
-            throws Exception
     {
         assertQuery("SELECT key, COUNT(*) FROM (" +
                 "SELECT CASE " +
@@ -2036,14 +1882,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testHistogram()
-            throws Exception
     {
         assertQuery("SELECT lines, COUNT(*) FROM (SELECT orderkey, COUNT(*) lines FROM lineitem GROUP BY orderkey) U GROUP BY lines");
     }
 
     @Test
     public void testSimpleJoin()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey");
         assertQuery("" +
@@ -2056,35 +1900,30 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithRightConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = 2");
     }
 
     @Test
     public void testJoinWithLeftConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON orders.orderkey = 2");
     }
 
     @Test
     public void testSimpleJoinWithLeftConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.orderkey = 2");
     }
 
     @Test
     public void testSimpleJoinWithRightConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.orderkey = 2");
     }
 
     @Test
     public void testJoinDoubleClauseWithLeftOverlap()
-            throws Exception
     {
         // Checks to make sure that we properly handle duplicate field references in join clauses
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.orderkey = orders.custkey");
@@ -2092,7 +1931,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinDoubleClauseWithRightOverlap()
-            throws Exception
     {
         // Checks to make sure that we properly handle duplicate field references in join clauses
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.orderkey = lineitem.partkey");
@@ -2100,21 +1938,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithAlias()
-            throws Exception
     {
         assertQuery("SELECT * FROM (lineitem JOIN orders ON lineitem.orderkey = orders.orderkey) x");
     }
 
     @Test
     public void testJoinWithConstantExpression()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND 123 = 123");
     }
 
     @Test
     public void testJoinWithConstantPredicatePushDown()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT\n" +
@@ -2134,7 +1969,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithInferredFalseJoinClause()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(*)\n" +
@@ -2146,7 +1980,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinUsing()
-            throws Exception
     {
         assertQuery(
                 "SELECT COUNT(*) FROM lineitem join orders using (orderkey)",
@@ -2156,7 +1989,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinCriteriaCoercion()
-            throws Exception
     {
         assertQuery(
                 "SELECT * FROM (VALUES (1.0, 2.0)) x (a, b) JOIN (VALUES (1, 3)) y (a, b) USING(a)",
@@ -2178,21 +2010,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithReversedComparison()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON orders.orderkey = lineitem.orderkey");
     }
 
     @Test
     public void testJoinWithComplexExpressions()
-            throws Exception
     {
         assertQuery("SELECT SUM(custkey) FROM lineitem JOIN orders ON lineitem.orderkey = CAST(orders.orderkey AS BIGINT)");
     }
 
     @Test
     public void testJoinWithComplexExpressions2()
-            throws Exception
     {
         assertQuery(
                 "SELECT SUM(custkey) FROM lineitem JOIN orders ON lineitem.orderkey = CASE WHEN orders.custkey = 1 and orders.orderstatus = 'F' THEN orders.orderkey ELSE NULL END");
@@ -2200,7 +2029,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithComplexExpressions3()
-            throws Exception
     {
         assertQuery(
                 "SELECT SUM(custkey) FROM lineitem JOIN orders ON lineitem.orderkey + 1 = orders.orderkey + 1",
@@ -2211,14 +2039,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSelfJoin()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM orders a JOIN orders b on a.orderkey = b.orderkey");
     }
 
     @Test
     public void testWildcardFromJoin()
-            throws Exception
     {
         assertQuery(
                 "SELECT * FROM (select orderkey, partkey from lineitem) a join (select orderkey, custkey from orders) b using (orderkey)",
@@ -2228,7 +2054,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testQualifiedWildcardFromJoin()
-            throws Exception
     {
         assertQuery(
                 "SELECT a.*, b.* FROM (select orderkey, partkey from lineitem) a join (select orderkey, custkey from orders) b using (orderkey)",
@@ -2238,7 +2063,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinAggregations()
-            throws Exception
     {
         assertQuery(
                 "SELECT x + y FROM (" +
@@ -2248,7 +2072,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testNonEqualityJoin()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity + length(orders.comment) > 7");
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND NOT lineitem.quantity > 2");
@@ -2279,7 +2102,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testNonEqualityLeftJoin()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM " +
                 "      (SELECT * FROM lineitem ORDER BY orderkey,linenumber LIMIT 5) l " +
@@ -2345,7 +2167,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testNonEqalityJoinWithScalarRequiringSessionParameter()
-            throws Exception
     {
         assertQuery("SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND from_unixtime(b) > current_timestamp",
                 "VALUES (1, 1, NULL, NULL), (1, 2, NULL, NULL)");
@@ -2353,7 +2174,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testNonEqualityJoinWithTryInFilter()
-            throws Exception
     {
         assertQuery("SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) " +
                 "             ON a=c AND TRY(1 / (b-a) != 1000)",
@@ -2367,7 +2187,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testLeftJoinWithEmptyInnerTable()
-            throws Exception
     {
         // Use orderkey = rand() to create an empty relation
         assertQuery("SELECT * FROM lineitem a LEFT JOIN (SELECT * FROM orders WHERE orderkey = rand()) b ON a.orderkey = b.orderkey");
@@ -2379,7 +2198,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRightJoinWithEmptyInnerTable()
-            throws Exception
     {
         // Use orderkey = rand() to create an empty relation
         assertQuery("SELECT * FROM orders b RIGHT JOIN (SELECT * FROM orders WHERE orderkey = rand()) a ON a.orderkey = b.orderkey");
@@ -2391,7 +2209,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testNonEqualityRightJoin()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM " +
                 "      (SELECT * FROM lineitem ORDER BY orderkey,linenumber LIMIT 5) l " +
@@ -2520,7 +2337,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testNonEqualityFullJoin()
-            throws Exception
     {
         assertQuery(
                 "SELECT COUNT(*) FROM lineitem FULL JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5 WHERE lineitem.orderkey IS NULL OR orders.orderkey IS NULL",
@@ -2583,14 +2399,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinOnMultipleFields()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.shipdate = orders.orderdate");
     }
 
     @Test
     public void testJoinUsingMultipleFields()
-            throws Exception
     {
         assertQuery(
                 "SELECT COUNT(*) FROM lineitem JOIN (SELECT orderkey, orderdate shipdate FROM ORDERS) T USING (orderkey, shipdate)",
@@ -2600,7 +2414,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testColocatedJoinWithLocalUnion()
-            throws Exception
     {
         assertQuery(
                 "select count(*) from ((select * from orders) union all (select * from orders)) join orders using (orderkey)",
@@ -2609,14 +2422,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithNonJoinExpression()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey = 1");
     }
 
     @Test
     public void testJoinWithNullValues()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT *\n" +
@@ -2635,7 +2446,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithMultipleInSubqueryClauses()
-            throws Exception
     {
         QueryTemplate.Parameter type = new QueryTemplate.Parameter("type", "");
         QueryTemplate.Parameter condition = new QueryTemplate.Parameter("condition", "true");
@@ -2683,7 +2493,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithInSubqueryToBeExecutedAsPostJoinFilter()
-            throws Exception
     {
         QueryTemplate.Parameter type = new QueryTemplate.Parameter("type", "");
         QueryTemplate.Parameter condition = new QueryTemplate.Parameter("condition", "true");
@@ -2716,7 +2525,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testOuterJoinWithComplexCorrelatedSubquery()
-            throws Exception
     {
         QueryTemplate.Parameter type = new QueryTemplate.Parameter("type");
         QueryTemplate.Parameter condition = new QueryTemplate.Parameter("condition");
@@ -2736,7 +2544,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithMultipleScalarSubqueryClauses()
-            throws Exception
     {
         QueryTemplate.Parameter type = new QueryTemplate.Parameter("type", "");
         QueryTemplate.Parameter condition = new QueryTemplate.Parameter("condition");
@@ -2768,7 +2575,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithScalarSubqueryToBeExecutedAsPostJoinFilter()
-            throws Exception
     {
         QueryTemplate.Parameter type = new QueryTemplate.Parameter("type", "");
         QueryTemplate.Parameter condition = new QueryTemplate.Parameter("condition");
@@ -2814,7 +2620,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithScalarSubqueryToBeExecutedAsPostJoinFilterWithEmptyInnerTable()
-            throws Exception
     {
         String noOutputQuery = "SELECT 1 WHERE false";
         QueryTemplate.Parameter type = new QueryTemplate.Parameter("type", "");
@@ -2888,7 +2693,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testLeftFilteredJoin()
-            throws Exception
     {
         // Test predicate move around
         assertQuery("SELECT custkey, linestatus, tax, totalprice, orderstatus FROM (SELECT * FROM lineitem WHERE orderkey % 2 = 0) a JOIN orders ON a.orderkey = orders.orderkey");
@@ -2896,7 +2700,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRightFilteredJoin()
-            throws Exception
     {
         // Test predicate move around
         assertQuery("SELECT custkey, linestatus, tax, totalprice, orderstatus FROM lineitem JOIN (SELECT *  FROM orders WHERE orderkey % 2 = 0) a ON lineitem.orderkey = a.orderkey");
@@ -2904,14 +2707,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithFullyPushedDownJoinClause()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON orders.custkey = 1 AND lineitem.orderkey = 1");
     }
 
     @Test
     public void testJoinPredicateMoveAround()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*)\n" +
                 "FROM (SELECT * FROM lineitem WHERE orderkey % 16 = 0 AND partkey % 2 = 0) lineitem\n" +
@@ -2922,7 +2723,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSimpleFullJoin()
-            throws Exception
     {
         assertQuery("SELECT a, b FROM (VALUES (1), (2)) t (a) FULL OUTER JOIN (VALUES (1), (3)) u (b) ON a = b",
                 "SELECT * FROM (VALUES (1, 1), (2, NULL), (NULL, 3))");
@@ -2954,7 +2754,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testFullJoinNormalizedToLeft()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem FULL JOIN orders ON lineitem.orderkey = orders.orderkey WHERE lineitem.orderkey IS NOT NULL",
                 "SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey WHERE lineitem.orderkey IS NOT NULL");
@@ -2967,7 +2766,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testFullJoinNormalizedToRight()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem FULL JOIN orders ON lineitem.orderkey = orders.orderkey WHERE orders.orderkey IS NOT NULL",
                 "SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey  WHERE orders.orderkey IS NOT NULL");
@@ -2980,7 +2778,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testFullJoinWithRightConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM (SELECT * FROM lineitem WHERE orderkey % 1024 = 0) lineitem FULL JOIN orders ON lineitem.orderkey = 1024",
                 "SELECT COUNT(*) FROM (" +
@@ -2993,7 +2790,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testFullJoinWithLeftConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM (SELECT * FROM lineitem WHERE orderkey % 1024 = 0) lineitem FULL JOIN orders ON orders.orderkey = 1024",
                 "SELECT COUNT(*) FROM (" +
@@ -3006,7 +2802,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSimpleFullJoinWithLeftConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem FULL JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.orderkey = 2",
                 "SELECT COUNT(*) FROM (" +
@@ -3019,7 +2814,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSimpleFullJoinWithRightConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem FULL JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.orderkey = 2",
                 "SELECT COUNT(*) FROM (" +
@@ -3032,7 +2826,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testOuterJoinWithNullsOnProbe()
-            throws Exception
     {
         assertQuery(
                 "SELECT DISTINCT a.orderkey FROM " +
@@ -3060,7 +2853,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testOuterJoinWithCommonExpression()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT count(1), count(one) " +
                 "FROM (values (1, 'a'), (2, 'a')) as l(k, a) " +
@@ -3076,7 +2868,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSimpleLeftJoin()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem LEFT JOIN orders ON lineitem.orderkey = orders.orderkey");
         assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey");
@@ -3094,56 +2885,48 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testLeftJoinNormalizedToInner()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem LEFT JOIN orders ON lineitem.orderkey = orders.orderkey WHERE orders.orderkey IS NOT NULL");
     }
 
     @Test
     public void testLeftJoinWithRightConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM (SELECT * FROM lineitem WHERE orderkey % 1024 = 0) lineitem LEFT JOIN orders ON lineitem.orderkey = 1024");
     }
 
     @Test
     public void testLeftJoinWithLeftConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM (SELECT * FROM lineitem WHERE orderkey % 1024 = 0) lineitem LEFT JOIN orders ON orders.orderkey = 1024");
     }
 
     @Test
     public void testSimpleLeftJoinWithLeftConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem LEFT JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.orderkey = 2");
     }
 
     @Test
     public void testSimpleLeftJoinWithRightConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem LEFT JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.orderkey = 2");
     }
 
     @Test
     public void testDoubleFilteredLeftJoinWithRightConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM (SELECT * FROM lineitem WHERE orderkey % 1024 = 0) lineitem LEFT JOIN (SELECT * FROM orders WHERE orderkey % 1024 = 0) orders ON orders.orderkey = 1024");
     }
 
     @Test
     public void testDoubleFilteredLeftJoinWithLeftConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM (SELECT * FROM lineitem WHERE orderkey % 1024 = 0) lineitem LEFT JOIN (SELECT * FROM orders WHERE orderkey % 1024 = 0) orders ON lineitem.orderkey = 1024");
     }
 
     @Test
     public void testLeftJoinDoubleClauseWithLeftOverlap()
-            throws Exception
     {
         // Checks to make sure that we properly handle duplicate field references in join clauses
         assertQuery("SELECT COUNT(*) FROM lineitem LEFT JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.orderkey = orders.custkey");
@@ -3151,7 +2934,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testLeftJoinDoubleClauseWithRightOverlap()
-            throws Exception
     {
         // Checks to make sure that we properly handle duplicate field references in join clauses
         assertQuery("SELECT COUNT(*) FROM lineitem LEFT JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.orderkey = lineitem.partkey");
@@ -3159,21 +2941,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testBuildFilteredLeftJoin()
-            throws Exception
     {
         assertQuery("SELECT * FROM lineitem LEFT JOIN (SELECT * FROM orders WHERE orderkey % 2 = 0) a ON lineitem.orderkey = a.orderkey");
     }
 
     @Test
     public void testProbeFilteredLeftJoin()
-            throws Exception
     {
         assertQuery("SELECT * FROM (SELECT * FROM lineitem WHERE orderkey % 2 = 0) a LEFT JOIN orders ON a.orderkey = orders.orderkey");
     }
 
     @Test
     public void testLeftJoinPredicateMoveAround()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*)\n" +
                 "FROM (SELECT * FROM lineitem WHERE orderkey % 16 = 0 AND partkey % 2 = 0) lineitem\n" +
@@ -3184,7 +2963,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testLeftJoinEqualityInference()
-            throws Exception
     {
         // Test that we can infer orders.orderkey % 4 = orders.custkey % 3 on the inner side
         assertQuery("SELECT COUNT(*)\n" +
@@ -3196,7 +2974,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testLeftJoinWithNullValues()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT *\n" +
@@ -3215,7 +2992,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSimpleRightJoin()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem RIGHT JOIN orders ON lineitem.orderkey = orders.orderkey");
         assertQuery("SELECT COUNT(*) FROM lineitem RIGHT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey");
@@ -3226,7 +3002,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRightJoinNormalizedToInner()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem RIGHT JOIN orders ON lineitem.orderkey = orders.orderkey WHERE lineitem.orderkey IS NOT NULL");
         assertQuery("SELECT COUNT(*) FROM lineitem RIGHT JOIN orders ON lineitem.orderkey = orders.custkey WHERE lineitem.orderkey IS NOT NULL");
@@ -3234,49 +3009,42 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRightJoinWithRightConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM (SELECT * FROM lineitem WHERE orderkey % 1024 = 0) lineitem RIGHT JOIN orders ON lineitem.orderkey = 1024");
     }
 
     @Test
     public void testRightJoinWithLeftConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM (SELECT * FROM lineitem WHERE orderkey % 1024 = 0) lineitem RIGHT JOIN orders ON orders.orderkey = 1024");
     }
 
     @Test
     public void testDoubleFilteredRightJoinWithRightConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM (SELECT * FROM lineitem WHERE orderkey % 1024 = 0) lineitem RIGHT JOIN (SELECT * FROM orders WHERE orderkey % 1024 = 0) orders ON orders.orderkey = 1024");
     }
 
     @Test
     public void testDoubleFilteredRightJoinWithLeftConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM (SELECT * FROM lineitem WHERE orderkey % 1024 = 0) lineitem RIGHT JOIN (SELECT * FROM orders WHERE orderkey % 1024 = 0) orders ON lineitem.orderkey = 1024");
     }
 
     @Test
     public void testSimpleRightJoinWithLeftConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem RIGHT JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.orderkey = 2");
     }
 
     @Test
     public void testSimpleRightJoinWithRightConstantEquality()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) FROM lineitem RIGHT JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.orderkey = 2");
     }
 
     @Test
     public void testRightJoinDoubleClauseWithLeftOverlap()
-            throws Exception
     {
         // Checks to make sure that we properly handle duplicate field references in join clauses
         assertQuery("SELECT COUNT(*) FROM lineitem RIGHT JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.orderkey = orders.custkey");
@@ -3284,7 +3052,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRightJoinDoubleClauseWithRightOverlap()
-            throws Exception
     {
         // Checks to make sure that we properly handle duplicate field references in join clauses
         assertQuery("SELECT COUNT(*) FROM lineitem RIGHT JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.orderkey = lineitem.partkey");
@@ -3292,21 +3059,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testBuildFilteredRightJoin()
-            throws Exception
     {
         assertQuery("SELECT custkey, linestatus, tax, totalprice, orderstatus FROM (SELECT * FROM lineitem WHERE orderkey % 2 = 0) a RIGHT JOIN orders ON a.orderkey = orders.orderkey");
     }
 
     @Test
     public void testProbeFilteredRightJoin()
-            throws Exception
     {
         assertQuery("SELECT custkey, linestatus, tax, totalprice, orderstatus FROM lineitem RIGHT JOIN (SELECT *  FROM orders WHERE orderkey % 2 = 0) a ON lineitem.orderkey = a.orderkey");
     }
 
     @Test
     public void testRightJoinPredicateMoveAround()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*)\n" +
                 "FROM (SELECT * FROM orders WHERE orderkey % 16 = 0 AND custkey % 2 = 0) orders\n" +
@@ -3317,7 +3081,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRightJoinEqualityInference()
-            throws Exception
     {
         // Test that we can infer orders.orderkey % 4 = orders.custkey % 3 on the inner side
         assertQuery("SELECT COUNT(*)\n" +
@@ -3329,7 +3092,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRightJoinWithNullValues()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT lineitem.orderkey, orders.orderkey\n" +
@@ -3348,7 +3110,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinWithDuplicateRelations()
-            throws Exception
     {
         assertQuery("SELECT * FROM orders JOIN orders USING (orderkey)", "SELECT * FROM orders o1 JOIN orders o2 ON o1.orderkey = o2.orderkey");
         assertQuery("SELECT * FROM lineitem x JOIN orders x USING (orderkey)", "SELECT * FROM lineitem l JOIN orders o ON l.orderkey = o.orderkey");
@@ -3367,7 +3128,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testAggregationOverRigthJoinOverSingleStreamProbe()
-            throws Exception
     {
         // this should return one row since value is always 'value'
         // this test verifies that the two streams produced by the right join
@@ -3398,28 +3158,24 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testOrderBy()
-            throws Exception
     {
         assertQueryOrdered("SELECT orderstatus FROM orders ORDER BY orderstatus");
     }
 
     @Test
     public void testOrderBy2()
-            throws Exception
     {
         assertQueryOrdered("SELECT orderstatus FROM orders ORDER BY orderkey DESC");
     }
 
     @Test
     public void testOrderByMultipleFields()
-            throws Exception
     {
         assertQueryOrdered("SELECT custkey, orderstatus FROM orders ORDER BY custkey DESC, orderstatus");
     }
 
     @Test
     public void testOrderByDuplicateFields()
-            throws Exception
     {
         assertQueryOrdered("SELECT custkey, custkey FROM orders ORDER BY custkey, custkey");
         assertQueryOrdered("SELECT custkey, custkey FROM orders ORDER BY custkey ASC, custkey DESC");
@@ -3427,7 +3183,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testOrderByWithNulls()
-            throws Exception
     {
         // nulls first
         assertQueryOrdered("SELECT orderkey, custkey, orderstatus FROM orders ORDER BY nullif(orderkey, 3) ASC NULLS FIRST, custkey ASC");
@@ -3445,35 +3200,30 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testOrderByAlias()
-            throws Exception
     {
         assertQueryOrdered("SELECT orderstatus x FROM orders ORDER BY x ASC");
     }
 
     @Test
     public void testOrderByAliasWithSameNameAsUnselectedColumn()
-            throws Exception
     {
         assertQueryOrdered("SELECT orderstatus orderdate FROM orders ORDER BY orderdate ASC");
     }
 
     @Test
     public void testOrderByOrdinal()
-            throws Exception
     {
         assertQueryOrdered("SELECT orderstatus, orderdate FROM orders ORDER BY 2, 1");
     }
 
     @Test
     public void testOrderByOrdinalWithWildcard()
-            throws Exception
     {
         assertQueryOrdered("SELECT * FROM orders ORDER BY 1");
     }
 
     @Test
     public void testGroupByOrdinal()
-            throws Exception
     {
         assertQuery(
                 "SELECT orderstatus, sum(totalprice) FROM orders GROUP BY 1",
@@ -3482,7 +3232,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupBySearchedCase()
-            throws Exception
     {
         assertQuery("SELECT CASE WHEN orderstatus = 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
                 "FROM orders\n" +
@@ -3499,7 +3248,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupBySearchedCaseNoElse()
-            throws Exception
     {
         // whole CASE in group by clause
         assertQuery("SELECT CASE WHEN orderstatus = 'O' THEN 'a' END, count(*)\n" +
@@ -3521,7 +3269,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupByCase()
-            throws Exception
     {
         // whole CASE in group by clause
         assertQuery("SELECT CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
@@ -3559,7 +3306,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupByCaseNoElse()
-            throws Exception
     {
         // whole CASE in group by clause
         assertQuery("SELECT CASE orderstatus WHEN 'O' THEN 'a' END, count(*)\n" +
@@ -3584,7 +3330,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupByCast()
-            throws Exception
     {
         // whole CAST in group by expression
         assertQuery("SELECT CAST(orderkey AS VARCHAR), count(*) FROM orders GROUP BY CAST(orderkey AS VARCHAR)");
@@ -3599,7 +3344,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupByCoalesce()
-            throws Exception
     {
         // whole COALESCE in group by
         assertQuery("SELECT COALESCE(orderkey, custkey), count(*) FROM orders GROUP BY COALESCE(orderkey, custkey)");
@@ -3618,7 +3362,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupByNullIf()
-            throws Exception
     {
         // whole NULLIF in group by
         assertQuery("SELECT NULLIF(orderkey, custkey), count(*) FROM orders GROUP BY NULLIF(orderkey, custkey)");
@@ -3636,7 +3379,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupByExtract()
-            throws Exception
     {
         // whole expression in group by
         assertQuery("SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY EXTRACT(YEAR FROM now())");
@@ -3651,7 +3393,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupByNullConstant()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT count(*)\n" +
@@ -3664,21 +3405,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testChecksum()
-            throws Exception
     {
         assertQuery("SELECT to_hex(checksum(0))", "select '0000000000000000'");
     }
 
     @Test
     public void testMaxBy()
-            throws Exception
     {
         assertQuery("SELECT MAX_BY(orderkey, totalprice) FROM orders", "SELECT orderkey FROM orders ORDER BY totalprice DESC LIMIT 1");
     }
 
     @Test
     public void testMaxByN()
-            throws Exception
     {
         assertQuery("SELECT y FROM (SELECT MAX_BY(orderkey, totalprice, 2) mx FROM orders) CROSS JOIN UNNEST(mx) u(y)",
                 "SELECT orderkey FROM orders ORDER BY totalprice DESC LIMIT 2");
@@ -3686,14 +3424,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testMinBy()
-            throws Exception
     {
         assertQuery("SELECT MIN_BY(orderkey, totalprice) FROM orders", "SELECT orderkey FROM orders ORDER BY totalprice ASC LIMIT 1");
     }
 
     @Test
     public void testMinByN()
-            throws Exception
     {
         assertQuery("SELECT y FROM (SELECT MIN_BY(orderkey, totalprice, 2) mx FROM orders) CROSS JOIN UNNEST(mx) u(y)",
                 "SELECT orderkey FROM orders ORDER BY totalprice ASC LIMIT 2");
@@ -3701,7 +3437,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupByBetween()
-            throws Exception
     {
         // whole expression in group by
         assertQuery("SELECT orderkey BETWEEN 1 AND 100 FROM orders GROUP BY orderkey BETWEEN 1 AND 100 ");
@@ -3718,7 +3453,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testAggregationImplicitCoercion()
-            throws Exception
     {
         assertQuery("SELECT 1.0 / COUNT(*) FROM orders");
         assertQuery("SELECT custkey, 1.0 / COUNT(*) FROM orders GROUP BY custkey");
@@ -3726,7 +3460,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWindowImplicitCoercion()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT orderkey, 1.0 / row_number() OVER (ORDER BY orderkey) FROM orders LIMIT 2");
 
@@ -3740,21 +3473,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testHaving()
-            throws Exception
     {
         assertQuery("SELECT orderstatus, sum(totalprice) FROM orders GROUP BY orderstatus HAVING orderstatus = 'O'");
     }
 
     @Test
     public void testHaving2()
-            throws Exception
     {
         assertQuery("SELECT custkey, sum(orderkey) FROM orders GROUP BY custkey HAVING sum(orderkey) > 400000");
     }
 
     @Test
     public void testHaving3()
-            throws Exception
     {
         assertQuery("SELECT custkey, sum(totalprice) * 2 FROM orders GROUP BY custkey");
         assertQuery("SELECT custkey, avg(totalprice + 5) FROM orders GROUP BY custkey");
@@ -3763,14 +3493,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testHavingWithoutGroupBy()
-            throws Exception
     {
         assertQuery("SELECT sum(orderkey) FROM orders HAVING sum(orderkey) > 400000");
     }
 
     @Test
     public void testGroupByAsJoinProbe()
-            throws Exception
     {
         // we join on customer key instead of order key because
         // orders is effectively distributed on order key due the
@@ -3790,7 +3518,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinEffectivePredicateWithNoRanges()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT * FROM orders a " +
@@ -3800,7 +3527,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testColumnAliases()
-            throws Exception
     {
         assertQuery(
                 "SELECT x, T.y, z + 1 FROM (SELECT custkey, orderstatus, totalprice FROM orders) T (x, y, z)",
@@ -3809,14 +3535,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSameInputToAggregates()
-            throws Exception
     {
         assertQuery("SELECT max(a), max(b) FROM (SELECT custkey a, custkey b FROM orders) x");
     }
 
     @Test
     public void testWindowFunctionWithImplicitCoercion()
-            throws Exception
     {
         assertQuery("SELECT *, 1.0 * sum(x) OVER () FROM (VALUES 1) t(x)", "SELECT 1, 1.0");
     }
@@ -3845,7 +3569,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWindowFunctionsFromAggregate()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT * FROM (\n" +
@@ -3874,7 +3597,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testOrderByWindowFunction()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderkey, row_number() OVER (ORDER BY orderkey)\n" +
@@ -3895,7 +3617,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSameWindowFunctionsTwoCoerces()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT 12.0 * row_number() OVER ()/row_number() OVER(),\n" +
@@ -3930,7 +3651,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowNumberNoOptimization()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderkey, orderstatus FROM (\n" +
@@ -3953,7 +3673,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowNumberLimit()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT row_number() OVER (PARTITION BY orderstatus) rn, orderstatus\n" +
@@ -3982,7 +3701,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowNumberMultipleFilters()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT * FROM (" +
@@ -3997,7 +3715,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowNumberFilterAndLimit()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT * FROM (" +
@@ -4027,7 +3744,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowNumberUnpartitionedFilter()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderkey, orderstatus FROM (\n" +
@@ -4061,7 +3777,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowNumberPartitionedFilter()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderkey, orderstatus FROM (\n" +
@@ -4089,7 +3804,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowNumberJoin()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT a, rn\n" +
                 "FROM (\n" +
@@ -4121,7 +3835,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowNumberUnpartitionedFilterLimit()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT row_number() OVER ()\n" +
@@ -4132,7 +3845,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRowNumberPropertyDerivation()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderkey, orderstatus, SUM(rn) OVER (PARTITION BY orderstatus) c\n" +
@@ -4159,7 +3871,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWindowPropertyDerivation()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, orderkey,\n" +
@@ -4190,7 +3901,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTopNUnpartitionedWindow()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT * FROM (\n" +
@@ -4204,7 +3914,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTopNUnpartitionedLargeWindow()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT * FROM (\n" +
@@ -4218,7 +3927,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTopNPartitionedWindow()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT * FROM (\n" +
@@ -4269,7 +3977,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTopNUnpartitionedWindowWithEqualityFilter()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT * FROM (\n" +
@@ -4284,7 +3991,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTopNUnpartitionedWindowWithCompositeFilter()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT * FROM (\n" +
@@ -4303,7 +4009,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTopNPartitionedWindowWithEqualityFilter()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT * FROM (\n" +
@@ -4345,7 +4050,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWindowFunctionWithGroupBy()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT *, rank() OVER (PARTITION BY x)\n" +
@@ -4361,7 +4065,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testPartialPrePartitionedWindowFunction()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderkey, COUNT(*) OVER (PARTITION BY orderkey, custkey)\n" +
@@ -4381,7 +4084,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testFullPrePartitionedWindowFunction()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderkey, COUNT(*) OVER (PARTITION BY orderkey)\n" +
@@ -4401,7 +4103,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testPartialPreSortedWindowFunction()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderkey, COUNT(*) OVER (ORDER BY orderkey, custkey)\n" +
@@ -4421,7 +4122,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testFullPreSortedWindowFunction()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderkey, COUNT(*) OVER (ORDER BY orderkey)\n" +
@@ -4441,7 +4141,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testFullyPartitionedAndPartiallySortedWindowFunction()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderkey, custkey, orderPriority, COUNT(*) OVER (PARTITION BY orderkey ORDER BY custkey, orderPriority)\n" +
@@ -4461,7 +4160,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testFullyPartitionedAndFullySortedWindowFunction()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderkey, custkey, COUNT(*) OVER (PARTITION BY orderkey ORDER BY custkey)\n" +
@@ -4481,7 +4179,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testOrderByWindowFunctionWithNulls()
-            throws Exception
     {
         MaterializedResult actual;
         MaterializedResult expected;
@@ -4593,14 +4290,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testScalarFunction()
-            throws Exception
     {
         assertQuery("SELECT SUBSTR('Quadratically', 5, 6) FROM orders LIMIT 1");
     }
 
     @Test
     public void testCast()
-            throws Exception
     {
         assertQuery("SELECT CAST('1' AS BIGINT) FROM orders");
         assertQuery("SELECT CAST(totalprice AS BIGINT) FROM orders");
@@ -4629,7 +4324,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testInvalidCast()
-            throws Exception
     {
         assertQueryFails(
                 "SELECT CAST(1 AS DATE) FROM orders",
@@ -4638,7 +4332,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testInvalidCastInMultilineQuery()
-            throws Exception
     {
         assertQueryFails(
                 "SELECT CAST(totalprice AS BIGINT),\n" +
@@ -4649,7 +4342,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTryInvalidCast()
-            throws Exception
     {
         assertQuery("SELECT TRY(CAST('a' AS BIGINT))",
                 "SELECT NULL");
@@ -4657,21 +4349,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testConcatOperator()
-            throws Exception
     {
         assertQuery("SELECT '12' || '34' FROM orders LIMIT 1");
     }
 
     @Test
     public void testQuotedIdentifiers()
-            throws Exception
     {
         assertQuery("SELECT \"TOTALPRICE\" \"my price\" FROM \"ORDERS\"");
     }
 
     @Test
     public void testInvalidColumn()
-            throws Exception
     {
         assertQueryFails(
                 "select * from lineitem l join (select orderkey_1, custkey from orders) o on l.orderkey = o.orderkey_1",
@@ -4680,21 +4369,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testUnaliasedSubqueries()
-            throws Exception
     {
         assertQuery("SELECT orderkey FROM (SELECT orderkey FROM orders)");
     }
 
     @Test
     public void testUnaliasedSubqueries1()
-            throws Exception
     {
         assertQuery("SELECT a FROM (SELECT orderkey a FROM orders)");
     }
 
     @Test
     public void testJoinUnaliasedSubqueries()
-            throws Exception
     {
         assertQuery(
                 "SELECT COUNT(*) FROM (SELECT * FROM lineitem) join (SELECT * FROM orders) using (orderkey)",
@@ -4704,7 +4390,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWith()
-            throws Exception
     {
         assertQuery("" +
                 "WITH a AS (SELECT * FROM orders) " +
@@ -4714,7 +4399,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWithQualifiedPrefix()
-            throws Exception
     {
         assertQuery("" +
                 "WITH a AS (SELECT 123 FROM orders LIMIT 1)" +
@@ -4724,7 +4408,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWithAliased()
-            throws Exception
     {
         assertQuery("" +
                 "WITH a AS (SELECT * FROM orders) " +
@@ -4734,7 +4417,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testReferenceToWithQueryInFromClause()
-            throws Exception
     {
         assertQuery(
                 "WITH a AS (SELECT * FROM orders)" +
@@ -4746,7 +4428,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWithChaining()
-            throws Exception
     {
         assertQuery("" +
                 "WITH a AS (SELECT orderkey n FROM orders)\n" +
@@ -4758,7 +4439,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWithSelfJoin()
-            throws Exception
     {
         assertQuery("" +
                 "WITH x AS (SELECT DISTINCT orderkey FROM orders ORDER BY orderkey LIMIT 10)\n" +
@@ -4770,7 +4450,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWithNestedSubqueries()
-            throws Exception
     {
         assertQuery("" +
                 "WITH a AS (\n" +
@@ -4795,7 +4474,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWithColumnAliasing()
-            throws Exception
     {
         assertQuery(
                 "WITH a (id) AS (SELECT 123 FROM orders LIMIT 1) SELECT id FROM a",
@@ -4808,7 +4486,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWithHiding()
-            throws Exception
     {
         assertQuery("" +
                 "WITH a AS (SELECT 1), " +
@@ -4829,7 +4506,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWithRecursive()
-            throws Exception
     {
         assertQueryFails(
                 "WITH RECURSIVE a AS (SELECT 123) SELECT * FROM a",
@@ -4838,14 +4514,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCaseNoElse()
-            throws Exception
     {
         assertQuery("SELECT orderkey, CASE orderstatus WHEN 'O' THEN 'a' END FROM orders");
     }
 
     @Test
     public void testCaseNoElseInconsistentResultType()
-        throws Exception
     {
         assertQueryFails(
                 "SELECT orderkey, CASE orderstatus WHEN 'O' THEN 'a' WHEN '1' THEN 2 END FROM orders",
@@ -4854,7 +4528,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testIfExpression()
-            throws Exception
     {
         assertQuery(
                 "SELECT sum(IF(orderstatus = 'F', totalprice, 0.0)) FROM orders",
@@ -4875,7 +4548,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testIn()
-            throws Exception
     {
         assertQuery("SELECT orderkey FROM orders WHERE orderkey IN (1, 2, 3)");
         assertQuery("SELECT orderkey FROM orders WHERE orderkey IN (1.5, 2.3)", "SELECT orderkey FROM orders LIMIT 0"); // H2 incorrectly matches rows
@@ -4900,7 +4572,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testLargeIn()
-        throws Exception
     {
         String longValues =  range(0, 5000).asLongStream()
                 .mapToObj(Long::toString)
@@ -4917,7 +4588,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testInSubqueryWithCrossJoin()
-            throws Exception
     {
         assertQuery("SELECT a FROM (VALUES (1),(2)) t(a) WHERE a IN " +
                     "(SELECT b FROM (VALUES (ARRAY[2])) AS t1 (a) CROSS JOIN UNNEST(a) as t2(b))", "SELECT 2");
@@ -4925,7 +4595,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupByIf()
-            throws Exception
     {
         assertQuery(
                 "SELECT IF(orderkey between 1 and 5, 'orders', 'others'), sum(totalprice) FROM orders GROUP BY 1",
@@ -4936,7 +4605,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testDuplicateFields()
-            throws Exception
     {
         assertQuery(
                 "SELECT * FROM (SELECT orderkey, orderkey FROM orders)",
@@ -4945,7 +4613,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testDuplicateColumnsInWindowOrderByClause()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT a, row_number() OVER (ORDER BY a, a) FROM (VALUES 3, 2, 1) t(a)");
 
@@ -4960,70 +4627,60 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testWildcardFromSubquery()
-            throws Exception
     {
         assertQuery("SELECT * FROM (SELECT orderkey X FROM orders)");
     }
 
     @Test
     public void testCaseInsensitiveOutputAliasInOrderBy()
-            throws Exception
     {
         assertQueryOrdered("SELECT orderkey X FROM orders ORDER BY x");
     }
 
     @Test
     public void testCaseInsensitiveAttribute()
-            throws Exception
     {
         assertQuery("SELECT x FROM (SELECT orderkey X FROM orders)");
     }
 
     @Test
     public void testCaseInsensitiveAliasedRelation()
-            throws Exception
     {
         assertQuery("SELECT A.* FROM orders a");
     }
 
     @Test
     public void testCaseInsensitiveRowFieldReference()
-            throws Exception
     {
         assertQuery("SELECT a.Col0 FROM (VALUES row(cast(ROW(1,2) as ROW(col0 integer, col1 integer)))) AS t (a)", "SELECT 1");
     }
 
     @Test
     public void testSubqueryBody()
-            throws Exception
     {
         assertQuery("(SELECT orderkey, custkey FROM ORDERS)");
     }
 
     @Test
     public void testSubqueryBodyOrderLimit()
-            throws Exception
     {
         assertQueryOrdered("(SELECT orderkey AS a, custkey AS b FROM ORDERS) ORDER BY a LIMIT 1");
     }
 
     @Test
     public void testSubqueryBodyProjectedOrderby()
-            throws Exception
     {
         assertQueryOrdered("(SELECT orderkey, custkey FROM ORDERS) ORDER BY orderkey * -1");
     }
 
     @Test
     public void testSubqueryBodyDoubleOrderby()
-            throws Exception
     {
         assertQueryOrdered("(SELECT orderkey, custkey FROM ORDERS ORDER BY custkey) ORDER BY orderkey");
     }
 
     @Test
     public void testNodeRoster()
-            throws Exception
     {
         List<MaterializedRow> result = computeActual("SELECT * FROM system.runtime.nodes").getMaterializedRows();
         assertEquals(result.size(), getNodeCount());
@@ -5031,7 +4688,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCountOnInternalTables()
-            throws Exception
     {
         List<MaterializedRow> rows = computeActual("SELECT count(*) FROM system.runtime.nodes").getMaterializedRows();
         assertEquals(((Long) rows.get(0).getField(0)).longValue(), getNodeCount());
@@ -5039,7 +4695,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTransactionsTable()
-            throws Exception
     {
         List<MaterializedRow> result = computeActual("SELECT * FROM system.runtime.transactions").getMaterializedRows();
         assertTrue(result.size() >= 1); // At least one row for the current transaction.
@@ -5186,7 +4841,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testShowCatalogs()
-            throws Exception
     {
         MaterializedResult result = computeActual("SHOW CATALOGS");
         assertTrue(result.getOnlyColumnAsSet().contains(getSession().getCatalog().get()));
@@ -5194,7 +4848,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testShowCatalogsLike()
-            throws Exception
     {
         MaterializedResult result = computeActual(format("SHOW CATALOGS LIKE '%s'", getSession().getCatalog().get()));
         assertEquals(result.getOnlyColumnAsSet(), ImmutableSet.of(getSession().getCatalog().get()));
@@ -5202,7 +4855,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testShowSchemas()
-            throws Exception
     {
         MaterializedResult result = computeActual("SHOW SCHEMAS");
         assertTrue(result.getOnlyColumnAsSet().containsAll(ImmutableSet.of(getSession().getSchema().get(), INFORMATION_SCHEMA)));
@@ -5210,7 +4862,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testShowSchemasFrom()
-            throws Exception
     {
         MaterializedResult result = computeActual(format("SHOW SCHEMAS FROM %s", getSession().getCatalog().get()));
         assertTrue(result.getOnlyColumnAsSet().containsAll(ImmutableSet.of(getSession().getSchema().get(), INFORMATION_SCHEMA)));
@@ -5218,7 +4869,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testShowSchemasLike()
-            throws Exception
     {
         MaterializedResult result = computeActual(format("SHOW SCHEMAS LIKE '%s'", getSession().getSchema().get()));
         assertEquals(result.getOnlyColumnAsSet(), ImmutableSet.of(getSession().getSchema().get()));
@@ -5226,7 +4876,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testShowTables()
-            throws Exception
     {
         Set<String> expectedTables = ImmutableSet.copyOf(transform(TpchTable.getTables(), tableNameGetter()));
 
@@ -5236,7 +4885,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testShowTablesFrom()
-            throws Exception
     {
         Set<String> expectedTables = ImmutableSet.copyOf(transform(TpchTable.getTables(), tableNameGetter()));
 
@@ -5263,7 +4911,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testShowTablesLike()
-            throws Exception
     {
         MaterializedResult result = computeActual("SHOW TABLES LIKE 'or%'");
         assertEquals(result.getOnlyColumnAsSet(), ImmutableSet.of(ORDERS.getTableName()));
@@ -5271,7 +4918,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testShowColumns()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
 
@@ -5306,7 +4952,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testAtTimeZone()
-            throws Exception
     {
         assertQuery("SELECT TIMESTAMP '2012-10-31 01:00' AT TIME ZONE INTERVAL '07:09' hour to minute", "SELECT TIMESTAMP '2012-10-30 18:00:00.000 America/Los_Angeles'");
         assertQuery("SELECT TIMESTAMP '2012-10-31 01:00' AT TIME ZONE 'Asia/Oral'", "SELECT TIMESTAMP '2012-10-30 18:00:00.000 America/Los_Angeles'");
@@ -5334,7 +4979,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testShowFunctions()
-            throws Exception
     {
         MaterializedResult result = computeActual("SHOW FUNCTIONS");
         ImmutableMultimap<String, MaterializedRow> functions = Multimaps.index(result.getMaterializedRows(), input -> {
@@ -5378,7 +5022,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testInformationSchemaFiltering()
-            throws Exception
     {
         assertQuery(
                 "SELECT table_name FROM information_schema.tables WHERE table_name = 'orders' LIMIT 1",
@@ -5387,7 +5030,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSelectColumnOfNulls()
-            throws Exception
     {
         // Currently nulls can confuse the local planner, so select some
         assertQueryOrdered("SELECT \n" +
@@ -5399,7 +5041,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSelectCaseInsensitive()
-            throws Exception
     {
         assertQuery("SELECT ORDERKEY FROM ORDERS");
         assertQuery("SELECT OrDeRkEy FROM OrDeRs");
@@ -5407,7 +5048,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testShowSession()
-            throws Exception
     {
         Session session = new Session(
                 getSession().getQueryId(),
@@ -5450,7 +5090,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTry()
-            throws Exception
     {
         // divide by zero
         assertQuery(
@@ -5478,7 +5117,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTryNoMergeProjections()
-        throws Exception
     {
         // no regexp specified because the JVM optimizes away exception message constructor if run enough times
         assertQueryFails("SELECT TRY(x) FROM (SELECT 1/y as x FROM (VALUES 1, 2, 3, 0, 4) t(y))", ".*");
@@ -5486,14 +5124,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testNoFrom()
-            throws Exception
     {
         assertQuery("SELECT 1 + 2, 3 + 4", "SELECT 1 + 2, 3 + 4 FROM orders LIMIT 1");
     }
 
     @Test
     public void testTopNByMultipleFields()
-            throws Exception
     {
         assertQueryOrdered("SELECT orderkey, custkey, orderstatus FROM orders ORDER BY orderkey ASC, custkey ASC LIMIT 10");
         assertQueryOrdered("SELECT orderkey, custkey, orderstatus FROM orders ORDER BY orderkey ASC, custkey DESC LIMIT 10");
@@ -5522,7 +5158,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testExchangeWithProjectionPushDown()
-            throws Exception
     {
         assertQuery(
                 "SELECT * FROM \n" +
@@ -5534,14 +5169,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testUnionWithProjectionPushDown()
-            throws Exception
     {
         assertQuery("SELECT key + 5, status FROM (SELECT orderkey key, orderstatus status FROM orders UNION ALL SELECT orderkey key, linestatus status FROM lineitem)");
     }
 
     @Test
     public void testJoinProjectionPushDown()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT *\n" +
@@ -5555,7 +5188,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testUnion()
-            throws Exception
     {
         assertQuery("SELECT orderkey FROM orders UNION SELECT custkey FROM orders");
         assertQuery("SELECT 123 UNION DISTINCT SELECT 123 UNION ALL SELECT 123");
@@ -5567,28 +5199,24 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testUnionDistinct()
-            throws Exception
     {
         assertQuery("SELECT orderkey FROM orders UNION DISTINCT SELECT custkey FROM orders");
     }
 
     @Test
     public void testUnionAll()
-            throws Exception
     {
         assertQuery("SELECT orderkey FROM orders UNION ALL SELECT custkey FROM orders");
     }
 
     @Test
     public void testUnionArray()
-            throws Exception
     {
         assertQuery("SELECT a[1] FROM (SELECT ARRAY[1] UNION ALL SELECT ARRAY[1]) t(a) LIMIT 1", "SELECT 1");
     }
 
     @Test
     public void testChainedUnionsWithOrder()
-            throws Exception
     {
         assertQueryOrdered(
                 "SELECT orderkey FROM orders UNION (SELECT custkey FROM orders UNION SELECT linenumber FROM lineitem) UNION ALL SELECT orderkey FROM lineitem ORDER BY orderkey");
@@ -5596,7 +5224,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testUnionWithJoin()
-            throws Exception
     {
         assertQuery(
                 "SELECT * FROM (" +
@@ -5608,7 +5235,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testUnionWithAggregation()
-            throws Exception
     {
         assertQuery(
                 "SELECT ds, count(*) FROM (" +
@@ -5675,7 +5301,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testUnionWithAggregationAndJoin()
-            throws Exception
     {
         assertQuery(
                 "SELECT * FROM ( " +
@@ -5690,7 +5315,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testUnionWithJoinOnNonTranslateableSymbols()
-            throws Exception
     {
         assertQuery("SELECT *\n" +
                 "FROM (SELECT orderdate ds, orderkey\n" +
@@ -5704,14 +5328,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSubqueryUnion()
-            throws Exception
     {
         assertQueryOrdered("SELECT * FROM (SELECT orderkey FROM orders UNION SELECT custkey FROM orders UNION SELECT orderkey FROM orders) ORDER BY orderkey LIMIT 1000");
     }
 
     @Test
     public void testUnionWithFilterNotInSelect()
-            throws Exception
     {
         assertQuery("SELECT orderkey, orderdate FROM orders WHERE custkey < 1000 UNION ALL SELECT orderkey, shipdate FROM lineitem WHERE linenumber < 2000");
         assertQuery("SELECT orderkey, orderdate FROM orders UNION ALL SELECT orderkey, shipdate FROM lineitem WHERE linenumber < 2000");
@@ -5720,21 +5342,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSelectOnlyUnion()
-            throws Exception
     {
         assertQuery("SELECT 123, 'foo' UNION ALL SELECT 999, 'bar'");
     }
 
     @Test
     public void testMultiColumnUnionAll()
-            throws Exception
     {
         assertQuery("SELECT * FROM orders UNION ALL SELECT * FROM orders");
     }
 
     @Test
     public void testUnionRequiringCoercion()
-            throws Exception
     {
         assertQuery("VALUES 1 UNION ALL VALUES 1.0, 2", "SELECT * FROM (VALUES 1) UNION ALL SELECT * FROM (VALUES 1.0, 2)");
         assertQuery("(VALUES 1) UNION ALL (VALUES 1.0, 2)", "SELECT * FROM (VALUES 1) UNION ALL SELECT * FROM (VALUES 1.0, 2)");
@@ -5750,35 +5369,30 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTableQuery()
-            throws Exception
     {
         assertQuery("TABLE orders", "SELECT * FROM orders");
     }
 
     @Test
     public void testTableQueryOrderLimit()
-            throws Exception
     {
         assertQueryOrdered("TABLE orders ORDER BY orderkey LIMIT 10", "SELECT * FROM orders ORDER BY orderkey LIMIT 10");
     }
 
     @Test
     public void testTableQueryInUnion()
-            throws Exception
     {
         assertQuery("(SELECT * FROM orders ORDER BY orderkey LIMIT 10) UNION ALL TABLE orders", "(SELECT * FROM orders ORDER BY orderkey LIMIT 10) UNION ALL SELECT * FROM orders");
     }
 
     @Test
     public void testTableAsSubquery()
-            throws Exception
     {
         assertQueryOrdered("(TABLE orders) ORDER BY orderkey", "(SELECT * FROM orders) ORDER BY orderkey");
     }
 
     @Test
     public void testLimitPushDown()
-            throws Exception
     {
         MaterializedResult actual = computeActual(
                 "(TABLE orders ORDER BY orderkey) UNION ALL " +
@@ -5794,21 +5408,18 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testOrderLimitCompaction()
-            throws Exception
     {
         assertQueryOrdered("SELECT * FROM (SELECT * FROM orders ORDER BY orderkey) LIMIT 10");
     }
 
     @Test
     public void testUnaliasSymbolReferencesWithUnion()
-            throws Exception
     {
         assertQuery("SELECT 1, 1, 'a', 'a' UNION ALL SELECT 1, 2, 'a', 'b'");
     }
 
     @Test
     public void testRandCrossJoins()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(*) " +
@@ -5818,7 +5429,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCrossJoins()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT a.custkey, b.orderkey " +
@@ -5828,7 +5438,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCrossJoinEmptyProbePage()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT a.custkey, b.orderkey " +
@@ -5838,7 +5447,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCrossJoinEmptyBuildPage()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT a.custkey, b.orderkey " +
@@ -5848,14 +5456,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSimpleCrossJoins()
-            throws Exception
     {
         assertQuery("SELECT * FROM (SELECT 1 a) x CROSS JOIN (SELECT 2 b) y");
     }
 
     @Test
     public void testCrossJoinsWithWhereClause()
-            throws Exception
     {
         assertQuery("" +
                         "SELECT a, b, c, d " +
@@ -5867,7 +5473,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCrossJoinsDifferentDataTypes()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT * " +
@@ -5876,7 +5481,7 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testCrossJoinWithNulls() throws Exception
+    public void testCrossJoinWithNulls()
     {
         assertQuery("SELECT a, b FROM (VALUES (1), (2)) t (a) CROSS JOIN (VALUES (1), (3)) u (b)",
                 "SELECT * FROM (VALUES  (1, 1), (1, 3), (2, 1), (2, 3))");
@@ -5888,7 +5493,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testImplicitCrossJoin()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT * FROM (SELECT * FROM orders ORDER BY orderkey LIMIT 3) a, " +
@@ -5923,7 +5527,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCrossJoinUnion()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT t.c " +
@@ -5937,7 +5540,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCrossJoinUnnestWithUnion()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT col, COUNT(*)\n" +
@@ -5952,7 +5554,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinOnConstantExpression()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT * FROM (SELECT * FROM orders ORDER BY orderkey LIMIT 5) a " +
@@ -5962,7 +5563,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSemiJoin()
-            throws Exception
     {
         assertQuery("SELECT linenumber, min(orderkey) " +
                 "FROM lineitem " +
@@ -6033,7 +5633,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinConstantPropagation()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT x, y, COUNT(*)\n" +
@@ -6045,7 +5644,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testAntiJoin()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT *, orderkey\n" +
@@ -6058,7 +5656,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSemiJoinLimitPushDown()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(*)\n" +
@@ -6074,7 +5671,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSemiJoinNullHandling()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT orderkey\n" +
@@ -6102,7 +5698,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSemiJoinWithGroupBy()
-            throws Exception
     {
         // using the same subquery in query
         assertQuery("SELECT linenumber, min(orderkey), 6 IN (SELECT orderkey FROM orders WHERE orderkey < 7)" +
@@ -6145,7 +5740,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSemiJoinUnionNullHandling()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT orderkey\n" +
@@ -6166,7 +5760,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSemiJoinAggregationNullHandling()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT orderkey\n" +
@@ -6184,7 +5777,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSemiJoinUnionAggregationNullHandling()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT orderkey\n" +
@@ -6206,7 +5798,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSemiJoinAggregationUnionNullHandling()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT orderkey\n" +
@@ -6231,7 +5822,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSameInPredicateInProjectionAndFilter()
-            throws Exception
     {
         assertQuery("SELECT x IN (SELECT * FROM (VALUES 1))\n" +
                         "FROM (VALUES 1) t(x)\n" +
@@ -6246,7 +5836,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testScalarSubquery()
-            throws Exception
     {
         // nested
         assertQuery("SELECT (SELECT (SELECT (SELECT 1)))");
@@ -6331,7 +5920,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testExistsSubquery()
-            throws Exception
     {
         // nested
         assertQuery("SELECT EXISTS(SELECT NOT EXISTS(SELECT EXISTS(SELECT 1)))");
@@ -6405,7 +5993,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testScalarSubqueryWithGroupBy()
-            throws Exception
     {
         // using the same subquery in query
         assertQuery("SELECT linenumber, min(orderkey), (SELECT max(orderkey) FROM orders WHERE orderkey < 7)" +
@@ -6448,7 +6035,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testOutputInEnforceSingleRow()
-            throws Exception
     {
         assertQuery("SELECT count(*) FROM (SELECT (SELECT 1))");
         assertQuery("SELECT * FROM (SELECT (SELECT 1))");
@@ -6459,7 +6045,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testExistsSubqueryWithGroupBy()
-            throws Exception
     {
         // using the same subquery in query
         assertQuery("SELECT linenumber, min(orderkey), EXISTS(SELECT orderkey FROM orders WHERE orderkey < 7)" +
@@ -6528,7 +6113,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCorrelatedScalarSubqueriesWithCountScalarAggregationAndEqualityPredicatesInWhere()
-            throws Exception
     {
         assertQuery("SELECT (SELECT count(*) WHERE o.orderkey = 1) FROM orders o");
         assertQuery("SELECT count(*) FROM orders o WHERE 1 = (SELECT count(*) WHERE o.orderkey = 0)");
@@ -6577,7 +6161,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCorrelatedScalarSubqueriesWithScalarAggregation()
-            throws Exception
     {
         // projection
         assertQuery(
@@ -6661,7 +6244,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCorrelatedExistsSubqueriesWithPrunedCorrelationSymbols()
-            throws Exception
     {
         assertQuery("SELECT EXISTS(SELECT o.orderkey) FROM orders o");
         assertQuery("SELECT count(*) FROM orders o WHERE EXISTS(SELECT o.orderkey)");
@@ -6689,7 +6271,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCorrelatedExistsSubqueriesWithEqualityPredicatesInWhere()
-            throws Exception
     {
         assertQuery("SELECT EXISTS(SELECT 1 WHERE o.orderkey = 1) FROM orders o");
         assertQuery("SELECT EXISTS(SELECT null WHERE o.orderkey = 1) FROM orders o");
@@ -6742,7 +6323,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCorrelatedExistsSubqueries()
-            throws Exception
     {
         // projection
         assertQuery(
@@ -6822,7 +6402,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTwoCorrelatedExistsSubqueries()
-            throws Exception
     {
         // This is simpliefied TPC-H q21
         assertQuery("SELECT\n" +
@@ -6849,7 +6428,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testPredicatePushdown()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT *\n" +
@@ -6864,7 +6442,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testJoinPredicatePushdown()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(*)\n" +
@@ -6879,7 +6456,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testLeftJoinAsInnerPredicatePushdown()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(*)\n" +
@@ -6894,7 +6470,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testPlainLeftJoinPredicatePushdown()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(*)\n" +
@@ -6909,7 +6484,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testLeftJoinPredicatePushdownWithSelfEquality()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(*)\n" +
@@ -6925,7 +6499,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testLeftJoinPredicatePushdownWithNullConstant()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT count(*)\n" +
@@ -6940,7 +6513,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRightJoinAsInnerPredicatePushdown()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(*)\n" +
@@ -6955,7 +6527,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testPlainRightJoinPredicatePushdown()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(*)\n" +
@@ -6970,7 +6541,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testRightJoinPredicatePushdownWithSelfEquality()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(*)\n" +
@@ -6986,7 +6556,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testPredicatePushdownJoinEqualityGroups()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT *\n" +
@@ -7008,7 +6577,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testGroupByKeyPredicatePushdown()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT *\n" +
@@ -7036,7 +6604,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testNonDeterministicJoinPredicatePushdown()
-            throws Exception
     {
         MaterializedResult materializedResult = computeActual("" +
                 "SELECT COUNT(*)\n" +
@@ -7060,14 +6627,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTrivialNonDeterministicPredicatePushdown()
-            throws Exception
     {
         assertQuery("SELECT COUNT(*) WHERE rand() >= 0");
     }
 
     @Test
     public void testNonDeterministicTableScanPredicatePushdown()
-            throws Exception
     {
         MaterializedResult materializedResult = computeActual("" +
                 "SELECT COUNT(*)\n" +
@@ -7086,7 +6651,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testNonDeterministicAggregationPredicatePushdown()
-            throws Exception
     {
         MaterializedResult materializedResult = computeActual("" +
                 "SELECT COUNT(*)\n" +
@@ -7106,7 +6670,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testSemiJoinPredicateMoveAround()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(*)\n" +
@@ -7122,7 +6685,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testUnionAllPredicateMoveAroundWithOverlappingProjections()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT COUNT(*)\n" +
@@ -7144,7 +6706,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTableSampleBernoulliBoundaryValues()
-            throws Exception
     {
         MaterializedResult fullSample = computeActual("SELECT orderkey FROM orders TABLESAMPLE BERNOULLI (100)");
         MaterializedResult emptySample = computeActual("SELECT orderkey FROM orders TABLESAMPLE BERNOULLI (0)");
@@ -7156,7 +6717,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTableSampleBernoulli()
-            throws Exception
     {
         DescriptiveStatistics stats = new DescriptiveStatistics();
 
@@ -7224,7 +6784,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testTimeLiterals()
-            throws Exception
     {
         MaterializedResult.Builder builder = resultBuilder(getSession(), DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE);
 
@@ -7245,7 +6804,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testArrayShuffle()
-            throws Exception
     {
         List<Integer> expected = IntStream.rangeClosed(1, 500).boxed().collect(toList());
         Set<List<Integer>> distinctResults = new HashSet<>();
@@ -7270,7 +6828,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testNonReservedTimeWords()
-            throws Exception
     {
         assertQuery("" +
                 "SELECT TIME, TIMESTAMP, DATE, INTERVAL\n" +
@@ -7279,7 +6836,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCustomAdd()
-            throws Exception
     {
         assertQuery(
                 "SELECT custom_add(orderkey, custkey) FROM orders",
@@ -7288,7 +6844,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCustomSum()
-            throws Exception
     {
         @Language("SQL") String sql = "SELECT orderstatus, custom_sum(orderkey) FROM orders GROUP BY orderstatus";
         assertQuery(sql, sql.replace("custom_sum", "sum"));
@@ -7296,7 +6851,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testCustomRank()
-            throws Exception
     {
         @Language("SQL") String sql = "" +
                 "SELECT orderstatus, clerk, sales\n" +
@@ -7313,7 +6867,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testApproxSetBigint()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(approx_set(custkey)) FROM orders");
 
@@ -7326,7 +6879,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testApproxSetVarchar()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(approx_set(CAST(custkey AS VARCHAR))) FROM orders");
 
@@ -7339,7 +6891,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testApproxSetDouble()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(approx_set(CAST(custkey AS DOUBLE))) FROM orders");
 
@@ -7352,7 +6903,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testApproxSetBigintGroupBy()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, cardinality(approx_set(custkey)) " +
@@ -7370,7 +6920,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testApproxSetVarcharGroupBy()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, cardinality(approx_set(CAST(custkey AS VARCHAR))) " +
@@ -7388,7 +6937,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testApproxSetDoubleGroupBy()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, cardinality(approx_set(CAST(custkey AS DOUBLE))) " +
@@ -7406,7 +6954,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testApproxSetWithNulls()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(approx_set(IF(orderstatus = 'O', custkey))) FROM orders");
 
@@ -7419,7 +6966,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testApproxSetOnlyNulls()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(approx_set(null)) FROM orders");
 
@@ -7432,7 +6978,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testApproxSetGroupByWithOnlyNullsInOneGroup()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, cardinality(approx_set(IF(orderstatus != 'O', custkey))) " +
@@ -7450,7 +6995,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testApproxSetGroupByWithNulls()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, cardinality(approx_set(IF(custkey % 2 <> 0, custkey))) " +
@@ -7468,7 +7012,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testMergeHyperLogLog()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(merge(create_hll(custkey))) FROM orders");
 
@@ -7481,7 +7024,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testMergeHyperLogLogGroupBy()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, cardinality(merge(create_hll(custkey))) " +
@@ -7499,7 +7041,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testMergeHyperLogLogWithNulls()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(merge(create_hll(IF(orderstatus = 'O', custkey)))) FROM orders");
 
@@ -7512,7 +7053,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testMergeHyperLogLogGroupByWithNulls()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, cardinality(merge(create_hll(IF(orderstatus != 'O', custkey)))) " +
@@ -7530,7 +7070,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testMergeHyperLogLogOnlyNulls()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(merge(null)) FROM orders");
 
@@ -7543,7 +7082,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testEmptyApproxSet()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(empty_approx_set())");
         MaterializedResult expected = resultBuilder(getSession(), BIGINT)
@@ -7554,7 +7092,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testMergeEmptyApproxSet()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(merge(empty_approx_set())) FROM orders");
         MaterializedResult expected = resultBuilder(getSession(), BIGINT)
@@ -7565,7 +7102,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testMergeEmptyNonEmptyApproxSet()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(merge(c)) FROM (SELECT create_hll(custkey) c FROM ORDERS UNION ALL SELECT empty_approx_set())");
         MaterializedResult expected = resultBuilder(getSession(), BIGINT)
@@ -7576,7 +7112,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testP4ApproxSetBigint()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(cast(approx_set(custkey) AS P4HYPERLOGLOG)) FROM orders");
 
@@ -7589,7 +7124,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testP4ApproxSetVarchar()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(cast(approx_set(CAST(custkey AS VARCHAR)) AS P4HYPERLOGLOG)) FROM orders");
 
@@ -7602,7 +7136,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testP4ApproxSetDouble()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(cast(approx_set(CAST(custkey AS DOUBLE)) AS P4HYPERLOGLOG)) FROM orders");
 
@@ -7615,7 +7148,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testP4ApproxSetBigintGroupBy()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, cardinality(cast(approx_set(custkey) AS P4HYPERLOGLOG)) " +
@@ -7633,7 +7165,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testP4ApproxSetVarcharGroupBy()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, cardinality(cast(approx_set(CAST(custkey AS VARCHAR)) AS P4HYPERLOGLOG)) " +
@@ -7651,7 +7182,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testP4ApproxSetDoubleGroupBy()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, cardinality(cast(approx_set(CAST(custkey AS DOUBLE)) AS P4HYPERLOGLOG)) " +
@@ -7669,7 +7199,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testP4ApproxSetWithNulls()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(cast(approx_set(IF(orderstatus = 'O', custkey)) AS P4HYPERLOGLOG)) FROM orders");
 
@@ -7682,7 +7211,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testP4ApproxSetOnlyNulls()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT cardinality(cast(approx_set(null) AS P4HYPERLOGLOG)) FROM orders");
 
@@ -7695,7 +7223,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testP4ApproxSetGroupByWithOnlyNullsInOneGroup()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, cardinality(cast(approx_set(IF(orderstatus != 'O', custkey)) AS P4HYPERLOGLOG)) " +
@@ -7713,7 +7240,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testP4ApproxSetGroupByWithNulls()
-            throws Exception
     {
         MaterializedResult actual = computeActual("" +
                 "SELECT orderstatus, cardinality(cast(approx_set(IF(custkey % 2 <> 0, custkey)) AS P4HYPERLOGLOG)) " +
@@ -7730,7 +7256,6 @@ public abstract class AbstractTestQueries
     }
     @Test
     public void testValuesWithNonTrivialType()
-            throws Exception
     {
         MaterializedResult actual = computeActual("VALUES (0.0/0.0, 1.0/0.0, -1.0/0.0)");
 
@@ -7745,7 +7270,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testValuesWithTimestamp()
-            throws Exception
     {
         MaterializedResult actual = computeActual("VALUES (current_timestamp, now())");
 
@@ -7758,7 +7282,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testValuesWithUnusedColumns()
-            throws Exception
     {
         MaterializedResult actual = computeActual("SELECT foo from (values (1, 2)) a(foo, bar)");
 
@@ -7771,7 +7294,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testFilterPushdownWithAggregation()
-            throws Exception
     {
         assertQuery("SELECT * FROM (SELECT count(*) FROM orders) WHERE 0=1");
         assertQuery("SELECT * FROM (SELECT count(*) FROM orders) WHERE null");
@@ -7779,7 +7301,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testAccessControl()
-            throws Exception
     {
         assertAccessDenied("SELECT COUNT(true) FROM orders", "Cannot select from table .*.orders.*", privilege("orders", SELECT_TABLE));
         assertAccessDenied("INSERT INTO orders SELECT * FROM orders", "Cannot insert into table .*.orders.*", privilege("orders", INSERT_TABLE));
@@ -7789,14 +7310,12 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testEmptyInputForUnnest()
-            throws Exception
     {
         assertQuery("select val from (select distinct vals from (values (array[2])) t(vals) where false) tmp cross join unnest(tmp.vals) tt(val)", "select 1 where 1=2");
     }
 
     @Test
     public void testCoercions()
-            throws Exception
     {
         // VARCHAR
         assertQuery("SELECT length(NULL)");
@@ -7895,7 +7414,7 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testExecute() throws Exception
+    public void testExecute()
     {
         Session session = Session.builder(getSession())
                 .addPreparedStatement("my_query", "SELECT 123, 'abc'")
@@ -7905,7 +7424,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testExecuteUsing()
-            throws Exception
     {
         String query = "SELECT a + 1, count(?) FROM (VALUES 1, 2, 3, 2) t1(a) JOIN (VALUES 1, 2, 3, 4) t2(b) ON b < ? WHERE a < ? GROUP BY a + 1 HAVING count(1) > ?";
         Session session = Session.builder(getSession())
@@ -7918,7 +7436,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testExecuteUsingWithSubquery()
-            throws Exception
     {
         String query = "SELECT ? in (SELECT orderkey FROM orders)";
         Session session = Session.builder(getSession())
@@ -7933,7 +7450,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testExecuteUsingWithSubqueryInJoin()
-        throws Exception
     {
         String query = "SELECT * " +
                 "FROM " +
@@ -7953,7 +7469,6 @@ public abstract class AbstractTestQueries
 
     @Test
     public void testExecuteWithParametersInGroupBy()
-            throws Exception
     {
         try {
             String query = "SELECT a + ?, count(1) FROM (VALUES 1, 2, 3, 2) t(a) GROUP BY a + ?";

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2548,7 +2548,7 @@ public abstract class AbstractTestQueries
         QueryTemplate.Parameter type = new QueryTemplate.Parameter("type", "");
         QueryTemplate.Parameter condition = new QueryTemplate.Parameter("condition");
         QueryTemplate queryTemplate = new QueryTemplate(
-                "SELECT * " + "FROM (VALUES 1,2,3,4) t(x) %type% JOIN (VALUES 1,2,3,5) t2(y) ON %condition%",
+                "SELECT * FROM (VALUES 1,2,3,4) t(x) %type% JOIN (VALUES 1,2,3,5) t2(y) ON %condition%",
                 type,
                 condition);
 
@@ -2616,6 +2616,17 @@ public abstract class AbstractTestQueries
         assertQuery(
                 queryTemplate.replace(type.of("full"), xPlusYEqualsSubqueryJoinCondition),
                 "VALUES (1,3), (2,2), (3,1), (4, null), (null, 5)");
+    }
+
+    @Test
+    public void testJoinWithScalarSubqueryInOnClause()
+            throws Exception
+    {
+        assertQuery(
+                "SELECT count() FROM nation a" +
+                        " INNER JOIN nation b ON a.name = (SELECT max(name) FROM nation)" +
+                        " INNER JOIN nation c ON c.name = split_part(b.name,'<',2)",
+                "SELECT 0");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -59,7 +59,6 @@ public abstract class AbstractTestQueryFramework
 
     @AfterClass(alwaysRun = true)
     public void close()
-            throws Exception
     {
         try {
             h2QueryRunner.close();
@@ -90,55 +89,46 @@ public abstract class AbstractTestQueryFramework
     }
 
     protected void assertQuery(@Language("SQL") String sql)
-            throws Exception
     {
         assertQuery(getSession(), sql);
     }
 
     protected void assertQuery(Session session, @Language("SQL") String sql)
-            throws Exception
     {
         QueryAssertions.assertQuery(queryRunner, session, sql, h2QueryRunner, sql, false, false);
     }
 
     public void assertQueryOrdered(@Language("SQL") String sql)
-            throws Exception
     {
         QueryAssertions.assertQuery(queryRunner, getSession(), sql, h2QueryRunner, sql, true, false);
     }
 
     protected void assertQuery(@Language("SQL") String actual, @Language("SQL") String expected)
-            throws Exception
     {
         QueryAssertions.assertQuery(queryRunner, getSession(), actual, h2QueryRunner, expected, false, false);
     }
 
     protected void assertQuery(Session session, @Language("SQL") String actual, @Language("SQL") String expected)
-            throws Exception
     {
         QueryAssertions.assertQuery(queryRunner, session, actual, h2QueryRunner, expected, false, false);
     }
 
     protected void assertQueryOrdered(@Language("SQL") String actual, @Language("SQL") String expected)
-            throws Exception
     {
         assertQueryOrdered(getSession(), actual, expected);
     }
 
     protected void assertQueryOrdered(Session session, @Language("SQL") String actual, @Language("SQL") String expected)
-            throws Exception
     {
         QueryAssertions.assertQuery(queryRunner, session, actual, h2QueryRunner, expected, true, false);
     }
 
     protected void assertUpdate(@Language("SQL") String actual, @Language("SQL") String expected)
-            throws Exception
     {
         assertUpdate(getSession(), actual, expected);
     }
 
     protected void assertUpdate(Session session, @Language("SQL") String actual, @Language("SQL") String expected)
-            throws Exception
     {
         QueryAssertions.assertQuery(queryRunner, session, actual, h2QueryRunner, expected, false, true);
     }
@@ -184,13 +174,11 @@ public abstract class AbstractTestQueryFramework
     }
 
     protected void assertAccessAllowed(@Language("SQL") String sql, TestingPrivilege... deniedPrivileges)
-            throws Exception
     {
         assertAccessAllowed(getSession(), sql, deniedPrivileges);
     }
 
     protected void assertAccessAllowed(Session session, @Language("SQL") String sql, TestingPrivilege... deniedPrivileges)
-            throws Exception
     {
         queryRunner.getExclusiveLock().lock();
         try {
@@ -204,7 +192,6 @@ public abstract class AbstractTestQueryFramework
     }
 
     protected void assertAccessDenied(@Language("SQL") String sql, @Language("RegExp") String exceptionsMessageRegExp, TestingPrivilege... deniedPrivileges)
-            throws Exception
     {
         assertAccessDenied(getSession(), sql, exceptionsMessageRegExp, deniedPrivileges);
     }
@@ -214,7 +201,6 @@ public abstract class AbstractTestQueryFramework
             @Language("SQL") String sql,
             @Language("RegExp") String exceptionsMessageRegExp,
             TestingPrivilege... deniedPrivileges)
-            throws Exception
     {
         queryRunner.getExclusiveLock().lock();
         try {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -75,7 +75,6 @@ public final class QueryAssertions
             @Language("SQL") String expected,
             boolean ensureOrdering,
             boolean compareUpdate)
-            throws Exception
     {
         long start = System.nanoTime();
         MaterializedResult actualResults = null;
@@ -175,7 +174,6 @@ public final class QueryAssertions
             @Language("SQL") String actual,
             H2QueryRunner h2QueryRunner,
             @Language("SQL") String expected)
-            throws Exception
     {
         long start = System.nanoTime();
         MaterializedResult actualResults = queryRunner.execute(session, actual);
@@ -186,7 +184,6 @@ public final class QueryAssertions
     }
 
     public static void assertApproximatelyEqual(List<MaterializedRow> actual, List<MaterializedRow> expected)
-            throws Exception
     {
         // TODO: support GROUP BY queries
         assertEquals(actual.size(), 1, "approximate query returned more than one row");
@@ -217,7 +214,6 @@ public final class QueryAssertions
             String sourceSchema,
             Session session,
             Iterable<TpchTable<?>> tables)
-            throws Exception
     {
         log.info("Loading data from %s.%s...", sourceCatalog, sourceSchema);
         long startTime = System.nanoTime();
@@ -228,7 +224,6 @@ public final class QueryAssertions
     }
 
     public static void copyTable(QueryRunner queryRunner, String sourceCatalog, String sourceSchema, String sourceTable, Session session)
-            throws Exception
     {
         QualifiedObjectName table = new QualifiedObjectName(sourceCatalog, sourceSchema, sourceTable);
         copyTable(queryRunner, table, session);


### PR DESCRIPTION
Do not prune ApplyNode subquery symbols are used in join criteria

Fixes #6493
