### PR TITLE
Add support for "show grants"

### DIFF
--- a/presto-docs/src/main/sphinx/connector/mysql.rst
+++ b/presto-docs/src/main/sphinx/connector/mysql.rst
@@ -67,3 +67,4 @@ The following SQL statements are not yet supported:
 * :doc:`/sql/create-table` (:doc:`/sql/create-table-as` is supported)
 * :doc:`/sql/grant`
 * :doc:`/sql/revoke`
+* :doc:`/sql/show-grants`

--- a/presto-docs/src/main/sphinx/connector/postgresql.rst
+++ b/presto-docs/src/main/sphinx/connector/postgresql.rst
@@ -72,3 +72,4 @@ The following SQL statements are not yet supported:
 * :doc:`/sql/create-table` (:doc:`/sql/create-table-as` is supported)
 * :doc:`/sql/grant`
 * :doc:`/sql/revoke`
+* :doc:`/sql/show-grants`

--- a/presto-docs/src/main/sphinx/sql.rst
+++ b/presto-docs/src/main/sphinx/sql.rst
@@ -34,6 +34,7 @@ This chapter describes the SQL syntax used in Presto.
     sql/show-create-table
     sql/show-create-view
     sql/show-functions
+    sql/show-grants
     sql/show-partitions
     sql/show-schemas
     sql/show-session

--- a/presto-docs/src/main/sphinx/sql/grant.rst
+++ b/presto-docs/src/main/sphinx/sql/grant.rst
@@ -51,3 +51,4 @@ See Also
 --------
 
 :doc:`revoke`
+:doc:`show-grants`

--- a/presto-docs/src/main/sphinx/sql/revoke.rst
+++ b/presto-docs/src/main/sphinx/sql/revoke.rst
@@ -51,3 +51,4 @@ See Also
 --------
 
 :doc:`grant`
+:doc:`show-grants`

--- a/presto-docs/src/main/sphinx/sql/show-grants.rst
+++ b/presto-docs/src/main/sphinx/sql/show-grants.rst
@@ -1,0 +1,46 @@
+===========
+SHOW GRANTS
+===========
+
+Synopsis
+--------
+
+.. code-block:: none
+
+    SHOW GRANTS [ ON [ TABLE ] table_name ]
+
+Description
+-----------
+
+List the grants for the current user on the specified table in the current catalog.
+
+If no table name is specified, the command lists the grants for the current user on all the tables in all schemas of the current catalog.
+
+The command requires the current catalog to be set.
+
+.. note::
+
+    Ensure that authentication has been enabled before running any of the authorization commands.
+
+Examples
+--------
+
+List the grants for the current user on table ``orders``::
+
+    SHOW GRANTS ON TABLE ``orders``;
+
+List the grants for the current user on all the tables in all schemas of the current catalog::
+
+    SHOW GRANTS;
+
+Limitations
+-----------
+
+Some connectors have no support for ``SHOW GRANTS``.
+See connector documentation for more details.
+
+See Also
+--------
+
+:doc:`grant`
+:doc:`revoke`

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePrivilegeInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePrivilegeInfo.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.metastore;
 
 import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo;
 import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hive.metastore.api.PrivilegeGrantInfo;
 
@@ -93,6 +94,8 @@ public class HivePrivilegeInfo
                 return INSERT;
             case DELETE:
                 return DELETE;
+            case UPDATE:
+                return UPDATE;
         }
         return null;
     }
@@ -102,6 +105,25 @@ public class HivePrivilegeInfo
         return (getHivePrivilege().equals(hivePrivilegeInfo.getHivePrivilege()) &&
                 (isGrantOption() == hivePrivilegeInfo.isGrantOption() ||
                         (!isGrantOption() && hivePrivilegeInfo.isGrantOption())));
+    }
+
+    public Set<PrivilegeInfo> toPrivilegeInfo()
+    {
+        switch (getHivePrivilege()) {
+            case SELECT:
+                return ImmutableSet.of(new PrivilegeInfo(Privilege.SELECT, isGrantOption()));
+            case INSERT:
+                return ImmutableSet.of(new PrivilegeInfo(Privilege.INSERT, isGrantOption()));
+            case DELETE:
+                return ImmutableSet.of(new PrivilegeInfo(Privilege.DELETE, isGrantOption()));
+            case UPDATE:
+                return ImmutableSet.of(new PrivilegeInfo(Privilege.UPDATE, isGrantOption()));
+            case OWNERSHIP:
+                return Arrays.asList(Privilege.values()).stream()
+                        .map(privilege -> new PrivilegeInfo(privilege, Boolean.TRUE))
+                        .collect(Collectors.toSet());
+        }
+        return null;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/LegacyAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/LegacyAccessControl.java
@@ -115,7 +115,7 @@ public class LegacyAccessControl
     }
 
     @Override
-    public void checkCanShowTables(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    public void checkCanShowTablesMetadata(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
     {
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
@@ -141,7 +141,7 @@ public class SqlStandardAccessControl
     }
 
     @Override
-    public void checkCanShowTables(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    public void checkCanShowTablesMetadata(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
     {
     }
 

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
@@ -794,7 +794,7 @@ public class TestPrestoDriver
         try (Connection connection = createConnection()) {
             try (ResultSet rs = connection.getMetaData().getColumns(TEST_CATALOG, "information_schema", "tab%", "table_name")) {
                 assertColumnMetadata(rs);
-                assertEquals(readRows(rs).size(), 1);
+                assertEquals(readRows(rs).size(), 2);
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.metadata.MetadataUtil.SchemaMetadataBuilder.sc
 import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static com.facebook.presto.metadata.MetadataUtil.findColumnMetadata;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.compose;
@@ -57,6 +58,7 @@ public class InformationSchemaMetadata
     public static final SchemaTableName TABLE_VIEWS = new SchemaTableName(INFORMATION_SCHEMA, "views");
     public static final SchemaTableName TABLE_SCHEMATA = new SchemaTableName(INFORMATION_SCHEMA, "schemata");
     public static final SchemaTableName TABLE_INTERNAL_PARTITIONS = new SchemaTableName(INFORMATION_SCHEMA, "__internal_partitions__");
+    public static final SchemaTableName TABLE_TABLE_PRIVILEGES = new SchemaTableName(INFORMATION_SCHEMA, "table_privileges");
 
     public static final Map<SchemaTableName, ConnectorTableMetadata> TABLES = schemaMetadataBuilder()
             .table(tableMetadataBuilder(TABLE_COLUMNS)
@@ -94,6 +96,16 @@ public class InformationSchemaMetadata
                     .column("partition_number", BIGINT)
                     .column("partition_key", createUnboundedVarcharType())
                     .column("partition_value", createUnboundedVarcharType())
+                    .build())
+            .table(tableMetadataBuilder(TABLE_TABLE_PRIVILEGES)
+                    .column("grantor", createUnboundedVarcharType())
+                    .column("grantee", createUnboundedVarcharType())
+                    .column("table_catalog", createUnboundedVarcharType())
+                    .column("table_schema", createUnboundedVarcharType())
+                    .column("table_name", createUnboundedVarcharType())
+                    .column("privilege_type", createUnboundedVarcharType())
+                    .column("is_grantable", BOOLEAN)
+                    .column("with_hierarchy", BOOLEAN)
                     .build())
             .build();
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.TableIdentity;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -272,6 +273,11 @@ public interface Metadata
      * Revokes the specified privilege on the specified table from the specified user
      */
     void revokeTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, String grantee, boolean grantOption);
+
+    /**
+     * Gets the privileges for the specified table available to the given grantee
+     */
+    List<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix);
 
     FunctionRegistry getFunctionRegistry();
 

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -89,7 +89,7 @@ public interface AccessControl
     void checkCanRenameTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName, QualifiedObjectName newTableName);
 
     /**
-     * Check if identity is allowed to execute SHOW TABLES in a catalog.
+     * Check if identity is allowed to show metadata of tables by executing SHOW TABLES, SHOW GRANTS etc. in a catalog.
      *
      * NOTE: This method is only present to give users an error message when listing is not allowed.
      * The {@link #filterTables} method must filter all results for unauthorized users,
@@ -97,7 +97,7 @@ public interface AccessControl
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */
-    void checkCanShowTables(TransactionId transactionId, Identity identity, CatalogSchemaName schema);
+    void checkCanShowTablesMetadata(TransactionId transactionId, Identity identity, CatalogSchemaName schema);
 
     /**
      * Filter the list of tables and views to those visible to the identity.

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -272,16 +272,16 @@ public class AccessControlManager
     }
 
     @Override
-    public void checkCanShowTables(TransactionId transactionId, Identity identity, CatalogSchemaName schema)
+    public void checkCanShowTablesMetadata(TransactionId transactionId, Identity identity, CatalogSchemaName schema)
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(schema, "schema is null");
 
-        authorizationCheck(() -> systemAccessControl.get().checkCanShowTables(identity, schema));
+        authorizationCheck(() -> systemAccessControl.get().checkCanShowTablesMetadata(identity, schema));
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, schema.getCatalogName());
         if (entry != null) {
-            authorizationCheck(() -> entry.getAccessControl().checkCanShowTables(entry.getTransactionHandle(transactionId), identity, schema.getSchemaName()));
+            authorizationCheck(() -> entry.getAccessControl().checkCanShowTablesMetadata(entry.getTransactionHandle(transactionId), identity, schema.getSchemaName()));
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
@@ -79,7 +79,7 @@ public class AllowAllAccessControl
     }
 
     @Override
-    public void checkCanShowTables(TransactionId transactionId, Identity identity, CatalogSchemaName schema)
+    public void checkCanShowTablesMetadata(TransactionId transactionId, Identity identity, CatalogSchemaName schema)
     {
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
@@ -111,7 +111,7 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
-    public void checkCanShowTables(Identity identity, CatalogSchemaName schema)
+    public void checkCanShowTablesMetadata(Identity identity, CatalogSchemaName schema)
     {
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -45,7 +45,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denySetCata
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetSystemSessionProperty;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetUser;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyShowSchemas;
-import static com.facebook.presto.spi.security.AccessDeniedException.denyShowTables;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyShowTablesMetadata;
 
 public class DenyAllAccessControl
         implements AccessControl
@@ -99,9 +99,9 @@ public class DenyAllAccessControl
     }
 
     @Override
-    public void checkCanShowTables(TransactionId transactionId, Identity identity, CatalogSchemaName schema)
+    public void checkCanShowTablesMetadata(TransactionId transactionId, Identity identity, CatalogSchemaName schema)
     {
-        denyShowTables(schema.toString());
+        denyShowTablesMetadata(schema.toString());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/ReadOnlySystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/ReadOnlySystemAccessControl.java
@@ -111,7 +111,7 @@ public class ReadOnlySystemAccessControl
     }
 
     @Override
-    public void checkCanShowTables(Identity identity, CatalogSchemaName schema)
+    public void checkCanShowTablesMetadata(Identity identity, CatalogSchemaName schema)
     {
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -92,6 +92,7 @@ import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
 import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.sql.tree.ShowFunctions;
+import com.facebook.presto.sql.tree.ShowGrants;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
@@ -217,6 +218,7 @@ public class CoordinatorModule
         executionBinder.addBinding(ShowCatalogs.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(Use.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(ShowSession.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
+        executionBinder.addBinding(ShowGrants.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(CreateTableAsSelect.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(Insert.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(Delete.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -61,6 +61,7 @@ import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
 import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.sql.tree.ShowFunctions;
+import com.facebook.presto.sql.tree.ShowGrants;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
@@ -86,6 +87,7 @@ import static com.facebook.presto.connector.informationSchema.InformationSchemaM
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_INTERNAL_PARTITIONS;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_SCHEMATA;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLES;
+import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLE_PRIVILEGES;
 import static com.facebook.presto.metadata.MetadataListing.listCatalogs;
 import static com.facebook.presto.metadata.MetadataUtil.createCatalogSchemaName;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedName;
@@ -195,6 +197,43 @@ final class ShowQueriesRewrite
                     from(schema.getCatalogName(), TABLE_TABLES),
                     predicate,
                     ordering(ascending("table_name")));
+        }
+
+        @Override
+        protected Node visitShowGrants(ShowGrants showGrants, Void context)
+        {
+            String catalogName = session.getCatalog().orElse(null);
+            Optional<Expression> predicate = Optional.empty();
+
+            Optional<QualifiedName> tableName = showGrants.getTableName();
+            if (tableName.isPresent()) {
+                QualifiedObjectName qualifiedTableName = createQualifiedObjectName(session, showGrants, tableName.get());
+
+                if (!metadata.getView(session, qualifiedTableName).isPresent() &&
+                        !metadata.getTableHandle(session, qualifiedTableName).isPresent()) {
+                    throw new SemanticException(MISSING_TABLE, showGrants, "Table '%s' does not exist", tableName);
+                }
+
+                catalogName = qualifiedTableName.getCatalogName();
+
+                predicate = Optional.of(equal(identifier("table_name"), new StringLiteral(qualifiedTableName.getObjectName())));
+            }
+
+            if (catalogName == null) {
+                throw new SemanticException(CATALOG_NOT_SPECIFIED, showGrants, "Catalog must be specified when session catalog is not set");
+            }
+
+            return simpleQuery(
+                    selectList(
+                            aliasedName("grantee", "Grantee"),
+                            aliasedName("table_catalog", "Catalog"),
+                            aliasedName("table_schema", "Schema"),
+                            aliasedName("table_name", "Table"),
+                            aliasedName("privilege_type", "Privilege"),
+                            aliasedName("is_grantable", "Grantable")),
+                    from(catalogName, TABLE_TABLE_PRIVILEGES),
+                    predicate,
+                    Optional.of(ordering(ascending("grantee"), ascending("table_name"))));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -176,7 +176,7 @@ final class ShowQueriesRewrite
         {
             CatalogSchemaName schema = createCatalogSchemaName(session, showTables, showTables.getSchema());
 
-            accessControl.checkCanShowTables(session.getRequiredTransactionId(), session.getIdentity(), schema);
+            accessControl.checkCanShowTablesMetadata(session.getRequiredTransactionId(), session.getIdentity(), schema);
 
             if (!metadata.schemaExists(session, schema)) {
                 throw new SemanticException(MISSING_SCHEMA, showTables, "Schema '%s' does not exist", schema.getSchemaName());

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -97,7 +97,7 @@ public class TestAccessControlManager
                     accessControlManager.checkCanCreateViewWithSelectFromTable(transactionId, identity, tableName);
                     accessControlManager.checkCanCreateViewWithSelectFromView(transactionId, identity, tableName);
                     accessControlManager.checkCanShowSchemas(transactionId, identity, "catalog");
-                    accessControlManager.checkCanShowTables(transactionId, identity, new CatalogSchemaName("catalog", "schema"));
+                    accessControlManager.checkCanShowTablesMetadata(transactionId, identity, new CatalogSchemaName("catalog", "schema"));
                     Set<String> catalogs = ImmutableSet.of("catalog");
                     assertEquals(accessControlManager.filterCatalogs(identity, catalogs), catalogs);
                     Set<String> schemas = ImmutableSet.of("schema");

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -61,6 +61,8 @@ statement
         (GRANT OPTION FOR)?
         (privilege (',' privilege)* | ALL PRIVILEGES)
         ON TABLE? qualifiedName FROM grantee=identifier                #revoke
+    | SHOW GRANTS
+        (ON TABLE? qualifiedName)?                                     #showGrants
     | EXPLAIN ANALYZE?
         ('(' explainOption (',' explainOption)* ')')? statement        #explain
     | SHOW CREATE TABLE qualifiedName                                  #showCreateTable
@@ -452,7 +454,7 @@ nonReserved
     | SERIALIZABLE | REPEATABLE | COMMITTED | UNCOMMITTED | READ | WRITE | ONLY
     | COMMENT
     | CALL
-    | GRANT | REVOKE | PRIVILEGES | PUBLIC | OPTION
+    | GRANT | REVOKE | PRIVILEGES | PUBLIC | OPTION | GRANTS
     | SUBSTRING
     | SCHEMA | CASCADE | RESTRICT
     | INPUT | OUTPUT
@@ -568,6 +570,7 @@ REVOKE: 'REVOKE';
 PRIVILEGES: 'PRIVILEGES';
 PUBLIC: 'PUBLIC';
 OPTION: 'OPTION';
+GRANTS: 'GRANTS';
 EXPLAIN: 'EXPLAIN';
 ANALYZE: 'ANALYZE';
 FORMAT: 'FORMAT';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -71,6 +71,7 @@ import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
 import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.sql.tree.ShowFunctions;
+import com.facebook.presto.sql.tree.ShowGrants;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
@@ -1059,6 +1060,23 @@ public final class SqlFormatter
             builder.append(node.getTableName())
                     .append(" FROM ")
                     .append(node.getGrantee());
+
+            return null;
+        }
+
+        @Override
+        public Void visitShowGrants(ShowGrants node, Integer indent)
+        {
+            builder.append("SHOW GRANTS ");
+
+            if (node.getTableName().isPresent()) {
+                builder.append("ON ");
+
+                if (node.getTable()) {
+                    builder.append("TABLE ");
+                }
+                builder.append(node.getTableName().get());
+            }
 
             return null;
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -119,6 +119,7 @@ import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
 import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.sql.tree.ShowFunctions;
+import com.facebook.presto.sql.tree.ShowGrants;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
@@ -754,6 +755,21 @@ class AstBuilder
                 context.TABLE() != null,
                 getQualifiedName(context.qualifiedName()),
                 context.grantee.getText());
+    }
+
+    @Override
+    public Node visitShowGrants(SqlBaseParser.ShowGrantsContext context)
+    {
+        Optional<QualifiedName> tableName = Optional.empty();
+
+        if (context.qualifiedName() != null) {
+            tableName = Optional.of(getQualifiedName(context.qualifiedName()));
+        }
+
+        return new ShowGrants(
+                getLocation(context),
+                context.TABLE() != null,
+                tableName);
     }
 
     // ***************** boolean expressions ******************

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -592,6 +592,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitShowGrants(ShowGrants node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitTransactionMode(TransactionMode node, C context)
     {
         return visitNode(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowGrants.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowGrants.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class ShowGrants
+    extends Statement
+{
+    private final boolean table;
+    private final Optional<QualifiedName> tableName;
+
+    public ShowGrants(boolean table, Optional<QualifiedName> tableName)
+    {
+        this(Optional.empty(), table, tableName);
+    }
+
+    public ShowGrants(NodeLocation location, boolean table, Optional<QualifiedName> tableName)
+    {
+        this(Optional.of(location), table, tableName);
+    }
+
+    public ShowGrants(Optional<NodeLocation> location, boolean table, Optional<QualifiedName> tableName)
+    {
+        super(location);
+        requireNonNull(tableName, "tableName is null");
+
+        this.table = table;
+        this.tableName = tableName;
+    }
+
+    public boolean getTable()
+    {
+        return table;
+    }
+
+    public Optional<QualifiedName> getTableName()
+    {
+        return tableName;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitShowGrants(this, context);
+    }
+
+    @Override
+    public List<Node> getChildren()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(table, tableName);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        ShowGrants o = (ShowGrants) obj;
+        return Objects.equals(table, o.table) &&
+                Objects.equals(tableName, o.tableName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("table", table)
+                .add("tableName", tableName)
+                .toString();
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -91,6 +91,7 @@ import com.facebook.presto.sql.tree.Rollup;
 import com.facebook.presto.sql.tree.Row;
 import com.facebook.presto.sql.tree.SetSession;
 import com.facebook.presto.sql.tree.ShowCatalogs;
+import com.facebook.presto.sql.tree.ShowGrants;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
@@ -1369,6 +1370,18 @@ public class TestSqlParser
                 new Revoke(false, Optional.empty(), true, QualifiedName.of("t"), "u"));
         assertStatement("REVOKE taco ON TABLE t FROM u",
                 new Revoke(false, Optional.of(ImmutableList.of("taco")), true, QualifiedName.of("t"), "u"));
+    }
+
+    @Test
+    public void testShowGrants()
+        throws Exception
+    {
+        assertStatement("SHOW GRANTS ON TABLE t",
+                new ShowGrants(true, Optional.of(QualifiedName.of("t"))));
+        assertStatement("SHOW GRANTS ON t",
+                new ShowGrants(false, Optional.of(QualifiedName.of("t"))));
+        assertStatement("SHOW GRANTS",
+                new ShowGrants(false, Optional.empty()));
     }
 
     @Test

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
@@ -228,6 +228,9 @@ public class TestStatementBuilder
         printStatement("revoke grant option for select on foo from alice");
         printStatement("revoke all privileges on foo from alice");
         printStatement("revoke insert, delete on foo from public"); //check support for public
+        printStatement("show grants on table t");
+        printStatement("show grants on t");
+        printStatement("show grants");
 
         printStatement("prepare p from select * from (select * from T) \"A B\"");
 

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/AllowAllAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/AllowAllAccessControl.java
@@ -51,7 +51,7 @@ public class AllowAllAccessControl
     }
 
     @Override
-    public void checkCanShowTables(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    public void checkCanShowTablesMetadata(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
     {
     }
 

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
@@ -99,7 +99,7 @@ public class FileBasedAccessControl
     }
 
     @Override
-    public void checkCanShowTables(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    public void checkCanShowTablesMetadata(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
     {
     }
 

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ReadOnlyAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ReadOnlyAccessControl.java
@@ -72,7 +72,7 @@ public class ReadOnlyAccessControl
     }
 
     @Override
-    public void checkCanShowTables(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    public void checkCanShowTablesMetadata(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
     {
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
@@ -39,7 +39,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denySelectT
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyShowSchemas;
-import static com.facebook.presto.spi.security.AccessDeniedException.denyShowTables;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyShowTablesMetadata;
 
 public interface ConnectorAccessControl
 {
@@ -126,7 +126,7 @@ public interface ConnectorAccessControl
     }
 
     /**
-     * Check if identity is allowed to execute SHOW TABLES in a catalog.
+     * Check if identity is allowed to show metadata of tables by executing SHOW TABLES, SHOW GRANTS etc. in a catalog.
      *
      * NOTE: This method is only present to give users an error message when listing is not allowed.
      * The {@link #filterTables} method must filter all results for unauthorized users,
@@ -134,9 +134,9 @@ public interface ConnectorAccessControl
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */
-    default void checkCanShowTables(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    default void checkCanShowTablesMetadata(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
     {
-        denyShowTables(schemaName);
+        denyShowTablesMetadata(schemaName);
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -33,6 +33,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.TableIdentity;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.Privilege;
 import io.airlift.slice.Slice;
 
@@ -374,6 +375,14 @@ public interface ConnectorMetadata
     default void revokeTablePrivileges(ConnectorSession session, SchemaTableName tableName, Set<Privilege> privileges, String grantee, boolean grantOption)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support revokes");
+    }
+
+    /**
+     * List the table privileges granted to the specified grantee for the tables that have the specified prefix
+     */
+    default List<GrantInfo> listTablePrivileges(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        return emptyList();
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.Privilege;
 import io.airlift.slice.Slice;
 
@@ -376,6 +377,13 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public List<GrantInfo> listTablePrivileges(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.listTablePrivileges(session, prefix);
+        }
+    }
+
     public TableIdentity getTableIdentity(ConnectorTableHandle connectorTableHandle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
@@ -108,14 +108,14 @@ public class AccessDeniedException
         throw new AccessDeniedException(format("Cannot rename table from %s to %s%s", tableName, newTableName, formatExtraInfo(extraInfo)));
     }
 
-    public static void denyShowTables(String schemaName)
+    public static void denyShowTablesMetadata(String schemaName)
     {
-        denyShowTables(schemaName, null);
+        denyShowTablesMetadata(schemaName, null);
     }
 
-    public static void denyShowTables(String schemaName, String extraInfo)
+    public static void denyShowTablesMetadata(String schemaName, String extraInfo)
     {
-        throw new AccessDeniedException(format("Cannot show tables in %s%s", schemaName, formatExtraInfo(extraInfo)));
+        throw new AccessDeniedException(format("Cannot show metadata of tables in %s%s", schemaName, formatExtraInfo(extraInfo)));
     }
 
     public static void denyAddColumn(String tableName)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/GrantInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/GrantInfo.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.security;
+
+import com.facebook.presto.spi.SchemaTableName;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+public class GrantInfo
+{
+    private final Set<PrivilegeInfo> privilegeInfo;
+    private final Identity grantee;
+    private final SchemaTableName schemaTableName;
+    private final Optional<Identity> grantor;
+    private final Optional<Boolean> withHierarchy;
+
+    public GrantInfo(Set<PrivilegeInfo> privilegeInfo, Identity grantee, SchemaTableName schemaTableName, Optional<Identity> grantor, Optional<Boolean> withHierarchy)
+    {
+        this.privilegeInfo = privilegeInfo;
+        this.grantee = grantee;
+        this.schemaTableName = schemaTableName;
+        this.grantor = grantor;
+        this.withHierarchy = withHierarchy;
+    }
+
+    public Set<PrivilegeInfo> getPrivilegeInfo()
+    {
+        return privilegeInfo;
+    }
+
+    public Identity getIdentity()
+    {
+        return grantee;
+    }
+
+    public SchemaTableName getSchemaTableName()
+    {
+        return schemaTableName;
+    }
+
+    public Optional<Identity> getGrantor()
+    {
+        return grantor;
+    }
+
+    public Optional<Boolean> getWithHierarchy()
+    {
+        return withHierarchy;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(privilegeInfo, grantee, schemaTableName, grantor, withHierarchy);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GrantInfo grantInfo = (GrantInfo) o;
+        return Objects.equals(privilegeInfo, grantInfo.getPrivilegeInfo()) &&
+                Objects.equals(grantee, grantInfo.getIdentity()) &&
+                Objects.equals(schemaTableName, grantInfo.getSchemaTableName()) &&
+                Objects.equals(grantor, grantInfo.getGrantor()) &&
+                Objects.equals(withHierarchy, grantInfo.getWithHierarchy());
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/Privilege.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/Privilege.java
@@ -15,5 +15,5 @@ package com.facebook.presto.spi.security;
 
 public enum Privilege
 {
-    SELECT, DELETE, INSERT
+    SELECT, DELETE, INSERT, UPDATE
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/PrivilegeInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/PrivilegeInfo.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.security;
+
+import java.util.Objects;
+
+public class PrivilegeInfo
+{
+    private final Privilege privilege;
+    private final boolean grantOption;
+
+    public PrivilegeInfo(Privilege privilege, boolean grantOption)
+    {
+        this.privilege = privilege;
+        this.grantOption = grantOption;
+    }
+
+    public Privilege getPrivilege()
+    {
+        return privilege;
+    }
+
+    public boolean isGrantOption()
+    {
+        return grantOption;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(privilege, grantOption);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PrivilegeInfo privilegeInfo = (PrivilegeInfo) o;
+        return Objects.equals(privilege, privilegeInfo.privilege) &&
+                Objects.equals(grantOption, privilegeInfo.grantOption);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -40,7 +40,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denySelectT
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyShowSchemas;
-import static com.facebook.presto.spi.security.AccessDeniedException.denyShowTables;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyShowTablesMetadata;
 
 public interface SystemAccessControl
 {
@@ -149,7 +149,7 @@ public interface SystemAccessControl
     }
 
     /**
-     * Check if identity is allowed to execute SHOW TABLES in a catalog.
+     * Check if identity is allowed to show metadata of tables by executing SHOW TABLES, SHOW GRANTS etc. in a catalog.
      *
      * NOTE: This method is only present to give users an error message when listing is not allowed.
      * The {@link #filterTables} method must filter all results for unauthorized users,
@@ -157,9 +157,9 @@ public interface SystemAccessControl
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */
-    default void checkCanShowTables(Identity identity, CatalogSchemaName schema)
+    default void checkCanShowTablesMetadata(Identity identity, CatalogSchemaName schema)
     {
-        denyShowTables(schema.toString());
+        denyShowTablesMetadata(schema.toString());
     }
 
     /**


### PR DESCRIPTION
This PR adds syntax support for "show grants" and its implementation for Hive connector. This command is not specified in SQL standard, so there there is no gold standard for the syntax. I have borrowed the syntax from Hive. Here is the syntax that the current version supports:
`SHOW GRANTS
        (USER identifier)?
        ON (TABLE? qualifiedName | ALL)`

It supports showing grants for users. I haven't tested the code for roles (I am planning to add support for roles later).
- When user name is speciified, `SHOW GRANTS USER identifier ...` will show grants for the specified user, provided the specified user is the same as the current user. Attempts to show grants for any other user than the current user will be denied.
- When user is not specified, `SHOW GRANTS ...` will show grants for the current user. 

The implementation follows the definition of `TABLE_PRIVILEGES` table specified in SQL standard:

``` sql
CREATE VIEW TABLE_PRIVILEGES AS
SELECT GRANTOR, GRANTEE, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME,
PRIVILEGE_TYPE, IS_GRANTABLE, WITH_HIERARCHY
FROM DEFINITION_SCHEMA.TABLE_PRIVILEGES
WHERE ( GRANTEE IN
( ’PUBLIC’, CURRENT_USER )
OR
GRANTOR = CURRENT_USER )
AND
TABLE_CATALOG
= ( SELECT CATALOG_NAME
FROM INFORMATION_SCHEMA_CATALOG_NAME );
```

except that:
1) We don't consider the case of grantor = current_user (I couldn't get the information about grantor for the hive connector)
2) grantee in `PUBLIC` is not taken into consideration - I am currently testing whether the `PUBLIC` keyword works as intended for grant/revoke, and once that's being done, I will add code for `PUBLIC`.

Internal review at TD: https://github.com/Teradata/presto/pull/387 and https://github.com/Teradata/presto/pull/414

PS: I will add documentation soon once this gets in.