### PR TITLE
Defer host resolution for Cassandra contact points

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
@@ -103,7 +103,6 @@ public class CassandraClientModule
 
         List<String> contactPoints = requireNonNull(config.getContactPoints(), "contactPoints is null");
         checkArgument(!contactPoints.isEmpty(), "empty contactPoints");
-        clusterBuilder.addContactPoints(contactPoints.toArray(new String[contactPoints.size()]));
 
         clusterBuilder.withPort(config.getNativeProtocolPort());
         clusterBuilder.withReconnectionPolicy(new ExponentialReconnectionPolicy(500, 10000));
@@ -158,6 +157,7 @@ public class CassandraClientModule
 
         return new CassandraSession(
                 connectorId.toString(),
+                contactPoints,
                 clusterBuilder,
                 config.getFetchSizeForPartitionKeySelect(),
                 config.getLimitForPartitionKeySelect(),

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
@@ -76,6 +76,7 @@ public class CassandraSession
     private LoadingCache<String, Session> sessionBySchema;
 
     public CassandraSession(String connectorId,
+            final List<String> contactPoints,
             final Builder clusterBuilder,
             int fetchSizeForPartitionKeySelect,
             int limitForPartitionKeySelect,
@@ -95,6 +96,7 @@ public class CassandraSession
                     public Session load(String key)
                             throws Exception
                     {
+                        clusterBuilder.addContactPoints(contactPoints.toArray(new String[contactPoints.size()]));
                         return clusterBuilder.build().connect();
                     }
                 });

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/MockCassandraSession.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/MockCassandraSession.java
@@ -46,6 +46,7 @@ public class MockCassandraSession
     public MockCassandraSession(String connectorId, CassandraClientConfig config)
     {
         super(connectorId,
+                ImmutableList.of(),
                 null,
                 config.getFetchSizeForPartitionKeySelect(),
                 config.getLimitForPartitionKeySelect(),


### PR DESCRIPTION
This is to allow Presto start regardless of host resolution in the moment of start-up.
Without that patch, Presto will fail to start when any entry from cassandra.contact-points is host (instead of IP) and it's not resolvable.

This patch postpones host resolution to the first query.

---

This PR addresses https://github.com/prestodb/presto/issues/6639