### PR TITLE
Do not convert type to uppercase

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -183,7 +183,7 @@ public class TestRowOperators
             fail("hyperloglog is not comparable");
         }
         catch (SemanticException e) {
-            if (!e.getMessage().matches("\\Qline 1:81: '=' cannot be applied to row(COL0 HyperLogLog), row(COL0 HyperLogLog)\\E")) {
+            if (!e.getMessage().matches("\\Qline 1:81: '=' cannot be applied to row(col0 HyperLogLog), row(col0 HyperLogLog)\\E")) {
                 throw e;
             }
             //Expected

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cast.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cast.java
@@ -64,7 +64,7 @@ public final class Cast
         requireNonNull(type, "type is null");
 
         this.expression = expression;
-        this.type = type.toUpperCase(ENGLISH);
+        this.type = type.toLowerCase(ENGLISH);
         this.safe = safe;
         this.typeOnly = typeOnly;
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6772,7 +6772,7 @@ public abstract class AbstractTestQueries
     @Test
     public void testInvalidType()
     {
-        assertQueryFails("SELECT CAST(null AS array(foo))", "\\Qline 1:8: Unknown type: ARRAY(FOO)\\E");
+        assertQueryFails("SELECT CAST(null AS array(foo))", "\\Qline 1:8: Unknown type: array(foo)\\E");
     }
 
     @Test


### PR DESCRIPTION
@martint here is the fix to `Cast`. With this I don't need to change `RowType` equality logic, but at the same time I am not sure why `type` was uppercased in the first place.

**Summary**
Converting the type to uppercase breaks type equality for row types as
the field names get uppercased. With that `TypeRegistry::getCommonSuperType()` infers the common super type of `row(c0 bigint)` and `row(C0 bigint)` as empty and below insert fails.

```
presto:nyigitbasi> desc test_insert3;
 Column |      Type      | Comment
--------+----------------+---------
 c      | row(c0 bigint) |
(1 row)


presto:nyigitbasi> insert into test_insert3 values (row(CAST(ROW(2) AS ROW(c0 bigint))));
Query 20161110_211137_00021_fy2h4 failed: Insert query has mismatched column types: Table: [row(c0 bigint)], Query: [row(C0 bigint)]
com.facebook.presto.sql.analyzer.SemanticException: Insert query has mismatched column types: Table: [row(c0 bigint)], Query: [row(C0 bigint)]
	at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitInsert(StatementAnalyzer.java:254)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitInsert(StatementAnalyzer.java:166)
	at com.facebook.presto.sql.tree.Insert.accept(Insert.java:61)
	at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
	at com.facebook.presto.sql.analyzer.Analyzer.analyze(Analyzer.java:67)
	at com.facebook.presto.sql.analyzer.Analyzer.analyze(Analyzer.java:59)
	at com.facebook.presto.execution.SqlQueryExecution.doAnalyzeQuery(SqlQueryExecution.java:285)
	at com.facebook.presto.execution.SqlQueryExecution.analyzeQuery(SqlQueryExecution.java:271)
	at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:229)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```