### PR TITLE
Add access control for SHOW and listings

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/LegacyAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/LegacyAccessControl.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.security.Privilege;
 import javax.inject.Inject;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
@@ -69,6 +70,17 @@ public class LegacyAccessControl
     @Override
     public void checkCanRenameSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName, String newSchemaName)
     {
+    }
+
+    @Override
+    public void checkCanShowSchemas(ConnectorTransactionHandle transactionHandle, Identity identity)
+    {
+    }
+
+    @Override
+    public Set<String> filterSchemas(ConnectorTransactionHandle transactionHandle, Identity identity, Set<String> schemaNames)
+    {
+        return schemaNames;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/LegacyAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/LegacyAccessControl.java
@@ -115,6 +115,17 @@ public class LegacyAccessControl
     }
 
     @Override
+    public void checkCanShowTables(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+    }
+
+    @Override
+    public Set<SchemaTableName> filterTables(ConnectorTransactionHandle transactionHandle, Identity identity, Set<SchemaTableName> tableNames)
+    {
+        return tableNames;
+    }
+
+    @Override
     public void checkCanAddColumn(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
     {
         if (!allowAddColumn) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
@@ -106,6 +106,17 @@ public class SqlStandardAccessControl
     }
 
     @Override
+    public void checkCanShowSchemas(ConnectorTransactionHandle transactionHandle, Identity identity)
+    {
+    }
+
+    @Override
+    public Set<String> filterSchemas(ConnectorTransactionHandle transactionHandle, Identity identity, Set<String> schemaNames)
+    {
+        return schemaNames;
+    }
+
+    @Override
     public void checkCanCreateTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
     {
         if (!isDatabaseOwner(transaction, identity, tableName.getSchemaName())) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
@@ -141,6 +141,17 @@ public class SqlStandardAccessControl
     }
 
     @Override
+    public void checkCanShowTables(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+    }
+
+    @Override
+    public Set<SchemaTableName> filterTables(ConnectorTransactionHandle transactionHandle, Identity identity, Set<SchemaTableName> tableNames)
+    {
+        return tableNames;
+    }
+
+    @Override
     public void checkCanAddColumn(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
     {
         if (!checkTablePermission(transaction, identity, tableName, OWNERSHIP)) {

--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -194,7 +194,7 @@ public class ConnectorManager
 
         MaterializedConnector informationSchemaConnector = new MaterializedConnector(
                 createInformationSchemaConnectorId(connectorId),
-                new InformationSchemaConnector(catalogName, nodeManager, metadataManager));
+                new InformationSchemaConnector(catalogName, nodeManager, metadataManager, accessControlManager));
 
         ConnectorId systemId = createSystemTablesConnectorId(connectorId);
         MaterializedConnector systemConnector = new MaterializedConnector(systemId, new SystemConnector(

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaConnector.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaConnector.java
@@ -15,6 +15,7 @@ package com.facebook.presto.connector.informationSchema;
 
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
@@ -32,7 +33,7 @@ public class InformationSchemaConnector
     private final ConnectorSplitManager splitManager;
     private final ConnectorPageSourceProvider pageSourceProvider;
 
-    public InformationSchemaConnector(String catalogName, InternalNodeManager nodeManager, Metadata metadata)
+    public InformationSchemaConnector(String catalogName, InternalNodeManager nodeManager, Metadata metadata, AccessControl accessControl)
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(nodeManager, "nodeManager is null");
@@ -40,7 +41,7 @@ public class InformationSchemaConnector
 
         this.metadata = new InformationSchemaMetadata(catalogName);
         this.splitManager = new InformationSchemaSplitManager(nodeManager);
-        this.pageSourceProvider = new InformationSchemaPageSourceProvider(metadata);
+        this.pageSourceProvider = new InformationSchemaPageSourceProvider(metadata, accessControl);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -44,7 +44,6 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.airlift.slice.Slice;
 
@@ -64,6 +63,9 @@ import static com.facebook.presto.connector.informationSchema.InformationSchemaM
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_VIEWS;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.informationSchemaTableColumns;
 import static com.facebook.presto.metadata.MetadataListing.listSchemas;
+import static com.facebook.presto.metadata.MetadataListing.listTableColumns;
+import static com.facebook.presto.metadata.MetadataListing.listTables;
+import static com.facebook.presto.metadata.MetadataListing.listViews;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -156,17 +158,18 @@ public class InformationSchemaPageSourceProvider
     private InternalTable buildColumns(Session session, String catalogName, Map<String, NullableValue> filters)
     {
         InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_COLUMNS));
-        for (Entry<QualifiedObjectName, List<ColumnMetadata>> entry : getColumnsList(session, catalogName, filters).entrySet()) {
-            QualifiedObjectName tableName = entry.getKey();
+        QualifiedTablePrefix prefix = extractQualifiedTablePrefix(catalogName, filters);
+        for (Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
+            SchemaTableName tableName = entry.getKey();
             int ordinalPosition = 1;
             for (ColumnMetadata column : entry.getValue()) {
                 if (column.isHidden()) {
                     continue;
                 }
                 table.add(
-                        tableName.getCatalogName(),
+                        catalogName,
                         tableName.getSchemaName(),
-                        tableName.getObjectName(),
+                        tableName.getTableName(),
                         column.getName(),
                         ordinalPosition,
                         null,
@@ -180,37 +183,23 @@ public class InformationSchemaPageSourceProvider
         return table.build();
     }
 
-    private Map<QualifiedObjectName, List<ColumnMetadata>> getColumnsList(Session session, String catalogName, Map<String, NullableValue> filters)
-    {
-        return metadata.listTableColumns(session, extractQualifiedTablePrefix(catalogName, filters));
-    }
-
     private InternalTable buildTables(Session session, String catalogName, Map<String, NullableValue> filters)
     {
-        Set<QualifiedObjectName> tables = ImmutableSet.copyOf(getTablesList(session, catalogName, filters));
-        Set<QualifiedObjectName> views = ImmutableSet.copyOf(getViewsList(session, catalogName, filters));
+        QualifiedTablePrefix prefix = extractQualifiedTablePrefix(catalogName, filters);
+        Set<SchemaTableName> tables = listTables(session, metadata, accessControl, prefix);
+        Set<SchemaTableName> views = listViews(session, metadata, accessControl, prefix);
 
         InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_TABLES));
-        for (QualifiedObjectName name : union(tables, views)) {
+        for (SchemaTableName name : union(tables, views)) {
             // if table and view names overlap, the view wins
             String type = views.contains(name) ? "VIEW" : "BASE TABLE";
             table.add(
-                    name.getCatalogName(),
+                    catalogName,
                     name.getSchemaName(),
-                    name.getObjectName(),
+                    name.getTableName(),
                     type);
         }
         return table.build();
-    }
-
-    private List<QualifiedObjectName> getTablesList(Session session, String catalogName, Map<String, NullableValue> filters)
-    {
-        return metadata.listTables(session, extractQualifiedTablePrefix(catalogName, filters));
-    }
-
-    private List<QualifiedObjectName> getViewsList(Session session, String catalogName, Map<String, NullableValue> filters)
-    {
-        return metadata.listViews(session, extractQualifiedTablePrefix(catalogName, filters));
     }
 
     private InternalTable buildViews(Session session, String catalogName, Map<String, NullableValue> filters)

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -24,6 +24,7 @@ import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.metadata.TableLayout;
 import com.facebook.presto.metadata.TableLayoutResult;
 import com.facebook.presto.metadata.ViewDefinition;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorPageSource;
@@ -62,6 +63,7 @@ import static com.facebook.presto.connector.informationSchema.InformationSchemaM
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLES;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_VIEWS;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.informationSchemaTableColumns;
+import static com.facebook.presto.metadata.MetadataListing.listSchemas;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -74,10 +76,12 @@ public class InformationSchemaPageSourceProvider
         implements ConnectorPageSourceProvider
 {
     private final Metadata metadata;
+    private final AccessControl accessControl;
 
-    public InformationSchemaPageSourceProvider(Metadata metadata)
+    public InformationSchemaPageSourceProvider(Metadata metadata, AccessControl accessControl)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
     }
 
     @Override
@@ -230,7 +234,7 @@ public class InformationSchemaPageSourceProvider
     private InternalTable buildSchemata(Session session, String catalogName)
     {
         InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_SCHEMATA));
-        for (String schema : metadata.listSchemaNames(session, catalogName)) {
+        for (String schema : listSchemas(session, metadata, accessControl, catalogName)) {
             table.add(catalogName, schema);
         }
         return table.build();

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/CatalogSystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/CatalogSystemTable.java
@@ -13,7 +13,10 @@
  */
 package com.facebook.presto.connector.system;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.InMemoryRecordSet;
@@ -23,13 +26,13 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
-import com.facebook.presto.transaction.TransactionId;
-import com.facebook.presto.transaction.TransactionManager;
 
 import javax.inject.Inject;
 
 import java.util.Map;
 
+import static com.facebook.presto.connector.system.SystemConnectorSessionUtil.toSession;
+import static com.facebook.presto.metadata.MetadataListing.listCatalogs;
 import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static com.facebook.presto.spi.SystemTable.Distribution.SINGLE_COORDINATOR;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
@@ -44,12 +47,14 @@ public class CatalogSystemTable
             .column("catalog_name", createUnboundedVarcharType())
             .column("connector_id", createUnboundedVarcharType())
             .build();
-    private final TransactionManager transactionManager;
+    private final Metadata metadata;
+    private final AccessControl accessControl;
 
     @Inject
-    public CatalogSystemTable(TransactionManager transactionManager)
+    public CatalogSystemTable(Metadata metadata, AccessControl accessControl)
     {
-        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
     }
 
     @Override
@@ -65,11 +70,11 @@ public class CatalogSystemTable
     }
 
     @Override
-    public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession connectorSession, TupleDomain<Integer> constraint)
     {
-        TransactionId transactionId = ((GlobalSystemTransactionHandle) transactionHandle).getTransactionId();
+        Session session = toSession(transactionHandle, connectorSession);
         Builder table = InMemoryRecordSet.builder(CATALOG_TABLE);
-        for (Map.Entry<String, ConnectorId> entry : transactionManager.getCatalogNames(transactionId).entrySet()) {
+        for (Map.Entry<String, ConnectorId> entry : listCatalogs(session, metadata, accessControl).entrySet()) {
             table.addRow(entry.getKey(), entry.getValue().toString());
         }
         return table.build().cursor();

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnectorSessionUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnectorSessionUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.system;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.transaction.TransactionId;
+
+public final class SystemConnectorSessionUtil
+{
+    private static final SystemSessionProperties SYSTEM_SESSION_PROPERTIES = new SystemSessionProperties();
+
+    private SystemConnectorSessionUtil() {}
+
+    // this does not preserve any connector properties (for the system connector)
+    public static Session toSession(ConnectorTransactionHandle transactionHandle, ConnectorSession session)
+    {
+        TransactionId transactionId = ((GlobalSystemTransactionHandle) transactionHandle).getTransactionId();
+        return Session.builder(new SessionPropertyManager(SYSTEM_SESSION_PROPERTIES))
+                .setQueryId(new QueryId(session.getQueryId()))
+                .setTransactionId(transactionId)
+                .setCatalog("catalog")
+                .setSchema("schema")
+                .setIdentity(session.getIdentity())
+                .setTimeZoneKey(session.getTimeZoneKey())
+                .setLocale(session.getLocale())
+                .setStartTime(session.getStartTime())
+                .build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
@@ -15,7 +15,6 @@ package com.facebook.presto.connector.system.jdbc;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.metadata.QualifiedTablePrefix;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -45,6 +44,7 @@ import static com.facebook.presto.connector.system.SystemConnectorSessionUtil.to
 import static com.facebook.presto.connector.system.jdbc.FilterUtil.filter;
 import static com.facebook.presto.connector.system.jdbc.FilterUtil.stringFilter;
 import static com.facebook.presto.metadata.MetadataListing.listCatalogs;
+import static com.facebook.presto.metadata.MetadataListing.listTableColumns;
 import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -123,14 +123,14 @@ public class ColumnJdbcTable
         Builder table = InMemoryRecordSet.builder(METADATA);
         for (String catalog : filter(listCatalogs(session, metadata, accessControl).keySet(), catalogFilter)) {
             QualifiedTablePrefix prefix = FilterUtil.tablePrefix(catalog, schemaFilter, tableFilter);
-            for (Entry<QualifiedObjectName, List<ColumnMetadata>> entry : metadata.listTableColumns(session, prefix).entrySet()) {
-                addColumnRows(table, entry.getKey(), entry.getValue());
+            for (Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
+                addColumnRows(table, catalog, entry.getKey(), entry.getValue());
             }
         }
         return table.build().cursor();
     }
 
-    private static void addColumnRows(Builder builder, QualifiedObjectName tableName, List<ColumnMetadata> columns)
+    private static void addColumnRows(Builder builder, String catalog, SchemaTableName tableName, List<ColumnMetadata> columns)
     {
         int ordinalPosition = 1;
         for (ColumnMetadata column : columns) {
@@ -138,9 +138,9 @@ public class ColumnJdbcTable
                 continue;
             }
             builder.addRow(
-                    tableName.getCatalogName(),
+                    catalog,
                     tableName.getSchemaName(),
-                    tableName.getObjectName(),
+                    tableName.getTableName(),
                     column.getName(),
                     jdbcDataType(column.getType()),
                     column.getType().getDisplayName(),

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
@@ -14,10 +14,10 @@
 package com.facebook.presto.connector.system.jdbc;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.connector.system.GlobalSystemTransactionHandle;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.metadata.QualifiedTablePrefix;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableMetadata;
@@ -41,9 +41,10 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
 
+import static com.facebook.presto.connector.system.SystemConnectorSessionUtil.toSession;
 import static com.facebook.presto.connector.system.jdbc.FilterUtil.filter;
 import static com.facebook.presto.connector.system.jdbc.FilterUtil.stringFilter;
-import static com.facebook.presto.connector.system.jdbc.FilterUtil.toSession;
+import static com.facebook.presto.metadata.MetadataListing.listCatalogs;
 import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -96,11 +97,13 @@ public class ColumnJdbcTable
             .build();
 
     private final Metadata metadata;
+    private final AccessControl accessControl;
 
     @Inject
-    public ColumnJdbcTable(Metadata metadata)
+    public ColumnJdbcTable(Metadata metadata, AccessControl accessControl)
     {
-        this.metadata = requireNonNull(metadata);
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
     }
 
     @Override
@@ -112,14 +115,13 @@ public class ColumnJdbcTable
     @Override
     public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession connectorSession, TupleDomain<Integer> constraint)
     {
-        GlobalSystemTransactionHandle transaction = (GlobalSystemTransactionHandle) transactionHandle;
-        Session session = toSession(transaction.getTransactionId(), connectorSession);
+        Session session = toSession(transactionHandle, connectorSession);
         Optional<String> catalogFilter = stringFilter(constraint, 0);
         Optional<String> schemaFilter = stringFilter(constraint, 1);
         Optional<String> tableFilter = stringFilter(constraint, 2);
 
         Builder table = InMemoryRecordSet.builder(METADATA);
-        for (String catalog : filter(metadata.getCatalogNames(session).keySet(), catalogFilter)) {
+        for (String catalog : filter(listCatalogs(session, metadata, accessControl).keySet(), catalogFilter)) {
             QualifiedTablePrefix prefix = FilterUtil.tablePrefix(catalog, schemaFilter, tableFilter);
             for (Entry<QualifiedObjectName, List<ColumnMetadata>> entry : metadata.listTableColumns(session, prefix).entrySet()) {
                 addColumnRows(table, entry.getKey(), entry.getValue());

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/FilterUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/FilterUtil.java
@@ -13,15 +13,9 @@
  */
 package com.facebook.presto.connector.system.jdbc;
 
-import com.facebook.presto.Session;
-import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.metadata.QualifiedTablePrefix;
-import com.facebook.presto.metadata.SessionPropertyManager;
-import com.facebook.presto.spi.ConnectorSession;
-import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
-import com.facebook.presto.transaction.TransactionId;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import io.airlift.slice.Slice;
@@ -30,24 +24,7 @@ import java.util.Optional;
 
 final class FilterUtil
 {
-    private static final SystemSessionProperties SYSTEM_SESSION_PROPERTIES = new SystemSessionProperties();
-
     private FilterUtil() {}
-
-    // this does not preserve any connector properties (for the system connector)
-    public static Session toSession(TransactionId transactionId, ConnectorSession session)
-    {
-        return Session.builder(new SessionPropertyManager(SYSTEM_SESSION_PROPERTIES))
-                .setQueryId(new QueryId(session.getQueryId()))
-                .setTransactionId(transactionId)
-                .setCatalog("catalog")
-                .setSchema("schema")
-                .setIdentity(session.getIdentity())
-                .setTimeZoneKey(session.getTimeZoneKey())
-                .setLocale(session.getLocale())
-                .setStartTime(session.getStartTime())
-                .build();
-    }
 
     public static Optional<String> stringFilter(TupleDomain<Integer> constraint, int index)
     {

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/SchemaJdbcTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/SchemaJdbcTable.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import static com.facebook.presto.connector.system.SystemConnectorSessionUtil.toSession;
 import static com.facebook.presto.connector.system.jdbc.FilterUtil.filter;
 import static com.facebook.presto.metadata.MetadataListing.listCatalogs;
+import static com.facebook.presto.metadata.MetadataListing.listSchemas;
 import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Objects.requireNonNull;
@@ -70,7 +71,7 @@ public class SchemaJdbcTable
 
         Builder table = InMemoryRecordSet.builder(METADATA);
         for (String catalog : filter(listCatalogs(session, metadata, accessControl).keySet(), catalogFilter)) {
-            for (String schema : metadata.listSchemaNames(session, catalog)) {
+            for (String schema : listSchemas(session, metadata, accessControl, catalog)) {
                 table.addRow(schema, catalog);
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/SchemaJdbcTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/SchemaJdbcTable.java
@@ -14,8 +14,8 @@
 package com.facebook.presto.connector.system.jdbc;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.connector.system.GlobalSystemTransactionHandle;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.InMemoryRecordSet;
@@ -29,8 +29,9 @@ import javax.inject.Inject;
 
 import java.util.Optional;
 
+import static com.facebook.presto.connector.system.SystemConnectorSessionUtil.toSession;
 import static com.facebook.presto.connector.system.jdbc.FilterUtil.filter;
-import static com.facebook.presto.connector.system.jdbc.FilterUtil.toSession;
+import static com.facebook.presto.metadata.MetadataListing.listCatalogs;
 import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Objects.requireNonNull;
@@ -46,11 +47,13 @@ public class SchemaJdbcTable
             .build();
 
     private final Metadata metadata;
+    private final AccessControl accessControl;
 
     @Inject
-    public SchemaJdbcTable(Metadata metadata)
+    public SchemaJdbcTable(Metadata metadata, AccessControl accessControl)
     {
-        this.metadata = requireNonNull(metadata);
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
     }
 
     @Override
@@ -62,12 +65,11 @@ public class SchemaJdbcTable
     @Override
     public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession connectorSession, TupleDomain<Integer> constraint)
     {
-        GlobalSystemTransactionHandle transaction = (GlobalSystemTransactionHandle) transactionHandle;
-        Session session = toSession(transaction.getTransactionId(), connectorSession);
+        Session session = toSession(transactionHandle, connectorSession);
         Optional<String> catalogFilter = FilterUtil.stringFilter(constraint, 1);
 
         Builder table = InMemoryRecordSet.builder(METADATA);
-        for (String catalog : filter(metadata.getCatalogNames(session).keySet(), catalogFilter)) {
+        for (String catalog : filter(listCatalogs(session, metadata, accessControl).keySet(), catalogFilter)) {
             for (String schema : metadata.listSchemaNames(session, catalog)) {
                 table.addRow(schema, catalog);
             }

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/TableJdbcTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/TableJdbcTable.java
@@ -15,7 +15,6 @@ package com.facebook.presto.connector.system.jdbc;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.metadata.QualifiedTablePrefix;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ConnectorSession;
@@ -36,6 +35,8 @@ import static com.facebook.presto.connector.system.jdbc.FilterUtil.filter;
 import static com.facebook.presto.connector.system.jdbc.FilterUtil.stringFilter;
 import static com.facebook.presto.connector.system.jdbc.FilterUtil.tablePrefix;
 import static com.facebook.presto.metadata.MetadataListing.listCatalogs;
+import static com.facebook.presto.metadata.MetadataListing.listTables;
+import static com.facebook.presto.metadata.MetadataListing.listViews;
 import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Objects.requireNonNull;
@@ -88,23 +89,23 @@ public class TableJdbcTable
             QualifiedTablePrefix prefix = tablePrefix(catalog, schemaFilter, tableFilter);
 
             if (FilterUtil.emptyOrEquals(typeFilter, "TABLE")) {
-                for (QualifiedObjectName name : metadata.listTables(session, prefix)) {
-                    table.addRow(tableRow(name, "TABLE"));
+                for (SchemaTableName name : listTables(session, metadata, accessControl, prefix)) {
+                    table.addRow(tableRow(catalog, name, "TABLE"));
                 }
             }
 
             if (FilterUtil.emptyOrEquals(typeFilter, "VIEW")) {
-                for (QualifiedObjectName name : metadata.listViews(session, prefix)) {
-                    table.addRow(tableRow(name, "VIEW"));
+                for (SchemaTableName name : listViews(session, metadata, accessControl, prefix)) {
+                    table.addRow(tableRow(catalog, name, "VIEW"));
                 }
             }
         }
         return table.build().cursor();
     }
 
-    private static Object[] tableRow(QualifiedObjectName name, String type)
+    private static Object[] tableRow(String catalog, SchemaTableName name, String type)
     {
-        return new Object[] {name.getCatalogName(), name.getSchemaName(), name.getObjectName(), type,
+        return new Object[] {catalog, name.getSchemaName(), name.getTableName(), type,
                              null, null, null, null, null, null};
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -99,7 +99,7 @@ public class CreateTableTask
             else if (element instanceof LikeClause) {
                 LikeClause likeClause = (LikeClause) element;
                 QualifiedObjectName likeTableName = createQualifiedObjectName(session, statement, likeClause.getTableName());
-                if (!metadata.getCatalogNames(session).containsKey(likeTableName.getCatalogName())) {
+                if (!metadata.getCatalogHandle(session, likeTableName.getCatalogName()).isPresent()) {
                     throw new SemanticException(MISSING_CATALOG, statement, "LIKE table catalog '%s' does not exist", likeTableName.getCatalogName());
                 }
                 if (!tableName.getCatalogName().equals(likeTableName.getCatalogName())) {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataListing.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataListing.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.security.AccessControl;
+import com.google.common.collect.ImmutableSortedMap;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+
+public final class MetadataListing
+{
+    private MetadataListing() {}
+
+    public static SortedMap<String, ConnectorId> listCatalogs(Session session, Metadata metadata, AccessControl accessControl)
+    {
+        Map<String, ConnectorId> catalogNames = metadata.getCatalogNames(session);
+        Set<String> allowedCatalogs = accessControl.filterCatalogs(session.getIdentity(), catalogNames.keySet());
+
+        ImmutableSortedMap.Builder<String, ConnectorId> result = ImmutableSortedMap.naturalOrder();
+        for (Map.Entry<String, ConnectorId> entry : catalogNames.entrySet()) {
+            if (allowedCatalogs.contains(entry.getKey())) {
+                result.put(entry);
+            }
+        }
+        return result.build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataListing.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataListing.java
@@ -16,11 +16,14 @@ package com.facebook.presto.metadata;
 import com.facebook.presto.Session;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.security.AccessControl;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
 
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.SortedSet;
 
 public final class MetadataListing
 {
@@ -38,5 +41,11 @@ public final class MetadataListing
             }
         }
         return result.build();
+    }
+
+    public static SortedSet<String> listSchemas(Session session, Metadata metadata, AccessControl accessControl, String catalogName)
+    {
+        Set<String> schemaNames = ImmutableSet.copyOf(metadata.listSchemaNames(session, catalogName));
+        return ImmutableSortedSet.copyOf(accessControl.filterSchemas(session.getRequiredTransactionId(), session.getIdentity(), catalogName, schemaNames));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.transaction.TransactionId;
 
 import java.security.Principal;
+import java.util.Set;
 
 public interface AccessControl
 {
@@ -28,6 +29,11 @@ public interface AccessControl
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */
     void checkCanSetUser(Principal principal, String userName);
+
+    /**
+     * Filter the list of catalogs to those visible to the identity.
+     */
+    Set<String> filterCatalogs(Identity identity, Set<String> catalogs);
 
     /**
      * Check if identity is allowed to create the specified schema.

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -15,6 +15,7 @@ package com.facebook.presto.security;
 
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.spi.CatalogSchemaName;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.transaction.TransactionId;
@@ -86,6 +87,22 @@ public interface AccessControl
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */
     void checkCanRenameTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName, QualifiedObjectName newTableName);
+
+    /**
+     * Check if identity is allowed to execute SHOW TABLES in a catalog.
+     *
+     * NOTE: This method is only present to give users an error message when listing is not allowed.
+     * The {@link #filterTables} method must filter all results for unauthorized users,
+     * since there are multiple ways to list tables.
+     *
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanShowTables(TransactionId transactionId, Identity identity, CatalogSchemaName schema);
+
+    /**
+     * Filter the list of tables and views to those visible to the identity.
+     */
+    Set<SchemaTableName> filterTables(TransactionId transactionId, Identity identity, String catalogName, Set<SchemaTableName> tableNames);
 
     /**
      * Check if identity is allowed to add columns to the specified table.

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -54,6 +54,22 @@ public interface AccessControl
     void checkCanRenameSchema(TransactionId transactionId, Identity identity, CatalogSchemaName schemaName, String newSchemaName);
 
     /**
+     * Check if identity is allowed to execute SHOW SCHEMAS in a catalog.
+     *
+     * NOTE: This method is only present to give users an error message when listing is not allowed.
+     * The {@link #filterSchemas} method must filter all results for unauthorized users,
+     * since there are multiple ways to list schemas.
+     *
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanShowSchemas(TransactionId transactionId, Identity identity, String catalogName);
+
+    /**
+     * Filter the list of schemas in a catalog to those visible to the identity.
+     */
+    Set<String> filterSchemas(TransactionId transactionId, Identity identity, String catalogName, Set<String> schemaNames);
+
+    /**
      * Check if identity is allowed to create the specified table.
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -41,6 +41,7 @@ import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -160,6 +161,15 @@ public class AccessControlManager
         requireNonNull(userName, "userName is null");
 
         authenticationCheck(() -> systemAccessControl.get().checkCanSetUser(principal, userName));
+    }
+
+    @Override
+    public Set<String> filterCatalogs(Identity identity, Set<String> catalogs)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(catalogs, "catalogs is null");
+
+        return systemAccessControl.get().filterCatalogs(identity, catalogs);
     }
 
     @Override
@@ -561,6 +571,12 @@ public class AccessControlManager
         @Override
         public void checkCanSetUser(Principal principal, String userName)
         {
+        }
+
+        @Override
+        public Set<String> filterCatalogs(Identity identity, Set<String> catalogs)
+        {
+            return catalogs;
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.transaction.TransactionId;
 
 import java.security.Principal;
+import java.util.Set;
 
 public class AllowAllAccessControl
         implements AccessControl
@@ -27,6 +28,12 @@ public class AllowAllAccessControl
     @Override
     public void checkCanSetUser(Principal principal, String userName)
     {
+    }
+
+    @Override
+    public Set<String> filterCatalogs(Identity identity, Set<String> catalogs)
+    {
+        return catalogs;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
@@ -52,6 +52,17 @@ public class AllowAllAccessControl
     }
 
     @Override
+    public void checkCanShowSchemas(TransactionId transactionId, Identity identity, String catalogName)
+    {
+    }
+
+    @Override
+    public Set<String> filterSchemas(TransactionId transactionId, Identity identity, String catalogName, Set<String> schemaNames)
+    {
+        return schemaNames;
+    }
+
+    @Override
     public void checkCanCreateTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName)
     {
     }

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
@@ -15,6 +15,7 @@ package com.facebook.presto.security;
 
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.spi.CatalogSchemaName;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.transaction.TransactionId;
@@ -75,6 +76,17 @@ public class AllowAllAccessControl
     @Override
     public void checkCanRenameTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName, QualifiedObjectName newTableName)
     {
+    }
+
+    @Override
+    public void checkCanShowTables(TransactionId transactionId, Identity identity, CatalogSchemaName schema)
+    {
+    }
+
+    @Override
+    public Set<SchemaTableName> filterTables(TransactionId transactionId, Identity identity, String catalogName, Set<SchemaTableName> tableNames)
+    {
+        return tableNames;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -15,6 +15,7 @@ package com.facebook.presto.security;
 
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.spi.CatalogSchemaName;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.transaction.TransactionId;
@@ -94,6 +95,18 @@ public class DenyAllAccessControl
     public void checkCanRenameTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName, QualifiedObjectName newTableName)
     {
         denyRenameTable(tableName.toString(), newTableName.toString());
+    }
+
+    @Override
+    public void checkCanShowTables(TransactionId transactionId, Identity identity, CatalogSchemaName schema)
+    {
+        denyShowSchemas(schema.toString());
+    }
+
+    @Override
+    public Set<SchemaTableName> filterTables(TransactionId transactionId, Identity identity, String catalogName, Set<SchemaTableName> tableNames)
+    {
+        return ImmutableSet.of();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -18,8 +18,10 @@ import com.facebook.presto.spi.CatalogSchemaName;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.transaction.TransactionId;
+import com.google.common.collect.ImmutableSet;
 
 import java.security.Principal;
+import java.util.Set;
 
 import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateSchema;
@@ -49,6 +51,12 @@ public class DenyAllAccessControl
     public void checkCanSetUser(Principal principal, String userName)
     {
         denySetUser(principal, userName);
+    }
+
+    @Override
+    public Set<String> filterCatalogs(Identity identity, Set<String> catalogs)
+    {
+        return ImmutableSet.of();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denySelectV
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetSystemSessionProperty;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetUser;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyShowSchemas;
 
 public class DenyAllAccessControl
         implements AccessControl
@@ -93,6 +94,18 @@ public class DenyAllAccessControl
     public void checkCanRenameTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName, QualifiedObjectName newTableName)
     {
         denyRenameTable(tableName.toString(), newTableName.toString());
+    }
+
+    @Override
+    public void checkCanShowSchemas(TransactionId transactionId, Identity identity, String catalogName)
+    {
+        denyShowSchemas();
+    }
+
+    @Override
+    public Set<String> filterSchemas(TransactionId transactionId, Identity identity, String catalogName, Set<String> schemaNames)
+    {
+        return ImmutableSet.of();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -176,6 +176,8 @@ final class ShowQueriesRewrite
         {
             CatalogSchemaName schema = createCatalogSchemaName(session, showTables, showTables.getSchema());
 
+            accessControl.checkCanShowTables(session.getRequiredTransactionId(), session.getIdentity(), schema);
+
             if (!metadata.schemaExists(session, schema)) {
                 throw new SemanticException(MISSING_SCHEMA, showTables, "Schema '%s' does not exist", schema.getSchemaName());
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -202,6 +202,9 @@ final class ShowQueriesRewrite
                 throw new SemanticException(CATALOG_NOT_SPECIFIED, node, "Catalog must be specified when session catalog is not set");
             }
 
+            String catalog = node.getCatalog().orElseGet(() -> session.getCatalog().get());
+            accessControl.checkCanShowSchemas(session.getRequiredTransactionId(), session.getIdentity(), catalog);
+
             Optional<Expression> predicate = Optional.empty();
             Optional<String> likePattern = node.getLikePattern();
             if (likePattern.isPresent()) {
@@ -210,7 +213,7 @@ final class ShowQueriesRewrite
 
             return simpleQuery(
                     selectList(aliasedName("schema_name", "Schema")),
-                    from(node.getCatalog().orElseGet(() -> session.getCatalog().get()), TABLE_SCHEMATA),
+                    from(catalog, TABLE_SCHEMATA),
                     predicate,
                     Optional.of(ordering(ascending("schema_name"))));
         }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -307,7 +307,7 @@ public class LocalQueryRunner
 
         GlobalSystemConnectorFactory globalSystemConnectorFactory = new GlobalSystemConnectorFactory(ImmutableSet.of(
                 new NodeSystemTable(nodeManager),
-                new CatalogSystemTable(transactionManager),
+                new CatalogSystemTable(metadata, accessControl),
                 new SchemaPropertiesSystemTable(transactionManager, metadata),
                 new TablePropertiesSystemTable(transactionManager, metadata),
                 new TransactionsSystemTable(typeRegistry, transactionManager)),

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -116,7 +116,7 @@ public class TestAccessControlManager
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
         accessControlManager.setSystemAccessControl("test", ImmutableMap.of());
 
-        ConnectorId connectorId = registerBogusConnector(catalogManager, transactionManager, "catalog");
+        ConnectorId connectorId = registerBogusConnector(catalogManager, transactionManager, accessControlManager, "catalog");
         accessControlManager.addCatalogAccessControl(connectorId, new DenyConnectorAccessControl());
 
         transaction(transactionManager, accessControlManager)
@@ -137,7 +137,7 @@ public class TestAccessControlManager
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
         accessControlManager.setSystemAccessControl("test", ImmutableMap.of());
 
-        registerBogusConnector(catalogManager, transactionManager, "connector");
+        registerBogusConnector(catalogManager, transactionManager, accessControlManager, "connector");
         accessControlManager.addCatalogAccessControl(new ConnectorId("connector"), new DenyConnectorAccessControl());
 
         transaction(transactionManager, accessControlManager)
@@ -146,7 +146,7 @@ public class TestAccessControlManager
                 });
     }
 
-    private static ConnectorId registerBogusConnector(CatalogManager catalogManager, TransactionManager transactionManager, String catalogName)
+    private static ConnectorId registerBogusConnector(CatalogManager catalogManager, TransactionManager transactionManager, AccessControl accessControl, String catalogName)
     {
         ConnectorId connectorId = new ConnectorId(catalogName);
         Connector connector = new TpchConnectorFactory().create(catalogName, ImmutableMap.of(), new TestingConnectorContext());
@@ -159,7 +159,7 @@ public class TestAccessControlManager
                 connectorId,
                 connector,
                 createInformationSchemaConnectorId(connectorId),
-                new InformationSchemaConnector(catalogName, nodeManager, metadata),
+                new InformationSchemaConnector(catalogName, nodeManager, metadata, accessControl),
                 systemId,
                 new SystemConnector(
                         systemId,

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -1308,7 +1308,7 @@ public class TestAnalyzer
                 connectorId,
                 connector,
                 createInformationSchemaConnectorId(connectorId),
-                new InformationSchemaConnector(catalogName, nodeManager, metadata),
+                new InformationSchemaConnector(catalogName, nodeManager, metadata, accessControl),
                 systemId,
                 new SystemConnector(
                         systemId,

--- a/presto-main/src/test/java/com/facebook/presto/transaction/TestTransactionManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/transaction/TestTransactionManager.java
@@ -21,6 +21,7 @@ import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
@@ -214,7 +215,7 @@ public class TestTransactionManager
                 connectorId,
                 connector,
                 createInformationSchemaConnectorId(connectorId),
-                new InformationSchemaConnector(catalogName, nodeManager, metadata),
+                new InformationSchemaConnector(catalogName, nodeManager, metadata, new AllowAllAccessControl()),
                 systemId,
                 new SystemConnector(
                         systemId,

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/AllowAllAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/AllowAllAccessControl.java
@@ -19,9 +19,22 @@ import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.Privilege;
 
+import java.util.Set;
+
 public class AllowAllAccessControl
         implements ConnectorAccessControl
 {
+    @Override
+    public void checkCanShowSchemas(ConnectorTransactionHandle transactionHandle, Identity identity)
+    {
+    }
+
+    @Override
+    public Set<String> filterSchemas(ConnectorTransactionHandle transactionHandle, Identity identity, Set<String> schemaNames)
+    {
+        return schemaNames;
+    }
+
     @Override
     public void checkCanCreateTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
     {

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/AllowAllAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/AllowAllAccessControl.java
@@ -51,6 +51,17 @@ public class AllowAllAccessControl
     }
 
     @Override
+    public void checkCanShowTables(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+    }
+
+    @Override
+    public Set<SchemaTableName> filterTables(ConnectorTransactionHandle transactionHandle, Identity identity, Set<SchemaTableName> tableNames)
+    {
+        return tableNames;
+    }
+
+    @Override
     public void checkCanAddColumn(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
     {
     }

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
@@ -72,6 +72,17 @@ public class FileBasedAccessControl
     }
 
     @Override
+    public void checkCanShowSchemas(ConnectorTransactionHandle transactionHandle, Identity identity)
+    {
+    }
+
+    @Override
+    public Set<String> filterSchemas(ConnectorTransactionHandle transactionHandle, Identity identity, Set<String> schemaNames)
+    {
+        return schemaNames;
+    }
+
+    @Override
     public void checkCanCreateTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
     {
         if (!isDatabaseOwner(identity, tableName.getSchemaName())) {

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
@@ -99,6 +99,17 @@ public class FileBasedAccessControl
     }
 
     @Override
+    public void checkCanShowTables(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+    }
+
+    @Override
+    public Set<SchemaTableName> filterTables(ConnectorTransactionHandle transactionHandle, Identity identity, Set<SchemaTableName> tableNames)
+    {
+        return tableNames;
+    }
+
+    @Override
     public void checkCanRenameTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName, SchemaTableName newTableName)
     {
         if (!checkTablePermission(identity, tableName, OWNERSHIP)) {

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ReadOnlyAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ReadOnlyAccessControl.java
@@ -19,6 +19,8 @@ import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.Privilege;
 
+import java.util.Set;
+
 import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateView;
@@ -34,6 +36,17 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyRevokeT
 public class ReadOnlyAccessControl
         implements ConnectorAccessControl
 {
+    @Override
+    public void checkCanShowSchemas(ConnectorTransactionHandle transactionHandle, Identity identity)
+    {
+    }
+
+    @Override
+    public Set<String> filterSchemas(ConnectorTransactionHandle transactionHandle, Identity identity, Set<String> schemaNames)
+    {
+        return schemaNames;
+    }
+
     @Override
     public void checkCanAddColumn(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
     {

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ReadOnlyAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ReadOnlyAccessControl.java
@@ -72,6 +72,17 @@ public class ReadOnlyAccessControl
     }
 
     @Override
+    public void checkCanShowTables(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+    }
+
+    @Override
+    public Set<SchemaTableName> filterTables(ConnectorTransactionHandle transactionHandle, Identity identity, Set<SchemaTableName> tableNames)
+    {
+        return tableNames;
+    }
+
+    @Override
     public void checkCanRenameColumn(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
     {
         denyRenameColumn(tableName.toString());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
@@ -39,6 +39,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denySelectT
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyShowSchemas;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyShowTables;
 
 public interface ConnectorAccessControl
 {
@@ -122,6 +123,28 @@ public interface ConnectorAccessControl
     default void checkCanRenameTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName, SchemaTableName newTableName)
     {
         denyRenameTable(tableName.toString(), newTableName.toString());
+    }
+
+    /**
+     * Check if identity is allowed to execute SHOW TABLES in a catalog.
+     *
+     * NOTE: This method is only present to give users an error message when listing is not allowed.
+     * The {@link #filterTables} method must filter all results for unauthorized users,
+     * since there are multiple ways to list tables.
+     *
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    default void checkCanShowTables(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+        denyShowTables(schemaName);
+    }
+
+    /**
+     * Filter the list of tables and views to those visible to the identity.
+     */
+    default Set<SchemaTableName> filterTables(ConnectorTransactionHandle transactionHandle, Identity identity, Set<SchemaTableName> tableNames)
+    {
+        return Collections.emptySet();
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
@@ -17,6 +17,9 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.Privilege;
 
+import java.util.Collections;
+import java.util.Set;
+
 import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateSchema;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;
@@ -35,6 +38,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyRevokeT
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyShowSchemas;
 
 public interface ConnectorAccessControl
 {
@@ -66,6 +70,28 @@ public interface ConnectorAccessControl
     default void checkCanRenameSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName, String newSchemaName)
     {
         denyRenameSchema(schemaName, newSchemaName);
+    }
+
+    /**
+     * Check if identity is allowed to execute SHOW SCHEMAS in a catalog.
+     *
+     * NOTE: This method is only present to give users an error message when listing is not allowed.
+     * The {@link #filterSchemas} method must handle filter all results for unauthorized users,
+     * since there are multiple way to list schemas.
+     *
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    default void checkCanShowSchemas(ConnectorTransactionHandle transactionHandle, Identity identity)
+    {
+        denyShowSchemas();
+    }
+
+    /**
+     * Filter the list of schemas to those visible to the identity.
+     */
+    default Set<String> filterSchemas(ConnectorTransactionHandle transactionHandle, Identity identity, Set<String> schemaNames)
+    {
+        return Collections.emptySet();
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
@@ -108,6 +108,16 @@ public class AccessDeniedException
         throw new AccessDeniedException(format("Cannot rename table from %s to %s%s", tableName, newTableName, formatExtraInfo(extraInfo)));
     }
 
+    public static void denyShowTables(String schemaName)
+    {
+        denyShowTables(schemaName, null);
+    }
+
+    public static void denyShowTables(String schemaName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot show tables in %s%s", schemaName, formatExtraInfo(extraInfo)));
+    }
+
     public static void denyAddColumn(String tableName)
     {
         denyAddColumn(tableName, null);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
@@ -68,6 +68,16 @@ public class AccessDeniedException
         throw new AccessDeniedException(format("Cannot rename schema from %s to %s%s", schemaName, newSchemaName, formatExtraInfo(extraInfo)));
     }
 
+    public static void denyShowSchemas()
+    {
+        denyShowSchemas(null);
+    }
+
+    public static void denyShowSchemas(String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot show schemas%s", formatExtraInfo(extraInfo)));
+    }
+
     public static void denyCreateTable(String tableName)
     {
         denyCreateTable(tableName, null);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyRevokeT
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyShowSchemas;
 
 public interface SystemAccessControl
 {
@@ -91,6 +92,28 @@ public interface SystemAccessControl
     default void checkCanRenameSchema(Identity identity, CatalogSchemaName schema, String newSchemaName)
     {
         denyRenameSchema(schema.toString(), newSchemaName);
+    }
+
+    /**
+     * Check if identity is allowed to execute SHOW SCHEMAS in a catalog.
+     *
+     * NOTE: This method is only present to give users an error message when listing is not allowed.
+     * The {@link #filterSchemas} method must filter all results for unauthorized users,
+     * since there are multiple ways to list schemas.
+     *
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    default void checkCanShowSchemas(Identity identity, String catalogName)
+    {
+        denyShowSchemas();
+    }
+
+    /**
+     * Filter the list of schemas in a catalog to those visible to the identity.
+     */
+    default Set<String> filterSchemas(Identity identity, String catalogName, Set<String> schemaNames)
+    {
+        return Collections.emptySet();
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.security;
 
 import com.facebook.presto.spi.CatalogSchemaName;
 import com.facebook.presto.spi.CatalogSchemaTableName;
+import com.facebook.presto.spi.SchemaTableName;
 
 import java.security.Principal;
 import java.util.Collections;
@@ -39,6 +40,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denySelectT
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyShowSchemas;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyShowTables;
 
 public interface SystemAccessControl
 {
@@ -144,6 +146,28 @@ public interface SystemAccessControl
     default void checkCanRenameTable(Identity identity, CatalogSchemaTableName table, CatalogSchemaTableName newTable)
     {
         denyRenameTable(table.toString(), newTable.toString());
+    }
+
+    /**
+     * Check if identity is allowed to execute SHOW TABLES in a catalog.
+     *
+     * NOTE: This method is only present to give users an error message when listing is not allowed.
+     * The {@link #filterTables} method must filter all results for unauthorized users,
+     * since there are multiple ways to list tables.
+     *
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    default void checkCanShowTables(Identity identity, CatalogSchemaName schema)
+    {
+        denyShowTables(schema.toString());
+    }
+
+    /**
+     * Filter the list of tables and views to those visible to the identity.
+     */
+    default Set<SchemaTableName> filterTables(Identity identity, String catalogName, Set<SchemaTableName> tableNames)
+    {
+        return Collections.emptySet();
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.CatalogSchemaName;
 import com.facebook.presto.spi.CatalogSchemaTableName;
 
 import java.security.Principal;
+import java.util.Collections;
+import java.util.Set;
 
 import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateSchema;
@@ -52,6 +54,14 @@ public interface SystemAccessControl
      * @throws AccessDeniedException if not allowed
      */
     void checkCanSetSystemSessionProperty(Identity identity, String propertyName);
+
+    /**
+     * Filter the list of catalogs to those visible to the identity.
+     */
+    default Set<String> filterCatalogs(Identity identity, Set<String> catalogs)
+    {
+        return Collections.emptySet();
+    }
 
     /**
      * Check if identity is allowed to create the specified schema in a catalog.


### PR DESCRIPTION
This PR adds access control to fail `SHOW` commands and limit listing of unauthorized items.

The difficulty with implementing enumeration of objects is that there are two different systems in Presto:
1) `SHOW` commands - in these commands we want to throw an access denied exception so the users knows they didn't mistype the name
2) `INFORMATION_SCHEMA`, JDBC, and system tables - this commands should filter out unauthorized items, but should not throw exceptions

Additionally, `SHOW` commands may be implemented on top of `INFORMATION_SCHEMA`

This is done by adding new access control checks `checkCanShow*` and `Set<T> filter*(Set<T> items)` methods to `SystemAccessControl` and `ConnectorAccessControl`.  For a `SHOW` command both methods are called, and for a listing access only the filter method is called.  It is expected that the implementor assures that the check and filter methods agree.

Further, it is assumed that all users have access to `SHOW CATALOGS` so there is no access check, but there is a filter.

As with other new checks the default implementation is "deny", so all existing implementation will need to be updated.