### PR TITLE
Update sphinx-maven plugin to Airlift fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -864,9 +864,9 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>kr.motd.maven</groupId>
+                    <groupId>io.airlift.maven.plugins</groupId>
                     <artifactId>sphinx-maven-plugin</artifactId>
-                    <version>1.3.1.Final</version>
+                    <version>2.0</version>
                 </plugin>
 
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->

--- a/presto-docs/pom.xml
+++ b/presto-docs/pom.xml
@@ -45,7 +45,7 @@
 
         <plugins>
             <plugin>
-                <groupId>kr.motd.maven</groupId>
+                <groupId>io.airlift.maven.plugins</groupId>
                 <artifactId>sphinx-maven-plugin</artifactId>
                 <configuration>
                     <fork>true</fork>


### PR DESCRIPTION
Airlift fork has the latest sphinx version builtin, and it supports
the fork mode, which is needed to prevent OOM errors.