### PR TITLE
Fix Travis build for Maven tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ env:
   global:
     - MAVEN_OPTS="-Xmx512M"
     - MAVEN_SKIP_CHECKS_AND_DOCS="-Dair.check.skip-all=true -Dmaven.javadoc.skip=true"
+    - MAVEN_FAST_INSTALL="-DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1"
   matrix:
     - MAVEN_CHECKS=true
-    - TEST_MODULES=!presto-tests,!presto-kafka,!presto-redis,!presto-cassandra,!presto-raptor,!presto-postgresql,!presto-mysql,!presto-accumulo
+    - TEST_MODULES=!presto-tests,!presto-kafka,!presto-redis,!presto-cassandra,!presto-raptor,!presto-postgresql,!presto-mysql,!presto-accumulo,!presto-docs,!presto-server,!presto-server-rpm
     - TEST_MODULES=presto-tests
     - TEST_MODULES=presto-accumulo
     - TEST_MODULES=presto-raptor,presto-redis,presto-cassandra,presto-kafka,presto-postgresql,presto-mysql
@@ -35,7 +36,11 @@ before_install:
 install:
   - |
     if [[ -v PRODUCT_TESTS || -v HIVE_TESTS ]]; then
-      ./mvnw install -DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1 -pl '!presto-docs,!presto-server-rpm'
+      ./mvnw install $MAVEN_FAST_INSTALL -pl '!presto-docs,!presto-server-rpm'
+    fi
+  - |
+    if [[ -v TEST_MODULES ]]; then
+      ./mvnw install $MAVEN_FAST_INSTALL -pl $TEST_MODULES -am
     fi
 
 script:
@@ -64,7 +69,7 @@ script:
   - |
     # Build presto-server-rpm for later artifact upload
     if [[ -v DEPLOY_S3_ACCESS_KEY && -v PRODUCT_TESTS ]]; then
-       ./mvnw install -DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1 -pl presto-server-rpm
+       ./mvnw install $MAVEN_FAST_INSTALL -pl presto-server-rpm
     fi
 
 before_cache:


### PR DESCRIPTION
The matrix items that run Maven tests for specific modules
need the module dependencies installed.