### PR TITLE
Build all of the Hive modules in the same travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ env:
     - MAVEN_FAST_INSTALL="-DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1"
   matrix:
     - MAVEN_CHECKS=true
-    - TEST_MODULES=!presto-tests,!presto-raptor,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-kafka,!presto-mysql,!presto-postgresql,!presto-redis,!presto-docs,!presto-server,!presto-server-rpm
+    - TEST_MODULES=!presto-tests,!presto-raptor,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-hive-cdh4,!presto-hive-cdh5,!presto-hive-hadoop1,!presto-hive-hadoop2,!presto-kafka,!presto-mysql,!presto-postgresql,!presto-redis,!presto-docs,!presto-server,!presto-server-rpm
     - TEST_MODULES=presto-tests
     - TEST_MODULES=presto-raptor
     - TEST_MODULES=presto-accumulo
-    - TEST_MODULES=presto-cassandra,presto-hive,presto-kafka,presto-mysql,presto-postgresql,presto-redis
+    - TEST_MODULES=presto-cassandra,presto-hive,presto-hive-cdh4,presto-hive-cdh5,presto-hive-hadoop1,presto-hive-hadoop2,presto-kafka,presto-mysql,presto-postgresql,presto-redis
     - PRODUCT_TESTS=true
     - HIVE_TESTS=true
 


### PR DESCRIPTION
For some reason when building branch with `presto-hive` excluded with more than 2 threads
(-T >2), build fails on `presto-hive-*` modules.

```
[ERROR] Failed to execute goal io.takari.maven.plugins:provisio-maven-plugin:0.1.40:provision (default-provision) on project presto-hive-hadoop2: Error provisioning assembly. Error copying /media/programs/projects/presto/presto-orc/target/classes to /media/programs/projects/presto/presto-hive-hadoop2/target/presto-hive-hadoop2-0.157-SNAPSHOT/classes: /media/programs/projects/presto/presto-orc/target/classes (Is a directory) -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :presto-hive-hadoop2
```

Travis: https://travis-ci.org/Teradata/presto/jobs/173791131