### PR TITLE
Remove no-op apply nodes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -43,6 +43,7 @@ import com.facebook.presto.sql.planner.optimizations.ProjectionPushDown;
 import com.facebook.presto.sql.planner.optimizations.PruneIdentityProjections;
 import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
 import com.facebook.presto.sql.planner.optimizations.PushTableWriteThroughUnion;
+import com.facebook.presto.sql.planner.optimizations.RemoveRedundantApply;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
 import com.facebook.presto.sql.planner.optimizations.SimplifyExpressions;
 import com.facebook.presto.sql.planner.optimizations.SingleDistinctOptimizer;
@@ -100,7 +101,8 @@ public class PlanOptimizers
                 new PruneUnreferencedOutputs(), // Make sure to run this at the end to help clean the plan for logging/execution and not remove info that other optimizers might need at an earlier point
                 new PruneIdentityProjections(), // This MUST run after PruneUnreferencedOutputs as it may introduce new redundant projections
                 new MetadataQueryOptimizer(metadata),
-                new EvaluateConstantApply());
+                new EvaluateConstantApply(),
+                new RemoveRedundantApply());
 
         if (featuresConfig.isOptimizeSingleDistinct()) {
             builder.add(new SingleDistinctOptimizer());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RemoveRedundantApply.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RemoveRedundantApply.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+
+import java.util.Map;
+
+/**
+ * Removes unnecessary apply nodes of the form
+ * <p>
+ * apply(x, r -> ())
+ * <p>
+ * or
+ * <p>
+ * apply(x, r -> scalar(...)), where the scalar subquery produces no columns
+ * <p>
+ * by rewriting them to x
+ */
+public class RemoveRedundantApply
+        implements PlanOptimizer
+{
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, Map<Symbol, Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        return SimplePlanRewriter.rewriteWith(new Rewriter(), plan);
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Void>
+    {
+        @Override
+        public PlanNode visitApply(ApplyNode node, RewriteContext<Void> context)
+        {
+            // if the subquery produces no columns...
+            if (node.getSubquery().getOutputSymbols().isEmpty()) {
+                // and it's guaranteed to produce a single row
+                if (node.getSubquery() instanceof EnforceSingleRowNode) {
+                    return node.getInput();
+                }
+            }
+
+            // or it's a VALUES with a single row
+            if ((node.getSubquery() instanceof ValuesNode)) {
+                if (((ValuesNode) node.getSubquery()).getRows().size() == 1) {
+                    return node.getInput();
+                }
+            }
+
+            return context.defaultRewrite(node);
+        }
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -8150,4 +8150,37 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails("DESCRIBE OUTPUT my_query", "Prepared statement not found: my_query");
     }
+
+    @Test
+    public void testSubqueriesWithDisjunction()
+            throws Exception
+    {
+        List<QueryTemplate.Parameter> projections = new QueryTemplate.Parameter("projection").of("count(*)", "*", "%condition%");
+        List<QueryTemplate.Parameter> conditions = new QueryTemplate.Parameter("condition").of(
+                "nationkey IN (SELECT 1) OR TRUE",
+                "EXISTS(SELECT 1) OR TRUE");
+
+        QueryTemplate queryTemplate = new QueryTemplate("SELECT %projection% FROM nation WHERE %condition%");
+        for (QueryTemplate.Parameter projection : projections) {
+            for (QueryTemplate.Parameter condition : conditions) {
+                assertQuery(queryTemplate.replace(projection, condition));
+            }
+        }
+
+        queryTemplate = new QueryTemplate("SELECT %projection% FROM nation WHERE (%condition%) AND nationkey <3");
+        for (QueryTemplate.Parameter projection : projections) {
+            for (QueryTemplate.Parameter condition : conditions) {
+                assertQuery(queryTemplate.replace(projection, condition));
+            }
+        }
+
+        assertQuery(
+                "SELECT count(*) FROM nation WHERE (SELECT true FROM (SELECT 1) t(a) WHERE a = nationkey) OR TRUE",
+                "SELECT 25");
+        assertQueryFails(
+                "SELECT (SELECT true FROM (SELECT 1) t(a) WHERE a = nationkey) " +
+                        "FROM nation " +
+                        "WHERE (SELECT true FROM (SELECT 1) t(a) WHERE a = nationkey) OR TRUE",
+                "Unsupported correlated subquery type");
+    }
 }


### PR DESCRIPTION
When the subquery of an apply node produces no columns
and is guaranteed to produce one row, it can be removed.

Fixes https://github.com/prestodb/presto/issues/6551