### PR TITLE
Remove JDK selection from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ env:
 sudo: required
 dist: trusty
 
-jdk:
-  - oraclejdk8
-
 cache:
   directories:
     - $HOME/.m2/repository


### PR DESCRIPTION
The current Travis images seem to have both 8u101 and 8u65 installed.
Specifying the JDK invokes "jdk_switcher use oraclejdk8" which
uses 8u65 instead of 8u101. Without this, version 8u101 is used.