### PR TITLE
Do not wrap with quotes for running product tests

### DIFF
--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -218,7 +218,7 @@ retry check_presto
 
 # run product tests
 set +e
-run_product_tests "$*"
+run_product_tests "$@"
 EXIT_CODE=$?
 set -e
 


### PR DESCRIPTION
Do not wrap with quotes for running product tests

That way run_on_docker is able to pass to tempto more than single
parameter, like:
/presto-product-tests/bin/run_on_docker.sh multinode -x
quarantine,big_query,profile_specific_tests -g tpch -t 11,12,22
