### PR TITLE
Validate schema rename for Hive

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/BridgingHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/BridgingHiveMetastore.java
@@ -109,6 +109,12 @@ public class BridgingHiveMetastore
                 .orElseThrow(() -> new SchemaNotFoundException(databaseName));
         database.setName(newDatabaseName);
         delegate.alterDatabase(databaseName, database);
+
+        delegate.getDatabase(databaseName).ifPresent(newDatabase -> {
+            if (newDatabase.getName().equals(databaseName)) {
+                throw new PrestoException(NOT_SUPPORTED, "Hive metastore does not support renaming schemas");
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
Current versions of the Hive metastore silently ignore attempts to rename
a database. We now detect this and throw an appropriate error messsage.