### PR TITLE
Fix base for counter in AssignUniqueIdOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/AssignUniqueIdOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/AssignUniqueIdOperator.java
@@ -106,7 +106,7 @@ public class AssignUniqueIdOperator
         this.rowIdPool = requireNonNull(rowIdPool, "rowIdPool is null");
 
         TaskId fullTaskId = operatorContext.getDriverContext().getTaskId();
-        uniqueValueMask = (fullTaskId.getStageId().getId() << 54L) | ((long) fullTaskId.getId() << 40L);
+        uniqueValueMask = ((long) fullTaskId.getStageId().getId() << 54L) | ((long) fullTaskId.getId() << 40L);
         inputPageChannelCount = types.size() - 1;
 
         requestValues();


### PR DESCRIPTION
Base for counter used as uniq id was incorrectly initialized
which could lead to duplicates generated by AssignUniqueIdOperator.