### PR TITLE
Enable product tests for Cassandra

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.27</dep.slice.version>
         <dep.aws-sdk.version>1.11.30</dep.aws-sdk.version>
-        <dep.tempto.version>1.14</dep.tempto.version>
+        <dep.tempto.version>1.18</dep.tempto.version>
 
         <!--
         Versions newer than 6.9 appear to have an issue where the @BeforeClass method in

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -197,6 +197,7 @@ environment_compose up -d hadoop-master
 # start external database containers
 environment_compose up -d mysql
 environment_compose up -d postgres
+environment_compose up -d cassandra
 
 # start docker logs for hadoop container
 environment_compose logs --no-color hadoop-master &

--- a/presto-product-tests/conf/docker/common/cassandra.yml
+++ b/presto-product-tests/conf/docker/common/cassandra.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+
+  cassandra:
+    hostname: cassandra
+    image: 'cassandra:2.1.15'
+    ports:
+      - '9042:9042'
+      - '9160:9160'
+

--- a/presto-product-tests/conf/docker/multinode/compose.sh
+++ b/presto-product-tests/conf/docker/multinode/compose.sh
@@ -5,5 +5,6 @@ source ${BASH_SOURCE%/*}/../common/compose-commons.sh
 docker-compose \
 -f ${BASH_SOURCE%/*}/../common/standard.yml \
 -f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \
+-f ${BASH_SOURCE%/*}/../common/cassandra.yml \
 -f ${BASH_SOURCE%/*}/docker-compose.yml \
 "$@"

--- a/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/compose.sh
@@ -5,5 +5,6 @@ source ${BASH_SOURCE%/*}/../common/compose-commons.sh
 docker-compose \
 -f ${BASH_SOURCE%/*}/../common/standard.yml \
 -f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \
+-f ${BASH_SOURCE%/*}/../common/cassandra.yml \
 -f ${BASH_SOURCE%/*}/docker-compose.yml \
 "$@"

--- a/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-impersonation/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-impersonation/compose.sh
@@ -6,5 +6,6 @@ docker-compose \
 -f ${BASH_SOURCE%/*}/../common/standard.yml \
 -f ${BASH_SOURCE%/*}/../common/kerberos.yml \
 -f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \
+-f ${BASH_SOURCE%/*}/../common/cassandra.yml \
 -f ${BASH_SOURCE%/*}/docker-compose.yml \
 "$@"

--- a/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-no-impersonation/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-no-impersonation/compose.sh
@@ -6,5 +6,6 @@ docker-compose \
 -f ${BASH_SOURCE%/*}/../common/standard.yml \
 -f ${BASH_SOURCE%/*}/../common/kerberos.yml \
 -f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \
+-f ${BASH_SOURCE%/*}/../common/cassandra.yml \
 -f ${BASH_SOURCE%/*}/docker-compose.yml \
 "$@"

--- a/presto-product-tests/conf/docker/singlenode/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode/compose.sh
@@ -5,5 +5,6 @@ source ${BASH_SOURCE%/*}/../common/compose-commons.sh
 docker-compose \
 -f ${BASH_SOURCE%/*}/../common/standard.yml \
 -f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \
+-f ${BASH_SOURCE%/*}/../common/cassandra.yml \
 -f ${BASH_SOURCE%/*}/docker-compose.yml \
 "$@"

--- a/presto-product-tests/conf/presto/etc/catalog/cassandra.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/cassandra.properties
@@ -1,0 +1,3 @@
+connector.name=cassandra
+cassandra.contact-points=cassandra
+cassandra.schema-cache-ttl=0s

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-default.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-default.yaml
@@ -4,3 +4,9 @@ databases:
   presto:
     host: presto-master
     configured_hdfs_user: hive
+  cassandra:
+    host: cassandra
+    port: 9042
+    default_schema: test
+    skip_create_schema: false
+    table_manager_type: cassandra

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -87,6 +87,10 @@
             <artifactId>http-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.airlift.tpch</groupId>
+            <artifactId>tpch</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.facebook.presto.hive</groupId>
             <artifactId>hive-apache-jdbc</artifactId>
             <scope>runtime</scope>

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -51,6 +51,7 @@ public final class TestGroups
     public static final String AUTHORIZATION = "authorization";
     public static final String POST_HIVE_1_0_1 = "post_hive_1_0_1";
     public static final String HIVE_COERCION = "hive_coercion";
+    public static final String CASSANDRA = "cassandra";
 
     private TestGroups() {}
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/CassandraTpchTableDefinitions.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/CassandraTpchTableDefinitions.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.cassandra;
+
+import com.google.common.collect.ImmutableList;
+import com.teradata.tempto.internal.fulfillment.table.cassandra.CassandraTableDefinition;
+import com.teradata.tempto.internal.fulfillment.table.cassandra.tpch.CassandraTpchDataSource;
+import io.airlift.tpch.TpchTable;
+
+import java.sql.JDBCType;
+
+import static com.facebook.presto.tests.cassandra.TestConstants.CONNECTOR_NAME;
+import static com.facebook.presto.tests.cassandra.TestConstants.KEY_SPACE;
+import static java.sql.JDBCType.BIGINT;
+import static java.sql.JDBCType.VARCHAR;
+
+public class CassandraTpchTableDefinitions
+{
+    private CassandraTpchTableDefinitions() {}
+
+    public static final ImmutableList<JDBCType> NATION_TYPES = ImmutableList.of(BIGINT, VARCHAR, BIGINT, VARCHAR);
+
+    // TpchTable.NATION does provide data in order: nationkey, name, regionkey, comment. Unfortunately Cassandra reorders columns,
+    // so schema will be: nationkey, comment, name, regionkey (primary key first - nationkey, then alphabetical order: comment, name, regionkey)
+    // reordering is solved by providing mapping list
+    public static final CassandraTableDefinition CASSANDRA_NATION = CassandraTableDefinition.cassandraBuilder("nation")
+            .withDatabase(CONNECTOR_NAME)
+            .withSchema(KEY_SPACE)
+            .setCreateTableDDLTemplate("CREATE TABLE %NAME%(" +
+                    "   n_nationkey     BIGINT," +
+                    "   n_name          VARCHAR," +
+                    "   n_regionkey     BIGINT," +
+                    "   n_comment       VARCHAR," +
+                    "   primary key(n_nationkey))")
+            .setDataSource(new CassandraTpchDataSource(TpchTable.NATION, ImmutableList.of(0, 2, 3, 1), NATION_TYPES, 1.0))
+            .build();
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/Select.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/Select.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.cassandra;
+
+import com.teradata.tempto.ProductTest;
+import com.teradata.tempto.Requirement;
+import com.teradata.tempto.RequirementsProvider;
+import com.teradata.tempto.configuration.Configuration;
+import com.teradata.tempto.query.QueryResult;
+import org.testng.annotations.Test;
+
+import java.sql.SQLException;
+
+import static com.facebook.presto.tests.TestGroups.CASSANDRA;
+import static com.facebook.presto.tests.TpchTableResults.PRESTO_NATION_RESULT;
+import static com.facebook.presto.tests.cassandra.CassandraTpchTableDefinitions.CASSANDRA_NATION;
+import static com.facebook.presto.tests.cassandra.TestConstants.CONNECTOR_NAME;
+import static com.facebook.presto.tests.cassandra.TestConstants.KEY_SPACE;
+import static com.facebook.presto.tests.utils.QueryExecutors.onPresto;
+import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static com.teradata.tempto.fulfillment.table.TableRequirements.immutableTable;
+import static java.lang.String.format;
+
+public class Select
+        extends ProductTest
+        implements RequirementsProvider
+{
+    @Override
+    public Requirement getRequirements(Configuration configuration)
+    {
+        return immutableTable(CASSANDRA_NATION);
+    }
+
+    @Test(groups = CASSANDRA)
+    public void testSelectNation()
+            throws SQLException
+    {
+        String sql = format(
+                "SELECT n_nationkey, n_name, n_regionkey, n_comment FROM %s.%s.%s",
+                CONNECTOR_NAME,
+                KEY_SPACE,
+                CASSANDRA_NATION.getName());
+        QueryResult queryResult = onPresto()
+                .executeQuery(sql);
+
+        assertThat(queryResult).matches(PRESTO_NATION_RESULT);
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/TestConstants.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/TestConstants.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.cassandra;
+
+public final class TestConstants
+{
+    public static final String CONNECTOR_NAME = "cassandra";
+    public static final String KEY_SPACE = "test";
+
+    private TestConstants() {}
+}


### PR DESCRIPTION
Only Java-base tests are enabled (no convention-base tests are supported) for now.

---

Internal TD review: https://github.com/Teradata/presto/pull/409