### PR TITLE
Simplify aggregation pushdown

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -132,7 +132,8 @@ public class PlanOptimizers
 
         // Optimizers above this do not need to care about aggregations with the type other than SINGLE
         // This optimizer must be run after all exchange-related optimizers
-        builder.add(new PartialAggregationPushDown(metadata));
+        builder.add(new PartialAggregationPushDown(metadata.getFunctionRegistry()));
+        builder.add(new PruneIdentityProjections());
 
         // DO NOT add optimizers that change the plan shape (computations) after this point
 


### PR DESCRIPTION
This is a rewrite of the partial aggregation pushdown
optimizer to make the code easier to follow and reason
about.

The approach is as follows:
1. Determine whether the optimization is applicable.
   At a minimum, there must be an aggregation on top
   of an exchange.
2. If the aggregation is SINGLE, split it into a FINAL
   on top of a PARTIAL and reprocess the resulting plan.
3. If the aggregation is a PARTIAL, push it underneath
   each branch of the exchange.

We use a couple of tricks to avoid having to juggle
and rename field names as the nodes are rewired:

1. When pushing the partial aggregation through the exchange,
   the names of the outputs of the aggregation are preserved.
2. If the input->output mappings in the exchange are not
   simple identity projections without rename, we introduce
   a projection under the partial aggregation. This helps
   avoid having to rewrite all the aggregation functions
   to refer to new names.

It also fixes a planning issue under certain scenarios
involving aggregation subqueries and partitioned tables.

E.g.,

    SELECT *
    FROM (
        SELECT count(*)
        FROM tpch.tiny.orders
        HAVING count(DISTINCT custkey) > 1
    )
    CROSS JOIN t

where "t" is a partitioned Hive table.

Fixes https://github.com/prestodb/presto/issues/6554