### PR TITLE
Add separate Travis install step for Maven

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
 
 install:
+  - ./mvnw -v
   - |
     if [[ -v TEST_SPECIFIC_MODULES ]]; then
       ./mvnw install $MAVEN_FAST_INSTALL -pl $TEST_SPECIFIC_MODULES -am


### PR DESCRIPTION
Maven wrapper downloads from Maven Central, so having a separate step
allows recording the timing separately.