### PR TITLE
Add several improvements to the Accumulo connector

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
@@ -71,6 +71,7 @@ import java.util.stream.Collectors;
 import static com.facebook.presto.accumulo.AccumuloErrorCode.ACCUMULO_TABLE_DNE;
 import static com.facebook.presto.accumulo.AccumuloErrorCode.ACCUMULO_TABLE_EXISTS;
 import static com.facebook.presto.accumulo.AccumuloErrorCode.UNEXPECTED_ACCUMULO_ERROR;
+import static com.facebook.presto.accumulo.io.PrestoBatchWriter.ROW_ID_COLUMN;
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
@@ -204,11 +205,11 @@ public class AccumuloClient
             }
 
             // Validate no column is mapped to the reserved entry
-            String reservedRowIdColumn = AccumuloPageSink.ROW_ID_COLUMN.toString();
+            String reservedRowIdColumn = ROW_ID_COLUMN.toString();
             if (columnMapping.get().values().stream()
                     .filter(pair -> pair.getKey().equals(reservedRowIdColumn) && pair.getValue().equals(reservedRowIdColumn))
                     .count() > 0) {
-                throw new PrestoException(INVALID_TABLE_PROPERTY, format("Column familiy/qualifier mapping of %s:%s is reserved", reservedRowIdColumn, reservedRowIdColumn));
+                throw new PrestoException(INVALID_TABLE_PROPERTY, format("Column family/qualifier mapping of %s:%s is reserved", reservedRowIdColumn, reservedRowIdColumn));
             }
         }
         else if (table.isExternal()) {
@@ -723,8 +724,7 @@ public class AccumuloClient
      * @throws AccumuloException If a generic Accumulo error occurs
      * @throws AccumuloSecurityException If a security exception occurs
      */
-    private Authorizations getScanAuthorizations(ConnectorSession session, String schema,
-            String table)
+    private Authorizations getScanAuthorizations(ConnectorSession session, String schema, String table)
             throws AccumuloException, AccumuloSecurityException
     {
         String sessionScanUser = AccumuloSessionProperties.getScanUsername(session);

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
@@ -111,7 +111,7 @@ public class AccumuloClient
         this.auths = connector.securityOperations().getUserAuthorizations(username);
 
         // Create the index lookup utility
-        this.indexLookup = new IndexLookup(connector, config.getCardinalityCacheSize(), config.getCardinalityCacheExpiration());
+        this.indexLookup = new IndexLookup(connector, config.getCardinalityCacheSize(), config.getCardinalityCacheExpiration(), config.getMaxIndexLookupCardinality());
     }
 
     public AccumuloTable createTable(ConnectorTableMetadata meta)

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
@@ -640,6 +640,7 @@ public class AccumuloClient
      * @param rowIdDomain Domain for the row ID
      * @param constraints Column constraints for the query
      * @param serializer Instance of a row serializer
+     * @param metricsStorage Metrics storage instance for the table
      * @param truncateTimestamps True if timestamp type metrics are truncated
      * @return List of TabletSplitMetadata objects for Presto
      */

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
@@ -909,7 +909,7 @@ public class AccumuloClient
         return rangeBuilder.build();
     }
 
-    private static Range getRangeFromPrestoRange(com.facebook.presto.spi.predicate.Range prestoRange, AccumuloRowSerializer serializer)
+    public static Range getRangeFromPrestoRange(com.facebook.presto.spi.predicate.Range prestoRange, AccumuloRowSerializer serializer)
             throws TableNotFoundException
     {
         Range accumuloRange;

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
@@ -440,9 +440,6 @@ public class AccumuloClient
     {
         SchemaTableName tableName = new SchemaTableName(table.getSchema(), table.getTable());
 
-        // Drop cardinality cache from index lookup
-        indexLookup.dropCache(tableName.getSchemaName(), tableName.getTableName());
-
         // Remove the table metadata from Presto
         if (metaManager.getTable(tableName) != null) {
             metaManager.deleteTableMetadata(tableName);

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
@@ -101,17 +101,16 @@ public class AccumuloClient
             Connector connector,
             AccumuloConfig config,
             ZooKeeperMetadataManager metaManager,
-            AccumuloTableManager tableManager)
+            AccumuloTableManager tableManager,
+            IndexLookup indexLookup)
             throws AccumuloException, AccumuloSecurityException
     {
         this.connector = requireNonNull(connector, "connector is null");
         this.username = requireNonNull(config, "config is null").getUsername();
         this.metaManager = requireNonNull(metaManager, "metaManager is null");
         this.tableManager = requireNonNull(tableManager, "tableManager is null");
+        this.indexLookup = requireNonNull(indexLookup, "indexLookup is null");
         this.auths = connector.securityOperations().getUserAuthorizations(username);
-
-        // Create the index lookup utility
-        this.indexLookup = new IndexLookup(connector, config.getCardinalityCacheSize(), config.getCardinalityCacheExpiration(), config.getMaxIndexLookupCardinality());
     }
 
     public AccumuloTable createTable(ConnectorTableMetadata meta)

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloMetadata.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloMetadata.java
@@ -94,7 +94,9 @@ public class AccumuloMetadata
                 table.getRowId(),
                 table.isExternal(),
                 table.getSerializerClassName(),
-                table.getScanAuthorizations());
+                table.getScanAuthorizations(),
+                table.getMetricsStorageClass(),
+                table.isTruncateTimestamps());
 
         setRollback(() -> rollbackCreateTable(table));
 
@@ -249,7 +251,9 @@ public class AccumuloMetadata
                     table.getRowId(),
                     table.isExternal(),
                     table.getSerializerClassName(),
-                    table.getScanAuthorizations());
+                    table.getScanAuthorizations(),
+                    table.getMetricsStorageClass(),
+                    table.isTruncateTimestamps());
         }
 
         return null;

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloModule.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloModule.java
@@ -16,6 +16,7 @@ package com.facebook.presto.accumulo;
 import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.conf.AccumuloSessionProperties;
 import com.facebook.presto.accumulo.conf.AccumuloTableProperties;
+import com.facebook.presto.accumulo.index.IndexLookup;
 import com.facebook.presto.accumulo.io.AccumuloPageSinkProvider;
 import com.facebook.presto.accumulo.io.AccumuloRecordSetProvider;
 import com.facebook.presto.accumulo.metadata.AccumuloTable;
@@ -96,6 +97,7 @@ public class AccumuloModule
         binder.bind(AccumuloTableProperties.class).in(Scopes.SINGLETON);
         binder.bind(ZooKeeperMetadataManager.class).in(Scopes.SINGLETON);
         binder.bind(AccumuloTableManager.class).in(Scopes.SINGLETON);
+        binder.bind(IndexLookup.class).in(Scopes.SINGLETON);
         binder.bind(Connector.class).toProvider(ConnectorProvider.class);
 
         configBinder(binder).bindConfig(AccumuloConfig.class);

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloSplitManager.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloSplitManager.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.accumulo;
 
+import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.model.AccumuloColumnConstraint;
 import com.facebook.presto.accumulo.model.AccumuloColumnHandle;
 import com.facebook.presto.accumulo.model.AccumuloSplit;
@@ -32,6 +33,7 @@ import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.predicate.TupleDomain.ColumnDomain;
 import com.google.common.collect.ImmutableList;
+import org.apache.accumulo.core.client.Connector;
 
 import javax.inject.Inject;
 
@@ -47,13 +49,19 @@ public class AccumuloSplitManager
 {
     private final String connectorId;
     private final AccumuloClient client;
+    private final AccumuloConfig config;
+    private final Connector connector;
 
     @Inject
     public AccumuloSplitManager(
+            Connector connector,
             AccumuloConnectorId connectorId,
+            AccumuloConfig config,
             AccumuloClient client)
     {
+        this.connector = requireNonNull(connector, "connector is null");
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
+        this.config = requireNonNull(config, "config is null");
         this.client = requireNonNull(client, "client is null");
     }
 
@@ -74,7 +82,7 @@ public class AccumuloSplitManager
         Optional<Domain> rDom = getRangeDomain(rowIdName, layoutHandle.getConstraint());
 
         // Call out to our client to retrieve all tablet split metadata using the row ID domain and the secondary index
-        List<TabletSplitMetadata> tabletSplits = client.getTabletSplits(session, schemaName, tableName, rDom, constraints, tableHandle.getSerializerInstance());
+        List<TabletSplitMetadata> tabletSplits = client.getTabletSplits(session, schemaName, tableName, rDom, constraints, tableHandle.getSerializerInstance(), tableHandle.getMetricsStorageInstance(connector, config), tableHandle.isTruncateTimestamps());
 
         // Pack the tablet split metadata into a connector split
         ImmutableList.Builder<ConnectorSplit> cSplits = ImmutableList.builder();
@@ -128,6 +136,7 @@ public class AccumuloSplitManager
                         columnHandle.getName(),
                         columnHandle.getFamily().get(),
                         columnHandle.getQualifier().get(),
+                        columnHandle.getType(),
                         Optional.of(columnDomain.getDomain()),
                         columnHandle.isIndexed()));
             }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloSplitManager.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloSplitManager.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.accumulo;
 
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.model.AccumuloColumnConstraint;
 import com.facebook.presto.accumulo.model.AccumuloColumnHandle;
 import com.facebook.presto.accumulo.model.AccumuloSplit;
@@ -49,19 +48,16 @@ public class AccumuloSplitManager
 {
     private final String connectorId;
     private final AccumuloClient client;
-    private final AccumuloConfig config;
     private final Connector connector;
 
     @Inject
     public AccumuloSplitManager(
             Connector connector,
             AccumuloConnectorId connectorId,
-            AccumuloConfig config,
             AccumuloClient client)
     {
         this.connector = requireNonNull(connector, "connector is null");
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
-        this.config = requireNonNull(config, "config is null");
         this.client = requireNonNull(client, "client is null");
     }
 
@@ -82,7 +78,7 @@ public class AccumuloSplitManager
         Optional<Domain> rDom = getRangeDomain(rowIdName, layoutHandle.getConstraint());
 
         // Call out to our client to retrieve all tablet split metadata using the row ID domain and the secondary index
-        List<TabletSplitMetadata> tabletSplits = client.getTabletSplits(session, schemaName, tableName, rDom, constraints, tableHandle.getSerializerInstance(), tableHandle.getMetricsStorageInstance(connector, config), tableHandle.isTruncateTimestamps());
+        List<TabletSplitMetadata> tabletSplits = client.getTabletSplits(session, schemaName, tableName, rDom, constraints, tableHandle.getSerializerInstance(), tableHandle.getMetricsStorageInstance(connector), tableHandle.isTruncateTimestamps());
 
         // Pack the tablet split metadata into a connector split
         ImmutableList.Builder<ConnectorSplit> cSplits = ImmutableList.builder();

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloConfig.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloConfig.java
@@ -34,6 +34,7 @@ public class AccumuloConfig
     public static final String ZOOKEEPER_METADATA_ROOT = "accumulo.zookeeper.metadata.root";
     public static final String CARDINALITY_CACHE_SIZE = "accumulo.cardinality.cache.size";
     public static final String CARDINALITY_CACHE_EXPIRE_DURATION = "accumulo.cardinality.cache.expire.duration";
+    public static final String RECORD_CURSOR_BUFFER_SIZE = "accumulo.record.cursor.buffer.size";
 
     private String instance;
     private String zooKeepers;
@@ -42,6 +43,7 @@ public class AccumuloConfig
     private String zkMetadataRoot = "/presto-accumulo";
     private int cardinalityCacheSize = 100_000;
     private Duration cardinalityCacheExpiration = new Duration(5, TimeUnit.MINUTES);
+    private int recordCursorBufferSize = 1_000_000;
 
     @NotNull
     public String getInstance()
@@ -137,5 +139,18 @@ public class AccumuloConfig
     public void setCardinalityCacheExpiration(Duration cardinalityCacheExpiration)
     {
         this.cardinalityCacheExpiration = cardinalityCacheExpiration;
+    }
+
+    @NotNull
+    public int getRecordCursorBufferSize()
+    {
+        return recordCursorBufferSize;
+    }
+
+    @Config(RECORD_CURSOR_BUFFER_SIZE)
+    @ConfigDescription("Sets the number of entries buffered in the record cursor to re-order entries as they are read from Accumulo")
+    public void setRecordCursorBufferSize(int recordCursorBufferSize)
+    {
+        this.recordCursorBufferSize = recordCursorBufferSize;
     }
 }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloConfig.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloConfig.java
@@ -35,6 +35,7 @@ public class AccumuloConfig
     public static final String CARDINALITY_CACHE_SIZE = "accumulo.cardinality.cache.size";
     public static final String CARDINALITY_CACHE_EXPIRE_DURATION = "accumulo.cardinality.cache.expire.duration";
     public static final String RECORD_CURSOR_BUFFER_SIZE = "accumulo.record.cursor.buffer.size";
+    public static final String MAX_INDEX_LOOKUP_CARDINALITY = "accumulo.max.index.lookup.cardinality";
 
     private String instance;
     private String zooKeepers;
@@ -44,6 +45,7 @@ public class AccumuloConfig
     private int cardinalityCacheSize = 100_000;
     private Duration cardinalityCacheExpiration = new Duration(5, TimeUnit.MINUTES);
     private int recordCursorBufferSize = 1_000_000;
+    private int maxIndexLookupCardinality = 20_000_000;
 
     @NotNull
     public String getInstance()
@@ -152,5 +154,18 @@ public class AccumuloConfig
     public void setRecordCursorBufferSize(int recordCursorBufferSize)
     {
         this.recordCursorBufferSize = recordCursorBufferSize;
+    }
+
+    @NotNull
+    public int getMaxIndexLookupCardinality()
+    {
+        return maxIndexLookupCardinality;
+    }
+
+    @Config(MAX_INDEX_LOOKUP_CARDINALITY)
+    @ConfigDescription("Sets an upper bound on the index lookup. Columns with a cardinality above this number will be excluded from the lookup.")
+    public void setMaxIndexLookupCardinality(int maxIndexLookupCardinality)
+    {
+        this.maxIndexLookupCardinality = maxIndexLookupCardinality;
     }
 }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloSessionProperties.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloSessionProperties.java
@@ -15,8 +15,10 @@ package com.facebook.presto.accumulo.conf;
 
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.session.PropertyMetadata;
+import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import io.airlift.units.Duration;
 
 import java.util.List;
 
@@ -44,6 +46,7 @@ public final class AccumuloSessionProperties
     private static final String INDEX_METRICS_ENABLED = "index_metrics_enabled";
     private static final String SCAN_USERNAME = "scan_username";
     private static final String INDEX_SHORT_CIRCUIT_CARDINALITY_FETCH = "index_short_circuit_cardinality_fetch";
+    private static final String INDEX_CARDINALITY_CACHE_POLLING_DURATION = "index_cardinality_cache_polling_duration";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -100,7 +103,16 @@ public final class AccumuloSessionProperties
                 true,
                 false);
 
-        sessionProperties = ImmutableList.of(s1, s2, s3, s4, s5, s6, s7, s8, s9);
+        PropertyMetadata<String> s10 = new PropertyMetadata<>(
+                INDEX_CARDINALITY_CACHE_POLLING_DURATION,
+                "Sets the cardinality cache polling duration for short circuit retrieval of index metrics. Default 10ms",
+                VarcharType.VARCHAR, String.class,
+                "10ms",
+                false,
+                x -> Duration.valueOf(x.toString()).toString(),
+                object -> object);
+
+        sessionProperties = ImmutableList.of(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10);
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -136,6 +148,23 @@ public final class AccumuloSessionProperties
     public static double getIndexSmallCardThreshold(ConnectorSession session)
     {
         return session.getProperty(INDEX_LOWEST_CARDINALITY_THRESHOLD, Double.class);
+    }
+
+    /**
+     * Gets the polling interval for the completion service that fetches cardinalities from Accumulo
+     * <br>
+     * The LoadingCache is not ordered and, as a result, some cached results (or a result retrieved
+     * from Accumulo in a short time) that have higher cardinalities are returned a few milliseconds
+     * before a significantly lower result. This parametmer controls the poll duration, adding 'waves
+     * of result retrieval from the LoadingCache. The results of any completed tasks are taken,
+     * and the smallest cardinality, if below the threshold, is used while the other tasks complete.
+     *
+     * @param session The current session
+     * @return The cardinality cache polling duration
+     */
+    public static Duration getIndexCardinalityCachePollingDuration(ConnectorSession session)
+    {
+        return Duration.valueOf(session.getProperty(INDEX_CARDINALITY_CACHE_POLLING_DURATION, String.class));
     }
 
     public static boolean isIndexMetricsEnabled(ConnectorSession session)

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloSessionProperties.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloSessionProperties.java
@@ -25,6 +25,7 @@ import java.util.List;
 import static com.facebook.presto.spi.session.PropertyMetadata.booleanSessionProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.doubleSessionProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.integerSessionProperty;
+import static com.facebook.presto.spi.session.PropertyMetadata.longSessionProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringSessionProperty;
 
 /**
@@ -43,6 +44,7 @@ public final class AccumuloSessionProperties
     private static final String INDEX_ROWS_PER_SPLIT = "index_rows_per_split";
     private static final String INDEX_THRESHOLD = "index_threshold";
     private static final String INDEX_LOWEST_CARDINALITY_THRESHOLD = "index_lowest_cardinality_threshold";
+    private static final String INDEX_LOWEST_CARDINALITY_ROW_THRESHOLD = "index_lowest_cardinality_row_threshold";
     private static final String INDEX_METRICS_ENABLED = "index_metrics_enabled";
     private static final String SCAN_USERNAME = "scan_username";
     private static final String INDEX_SHORT_CIRCUIT_CARDINALITY_FETCH = "index_short_circuit_cardinality_fetch";
@@ -87,23 +89,29 @@ public final class AccumuloSessionProperties
 
         PropertyMetadata<Double> s7 = doubleSessionProperty(
                 INDEX_LOWEST_CARDINALITY_THRESHOLD,
-                "The threshold where the column with the lowest cardinality will be used instead of computing an intersection of ranges in the secondary index. Secondary index must be enabled. Default .01",
+                "The threshold (as a percentage) where the column with the lowest cardinality will be used instead of computing an intersection of ranges in the secondary index. The minimum value of this value times the number of rows in the table and the row threshold will be used. Secondary index must be enabled. Default .01",
                 0.01,
                 false);
 
-        PropertyMetadata<Boolean> s8 = booleanSessionProperty(
+        PropertyMetadata<Long> s8 = longSessionProperty(
+                INDEX_LOWEST_CARDINALITY_ROW_THRESHOLD,
+                "The threshold (as number of rows) where the column with the lowest cardinality will be used instead of computing an intersection of ranges in the secondary index. The minimum value of this value and the percentage threshold will be used. Secondary index must be enabled. Default 500000",
+                500_000L,
+                false);
+
+        PropertyMetadata<Boolean> s9 = booleanSessionProperty(
                 INDEX_METRICS_ENABLED,
                 "Set to true to enable usage of the metrics table to optimize usage of the index. Default true",
                 true,
                 false);
 
-        PropertyMetadata<Boolean> s9 = booleanSessionProperty(
+        PropertyMetadata<Boolean> s10 = booleanSessionProperty(
                 INDEX_SHORT_CIRCUIT_CARDINALITY_FETCH,
                 "Short circuit the retrieval of index metrics once any column is less than the lowest cardinality threshold. Default true",
                 true,
                 false);
 
-        PropertyMetadata<String> s10 = new PropertyMetadata<>(
+        PropertyMetadata<String> s11 = new PropertyMetadata<>(
                 INDEX_CARDINALITY_CACHE_POLLING_DURATION,
                 "Sets the cardinality cache polling duration for short circuit retrieval of index metrics. Default 10ms",
                 VarcharType.VARCHAR, String.class,
@@ -112,7 +120,7 @@ public final class AccumuloSessionProperties
                 x -> Duration.valueOf(x.toString()).toString(),
                 object -> object);
 
-        sessionProperties = ImmutableList.of(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10);
+        sessionProperties = ImmutableList.of(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11);
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -145,9 +153,40 @@ public final class AccumuloSessionProperties
         return session.getProperty(INDEX_ROWS_PER_SPLIT, Integer.class);
     }
 
+    /**
+     * Gets the configured threshold (as a percentage) for using the column with the smallest
+     * cardinality, instead of computing the index.
+     * <br>
+     * The connector typically computes an intersection of row IDs across all indexed columns,
+     * but if the column with the smallest cardinality is significantly small, we can just use these
+     * rows and let Presto filter out the rows that do not match the remaining predicates.
+     * <br>
+     * The minimum value of this value times the number of rows in the table and the row threshold will be used.
+     *
+     * @param session The current session
+     * @return The index threshold, 0 - 1
+     */
     public static double getIndexSmallCardThreshold(ConnectorSession session)
     {
         return session.getProperty(INDEX_LOWEST_CARDINALITY_THRESHOLD, Double.class);
+    }
+
+    /**
+     * Gets the configured threshold (as number of rows) for using the column with the smallest
+     * cardinality, instead of computing the index.
+     * <br>
+     * The connector typically computes an intersection of row IDs across all indexed columns,
+     * but if the column with the lowest cardinality is significantly small, we can just use these
+     * rows and let Presto filter out the rows that do not match the remaining predicates.
+     * <br>
+     * The minimum value of this value and the percentage threshold will be used.
+     *
+     * @param session The current session
+     * @return The index threshold as number of rows
+     */
+    public static long getIndexSmallCardRowThreshold(ConnectorSession session)
+    {
+        return session.getProperty(INDEX_LOWEST_CARDINALITY_ROW_THRESHOLD, Long.class);
     }
 
     /**

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloSessionProperties.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloSessionProperties.java
@@ -43,6 +43,7 @@ public final class AccumuloSessionProperties
     private static final String INDEX_LOWEST_CARDINALITY_THRESHOLD = "index_lowest_cardinality_threshold";
     private static final String INDEX_METRICS_ENABLED = "index_metrics_enabled";
     private static final String SCAN_USERNAME = "scan_username";
+    private static final String INDEX_SHORT_CIRCUIT_CARDINALITY_FETCH = "index_short_circuit_cardinality_fetch";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -93,7 +94,13 @@ public final class AccumuloSessionProperties
                 true,
                 false);
 
-        sessionProperties = ImmutableList.of(s1, s2, s3, s4, s5, s6, s7, s8);
+        PropertyMetadata<Boolean> s9 = booleanSessionProperty(
+                INDEX_SHORT_CIRCUIT_CARDINALITY_FETCH,
+                "Short circuit the retrieval of index metrics once any column is less than the lowest cardinality threshold. Default true",
+                true,
+                false);
+
+        sessionProperties = ImmutableList.of(s1, s2, s3, s4, s5, s6, s7, s8, s9);
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -139,5 +146,10 @@ public final class AccumuloSessionProperties
     public static String getScanUsername(ConnectorSession session)
     {
         return session.getProperty(SCAN_USERNAME, String.class);
+    }
+
+    public static boolean isIndexShortCircuitEnabled(ConnectorSession session)
+    {
+        return session.getProperty(INDEX_SHORT_CIRCUIT_CARDINALITY_FETCH, Boolean.class);
     }
 }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloTableProperties.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloTableProperties.java
@@ -245,7 +245,7 @@ public final class AccumuloTableProperties
         requireNonNull(tableProperties);
 
         @SuppressWarnings("unchecked")
-        Boolean serializerClass = (Boolean) tableProperties.get(EXTERNAL);
-        return serializerClass;
+        Boolean external = (Boolean) tableProperties.get(EXTERNAL);
+        return external;
     }
 }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.accumulo.index;
 
 import com.facebook.presto.accumulo.conf.AccumuloConfig;
+import com.facebook.presto.accumulo.iterators.ValueSummingIterator;
 import com.facebook.presto.accumulo.model.AccumuloColumnConstraint;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.cache.CacheBuilder;
@@ -29,6 +30,7 @@ import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
@@ -326,6 +328,10 @@ public class ColumnCardinalityCache
             try {
                 scanner.setRanges(connector.tableOperations().splitRangeByTablets(metricsTable, key.range, Integer.MAX_VALUE));
                 scanner.fetchColumn(columnFamily, Indexer.CARDINALITY_CQ_AS_TEXT);
+
+                IteratorSetting setting = new IteratorSetting(Integer.MAX_VALUE, "valuesummingcombiner", ValueSummingIterator.class);
+                ValueSummingIterator.setEncodingType(setting, Indexer.ENCODER_TYPE);
+                scanner.addScanIterator(setting);
 
                 // Sum the entries to get the cardinality
                 long sum = 0;

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
@@ -159,8 +159,8 @@ public class ColumnCardinalityCache
                 Optional<Entry<Long, AccumuloColumnConstraint>> smallestCardinality = cardinalityToConstraints.entries().stream().findFirst();
                 if (smallestCardinality.isPresent()) {
                     if (smallestCardinality.get().getKey() <= earlyReturnThreshold) {
-                        LOG.info("Cardinality %s, is below threshold. Returning early while other tasks finish",
-                                smallestCardinality);
+                        LOG.info("Cardinality for column %s is below threshold of %s. Returning early while other tasks finish",
+                                smallestCardinality.get().getValue().getName(), earlyReturnThreshold);
                         earlyReturn = true;
                     }
                 }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
@@ -14,37 +14,48 @@
 package com.facebook.presto.accumulo.index;
 
 import com.facebook.presto.accumulo.conf.AccumuloConfig;
-import com.facebook.presto.accumulo.metadata.AccumuloTable;
 import com.facebook.presto.accumulo.model.AccumuloColumnConstraint;
+import com.facebook.presto.spi.PrestoException;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
+import com.google.common.collect.MultimapBuilder;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.io.Text;
-
-import javax.annotation.concurrent.GuardedBy;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.accumulo.AccumuloErrorCode.INTERNAL_ERROR;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
@@ -60,11 +71,8 @@ public class ColumnCardinalityCache
     private final Authorizations auths;
     private static final Logger LOG = Logger.get(ColumnCardinalityCache.class);
     private final Connector connector;
-    private final int size;
-    private final Duration expireDuration;
-
-    @GuardedBy("this")
-    private final Map<String, TableColumnCache> tableToCache = new HashMap<>();
+    private final ExecutorService executorService;
+    private final LoadingCache<CacheKey, Long> cache;
 
     public ColumnCardinalityCache(
             Connector connector,
@@ -72,25 +80,33 @@ public class ColumnCardinalityCache
             Authorizations auths)
     {
         this.connector = requireNonNull(connector, "connector is null");
-        this.size = requireNonNull(config, "config is null").getCardinalityCacheSize();
-        this.expireDuration = config.getCardinalityCacheExpiration();
         this.auths = requireNonNull(auths, "auths is null");
-    }
+        int size = requireNonNull(config, "config is null").getCardinalityCacheSize();
+        Duration expireDuration = config.getCardinalityCacheExpiration();
 
-    /**
-     * Deletes any cache for the given table, no-op of table does not exist in the cache
-     *
-     * @param schema Schema name
-     * @param table Table name
-     */
-    public synchronized void deleteCache(String schema, String table)
-    {
-        LOG.debug("Deleting cache for %s.%s", schema, table);
-        if (tableToCache.containsKey(table)) {
-            // clear the cache and remove it
-            getTableCache(schema, table).clear();
-            tableToCache.remove(table);
+        // Create executor service with one hot thread, pool size capped at 4x processors,
+        // one minute keep alive, and a labeled ThreadFactory
+        AtomicLong threadCount = new AtomicLong(0);
+        this.executorService = MoreExecutors.getExitingExecutorService(
+                new ThreadPoolExecutor(
+                        1,
+                        4 * Runtime.getRuntime().availableProcessors(),
+                        60L,
+                        TimeUnit.SECONDS,
+                        new SynchronousQueue<>(),
+                        runnable -> new Thread(runnable, "cardinality-lookup-thread-" + threadCount.getAndIncrement())
+                ));
+
+        LOG.debug("Created new cache size %d expiry %s", size, expireDuration);
+        CacheBuilder cacheBuilder = CacheBuilder.newBuilder()
+                .maximumSize(size)
+                .expireAfterWrite(expireDuration.toMillis(), TimeUnit.MILLISECONDS);
+
+        if (LOG.isDebugEnabled()) {
+            cacheBuilder.recordStats();
         }
+
+        cache = (LoadingCache<CacheKey, Long>) cacheBuilder.build(new CardinalityCacheLoader());
     }
 
     /**
@@ -100,160 +116,165 @@ public class ColumnCardinalityCache
      * @param schema Schema name
      * @param table Table name
      * @param idxConstraintRangePairs Mapping of all ranges for a given constraint
+     * @param earlyReturnThreshold Smallest acceptable cardinality to return early while other tasks complete
      * @return An immutable multimap of cardinality to column constraint, sorted by cardinality from smallest to largest
      * @throws TableNotFoundException If the metrics table does not exist
      * @throws ExecutionException If another error occurs; I really don't even know anymore.
      */
-    public Multimap<Long, AccumuloColumnConstraint> getCardinalities(String schema, String table, Multimap<AccumuloColumnConstraint, Range> idxConstraintRangePairs)
+    public Multimap<Long, AccumuloColumnConstraint> getCardinalities(String schema, String table, Multimap<AccumuloColumnConstraint, Range> idxConstraintRangePairs, long earlyReturnThreshold)
             throws ExecutionException, TableNotFoundException
     {
-        // Create a multi map sorted by cardinality, sort columns by name
-        TreeMultimap<Long, AccumuloColumnConstraint> cardinalityToConstraints = TreeMultimap.create(
-                Long::compare,
-                (AccumuloColumnConstraint o1, AccumuloColumnConstraint o2) -> o1.getName().compareTo(o2.getName()));
+        // Submit tasks to the executor to fetch column cardinality, adding it to the Guava cache if necessary
+        CompletionService<Pair<Long, AccumuloColumnConstraint>> executor = new ExecutorCompletionService<>(executorService);
+        idxConstraintRangePairs.asMap().entrySet().forEach(e ->
+                executor.submit(() -> {
+                            long cardinality = getColumnCardinality(schema, table, e.getKey().getFamily(), e.getKey().getQualifier(), e.getValue());
+                            LOG.info("Cardinality for column %s is %d", e.getKey().getName(), cardinality);
+                            return Pair.of(cardinality, e.getKey());
+                        }
+                ));
 
-        for (Entry<AccumuloColumnConstraint, Collection<Range>> entry : idxConstraintRangePairs.asMap().entrySet()) {
-            long card = getColumnCardinality(schema, table, entry.getKey(), entry.getValue());
-            LOG.debug("Cardinality for column %s is %s", entry.getKey().getName(), card);
-            cardinalityToConstraints.put(card, entry.getKey());
+        // Create a multi map sorted by cardinality
+        ListMultimap<Long, AccumuloColumnConstraint> cardinalityToConstraints = MultimapBuilder.treeKeys().arrayListValues().build();
+        try {
+            int numTasks = idxConstraintRangePairs.asMap().entrySet().size();
+            for (int i = 0; i < numTasks; ++i) {
+                Pair<Long, AccumuloColumnConstraint> columnCardinality = executor.take().get();
+                cardinalityToConstraints.put(columnCardinality.getLeft(), columnCardinality.getRight());
+                if (columnCardinality.getLeft() <= earlyReturnThreshold) {
+                    LOG.info("Cardinality %d, is below threshold. Returning early while other tasks finish",
+                            columnCardinality);
+                    break;
+                }
+            }
+        }
+        catch (ExecutionException | InterruptedException e) {
+            throw new PrestoException(INTERNAL_ERROR, "Exception when getting cardinality", e);
         }
 
+        // Create a copy of the cardinalities
         return ImmutableMultimap.copyOf(cardinalityToConstraints);
     }
 
     /**
-     * Gets the cardinality for the given column constraint with the given Ranges.
-     * Ranges can be exact values or a range of values.
+     * Gets the column cardinality for all of the given range values. May reach out to the
+     * metrics table in Accumulo to retrieve new cache elements.
      *
-     * @param schema Schema name
+     * @param schema Table schema
      * @param table Table name
-     * @param columnConstraint Mapping of all ranges for a given constraint
-     * @param indexRanges Ranges for each exact or ranged value of the column constraint
-     * @return The cardinality for the column
-     * @throws TableNotFoundException If the metrics table does not exist
-     * @throws ExecutionException If another error occurs; I really don't even know anymore.
+     * @param family Accumulo column family
+     * @param qualifier Accumulo column qualifier
+     * @param colValues All range values to summarize for the cardinality
+     * @return The cardinality of the column
      */
-    private long getColumnCardinality(String schema, String table, AccumuloColumnConstraint columnConstraint, Collection<Range> indexRanges)
-            throws ExecutionException, TableNotFoundException
+    public long getColumnCardinality(String schema, String table, String family, String qualifier, Collection<Range> colValues)
+            throws ExecutionException
     {
-        return getTableCache(schema, table)
-                .getColumnCardinality(
-                        columnConstraint.getName(),
-                        columnConstraint.getFamily(),
-                        columnConstraint.getQualifier(),
-                        indexRanges);
-    }
+        LOG.debug("Getting cardinality for %s:%s", family, qualifier);
 
-    /**
-     * Gets the {@link TableColumnCache} for the given table, creating a new one if necessary.
-     *
-     * @param schema Schema name
-     * @param table Table name
-     * @return An existing or new TableColumnCache
-     */
-    private synchronized TableColumnCache getTableCache(String schema, String table)
-    {
-        String fullName = AccumuloTable.getFullTableName(schema, table);
-        TableColumnCache cache = tableToCache.get(fullName);
-        if (cache == null) {
-            LOG.debug("Creating new TableColumnCache for %s.%s %s", schema, table, this);
-            cache = new TableColumnCache(schema, table);
-            tableToCache.put(fullName, cache);
+        // Collect all exact Accumulo Ranges, i.e. single value entries vs. a full scan
+        Collection<CacheKey> exactRanges =
+                colValues.stream().filter(this::isExact).map(range ->
+                        new CacheKey(schema, table, family, qualifier, range)).collect(Collectors.toList());
+
+        LOG.debug("Column values contain %s exact ranges of %s", exactRanges.size(),
+                colValues.size());
+
+        // Sum the cardinalities for the exact-value Ranges
+        // This is where the reach-out to Accumulo occurs for all Ranges that have not
+        // previously been fetched
+        long sum = 0;
+        for (Long e : cache.getAll(exactRanges).values()) {
+            sum += e;
         }
-        return cache;
+
+        // If these collection sizes are not equal,
+        // then there is at least one non-exact range
+        if (exactRanges.size() != colValues.size()) {
+            // for each range in the column value
+            for (Range range : colValues) {
+                // if this range is not exact
+                if (!isExact(range)) {
+                    // Then get the value for this range using the single-value cache lookup
+                    CacheKey key = new CacheKey(schema, table, family, qualifier, range);
+                    long val = cache.get(key);
+
+                    // add our value to the cache and our sum
+                    cache.put(key, val);
+                    sum += val;
+                }
+            }
+        }
+
+        LOG.debug("Cache stats : size=%s, %s", cache.size(), cache.stats());
+        return sum;
+    }
+
+    private boolean isExact(Range r)
+    {
+        return !r.isInfiniteStartKey()
+                && !r.isInfiniteStopKey()
+                && r.getStartKey().followingKey(PartialKey.ROW).equals(r.getEndKey());
     }
 
     /**
-     * Internal class for holding the mapping of column names to the LoadingCache
+     * Complex key for the CacheLoader
      */
-    private class TableColumnCache
+    private class CacheKey
     {
-        private final Map<String, LoadingCache<Range, Long>> columnToCache = new HashMap<>();
-        private final String schema;
-        private final String table;
+        String schema;
+        String table;
+        String family;
+        String qualifier;
+        Range range;
 
-        public TableColumnCache(String schema,
-                String table)
+        public CacheKey(String schema,
+                String table,
+                String family,
+                String qualifier,
+                Range range)
         {
             this.schema = schema;
             this.table = table;
+            this.family = family;
+            this.qualifier = qualifier;
+            this.range = range;
         }
 
-        /**
-         * Clears and removes all caches as if the object had been first created
-         */
-        public void clear()
+        @Override
+        public int hashCode()
         {
-            columnToCache.values().forEach(LoadingCache::invalidateAll);
-            columnToCache.clear();
+            return Objects.hash(schema, table, family, qualifier, range);
         }
 
-        /**
-         * Gets the column cardinality for all of the given range values.
-         * May reach out to the metrics table in Accumulo to retrieve new cache elements.
-         *
-         * @param column Presto column name
-         * @param family Accumulo column family
-         * @param qualifier Accumulo column qualifier
-         * @param colValues All range values to summarize for the cardinality
-         * @return The cardinality of the column
-         */
-        public long getColumnCardinality(String column, String family, String qualifier, Collection<Range> colValues)
-                throws ExecutionException, TableNotFoundException
+        @Override
+        public boolean equals(Object obj)
         {
-            // Get the column cache for this column, creating a new one if necessary
-            LoadingCache<Range, Long> cache = columnToCache.get(column);
-            if (cache == null) {
-                cache = newCache(schema, table, family, qualifier);
-                columnToCache.put(column, cache);
+            if (this == obj) {
+                return true;
             }
 
-            // Collect all exact Accumulo Ranges, i.e. single value entries vs. a full scan
-            Collection<Range> exactRanges = colValues.stream().filter(this::isExact).collect(Collectors.toList());
-            LOG.debug("Column values contain %s exact ranges of %s", exactRanges.size(), colValues.size());
-
-            // Sum the cardinalities for the exact-value Ranges
-            // This is where the reach-out to Accumulo occurs for all Ranges that have not previously been fetched
-            long sum = 0;
-            for (Long value : cache.getAll(exactRanges).values()) {
-                sum += value;
+            if ((obj == null) || (getClass() != obj.getClass())) {
+                return false;
             }
 
-            // If these collection sizes are not equal, then there is at least one non-exact range
-            if (exactRanges.size() != colValues.size()) {
-                // for each range in the column value
-                for (Range range : colValues) {
-                    // if this range is not exact
-                    if (!isExact(range)) {
-                        // Then get the value for this range using the single-value cache lookup
-                        long value = cache.get(range);
-
-                        // add our value to the cache and our sum
-                        cache.put(range, value);
-                        sum += value;
-                    }
-                }
-            }
-
-            LOG.debug("Cache stats : size=%s, %s", cache.size(), cache.stats());
-            return sum;
+            CacheKey other = (CacheKey) obj;
+            return Objects.equals(this.range, other.range)
+                    && Objects.equals(this.schema, other.schema)
+                    && Objects.equals(this.table, other.table)
+                    && Objects.equals(this.family, other.family)
+                    && Objects.equals(this.qualifier, other.qualifier);
         }
 
-        private boolean isExact(Range range)
+        @Override
+        public String toString()
         {
-            return !range.isInfiniteStartKey()
-                    && !range.isInfiniteStopKey()
-                    && range.getStartKey().followingKey(PartialKey.ROW).equals(range.getEndKey());
-        }
-
-        private LoadingCache<Range, Long> newCache(String schema, String table, String family, String qualifier)
-        {
-            LOG.debug("Created new cache for %s.%s, column %s:%s, size %s expiry %s", schema, table, family, qualifier, size, expireDuration);
-            return CacheBuilder
-                    .newBuilder()
-                    .maximumSize(size)
-                    .expireAfterWrite(expireDuration.toMillis(), TimeUnit.MILLISECONDS)
-                    .build(new CardinalityCacheLoader(schema, table, family, qualifier));
+            return toStringHelper(this)
+                    .add("schema", schema)
+                    .add("table", table)
+                    .add("family", family)
+                    .add("qualifier", qualifier)
+                    .add("range", range).toString();
         }
     }
 
@@ -261,23 +282,8 @@ public class ColumnCardinalityCache
      * Internal class for loading the cardinality from Accumulo
      */
     private class CardinalityCacheLoader
-            extends CacheLoader<Range, Long>
+            extends CacheLoader<CacheKey, Long>
     {
-        private final String metricsTable;
-        private final Text columnFamily;
-
-        public CardinalityCacheLoader(
-                String schema,
-                String table,
-                String family,
-                String qualifier)
-        {
-            this.metricsTable = Indexer.getMetricsTableName(schema, table);
-
-            // Create the column family for our scanners
-            this.columnFamily = new Text(Indexer.getIndexColumnFamily(family.getBytes(UTF_8), qualifier.getBytes(UTF_8)).array());
-        }
-
         /**
          * Loads the cardinality for the given Range. Uses a BatchScanner and sums the cardinality for all values that encapsulate the Range.
          *
@@ -285,46 +291,87 @@ public class ColumnCardinalityCache
          * @return The cardinality of the column, which would be zero if the value does not exist
          */
         @Override
-        public Long load(Range key)
+        public Long load(CacheKey key)
                 throws Exception
         {
-            // Create a BatchScanner against our metrics table, setting the value range and fetching the appropriate column
-            BatchScanner scanner = connector.createBatchScanner(metricsTable, auths, 10);
-            scanner.setRanges(ImmutableList.of(key));
-            scanner.fetchColumn(columnFamily, Indexer.CARDINALITY_CQ_AS_TEXT);
+            LOG.debug("Loading a non-exact range from Accumulo: %s", key);
+            // Get metrics table name and the column family for the scanner
+            String metricsTable = Indexer.getMetricsTableName(key.schema, key.table);
+            Text columnFamily = new Text(Indexer.getIndexColumnFamily(key.family.getBytes(UTF_8), key.qualifier.getBytes(UTF_8)).array());
 
-            // Sum all those entries!
-            long sum = 0;
-            for (Entry<Key, Value> entry : scanner) {
-                sum += Long.parseLong(entry.getValue().toString());
+            // Create scanner for querying the range
+            Scanner scanner = connector.createScanner(metricsTable, auths);
+            try {
+                scanner.setRange(key.range);
+                scanner.fetchColumn(columnFamily, Indexer.CARDINALITY_CQ_AS_TEXT);
+
+                // Sum the entries to get the cardinality
+                long numEntries = 0;
+                for (Entry<Key, Value> entry : scanner) {
+                    numEntries += Long.parseLong(entry.getValue().toString());
+                }
+                return numEntries;
             }
-
-            scanner.close();
-            return sum;
+            finally {
+                if (scanner != null) {
+                    // Don't forget to close your scanner before returning the cardinalities
+                    scanner.close();
+                }
+            }
         }
 
-        @SuppressWarnings("unchecked")
         @Override
-        public Map<Range, Long> loadAll(Iterable<? extends Range> keys)
+        public Map<CacheKey, Long> loadAll(Iterable<? extends CacheKey> keys)
                 throws Exception
         {
-            LOG.debug("Loading %s exact ranges from Accumulo", ((Collection<Range>) keys).size());
-
-            // Create batch scanner for querying all ranges
-            BatchScanner scanner = connector.createBatchScanner(metricsTable, auths, 10);
-            scanner.setRanges((Collection<Range>) keys);
-            scanner.fetchColumn(columnFamily, Indexer.CARDINALITY_CQ_AS_TEXT);
-
-            // Create a new map to hold our cardinalities for each range, returning a default of zero for each non-existent Key
-            Map<Range, Long> rangeValues = new MapDefaultZero();
-            for (Entry<Key, Value> entry : scanner) {
-                rangeValues.put(
-                        Range.exact(entry.getKey().getRow()),
-                        Long.parseLong(entry.getValue().toString()));
+            @SuppressWarnings("unchecked")
+            Collection<CacheKey> cacheKeys = (Collection<CacheKey>) keys;
+            if (cacheKeys.isEmpty()) {
+                return ImmutableMap.of();
             }
 
-            scanner.close();
-            return rangeValues;
+            LOG.debug("Loading %s exact ranges from Accumulo", cacheKeys.size());
+
+            // In order to simplify the implementation, we are making a (safe) assumption
+            // that the CacheKeys will all contain the same combination of schema/table/family/qualifier
+            // This is asserted with the below internal error
+            CacheKey key = cacheKeys.stream().findAny().get();
+            cacheKeys.forEach(k -> {
+                if (!k.schema.equals(key.schema) || !k.table.equals(key.table) || !k.family.equals(key.family) || !k.qualifier.equals(key.qualifier)) {
+                    throw new PrestoException(INTERNAL_ERROR, "loadAll called with a non-homogeneous collection of cache keys");
+                }
+            });
+
+            ImmutableMap.Builder<Range, CacheKey> rangeToKeyBuilder = ImmutableMap.builder();
+            cacheKeys.forEach(k -> rangeToKeyBuilder.put(k.range, k));
+            Map<Range, CacheKey> rangeToKey = rangeToKeyBuilder.build();
+            LOG.debug("rangeToKey size is " + rangeToKey.size());
+
+            // Get metrics table name and the column family for the scanner
+            String metricsTable = Indexer.getMetricsTableName(key.schema, key.table);
+            Text columnFamily = new Text(
+                    Indexer.getIndexColumnFamily(key.family.getBytes(UTF_8), key.qualifier.getBytes(UTF_8)).array());
+
+            BatchScanner bScanner = connector.createBatchScanner(metricsTable, auths, 10);
+            try {
+                bScanner.setRanges(cacheKeys.stream().map(k -> k.range).collect(Collectors.toList()));
+                bScanner.fetchColumn(columnFamily, Indexer.CARDINALITY_CQ_AS_TEXT);
+
+                // Create a new map to hold our cardinalities for each range, returning a default of
+                // Zero for each non-existent Key
+                Map<CacheKey, Long> rangeValues = new MapDefaultZero();
+                for (Entry<Key, Value> entry : bScanner) {
+                    rangeValues.put(rangeToKey.get(Range.exact(entry.getKey().getRow())),
+                            Long.parseLong(entry.getValue().toString()));
+                }
+                return rangeValues;
+            }
+            finally {
+                if (bScanner != null) {
+                    // Don't forget to close your scanner before returning the cardinalities
+                    bScanner.close();
+                }
+            }
         }
 
         /**
@@ -333,7 +380,7 @@ public class ColumnCardinalityCache
          * which occurs when there is no key in Accumulo.
          */
         public class MapDefaultZero
-                extends HashMap<Range, Long>
+                extends HashMap<CacheKey, Long>
         {
             @Override
             public Long get(Object key)

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
@@ -135,7 +135,8 @@ public class ColumnCardinalityCache
         idxConstraintRangePairs.asMap().entrySet().forEach(e ->
                 executor.submit(() -> {
                             long cardinality = getColumnCardinality(schema, table, e.getKey().getFamily(), e.getKey().getQualifier(), metricsStorage, truncateTimestamps && e.getKey().getType() == TimestampType.TIMESTAMP, auths, e.getValue());
-                            LOG.debug("Cardinality for column %s is %s", e.getKey().getName(), cardinality);
+                            long start = System.currentTimeMillis();
+                            LOG.debug("Cardinality for column %s is %s, took %s ms", e.getKey().getName(), cardinality, System.currentTimeMillis() - start);
                             return Pair.of(cardinality, e.getKey());
                         }
                 ));
@@ -223,8 +224,13 @@ public class ColumnCardinalityCache
         // This is where the reach-out to Accumulo occurs for all Ranges that have not
         // previously been fetched
         long sum = 0;
-        for (Long value : cache.getAll(exactRanges).values()) {
-            sum += value;
+        if (exactRanges.size() == 1) {
+            sum = cache.get(exactRanges.stream().findAny().get());
+        }
+        else {
+            for (Long value : cache.getAll(exactRanges).values()) {
+                sum += value;
+            }
         }
 
         // If these collection sizes are not equal,

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.accumulo.index;
 
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.index.metrics.MetricCacheKey;
 import com.facebook.presto.accumulo.index.metrics.MetricsStorage;
 import com.facebook.presto.accumulo.model.AccumuloColumnConstraint;
@@ -53,7 +52,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
-import static com.facebook.presto.accumulo.AccumuloErrorCode.INTERNAL_ERROR;
+import static com.facebook.presto.accumulo.AccumuloErrorCode.UNEXPECTED_ACCUMULO_ERROR;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -70,10 +69,9 @@ public class ColumnCardinalityCache
     private final LoadingCache<MetricCacheKey, Long> cache;
 
     @SuppressWarnings("unchecked")
-    public ColumnCardinalityCache(AccumuloConfig config)
+    public ColumnCardinalityCache(int size, Duration expireDuration)
     {
-        int size = requireNonNull(config, "config is null").getCardinalityCacheSize();
-        Duration expireDuration = config.getCardinalityCacheExpiration();
+        requireNonNull(expireDuration, "expireDuration is null");
 
         // Create executor service with one hot thread, pool size capped at 4x processors,
         // one minute keep alive, and a labeled ThreadFactory
@@ -176,7 +174,7 @@ public class ColumnCardinalityCache
             while (!earlyReturn && cardinalityToConstraints.entries().size() < numTasks);
         }
         catch (ExecutionException | InterruptedException e) {
-            throw new PrestoException(INTERNAL_ERROR, "Exception when getting cardinality", e);
+            throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Exception when getting cardinality", e);
         }
 
         // Create a copy of the cardinalities

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.accumulo.index;
 
 import com.facebook.presto.accumulo.AccumuloClient;
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.conf.AccumuloSessionProperties;
 import com.facebook.presto.accumulo.index.metrics.MetricsReader;
 import com.facebook.presto.accumulo.index.metrics.MetricsStorage;
@@ -75,10 +74,10 @@ public class IndexLookup
     private final ColumnCardinalityCache cardinalityCache;
     private final ExecutorService executor;
 
-    public IndexLookup(AccumuloConfig config, Connector connector)
+    public IndexLookup(Connector connector, int cacheSize, Duration cacheExpireDuration)
     {
         this.connector = requireNonNull(connector, "connector is null");
-        this.cardinalityCache = new ColumnCardinalityCache(requireNonNull(config, "config is null"));
+        this.cardinalityCache = new ColumnCardinalityCache(cacheSize, requireNonNull(cacheExpireDuration, "cacheExpireDuration is null"));
         AtomicLong threadCount = new AtomicLong(0);
         this.executor = MoreExecutors.getExitingExecutorService(
                 new ThreadPoolExecutor(1, 4 * Runtime.getRuntime().availableProcessors(), 60L,

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -39,17 +40,24 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
+import static com.facebook.presto.accumulo.AccumuloErrorCode.UNEXPECTED_ACCUMULO_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -64,6 +72,7 @@ public class IndexLookup
     private static final Range METRICS_TABLE_ROWID_RANGE = new Range(Indexer.METRICS_TABLE_ROWID_AS_TEXT);
     private final ColumnCardinalityCache cardinalityCache;
     private final Connector connector;
+    private final ExecutorService executor;
 
     public IndexLookup(
             Connector connector,
@@ -72,6 +81,12 @@ public class IndexLookup
     {
         this.connector = requireNonNull(connector, "connector is null");
         this.cardinalityCache = new ColumnCardinalityCache(connector, requireNonNull(config, "config is null"), auths);
+        AtomicLong threadCount = new AtomicLong(0);
+        this.executor = MoreExecutors.getExitingExecutorService(
+                new ThreadPoolExecutor(1, 4 * Runtime.getRuntime().availableProcessors(), 60L,
+                        TimeUnit.SECONDS, new SynchronousQueue<>(), runnable ->
+                        new Thread(runnable, "index-range-scan-thread-" + threadCount.getAndIncrement())
+                ));
     }
 
     /**
@@ -209,7 +224,7 @@ public class IndexLookup
             if (cardinalities.size() == 1) {
                 long numEntries = lowestCardinality.getKey();
                 double ratio = ((double) numEntries / (double) numRows);
-                LOG.debug("Use of index would scan %d of %d rows, ratio %s. Threshold %2f, Using for table? %b", numEntries, numRows, ratio, threshold, ratio < threshold);
+                LOG.debug("Use of index would scan %d of %d rows, ratio %s. Threshold %2f, Using for index table? %b", numEntries, numRows, ratio, threshold, ratio < threshold);
                 if (ratio >= threshold) {
                     return false;
                 }
@@ -284,58 +299,60 @@ public class IndexLookup
     }
 
     private List<Range> getIndexRanges(String indexTable, Multimap<AccumuloColumnConstraint, Range> constraintRanges, Collection<Range> rowIDRanges, Authorizations auths)
-            throws TableNotFoundException
+            throws TableNotFoundException, InterruptedException
     {
-        Set<Range> finalRanges = null;
-        // For each column/constraint pair
-        for (Entry<AccumuloColumnConstraint, Collection<Range>> constraintEntry : constraintRanges.asMap().entrySet()) {
-            // Create a batch scanner against the index table, setting the ranges
-            BatchScanner scanner = connector.createBatchScanner(indexTable, auths, 10);
-            scanner.setRanges(constraintEntry.getValue());
+        Set<Range> finalRanges = new HashSet<>();
+        // For each column/constraint pair we submit a task to scan the index ranges
+        List<Callable<Set<Range>>> tasks = new ArrayList<>();
+        for (Entry<AccumuloColumnConstraint, Collection<Range>> e : constraintRanges.asMap().entrySet()) {
+            Callable<Set<Range>> task = () -> {
+                // Create a batch scanner against the index table, setting the ranges
+                BatchScanner scan = connector.createBatchScanner(indexTable, auths, 10);
+                scan.setRanges(e.getValue());
 
-            // Fetch the column family for this specific column
-            Text family = new Text(
-                    Indexer.getIndexColumnFamily(
-                            constraintEntry.getKey().getFamily().getBytes(UTF_8),
-                            constraintEntry.getKey().getQualifier().getBytes(UTF_8)).array());
-            scanner.fetchColumnFamily(family);
+                // Fetch the column family for this specific column
+                Text cf = new Text(Indexer.getIndexColumnFamily(e.getKey().getFamily().getBytes(),
+                        e.getKey().getQualifier().getBytes()).array());
+                scan.fetchColumnFamily(cf);
 
-            // For each entry in the scanner
-            Text tmpQualifier = new Text();
-            Set<Range> columnRanges = new HashSet<>();
-            for (Entry<Key, Value> entry : scanner) {
-                entry.getKey().getColumnQualifier(tmpQualifier);
+                // For each entry in the scanner
+                Text tmpQualifier = new Text();
+                Set<Range> columnRanges = new HashSet<>();
+                for (Entry<Key, Value> entry : scan) {
+                    entry.getKey().getColumnQualifier(tmpQualifier);
 
-                // Add to our column ranges if it is in one of the row ID ranges
-                if (inRange(tmpQualifier, rowIDRanges)) {
-                    columnRanges.add(new Range(tmpQualifier));
+                    // Add to our column ranges if it is in one of the row ID ranges
+                    if (inRange(tmpQualifier, rowIDRanges)) {
+                        columnRanges.add(new Range(tmpQualifier));
+                    }
+                }
+
+                LOG.info("Retrieved %d ranges for index column %s", columnRanges.size(), e.getKey().getName());
+                // Close the scanner
+                scan.close();
+                return columnRanges;
+            };
+            tasks.add(task);
+        }
+
+        executor.invokeAll(tasks).forEach(future ->
+        {
+            try {
+                // If finalRanges is null, we have not yet added any column ranges
+                if (finalRanges.isEmpty()) {
+                    finalRanges.addAll(future.get());
+                }
+                else {
+                    // Retain only the row IDs for this column that have already been added
+                    // This is your set intersection operation!
+                    finalRanges.retainAll(future.get());
                 }
             }
-
-            LOG.debug("Retrieved %d ranges for column %s", columnRanges.size(), constraintEntry.getKey().getName());
-
-            // If finalRanges is null, we have not yet added any column ranges
-            if (finalRanges == null) {
-                finalRanges = new HashSet<>();
-                finalRanges.addAll(columnRanges);
+            catch (ExecutionException | InterruptedException e) {
+                throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Exception when getting index ranges", e);
             }
-            else {
-                // Retain only the row IDs for this column that have already been added
-                // This is your set intersection operation!
-                finalRanges.retainAll(columnRanges);
-            }
-
-            // Close the scanner
-            scanner.close();
-        }
-
-        // Return the final ranges for all constraint pairs
-        if (finalRanges != null) {
-            return ImmutableList.copyOf(finalRanges);
-        }
-        else {
-            return ImmutableList.of();
-        }
+        });
+        return ImmutableList.copyOf(finalRanges);
     }
 
     private static void binRanges(int numRangesPerBin, List<Range> splitRanges, List<TabletSplitMetadata> prestoSplits)

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
@@ -57,6 +57,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static com.facebook.presto.accumulo.AccumuloErrorCode.UNEXPECTED_ACCUMULO_ERROR;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -67,14 +68,14 @@ import static java.util.Objects.requireNonNull;
  */
 public class IndexLookup
 {
-    private static final Authorizations EMPTY_AUTHS = new Authorizations();
     private static final Logger LOG = Logger.get(IndexLookup.class);
 
     private final Connector connector;
     private final ColumnCardinalityCache cardinalityCache;
     private final ExecutorService executor;
+    private final int maxIndexLookup;
 
-    public IndexLookup(Connector connector, int cacheSize, Duration cacheExpireDuration)
+    public IndexLookup(Connector connector, int cacheSize, Duration cacheExpireDuration, int maxIndexLookup)
     {
         this.connector = requireNonNull(connector, "connector is null");
         this.cardinalityCache = new ColumnCardinalityCache(cacheSize, requireNonNull(cacheExpireDuration, "cacheExpireDuration is null"));
@@ -84,6 +85,8 @@ public class IndexLookup
                         TimeUnit.SECONDS, new SynchronousQueue<>(), runnable ->
                         new Thread(runnable, "index-range-scan-thread-" + threadCount.getAndIncrement())
                 ));
+
+        this.maxIndexLookup = maxIndexLookup;
     }
 
     /**
@@ -228,7 +231,7 @@ public class IndexLookup
         // If the smallest cardinality in our list is above the lowest cardinality threshold,
         // we should look at intersecting the row ID ranges to try and get under the threshold.
         if (smallestCardAboveThreshold(session, numRows, lowestCardinality.getKey())) {
-            // If we only have one column, we can skip the intersection process and just check the index threshold
+            // If we only have one column, we can check the index threshold without doing the row intersection
             if (cardinalities.size() == 1) {
                 long numEntries = lowestCardinality.getKey();
                 double ratio = ((double) numEntries / (double) numRows);
@@ -238,10 +241,24 @@ public class IndexLookup
                 }
             }
 
-            // Else, get the intersection of all row IDs for all column constraints
-            LOG.debug("%d indexed columns, intersecting ranges", constraintRanges.size());
-            indexRanges = getIndexRanges(indexTable, constraintRanges, rowIdRanges, auths);
-            LOG.debug("Intersection results in %d ranges from secondary index", indexRanges.size());
+            // Else, remove columns with a large number of rows
+            ImmutableSetMultimap.Builder<AccumuloColumnConstraint, Range> builder = ImmutableSetMultimap.builder();
+            cardinalities.entries().stream().filter(x -> x.getKey() < maxIndexLookup).map(Entry::getValue).forEach(constraint -> {
+                LOG.debug(format("Cardinality of column %s is below the max index lookup threshold %s, added for intersection", constraint.getName(), maxIndexLookup));
+                builder.putAll(constraint, constraintRanges.get(constraint));
+            });
+            Multimap<AccumuloColumnConstraint, Range> intersectionColumns = builder.build();
+
+            // If there are columns to do row intersection, then do so
+            if (intersectionColumns.size() > 0) {
+                LOG.debug("%d indexed columns, intersecting ranges", intersectionColumns.size());
+                indexRanges = getIndexRanges(indexTable, intersectionColumns, rowIdRanges, auths);
+                LOG.debug("Intersection results in %d ranges from secondary index", indexRanges.size());
+            }
+            else {
+                LOG.debug("No columns have few enough entries to allow intersection, doing a full table scan");
+                return false;
+            }
         }
         else {
             // Else, we don't need to intersect the columns and we can just use the column with the lowest cardinality,

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
@@ -69,6 +69,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class IndexLookup
 {
+    private static final Authorizations EMPTY_AUTHS = new Authorizations();
     private static final Logger LOG = Logger.get(IndexLookup.class);
     private static final Range METRICS_TABLE_ROWID_RANGE = new Range(Indexer.METRICS_TABLE_ROWID_AS_TEXT);
     private final ColumnCardinalityCache cardinalityCache;
@@ -296,7 +297,7 @@ public class IndexLookup
             throws TableNotFoundException
     {
         // Create scanner against the metrics table, pulling the special column and the rows column
-        Scanner scanner = connector.createScanner(metricsTable, auths);
+        Scanner scanner = connector.createScanner(metricsTable, EMPTY_AUTHS);
         scanner.setRange(METRICS_TABLE_ROWID_RANGE);
         scanner.fetchColumn(Indexer.METRICS_TABLE_ROWS_CF_AS_TEXT, Indexer.CARDINALITY_CQ_AS_TEXT);
         IteratorSetting setting = new IteratorSetting(Integer.MAX_VALUE, "valuesummingiterator", ValueSummingIterator.class);

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
@@ -80,7 +80,7 @@ public class IndexLookup
             Authorizations auths)
     {
         this.connector = requireNonNull(connector, "connector is null");
-        this.cardinalityCache = new ColumnCardinalityCache(connector, requireNonNull(config, "config is null"), auths);
+        this.cardinalityCache = new ColumnCardinalityCache(connector, requireNonNull(config, "config is null"));
         AtomicLong threadCount = new AtomicLong(0);
         this.executor = MoreExecutors.getExitingExecutorService(
                 new ThreadPoolExecutor(1, 4 * Runtime.getRuntime().availableProcessors(), 60L,
@@ -198,13 +198,13 @@ public class IndexLookup
         // Get the cardinalities from the metrics table
         Multimap<Long, AccumuloColumnConstraint> cardinalities;
         if (AccumuloSessionProperties.isIndexShortCircuitEnabled(session)) {
-            cardinalities = cardinalityCache.getCardinalities(schema, table, constraintRanges,
+            cardinalities = cardinalityCache.getCardinalities(schema, table, constraintRanges, auths,
                     getSmallestCardinalityThreshold(session, numRows),
                     AccumuloSessionProperties.getIndexCardinalityCachePollingDuration(session));
         }
         else {
             // disable short circuit using 0
-            cardinalities = cardinalityCache.getCardinalities(schema, table, constraintRanges, 0, new Duration(0, TimeUnit.MILLISECONDS));
+            cardinalities = cardinalityCache.getCardinalities(schema, table, constraintRanges, auths, 0, new Duration(0, TimeUnit.MILLISECONDS));
         }
 
         Optional<Entry<Long, AccumuloColumnConstraint>> entry = cardinalities.entries().stream().findFirst();

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/Indexer.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/Indexer.java
@@ -109,6 +109,7 @@ public class Indexer
     private static final TypedValueCombiner.Encoder<Long> ENCODER = new LongCombiner.StringEncoder();
     private static final byte[] EMPTY_BYTES = new byte[0];
     private static final byte UNDERSCORE = '_';
+    private static final ColumnVisibility EMPTY_COLUMN_VISIBILITY = new ColumnVisibility();
 
     private final AccumuloTable table;
     private final BatchWriter indexWriter;
@@ -182,7 +183,7 @@ public class Indexer
 
         // Increment the cardinality for the number of rows in the table
         ColumnVisibility rowVisibility = new ColumnVisibility(mutation.getUpdates().stream().findAny().get().getColumnVisibility());
-        incrementMetric(METRICS_TABLE_ROW_ID, METRICS_TABLE_ROWS_CF, rowVisibility);
+        incrementMetric(METRICS_TABLE_ROW_ID, METRICS_TABLE_ROWS_CF, EMPTY_COLUMN_VISIBILITY);
 
         // For each column update in this mutation
         for (ColumnUpdate columnUpdate : mutation.getUpdates()) {

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/Indexer.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/Indexer.java
@@ -22,18 +22,26 @@ import com.facebook.presto.accumulo.serializers.AccumuloRowSerializer;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.ColumnUpdate;
+import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.io.Text;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -43,6 +51,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -97,7 +106,9 @@ public class Indexer
     private static final byte[] EMPTY_BYTES = new byte[0];
     private static final byte UNDERSCORE = '_';
 
+    private final AccumuloTable table;
     private final BatchWriter indexWriter;
+    private final Connector connector;
     private final MetricsWriter metricsWriter;
     private final Multimap<ByteBuffer, ByteBuffer> indexColumns;
     private final Map<ByteBuffer, Map<ByteBuffer, Type>> indexColumnTypes;
@@ -105,18 +116,18 @@ public class Indexer
     private final boolean truncateTimestamps;
 
     public Indexer(
+            Connector connector,
             AccumuloConfig config,
-            Authorizations auths,
             AccumuloTable table,
             BatchWriter indexWriter,
             MetricsWriter metricsWriter)
             throws TableNotFoundException
     {
+        this.connector = requireNonNull(connector, "connector is null");
         requireNonNull(config, "config is null");
+        this.table = requireNonNull(table, "connector is null");
         this.indexWriter = requireNonNull(indexWriter, "indexWriter is null");
         this.metricsWriter = requireNonNull(metricsWriter, "metricsWriter is null");
-        requireNonNull(auths, "auths is null");
-        requireNonNull(table, "table is null");
 
         this.serializer = table.getSerializerInstance();
         this.truncateTimestamps = table.isTruncateTimestamps();
@@ -154,10 +165,10 @@ public class Indexer
     }
 
     /**
-     * Index the given mutation, adding mutations to the index and metrics table
+     * Index the given mutation, adding mutations to the index and metrics storage
      * <p>
      * Like typical use of a BatchWriter, this method does not flush mutations to the underlying index table.
-     * For higher throughput the modifications to the metrics table are tracked in memory and added to the metrics table when the indexer is flushed or closed.
+     * For higher throughput the modifications to the metrics table are tracked in memory and added to the metrics storage when the indexer is flushed or closed.
      *
      * @param mutation Mutation to index
      */
@@ -165,6 +176,7 @@ public class Indexer
             throws MutationsRejectedException
     {
         checkArgument(mutation.getUpdates().size() > 0, "Mutation must have at least one column update");
+        checkArgument(!mutation.getUpdates().stream().anyMatch(ColumnUpdate::isDeleted), "Mutation must not contain any delete entries. Use Indexer#delete, then index the Mutation");
 
         // Increment the cardinality for the number of rows in the table
         metricsWriter.incrementRowCount();
@@ -194,11 +206,11 @@ public class Indexer
                         Type elementType = Types.getElementType(type);
                         List<?> elements = serializer.decode(type, columnUpdate.getValue());
                         for (Object element : elements) {
-                            addIndexMutation(wrap(serializer.encode(elementType, element)), indexFamily, visibility, mutation.getRow(), truncateTimestamps && type == TIMESTAMP);
+                            addIndexMutation(wrap(serializer.encode(elementType, element)), indexFamily, mutation.getRow(), visibility, truncateTimestamps && elementType == TIMESTAMP);
                         }
                     }
                     else {
-                        addIndexMutation(wrap(columnUpdate.getValue()), indexFamily, visibility, mutation.getRow(), truncateTimestamps && type == TIMESTAMP);
+                        addIndexMutation(wrap(columnUpdate.getValue()), indexFamily, mutation.getRow(), visibility, truncateTimestamps && type == TIMESTAMP);
                     }
                 }
             }
@@ -213,17 +225,206 @@ public class Indexer
         }
     }
 
-    private void addIndexMutation(ByteBuffer row, ByteBuffer family, ColumnVisibility visibility, byte[] qualifier, boolean truncateTimestamp)
+    /**
+     * Update the index value and metrics for the given row ID using the provided column updates.
+     * <p>
+     * This method uses a Scanner to fetch the existing values of row, applying delete Mutations to
+     * the given columns with the visibility they were written with (using the Authorizations to scan
+     * the table), and then applying the new updates.
+     *
+     * @param rowBytes Serialized bytes of the row ID to update
+     * @param columnUpdates Map of a Triple containg column family, column qualifier, and NEW column visibility to the new column value.
+     * @param auths Authorizations to scan the table for deleting the entries.  For proper deletes, these authorizations must encapsulate whatever the visibility of the existing row is, otherwise you'll have duplicate values
+     */
+    public void update(byte[] rowBytes, Map<Triple<String, String, ColumnVisibility>, Object> columnUpdates, Authorizations auths)
+            throws MutationsRejectedException, TableNotFoundException
+    {
+        // Delete the column updates
+        long deleteTimestamp = System.currentTimeMillis();
+        Scanner scanner = null;
+        try {
+            scanner = connector.createScanner(table.getFullTableName(), auths);
+            scanner.setRange(Range.exact(new Text(rowBytes)));
+
+            for (Triple<String, String, ColumnVisibility> update : columnUpdates.keySet()) {
+                scanner.fetchColumn(new Text(update.getLeft()), new Text(update.getMiddle()));
+            }
+
+            // First, delete all index entries for this column
+            Text familyText = new Text();
+            Text qualifierText = new Text();
+            Text visibilityText = new Text();
+            for (Entry<Key, Value> entry : scanner) {
+                ByteBuffer familyBytes = wrap(entry.getKey().getColumnFamily(familyText).copyBytes());
+                ByteBuffer qualifierBytes = wrap(entry.getKey().getColumnQualifier(qualifierText).copyBytes());
+                ColumnVisibility visibility = new ColumnVisibility(entry.getKey().getColumnVisibility(visibilityText).copyBytes());
+
+                ByteBuffer indexFamily = Indexer.getIndexColumnFamily(familyBytes.array(), qualifierBytes.array());
+                Type type = indexColumnTypes.get(familyBytes).get(qualifierBytes);
+
+                // If this is an array type, then update each individual element in the array
+                if (Types.isArrayType(type)) {
+                    Type elementType = Types.getElementType(type);
+                    List<?> elements = serializer.decode(type, entry.getValue().get());
+                    for (Object element : elements) {
+                        deleteIndexMutation(wrap(serializer.encode(elementType, element)), indexFamily, rowBytes, visibility, deleteTimestamp, truncateTimestamps && elementType == TIMESTAMP);
+                    }
+                }
+                else {
+                    deleteIndexMutation(wrap(entry.getValue().get()), indexFamily, rowBytes, visibility, deleteTimestamp, truncateTimestamps && type == TIMESTAMP);
+                }
+            }
+        }
+        finally {
+            if (scanner != null) {
+                scanner.close();
+            }
+        }
+
+        // And now insert the updates
+        long updateTimestamp = deleteTimestamp + 1;
+        for (Map.Entry<Triple<String, String, ColumnVisibility>, Object> entry : columnUpdates.entrySet()) {
+            ByteBuffer family = wrap(entry.getKey().getLeft().getBytes(UTF_8));
+            ByteBuffer qualifier = wrap(entry.getKey().getMiddle().getBytes(UTF_8));
+            ByteBuffer indexFamily = Indexer.getIndexColumnFamily(family.array(), qualifier.array());
+            Type type = indexColumnTypes.get(family).get(qualifier);
+
+            // If this is an array type, then update each individual element in the array
+            if (Types.isArrayType(type)) {
+                Type elementType = Types.getElementType(type);
+                for (Object element : (List<?>) entry.getValue()) {
+                    addIndexMutation(wrap(serializer.encode(elementType, element)), indexFamily, rowBytes, entry.getKey().getRight(), updateTimestamp, truncateTimestamps && elementType == TIMESTAMP);
+                }
+            }
+            else {
+                addIndexMutation(wrap(serializer.encode(type, entry.getValue())), indexFamily, rowBytes, entry.getKey().getRight(), updateTimestamp, truncateTimestamps && type == TIMESTAMP);
+            }
+        }
+    }
+
+    /**
+     * Deletes the index entries associated with the given row ID, as well as decrementing the associated metrics.
+     * <p>
+     * This method creates a new BatchScanner per call, so use {@link Indexer#delete(Authorizations, Iterable)} if deleting multiple entries.
+     * <p>
+     * Like typical use of a BatchWriter, this method does not flush mutations to the underlying index table.
+     * For higher throughput the modifications to the metrics table are tracked in memory and added to the metrics table when the indexer is flushed or closed.
+     *
+     * @param auths Authorizations for scanning and deleting index/metric entries
+     * @param rowId The row to delete
+     */
+    public void delete(Authorizations auths, byte[] rowId)
+            throws MutationsRejectedException, TableNotFoundException
+    {
+        delete(auths, ImmutableList.of(rowId));
+    }
+
+    /**
+     * Deletes the index entries associated with the given row ID, as well as decrementing the associated metrics.
+     * <p>
+     * This method creates a new BatchScanner per call.
+     * <p>
+     * Like typical use of a BatchWriter, this method does not flush mutations to the underlying index table.
+     * For higher throughput the modifications to the metrics table are tracked in memory and added to the metrics table when the indexer is flushed or closed.
+     *
+     * @param auths Authorizations for scanning and deleting index/metric entries
+     * @param rowIds The row to delete
+     */
+    public void delete(Authorizations auths, Iterable<byte[]> rowIds)
+            throws MutationsRejectedException, TableNotFoundException
+    {
+        ImmutableList.Builder<Range> rangeBuilder = ImmutableList.builder();
+        rowIds.forEach(x -> rangeBuilder.add(new Range(new Text(x))));
+        List<Range> ranges = rangeBuilder.build();
+
+        BatchScanner scanner = null;
+        try {
+            scanner = connector.createBatchScanner(table.getFullTableName(), auths, 10);
+            scanner.setRanges(ranges);
+
+            Text text = new Text();
+            Text previousRowId = null;
+            // Scan each row to be deleted, creating a delete mutation for each
+            for (Entry<Key, Value> entry : scanner) {
+                // Decrement the cardinality for the number of rows in the table
+                entry.getKey().getRow(text);
+                if (previousRowId == null || !previousRowId.equals(text)) {
+                    metricsWriter.decrementRowCount();
+                }
+                previousRowId = new Text(text);
+
+                // Get the column qualifiers we want to index for this column family (if any)
+                ByteBuffer family = wrap(entry.getKey().getColumnFamily(text).copyBytes());
+                Collection<ByteBuffer> indexQualifiers = indexColumns.get(family);
+
+                // If we have column qualifiers we want to index for this column family
+                if (indexQualifiers != null) {
+                    // Check if we want to index this particular qualifier
+                    ByteBuffer qualifier = wrap(entry.getKey().getColumnQualifier(text).copyBytes());
+                    if (indexQualifiers.contains(qualifier)) {
+                        // If so, create a delete mutation using the following mapping:
+                        // Row ID = column value
+                        // Column Family = columnqualifier_columnfamily
+                        // Column Qualifier = row ID
+                        ByteBuffer indexFamily = Indexer.getIndexColumnFamily(family.array(), qualifier.array());
+                        Type type = indexColumnTypes.get(family).get(qualifier);
+                        ColumnVisibility visibility = new ColumnVisibility(entry.getKey().getColumnVisibility());
+
+                        // If this is an array type, then delete each individual element in the array
+                        if (Types.isArrayType(type)) {
+                            Type elementType = Types.getElementType(type);
+                            List<?> elements = serializer.decode(type, entry.getValue().get());
+                            for (Object element : elements) {
+                                deleteIndexMutation(wrap(serializer.encode(elementType, element)), indexFamily, entry.getKey().getRow(text).copyBytes(), visibility, truncateTimestamps && elementType == TIMESTAMP);
+                            }
+                        }
+                        else {
+                            deleteIndexMutation(wrap(entry.getValue().get()), indexFamily, entry.getKey().getRow(text).copyBytes(), visibility, truncateTimestamps && type == TIMESTAMP);
+                        }
+                    }
+                }
+            }
+        }
+        finally {
+            if (scanner != null) {
+                scanner.close();
+            }
+        }
+    }
+
+    private void addIndexMutation(ByteBuffer row, ByteBuffer family, byte[] qualifier, ColumnVisibility visibility, boolean truncateTimestamp)
+            throws MutationsRejectedException
+    {
+        addIndexMutation(row, family, qualifier, visibility, System.currentTimeMillis(), truncateTimestamp);
+    }
+
+    private void addIndexMutation(ByteBuffer row, ByteBuffer family, byte[] qualifier, ColumnVisibility visibility, long timestamp, boolean truncateTimestamp)
             throws MutationsRejectedException
     {
         // Create the mutation and add it to the batch writer
         Mutation indexMutation = new Mutation(row.array());
-        indexMutation.put(family.array(), qualifier, visibility, EMPTY_BYTES);
+        indexMutation.put(family.array(), qualifier, visibility, timestamp, EMPTY_BYTES);
         indexWriter.addMutation(indexMutation);
 
         // Increment the cardinality metrics for this value of index
         // metrics is a mapping of row ID to column family
         metricsWriter.incrementCardinality(row, family, visibility, truncateTimestamp);
+    }
+
+    private void deleteIndexMutation(ByteBuffer row, ByteBuffer family, byte[] qualifier, ColumnVisibility visibility, boolean truncateTimestamp)
+            throws MutationsRejectedException
+    {
+        deleteIndexMutation(row, family, qualifier, visibility, System.currentTimeMillis(), truncateTimestamp);
+    }
+
+    private void deleteIndexMutation(ByteBuffer row, ByteBuffer family, byte[] qualifier, ColumnVisibility visibility, long timestamp, boolean truncateTimestamp)
+            throws MutationsRejectedException
+    {
+        // Create the mutation and add it to the batch writer
+        Mutation indexMutation = new Mutation(row.array());
+        indexMutation.putDelete(family.array(), qualifier, visibility, timestamp);
+        indexWriter.addMutation(indexMutation);
+        metricsWriter.decrementCardinality(row, family, visibility, truncateTimestamp);
     }
 
     /**

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/Indexer.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/Indexer.java
@@ -114,10 +114,11 @@ public class Indexer
     public static final Text CARDINALITY_CQ_AS_TEXT = new Text(CARDINALITY_CQ);
     public static final Text METRICS_TABLE_ROWS_CF_AS_TEXT = new Text(METRICS_TABLE_ROWS_CF.array());
     public static final Text METRICS_TABLE_ROWID_AS_TEXT = new Text(METRICS_TABLE_ROW_ID.array());
+    public static final LongCombiner.Type ENCODER_TYPE = LongCombiner.Type.STRING;
 
+    private static final TypedValueCombiner.Encoder<Long> ENCODER = new LongCombiner.StringEncoder();
     private static final byte[] EMPTY_BYTES = new byte[0];
     private static final byte UNDERSCORE = '_';
-    private static final TypedValueCombiner.Encoder<Long> ENCODER = new LongCombiner.StringEncoder();
 
     private final AccumuloTable table;
     private final BatchWriter indexWriter;

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/Indexer.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/Indexer.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.accumulo.index;
 
 import com.facebook.presto.accumulo.Types;
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.index.metrics.MetricsWriter;
 import com.facebook.presto.accumulo.metadata.AccumuloTable;
 import com.facebook.presto.accumulo.model.AccumuloColumnHandle;
@@ -117,14 +116,12 @@ public class Indexer
 
     public Indexer(
             Connector connector,
-            AccumuloConfig config,
             AccumuloTable table,
             BatchWriter indexWriter,
             MetricsWriter metricsWriter)
             throws TableNotFoundException
     {
         this.connector = requireNonNull(connector, "connector is null");
-        requireNonNull(config, "config is null");
         this.table = requireNonNull(table, "connector is null");
         this.indexWriter = requireNonNull(indexWriter, "indexWriter is null");
         this.metricsWriter = requireNonNull(metricsWriter, "metricsWriter is null");

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/AccumuloMetricsStorage.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/AccumuloMetricsStorage.java
@@ -253,7 +253,7 @@ public class AccumuloMetricsStorage
             ImmutableList.Builder<Mutation> mutationBuilder = ImmutableList.builder();
             // Mapping of column value to column to number of row IDs that contain that value
             for (Map.Entry<CardinalityKey, AtomicLong> entry : metrics.entrySet()) {
-                if (entry.getValue().get() > 0) {
+                if (entry.getValue().get() != 0) {
                     // Row ID: Column value
                     // Family: columnfamily_columnqualifier
                     // Qualifier: CARDINALITY_CQ
@@ -273,7 +273,7 @@ public class AccumuloMetricsStorage
             }
 
             for (Map.Entry<TimestampTruncateKey, AtomicLong> entry : timestampMetrics.entrySet()) {
-                if (entry.getValue().get() > 0) {
+                if (entry.getValue().get() != 0) {
                     Mutation mut = new Mutation(entry.getKey().value.array());
                     mut.put(
                             Bytes.concat(entry.getKey().column.array(), TIMESTAMP_CARDINALITY_FAMILIES.get(entry.getKey().level)),

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/AccumuloMetricsStorage.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/AccumuloMetricsStorage.java
@@ -52,7 +52,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -66,6 +65,7 @@ import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class AccumuloMetricsStorage
         extends MetricsStorage
@@ -300,7 +300,7 @@ public class AccumuloMetricsStorage
         {
             super(storage);
             this.connector = requireNonNull(connector, "connector is null");
-            this.executorService = MoreExecutors.getExitingExecutorService(new ThreadPoolExecutor(0, 5, 60L, TimeUnit.SECONDS, new SynchronousQueue<>()));
+            this.executorService = MoreExecutors.getExitingExecutorService(new ThreadPoolExecutor(0, 5, 60L, SECONDS, new SynchronousQueue<>()));
         }
 
         @Override

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/AccumuloMetricsStorage.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/AccumuloMetricsStorage.java
@@ -1,0 +1,458 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.index.metrics;
+
+import com.facebook.presto.accumulo.AccumuloTableManager;
+import com.facebook.presto.accumulo.conf.AccumuloConfig;
+import com.facebook.presto.accumulo.index.Indexer;
+import com.facebook.presto.accumulo.iterators.ValueSummingIterator;
+import com.facebook.presto.accumulo.metadata.AccumuloTable;
+import com.facebook.presto.accumulo.model.AccumuloColumnHandle;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Bytes;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.airlift.log.Logger;
+import org.apache.accumulo.core.client.BatchScanner;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.LongCombiner;
+import org.apache.accumulo.core.iterators.TypedValueCombiner;
+import org.apache.accumulo.core.iterators.user.SummingCombiner;
+import org.apache.hadoop.io.Text;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.accumulo.AccumuloErrorCode.ACCUMULO_TABLE_DNE;
+import static com.facebook.presto.accumulo.AccumuloErrorCode.UNEXPECTED_ACCUMULO_ERROR;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.DAY;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.HOUR;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.MINUTE;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.SECOND;
+import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class AccumuloMetricsStorage
+        extends MetricsStorage
+{
+    private static final byte[] CARDINALITY_CQ = "___card___".getBytes(UTF_8);
+    private static final LongCombiner.Type ENCODER_TYPE = LongCombiner.Type.STRING;
+    private static final TypedValueCombiner.Encoder<Long> ENCODER = new LongCombiner.StringEncoder();
+    private static final Map<TimestampPrecision, byte[]> TIMESTAMP_CARDINALITY_FAMILIES = ImmutableMap.of(
+            SECOND, "_tss".getBytes(UTF_8),
+            MINUTE, "_tsm".getBytes(UTF_8),
+            HOUR, "_tsh".getBytes(UTF_8),
+            DAY, "_tsd".getBytes(UTF_8));
+
+    private final AccumuloTableManager tableManager;
+
+    public AccumuloMetricsStorage(Connector connector, AccumuloConfig config)
+    {
+        super(connector, config);
+        tableManager = new AccumuloTableManager(connector);
+    }
+
+    @Override
+    public void create(AccumuloTable table)
+    {
+        String metricsTableName = getMetricsTableName(table.getSchema(), table.getTable());
+        if (!tableManager.exists(metricsTableName)) {
+            tableManager.createAccumuloTable(metricsTableName);
+        }
+
+        tableManager.setLocalityGroups(metricsTableName, getLocalityGroups(table));
+
+        // Attach iterators to metrics table
+        for (IteratorSetting setting : getMetricIterators(table)) {
+            tableManager.setIterator(metricsTableName, setting);
+        }
+    }
+
+    private Map<String, Set<Text>> getLocalityGroups(AccumuloTable table)
+    {
+        ImmutableMap.Builder<String, Set<Text>> groups = ImmutableMap.builder();
+
+        // For each indexed column
+        for (AccumuloColumnHandle columnHandle : table.getColumns().stream().filter(AccumuloColumnHandle::isIndexed).collect(Collectors.toList())) {
+            // Create a Text version of the index column family
+            Text indexColumnFamily = new Text(Indexer.getIndexColumnFamily(columnHandle.getFamily().get().getBytes(UTF_8), columnHandle.getQualifier().get().getBytes(UTF_8)).array());
+            groups.put(indexColumnFamily.toString(), ImmutableSet.of(indexColumnFamily));
+
+            if (table.isTruncateTimestamps() && columnHandle.getType() == TIMESTAMP) {
+                for (byte[] family : TIMESTAMP_CARDINALITY_FAMILIES.values()) {
+                    Text timestampFamily = new Text(Bytes.concat(indexColumnFamily.copyBytes(), family));
+                    groups.put(timestampFamily.toString(), ImmutableSet.of(timestampFamily));
+                }
+            }
+        }
+
+        return groups.build();
+    }
+
+    @Override
+    public void rename(AccumuloTable oldTable, AccumuloTable newTable)
+    {
+        String oldTableName = getMetricsTableName(oldTable.getSchema(), oldTable.getTable());
+        String newTableName = getMetricsTableName(newTable.getSchema(), newTable.getTable());
+        tableManager.renameAccumuloTable(oldTableName, newTableName);
+    }
+
+    @Override
+    public boolean exists(SchemaTableName table)
+    {
+        String metricsTableName = getMetricsTableName(table.getSchemaName(), table.getTableName());
+        return tableManager.exists(metricsTableName);
+    }
+
+    @Override
+    public void drop(AccumuloTable table)
+    {
+        if (table.isExternal()) {
+            return;
+        }
+
+        String metricsTableName = getMetricsTableName(table.getSchema(), table.getTable());
+        if (tableManager.exists(metricsTableName)) {
+            tableManager.deleteAccumuloTable(metricsTableName);
+        }
+    }
+
+    @Override
+    public MetricsWriter newWriter(AccumuloTable table)
+    {
+        return new AccumuloMetricsWriter(config, connector, table);
+    }
+
+    @Override
+    public MetricsReader newReader()
+    {
+        return new AccumuloMetricsReader(this, connector);
+    }
+
+    /**
+     * Gets the fully-qualified index metrics table name for the given table
+     *
+     * @param schema Schema name
+     * @param table Table name
+     * @return Qualified index metrics table name
+     */
+    private static String getMetricsTableName(String schema, String table)
+    {
+        return schema.equals("default")
+                ? table + "_idx_metrics"
+                : schema + '.' + table + "_idx_metrics";
+    }
+
+    /**
+     * Gets a collection of iterator settings that should be added to the metric table for the given
+     * Accumulo table. Don't forget! Please!
+     *
+     * @param table Table for retrieving metrics iterators, see AccumuloClient#getTable
+     * @return Collection of iterator settings
+     */
+    private Collection<IteratorSetting> getMetricIterators(AccumuloTable table)
+    {
+        String cardQualifier = new String(CARDINALITY_CQ, UTF_8);
+        String rowsFamily = new String(METRICS_TABLE_ROWS_COLUMN.array(), UTF_8);
+
+        // Build a string for all columns where the summing combiner should be applied, i.e. all indexed columns
+        ImmutableList.Builder<IteratorSetting.Column> columnBuilder = ImmutableList.builder();
+        columnBuilder.add(new IteratorSetting.Column(rowsFamily, cardQualifier));
+        for (String s : getLocalityGroups(table).keySet()) {
+            columnBuilder.add(new IteratorSetting.Column(s, cardQualifier));
+        }
+
+        // Summing combiner for cardinality columns
+        IteratorSetting s1 = new IteratorSetting(1, SummingCombiner.class);
+        SummingCombiner.setEncodingType(s1, LongCombiner.Type.STRING);
+        SummingCombiner.setColumns(s1, columnBuilder.build());
+
+        return ImmutableList.of(s1);
+    }
+
+    private static class AccumuloMetricsWriter
+            extends MetricsWriter
+    {
+        private static final byte[] CARDINALITY_CQ = "___card___".getBytes(UTF_8);
+
+        private final BatchWriterConfig writerConfig;
+        private final Connector connector;
+
+        public AccumuloMetricsWriter(AccumuloConfig config, Connector connector, AccumuloTable table)
+        {
+            super(config, table);
+            this.connector = requireNonNull(connector, "connector is null");
+            this.writerConfig = new BatchWriterConfig();
+        }
+
+        @Override
+        public void flush()
+        {
+            // Write out metrics mutations
+            try {
+                Collection<Mutation> mutations = this.getMetricsMutations();
+                if (mutations.size() > 0) {
+                    BatchWriter metricsWriter = connector.createBatchWriter(getMetricsTableName(table.getSchema(), table.getTable()), writerConfig);
+                    metricsWriter.addMutations(mutations);
+                    metricsWriter.close();
+                }
+                metrics.clear();
+                timestampMetrics.clear();
+            }
+            catch (MutationsRejectedException e) {
+                throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Mutation was rejected by server on close", e);
+            }
+            catch (TableNotFoundException e) {
+                throw new PrestoException(ACCUMULO_TABLE_DNE, "Accumulo table does not exist", e);
+            }
+        }
+
+        /**
+         * Gets a collection of mutations based on the current metric map
+         *
+         * @return A collection of Mutations
+         */
+        private Collection<Mutation> getMetricsMutations()
+        {
+            ImmutableList.Builder<Mutation> mutationBuilder = ImmutableList.builder();
+            // Mapping of column value to column to number of row IDs that contain that value
+            for (Map.Entry<CardinalityKey, AtomicLong> entry : metrics.entrySet()) {
+                if (entry.getValue().get() > 0) {
+                    // Row ID: Column value
+                    // Family: columnfamily_columnqualifier
+                    // Qualifier: CARDINALITY_CQ
+                    // Visibility: Inherited from indexed Mutation
+                    // Value: Cardinality
+
+                    Mutation mut = new Mutation(entry.getKey().value.array());
+                    mut.put(
+                            entry.getKey().column.array(),
+                            CARDINALITY_CQ,
+                            entry.getKey().visibility,
+                            ENCODER.encode(entry.getValue().get()));
+
+                    // Add to our list of mutations
+                    mutationBuilder.add(mut);
+                }
+            }
+
+            for (Map.Entry<TimestampTruncateKey, AtomicLong> entry : timestampMetrics.entrySet()) {
+                if (entry.getValue().get() > 0) {
+                    Mutation mut = new Mutation(entry.getKey().value.array());
+                    mut.put(
+                            Bytes.concat(entry.getKey().column.array(), TIMESTAMP_CARDINALITY_FAMILIES.get(entry.getKey().level)),
+                            CARDINALITY_CQ,
+                            entry.getKey().visibility,
+                            ENCODER.encode(entry.getValue().get()));
+                    mutationBuilder.add(mut);
+                }
+            }
+
+            return mutationBuilder.build();
+        }
+    }
+
+    private static class AccumuloMetricsReader
+            extends MetricsReader
+    {
+        private static final Logger LOG = Logger.get(AccumuloMetricsReader.class);
+        private static final Text CARDINALITY_CQ_TEXT = new Text(CARDINALITY_CQ);
+
+        private final Connector connector;
+        private final ExecutorService executorService;
+
+        public AccumuloMetricsReader(AccumuloMetricsStorage storage, Connector connector)
+        {
+            super(storage);
+            this.connector = requireNonNull(connector, "connector is null");
+            this.executorService = MoreExecutors.getExitingExecutorService(new ThreadPoolExecutor(0, 5, 60L, TimeUnit.SECONDS, new SynchronousQueue<>()));
+        }
+
+        @Override
+        public long getCardinality(MetricCacheKey key)
+                throws Exception
+        {
+            LOG.debug("Loading a non-exact range from Accumulo: %s", key);
+            // Get metrics table name and the column family for the scanner
+            String metricsTable = getMetricsTableName(key.schema, key.table);
+            Text columnFamily = new Text(super.getColumnFamily(key));
+
+            IteratorSetting setting = new IteratorSetting(Integer.MAX_VALUE, "valuesummingcombiner", ValueSummingIterator.class);
+            ValueSummingIterator.setEncodingType(setting, ENCODER_TYPE);
+
+            // Create scanner for querying the range
+            if (!key.truncateTimestamps) {
+                BatchScanner scanner = null;
+                try {
+                    scanner = connector.createBatchScanner(metricsTable, key.auths, 10);
+                    scanner.setRanges(connector.tableOperations().splitRangeByTablets(metricsTable, key.range, Integer.MAX_VALUE));
+                    scanner.fetchColumn(columnFamily, CARDINALITY_CQ_TEXT);
+                    scanner.addScanIterator(setting);
+
+                    // Sum the entries to get the cardinality
+                    long sum = 0;
+                    for (Entry<Key, Value> entry : scanner) {
+                        sum += Long.parseLong(entry.getValue().toString());
+                    }
+                    return sum;
+                }
+                finally {
+                    if (scanner != null) {
+                        scanner.close();
+                    }
+                }
+            }
+            else {
+                // For timestamp columns
+                List<Future<Long>> tasks = MetricsStorage.splitTimestampRange(key.range).asMap().entrySet().stream().map(timestampEntry ->
+                        executorService.submit(() -> {
+                                    long sum = 0;
+                                    BatchScanner scanner = null;
+                                    try {
+                                        scanner = connector.createBatchScanner(metricsTable, key.auths, 10);
+                                        scanner.setRanges(timestampEntry.getValue());
+                                        scanner.addScanIterator(setting);
+
+                                        if (timestampEntry.getKey() == TimestampPrecision.MILLISECOND) {
+                                            scanner.fetchColumn(columnFamily, CARDINALITY_CQ_TEXT);
+                                        }
+                                        else {
+                                            scanner.fetchColumn(new Text(Bytes.concat(columnFamily.copyBytes(), TIMESTAMP_CARDINALITY_FAMILIES.get(timestampEntry.getKey()))), CARDINALITY_CQ_TEXT);
+                                        }
+
+                                        // Sum the entries to get the cardinality
+                                        for (Entry<Key, Value> entry : scanner) {
+                                            sum += Long.parseLong(entry.getValue().toString());
+                                        }
+                                        LOG.debug("Sum for %s is %s, %s ranges", timestampEntry.getKey(), sum, timestampEntry.getValue().size());
+                                        return sum;
+                                    }
+                                    finally {
+                                        if (scanner != null) {
+                                            scanner.close();
+                                        }
+                                    }
+                                }
+                        )).collect(Collectors.toList());
+
+                long sum = 0;
+                for (Future<Long> task : tasks) {
+                    sum += task.get();
+                }
+                LOG.debug("Final sum is %s", sum);
+                return sum;
+            }
+        }
+
+        @Override
+        public Map<MetricCacheKey, Long> getCardinalities(Collection<MetricCacheKey> keys)
+        {
+            if (keys.isEmpty()) {
+                return ImmutableMap.of();
+            }
+
+            LOG.debug("Loading %s exact ranges from Accumulo", keys.size());
+
+            // Transform the collection into a map of each CacheKey's Range to the key itself
+            // This allows us to look up the corresponding CacheKey based on the Row
+            // we receive from the scanner, and we can then back-fill our returned map
+            // With any values that were not returned by the scan (cardinality zero)
+            Map<Range, MetricCacheKey> rangeToKey = new HashMap<>(keys.size());
+            keys.forEach(k -> rangeToKey.put(k.range, k));
+
+            // Create a copy of the map which we will use to fill out the zeroes
+            Map<Range, MetricCacheKey> remainingKeys = new HashMap<>(rangeToKey);
+
+            MetricCacheKey anyKey = super.getAnyKey(keys);
+
+            // Get metrics table name and the column family for the scanner
+            String metricsTable = getMetricsTableName(anyKey.schema, anyKey.table);
+            Text columnFamily = new Text(super.getColumnFamily(anyKey));
+
+            // Create batch scanner for querying all ranges
+            BatchScanner scanner = null;
+            try {
+                scanner = connector.createBatchScanner(metricsTable, anyKey.auths, 10);
+                scanner.setRanges(keys.stream().map(k -> k.range).collect(Collectors.toList()));
+                scanner.fetchColumn(columnFamily, CARDINALITY_CQ_TEXT);
+
+                // Create a new map to hold our cardinalities for each range
+                // retrieved from the scanner
+                Map<MetricCacheKey, Long> rangeValues = new HashMap<>();
+                for (Map.Entry<Key, Value> entry : scanner) {
+                    // Convert the row ID into an exact range and get the CacheKey
+                    Range range = Range.exact(entry.getKey().getRow());
+                    MetricCacheKey cacheKey = rangeToKey.get(range);
+                    if (cacheKey == null) {
+                        throw new PrestoException(FUNCTION_IMPLEMENTATION_ERROR, "rangeToKey had no entry for " + range);
+                    }
+
+                    // Remove this range from remaining keys since we have a value
+                    remainingKeys.remove(range);
+
+                    // Sum the values (if a value exists already)
+                    Long value = rangeValues.get(cacheKey);
+                    rangeValues.put(cacheKey, Long.parseLong(entry.getValue().toString()) + (value == null ? 0 : value));
+                }
+
+                // Add the remaining cache keys to our return list with a cardinality of zero
+                for (MetricCacheKey remainingKey : remainingKeys.values()) {
+                    rangeValues.put(remainingKey, 0L);
+                }
+
+                return ImmutableMap.copyOf(rangeValues);
+            }
+            catch (TableNotFoundException e) {
+                throw new PrestoException(ACCUMULO_TABLE_DNE, "Accumulo table does not exist", e);
+            }
+            finally {
+                if (scanner != null) {
+                    scanner.close();
+                }
+            }
+        }
+
+        @Override
+        public void close()
+                throws Exception
+        {
+            // noop
+        }
+    }
+}

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/AccumuloMetricsStorage.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/AccumuloMetricsStorage.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.accumulo.index.metrics;
 
 import com.facebook.presto.accumulo.AccumuloTableManager;
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.index.Indexer;
 import com.facebook.presto.accumulo.iterators.ValueSummingIterator;
 import com.facebook.presto.accumulo.metadata.AccumuloTable;
@@ -82,9 +81,9 @@ public class AccumuloMetricsStorage
 
     private final AccumuloTableManager tableManager;
 
-    public AccumuloMetricsStorage(Connector connector, AccumuloConfig config)
+    public AccumuloMetricsStorage(Connector connector)
     {
-        super(connector, config);
+        super(connector);
         tableManager = new AccumuloTableManager(connector);
     }
 
@@ -156,7 +155,7 @@ public class AccumuloMetricsStorage
     @Override
     public MetricsWriter newWriter(AccumuloTable table)
     {
-        return new AccumuloMetricsWriter(config, connector, table);
+        return new AccumuloMetricsWriter(connector, table);
     }
 
     @Override
@@ -214,9 +213,9 @@ public class AccumuloMetricsStorage
         private final BatchWriterConfig writerConfig;
         private final Connector connector;
 
-        public AccumuloMetricsWriter(AccumuloConfig config, Connector connector, AccumuloTable table)
+        public AccumuloMetricsWriter(Connector connector, AccumuloTable table)
         {
-            super(config, table);
+            super(table);
             this.connector = requireNonNull(connector, "connector is null");
             this.writerConfig = new BatchWriterConfig();
         }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricCacheKey.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricCacheKey.java
@@ -39,6 +39,7 @@ public class MetricCacheKey
     /**
      * Creates a new instance of a MetricCacheKey
      *
+     * @param storage Metrics storage instance
      * @param schema Schema name
      * @param table Table name
      * @param family Column family
@@ -62,7 +63,7 @@ public class MetricCacheKey
     @Override
     public int hashCode()
     {
-        return Objects.hash(schema, table, family, qualifier, truncateTimestamps, auths, range);
+        return Objects.hash(storage, schema, table, family, qualifier, truncateTimestamps, auths, range);
     }
 
     @Override
@@ -82,13 +83,15 @@ public class MetricCacheKey
                 && Objects.equals(this.family, other.family)
                 && Objects.equals(this.truncateTimestamps, other.truncateTimestamps)
                 && Objects.equals(this.auths, other.auths)
-                && Objects.equals(this.qualifier, other.qualifier);
+                && Objects.equals(this.qualifier, other.qualifier)
+                && Objects.equals(this.storage, other.storage);
     }
 
     @Override
     public String toString()
     {
         return toStringHelper(this)
+                .add("storage", storage.getClass())
                 .add("schema", schema)
                 .add("table", table)
                 .add("family", family)

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricCacheKey.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricCacheKey.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.index.metrics;
+
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.security.Authorizations;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+/**
+ * Key used to retrieve metrics from {@link MetricsStorage}, used by {@link com.facebook.presto.accumulo.index.ColumnCardinalityCache}
+ * to locally cache entries retrieved from the external source.
+ */
+public class MetricCacheKey
+{
+    public final MetricsStorage storage;
+    public final String schema;
+    public final String table;
+    public final String family;
+    public final Optional<String> qualifier;
+    public final boolean truncateTimestamps;
+    public final Authorizations auths;
+    public final Range range;
+
+    /**
+     * Creates a new instance of a MetricCacheKey
+     *
+     * @param schema Schema name
+     * @param table Table name
+     * @param family Column family
+     * @param qualifier Column qualifier
+     * @param truncateTimestamps True if timestamps are truncated AND this is a Timestamp type, false otherwise
+     * @param auths Authorizations for this metric
+     * @param range Range representing the cell value
+     */
+    public MetricCacheKey(MetricsStorage storage, String schema, String table, String family, String qualifier, boolean truncateTimestamps, Authorizations auths, Range range)
+    {
+        this.storage = storage;
+        this.schema = schema;
+        this.table = table;
+        this.family = family;
+        this.qualifier = Optional.ofNullable(qualifier);
+        this.truncateTimestamps = truncateTimestamps;
+        this.auths = auths;
+        this.range = range;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(schema, table, family, qualifier, truncateTimestamps, auths, range);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        MetricCacheKey other = (MetricCacheKey) obj;
+        return Objects.equals(this.range, other.range)
+                && Objects.equals(this.schema, other.schema)
+                && Objects.equals(this.table, other.table)
+                && Objects.equals(this.family, other.family)
+                && Objects.equals(this.truncateTimestamps, other.truncateTimestamps)
+                && Objects.equals(this.auths, other.auths)
+                && Objects.equals(this.qualifier, other.qualifier);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("schema", schema)
+                .add("table", table)
+                .add("family", family)
+                .add("qualifier", qualifier)
+                .add("truncateTimestamps", truncateTimestamps)
+                .add("auths", auths)
+                .add("range", range)
+                .toString();
+    }
+}

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsReader.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsReader.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.index.metrics;
+
+import com.facebook.presto.accumulo.conf.AccumuloConfig;
+import com.facebook.presto.accumulo.index.Indexer;
+import com.facebook.presto.spi.PrestoException;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.hadoop.io.Text;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.METRICS_TABLE_ROWS_COLUMN;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.METRICS_TABLE_ROW_ID;
+import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Abstract class used to read metrics regarding the table index.
+ */
+public abstract class MetricsReader
+        implements AutoCloseable
+{
+    private static final Range METRICS_TABLE_ROWID_RANGE = new Range(new Text(METRICS_TABLE_ROW_ID.array()));
+    private static final String METRICS_TABLE_ROWS_COLUMN_STRING = new String(METRICS_TABLE_ROWS_COLUMN.array(), UTF_8);
+    private static final Authorizations EMPTY_AUTHS = new Authorizations();
+
+    protected MetricsStorage metricsStorage;
+
+    public MetricsReader(MetricsStorage storage)
+    {
+        this.metricsStorage = requireNonNull(storage, "storage is null");
+    }
+
+    /**
+     * Gets the number of rows for the given table based on the user authorizations
+     *
+     * @param schema Schema name
+     * @param table Table name
+     * @return Number of rows in the given table
+     */
+    public long getNumRowsInTable(String schema, String table)
+            throws Exception
+    {
+        return getCardinality(new MetricCacheKey(metricsStorage, schema, table, METRICS_TABLE_ROWS_COLUMN_STRING, null, false, EMPTY_AUTHS, METRICS_TABLE_ROWID_RANGE));
+    }
+
+    /**
+     * Gets the number of rows in the table where a column contains a specific value,
+     * based on the data in the given {@link MetricCacheKey}.
+     * <p>
+     * Implementations must account for both exact and non-exact Accumulo Range objects.
+     *
+     * @param key Metric key
+     * @return Cardinality of the given value/column combination
+     */
+    public abstract long getCardinality(MetricCacheKey key)
+            throws Exception;
+
+    /**
+     * Gets the number of rows in the table where a column contains a specific value,
+     * based on the data in the given collection of {@link MetricCacheKey}.  All Range objects
+     * in the collection of keys contain <b>exact</b> Accumulo Range objects, i.e. they are a
+     * single value (vs. a range of values).
+     * <p>
+     * Note that the returned map <b>must</b> contain an entry for each key in the given collection.
+     *
+     * @param keys Collection of metric keys
+     * @return A map containing the cardinality
+     */
+    public abstract Map<MetricCacheKey, Long> getCardinalities(Collection<MetricCacheKey> keys)
+            throws Exception;
+
+    /**
+     * Gets any key from the given non-empty collection, validating that all other keys
+     * in the collection are the same (except for the Range in the key).
+     * <p>
+     * In order to simplify the implementation of {@link MetricsReader#getCardinalities}, we are making a (safe) assumption
+     * that the CacheKeys will all contain the same combination of schema/table/family/qualifier/authorizations.
+     *
+     * @param keys Non-empty collection of keys
+     * @return Any key
+     */
+    public MetricCacheKey getAnyKey(Collection<MetricCacheKey> keys)
+    {
+        MetricCacheKey anyKey = keys.stream().findAny().get();
+        keys.forEach(k -> {
+            if (!k.schema.equals(anyKey.schema) || !k.table.equals(anyKey.table) || !k.family.equals(anyKey.family) || !k.qualifier.equals(anyKey.qualifier) || !k.auths.equals(anyKey.auths)) {
+                throw new PrestoException(FUNCTION_IMPLEMENTATION_ERROR, "loadAll called with a non-homogeneous collection of cache keys");
+            }
+        });
+        return anyKey;
+    }
+
+    /**
+     * Gets the column family of the given cache key, accounting for the optional qualifier.
+     * <p>
+     * If qualifier is null, the key's column family is returned.  Else, the family is concatenated with the
+     * qualifier, split by an underscore, i.e. &lt;family&gt;_&lt;qualifier&gt;
+     *
+     * @param key Metric cache key
+     * @return Text object of the column family
+     */
+    public String getColumnFamily(MetricCacheKey key)
+    {
+        if (key.qualifier.isPresent()) {
+            return new String(Indexer.getIndexColumnFamily(key.family.getBytes(UTF_8), key.qualifier.get().getBytes(UTF_8)).array(), UTF_8);
+        }
+        else {
+            return key.family;
+        }
+    }
+}

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsReader.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsReader.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.accumulo.index.metrics;
 
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.index.Indexer;
 import com.facebook.presto.spi.PrestoException;
 import org.apache.accumulo.core.data.Range;

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsStorage.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsStorage.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.accumulo.index.metrics;
 
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.metadata.AccumuloTable;
 import com.facebook.presto.accumulo.serializers.LexicoderRowSerializer;
 import com.facebook.presto.spi.PrestoException;
@@ -65,7 +64,6 @@ public abstract class MetricsStorage
     public static final ByteBuffer METRICS_TABLE_ROW_ID = wrap("___METRICS_TABLE___".getBytes(UTF_8));
     public static final ByteBuffer METRICS_TABLE_ROWS_COLUMN = wrap("___rows___".getBytes(UTF_8));
 
-    protected final AccumuloConfig config;
     protected final Connector connector;
 
     private static final LexicoderRowSerializer SERIALIZER = new LexicoderRowSerializer();
@@ -75,18 +73,16 @@ public abstract class MetricsStorage
      * Gets the default implementation of {@link MetricsStorage}, {@link AccumuloMetricsStorage}
      *
      * @param connector Accumulo Connector
-     * @param config Connector configuration
      * @return The default implementation
      */
-    public static MetricsStorage getDefault(Connector connector, AccumuloConfig config)
+    public static MetricsStorage getDefault(Connector connector)
     {
-        return new AccumuloMetricsStorage(connector, config);
+        return new AccumuloMetricsStorage(connector);
     }
 
-    public MetricsStorage(Connector connector, AccumuloConfig config)
+    public MetricsStorage(Connector connector)
     {
         this.connector = requireNonNull(connector, "connector is null");
-        this.config = requireNonNull(config, "config is null");
     }
 
     /**

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsStorage.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsStorage.java
@@ -1,0 +1,374 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.index.metrics;
+
+import com.facebook.presto.accumulo.conf.AccumuloConfig;
+import com.facebook.presto.accumulo.metadata.AccumuloTable;
+import com.facebook.presto.accumulo.serializers.LexicoderRowSerializer;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+import io.airlift.log.Logger;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.io.Text;
+
+import java.nio.ByteBuffer;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Map;
+
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.DAY;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.HOUR;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.MILLISECOND;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.MINUTE;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.SECOND;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static java.lang.String.format;
+import static java.nio.ByteBuffer.wrap;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Abstract class for storing index metrics.  Implementors will be notified when they'll need to create
+ * a resource when a Presto table is created, dropped, or renamed.  Also contains functions to factory
+ * implementations of {@link MetricsWriter} and {@link MetricsReader}.
+ */
+public abstract class MetricsStorage
+{
+    public enum TimestampPrecision
+    {
+        MILLISECOND,
+        SECOND,
+        MINUTE,
+        HOUR,
+        DAY
+    }
+
+    public static final ByteBuffer METRICS_TABLE_ROW_ID = wrap("___METRICS_TABLE___".getBytes(UTF_8));
+    public static final ByteBuffer METRICS_TABLE_ROWS_COLUMN = wrap("___rows___".getBytes(UTF_8));
+
+    protected final AccumuloConfig config;
+    protected final Connector connector;
+
+    private static final LexicoderRowSerializer SERIALIZER = new LexicoderRowSerializer();
+    private static final Logger LOG = Logger.get(MetricsStorage.class);
+
+    /**
+     * Gets the default implementation of {@link MetricsStorage}, {@link AccumuloMetricsStorage}
+     *
+     * @param connector Accumulo Connector
+     * @param config Connector configuration
+     * @return The default implementation
+     */
+    public static MetricsStorage getDefault(Connector connector, AccumuloConfig config)
+    {
+        return new AccumuloMetricsStorage(connector, config);
+    }
+
+    public MetricsStorage(Connector connector, AccumuloConfig config)
+    {
+        this.connector = requireNonNull(connector, "connector is null");
+        this.config = requireNonNull(config, "config is null");
+    }
+
+    /**
+     * Gets a Boolean value indicating whether or not metric storage exists for the given Presto table
+     *
+     * @param table Presto table
+     * @return True if it exists, false otherwise
+     */
+    public abstract boolean exists(SchemaTableName table);
+
+    /**
+     * Create metric storage for the given Presto table.
+     * <p>
+     * This method must always succeed (barring any exception),
+     * i.e. if the metric storage already exists for the table, then do not
+     * attempt to re-create it or throw an exception.
+     *
+     * @param table Presto table
+     */
+    public abstract void create(AccumuloTable table);
+
+    /**
+     * Rename the metric storage for the 'old' Presto table to the new Presto table
+     *
+     * @param oldTable Previous table info
+     * @param newTable New table info
+     */
+    public abstract void rename(AccumuloTable oldTable, AccumuloTable newTable);
+
+    /**
+     * Drop metric storage for the given Presto table
+     * <p>
+     * This method must always succeed (barring any exception),
+     * i.e. if the metric storage does not exist for the table, then do nothing
+     * -- do not raise an exception.
+     *
+     * @param table Presto table
+     */
+    public abstract void drop(AccumuloTable table);
+
+    /**
+     * Creates a new instance of {@link MetricsWriter} for the given table
+     *
+     * @param table Presto table
+     * @return Metrics writer
+     */
+    public abstract MetricsWriter newWriter(AccumuloTable table);
+
+    /**
+     * Creates a new instance of {@link MetricsReader}
+     *
+     * @return Metrics reader
+     */
+    public abstract MetricsReader newReader();
+
+    public static Map<TimestampPrecision, Long> getTruncatedTimestamps(long value)
+    {
+        return ImmutableMap.of(
+                DAY, value / 86400000L * 86400000L,
+                HOUR, value / 3600000L * 3600000L,
+                MINUTE, value / 60000L * 60000L,
+                SECOND, value / 1000L * 1000L);
+    }
+
+    /**
+     * Gets a Boolean value indicating if the given Range is an exact value
+     *
+     * @param range Range to check
+     * @return True if exact, false otherwise
+     */
+    public static boolean isExact(Range range)
+    {
+        return !range.isInfiniteStartKey() && !range.isInfiniteStopKey()
+                && range.getStartKey().followingKey(PartialKey.ROW).equals(range.getEndKey());
+    }
+
+    public static Multimap<TimestampPrecision, Range> splitTimestampRange(Range value)
+    {
+        requireNonNull(value);
+
+        // Selfishly refusing to split any infinite-ended ranges
+        if (value.isInfiniteStopKey() || value.isInfiniteStartKey() || isExact(value)) {
+            return ImmutableMultimap.of(MILLISECOND, value);
+        }
+
+        Multimap<TimestampPrecision, Range> splitTimestampRange = MultimapBuilder.enumKeys(TimestampPrecision.class).arrayListValues().build();
+
+        Text text = new Text();
+        value.getStartKey().getRow(text);
+        boolean startKeyInclusive = text.getLength() == 9;
+        Timestamp startTime = new Timestamp(SERIALIZER.decode(TIMESTAMP, Arrays.copyOfRange(text.getBytes(), 0, 9)));
+
+        value.getEndKey().getRow(text);
+        Timestamp endTime = new Timestamp(SERIALIZER.decode(TIMESTAMP, Arrays.copyOfRange(text.getBytes(), 0, 9)));
+        boolean endKeyInclusive = text.getLength() == 10;
+        LOG.debug(format("Start: %s  %s  End: %s %s", startTime, startKeyInclusive, endTime, endKeyInclusive));
+        if (startTime.getTime() + 1000L > endTime.getTime()) {
+            LOG.debug(format("%s %s %s", MILLISECOND, new Timestamp(SERIALIZER.decode(TIMESTAMP, value.getStartKey().getRow().copyBytes())), new Timestamp(SERIALIZER.decode(TIMESTAMP, value.getEndKey().getRow().copyBytes()))));
+            return ImmutableMultimap.of(MILLISECOND, value);
+        }
+
+        Pair<TimestampPrecision, Timestamp> nextTime = Pair.of(getPrecision(startTime), startTime);
+        Pair<TimestampPrecision, Range> previousRange = null;
+
+        switch (nextTime.getLeft()) {
+            case MILLISECOND:
+                break;
+            case SECOND:
+                int compare = Long.compare(startTime.getTime() + 1000L, endTime.getTime());
+                if (compare < 0) {
+                    previousRange = Pair.of(SECOND, new Range(new Text(SERIALIZER.encode(TIMESTAMP, startTime.getTime()))));
+                }
+                break;
+            case MINUTE:
+                compare = Long.compare(startTime.getTime() + 60000L, endTime.getTime());
+                if (compare < 0) {
+                    previousRange = Pair.of(MINUTE, new Range(new Text(SERIALIZER.encode(TIMESTAMP, startTime.getTime()))));
+                }
+                else {
+                    previousRange = Pair.of(SECOND, new Range(new Text(SERIALIZER.encode(TIMESTAMP, startTime.getTime()))));
+                }
+                break;
+            case HOUR:
+                compare = Long.compare(startTime.getTime() + 3600000L, endTime.getTime());
+                if (compare < 0) {
+                    previousRange = Pair.of(HOUR, new Range(new Text(SERIALIZER.encode(TIMESTAMP, startTime.getTime()))));
+                }
+                else {
+                    previousRange = Pair.of(MINUTE, new Range(new Text(SERIALIZER.encode(TIMESTAMP, startTime.getTime()))));
+                }
+                break;
+            case DAY:
+                compare = Long.compare(startTime.getTime() + 86400000L, endTime.getTime());
+                if (compare < 0) {
+                    previousRange = Pair.of(DAY, new Range(new Text(SERIALIZER.encode(TIMESTAMP, startTime.getTime()))));
+                }
+                else {
+                    previousRange = Pair.of(HOUR, new Range(new Text(SERIALIZER.encode(TIMESTAMP, startTime.getTime()))));
+                }
+                break;
+        }
+
+        boolean cont = true;
+        do {
+            Pair<TimestampPrecision, Timestamp> prevTime = nextTime;
+            nextTime = getNextTimestamp(prevTime.getRight(), endTime);
+
+            Pair<TimestampPrecision, Range> nextRange;
+            if (prevTime.getLeft() == MILLISECOND && nextTime.getLeft() == MILLISECOND) {
+                nextRange = Pair.of(MILLISECOND, new Range(new Text(SERIALIZER.encode(TIMESTAMP, prevTime.getRight().getTime())), startKeyInclusive, new Text(SERIALIZER.encode(TIMESTAMP, nextTime.getRight().getTime())), true));
+            }
+            else if (nextTime.getLeft() == MILLISECOND) {
+                Pair<TimestampPrecision, Timestamp> followingTime = getNextTimestamp(nextTime.getRight(), endTime);
+                nextRange = Pair.of(MILLISECOND, new Range(new Text(SERIALIZER.encode(TIMESTAMP, nextTime.getRight().getTime())), true, new Text(SERIALIZER.encode(TIMESTAMP, followingTime.getRight().getTime())), endKeyInclusive));
+                cont = false;
+            }
+            else {
+                nextRange = Pair.of(nextTime.getLeft(), new Range(new Text(SERIALIZER.encode(TIMESTAMP, nextTime.getRight().getTime()))));
+            }
+
+            // Combine this range into previous range
+            if (previousRange != null) {
+                if (previousRange.getLeft().equals(nextRange.getLeft())) {
+                    previousRange = Pair.of(previousRange.getLeft(), new Range(
+                            previousRange.getRight().getStartKey(),
+                            previousRange.getRight().isStartKeyInclusive(),
+                            nextRange.getRight().getEndKey(),
+                            nextRange.getRight().isEndKeyInclusive()));
+                }
+                else {
+                    // Add range to map and roll over
+                    Timestamp s = new Timestamp(SERIALIZER.decode(TIMESTAMP, Arrays.copyOfRange(previousRange.getRight().getStartKey().getRow().getBytes(), 0, 9)));
+                    if (isExact(previousRange.getRight())) {
+                        LOG.debug(format("%s %s", previousRange.getLeft(), s));
+                    }
+                    else {
+                        Timestamp e = new Timestamp(SERIALIZER.decode(TIMESTAMP, Arrays.copyOfRange(previousRange.getRight().getEndKey().getRow().getBytes(), 0, 9)));
+                        LOG.debug(format("%s %s %s", previousRange.getLeft(), s, e));
+                    }
+
+                    splitTimestampRange.put(previousRange.getLeft(), previousRange.getRight());
+                    previousRange = nextRange;
+                }
+            }
+            else {
+                previousRange = nextRange;
+            }
+        }
+        while (cont && !nextTime.getRight().equals(endTime));
+
+        Timestamp s = new Timestamp(SERIALIZER.decode(TIMESTAMP, Arrays.copyOfRange(previousRange.getRight().getStartKey().getRow().getBytes(), 0, 9)));
+        if (isExact(previousRange.getRight())) {
+            LOG.debug(format("%s %s", previousRange.getLeft(), s));
+        }
+        else {
+            Timestamp e = new Timestamp(SERIALIZER.decode(TIMESTAMP, Arrays.copyOfRange(previousRange.getRight().getEndKey().getRow().getBytes(), 0, 9)));
+            LOG.debug(format("%s %s %s", previousRange.getLeft(), s, e));
+        }
+
+        splitTimestampRange.put(previousRange.getLeft(), previousRange.getRight());
+        return ImmutableMultimap.copyOf(splitTimestampRange);
+    }
+
+    private static Pair<TimestampPrecision, Timestamp> getNextTimestamp(Timestamp start, Timestamp end)
+    {
+        Timestamp nextTimestamp = advanceTimestamp(start, end);
+        TimestampPrecision nextPrecision = getPrecision(nextTimestamp);
+        if (nextTimestamp.equals(end)) {
+            return Pair.of(nextPrecision, nextTimestamp);
+        }
+
+        TimestampPrecision followingPrecision = getPrecision(advanceTimestamp(nextTimestamp, end));
+
+        int compare = nextPrecision.compareTo(followingPrecision);
+        if (compare == 0) {
+            return Pair.of(nextPrecision, nextTimestamp);
+        }
+        else if (compare < 0) {
+            return Pair.of(nextPrecision, nextTimestamp);
+        }
+        else {
+            return Pair.of(followingPrecision, nextTimestamp);
+        }
+    }
+
+    private static Timestamp advanceTimestamp(Timestamp start, Timestamp end)
+    {
+        switch (getPrecision(start)) {
+            case DAY:
+                long time = start.getTime() + 86400000L;
+                if (time < end.getTime()) {
+                    return new Timestamp(time);
+                }
+            case HOUR:
+                time = start.getTime() + 3600000L;
+                if (time < end.getTime()) {
+                    return new Timestamp(time);
+                }
+            case MINUTE:
+                time = start.getTime() + 60000L;
+                if (time < end.getTime()) {
+                    return new Timestamp(time);
+                }
+            case SECOND:
+                time = start.getTime() + 1000L;
+                if (time < end.getTime()) {
+                    return new Timestamp(time);
+                }
+            case MILLISECOND:
+                if ((start.getTime() - 999L) % 1000 == 0) {
+                    return new Timestamp(Math.min(start.getTime() + 1, end.getTime()));
+                }
+                else {
+                    return new Timestamp(Math.min((start.getTime() / 1000L * 1000L) + 999L, end.getTime()));
+                }
+            default:
+                throw new PrestoException(NOT_FOUND, "Unknown precision:" + getPrecision(start));
+        }
+    }
+
+    private static TimestampPrecision getPrecision(Timestamp time)
+    {
+        if (time.getTime() % 1000 == 0) {
+            if (time.getTime() % 60000L == 0) {
+                if (time.getTime() % 3600000L == 0) {
+                    if (time.getTime() % 86400000L == 0) {
+                        return DAY;
+                    }
+                    else {
+                        return HOUR;
+                    }
+                }
+                else {
+                    return MINUTE;
+                }
+            }
+            else {
+                return SECOND;
+            }
+        }
+        else {
+            return MILLISECOND;
+        }
+    }
+}

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsWriter.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsWriter.java
@@ -168,11 +168,9 @@ public abstract class MetricsWriter
          */
         public CardinalityKey(ByteBuffer value, ByteBuffer column, ColumnVisibility visibility)
         {
-            requireNonNull(value, "value is null");
-            requireNonNull(column, "column is null");
+            this.value = requireNonNull(value, "value is null");
+            this.column = requireNonNull(column, "column is null");
             requireNonNull(visibility, "visibility is null");
-            this.value = value;
-            this.column = column;
             this.visibility = visibility.getExpression() != null ? visibility : EMPTY_VISIBILITY;
         }
 
@@ -225,7 +223,7 @@ public abstract class MetricsWriter
         public TimestampTruncateKey(TimestampPrecision level, ByteBuffer value, ByteBuffer column, ColumnVisibility visibility)
         {
             super(value, column, visibility);
-            this.level = requireNonNull(level);
+            this.level = requireNonNull(level, "level is null");
         }
 
         @Override

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsWriter.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsWriter.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.index.metrics;
+
+import com.facebook.presto.accumulo.conf.AccumuloConfig;
+import com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision;
+import com.facebook.presto.accumulo.metadata.AccumuloTable;
+import com.facebook.presto.accumulo.serializers.LexicoderRowSerializer;
+import org.apache.accumulo.core.security.ColumnVisibility;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.METRICS_TABLE_ROWS_COLUMN;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.METRICS_TABLE_ROW_ID;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.getTruncatedTimestamps;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.nio.ByteBuffer.wrap;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Abstract class used to write metrics regarding the table index.
+ * Implementors should respect column visibility labels for more fine-grained metrics
+ */
+public abstract class MetricsWriter
+        implements AutoCloseable
+{
+    protected final Map<CardinalityKey, AtomicLong> metrics = new HashMap<>();
+    protected final Map<TimestampTruncateKey, AtomicLong> timestampMetrics = new HashMap<>();
+    protected final AccumuloConfig config;
+    protected final AccumuloTable table;
+    protected final LexicoderRowSerializer serializer = new LexicoderRowSerializer();
+
+    private static final ColumnVisibility EMPTY_VISIBILITY = new ColumnVisibility();
+
+    /**
+     * Creates a new instance of {@link MetricsWriter}
+     *
+     * @param config Connector configuration
+     * @param table Accumulo table metadata for the writer
+     */
+    public MetricsWriter(AccumuloConfig config, AccumuloTable table)
+    {
+        this.config = requireNonNull(config, "config is null");
+        this.table = requireNonNull(table, "table is null");
+    }
+
+    /**
+     * Increment the number of rows in the table by one
+     */
+    public void incrementRowCount()
+    {
+        incrementCardinality(METRICS_TABLE_ROW_ID, METRICS_TABLE_ROWS_COLUMN, EMPTY_VISIBILITY, false);
+    }
+
+    /**
+     * Increment the cardinality of the given value and column, accounting for the visibility of the column
+     *
+     * @param value Cell's value
+     * @param column Column of the row
+     * @param visibility Row's visibility
+     * @param truncateTimestamp True if this column is a TIMESTAMP type AND truncate timestamps is enabled, otherwise false
+     */
+    public void incrementCardinality(ByteBuffer value, ByteBuffer column, ColumnVisibility visibility, boolean truncateTimestamp)
+    {
+        CardinalityKey key = new CardinalityKey(value, column, visibility);
+        AtomicLong count = metrics.get(key);
+        if (count == null) {
+            count = new AtomicLong(0);
+            metrics.put(key, count);
+        }
+
+        count.incrementAndGet();
+
+        if (truncateTimestamp) {
+            for (Entry<TimestampPrecision, Long> entry : getTruncatedTimestamps(serializer.decode(TIMESTAMP, value.array())).entrySet()) {
+                TimestampTruncateKey truncatedKey = new TimestampTruncateKey(entry.getKey(), wrap(serializer.encode(TIMESTAMP, entry.getValue())), column, visibility);
+                AtomicLong truncatedCount = timestampMetrics.get(truncatedKey);
+                if (truncatedCount == null) {
+                    truncatedCount = new AtomicLong(0);
+                    timestampMetrics.put(truncatedKey, truncatedCount);
+                }
+                truncatedCount.incrementAndGet();
+            }
+        }
+    }
+
+    /**
+     * Flush all current metrics
+     */
+    public abstract void flush();
+
+    /**
+     * Closes the writer
+     */
+    @Override
+    public void close()
+    {
+        flush();
+    }
+
+    protected static class CardinalityKey
+    {
+        public ByteBuffer value;
+        public ByteBuffer column;
+        public ColumnVisibility visibility;
+        private static final ColumnVisibility EMPTY_VISIBILITY = new ColumnVisibility();
+
+        /**
+         * Creates a new instance of {@link CardinalityKey}
+         *
+         * @param value The value of the cell
+         * @param column The column of the row
+         * @param visibility The column visibility
+         */
+        public CardinalityKey(ByteBuffer value, ByteBuffer column, ColumnVisibility visibility)
+        {
+            requireNonNull(value, "value is null");
+            requireNonNull(column, "column is null");
+            requireNonNull(visibility, "visibility is null");
+            this.value = value;
+            this.column = column;
+            this.visibility = visibility.getExpression() != null ? visibility : EMPTY_VISIBILITY;
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if ((obj == null) || (getClass() != obj.getClass())) {
+                return false;
+            }
+
+            CardinalityKey other = (CardinalityKey) obj;
+            return Objects.equals(this.value, other.value)
+                    && Objects.equals(this.column, other.column)
+                    && Objects.equals(this.visibility, other.visibility);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(value, column, visibility);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("value", new String(value.array(), UTF_8))
+                    .add("column", new String(column.array(), UTF_8))
+                    .add("visibility", visibility.toString())
+                    .toString();
+        }
+    }
+
+    protected static class TimestampTruncateKey
+            extends CardinalityKey
+    {
+        public TimestampPrecision level;
+
+        /**
+         * Creates a new instance of {@link TimestampTruncateKey}
+         *
+         * @param level Truncate level for this key
+         * @param value The value of the cell
+         * @param column The column of the row
+         * @param visibility The column visibility
+         */
+        public TimestampTruncateKey(TimestampPrecision level, ByteBuffer value, ByteBuffer column, ColumnVisibility visibility)
+        {
+            super(value, column, visibility);
+            this.level = requireNonNull(level);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if ((obj == null) || (getClass() != obj.getClass())) {
+                return false;
+            }
+
+            TimestampTruncateKey other = (TimestampTruncateKey) obj;
+            return Objects.equals(this.value, other.value)
+                    && Objects.equals(this.column, other.column)
+                    && Objects.equals(this.visibility, other.visibility)
+                    && Objects.equals(this.level, other.level);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(value, column, visibility);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("value", new String(value.array(), UTF_8))
+                    .add("column", new String(column.array(), UTF_8))
+                    .add("visibility", visibility.toString())
+                    .add("level", level.toString())
+                    .toString();
+        }
+    }
+}

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsWriter.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/metrics/MetricsWriter.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.accumulo.index.metrics;
 
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision;
 import com.facebook.presto.accumulo.metadata.AccumuloTable;
 import com.facebook.presto.accumulo.serializers.LexicoderRowSerializer;
@@ -44,7 +43,6 @@ public abstract class MetricsWriter
 {
     protected final Map<CardinalityKey, AtomicLong> metrics = new HashMap<>();
     protected final Map<TimestampTruncateKey, AtomicLong> timestampMetrics = new HashMap<>();
-    protected final AccumuloConfig config;
     protected final AccumuloTable table;
     protected final LexicoderRowSerializer serializer = new LexicoderRowSerializer();
 
@@ -53,12 +51,10 @@ public abstract class MetricsWriter
     /**
      * Creates a new instance of {@link MetricsWriter}
      *
-     * @param config Connector configuration
      * @param table Accumulo table metadata for the writer
      */
-    public MetricsWriter(AccumuloConfig config, AccumuloTable table)
+    public MetricsWriter(AccumuloTable table)
     {
-        this.config = requireNonNull(config, "config is null");
         this.table = requireNonNull(table, "table is null");
     }
 

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloPageSink.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloPageSink.java
@@ -15,6 +15,7 @@ package com.facebook.presto.accumulo.io;
 
 import com.facebook.presto.accumulo.Types;
 import com.facebook.presto.accumulo.index.Indexer;
+import com.facebook.presto.accumulo.index.metrics.MetricsWriter;
 import com.facebook.presto.accumulo.metadata.AccumuloTable;
 import com.facebook.presto.accumulo.model.AccumuloColumnHandle;
 import com.facebook.presto.accumulo.model.Field;
@@ -80,6 +81,7 @@ public class AccumuloPageSink
     private final BatchWriter writer;
     private final MultiTableBatchWriter multiTableBatchWriter;
     private final Optional<Indexer> indexer;
+    private final MetricsWriter metricsWriter;
     private final List<AccumuloColumnHandle> columns;
     private final int rowIdOrdinal;
     private long numRows;
@@ -114,14 +116,17 @@ public class AccumuloPageSink
 
             // If the table is indexed, create an instance of an Indexer, else empty
             if (table.isIndexed()) {
+                metricsWriter = table.getMetricsStorageInstance(connector, config).newWriter(table);
                 indexer = Optional.of(
                         new Indexer(
+                                config,
                                 connector.securityOperations().getUserAuthorizations(username),
                                 table,
                                 multiTableBatchWriter.getBatchWriter(table.getIndexTableName()),
-                                multiTableBatchWriter.getBatchWriter(table.getMetricsTableName())));
+                                metricsWriter));
             }
             else {
+                metricsWriter = null;
                 indexer = Optional.empty();
             }
         }
@@ -272,7 +277,8 @@ public class AccumuloPageSink
         try {
             // Done serializing rows, so flush and close all batch writers
             if (indexer.isPresent()) {
-                indexer.get().addMetricMutations();
+                // MetricsWriter is non-null if Indexer is present
+                metricsWriter.close();
             }
             multiTableBatchWriter.close();
         }
@@ -294,8 +300,8 @@ public class AccumuloPageSink
     {
         try {
             if (indexer.isPresent()) {
-                indexer.get().addMetricMutations();
                 // MetricsWriter is non-null if Indexer is present
+                metricsWriter.flush();
             }
             multiTableBatchWriter.flush();
         }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloPageSink.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloPageSink.java
@@ -13,54 +13,28 @@
  */
 package com.facebook.presto.accumulo.io;
 
-import com.facebook.presto.accumulo.Types;
-import com.facebook.presto.accumulo.index.Indexer;
-import com.facebook.presto.accumulo.index.metrics.MetricsWriter;
 import com.facebook.presto.accumulo.metadata.AccumuloTable;
 import com.facebook.presto.accumulo.model.AccumuloColumnHandle;
-import com.facebook.presto.accumulo.model.Field;
 import com.facebook.presto.accumulo.model.Row;
-import com.facebook.presto.accumulo.serializers.AccumuloRowSerializer;
 import com.facebook.presto.spi.ConnectorPageSink;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeUtils;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
-import org.apache.accumulo.core.client.BatchWriter;
-import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
-import org.apache.accumulo.core.client.MultiTableBatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Value;
-import org.apache.hadoop.io.Text;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.accumulo.AccumuloErrorCode.ACCUMULO_TABLE_DNE;
 import static com.facebook.presto.accumulo.AccumuloErrorCode.UNEXPECTED_ACCUMULO_ERROR;
-import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
-import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
-import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
-import static com.facebook.presto.spi.type.DateType.DATE;
-import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
-import static com.facebook.presto.spi.type.IntegerType.INTEGER;
-import static com.facebook.presto.spi.type.RealType.REAL;
-import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
-import static com.facebook.presto.spi.type.TimeType.TIME;
-import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
-import static com.facebook.presto.spi.type.TinyintType.TINYINT;
-import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -76,161 +50,31 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 public class AccumuloPageSink
         implements ConnectorPageSink
 {
-    public static final Text ROW_ID_COLUMN = new Text("___ROW___");
-    private final AccumuloRowSerializer serializer;
-    private final BatchWriter writer;
-    private final MultiTableBatchWriter multiTableBatchWriter;
-    private final Optional<Indexer> indexer;
-    private final MetricsWriter metricsWriter;
+    private final PrestoBatchWriter batchWriter;
     private final List<AccumuloColumnHandle> columns;
-    private final int rowIdOrdinal;
     private long numRows;
 
     public AccumuloPageSink(
             Connector connector,
             AccumuloTable table,
+            Authorizations auths,
             String username)
     {
+        requireNonNull(connector, "connector is null");
+        requireNonNull(config, "config is null");
+        requireNonNull(auths, "auths is null");
         requireNonNull(table, "table is null");
 
         this.columns = table.getColumns();
 
-        // Fetch the row ID ordinal, throwing an exception if not found for safety
-        Optional<Integer> ordinal = columns.stream()
-                .filter(columnHandle -> columnHandle.getName().equals(table.getRowId()))
-                .map(AccumuloColumnHandle::getOrdinal)
-                .findAny();
-
-        if (!ordinal.isPresent()) {
-            throw new PrestoException(FUNCTION_IMPLEMENTATION_ERROR, "Row ID ordinal not found");
-        }
-
-        this.rowIdOrdinal = ordinal.get();
-        this.serializer = table.getSerializerInstance();
-
         try {
-            // Create a BatchWriter to the Accumulo table
-            BatchWriterConfig conf = new BatchWriterConfig();
-            multiTableBatchWriter = connector.createMultiTableBatchWriter(conf);
-            writer = multiTableBatchWriter.getBatchWriter(table.getFullTableName());
-
-            // If the table is indexed, create an instance of an Indexer, else empty
-            if (table.isIndexed()) {
-                metricsWriter = table.getMetricsStorageInstance(connector, config).newWriter(table);
-                indexer = Optional.of(
-                        new Indexer(
-                                config,
-                                connector.securityOperations().getUserAuthorizations(username),
-                                table,
-                                multiTableBatchWriter.getBatchWriter(table.getIndexTableName()),
-                                metricsWriter));
-            }
-            else {
-                metricsWriter = null;
-                indexer = Optional.empty();
-            }
+            this.batchWriter = new PrestoBatchWriter(connector, config, auths, table);
         }
         catch (AccumuloException | AccumuloSecurityException e) {
-            throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Accumulo error when creating BatchWriter and/or Indexer", e);
+            throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Accumulo error when creating PrestoBatchWriter", e);
         }
         catch (TableNotFoundException e) {
-            throw new PrestoException(ACCUMULO_TABLE_DNE, "Accumulo error when creating BatchWriter and/or Indexer, table does not exist", e);
-        }
-    }
-
-    /**
-     * Converts a {@link Row} to an Accumulo mutation.
-     *
-     * @param row Row object
-     * @param rowIdOrdinal Ordinal in the list of columns that is the row ID. This isn't checked at all, so I hope you're right. Also, it is expected that the list of column handles is sorted in ordinal order. This is a very demanding function.
-     * @param columns All column handles for the Row, sorted by ordinal.
-     * @param serializer Instance of {@link AccumuloRowSerializer} used to encode the values of the row to the Mutation
-     * @return Mutation
-     */
-    public static Mutation toMutation(Row row, int rowIdOrdinal, List<AccumuloColumnHandle> columns, AccumuloRowSerializer serializer)
-    {
-        // Set our value to the row ID
-        Text value = new Text();
-        Field rowField = row.getField(rowIdOrdinal);
-        if (rowField.isNull()) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Column mapped as the Accumulo row ID cannot be null");
-        }
-
-        setText(rowField, value, serializer);
-
-        // Iterate through all the column handles, setting the Mutation's columns
-        Mutation mutation = new Mutation(value);
-
-        // Store row ID in a special column
-        mutation.put(ROW_ID_COLUMN, ROW_ID_COLUMN, new Value(value.copyBytes()));
-        for (AccumuloColumnHandle columnHandle : columns) {
-            // Skip the row ID ordinal
-            if (columnHandle.getOrdinal() == rowIdOrdinal) {
-                continue;
-            }
-
-            // If the value of the field is not null
-            if (!row.getField(columnHandle.getOrdinal()).isNull()) {
-                // Serialize the value to the text
-                setText(row.getField(columnHandle.getOrdinal()), value, serializer);
-
-                // And add the bytes to the Mutation
-                mutation.put(columnHandle.getFamily().get(), columnHandle.getQualifier().get(), new Value(value.copyBytes()));
-            }
-        }
-
-        return mutation;
-    }
-
-    private static void setText(Field field, Text value, AccumuloRowSerializer serializer)
-    {
-        Type type = field.getType();
-        if (Types.isArrayType(type)) {
-            serializer.setArray(value, type, field.getArray());
-        }
-        else if (Types.isMapType(type)) {
-            serializer.setMap(value, type, field.getMap());
-        }
-        else {
-            if (type.equals(BIGINT)) {
-                serializer.setLong(value, field.getLong());
-            }
-            else if (type.equals(BOOLEAN)) {
-                serializer.setBoolean(value, field.getBoolean());
-            }
-            else if (type.equals(DATE)) {
-                serializer.setDate(value, field.getDate());
-            }
-            else if (type.equals(DOUBLE)) {
-                serializer.setDouble(value, field.getDouble());
-            }
-            else if (type.equals(INTEGER)) {
-                serializer.setInt(value, field.getInt());
-            }
-            else if (type.equals(REAL)) {
-                serializer.setFloat(value, field.getFloat());
-            }
-            else if (type.equals(SMALLINT)) {
-                serializer.setShort(value, field.getShort());
-            }
-            else if (type.equals(TIME)) {
-                serializer.setTime(value, field.getTime());
-            }
-            else if (type.equals(TINYINT)) {
-                serializer.setByte(value, field.getByte());
-            }
-            else if (type.equals(TIMESTAMP)) {
-                serializer.setTimestamp(value, field.getTimestamp());
-            }
-            else if (type.equals(VARBINARY)) {
-                serializer.setVarbinary(value, field.getVarbinary());
-            }
-            else if (type instanceof VarcharType) {
-                serializer.setVarchar(value, field.getVarchar());
-            }
-            else {
-                throw new UnsupportedOperationException("Unsupported type " + type);
-            }
+            throw new PrestoException(ACCUMULO_TABLE_DNE, "Accumulo error when creating PrestoBatchWriter, table does not exist", e);
         }
     }
 
@@ -250,21 +94,15 @@ public class AccumuloPageSink
             }
 
             try {
-                // Convert row to a Mutation, writing and indexing it
-                Mutation mutation = toMutation(row, rowIdOrdinal, columns, serializer);
-                writer.addMutation(mutation);
-                if (indexer.isPresent()) {
-                    indexer.get().index(mutation);
+                batchWriter.addRow(row);
+
+                // TODO Fix arbitrary flush every 100k rows
+                if (++numRows % 100_000 == 0) {
+                    batchWriter.flush();
                 }
-                ++numRows;
             }
             catch (MutationsRejectedException e) {
-                throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Mutation rejected by server", e);
-            }
-
-            // TODO Fix arbitrary flush every 100k rows
-            if (numRows % 100_000 == 0) {
-                flush();
+                throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Mutation rejected by server on flush", e);
             }
         }
 
@@ -275,12 +113,7 @@ public class AccumuloPageSink
     public CompletableFuture<Collection<Slice>> finish()
     {
         try {
-            // Done serializing rows, so flush and close all batch writers
-            if (indexer.isPresent()) {
-                // MetricsWriter is non-null if Indexer is present
-                metricsWriter.close();
-            }
-            multiTableBatchWriter.close();
+            batchWriter.close();
         }
         catch (MutationsRejectedException e) {
             throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Mutation rejected by server on flush", e);
@@ -294,19 +127,5 @@ public class AccumuloPageSink
     public void abort()
     {
         getFutureValue(finish());
-    }
-
-    private void flush()
-    {
-        try {
-            if (indexer.isPresent()) {
-                // MetricsWriter is non-null if Indexer is present
-                metricsWriter.flush();
-            }
-            multiTableBatchWriter.flush();
-        }
-        catch (MutationsRejectedException e) {
-            throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Mutation rejected by server on flush", e);
-        }
     }
 }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloPageSink.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloPageSink.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.security.Authorizations;
 
 import java.util.Collection;
 import java.util.List;
@@ -57,18 +58,16 @@ public class AccumuloPageSink
     public AccumuloPageSink(
             Connector connector,
             AccumuloTable table,
-            Authorizations auths,
-            String username)
+            Authorizations auths)
     {
         requireNonNull(connector, "connector is null");
-        requireNonNull(config, "config is null");
         requireNonNull(auths, "auths is null");
         requireNonNull(table, "table is null");
 
         this.columns = table.getColumns();
 
         try {
-            this.batchWriter = new PrestoBatchWriter(connector, config, auths, table);
+            this.batchWriter = new PrestoBatchWriter(connector, auths, table);
         }
         catch (AccumuloException | AccumuloSecurityException e) {
             throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Accumulo error when creating PrestoBatchWriter", e);

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloPageSinkProvider.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloPageSinkProvider.java
@@ -62,7 +62,7 @@ public class AccumuloPageSinkProvider
     {
         try {
             AccumuloTableHandle tableHandle = checkType(outputTableHandle, AccumuloTableHandle.class, "tableHandle");
-            return new AccumuloPageSink(connector, config, connector.securityOperations().getUserAuthorizations(username), client.getTable(tableHandle.toSchemaTableName()));
+            return new AccumuloPageSink(connector, client.getTable(tableHandle.toSchemaTableName()), connector.securityOperations().getUserAuthorizations(username));
         }
         catch (AccumuloException | AccumuloSecurityException e) {
             throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Failed to get user authorizations for writing data. Configured Accumulo user must have super-user privileges", e);

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloPageSinkProvider.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloPageSinkProvider.java
@@ -20,12 +20,16 @@ import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorPageSink;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
 
 import javax.inject.Inject;
 
+import static com.facebook.presto.accumulo.AccumuloErrorCode.UNEXPECTED_ACCUMULO_ERROR;
 import static com.facebook.presto.accumulo.Types.checkType;
 import static java.util.Objects.requireNonNull;
 
@@ -54,9 +58,15 @@ public class AccumuloPageSinkProvider
 
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle)
+            throws PrestoException
     {
-        AccumuloTableHandle tableHandle = checkType(outputTableHandle, AccumuloTableHandle.class, "tableHandle");
-        return new AccumuloPageSink(connector, client.getTable(tableHandle.toSchemaTableName()), username);
+        try {
+            AccumuloTableHandle tableHandle = checkType(outputTableHandle, AccumuloTableHandle.class, "tableHandle");
+            return new AccumuloPageSink(connector, config, connector.securityOperations().getUserAuthorizations(username), client.getTable(tableHandle.toSchemaTableName()));
+        }
+        catch (AccumuloException | AccumuloSecurityException e) {
+            throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Failed to get user authorizations for writing data. Configured Accumulo user must have super-user privileges", e);
+        }
     }
 
     @Override

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Map.Entry;
 
 import static com.facebook.presto.accumulo.AccumuloErrorCode.IO_ERROR;
-import static com.facebook.presto.accumulo.io.AccumuloPageSink.ROW_ID_COLUMN;
+import static com.facebook.presto.accumulo.io.PrestoBatchWriter.ROW_ID_COLUMN;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
@@ -131,7 +131,7 @@ public class AccumuloRecordCursor
             }
         }
 
-        iterator = this.scanner.iterator();
+        iterator = new SortedEntryIterator(this.scanner.iterator());
     }
 
     @Override

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordSet.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordSet.java
@@ -59,18 +59,21 @@ public class AccumuloRecordSet
     private final AccumuloRowSerializer serializer;
     private final BatchScanner scanner;
     private final String rowIdName;
+    private final int bufferSize;
 
     public AccumuloRecordSet(
             Connector connector,
             ConnectorSession session,
             AccumuloSplit split,
             String username,
-            List<AccumuloColumnHandle> columnHandles)
+            List<AccumuloColumnHandle> columnHandles,
+            int bufferSize)
     {
         requireNonNull(session, "session is null");
         requireNonNull(split, "split is null");
         requireNonNull(username, "username is null");
         constraints = requireNonNull(split.getConstraints(), "constraints is null");
+        this.bufferSize = bufferSize;
 
         rowIdName = split.getRowId();
 
@@ -145,6 +148,6 @@ public class AccumuloRecordSet
     @Override
     public RecordCursor cursor()
     {
-        return new AccumuloRecordCursor(serializer, scanner, rowIdName, columnHandles, constraints);
+        return new AccumuloRecordCursor(serializer, scanner, rowIdName, columnHandles, constraints, bufferSize);
     }
 }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordSetProvider.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordSetProvider.java
@@ -46,6 +46,7 @@ public class AccumuloRecordSetProvider
     private final Connector connector;
     private final String connectorId;
     private final String username;
+    private final int bufferSize;
 
     @Inject
     public AccumuloRecordSetProvider(
@@ -56,6 +57,7 @@ public class AccumuloRecordSetProvider
         this.connector = requireNonNull(connector, "connector is null");
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
         this.username = requireNonNull(config, "config is null").getUsername();
+        this.bufferSize = config.getRecordCursorBufferSize();
     }
 
     @Override
@@ -75,6 +77,6 @@ public class AccumuloRecordSetProvider
         }
 
         // Return new record set
-        return new AccumuloRecordSet(connector, session, accSplit, username, handles.build());
+        return new AccumuloRecordSet(connector, session, accSplit, username, handles.build(), bufferSize);
     }
 }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/BoundedPriorityBlockingQueue.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/BoundedPriorityBlockingQueue.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.io;
+
+import javax.annotation.Nonnull;
+
+import java.util.AbstractQueue;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.PriorityQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class BoundedPriorityBlockingQueue<E>
+        extends AbstractQueue<E>
+        implements BlockingQueue<E>
+{
+    private final PriorityQueue<E> queue;
+    private final int maxCapacity;
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Condition notFull = lock.newCondition();
+    private final Condition notEmpty = lock.newCondition();
+
+    public BoundedPriorityBlockingQueue(int initialCapacity, Comparator<? super E> comparator, int maxCapacity)
+    {
+        queue = new PriorityQueue<>(initialCapacity, comparator);
+        this.maxCapacity = maxCapacity;
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<E> iterator()
+    {
+        lock.lock();
+        try {
+            return new PriorityQueue<>(queue).iterator();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public int size()
+    {
+        lock.lock();
+        try {
+            return queue.size();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public void put(E element)
+            throws InterruptedException
+    {
+        lock.lockInterruptibly();
+        try {
+            try {
+                while (queue.size() == maxCapacity) {
+                    notFull.await();
+                }
+            }
+            catch (InterruptedException e) {
+                notFull.signal();
+                throw e;
+            }
+            offer(element);
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean offer(E element, long timeout, @Nonnull TimeUnit unit)
+            throws InterruptedException
+    {
+        lock.lockInterruptibly();
+        try {
+            if (queue.size() < maxCapacity) {
+                return offer(element);
+            }
+            notEmpty.await(timeout, unit);
+            return offer(element);
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public E take()
+            throws InterruptedException
+    {
+        lock.lockInterruptibly();
+        try {
+            try {
+                while (queue.size() == 0) {
+                    notEmpty.await();
+                }
+            }
+            catch (InterruptedException e) {
+                notEmpty.signal();
+                throw e;
+            }
+            return poll();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public E poll(long timeout, @Nonnull TimeUnit unit)
+            throws InterruptedException
+    {
+        lock.lockInterruptibly();
+        try {
+            E element = poll();
+            if (element != null) {
+                return element;
+            }
+            notEmpty.await(timeout, unit);
+            return poll();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public int remainingCapacity()
+    {
+        lock.lock();
+        try {
+            return maxCapacity - queue.size();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public int drainTo(@Nonnull Collection<? super E> objects)
+    {
+        requireNonNull(objects, "objects is null");
+        checkArgument(objects != this, "collection cannot be 'this'");
+
+        lock.lock();
+        try {
+            int numAdded = 0;
+            while (size() > 0) {
+                objects.add(poll());
+                ++numAdded;
+            }
+            return numAdded;
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public int drainTo(@Nonnull Collection<? super E> objects, int maxElements)
+    {
+        requireNonNull(objects, "objects is null");
+        checkArgument(objects != this, "collection cannot be 'this'");
+
+        lock.lock();
+        try {
+            int numAdded = 0;
+            while (size() > 0 && numAdded < maxElements) {
+                objects.add(poll());
+                ++numAdded;
+            }
+            return numAdded;
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean offer(@Nonnull E element)
+    {
+        lock.lock();
+        try {
+            if (queue.size() == maxCapacity) {
+                return false;
+            }
+            queue.offer(element);
+            notEmpty.signal();
+            return true;
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public E poll()
+    {
+        lock.lock();
+        try {
+            E element = queue.poll();
+            if (element != null) {
+                notFull.signal();
+            }
+            return element;
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public E peek()
+    {
+        lock.lock();
+        try {
+            return queue.peek();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean contains(Object o)
+    {
+        lock.lock();
+        try {
+            return queue.contains(o);
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    @Nonnull
+    @Override
+    public <T> T[] toArray(@Nonnull T[] ts)
+    {
+        lock.lock();
+        try {
+            return queue.toArray(ts);
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        lock.lock();
+        try {
+            return queue.toString();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void clear()
+    {
+        lock.lock();
+        try {
+            queue.clear();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean remove(Object o)
+    {
+        lock.lock();
+        try {
+            return queue.remove(o);
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+}

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/PrestoBatchWriter.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/PrestoBatchWriter.java
@@ -1,0 +1,599 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.io;
+
+import com.facebook.presto.accumulo.Types;
+import com.facebook.presto.accumulo.conf.AccumuloConfig;
+import com.facebook.presto.accumulo.index.Indexer;
+import com.facebook.presto.accumulo.index.metrics.MetricsWriter;
+import com.facebook.presto.accumulo.metadata.AccumuloTable;
+import com.facebook.presto.accumulo.model.AccumuloColumnHandle;
+import com.facebook.presto.accumulo.model.Field;
+import com.facebook.presto.accumulo.model.Row;
+import com.facebook.presto.accumulo.serializers.AccumuloRowSerializer;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.BatchScanner;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.MultiTableBatchWriter;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.user.WholeRowIterator;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.hadoop.io.Text;
+
+import java.io.IOException;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import static com.facebook.presto.accumulo.AccumuloErrorCode.INTERNAL_ERROR;
+import static com.facebook.presto.accumulo.AccumuloErrorCode.USER_ERROR;
+import static com.facebook.presto.accumulo.AccumuloErrorCode.VALIDATION;
+import static com.facebook.presto.accumulo.serializers.AccumuloRowSerializer.getBlockFromArray;
+import static com.facebook.presto.accumulo.serializers.AccumuloRowSerializer.getBlockFromMap;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimeType.TIME;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class has similar functionality to an Accumulo BatchWriter, but manages writing index entries
+ * as well as updating the metrics storage.  Supports adding, deleting, and updating rows.
+ */
+public class PrestoBatchWriter
+{
+    public static final Text ROW_ID_COLUMN = new Text("___ROW___");
+
+    private final AccumuloTable table;
+    private final Authorizations auths;
+    private final Connector connector;
+    private final MultiTableBatchWriter multiTableBatchWriter;
+    private final BatchWriter dataWriter;
+    private final Optional<Indexer> indexer;
+    private final Optional<MetricsWriter> metricsWriter;
+    private final List<AccumuloColumnHandle> columns;
+    private final AccumuloRowSerializer serializer;
+    private final int rowIdOrdinal;
+
+    /**
+     * Creates a new PrestoBatchWriter with the default BatchWriterConfig for the underlying MultiTableBatchWriter
+     *
+     * @param connector Accumulo Connector
+     * @param config Presto connector configuration
+     * @param auths Authorizations, used for updating/delete rows.  Expected to have super-user-like access to the data
+     * @param table Accumulo table to write Mutations
+     */
+    public PrestoBatchWriter(Connector connector, AccumuloConfig config, Authorizations auths, AccumuloTable table)
+            throws AccumuloException, AccumuloSecurityException, TableNotFoundException
+    {
+        this(connector, config, auths, table, new BatchWriterConfig());
+    }
+
+    /**
+     * Creates a new PrestoBatchWriter using the provided BatchWriterConfig
+     *
+     * @param connector Accumulo Connector
+     * @param config Presto connector configuration
+     * @param auths Authorizations, used for updating/delete rows.  Expected to have super-user-like access to the data
+     * @param table Accumulo table to write Mutations
+     * @param batchWriterConfig Configuration for the underlying MultiTableBatchWriter
+     */
+    public PrestoBatchWriter(Connector connector, AccumuloConfig config, Authorizations auths, AccumuloTable table, BatchWriterConfig batchWriterConfig)
+            throws AccumuloException, AccumuloSecurityException, TableNotFoundException
+    {
+        this(connector, config, auths, table, connector.createMultiTableBatchWriter(batchWriterConfig));
+    }
+
+    /**
+     * Creates a new PrestoBatchWriter using the provided MultiTableBatchWriter
+     *
+     * @param connector Accumulo Connector
+     * @param config Presto connector configuration
+     * @param auths Authorizations, used for updating/delete rows.  Expected to have super-user-like access to the data
+     * @param table Accumulo table to write Mutations
+     * @param multiTableBatchWriter MultiTableBatchWriter for writing mutations to
+     */
+    public PrestoBatchWriter(Connector connector, AccumuloConfig config, Authorizations auths, AccumuloTable table, MultiTableBatchWriter multiTableBatchWriter)
+            throws AccumuloException, AccumuloSecurityException, TableNotFoundException
+    {
+        this.connector = requireNonNull(connector, "connector is null");
+        requireNonNull(config, "config is null");
+        this.auths = requireNonNull(auths, "auths is null");
+        this.table = requireNonNull(table, "table is null");
+        this.multiTableBatchWriter = requireNonNull(multiTableBatchWriter, "multiTableBatchWriter is null");
+
+        dataWriter = multiTableBatchWriter.getBatchWriter(table.getFullTableName());
+        if (table.isIndexed()) {
+            metricsWriter = Optional.of(table.getMetricsStorageInstance(connector, config).newWriter(table));
+            indexer = Optional.of(new Indexer(connector, config, table, multiTableBatchWriter.getBatchWriter(table.getIndexTableName()), metricsWriter.get()));
+        }
+        else {
+            indexer = Optional.empty();
+            metricsWriter = Optional.empty();
+        }
+
+        this.columns = table.getColumns();
+
+        // Fetch the row ID ordinal, throwing an exception if not found for safety
+        Optional<Integer> ordinal = columns.stream()
+                .filter(columnHandle -> columnHandle.getName().equals(table.getRowId()))
+                .map(AccumuloColumnHandle::getOrdinal)
+                .findAny();
+
+        if (!ordinal.isPresent()) {
+            throw new PrestoException(INTERNAL_ERROR, "Row ID ordinal not found");
+        }
+
+        this.rowIdOrdinal = ordinal.get();
+        this.serializer = table.getSerializerInstance();
+    }
+
+    /**
+     * Add a {@link Row} to the table
+     *
+     * @param row Row to write
+     */
+    public void addRow(Row row)
+            throws MutationsRejectedException
+    {
+        // Convert row to a Mutation, write, and index it
+        Mutation mutation = toMutation(row, rowIdOrdinal, columns, serializer);
+        dataWriter.addMutation(mutation);
+        if (indexer.isPresent()) {
+            indexer.get().index(mutation);
+        }
+    }
+
+    /**
+     * Add a {@link Row} to the table
+     *
+     * @param rows Rows to write
+     */
+    public void addRows(Iterable<Row> rows)
+            throws MutationsRejectedException
+    {
+        ImmutableList.Builder<Mutation> mutationBuilder = ImmutableList.builder();
+        rows.forEach(row -> mutationBuilder.add(toMutation(row, rowIdOrdinal, columns, serializer)));
+        addMutations(mutationBuilder.build());
+    }
+
+    /**
+     * Add a raw Mutation to the table
+     *
+     * @param mutation Mutation to write
+     */
+    public void addMutation(Mutation mutation)
+            throws MutationsRejectedException
+    {
+        dataWriter.addMutation(mutation);
+        if (indexer.isPresent()) {
+            indexer.get().index(mutation);
+        }
+    }
+
+    /**
+     * Add multiple Mutations to the table
+     *
+     * @param mutations Mutations to write
+     */
+    public void addMutations(Iterable<Mutation> mutations)
+            throws MutationsRejectedException
+    {
+        dataWriter.addMutations(mutations);
+        if (indexer.isPresent()) {
+            indexer.get().index(mutations);
+        }
+    }
+
+    /**
+     * Update the column of the row to the given value, identified by the Presto column name, using an empty column visibility.
+     * <p>
+     * This method will remove the existing entry, regardless of the new visibility (assuming the given authorizations are able to scan the entry)
+     *
+     * @param rowId Row ID, a Java object of the row value
+     * @param columnName Presto column name to update
+     * @param value New value of the row
+     */
+    public void updateColumnByName(Object rowId, String columnName, Object value)
+            throws MutationsRejectedException, TableNotFoundException
+    {
+        updateColumnByName(rowId, columnName, new ColumnVisibility(), value);
+    }
+
+    /**
+     * Update the column of the row to the given value, identified by the Presto column name, using the given visibility.
+     * <p>
+     * This method will remove the existing entry, regardless of the new visibility (assuming the given authorizations are able to scan the entry)
+     *
+     * @param rowId Row ID, a Java object of the row value
+     * @param columnName Presto column name to update
+     * @param visibility Column visibility of the new cell in the table
+     * @param value New value of the row
+     */
+    public void updateColumnByName(Object rowId, String columnName, ColumnVisibility visibility, Object value)
+            throws MutationsRejectedException, TableNotFoundException
+    {
+        Pair<String, String> column = findColumnFamilyQualifier(columnName);
+        updateColumn(rowId, column.getLeft(), column.getRight(), visibility, value);
+    }
+
+    /**
+     * Update all the given columns of the row to the given values, identified by the Presto column name.
+     * <p>
+     * This method will remove the existing entry, regardless of the new visibility (assuming the given authorizations are able to scan the entry)
+     *
+     * @param rowId Row ID, a Java object of the row value
+     * @param columnUpdates A map of Presto column name/visibility pairs to their new value
+     */
+    public void updateColumnByName(Object rowId, Map<Pair<String, ColumnVisibility>, Object> columnUpdates)
+            throws MutationsRejectedException, TableNotFoundException
+    {
+        ImmutableMap.Builder<Triple<String, String, ColumnVisibility>, Object> columnUpdateBuilder = ImmutableMap.builder();
+        columnUpdates.entrySet().forEach(entry -> {
+            Pair<String, String> column = findColumnFamilyQualifier(entry.getKey().getLeft());
+            columnUpdateBuilder.put(Triple.of(column.getLeft(), column.getRight(), entry.getKey().getRight()), entry.getValue());
+        });
+        updateColumns(rowId, columnUpdateBuilder.build());
+    }
+
+    /**
+     * Update the given column of the row to the given value, identified by the Accumulo column family/qualifier/visibility.
+     * <p>
+     * This method will remove the existing entry, regardless of the new visibility (assuming the given authorizations are able to scan the entry)
+     *
+     * @param rowId Row ID, a Java object of the row value
+     * @param family Accumulo column family
+     * @param qualifier Accumulo column qualifier
+     * @param visibility Accumulo column visibility
+     * @param value New value of the row
+     */
+    public void updateColumn(Object rowId, String family, String qualifier, ColumnVisibility visibility, Object value)
+            throws MutationsRejectedException, TableNotFoundException
+    {
+        updateColumns(rowId, ImmutableMap.of(Triple.of(family, qualifier, visibility), value));
+    }
+
+    /**
+     * Update all the given columns of the row to their mapped value, identified by the Accumulo column family/qualifier/visibility.
+     * <p>
+     * This method will remove the existing entry, regardless of the new visibility (assuming the given authorizations are able to scan the entry)
+     *
+     * @param rowId Row ID, a Java object of the row value
+     * @param columnUpdates A map of Accumulo column family/qualifier/visibility triples to their new value
+     */
+    public void updateColumns(Object rowId, Map<Triple<String, String, ColumnVisibility>, Object> columnUpdates)
+            throws MutationsRejectedException, TableNotFoundException
+    {
+        // Get Row ID
+        Text text = new Text();
+        byte[] rowBytes = setText(columns.get(rowIdOrdinal).getType(), rowId, text, serializer).copyBytes();
+
+        // Update index first, which uses the existing entry in the data table
+        if (indexer.isPresent()) {
+            indexer.get().update(rowBytes, columnUpdates, auths);
+        }
+
+        // Create delete mutation for data store
+        long deleteTimestamp = System.currentTimeMillis();
+        Scanner scanner = null;
+        try {
+            scanner = connector.createScanner(table.getFullTableName(), auths);
+            scanner.setRange(new Range(new Text(rowBytes)));
+            for (Triple<String, String, ColumnVisibility> column : columnUpdates.keySet()) {
+                scanner.fetchColumn(new Text(column.getLeft()), new Text(column.getMiddle()));
+            }
+
+            Mutation deleteMutation = new Mutation(rowBytes);
+            for (Entry<Key, Value> entry : scanner) {
+                deleteMutation.putDelete(entry.getKey().getColumnFamily(), entry.getKey().getColumnQualifier(), entry.getKey().getColumnVisibilityParsed(), deleteTimestamp);
+            }
+            dataWriter.addMutation(deleteMutation);
+        }
+        finally {
+            if (scanner != null) {
+                scanner.close();
+            }
+        }
+
+        // Create update mutation
+        long updateTimestamp = deleteTimestamp + 1;
+        Mutation updateMutation = new Mutation(rowBytes);
+        for (Entry<Triple<String, String, ColumnVisibility>, Object> entry : columnUpdates.entrySet()) {
+            Type type = findColumnHandle(Pair.of(entry.getKey().getLeft(), entry.getKey().getMiddle())).getType();
+
+            if (Types.isArrayType(type)) {
+                // Encode list as a Block
+                Value value = new Value(setText(type, getBlockFromArray(Types.getElementType(type), (List<?>) entry.getValue()), text, serializer).copyBytes());
+                updateMutation.put(entry.getKey().getLeft(), entry.getKey().getMiddle(), entry.getKey().getRight(), updateTimestamp, value);
+            }
+            else if (Types.isMapType(type)) {
+                // Encode map as a Block
+                Value value = new Value(setText(type, getBlockFromMap(type, (Map<?, ?>) entry.getValue()), text, serializer).copyBytes());
+                updateMutation.put(entry.getKey().getLeft(), entry.getKey().getMiddle(), entry.getKey().getRight(), updateTimestamp, value);
+            }
+            else {
+                Value value = new Value(setText(type, entry.getValue(), text, serializer).copyBytes());
+                updateMutation.put(entry.getKey().getLeft(), entry.getKey().getMiddle(), entry.getKey().getRight(), updateTimestamp, value);
+            }
+        }
+
+        // Update data table
+        dataWriter.addMutation(updateMutation);
+    }
+
+    /**
+     * Delete the row identifed by the given row ID, which is a Java object of the corresponding type.
+     * <p>
+     * If deleting multiple rows, use {@link PrestoBatchWriter#deleteRows(Iterable)} for more efficient deleting.
+     *
+     * @param rowId Identifier of the row
+     */
+    public void deleteRow(Object rowId)
+            throws MutationsRejectedException, TableNotFoundException
+    {
+        // Convert row to a Mutation, write it to Accumulo, and delete the index entries
+        byte[] rowBytes = setText(columns.get(rowIdOrdinal).getType(), rowId, new Text(), serializer).copyBytes();
+
+        long deleteTimestamp = System.currentTimeMillis();
+        Scanner scanner = null;
+        try {
+            scanner = connector.createScanner(table.getFullTableName(), auths);
+            scanner.setRange(new Range(new Text(rowBytes)));
+            Mutation deleteMutation = new Mutation(rowBytes);
+            for (Entry<Key, Value> entry : scanner) {
+                deleteMutation.putDelete(entry.getKey().getColumnFamily(), entry.getKey().getColumnQualifier(), entry.getKey().getColumnVisibilityParsed(), deleteTimestamp);
+            }
+            dataWriter.addMutation(deleteMutation);
+        }
+        finally {
+            if (scanner != null) {
+                scanner.close();
+            }
+        }
+
+        if (indexer.isPresent()) {
+            indexer.get().delete(auths, rowBytes);
+        }
+    }
+
+    /**
+     * Delete all rows by their Java object
+     *
+     * @param rowIds Row IDs, an iterable of Java objects which are the row values
+     */
+    public void deleteRows(Iterable<Object> rowIds)
+            throws MutationsRejectedException, TableNotFoundException
+    {
+        AccumuloColumnHandle rowIdColumn = columns.get(rowIdOrdinal);
+
+        long deleteTimestamp = System.currentTimeMillis();
+        BatchScanner scanner = null;
+        try {
+            scanner = connector.createBatchScanner(table.getFullTableName(), auths, 10);
+
+            ImmutableList.Builder<Range> rangeBuilder = ImmutableList.builder();
+            Text text = new Text();
+            rowIds.forEach(rowId -> {
+                setText(rowIdColumn.getType(), rowId, text, serializer);
+                rangeBuilder.add(new Range(text));
+            });
+            scanner.setRanges(rangeBuilder.build());
+
+            scanner.addScanIterator(new IteratorSetting(Integer.MAX_VALUE, WholeRowIterator.class));
+
+            ImmutableList.Builder<byte[]> rowIDsBuilder = ImmutableList.builder();
+            for (Entry<Key, Value> row : scanner) {
+                for (Entry<Key, Value> entry : WholeRowIterator.decodeRow(row.getKey(), row.getValue()).entrySet()) {
+                    Mutation deleteMutation = new Mutation(entry.getKey().getRow(text));
+                    rowIDsBuilder.add(text.copyBytes());
+
+                    deleteMutation.putDelete(entry.getKey().getColumnFamily(), entry.getKey().getColumnQualifier(), entry.getKey().getColumnVisibilityParsed(), deleteTimestamp);
+                    dataWriter.addMutation(deleteMutation);
+                }
+            }
+
+            // Delete index mutations
+            if (indexer.isPresent()) {
+                indexer.get().delete(auths, rowIDsBuilder.build());
+            }
+        }
+        catch (IOException e) {
+            throw new PrestoException(INTERNAL_ERROR, "Error decoding row", e);
+        }
+        finally {
+            if (scanner != null) {
+                scanner.close();
+            }
+        }
+    }
+
+    public void flush()
+            throws MutationsRejectedException
+    {
+        if (metricsWriter.isPresent()) {
+            metricsWriter.get().flush();
+        }
+        multiTableBatchWriter.flush();
+    }
+
+    public void close()
+            throws MutationsRejectedException
+    {
+        if (metricsWriter.isPresent()) {
+            metricsWriter.get().close();
+        }
+
+        multiTableBatchWriter.close();
+    }
+
+    /**
+     * Converts a {@link Row} to an Accumulo mutation.
+     *
+     * @param row Row object
+     * @param rowIdOrdinal Ordinal in the list of columns that is the row ID. This isn't checked at all, so I hope you're right. Also, it is expected that the list of column handles is sorted in ordinal order. This is a very demanding function.
+     * @param columns All column handles for the Row, sorted by ordinal.
+     * @param serializer Instance of {@link AccumuloRowSerializer} used to encode the values of the row to the Mutation
+     * @return Mutation
+     */
+    public static Mutation toMutation(Row row, int rowIdOrdinal, List<AccumuloColumnHandle> columns, AccumuloRowSerializer serializer)
+    {
+        // Set our value to the row ID
+        Text value = new Text();
+        Field rowField = row.getField(rowIdOrdinal);
+        if (rowField.isNull()) {
+            throw new PrestoException(VALIDATION, "Column mapped as the Accumulo row ID cannot be null");
+        }
+
+        setText(rowField.getType(), rowField.getObject(), value, serializer);
+
+        // Store row ID in a special column
+        Mutation mutation = new Mutation(value);
+        mutation.put(ROW_ID_COLUMN, ROW_ID_COLUMN, new Value(value.copyBytes()));
+
+        // Iterate through all the column handles, setting the Mutation's columns
+        for (AccumuloColumnHandle columnHandle : columns) {
+            // Skip the row ID column and null values
+            if (columnHandle.getOrdinal() == rowIdOrdinal || row.getField(columnHandle.getOrdinal()).isNull()) {
+                continue;
+            }
+
+            // Serialize the value to the text
+            Field field = row.getField(columnHandle.getOrdinal());
+            setText(field.getType(), field.getObject(), value, serializer);
+
+            // And add the bytes to the Mutation
+            mutation.put(columnHandle.getFamily().get(), columnHandle.getQualifier().get(), new Value(value.copyBytes()));
+        }
+
+        if (mutation.size() == 0) {
+            throw new PrestoException(INTERNAL_ERROR, "Mutation contains no updates");
+        }
+
+        return mutation;
+    }
+
+    private static Text setText(Type type, Object fieldValue, Text destination, AccumuloRowSerializer serializer)
+    {
+        if (Types.isArrayType(type)) {
+            serializer.setArray(destination, type, (Block) fieldValue);
+        }
+        else if (Types.isMapType(type)) {
+            serializer.setMap(destination, type, (Block) fieldValue);
+        }
+        else {
+            if (type.equals(BIGINT)) {
+                serializer.setLong(destination, (Long) fieldValue);
+            }
+            else if (type.equals(BOOLEAN)) {
+                serializer.setBoolean(destination, (Boolean) fieldValue);
+            }
+            else if (type.equals(DATE)) {
+                serializer.setDate(destination, (Date) fieldValue);
+            }
+            else if (type.equals(DOUBLE)) {
+                serializer.setDouble(destination, (Double) fieldValue);
+            }
+            else if (type.equals(INTEGER)) {
+                serializer.setInt(destination, (Integer) fieldValue);
+            }
+            else if (type.equals(REAL)) {
+                serializer.setFloat(destination, (Float) fieldValue);
+            }
+            else if (type.equals(SMALLINT)) {
+                serializer.setShort(destination, (Short) fieldValue);
+            }
+            else if (type.equals(TIME)) {
+                serializer.setTime(destination, (Time) fieldValue);
+            }
+            else if (type.equals(TINYINT)) {
+                serializer.setByte(destination, (Byte) fieldValue);
+            }
+            else if (type.equals(TIMESTAMP)) {
+                serializer.setTimestamp(destination, (Timestamp) fieldValue);
+            }
+            else if (type.equals(VARBINARY)) {
+                serializer.setVarbinary(destination, (byte[]) fieldValue);
+            }
+            else if (type instanceof VarcharType) {
+                serializer.setVarchar(destination, (String) fieldValue);
+            }
+            else {
+                throw new UnsupportedOperationException("Unsupported type " + type);
+            }
+        }
+
+        return destination;
+    }
+
+    private AccumuloColumnHandle findColumnHandle(Pair<String, String> familyQualifierPair)
+    {
+        Optional<AccumuloColumnHandle> column = columns.stream()
+                .filter(columnHandle -> columnHandle.getFamily().isPresent() && columnHandle.getQualifier().isPresent())
+                .filter(columnHandle -> columnHandle.getFamily().get().equals(familyQualifierPair.getLeft()) && columnHandle.getQualifier().get().equals(familyQualifierPair.getRight()))
+                .findAny();
+
+        if (column.isPresent()) {
+            return column.get();
+        }
+        else {
+            throw new PrestoException(USER_ERROR, "Given column does not exist for the table");
+        }
+    }
+
+    private Pair<String, String> findColumnFamilyQualifier(String name)
+    {
+        Optional<AccumuloColumnHandle> column = columns.stream().filter(columnHandle -> columnHandle.getName().equalsIgnoreCase(name)).findAny();
+        if (column.isPresent()) {
+            if (column.get().getFamily().isPresent() && column.get().getQualifier().isPresent()) {
+                return Pair.of(column.get().getFamily().get(), column.get().getQualifier().get());
+            }
+            else {
+                throw new PrestoException(USER_ERROR, "Column definition has no mapping for family and/or qualifier, is this column mapped to the row ID?");
+            }
+        }
+        else {
+            throw new PrestoException(USER_ERROR, "Given column name does not exist for the table");
+        }
+    }
+}

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/SortedEntryIterator.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/SortedEntryIterator.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.io;
+
+import com.facebook.presto.spi.PrestoException;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.facebook.presto.accumulo.AccumuloErrorCode.IO_ERROR;
+import static java.util.Objects.requireNonNull;
+
+public class SortedEntryIterator
+        implements Iterator<Entry<Key, Value>>
+{
+    public static final int FILL_SIZE = 10_000;
+    private final BlockingQueue<Entry<Key, Value>> orderedEntries = new BoundedPriorityBlockingQueue<>(FILL_SIZE, new KeyValueEntryComparator(), FILL_SIZE * 2);
+    private final AtomicBoolean finishedScan = new AtomicBoolean(false);
+
+    public SortedEntryIterator(Iterator<Entry<Key, Value>> parent)
+    {
+        requireNonNull(parent, "parent iterator is null");
+
+        // Begin reading from the parent iterator, adding entries to the queue
+        new Thread(() ->
+        {
+            while (parent.hasNext()) {
+                try {
+                    orderedEntries.put(parent.next());
+                }
+                catch (InterruptedException e) {
+                    Thread.interrupted();
+                    throw new PrestoException(IO_ERROR, "Received InterruptedException when adding an entry");
+                }
+            }
+
+            finishedScan.set(true);
+        }).start();
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        // Wait for the scan to finish or there are at least FILL_SIZE entries
+        // This will guarantee ordering of the last FILL_SIZE entries that were put in the queue
+        while (!finishedScan.get() && orderedEntries.size() < FILL_SIZE) {
+            try {
+                Thread.sleep(1);
+            }
+            catch (InterruptedException e) {
+                Thread.interrupted();
+            }
+        }
+
+        return !orderedEntries.isEmpty() || !finishedScan.get();
+    }
+
+    @Override
+    public Entry<Key, Value> next()
+    {
+        return orderedEntries.poll();
+    }
+
+    private static class KeyValueEntryComparator
+            implements Comparator<Entry<Key, Value>>
+    {
+        @Override
+        public int compare(Entry<Key, Value> o1, Entry<Key, Value> o2)
+        {
+            return o1.getKey().compareTo(o2.getKey());
+        }
+    }
+}

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/iterators/ValueSummingIterator.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/iterators/ValueSummingIterator.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.iterators;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.LongCombiner;
+import org.apache.accumulo.core.iterators.LongCombiner.Type;
+import org.apache.accumulo.core.iterators.OptionDescriber;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.TypedValueCombiner.Encoder;
+import org.apache.accumulo.core.iterators.WrappingIterator;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.apache.accumulo.core.iterators.LongCombiner.FIXED_LEN_ENCODER;
+import static org.apache.accumulo.core.iterators.LongCombiner.STRING_ENCODER;
+import static org.apache.accumulo.core.iterators.LongCombiner.VAR_LEN_ENCODER;
+
+/**
+ * An iterator the sums all values, ignoring the keys.  Uses {@link LongCombiner} encoders and expects an option for "type".
+ */
+public class ValueSummingIterator
+        extends WrappingIterator
+        implements OptionDescriber
+{
+    public static final String TYPE = "type";
+
+    private Encoder<Long> encoder = null;
+    private Key topKey = null;
+    private Value topValue = null;
+    private boolean hasTop = false;
+    private String type = null;
+    private long sum = 0;
+
+    /**
+     * A convenience method for setting the long encoding type.
+     *
+     * @param is IteratorSetting object to configure.
+     * @param type LongCombiner.Type specifying the encoding type.
+     */
+    public static void setEncodingType(IteratorSetting is, Type type)
+    {
+        is.addOption(TYPE, type.toString());
+    }
+
+    @Override
+    public void init(SortedKeyValueIterator<Key, Value> source, Map<String, String> options, IteratorEnvironment env)
+            throws IOException
+    {
+        super.init(source, options, env);
+        validateOptions(options);
+        sum = 0;
+        hasTop = false;
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive)
+            throws IOException
+    {
+        super.seek(range, columnFamilies, inclusive);
+
+        if (!super.hasTop()) {
+            return;
+        }
+
+        do {
+            topKey = super.getTopKey();
+            if (!topKey.isDeleted()) {
+                topValue = super.getTopValue();
+                sum += encoder.decode(super.getTopValue().get());
+            }
+            super.next();
+        }
+        while (super.hasTop());
+
+        topValue = new Value(encoder.encode(sum));
+        hasTop = true;
+    }
+
+    @Override
+    public boolean hasTop()
+    {
+        return hasTop;
+    }
+
+    @Override
+    public Key getTopKey()
+    {
+        return topKey;
+    }
+
+    @Override
+    public Value getTopValue()
+    {
+        return topValue;
+    }
+
+    @Override
+    public void next()
+            throws IOException
+    {
+        hasTop = false;
+        sum = 0;
+    }
+
+    @Override
+    public SortedKeyValueIterator<Key, Value> deepCopy(IteratorEnvironment env)
+    {
+        ValueSummingIterator iterator = new ValueSummingIterator();
+        iterator.encoder = encoder;
+        iterator.hasTop = true;
+        iterator.sum = sum;
+        iterator.type = type;
+
+        switch (Type.valueOf(type)) {
+            case VARLEN:
+                iterator.encoder = VAR_LEN_ENCODER;
+                break;
+            case FIXEDLEN:
+                iterator.encoder = FIXED_LEN_ENCODER;
+                break;
+            case STRING:
+                iterator.encoder = STRING_ENCODER;
+                break;
+        }
+
+        return iterator;
+    }
+
+    @Override
+    public OptionDescriber.IteratorOptions describeOptions()
+    {
+        OptionDescriber.IteratorOptions io = new IteratorOptions("keysummingcombiner", "LongCombiner can interpret Values as Longs in a variety of encodings (variable length, fixed length, or string) before combining", null, null);
+        io.addNamedOption(TYPE, "<VARLEN|FIXEDLEN|STRING>");
+        return io;
+    }
+
+    @Override
+    public boolean validateOptions(Map<String, String> options)
+    {
+        try {
+            this.type = options.get(TYPE);
+            if (type == null) {
+                throw new IllegalArgumentException("no type specified");
+            }
+
+            switch (Type.valueOf(type)) {
+                case VARLEN:
+                    this.encoder = VAR_LEN_ENCODER;
+                    break;
+                case FIXEDLEN:
+                    this.encoder = FIXED_LEN_ENCODER;
+                    break;
+                case STRING:
+                    this.encoder = STRING_ENCODER;
+                    break;
+            }
+        }
+        catch (Exception e) {
+            throw new IllegalArgumentException("bad encoder option", e);
+        }
+        return true;
+    }
+}

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/metadata/AccumuloTable.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/metadata/AccumuloTable.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.accumulo.metadata;
 
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.index.Indexer;
 import com.facebook.presto.accumulo.index.metrics.AccumuloMetricsStorage;
 import com.facebook.presto.accumulo.index.metrics.MetricsStorage;
@@ -199,14 +198,14 @@ public class AccumuloTable
     }
 
     @JsonIgnore
-    public MetricsStorage getMetricsStorageInstance(Connector connector, AccumuloConfig config)
+    public MetricsStorage getMetricsStorageInstance(Connector connector)
     {
         try {
-            return (MetricsStorage) Class.forName(metricsStorageClass.orElse(AccumuloMetricsStorage.class.getCanonicalName())).getConstructor(Connector.class, AccumuloConfig.class).newInstance(connector, config);
+            return (MetricsStorage) Class.forName(metricsStorageClass.orElse(AccumuloMetricsStorage.class.getCanonicalName())).getConstructor(Connector.class).newInstance(connector);
         }
         catch (ClassNotFoundException | IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException e) {
             e.printStackTrace();
-            throw new PrestoException(VALIDATION, "Configured metrics storage class not found", e);
+            throw new PrestoException(NOT_FOUND, "Configured metrics storage class not found", e);
         }
     }
 

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/AccumuloColumnConstraint.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/AccumuloColumnConstraint.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.accumulo.model;
 
 import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -28,6 +29,7 @@ public class AccumuloColumnConstraint
     private final String name;
     private final String family;
     private final String qualifier;
+    private final Type type;
     private final boolean indexed;
     private final Optional<Domain> domain;
 
@@ -36,12 +38,14 @@ public class AccumuloColumnConstraint
             @JsonProperty("name") String name,
             @JsonProperty("family") String family,
             @JsonProperty("qualifier") String qualifier,
+            @JsonProperty("type") Type type,
             @JsonProperty("domain") Optional<Domain> domain,
             @JsonProperty("indexed") boolean indexed)
     {
         this.name = requireNonNull(name, "name is null");
         this.family = requireNonNull(family, "family is null");
         this.qualifier = requireNonNull(qualifier, "qualifier is null");
+        this.type = requireNonNull(type, "type is null");
         this.indexed = requireNonNull(indexed, "indexed is null");
         this.domain = requireNonNull(domain, "domain is null");
     }
@@ -71,6 +75,12 @@ public class AccumuloColumnConstraint
     }
 
     @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
     public Optional<Domain> getDomain()
     {
         return domain;
@@ -79,7 +89,7 @@ public class AccumuloColumnConstraint
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, family, qualifier, domain, indexed);
+        return Objects.hash(name, family, qualifier, type, domain, indexed);
     }
 
     @Override
@@ -97,6 +107,7 @@ public class AccumuloColumnConstraint
         return Objects.equals(this.name, other.name)
                 && Objects.equals(this.family, other.family)
                 && Objects.equals(this.qualifier, other.qualifier)
+                && Objects.equals(this.type, other.type)
                 && Objects.equals(this.domain, other.domain)
                 && Objects.equals(this.indexed, other.indexed);
     }
@@ -108,6 +119,7 @@ public class AccumuloColumnConstraint
                 .add("name", this.name)
                 .add("family", this.family)
                 .add("qualifier", this.qualifier)
+                .add("type", this.type)
                 .add("indexed", this.indexed)
                 .add("domain", this.domain)
                 .toString();

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/AccumuloTableHandle.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/AccumuloTableHandle.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.accumulo.model;
 
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.index.metrics.AccumuloMetricsStorage;
 import com.facebook.presto.accumulo.index.metrics.MetricsStorage;
 import com.facebook.presto.accumulo.serializers.AccumuloRowSerializer;
@@ -137,13 +136,13 @@ public final class AccumuloTableHandle
     }
 
     @JsonIgnore
-    public MetricsStorage getMetricsStorageInstance(Connector connector, AccumuloConfig config)
+    public MetricsStorage getMetricsStorageInstance(Connector connector)
     {
         try {
-            return (MetricsStorage) Class.forName(metricsStorageClass).getConstructor(Connector.class, AccumuloConfig.class).newInstance(connector, config);
+            return (MetricsStorage) Class.forName(metricsStorageClass).getConstructor(Connector.class).newInstance(connector);
         }
         catch (ClassNotFoundException | IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException e) {
-            throw new PrestoException(VALIDATION, "Configured metrics storage class not found", e);
+            throw new PrestoException(NOT_FOUND, "Configured metrics storage class not found", e);
         }
     }
 

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/LexicoderRowSerializer.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/LexicoderRowSerializer.java
@@ -38,7 +38,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import static com.facebook.presto.accumulo.io.AccumuloPageSink.ROW_ID_COLUMN;
+import static com.facebook.presto.accumulo.io.PrestoBatchWriter.ROW_ID_COLUMN;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/StringRowSerializer.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/StringRowSerializer.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import static com.facebook.presto.accumulo.io.AccumuloPageSink.ROW_ID_COLUMN;
+import static com.facebook.presto.accumulo.io.PrestoBatchWriter.ROW_ID_COLUMN;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/AccumuloQueryRunner.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/AccumuloQueryRunner.java
@@ -166,7 +166,7 @@ public final class AccumuloQueryRunner
      *
      * @return Accumulo connector
      */
-    private static Connector getAccumuloConnector()
+    public static synchronized Connector getAccumuloConnector()
     {
         if (connector != null) {
             return connector;

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/AccumuloQueryRunner.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/AccumuloQueryRunner.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.accumulo;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.serializers.LexicoderRowSerializer;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.spi.PrestoException;
@@ -43,6 +42,12 @@ import java.util.Map;
 
 import static com.facebook.presto.accumulo.AccumuloErrorCode.MINI_ACCUMULO;
 import static com.facebook.presto.accumulo.AccumuloErrorCode.UNEXPECTED_ACCUMULO_ERROR;
+import static com.facebook.presto.accumulo.conf.AccumuloConfig.INSTANCE;
+import static com.facebook.presto.accumulo.conf.AccumuloConfig.PASSWORD;
+import static com.facebook.presto.accumulo.conf.AccumuloConfig.RECORD_CURSOR_BUFFER_SIZE;
+import static com.facebook.presto.accumulo.conf.AccumuloConfig.USERNAME;
+import static com.facebook.presto.accumulo.conf.AccumuloConfig.ZOOKEEPERS;
+import static com.facebook.presto.accumulo.conf.AccumuloConfig.ZOOKEEPER_METADATA_ROOT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
@@ -73,11 +78,12 @@ public final class AccumuloQueryRunner
         queryRunner.installPlugin(new AccumuloPlugin());
         Map<String, String> accumuloProperties =
                 ImmutableMap.<String, String>builder()
-                        .put(AccumuloConfig.INSTANCE, connector.getInstance().getInstanceName())
-                        .put(AccumuloConfig.ZOOKEEPERS, connector.getInstance().getZooKeepers())
-                        .put(AccumuloConfig.USERNAME, MAC_USER)
-                        .put(AccumuloConfig.PASSWORD, MAC_PASSWORD)
-                        .put(AccumuloConfig.ZOOKEEPER_METADATA_ROOT, "/presto-accumulo-test")
+                        .put(INSTANCE, connector.getInstance().getInstanceName())
+                        .put(ZOOKEEPERS, connector.getInstance().getZooKeepers())
+                        .put(USERNAME, MAC_USER)
+                        .put(PASSWORD, MAC_PASSWORD)
+                        .put(ZOOKEEPER_METADATA_ROOT, "/presto-accumulo-test")
+                        .put(RECORD_CURSOR_BUFFER_SIZE, "10000")
                         .build();
 
         queryRunner.createCatalog("accumulo", "accumulo", accumuloProperties);

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestSortedEntryIterator.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestSortedEntryIterator.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo;
+
+import com.facebook.presto.accumulo.io.SortedEntryIterator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.accumulo.core.client.lexicoder.IntegerLexicoder;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.io.Text;
+import org.testng.annotations.Test;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static com.facebook.presto.accumulo.io.SortedEntryIterator.FILL_SIZE;
+import static java.lang.Math.abs;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertFalse;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+public class TestSortedEntryIterator
+{
+    @Test
+    public void testEmpty()
+            throws Exception
+    {
+        assertScan(ImmutableList.of());
+    }
+
+    @Test
+    public void testNumEntriesIsFillSize()
+            throws Exception
+    {
+        List<Entry<Key, Value>> entries = new ArrayList<>();
+        for (int i = 0; i < FILL_SIZE; ++i) {
+            entries.add(new SimpleEntry<>(new Key(
+                    new Text(uuid()),
+                    new Text(uuid()),
+                    new Text(uuid()),
+                    new Text(uuid()),
+                    0L),
+                    new Value(uuid().getBytes(UTF_8))));
+        }
+
+        assertScan(entries);
+    }
+
+    @Test
+    public void testNumEntriesIsLessThanFillSize()
+            throws Exception
+    {
+        List<Entry<Key, Value>> entries = new ArrayList<>();
+        for (int i = 0; i < FILL_SIZE / 10; ++i) {
+            entries.add(new SimpleEntry<>(new Key(
+                    new Text(uuid()),
+                    new Text(uuid()),
+                    new Text(uuid()),
+                    new Text(uuid()),
+                    0L),
+                    new Value(uuid().getBytes(UTF_8))));
+        }
+
+        assertScan(entries);
+    }
+
+    @Test
+    public void testNumEntriesIsGreaterThanFillSize()
+            throws Exception
+    {
+        int numTasks = 10;
+        // Generate random data from ten threads
+        // Each thread generates keys that are increasing by row ID,
+        // simulating how a BatchScanner reads data from multiple threads
+        List<Entry<Key, Value>> entries = Collections.synchronizedList(new ArrayList<>());
+        ExecutorService service = MoreExecutors.getExitingExecutorService(
+                new ThreadPoolExecutor(
+                        numTasks,
+                        numTasks,
+                        0,
+                        SECONDS,
+                        new SynchronousQueue<>()
+                ));
+
+        for (Future<Void> task : service.invokeAll(Collections.nCopies(numTasks, new GenerateOrderedData(entries)))) {
+            task.get();
+        }
+
+        assertScan(entries);
+    }
+
+    private void assertScan(List<Entry<Key, Value>> entries)
+            throws Exception
+    {
+        SortedEntryIterator iterator = new SortedEntryIterator(entries.iterator());
+
+        if (entries.isEmpty()) {
+            assertFalse(iterator.hasNext());
+        }
+        else {
+            assertTrue(iterator.hasNext());
+            Entry<Key, Value> previousEntry = iterator.next();
+            long numEntries = 1;
+            while (iterator.hasNext()) {
+                Entry<Key, Value> entry = iterator.next();
+                assertTrue(
+                        format("Entries are not correctly ordered, %s %s", previousEntry, entry),
+                        previousEntry.getKey().compareTo(entry.getKey()) < 0);
+                ++numEntries;
+            }
+
+            assertEquals(entries.size(), numEntries);
+        }
+    }
+
+    private static class GenerateOrderedData
+            implements Callable<Void>
+    {
+        private final List<Entry<Key, Value>> entries;
+
+        public GenerateOrderedData(List<Entry<Key, Value>> entries)
+        {
+            this.entries = requireNonNull(entries, "entries is null");
+        }
+
+        @Override
+        public Void call()
+                throws Exception
+        {
+            // Append monotonically increasing rows to the given list
+            Random random = new Random();
+            IntegerLexicoder lexicoder = new IntegerLexicoder();
+            for (int i = 0; i < FILL_SIZE; ++i) {
+                entries.add(new SimpleEntry<>(new Key(
+                        new Text(lexicoder.encode(i)),
+                        new Text(uuid()),
+                        new Text(uuid()),
+                        new Text(uuid()),
+                        abs(random.nextLong())),
+                        new Value(uuid().getBytes(UTF_8))));
+            }
+            return null;
+        }
+    }
+
+    private static String uuid()
+    {
+        return randomUUID().toString();
+    }
+}

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestColumnCardinalityCache.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestColumnCardinalityCache.java
@@ -211,9 +211,7 @@ public class TestColumnCardinalityCache
             throws Exception
     {
         ColumnCardinalityCache cache = new ColumnCardinalityCache(CONFIG.getCardinalityCacheSize(), CONFIG.getCardinalityCacheExpiration());
-
-        Multimap<Long, AccumuloColumnConstraint> cardinalities =
-                cache.getCardinalities(SCHEMA, TABLE, ImmutableMultimap.of(), AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
+        Multimap<Long, AccumuloColumnConstraint> cardinalities = cache.getCardinalities(SCHEMA, TABLE, ImmutableMultimap.of(), AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
         assertEquals(cardinalities.size(), 0);
     }
 
@@ -248,11 +246,9 @@ public class TestColumnCardinalityCache
         ColumnCardinalityCache cache = new ColumnCardinalityCache(CONFIG.getCardinalityCacheSize(), CONFIG.getCardinalityCacheExpiration());
         Range range = Range.equal(DATE, tld("1998-01-01"));
         AccumuloColumnConstraint constraint = acc("receiptdate", DATE, Domain.create(ValueSet.ofRanges(range), false));
-        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
-                ImmutableMultimap.of(constraint, getRangeFromPrestoRange(range, SERIALIZER));
+        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints = ImmutableMultimap.of(constraint, getRangeFromPrestoRange(range, SERIALIZER));
 
-        Multimap<Long, AccumuloColumnConstraint> cardinalities =
-                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
+        Multimap<Long, AccumuloColumnConstraint> cardinalities = cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
         assertEquals(cardinalities.size(), 1);
 
         Collection<AccumuloColumnConstraint> card = cardinalities.get(29L);
@@ -270,11 +266,11 @@ public class TestColumnCardinalityCache
         Range range2 = Range.equal(DATE, tld("1998-01-02"));
         AccumuloColumnConstraint constraint = acc("receiptdate", DATE, Domain.create(ValueSet.ofRanges(range1, range2), false));
         Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
-                ImmutableMultimap.of(constraint, getRangeFromPrestoRange(range1, SERIALIZER),
+                ImmutableMultimap.of(
+                        constraint, getRangeFromPrestoRange(range1, SERIALIZER),
                         constraint, getRangeFromPrestoRange(range2, SERIALIZER));
 
-        Multimap<Long, AccumuloColumnConstraint> cardinalities =
-                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
+        Multimap<Long, AccumuloColumnConstraint> cardinalities = cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
         assertEquals(cardinalities.size(), 1);
 
         Collection<AccumuloColumnConstraint> card = cardinalities.get(50L);
@@ -290,11 +286,9 @@ public class TestColumnCardinalityCache
         ColumnCardinalityCache cache = new ColumnCardinalityCache(CONFIG.getCardinalityCacheSize(), CONFIG.getCardinalityCacheExpiration());
         Range range = Range.range(DATE, tld("1998-01-01"), false, tld("1998-01-03"), false);
         AccumuloColumnConstraint constraint = acc("receiptdate", DATE, Domain.create(ValueSet.ofRanges(range), false));
-        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
-                ImmutableMultimap.of(constraint, getRangeFromPrestoRange(range, SERIALIZER));
+        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints = ImmutableMultimap.of(constraint, getRangeFromPrestoRange(range, SERIALIZER));
 
-        Multimap<Long, AccumuloColumnConstraint> cardinalities =
-                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
+        Multimap<Long, AccumuloColumnConstraint> cardinalities = cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
         assertEquals(cardinalities.size(), 1);
 
         Collection<AccumuloColumnConstraint> card = cardinalities.get(21L);
@@ -312,11 +306,11 @@ public class TestColumnCardinalityCache
         Range range2 = Range.range(DATE, tld("1998-01-10"), true, tld("1998-01-13"), true);
         AccumuloColumnConstraint constraint = acc("receiptdate", DATE, Domain.create(ValueSet.ofRanges(range1, range2), false));
         Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
-                ImmutableMultimap.of(constraint, getRangeFromPrestoRange(range1, SERIALIZER),
+                ImmutableMultimap.of(
+                        constraint, getRangeFromPrestoRange(range1, SERIALIZER),
                         constraint, getRangeFromPrestoRange(range2, SERIALIZER));
 
-        Multimap<Long, AccumuloColumnConstraint> cardinalities =
-                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
+        Multimap<Long, AccumuloColumnConstraint> cardinalities = cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
         assertEquals(cardinalities.size(), 1);
 
         Collection<AccumuloColumnConstraint> card = cardinalities.get(127L);
@@ -337,11 +331,11 @@ public class TestColumnCardinalityCache
         AccumuloColumnConstraint lnConstraint = acc("linenumber", INTEGER, Domain.create(ValueSet.ofRanges(lnRange), false));
 
         Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
-                ImmutableMultimap.of(rdConstraint, getRangeFromPrestoRange(rdRange, SERIALIZER),
+                ImmutableMultimap.of(
+                        rdConstraint, getRangeFromPrestoRange(rdRange, SERIALIZER),
                         lnConstraint, getRangeFromPrestoRange(lnRange, SERIALIZER));
 
-        Multimap<Long, AccumuloColumnConstraint> cardinalities =
-                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
+        Multimap<Long, AccumuloColumnConstraint> cardinalities = cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
         assertEquals(cardinalities.size(), 2);
 
         Iterator<Entry<Long, Collection<AccumuloColumnConstraint>>> iterator = cardinalities.asMap().entrySet().iterator();
@@ -373,13 +367,13 @@ public class TestColumnCardinalityCache
         AccumuloColumnConstraint lnConstraint = acc("linenumber", INTEGER, Domain.create(ValueSet.ofRanges(lnRange1, lnRange2), false));
 
         Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
-                ImmutableMultimap.of(rdConstraint, getRangeFromPrestoRange(rdRange1, SERIALIZER),
+                ImmutableMultimap.of(
+                        rdConstraint, getRangeFromPrestoRange(rdRange1, SERIALIZER),
                         rdConstraint, getRangeFromPrestoRange(rdRange2, SERIALIZER),
                         lnConstraint, getRangeFromPrestoRange(lnRange1, SERIALIZER),
                         lnConstraint, getRangeFromPrestoRange(lnRange2, SERIALIZER));
 
-        Multimap<Long, AccumuloColumnConstraint> cardinalities =
-                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
+        Multimap<Long, AccumuloColumnConstraint> cardinalities = cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
         assertEquals(cardinalities.size(), 2);
 
         Iterator<Entry<Long, Collection<AccumuloColumnConstraint>>> iterator = cardinalities.asMap().entrySet().iterator();
@@ -409,11 +403,11 @@ public class TestColumnCardinalityCache
         AccumuloColumnConstraint lnConstraint = acc("linenumber", INTEGER, Domain.create(ValueSet.ofRanges(lnRange), false));
 
         Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
-                ImmutableMultimap.of(rdConstraint, getRangeFromPrestoRange(rdRange, SERIALIZER),
+                ImmutableMultimap.of(
+                        rdConstraint, getRangeFromPrestoRange(rdRange, SERIALIZER),
                         lnConstraint, getRangeFromPrestoRange(lnRange, SERIALIZER));
 
-        Multimap<Long, AccumuloColumnConstraint> cardinalities =
-                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
+        Multimap<Long, AccumuloColumnConstraint> cardinalities = cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
         assertEquals(cardinalities.size(), 2);
 
         Iterator<Entry<Long, Collection<AccumuloColumnConstraint>>> iterator = cardinalities.asMap().entrySet().iterator();
@@ -445,13 +439,13 @@ public class TestColumnCardinalityCache
         AccumuloColumnConstraint lnConstraint = acc("linenumber", INTEGER, Domain.create(ValueSet.ofRanges(lnRange1, lnRange2), false));
 
         Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
-                ImmutableMultimap.of(rdConstraint, getRangeFromPrestoRange(rdRange1, SERIALIZER),
+                ImmutableMultimap.of(
+                        rdConstraint, getRangeFromPrestoRange(rdRange1, SERIALIZER),
                         rdConstraint, getRangeFromPrestoRange(rdRange2, SERIALIZER),
                         lnConstraint, getRangeFromPrestoRange(lnRange1, SERIALIZER),
                         lnConstraint, getRangeFromPrestoRange(lnRange2, SERIALIZER));
 
-        Multimap<Long, AccumuloColumnConstraint> cardinalities =
-                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
+        Multimap<Long, AccumuloColumnConstraint> cardinalities = cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
         assertEquals(cardinalities.size(), 2);
 
         Iterator<Entry<Long, Collection<AccumuloColumnConstraint>>> iterator = cardinalities.asMap().entrySet().iterator();
@@ -481,11 +475,11 @@ public class TestColumnCardinalityCache
         AccumuloColumnConstraint lnConstraint = acc("linenumber", INTEGER, Domain.create(ValueSet.ofRanges(lnRange), false));
 
         Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
-                ImmutableMultimap.of(rdConstraint, getRangeFromPrestoRange(rdRange, SERIALIZER),
+                ImmutableMultimap.of(
+                        rdConstraint, getRangeFromPrestoRange(rdRange, SERIALIZER),
                         lnConstraint, getRangeFromPrestoRange(lnRange, SERIALIZER));
 
-        Multimap<Long, AccumuloColumnConstraint> cardinalities =
-                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
+        Multimap<Long, AccumuloColumnConstraint> cardinalities = cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
         assertEquals(cardinalities.size(), 2);
 
         Iterator<Entry<Long, Collection<AccumuloColumnConstraint>>> iterator = cardinalities.asMap().entrySet().iterator();
@@ -546,11 +540,9 @@ public class TestColumnCardinalityCache
         Range range = Range.equal(VARCHAR, Slices.copiedBuffer("2", UTF_8));
         AccumuloColumnConstraint constraint = acc("b", VARCHAR, Domain.create(ValueSet.ofRanges(range), false));
 
-        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
-                ImmutableMultimap.of(constraint, getRangeFromPrestoRange(range, SERIALIZER));
+        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints = ImmutableMultimap.of(constraint, getRangeFromPrestoRange(range, SERIALIZER));
 
-        Multimap<Long, AccumuloColumnConstraint> cardinalities =
-                cache.getCardinalities(tableName.getSchemaName(), tableName.getTableName(), constraints, new Authorizations("private"), EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
+        Multimap<Long, AccumuloColumnConstraint> cardinalities = cache.getCardinalities(tableName.getSchemaName(), tableName.getTableName(), constraints, new Authorizations("private"), EARLY_RETURN_THRESHOLD, POLLING_DURATION, storage, false);
         assertEquals(cardinalities.size(), 1);
 
         Iterator<Entry<Long, Collection<AccumuloColumnConstraint>>> iterator = cardinalities.asMap().entrySet().iterator();

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestColumnCardinalityCache.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestColumnCardinalityCache.java
@@ -107,7 +107,7 @@ public class TestColumnCardinalityCache
 
         storage = MetricsStorage.getDefault(connector);
 
-        client = new AccumuloClient(connector, CONFIG, new ZooKeeperMetadataManager(CONFIG, new TypeRegistry()), new AccumuloTableManager(connector));
+        client = new AccumuloClient(connector, CONFIG, new ZooKeeperMetadataManager(CONFIG, new TypeRegistry()), new AccumuloTableManager(connector), new IndexLookup(connector, CONFIG));
         connector.securityOperations().changeUserAuthorizations("root", new Authorizations("private", "moreprivate", "foo", "bar", "xyzzy"));
         writeTestData();
     }

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestColumnCardinalityCache.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestColumnCardinalityCache.java
@@ -1,0 +1,507 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.index;
+
+import com.facebook.presto.accumulo.AccumuloClient;
+import com.facebook.presto.accumulo.conf.AccumuloConfig;
+import com.facebook.presto.accumulo.conf.AccumuloTableProperties;
+import com.facebook.presto.accumulo.io.AccumuloPageSink;
+import com.facebook.presto.accumulo.metadata.AccumuloTable;
+import com.facebook.presto.accumulo.model.AccumuloColumnConstraint;
+import com.facebook.presto.accumulo.model.AccumuloColumnHandle;
+import com.facebook.presto.accumulo.model.Row;
+import com.facebook.presto.accumulo.model.RowSchema;
+import com.facebook.presto.accumulo.serializers.AccumuloRowSerializer;
+import com.facebook.presto.accumulo.serializers.LexicoderRowSerializer;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.type.TypeRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import io.airlift.tpch.LineItem;
+import io.airlift.tpch.TpchColumn;
+import io.airlift.tpch.TpchTable;
+import io.airlift.units.Duration;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.lang.StringUtils;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.accumulo.AccumuloClient.getRangeFromPrestoRange;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.tpch.TpchMetadata.getPrestoType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+
+public class TestColumnCardinalityCache
+{
+    private static final AccumuloConfig CONFIG = new AccumuloConfig();
+    private static final BatchWriterConfig BWC = new BatchWriterConfig();
+    private static final String SCHEMA = "schema";
+    private static final String TABLE = TpchTable.LINE_ITEM.getTableName();
+    private static final Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> EMPTY_CONSTRAINTS = ImmutableMultimap.of();
+    private static final Authorizations AUTHS = new Authorizations();
+    private static final long EARLY_RETURN_THRESHOLD = 1000;
+    private static final Duration POLLING_DURATION = new Duration(1, TimeUnit.SECONDS);
+    private static final AccumuloRowSerializer SERIALIZER = new LexicoderRowSerializer();
+    private static final DateTimeFormatter DATE_FORMATTER = ISODateTimeFormat.date();
+
+    private final Connector connector;
+    private final AccumuloClient client;
+
+    public TestColumnCardinalityCache()
+            throws Exception
+    {
+        CONFIG.setUsername("root");
+        CONFIG.setMiniAccumuloCluster(true);
+        client = new AccumuloClient(CONFIG, new TypeRegistry());
+        connector = AccumuloClient.getAccumuloConnector(CONFIG);
+        writeTestData();
+    }
+
+    private RowSchema fromColumns(List<TpchColumn<LineItem>> columns)
+    {
+        RowSchema schema = new RowSchema();
+        schema.addColumn("UUID", Optional.empty(), Optional.empty(), VarcharType.VARCHAR);
+        for (TpchColumn<?> column : columns) {
+            schema.addColumn(column.getColumnName(), Optional.of(column.getColumnName()), Optional.of(column.getColumnName()), getPrestoType(column.getType()));
+        }
+        return schema;
+    }
+
+    private List<AccumuloColumnHandle> fromTpchColumns(List<TpchColumn<LineItem>> columns)
+    {
+        int ordinal = 0;
+        ImmutableList.Builder<AccumuloColumnHandle> builder = ImmutableList.builder();
+        builder.add(new AccumuloColumnHandle("UUID", Optional.empty(), Optional.empty(), VarcharType.VARCHAR, ordinal++, "", false));
+        for (TpchColumn<?> column : columns) {
+            builder.add(new AccumuloColumnHandle(column.getColumnName(), Optional.of(column.getColumnName()), Optional.of(column.getColumnName()), getPrestoType(column.getType()), ordinal++, "", true));
+        }
+        return builder.build();
+    }
+
+    private static ConnectorTableMetadata getTableMetadata(String schemaName, TpchTable<LineItem> tpchTable)
+    {
+        ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
+        for (TpchColumn<?> column : tpchTable.getColumns()) {
+            columns.add(new ColumnMetadata(column.getColumnName(), getPrestoType(column.getType())));
+        }
+
+        String indexColumns = StringUtils.join(tpchTable.getColumns().stream().map(TpchColumn::getColumnName).collect(Collectors.toList()), ",");
+        Map<String, Object> properties = new HashMap<>();
+        new AccumuloTableProperties().getTableProperties().forEach(meta -> properties.put(meta.getName(), meta.getDefaultValue()));
+        properties.put("index_columns", indexColumns);
+        SchemaTableName tableName = new SchemaTableName(schemaName, tpchTable.getTableName());
+        return new ConnectorTableMetadata(tableName, columns.build(), properties);
+    }
+
+    private void writeTestData()
+            throws Exception
+    {
+        AccumuloTable table = client.createTable(getTableMetadata(SCHEMA, TpchTable.LINE_ITEM));
+        RowSchema schema = fromColumns(TpchTable.LINE_ITEM.getColumns());
+
+        List<AccumuloColumnHandle> columns = fromTpchColumns(TpchTable.LINE_ITEM.getColumns());
+        AccumuloRowSerializer serializer = new LexicoderRowSerializer();
+        String indexTable = Indexer.getMetricsTableName(SCHEMA, TpchTable.LINE_ITEM.getTableName());
+        BatchWriter writer = connector.createBatchWriter(indexTable, BWC);
+        Indexer indexer = new Indexer(connector, AUTHS, table, BWC);
+
+        for (LineItem item : TpchTable.LINE_ITEM.createGenerator(.01f, 1, 1)) {
+            String line = item.toLine();
+            line = UUID.randomUUID() + "|" + item.toLine().substring(0, line.length() - 1);
+            Row row = Row.fromString(schema, line, '|');
+            Mutation data = AccumuloPageSink.toMutation(row, 0, columns, serializer);
+            writer.addMutation(data);
+            indexer.index(data);
+        }
+
+        indexer.close();
+        writer.close();
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullConnector()
+            throws Exception
+    {
+        new ColumnCardinalityCache(null, CONFIG);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullConfig()
+            throws Exception
+    {
+        new ColumnCardinalityCache(connector, null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullSchema()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        cache.getCardinalities(null, TABLE, EMPTY_CONSTRAINTS, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullTable()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        cache.getCardinalities(SCHEMA, null, EMPTY_CONSTRAINTS, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullConstraints()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        cache.getCardinalities(SCHEMA, TABLE, null, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+    }
+
+    @Test
+    public void testEmptyConstraints()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+
+        Multimap<Long, AccumuloColumnConstraint> cardinalities =
+                cache.getCardinalities(SCHEMA, TABLE, ImmutableMultimap.of(), AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+        assertEquals(cardinalities.size(), 0);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullAuths()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        cache.getCardinalities(SCHEMA, TABLE, EMPTY_CONSTRAINTS, null, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullDuration()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        cache.getCardinalities(SCHEMA, TABLE, EMPTY_CONSTRAINTS, AUTHS, EARLY_RETURN_THRESHOLD, null);
+    }
+
+    @Test
+    public void testExactRange()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        Range range = Range.equal(DATE, tld("1998-01-01"));
+        AccumuloColumnConstraint constraint = acc("receiptdate", Domain.create(ValueSet.ofRanges(range), false));
+        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
+                ImmutableMultimap.of(constraint, getRangeFromPrestoRange(range, SERIALIZER));
+
+        Multimap<Long, AccumuloColumnConstraint> cardinalities =
+                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+        assertEquals(cardinalities.size(), 1);
+
+        Collection<AccumuloColumnConstraint> card = cardinalities.get(29L);
+        assertNotNull(card);
+        assertEquals(card.size(), 1);
+        assertEquals(constraint, card.iterator().next());
+    }
+
+    @Test
+    public void testMultipleExactRanges()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        Range range1 = Range.equal(DATE, tld("1998-01-01"));
+        Range range2 = Range.equal(DATE, tld("1998-01-02"));
+        AccumuloColumnConstraint constraint = acc("receiptdate", Domain.create(ValueSet.ofRanges(range1, range2), false));
+        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
+                ImmutableMultimap.of(constraint, getRangeFromPrestoRange(range1, SERIALIZER),
+                        constraint, getRangeFromPrestoRange(range2, SERIALIZER));
+
+        Multimap<Long, AccumuloColumnConstraint> cardinalities =
+                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+        assertEquals(cardinalities.size(), 1);
+
+        Collection<AccumuloColumnConstraint> card = cardinalities.get(50L);
+        assertNotNull(card);
+        assertEquals(card.size(), 1);
+        assertEquals(constraint, card.iterator().next());
+    }
+
+    @Test
+    public void testRange()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        Range range = Range.range(DATE, tld("1998-01-01"), false, tld("1998-01-03"), false);
+        AccumuloColumnConstraint constraint = acc("receiptdate", Domain.create(ValueSet.ofRanges(range), false));
+        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
+                ImmutableMultimap.of(constraint, getRangeFromPrestoRange(range, SERIALIZER));
+
+        Multimap<Long, AccumuloColumnConstraint> cardinalities =
+                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+        assertEquals(cardinalities.size(), 1);
+
+        Collection<AccumuloColumnConstraint> card = cardinalities.get(21L);
+        assertNotNull(card);
+        assertEquals(card.size(), 1);
+        assertEquals(constraint, card.iterator().next());
+    }
+
+    @Test
+    public void testMultipleRanges()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        Range range1 = Range.range(DATE, tld("1998-01-01"), false, tld("1998-01-03"), false);
+        Range range2 = Range.range(DATE, tld("1998-01-10"), true, tld("1998-01-13"), true);
+        AccumuloColumnConstraint constraint = acc("receiptdate", Domain.create(ValueSet.ofRanges(range1, range2), false));
+        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
+                ImmutableMultimap.of(constraint, getRangeFromPrestoRange(range1, SERIALIZER),
+                        constraint, getRangeFromPrestoRange(range2, SERIALIZER));
+
+        Multimap<Long, AccumuloColumnConstraint> cardinalities =
+                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+        assertEquals(cardinalities.size(), 1);
+
+        Collection<AccumuloColumnConstraint> card = cardinalities.get(127L);
+        assertNotNull(card);
+        assertEquals(card.size(), 1);
+        assertEquals(constraint, card.iterator().next());
+    }
+
+    @Test
+    public void testManyColumnExactRange()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        Range rdRange = Range.equal(DATE, tld("1998-01-01"));
+        AccumuloColumnConstraint rdConstraint = acc("receiptdate", Domain.create(ValueSet.ofRanges(rdRange), false));
+
+        Range lnRange = Range.equal(INTEGER, 7L);
+        AccumuloColumnConstraint lnConstraint = acc("linenumber", Domain.create(ValueSet.ofRanges(lnRange), false));
+
+        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
+                ImmutableMultimap.of(rdConstraint, getRangeFromPrestoRange(rdRange, SERIALIZER),
+                        lnConstraint, getRangeFromPrestoRange(lnRange, SERIALIZER));
+
+        Multimap<Long, AccumuloColumnConstraint> cardinalities =
+                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+        assertEquals(cardinalities.size(), 2);
+
+        Iterator<Entry<Long, Collection<AccumuloColumnConstraint>>> iterator = cardinalities.asMap().entrySet().iterator();
+        Entry<Long, Collection<AccumuloColumnConstraint>> card = iterator.next();
+        assertNotNull(card);
+        assertEquals(card.getKey().longValue(), 29L);
+        assertEquals(card.getValue().size(), 1);
+        assertEquals(rdConstraint, card.getValue().iterator().next());
+
+        card = iterator.next();
+        assertNotNull(card);
+        assertEquals(card.getKey().longValue(), 2173L);
+        assertEquals(card.getValue().size(), 1);
+        assertEquals(lnConstraint, card.getValue().iterator().next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testManyColumnMultipleExactRanges()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        Range rdRange1 = Range.equal(DATE, tld("1998-01-01"));
+        Range rdRange2 = Range.equal(DATE, tld("1998-01-02"));
+        AccumuloColumnConstraint rdConstraint = acc("receiptdate", Domain.create(ValueSet.ofRanges(rdRange1, rdRange2), false));
+
+        Range lnRange1 = Range.equal(INTEGER, 7L);
+        Range lnRange2 = Range.equal(INTEGER, 6L);
+        AccumuloColumnConstraint lnConstraint = acc("linenumber", Domain.create(ValueSet.ofRanges(lnRange1, lnRange2), false));
+
+        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
+                ImmutableMultimap.of(rdConstraint, getRangeFromPrestoRange(rdRange1, SERIALIZER),
+                        rdConstraint, getRangeFromPrestoRange(rdRange2, SERIALIZER),
+                        lnConstraint, getRangeFromPrestoRange(lnRange1, SERIALIZER),
+                        lnConstraint, getRangeFromPrestoRange(lnRange2, SERIALIZER));
+
+        Multimap<Long, AccumuloColumnConstraint> cardinalities =
+                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+        assertEquals(cardinalities.size(), 2);
+
+        Iterator<Entry<Long, Collection<AccumuloColumnConstraint>>> iterator = cardinalities.asMap().entrySet().iterator();
+        Entry<Long, Collection<AccumuloColumnConstraint>> card = iterator.next();
+        assertNotNull(card);
+        assertEquals(card.getKey().longValue(), 50L);
+        assertEquals(card.getValue().size(), 1);
+        assertEquals(rdConstraint, card.getValue().iterator().next());
+
+        card = iterator.next();
+        assertNotNull(card);
+        assertEquals(card.getKey().longValue(), 6493L);
+        assertEquals(card.getValue().size(), 1);
+        assertEquals(lnConstraint, card.getValue().iterator().next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testManyColumnRange()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        Range rdRange = Range.range(DATE, tld("1998-01-01"), false, tld("1998-01-03"), false);
+        AccumuloColumnConstraint rdConstraint = acc("receiptdate", Domain.create(ValueSet.ofRanges(rdRange), false));
+
+        Range lnRange = Range.range(INTEGER, 6L, false, 8L, false);
+        AccumuloColumnConstraint lnConstraint = acc("linenumber", Domain.create(ValueSet.ofRanges(lnRange), false));
+
+        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
+                ImmutableMultimap.of(rdConstraint, getRangeFromPrestoRange(rdRange, SERIALIZER),
+                        lnConstraint, getRangeFromPrestoRange(lnRange, SERIALIZER));
+
+        Multimap<Long, AccumuloColumnConstraint> cardinalities =
+                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+        assertEquals(cardinalities.size(), 2);
+
+        Iterator<Entry<Long, Collection<AccumuloColumnConstraint>>> iterator = cardinalities.asMap().entrySet().iterator();
+        Entry<Long, Collection<AccumuloColumnConstraint>> card = iterator.next();
+        assertNotNull(card);
+        assertEquals(card.getKey().longValue(), 21L);
+        assertEquals(card.getValue().size(), 1);
+        assertEquals(rdConstraint, card.getValue().iterator().next());
+
+        card = iterator.next();
+        assertNotNull(card);
+        assertEquals(card.getKey().longValue(), 2173L);
+        assertEquals(card.getValue().size(), 1);
+        assertEquals(lnConstraint, card.getValue().iterator().next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testManyColumnMultipleRanges()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        Range rdRange1 = Range.range(DATE, tld("1998-01-01"), false, tld("1998-01-03"), false);
+        Range rdRange2 = Range.range(DATE, tld("1998-01-10"), true, tld("1998-01-13"), true);
+        AccumuloColumnConstraint rdConstraint = acc("receiptdate", Domain.create(ValueSet.ofRanges(rdRange1, rdRange2), false));
+
+        Range lnRange1 = Range.range(INTEGER, 6L, true, 8L, false);
+        Range lnRange2 = Range.range(INTEGER, 4L, false, 5L, true);
+        AccumuloColumnConstraint lnConstraint = acc("linenumber", Domain.create(ValueSet.ofRanges(lnRange1, lnRange2), false));
+
+        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
+                ImmutableMultimap.of(rdConstraint, getRangeFromPrestoRange(rdRange1, SERIALIZER),
+                        rdConstraint, getRangeFromPrestoRange(rdRange2, SERIALIZER),
+                        lnConstraint, getRangeFromPrestoRange(lnRange1, SERIALIZER),
+                        lnConstraint, getRangeFromPrestoRange(lnRange2, SERIALIZER));
+
+        Multimap<Long, AccumuloColumnConstraint> cardinalities =
+                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+        assertEquals(cardinalities.size(), 2);
+
+        Iterator<Entry<Long, Collection<AccumuloColumnConstraint>>> iterator = cardinalities.asMap().entrySet().iterator();
+        Entry<Long, Collection<AccumuloColumnConstraint>> card = iterator.next();
+        assertNotNull(card);
+        assertEquals(card.getKey().longValue(), 127);
+        assertEquals(card.getValue().size(), 1);
+        assertEquals(rdConstraint, card.getValue().iterator().next());
+
+        card = iterator.next();
+        assertNotNull(card);
+        assertEquals(card.getKey().longValue(), 12930L);
+        assertEquals(card.getValue().size(), 1);
+        assertEquals(lnConstraint, card.getValue().iterator().next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testManyColumnMixedRanges()
+            throws Exception
+    {
+        ColumnCardinalityCache cache = new ColumnCardinalityCache(connector, CONFIG);
+        Range rdRange = Range.range(DATE, tld("1970-01-01"), true, tld("2016-01-01"), true);
+        AccumuloColumnConstraint rdConstraint = acc("receiptdate", Domain.create(ValueSet.ofRanges(rdRange), false));
+
+        Range lnRange = Range.equal(INTEGER, 7L);
+        AccumuloColumnConstraint lnConstraint = acc("linenumber", Domain.create(ValueSet.ofRanges(lnRange), false));
+
+        Multimap<AccumuloColumnConstraint, org.apache.accumulo.core.data.Range> constraints =
+                ImmutableMultimap.of(rdConstraint, getRangeFromPrestoRange(rdRange, SERIALIZER),
+                        lnConstraint, getRangeFromPrestoRange(lnRange, SERIALIZER));
+
+        Multimap<Long, AccumuloColumnConstraint> cardinalities =
+                cache.getCardinalities(SCHEMA, TABLE, constraints, AUTHS, EARLY_RETURN_THRESHOLD, POLLING_DURATION);
+        assertEquals(cardinalities.size(), 2);
+
+        Iterator<Entry<Long, Collection<AccumuloColumnConstraint>>> iterator = cardinalities.asMap().entrySet().iterator();
+        Entry<Long, Collection<AccumuloColumnConstraint>> card = iterator.next();
+        assertNotNull(card);
+        assertEquals(card.getKey().longValue(), 2173L);
+        assertEquals(card.getValue().size(), 1);
+        assertEquals(lnConstraint, card.getValue().iterator().next());
+
+        card = iterator.next();
+        assertNotNull(card);
+        assertEquals(card.getKey().longValue(), 60169L);
+        assertEquals(card.getValue().size(), 1);
+        assertEquals(rdConstraint, card.getValue().iterator().next());
+        assertFalse(iterator.hasNext());
+    }
+
+    /**
+     * Converts the given date string to number of days as a long
+     *
+     * @param date
+     * @return Number of days as long
+     */
+    private static long tld(String date)
+    {
+        return TimeUnit.MILLISECONDS.toDays(DATE_FORMATTER.parseDateTime(date).getMillis());
+    }
+
+    /**
+     * Creates an AccumuloColumnConstraint from the given Presto column name and domain
+     *
+     * @param name Presto column name
+     * @param domain Presto Domain
+     * @return
+     */
+    private static AccumuloColumnConstraint acc(String name, Domain domain)
+    {
+        return new AccumuloColumnConstraint(name, name, name, Optional.of(domain), true);
+    }
+}

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestIndexer.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestIndexer.java
@@ -312,19 +312,19 @@ public class TestIndexer
 
     private static void assertKeyValuePair(Entry<Key, Value> e, byte[] row, String cf, String cq, String value)
     {
-        assertEquals(row, e.getKey().getRow().copyBytes());
-        assertEquals(cf, e.getKey().getColumnFamily().toString());
-        assertEquals(cq, e.getKey().getColumnQualifier().toString());
-        assertEquals(value, e.getValue().toString());
+        assertEquals(e.getKey().getRow().copyBytes(), row);
+        assertEquals(e.getKey().getColumnFamily().toString(), cf);
+        assertEquals(e.getKey().getColumnQualifier().toString(), cq);
+        assertEquals(e.getValue().toString(), value);
     }
 
     private static void assertKeyValuePair(Entry<Key, Value> e, byte[] row, String cf, String cq, String cv, String value)
     {
-        assertEquals(row, e.getKey().getRow().copyBytes());
-        assertEquals(cf, e.getKey().getColumnFamily().toString());
-        assertEquals(cq, e.getKey().getColumnQualifier().toString());
-        assertEquals(cv, e.getKey().getColumnVisibility().toString());
-        assertEquals(value, e.getValue().toString());
+        assertEquals(e.getKey().getRow().copyBytes(), row);
+        assertEquals(e.getKey().getColumnFamily().toString(), cf);
+        assertEquals(e.getKey().getColumnQualifier().toString(), cq);
+        assertEquals(e.getKey().getColumnVisibility().toString(), cv);
+        assertEquals(e.getValue().toString(), value);
     }
 
     private static byte[] bytes(String s)

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestIndexer.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestIndexer.java
@@ -257,8 +257,7 @@ public class TestIndexer
         iter = scan.iterator();
         assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "___card___", "1");
         assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "___card___", "private", "1");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___card___", "1");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___card___", "private", "1");
+        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___card___", "2");
         assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "___card___", "1");
         assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "___card___", "private", "1");
         assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "___card___", "1");
@@ -302,9 +301,7 @@ public class TestIndexer
         assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "___card___", "1");
         assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "___card___", "moreprivate", "1");
         assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "___card___", "private", "1");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___card___", "1");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___card___", "moreprivate", "1");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___card___", "private", "1");
+        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___card___", "3");
         assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "___card___", "1");
         assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "___card___", "private", "1");
         assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "___card___", "1");
@@ -346,7 +343,7 @@ public class TestIndexer
         scan.addScanIterator(setting);
         Iterator<Entry<Key, Value>> iter = scan.iterator();
         assertTrue(iter.hasNext());
-        assertEquals(iter.next().getValue().get(), "6".getBytes(UTF_8));
+        assertEquals(iter.next().getValue().get(), "8".getBytes(UTF_8));
         assertFalse(iter.hasNext());
 
         scan.close();
@@ -355,7 +352,7 @@ public class TestIndexer
         scan.addScanIterator(setting);
         iter = scan.iterator();
         assertTrue(iter.hasNext());
-        assertEquals(iter.next().getValue().get(), "12".getBytes(UTF_8));
+        assertEquals(iter.next().getValue().get(), "13".getBytes(UTF_8));
         assertFalse(iter.hasNext());
 
         scan.close();

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestIndexer.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestIndexer.java
@@ -146,8 +146,6 @@ public class TestIndexer
         iter = scan.iterator();
         assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "___card___", "1");
         assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___card___", "1");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___first_row___", "row1");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___last_row___", "row1");
         assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "___card___", "1");
         assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "___card___", "1");
         assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "___card___", "1");
@@ -182,8 +180,6 @@ public class TestIndexer
         iter = scan.iterator();
         assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "___card___", "2");
         assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___card___", "2");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___first_row___", "row1");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___last_row___", "row2");
         assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "___card___", "2");
         assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "___card___", "1");
         assertKeyValuePair(iter.next(), M2_FNAME_VALUE, "cf_firstname", "___card___", "1");
@@ -239,8 +235,6 @@ public class TestIndexer
         assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "___card___", "1");
         assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "___card___", "private", "1");
         assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___card___", "2");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___first_row___", "row1");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___last_row___", "row1");
         assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "___card___", "1");
         assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "___card___", "moreprivate", "1");
         assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "___card___", "1");
@@ -291,8 +285,6 @@ public class TestIndexer
         assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "___card___", "2");
         assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "___card___", "private", "2");
         assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___card___", "4");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___first_row___", "row1");
-        assertKeyValuePair(iter.next(), Indexer.METRICS_TABLE_ROW_ID.array(), "___rows___", "___last_row___", "row2");
         assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "___card___", "2");
         assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "___card___", "moreprivate", "2");
         assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "___card___", "1");

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestIndexer.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/TestIndexer.java
@@ -94,7 +94,7 @@ public class TestIndexer
 
         connector = AccumuloQueryRunner.getAccumuloConnector();
         connector.securityOperations().changeUserAuthorizations("root", new Authorizations("private", "moreprivate", "foo", "bar", "xyzzy"));
-        metricsStorage = MetricsStorage.getDefault(connector, CONFIG);
+        metricsStorage = MetricsStorage.getDefault(connector);
 
         AccumuloColumnHandle c1 = new AccumuloColumnHandle("id", Optional.empty(), Optional.empty(), VARCHAR, 0, "", false);
         AccumuloColumnHandle c2 = new AccumuloColumnHandle("age", Optional.of("cf"), Optional.of("age"), BIGINT, 1, "", true);
@@ -151,8 +151,8 @@ public class TestIndexer
 
         MultiTableBatchWriter multiTableBatchWriter = connector.createMultiTableBatchWriter(new BatchWriterConfig());
         BatchWriter dataWriter = multiTableBatchWriter.getBatchWriter(table.getFullTableName());
-        MetricsWriter metricsWriter = table.getMetricsStorageInstance(connector, CONFIG).newWriter(table);
-        Indexer indexer = new Indexer(connector, CONFIG, table, multiTableBatchWriter.getBatchWriter(table.getIndexTableName()), metricsWriter);
+        MetricsWriter metricsWriter = table.getMetricsStorageInstance(connector).newWriter(table);
+        Indexer indexer = new Indexer(connector, table, multiTableBatchWriter.getBatchWriter(table.getIndexTableName()), metricsWriter);
 
         dataWriter.addMutation(m1);
         indexer.index(m1);
@@ -219,8 +219,8 @@ public class TestIndexer
 
         MultiTableBatchWriter multiTableBatchWriter = connector.createMultiTableBatchWriter(new BatchWriterConfig());
         BatchWriter dataWriter = multiTableBatchWriter.getBatchWriter(table.getFullTableName());
-        MetricsWriter metricsWriter = table.getMetricsStorageInstance(connector, CONFIG).newWriter(table);
-        Indexer indexer = new Indexer(connector, CONFIG, table, multiTableBatchWriter.getBatchWriter(table.getIndexTableName()), metricsWriter);
+        MetricsWriter metricsWriter = table.getMetricsStorageInstance(connector).newWriter(table);
+        Indexer indexer = new Indexer(connector, table, multiTableBatchWriter.getBatchWriter(table.getIndexTableName()), metricsWriter);
 
         dataWriter.addMutation(m1);
         indexer.index(m1);
@@ -324,8 +324,8 @@ public class TestIndexer
         testMutationIndex();
 
         MultiTableBatchWriter multiTableBatchWriter = connector.createMultiTableBatchWriter(new BatchWriterConfig());
-        MetricsWriter metricsWriter = table.getMetricsStorageInstance(connector, CONFIG).newWriter(table);
-        Indexer indexer = new Indexer(connector, CONFIG, table, multiTableBatchWriter.getBatchWriter(table.getIndexTableName()), metricsWriter);
+        MetricsWriter metricsWriter = table.getMetricsStorageInstance(connector).newWriter(table);
+        Indexer indexer = new Indexer(connector, table, multiTableBatchWriter.getBatchWriter(table.getIndexTableName()), metricsWriter);
         indexer.delete(connector.securityOperations().getUserAuthorizations("root"), M1_ROWID);
         metricsWriter.flush();
         multiTableBatchWriter.flush();
@@ -380,8 +380,8 @@ public class TestIndexer
         testMutationIndexWithVisibilities();
 
         MultiTableBatchWriter multiTableBatchWriter = connector.createMultiTableBatchWriter(new BatchWriterConfig());
-        MetricsWriter metricsWriter = table.getMetricsStorageInstance(connector, CONFIG).newWriter(table);
-        Indexer indexer = new Indexer(connector, CONFIG, table, multiTableBatchWriter.getBatchWriter(table.getIndexTableName()), metricsWriter);
+        MetricsWriter metricsWriter = table.getMetricsStorageInstance(connector).newWriter(table);
+        Indexer indexer = new Indexer(connector, table, multiTableBatchWriter.getBatchWriter(table.getIndexTableName()), metricsWriter);
 
         indexer.delete(connector.securityOperations().getUserAuthorizations("root"), M1_ROWID);
         metricsWriter.flush();

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/metrics/TestAbstractMetricStorage.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/metrics/TestAbstractMetricStorage.java
@@ -59,7 +59,6 @@ public abstract class TestAbstractMetricStorage
     protected AccumuloConfig config = new AccumuloConfig();
     protected AccumuloTable table;
     protected AccumuloTable table2;
-    protected AccumuloTable externalTable;
 
     protected AccumuloColumnHandle c1 = new AccumuloColumnHandle("id", Optional.empty(), Optional.empty(), VARCHAR, 0, "", false);
     protected AccumuloColumnHandle c2 = new AccumuloColumnHandle("age", Optional.of("cf"), Optional.of("age"), BIGINT, 1, "", true);
@@ -118,7 +117,6 @@ public abstract class TestAbstractMetricStorage
         storage = getMetricsStorage(config);
         table = new AccumuloTable("default", "index_test_table", ImmutableList.of(c1, c2, c3, c4), "id", false, LexicoderRowSerializer.class.getCanonicalName(), null, Optional.of(storage.getClass().getCanonicalName()), false);
         table2 = new AccumuloTable("default", "index_test_table_two", ImmutableList.of(c1, c2, c3, c4), "id", false, LexicoderRowSerializer.class.getCanonicalName(), null, Optional.of(storage.getClass().getCanonicalName()), false);
-        externalTable = new AccumuloTable("default", "index_test_table", ImmutableList.of(c1, c2, c3, c4), "id", true, LexicoderRowSerializer.class.getCanonicalName(), null, Optional.of(storage.getClass().getCanonicalName()), false);
     }
 
     @Test

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/metrics/TestAbstractMetricStorage.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/metrics/TestAbstractMetricStorage.java
@@ -1,0 +1,519 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.index.metrics;
+
+import com.facebook.presto.accumulo.conf.AccumuloConfig;
+import com.facebook.presto.accumulo.metadata.AccumuloTable;
+import com.facebook.presto.accumulo.model.AccumuloColumnHandle;
+import com.facebook.presto.accumulo.serializers.LexicoderRowSerializer;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.ArrayType;
+import com.google.common.collect.ImmutableList;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.hadoop.io.Text;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static java.nio.ByteBuffer.wrap;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public abstract class TestAbstractMetricStorage
+{
+    protected static final Optional<Type> TIMESTAMP_TYPE = Optional.of(TimestampType.TIMESTAMP);
+    protected static final DateTimeFormatter PARSER = ISODateTimeFormat.dateTimeParser();
+    protected static final Long START_TIMESTAMP = PARSER.parseDateTime("2001-08-22T00:00:00.000+0000").getMillis();
+    protected static final Long END_TIMESTAMP = PARSER.parseDateTime("2001-08-23T00:00:00.000+0000").getMillis();
+    protected static final Long TIMESTAMP = PARSER.parseDateTime("2001-08-22T03:04:05.321+0000").getMillis();
+    protected static final Long SECOND_TIMESTAMP = PARSER.parseDateTime("2001-08-22T03:04:05.000+0000").getMillis();
+    protected static final Long MINUTE_TIMESTAMP = PARSER.parseDateTime("2001-08-22T03:04:00.000+0000").getMillis();
+    protected static final Long HOUR_TIMESTAMP = PARSER.parseDateTime("2001-08-22T03:00:00.000+0000").getMillis();
+    protected static final Long DAY_TIMESTAMP = PARSER.parseDateTime("2001-08-22T00:00:00.000+0000").getMillis();
+
+    protected AccumuloConfig config = new AccumuloConfig();
+    protected AccumuloTable table;
+    protected AccumuloTable table2;
+    protected AccumuloTable externalTable;
+
+    protected AccumuloColumnHandle c1 = new AccumuloColumnHandle("id", Optional.empty(), Optional.empty(), VARCHAR, 0, "", false);
+    protected AccumuloColumnHandle c2 = new AccumuloColumnHandle("age", Optional.of("cf"), Optional.of("age"), BIGINT, 1, "", true);
+    protected AccumuloColumnHandle c3 = new AccumuloColumnHandle("firstname", Optional.of("cf"), Optional.of("firstname"), VARCHAR, 2, "", true);
+    protected AccumuloColumnHandle c4 = new AccumuloColumnHandle("arr", Optional.of("cf"), Optional.of("arr"), new ArrayType(VARCHAR), 3, "", true);
+
+    protected LexicoderRowSerializer serializer = new LexicoderRowSerializer();
+    protected MetricsStorage storage;
+
+    public abstract MetricsStorage getMetricsStorage(AccumuloConfig config);
+
+    @Test
+    public abstract void testCreateTable()
+            throws Exception;
+
+    @Test
+    public abstract void testCreateTableAlreadyExists()
+            throws Exception;
+
+    @Test
+    public abstract void testDropTable()
+            throws Exception;
+
+    @Test
+    public abstract void testDropTableDoesNotExist()
+            throws Exception;
+
+    @Test
+    public abstract void testDropExternalTable()
+            throws Exception;
+
+    @Test
+    public abstract void testRenameTable()
+            throws Exception;
+
+    @Test(expectedExceptions = PrestoException.class)
+    public abstract void testRenameTableDoesNotExist()
+            throws Exception;
+
+    @Test(expectedExceptions = PrestoException.class)
+    public abstract void testRenameTableNewTableExists()
+            throws Exception;
+
+    @Test
+    public abstract void testExists()
+            throws Exception;
+
+    @Test
+    public abstract void testTimestampInserts()
+            throws Exception;
+
+    @BeforeClass
+    public void setupClass()
+            throws Exception
+    {
+        storage = getMetricsStorage(config);
+        table = new AccumuloTable("default", "index_test_table", ImmutableList.of(c1, c2, c3, c4), "id", false, LexicoderRowSerializer.class.getCanonicalName(), null, Optional.of(storage.getClass().getCanonicalName()), false);
+        table2 = new AccumuloTable("default", "index_test_table_two", ImmutableList.of(c1, c2, c3, c4), "id", false, LexicoderRowSerializer.class.getCanonicalName(), null, Optional.of(storage.getClass().getCanonicalName()), false);
+        externalTable = new AccumuloTable("default", "index_test_table", ImmutableList.of(c1, c2, c3, c4), "id", true, LexicoderRowSerializer.class.getCanonicalName(), null, Optional.of(storage.getClass().getCanonicalName()), false);
+    }
+
+    @Test
+    public void testIncrementRows()
+            throws Exception
+    {
+        storage.create(table);
+
+        MetricsWriter writer = storage.newWriter(table);
+        assertEquals(storage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 0);
+        writer.incrementRowCount();
+        writer.flush();
+        assertEquals(storage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 1);
+        writer.incrementRowCount();
+        writer.flush();
+        assertEquals(storage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 2);
+        writer.incrementRowCount();
+        writer.flush();
+        assertEquals(storage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 3);
+    }
+
+    @Test
+    public void testIncrementRowsWithVisibility()
+            throws Exception
+    {
+        storage.create(table);
+
+        MetricsWriter writer = storage.newWriter(table);
+        assertEquals(storage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 0);
+        writer.incrementRowCount();
+        writer.flush();
+        assertEquals(storage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 1);
+        writer.incrementRowCount();
+        writer.flush();
+        assertEquals(storage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 2);
+        writer.incrementRowCount();
+        writer.flush();
+        assertEquals(storage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 3);
+
+        writer.incrementRowCount();
+        writer.flush();
+        assertEquals(storage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 4);
+
+        writer.incrementRowCount();
+        writer.flush();
+        assertEquals(storage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 5);
+    }
+
+    @Test
+    public void testGetCardinality()
+            throws Exception
+    {
+        storage.create(table);
+
+        MetricsWriter writer = storage.newWriter(table);
+
+        assertEquals(storage.newReader().getCardinality(mck("abc", "cf", "firstname", false, new Authorizations())), 0);
+        assertEquals(storage.newReader().getCardinality(mck("def", "cf", "firstname", false, new Authorizations())), 0);
+        assertEquals(storage.newReader().getCardinality(mck("ghi", "cf", "firstname", false, new Authorizations())), 0);
+        assertEquals(storage.newReader().getCardinality(mck("1", "cf", "age", false, new Authorizations())), 0);
+        assertEquals(storage.newReader().getCardinality(mck("2", "cf", "age", false, new Authorizations())), 0);
+        assertEquals(storage.newReader().getCardinality(mck("3", "cf", "age", false, new Authorizations())), 0);
+
+        writer.incrementCardinality(bb("abc"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("def"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("ghi"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("1"), bb("cf_age"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("2"), bb("cf_age"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("3"), bb("cf_age"), new ColumnVisibility(), false);
+        writer.flush();
+
+        assertEquals(storage.newReader().getCardinality(mck("abc", "cf", "firstname", false, new Authorizations())), 1);
+        assertEquals(storage.newReader().getCardinality(mck("def", "cf", "firstname", false, new Authorizations())), 1);
+        assertEquals(storage.newReader().getCardinality(mck("ghi", "cf", "firstname", false, new Authorizations())), 1);
+        assertEquals(storage.newReader().getCardinality(mck("1", "cf", "age", false, new Authorizations())), 1);
+        assertEquals(storage.newReader().getCardinality(mck("2", "cf", "age", false, new Authorizations())), 1);
+        assertEquals(storage.newReader().getCardinality(mck("3", "cf", "age", false, new Authorizations())), 1);
+
+        writer.incrementCardinality(bb("abc"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("def"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("ghi"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("1"), bb("cf_age"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("2"), bb("cf_age"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("3"), bb("cf_age"), new ColumnVisibility(), false);
+        writer.flush();
+
+        assertEquals(storage.newReader().getCardinality(mck("abc", "cf", "firstname", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("def", "cf", "firstname", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("ghi", "cf", "firstname", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("1", "cf", "age", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("2", "cf", "age", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("3", "cf", "age", false, new Authorizations())), 2);
+
+        writer.incrementCardinality(bb("abc"), bb("cf_firstname"), new ColumnVisibility("foo"), false);
+        writer.incrementCardinality(bb("def"), bb("cf_firstname"), new ColumnVisibility("foo"), false);
+        writer.incrementCardinality(bb("ghi"), bb("cf_firstname"), new ColumnVisibility("foo"), false);
+        writer.incrementCardinality(bb("1"), bb("cf_age"), new ColumnVisibility("foo"), false);
+        writer.incrementCardinality(bb("2"), bb("cf_age"), new ColumnVisibility("foo"), false);
+        writer.incrementCardinality(bb("3"), bb("cf_age"), new ColumnVisibility("foo"), false);
+        writer.flush();
+
+        assertEquals(storage.newReader().getCardinality(mck("abc", "cf", "firstname", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("def", "cf", "firstname", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("ghi", "cf", "firstname", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("1", "cf", "age", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("2", "cf", "age", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("3", "cf", "age", false, new Authorizations())), 2);
+
+        assertEquals(storage.newReader().getCardinality(mck("abc", "cf", "firstname", false, new Authorizations("foo"))), 3);
+        assertEquals(storage.newReader().getCardinality(mck("def", "cf", "firstname", false, new Authorizations("foo"))), 3);
+        assertEquals(storage.newReader().getCardinality(mck("ghi", "cf", "firstname", false, new Authorizations("foo"))), 3);
+        assertEquals(storage.newReader().getCardinality(mck("1", "cf", "age", false, new Authorizations("foo"))), 3);
+        assertEquals(storage.newReader().getCardinality(mck("2", "cf", "age", false, new Authorizations("foo"))), 3);
+        assertEquals(storage.newReader().getCardinality(mck("3", "cf", "age", false, new Authorizations("foo"))), 3);
+
+        writer.incrementCardinality(bb("abc"), bb("cf_firstname"), new ColumnVisibility("bar"), false);
+        writer.incrementCardinality(bb("def"), bb("cf_firstname"), new ColumnVisibility("bar"), false);
+        writer.incrementCardinality(bb("ghi"), bb("cf_firstname"), new ColumnVisibility("bar"), false);
+        writer.incrementCardinality(bb("1"), bb("cf_age"), new ColumnVisibility("bar"), false);
+        writer.incrementCardinality(bb("2"), bb("cf_age"), new ColumnVisibility("bar"), false);
+        writer.incrementCardinality(bb("3"), bb("cf_age"), new ColumnVisibility("bar"), false);
+        writer.flush();
+
+        assertEquals(storage.newReader().getCardinality(mck("abc", "cf", "firstname", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("def", "cf", "firstname", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("ghi", "cf", "firstname", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("1", "cf", "age", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("2", "cf", "age", false, new Authorizations())), 2);
+        assertEquals(storage.newReader().getCardinality(mck("3", "cf", "age", false, new Authorizations())), 2);
+
+        assertEquals(storage.newReader().getCardinality(mck("abc", "cf", "firstname", false, new Authorizations("foo"))), 3);
+        assertEquals(storage.newReader().getCardinality(mck("def", "cf", "firstname", false, new Authorizations("foo"))), 3);
+        assertEquals(storage.newReader().getCardinality(mck("ghi", "cf", "firstname", false, new Authorizations("foo"))), 3);
+        assertEquals(storage.newReader().getCardinality(mck("1", "cf", "age", false, new Authorizations("foo"))), 3);
+        assertEquals(storage.newReader().getCardinality(mck("2", "cf", "age", false, new Authorizations("foo"))), 3);
+        assertEquals(storage.newReader().getCardinality(mck("3", "cf", "age", false, new Authorizations("foo"))), 3);
+
+        assertEquals(storage.newReader().getCardinality(mck("abc", "cf", "firstname", false, new Authorizations("foo", "bar"))), 4);
+        assertEquals(storage.newReader().getCardinality(mck("def", "cf", "firstname", false, new Authorizations("foo", "bar"))), 4);
+        assertEquals(storage.newReader().getCardinality(mck("ghi", "cf", "firstname", false, new Authorizations("foo", "bar"))), 4);
+        assertEquals(storage.newReader().getCardinality(mck("1", "cf", "age", false, new Authorizations("foo", "bar"))), 4);
+        assertEquals(storage.newReader().getCardinality(mck("2", "cf", "age", false, new Authorizations("foo", "bar"))), 4);
+        assertEquals(storage.newReader().getCardinality(mck("3", "cf", "age", false, new Authorizations("foo", "bar"))), 4);
+    }
+
+    @Test
+    public void testGetCardinalityWithRange()
+            throws Exception
+    {
+        storage.create(table);
+
+        MetricsWriter writer = storage.newWriter(table);
+
+        assertEquals(storage.newReader().getCardinality(mck("a", "z", "cf", "firstname", false, new Authorizations())), 0);
+        assertEquals(storage.newReader().getCardinality(mck("0", "9", "cf", "age", false, new Authorizations())), 0);
+
+        writer.incrementCardinality(bb("abc"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("def"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("ghi"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("1"), bb("cf_age"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("2"), bb("cf_age"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("3"), bb("cf_age"), new ColumnVisibility(), false);
+        writer.flush();
+
+        assertEquals(storage.newReader().getCardinality(mck("a", "z", "cf", "firstname", false, new Authorizations())), 3);
+        assertEquals(storage.newReader().getCardinality(mck("0", "9", "cf", "age", false, new Authorizations())), 3);
+
+        writer.incrementCardinality(bb("abc"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("def"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("ghi"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("1"), bb("cf_age"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("2"), bb("cf_age"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("3"), bb("cf_age"), new ColumnVisibility(), false);
+        writer.flush();
+
+        assertEquals(storage.newReader().getCardinality(mck("a", "z", "cf", "firstname", false, new Authorizations())), 6);
+        assertEquals(storage.newReader().getCardinality(mck("0", "9", "cf", "age", false, new Authorizations())), 6);
+
+        writer.incrementCardinality(bb("abc"), bb("cf_firstname"), new ColumnVisibility("foo"), false);
+        writer.incrementCardinality(bb("def"), bb("cf_firstname"), new ColumnVisibility("foo"), false);
+        writer.incrementCardinality(bb("ghi"), bb("cf_firstname"), new ColumnVisibility("foo"), false);
+        writer.incrementCardinality(bb("1"), bb("cf_age"), new ColumnVisibility("foo"), false);
+        writer.incrementCardinality(bb("2"), bb("cf_age"), new ColumnVisibility("foo"), false);
+        writer.incrementCardinality(bb("3"), bb("cf_age"), new ColumnVisibility("foo"), false);
+        writer.flush();
+
+        assertEquals(storage.newReader().getCardinality(mck("a", "z", "cf", "firstname", false, new Authorizations())), 6);
+        assertEquals(storage.newReader().getCardinality(mck("0", "9", "cf", "age", false, new Authorizations())), 6);
+
+        assertEquals(storage.newReader().getCardinality(mck("a", "z", "cf", "firstname", false, new Authorizations("foo"))), 9);
+        assertEquals(storage.newReader().getCardinality(mck("0", "9", "cf", "age", false, new Authorizations("foo"))), 9);
+
+        writer.incrementCardinality(bb("abc"), bb("cf_firstname"), new ColumnVisibility("bar"), false);
+        writer.incrementCardinality(bb("def"), bb("cf_firstname"), new ColumnVisibility("bar"), false);
+        writer.incrementCardinality(bb("ghi"), bb("cf_firstname"), new ColumnVisibility("bar"), false);
+        writer.incrementCardinality(bb("1"), bb("cf_age"), new ColumnVisibility("bar"), false);
+        writer.incrementCardinality(bb("2"), bb("cf_age"), new ColumnVisibility("bar"), false);
+        writer.incrementCardinality(bb("3"), bb("cf_age"), new ColumnVisibility("bar"), false);
+        writer.flush();
+
+        assertEquals(storage.newReader().getCardinality(mck("a", "z", "cf", "firstname", false, new Authorizations())), 6);
+        assertEquals(storage.newReader().getCardinality(mck("0", "9", "cf", "age", false, new Authorizations())), 6);
+
+        assertEquals(storage.newReader().getCardinality(mck("a", "z", "cf", "firstname", false, new Authorizations("foo"))), 9);
+        assertEquals(storage.newReader().getCardinality(mck("0", "9", "cf", "age", false, new Authorizations("foo"))), 9);
+
+        assertEquals(storage.newReader().getCardinality(mck("a", "z", "cf", "firstname", false, new Authorizations("foo", "bar"))), 12);
+        assertEquals(storage.newReader().getCardinality(mck("0", "9", "cf", "age", false, new Authorizations("foo", "bar"))), 12);
+    }
+
+    @Test
+    public void testGetCardinalities()
+            throws Exception
+    {
+        storage.create(table);
+
+        MetricsWriter writer = storage.newWriter(table);
+
+        List<MetricCacheKey> keys = ImmutableList.of(
+                mck("abc", "cf", "firstname", false, new Authorizations()),
+                mck("def", "cf", "firstname", false, new Authorizations()),
+                mck("ghi", "cf", "firstname", false, new Authorizations())
+        );
+
+        List<MetricCacheKey> fooKeys = ImmutableList.of(
+                mck("abc", "cf", "firstname", false, new Authorizations("foo")),
+                mck("def", "cf", "firstname", false, new Authorizations("foo")),
+                mck("ghi", "cf", "firstname", false, new Authorizations("foo"))
+        );
+
+        List<MetricCacheKey> barKeys = ImmutableList.of(
+                mck("abc", "cf", "firstname", false, new Authorizations("bar")),
+                mck("def", "cf", "firstname", false, new Authorizations("bar")),
+                mck("ghi", "cf", "firstname", false, new Authorizations("bar"))
+        );
+
+        List<MetricCacheKey> fooBarKeys = ImmutableList.of(
+                mck("abc", "cf", "firstname", false, new Authorizations("foo", "bar")),
+                mck("def", "cf", "firstname", false, new Authorizations("foo", "bar")),
+                mck("ghi", "cf", "firstname", false, new Authorizations("foo", "bar"))
+        );
+
+        Map<MetricCacheKey, Long> cardinalities = storage.newReader().getCardinalities(keys);
+        for (MetricCacheKey key : keys) {
+            assertNotNull(cardinalities.get(key));
+            assertEquals(cardinalities.get(key).longValue(), 0);
+        }
+
+        writer.incrementCardinality(bb("abc"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("def"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("ghi"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.flush();
+
+        cardinalities = storage.newReader().getCardinalities(keys);
+        for (MetricCacheKey key : keys) {
+            assertNotNull(cardinalities.get(key));
+            assertEquals(cardinalities.get(key).longValue(), 1);
+        }
+
+        writer.incrementCardinality(bb("abc"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("def"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.incrementCardinality(bb("ghi"), bb("cf_firstname"), new ColumnVisibility(), false);
+        writer.flush();
+
+        cardinalities = storage.newReader().getCardinalities(keys);
+        for (MetricCacheKey key : keys) {
+            assertNotNull(cardinalities.get(key));
+            assertEquals(cardinalities.get(key).longValue(), 2);
+        }
+
+        writer.incrementCardinality(bb("abc"), bb("cf_firstname"), new ColumnVisibility("foo"), false);
+        writer.incrementCardinality(bb("def"), bb("cf_firstname"), new ColumnVisibility("foo"), false);
+        writer.incrementCardinality(bb("ghi"), bb("cf_firstname"), new ColumnVisibility("foo"), false);
+        writer.flush();
+
+        cardinalities = storage.newReader().getCardinalities(keys);
+        for (MetricCacheKey key : keys) {
+            assertNotNull(cardinalities.get(key));
+            assertEquals(cardinalities.get(key).longValue(), 2);
+        }
+
+        cardinalities = storage.newReader().getCardinalities(fooKeys);
+        for (MetricCacheKey key : fooKeys) {
+            assertNotNull(cardinalities.get(key));
+            assertEquals(cardinalities.get(key).longValue(), 3);
+        }
+
+        writer.incrementCardinality(bb("abc"), bb("cf_firstname"), new ColumnVisibility("bar"), false);
+        writer.incrementCardinality(bb("def"), bb("cf_firstname"), new ColumnVisibility("bar"), false);
+        writer.incrementCardinality(bb("ghi"), bb("cf_firstname"), new ColumnVisibility("bar"), false);
+        writer.flush();
+
+        cardinalities = storage.newReader().getCardinalities(keys);
+        for (MetricCacheKey key : keys) {
+            assertNotNull(cardinalities.get(key));
+            assertEquals(cardinalities.get(key).longValue(), 2);
+        }
+
+        cardinalities = storage.newReader().getCardinalities(fooKeys);
+        for (MetricCacheKey key : fooKeys) {
+            assertNotNull(cardinalities.get(key));
+            assertEquals(cardinalities.get(key).longValue(), 3);
+        }
+
+        cardinalities = storage.newReader().getCardinalities(barKeys);
+        for (MetricCacheKey key : barKeys) {
+            assertNotNull(cardinalities.get(key));
+            assertEquals(cardinalities.get(key).longValue(), 3);
+        }
+
+        cardinalities = storage.newReader().getCardinalities(fooBarKeys);
+        for (MetricCacheKey key : fooBarKeys) {
+            assertNotNull(cardinalities.get(key));
+            assertEquals(cardinalities.get(key).longValue(), 4);
+        }
+    }
+
+    @Test
+    public void testTimestampReads()
+            throws Exception
+    {
+        AccumuloTable table = new AccumuloTable(
+                "default",
+                "test_timestamp_reads",
+                ImmutableList.of(c1, new AccumuloColumnHandle("time", Optional.of("cf"), Optional.of("time"), TIMESTAMP_TYPE.get(), 1, "", true)),
+                "id",
+                false,
+                LexicoderRowSerializer.class.getCanonicalName(),
+                null,
+                Optional.of(storage.getClass().getCanonicalName()),
+                true);
+
+        MetricCacheKey metricCacheKey =
+                new MetricCacheKey(
+                        storage,
+                        "default",
+                        "test_timestamp_reads",
+                        "cf",
+                        "time",
+                        true,
+                        new Authorizations(),
+                        new Range(
+                                new Text(serializer.encode(TIMESTAMP_TYPE.get(), START_TIMESTAMP)),
+                                true,
+                                new Text(serializer.encode(TIMESTAMP_TYPE.get(), END_TIMESTAMP)), false));
+
+        storage.create(table);
+
+        assertTrue(storage.exists(table.getSchemaTableName()));
+
+        MetricsWriter writer = storage.newWriter(table);
+
+        writer.incrementCardinality(bb(TIMESTAMP), bb("cf_time"), new ColumnVisibility(), true);
+        writer.flush();
+
+        assertEquals(storage.newReader().getCardinality(metricCacheKey), 1L);
+
+        writer.incrementCardinality(bb(TIMESTAMP), bb("cf_time"), new ColumnVisibility(), true);
+        writer.flush();
+
+        assertEquals(storage.newReader().getCardinality(metricCacheKey), 2L);
+
+        writer.incrementCardinality(bb(TIMESTAMP), bb("cf_time"), new ColumnVisibility(), true);
+        writer.flush();
+
+        assertEquals(storage.newReader().getCardinality(metricCacheKey), 3L);
+
+        writer.incrementCardinality(bb(TIMESTAMP), bb("cf_time"), new ColumnVisibility(), true);
+        writer.close();
+
+        assertEquals(storage.newReader().getCardinality(metricCacheKey), 4L);
+    }
+
+    protected static ByteBuffer bb(String v)
+    {
+        return wrap(b(v));
+    }
+
+    protected static byte[] b(String v)
+    {
+        return v.getBytes(UTF_8);
+    }
+
+    protected ByteBuffer bb(Long v)
+    {
+        return wrap(serializer.encode(TIMESTAMP_TYPE.get(), v));
+    }
+
+    protected MetricCacheKey mck(String value, String family, String qualifier, boolean truncateTimestamp, Authorizations auths)
+    {
+        return new MetricCacheKey(storage, table.getSchema(), table.getTable(), family, qualifier, truncateTimestamp, auths, new Range(new Text(value.getBytes(UTF_8))));
+    }
+
+    protected MetricCacheKey mck(String begin, String end, String family, String qualifier, boolean truncateTimestamp, Authorizations auths)
+    {
+        return new MetricCacheKey(storage, table.getSchema(), table.getTable(), family, qualifier, truncateTimestamp, auths, new Range(new Text(begin.getBytes(UTF_8)), new Text(end.getBytes(UTF_8))));
+    }
+}

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/metrics/TestAbstractMetricStorage.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/metrics/TestAbstractMetricStorage.java
@@ -461,7 +461,8 @@ public abstract class TestAbstractMetricStorage
                         new Range(
                                 new Text(serializer.encode(TIMESTAMP_TYPE.get(), START_TIMESTAMP)),
                                 true,
-                                new Text(serializer.encode(TIMESTAMP_TYPE.get(), END_TIMESTAMP)), false));
+                                new Text(serializer.encode(TIMESTAMP_TYPE.get(), END_TIMESTAMP)),
+                                false));
 
         storage.create(table);
 

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/metrics/TestAccumuloMetricStorage.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/metrics/TestAccumuloMetricStorage.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.index.metrics;
+
+import com.facebook.presto.accumulo.AccumuloQueryRunner;
+import com.facebook.presto.accumulo.conf.AccumuloConfig;
+import com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision;
+import com.facebook.presto.accumulo.metadata.AccumuloTable;
+import com.facebook.presto.accumulo.model.AccumuloColumnHandle;
+import com.facebook.presto.accumulo.serializers.LexicoderRowSerializer;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Bytes;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.hadoop.io.Text;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.DAY;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.HOUR;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.MINUTE;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.SECOND;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestAccumuloMetricStorage
+        extends TestAbstractMetricStorage
+{
+    private static final Map<TimestampPrecision, byte[]> TIMESTAMP_CARDINALITY_FAMILIES = ImmutableMap.of(
+            SECOND, "_tss".getBytes(UTF_8),
+            MINUTE, "_tsm".getBytes(UTF_8),
+            HOUR, "_tsh".getBytes(UTF_8),
+            DAY, "_tsd".getBytes(UTF_8));
+
+    private Connector connector;
+
+    @Override
+    public MetricsStorage getMetricsStorage(AccumuloConfig config)
+    {
+        return new AccumuloMetricsStorage(connector, config);
+    }
+
+    @BeforeClass
+    @Override
+    public void setupClass()
+            throws Exception
+    {
+        config.setUsername("root");
+        config.setPassword("secret");
+
+        connector = AccumuloQueryRunner.getAccumuloConnector();
+        connector.securityOperations().changeUserAuthorizations("root", new Authorizations("private", "moreprivate", "foo", "bar", "xyzzy"));
+
+        super.setupClass();
+    }
+
+    @AfterMethod
+    public void cleanup()
+            throws Exception
+    {
+        for (String table : connector.tableOperations().list()) {
+            if (table.contains(super.table.getFullTableName()) || table.contains(super.table2.getFullTableName())) {
+                connector.tableOperations().delete(table);
+            }
+        }
+    }
+
+    @Test
+    public void testCreateTable()
+            throws Exception
+    {
+        table.setTable("test_accumulo_metric_storage_create");
+        storage.create(table);
+        assertTrue(connector.tableOperations().exists(table.getIndexTableName() + "_metrics"));
+    }
+
+    @Test
+    public void testCreateTableAlreadyExists()
+            throws Exception
+    {
+        table.setTable("test_accumulo_metric_storage_create_already_exists");
+        connector.tableOperations().create(table.getIndexTableName() + "_metrics");
+        storage.create(table);
+        assertTrue(connector.tableOperations().exists(table.getIndexTableName() + "_metrics"));
+    }
+
+    @Test
+    public void testDropTable()
+            throws Exception
+    {
+        table.setTable("test_accumulo_metric_storage_drop_table");
+        storage.create(table);
+        assertTrue(connector.tableOperations().exists(table.getIndexTableName() + "_metrics"));
+        storage.drop(table);
+        assertFalse(connector.tableOperations().exists(table.getIndexTableName() + "_metrics"));
+    }
+
+    @Test
+    public void testDropTableDoesNotExist()
+            throws Exception
+    {
+        table.setTable("test_accumulo_metric_storage_drop_table_does_not_exist");
+        storage.drop(table);
+        assertFalse(connector.tableOperations().exists(table.getIndexTableName() + "_metrics"));
+    }
+
+    @Override
+    public void testDropExternalTable()
+            throws Exception
+    {
+        externalTable.setTable("test_accumulo_metric_storage_drop_external_table");
+        storage.create(externalTable);
+        assertTrue(connector.tableOperations().exists(externalTable.getIndexTableName() + "_metrics"));
+        storage.drop(externalTable);
+        assertTrue(connector.tableOperations().exists(externalTable.getIndexTableName() + "_metrics"));
+    }
+
+    @Test
+    public void testRenameTable()
+            throws Exception
+    {
+        table.setTable("test_accumulo_metric_storage_rename_table");
+        table2.setTable("test_accumulo_metric_storage_rename_table2");
+        storage.create(table);
+        storage.rename(table, table2);
+        assertFalse(connector.tableOperations().exists(table.getIndexTableName() + "_metrics"));
+        assertTrue(connector.tableOperations().exists(table2.getIndexTableName() + "_metrics"));
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testRenameTableDoesNotExist()
+            throws Exception
+    {
+        table.setTable("test_accumulo_metric_storage_rename_table_does_not_exist");
+        table2.setTable("test_accumulo_metric_storage_rename_table_does_not_exist2");
+        storage.rename(table, table2);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testRenameTableNewTableExists()
+            throws Exception
+    {
+        table.setTable("test_accumulo_metric_storage_rename_new_table_exists");
+        table2.setTable("test_accumulo_metric_storage_rename_new_table_exists2");
+        storage.create(table);
+        connector.tableOperations().create(table2.getIndexTableName() + "_metrics");
+        storage.rename(table, table2);
+    }
+
+    @Test
+    public void testExists()
+            throws Exception
+    {
+        table.setTable("test_accumulo_metric_storage_exists");
+        assertFalse(storage.exists(table.getSchemaTableName()));
+        storage.create(table);
+        assertTrue(storage.exists(table.getSchemaTableName()));
+    }
+
+    @Override
+    public void testTimestampInserts()
+            throws Exception
+    {
+        AccumuloTable table = new AccumuloTable(
+                "default",
+                "test_accumulo_timestamp_inserts",
+                ImmutableList.of(c1, new AccumuloColumnHandle("time", Optional.of("cf"), Optional.of("time"), TIMESTAMP_TYPE.get(), 1, "", true)),
+                "id",
+                false,
+                LexicoderRowSerializer.class.getCanonicalName(),
+                null,
+                Optional.of(storage.getClass().getCanonicalName()),
+                true);
+
+        storage.create(table);
+
+        assertTrue(storage.exists(table.getSchemaTableName()));
+
+        MetricsWriter writer = storage.newWriter(table);
+
+        writer.incrementCardinality(bb(TIMESTAMP), bb("cf_time"), new ColumnVisibility(), true);
+        writer.flush();
+
+        assertEquals(getAccumuloHashValue(table, SECOND, "cf_time", SECOND_TIMESTAMP), 1L);
+        assertEquals(getAccumuloHashValue(table, MINUTE, "cf_time", MINUTE_TIMESTAMP), 1L);
+        assertEquals(getAccumuloHashValue(table, HOUR, "cf_time", HOUR_TIMESTAMP), 1L);
+        assertEquals(getAccumuloHashValue(table, DAY, "cf_time", DAY_TIMESTAMP), 1L);
+
+        writer.incrementCardinality(bb(TIMESTAMP), bb("cf_time"), new ColumnVisibility(), true);
+        writer.flush();
+
+        assertEquals(getAccumuloHashValue(table, SECOND, "cf_time", SECOND_TIMESTAMP), 2L);
+        assertEquals(getAccumuloHashValue(table, MINUTE, "cf_time", MINUTE_TIMESTAMP), 2L);
+        assertEquals(getAccumuloHashValue(table, HOUR, "cf_time", HOUR_TIMESTAMP), 2L);
+        assertEquals(getAccumuloHashValue(table, DAY, "cf_time", DAY_TIMESTAMP), 2L);
+
+        writer.incrementCardinality(bb(TIMESTAMP), bb("cf_time"), new ColumnVisibility(), true);
+        writer.flush();
+
+        assertEquals(getAccumuloHashValue(table, SECOND, "cf_time", SECOND_TIMESTAMP), 3L);
+        assertEquals(getAccumuloHashValue(table, MINUTE, "cf_time", MINUTE_TIMESTAMP), 3L);
+        assertEquals(getAccumuloHashValue(table, HOUR, "cf_time", HOUR_TIMESTAMP), 3L);
+        assertEquals(getAccumuloHashValue(table, DAY, "cf_time", DAY_TIMESTAMP), 3L);
+
+        writer.incrementCardinality(bb(TIMESTAMP), bb("cf_time"), new ColumnVisibility(), true);
+        writer.close();
+
+        assertEquals(getAccumuloHashValue(table, SECOND, "cf_time", SECOND_TIMESTAMP), 4L);
+        assertEquals(getAccumuloHashValue(table, MINUTE, "cf_time", MINUTE_TIMESTAMP), 4L);
+        assertEquals(getAccumuloHashValue(table, HOUR, "cf_time", HOUR_TIMESTAMP), 4L);
+        assertEquals(getAccumuloHashValue(table, DAY, "cf_time", DAY_TIMESTAMP), 4L);
+    }
+
+    private long getAccumuloHashValue(AccumuloTable table, TimestampPrecision level, String family, Long value)
+            throws Exception
+    {
+        Scanner scanner = null;
+        try {
+            scanner = connector.createScanner(table.getIndexTableName() + "_metrics", new Authorizations());
+            scanner.setRange(new Range(new Text(serializer.encode(TIMESTAMP_TYPE.get(), value))));
+            scanner.fetchColumn(new Text(Bytes.concat(family.getBytes(UTF_8), TIMESTAMP_CARDINALITY_FAMILIES.get(level))), new Text("___card___"));
+
+            long sum = 0;
+            for (Entry<Key, Value> entry : scanner) {
+                sum += Long.parseLong(entry.getValue().toString());
+            }
+            return sum;
+        }
+        finally {
+            if (scanner != null) {
+                scanner.close();
+            }
+        }
+    }
+}

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/metrics/TestAccumuloMetricStorage.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/metrics/TestAccumuloMetricStorage.java
@@ -63,7 +63,7 @@ public class TestAccumuloMetricStorage
     @Override
     public MetricsStorage getMetricsStorage(AccumuloConfig config)
     {
-        return new AccumuloMetricsStorage(connector, config);
+        return new AccumuloMetricsStorage(connector);
     }
 
     @BeforeClass
@@ -95,7 +95,7 @@ public class TestAccumuloMetricStorage
     public void testCreateTable()
             throws Exception
     {
-        table.setTable("test_accumulo_metric_storage_create");
+        AccumuloTable table = getTable("test_accumulo_metric_storage_create");
         storage.create(table);
         assertTrue(connector.tableOperations().exists(table.getIndexTableName() + "_metrics"));
     }
@@ -104,7 +104,7 @@ public class TestAccumuloMetricStorage
     public void testCreateTableAlreadyExists()
             throws Exception
     {
-        table.setTable("test_accumulo_metric_storage_create_already_exists");
+        AccumuloTable table = getTable("test_accumulo_metric_storage_create_already_exists");
         connector.tableOperations().create(table.getIndexTableName() + "_metrics");
         storage.create(table);
         assertTrue(connector.tableOperations().exists(table.getIndexTableName() + "_metrics"));
@@ -114,7 +114,7 @@ public class TestAccumuloMetricStorage
     public void testDropTable()
             throws Exception
     {
-        table.setTable("test_accumulo_metric_storage_drop_table");
+        AccumuloTable table = getTable("test_accumulo_metric_storage_drop_table");
         storage.create(table);
         assertTrue(connector.tableOperations().exists(table.getIndexTableName() + "_metrics"));
         storage.drop(table);
@@ -125,7 +125,7 @@ public class TestAccumuloMetricStorage
     public void testDropTableDoesNotExist()
             throws Exception
     {
-        table.setTable("test_accumulo_metric_storage_drop_table_does_not_exist");
+        AccumuloTable table = getTable("test_accumulo_metric_storage_drop_table_does_not_exist");
         storage.drop(table);
         assertFalse(connector.tableOperations().exists(table.getIndexTableName() + "_metrics"));
     }
@@ -134,7 +134,7 @@ public class TestAccumuloMetricStorage
     public void testDropExternalTable()
             throws Exception
     {
-        externalTable.setTable("test_accumulo_metric_storage_drop_external_table");
+        AccumuloTable externalTable = getTable("test_accumulo_metric_storage_drop_external_table", true);
         storage.create(externalTable);
         assertTrue(connector.tableOperations().exists(externalTable.getIndexTableName() + "_metrics"));
         storage.drop(externalTable);
@@ -145,8 +145,8 @@ public class TestAccumuloMetricStorage
     public void testRenameTable()
             throws Exception
     {
-        table.setTable("test_accumulo_metric_storage_rename_table");
-        table2.setTable("test_accumulo_metric_storage_rename_table2");
+        AccumuloTable table = getTable("test_accumulo_metric_storage_rename_table");
+        AccumuloTable table2 = getTable("test_accumulo_metric_storage_rename_table2");
         storage.create(table);
         storage.rename(table, table2);
         assertFalse(connector.tableOperations().exists(table.getIndexTableName() + "_metrics"));
@@ -157,8 +157,8 @@ public class TestAccumuloMetricStorage
     public void testRenameTableDoesNotExist()
             throws Exception
     {
-        table.setTable("test_accumulo_metric_storage_rename_table_does_not_exist");
-        table2.setTable("test_accumulo_metric_storage_rename_table_does_not_exist2");
+        AccumuloTable table = getTable("test_accumulo_metric_storage_rename_table_does_not_exist");
+        AccumuloTable table2 = getTable("test_accumulo_metric_storage_rename_table_does_not_exist2");
         storage.rename(table, table2);
     }
 
@@ -166,8 +166,8 @@ public class TestAccumuloMetricStorage
     public void testRenameTableNewTableExists()
             throws Exception
     {
-        table.setTable("test_accumulo_metric_storage_rename_new_table_exists");
-        table2.setTable("test_accumulo_metric_storage_rename_new_table_exists2");
+        AccumuloTable table = getTable("test_accumulo_metric_storage_rename_new_table_exists");
+        AccumuloTable table2 = getTable("test_accumulo_metric_storage_rename_new_table_exists2");
         storage.create(table);
         connector.tableOperations().create(table2.getIndexTableName() + "_metrics");
         storage.rename(table, table2);
@@ -177,7 +177,7 @@ public class TestAccumuloMetricStorage
     public void testExists()
             throws Exception
     {
-        table.setTable("test_accumulo_metric_storage_exists");
+        AccumuloTable table = getTable("test_accumulo_metric_storage_exists");
         assertFalse(storage.exists(table.getSchemaTableName()));
         storage.create(table);
         assertTrue(storage.exists(table.getSchemaTableName()));
@@ -257,5 +257,15 @@ public class TestAccumuloMetricStorage
                 scanner.close();
             }
         }
+    }
+
+    private AccumuloTable getTable(String tablename)
+    {
+        return getTable(tablename, false);
+    }
+
+    private AccumuloTable getTable(String tablename, boolean external)
+    {
+        return new AccumuloTable(table.getSchema(), tablename, table.getColumns(), table.getRowId(), external, table.getSerializerClassName(), table.getScanAuthorizations(), table.getMetricsStorageClass(), table.isTruncateTimestamps());
     }
 }

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/metrics/TestMetricStorage.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/index/metrics/TestMetricStorage.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.index.metrics;
+
+import com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision;
+import com.facebook.presto.accumulo.serializers.LexicoderRowSerializer;
+import com.facebook.presto.spi.type.TimestampType;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import org.apache.accumulo.core.data.Range;
+import org.apache.hadoop.io.Text;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.testng.annotations.Test;
+
+import java.sql.Timestamp;
+import java.util.Map;
+
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.DAY;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.HOUR;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.MILLISECOND;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.MINUTE;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.TimestampPrecision.SECOND;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.getTruncatedTimestamps;
+import static com.facebook.presto.accumulo.index.metrics.MetricsStorage.splitTimestampRange;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestMetricStorage
+{
+    private static final DateTimeFormatter PARSER = ISODateTimeFormat.dateTimeParser();
+    private static final Long TIMESTAMP = PARSER.parseDateTime("2001-08-22T03:04:05.321+0000").getMillis();
+    private static final Long SECOND_TIMESTAMP = PARSER.parseDateTime("2001-08-22T03:04:05.000+0000").getMillis();
+    private static final Long MINUTE_TIMESTAMP = PARSER.parseDateTime("2001-08-22T03:04:00.000+0000").getMillis();
+    private static final Long HOUR_TIMESTAMP = PARSER.parseDateTime("2001-08-22T03:00:00.000+0000").getMillis();
+    private static final Long DAY_TIMESTAMP = PARSER.parseDateTime("2001-08-22T00:00:00.000+0000").getMillis();
+
+    private static final LexicoderRowSerializer SERIALIZER = new LexicoderRowSerializer();
+
+    @Test
+    public void testTruncateTimestamp()
+    {
+        Map<TimestampPrecision, Long> expected = ImmutableMap.of(
+                SECOND, SECOND_TIMESTAMP,
+                MINUTE, MINUTE_TIMESTAMP,
+                HOUR, HOUR_TIMESTAMP,
+                DAY, DAY_TIMESTAMP);
+        assertEquals(getTruncatedTimestamps(TIMESTAMP), expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeNone()
+    {
+        String startTime = "2001-08-02T00:30:05.321+0000";
+        String endTime = "2001-08-02T00:30:05.456+0000";
+        Range splitRange = new Range(text(startTime), text(endTime));
+
+        ImmutableMultimap<TimestampPrecision, Range> expected = ImmutableMultimap.of(MILLISECOND, splitRange);
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeNoneExclusive()
+    {
+        String startTime = "2001-08-02T00:30:05.321+0000";
+        String endTime = "2001-08-02T00:30:05.456+0000";
+        Range splitRange = new Range(text(startTime), false, text(endTime), false);
+
+        ImmutableMultimap<TimestampPrecision, Range> expected = ImmutableMultimap.of(MILLISECOND, splitRange);
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeSecond()
+    {
+        String startTime = "2001-08-02T00:30:05.321+0000";
+        String endTime = "2001-08-02T00:30:12.456+0000";
+        Range splitRange = new Range(text(startTime), text(endTime));
+
+        ImmutableMultimap.Builder<TimestampPrecision, Range> builder = ImmutableMultimap.builder();
+        builder.put(MILLISECOND, new Range(text(startTime), text("2001-08-02T00:30:05.999+0000")))
+                .put(SECOND, new Range(text("2001-08-02T00:30:06.000+0000"), text("2001-08-02T00:30:11.000+0000")))
+                .put(MILLISECOND, new Range(text("2001-08-02T00:30:12.000+0000"), text(endTime)));
+        Multimap<TimestampPrecision, Range> expected = builder.build();
+
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeSecondExclusive()
+    {
+        String startTime = "2001-08-02T00:30:05.321+0000";
+        String endTime = "2001-08-02T00:30:12.456+0000";
+        Range splitRange = new Range(text(startTime), false, text(endTime), false);
+
+        ImmutableMultimap.Builder<TimestampPrecision, Range> builder = ImmutableMultimap.builder();
+        builder.put(MILLISECOND, new Range(text(startTime), false, text("2001-08-02T00:30:05.999+0000"), true))
+                .put(SECOND, new Range(text("2001-08-02T00:30:06.000+0000"), text("2001-08-02T00:30:11.000+0000")))
+                .put(MILLISECOND, new Range(text("2001-08-02T00:30:12.000+0000"), true, text(endTime), false));
+        Multimap<TimestampPrecision, Range> expected = builder.build();
+
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeMinute()
+    {
+        String startTime = "2001-08-02T00:30:58.321+0000";
+        String endTime = "2001-08-02T00:33:03.456+0000";
+        Range splitRange = new Range(text(startTime), text(endTime));
+
+        ImmutableMultimap.Builder<TimestampPrecision, Range> builder = ImmutableMultimap.builder();
+        builder.put(MILLISECOND, new Range(text(startTime), text("2001-08-02T00:30:58.999+0000")))
+                .put(SECOND, new Range(text("2001-08-02T00:30:59.000+0000")))
+                .put(MINUTE, new Range(text("2001-08-02T00:31:00.000+0000"), text("2001-08-02T00:32:00.000+0000")))
+                .put(SECOND, new Range(text("2001-08-02T00:33:00.000+0000"), text("2001-08-02T00:33:02.000+0000")))
+                .put(MILLISECOND, new Range(text("2001-08-02T00:33:03.000+0000"), text(endTime)));
+        Multimap<TimestampPrecision, Range> expected = builder.build();
+
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeMinuteExclusive()
+    {
+        String startTime = "2001-08-02T00:30:58.321+0000";
+        String endTime = "2001-08-02T00:33:03.456+0000";
+        Range splitRange = new Range(text(startTime), false, text(endTime), false);
+
+        ImmutableMultimap.Builder<TimestampPrecision, Range> builder = ImmutableMultimap.builder();
+        builder.put(MILLISECOND, new Range(text(startTime), false, text("2001-08-02T00:30:58.999+0000"), true))
+                .put(SECOND, new Range(text("2001-08-02T00:30:59.000+0000")))
+                .put(MINUTE, new Range(text("2001-08-02T00:31:00.000+0000"), text("2001-08-02T00:32:00.000+0000")))
+                .put(SECOND, new Range(text("2001-08-02T00:33:00.000+0000"), text("2001-08-02T00:33:02.000+0000")))
+                .put(MILLISECOND, new Range(text("2001-08-02T00:33:03.000+0000"), true, text(endTime), false));
+        Multimap<TimestampPrecision, Range> expected = builder.build();
+
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeHour()
+    {
+        String startTime = "2001-08-02T00:58:58.321+0000";
+        String endTime = "2001-08-02T03:03:03.456+0000";
+        Range splitRange = new Range(text(startTime), text(endTime));
+
+        ImmutableMultimap.Builder<TimestampPrecision, Range> builder = ImmutableMultimap.builder();
+        builder.put(MILLISECOND, new Range(text(startTime), text("2001-08-02T00:58:58.999+0000")))
+                .put(SECOND, new Range(text("2001-08-02T00:58:59.000+0000")))
+                .put(MINUTE, new Range(text("2001-08-02T00:59:00.000+0000")))
+                .put(HOUR, new Range(text("2001-08-02T01:00:00.000+0000"), text("2001-08-02T02:00:00.000+0000")))
+                .put(MINUTE, new Range(text("2001-08-02T03:00:00.000+0000"), text("2001-08-02T03:02:00.000+0000")))
+                .put(SECOND, new Range(text("2001-08-02T03:03:00.000+0000"), text("2001-08-02T03:03:02.000+0000")))
+                .put(MILLISECOND, new Range(text("2001-08-02T03:03:03.000+0000"), text(endTime)));
+        Multimap<TimestampPrecision, Range> expected = builder.build();
+
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeHourExclusive()
+    {
+        String startTime = "2001-08-02T00:58:58.321+0000";
+        String endTime = "2001-08-02T03:03:03.456+0000";
+        Range splitRange = new Range(text(startTime), false, text(endTime), false);
+
+        ImmutableMultimap.Builder<TimestampPrecision, Range> builder = ImmutableMultimap.builder();
+        builder.put(MILLISECOND, new Range(text(startTime), false, text("2001-08-02T00:58:58.999+0000"), true))
+                .put(SECOND, new Range(text("2001-08-02T00:58:59.000+0000")))
+                .put(MINUTE, new Range(text("2001-08-02T00:59:00.000+0000")))
+                .put(HOUR, new Range(text("2001-08-02T01:00:00.000+0000"), text("2001-08-02T02:00:00.000+0000")))
+                .put(MINUTE, new Range(text("2001-08-02T03:00:00.000+0000"), text("2001-08-02T03:02:00.000+0000")))
+                .put(SECOND, new Range(text("2001-08-02T03:03:00.000+0000"), text("2001-08-02T03:03:02.000+0000")))
+                .put(MILLISECOND, new Range(text("2001-08-02T03:03:03.000+0000"), true, text(endTime), false));
+        Multimap<TimestampPrecision, Range> expected = builder.build();
+
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeDay()
+    {
+        String startTime = "2001-08-02T22:58:58.321+0000";
+        String endTime = "2001-08-05T01:03:03.456+0000";
+        Range splitRange = new Range(text(startTime), text(endTime));
+
+        ImmutableMultimap.Builder<TimestampPrecision, Range> builder = ImmutableMultimap.builder();
+        builder.put(MILLISECOND, new Range(text(startTime), text("2001-08-02T22:58:58.999+0000")))
+                .put(SECOND, new Range(text("2001-08-02T22:58:59.000+0000")))
+                .put(MINUTE, new Range(text("2001-08-02T22:59:00.000+0000")))
+                .put(HOUR, new Range(text("2001-08-02T23:00:00.000+0000")))
+                .put(DAY, new Range(text("2001-08-03T00:00:00.000+0000"), text("2001-08-04T00:00:00.000+0000")))
+                .put(HOUR, new Range(text("2001-08-05T00:00:00.000+0000")))
+                .put(MINUTE, new Range(text("2001-08-05T01:00:00.000+0000"), text("2001-08-05T01:02:00.000+0000")))
+                .put(SECOND, new Range(text("2001-08-05T01:03:00.000+0000"), text("2001-08-05T01:03:02.000+0000")))
+                .put(MILLISECOND, new Range(text("2001-08-05T01:03:03.000+0000"), text(endTime)));
+        Multimap<TimestampPrecision, Range> expected = builder.build();
+
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeDayExclusive()
+    {
+        String startTime = "2001-08-02T22:58:58.321+0000";
+        String endTime = "2001-08-05T01:03:03.456+0000";
+        Range splitRange = new Range(text(startTime), false, text(endTime), false);
+
+        ImmutableMultimap.Builder<TimestampPrecision, Range> builder = ImmutableMultimap.builder();
+        builder.put(MILLISECOND, new Range(text(startTime), false, text("2001-08-02T22:58:58.999+0000"), true))
+                .put(SECOND, new Range(text("2001-08-02T22:58:59.000+0000")))
+                .put(MINUTE, new Range(text("2001-08-02T22:59:00.000+0000")))
+                .put(HOUR, new Range(text("2001-08-02T23:00:00.000+0000")))
+                .put(DAY, new Range(text("2001-08-03T00:00:00.000+0000"), text("2001-08-04T00:00:00.000+0000")))
+                .put(HOUR, new Range(text("2001-08-05T00:00:00.000+0000")))
+                .put(MINUTE, new Range(text("2001-08-05T01:00:00.000+0000"), text("2001-08-05T01:02:00.000+0000")))
+                .put(SECOND, new Range(text("2001-08-05T01:03:00.000+0000"), text("2001-08-05T01:03:02.000+0000")))
+                .put(MILLISECOND, new Range(text("2001-08-05T01:03:03.000+0000"), true, text(endTime), false));
+        Multimap<TimestampPrecision, Range> expected = builder.build();
+
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeHourRange()
+    {
+        String startTime = "2001-08-02T22:58:00.000+0000";
+        String endTime = "2001-08-05T02:02:00.000+0000";
+        Range splitRange = new Range(text(startTime), text(endTime));
+
+        ImmutableMultimap.Builder<TimestampPrecision, Range> builder = ImmutableMultimap.builder();
+        builder.put(MINUTE, new Range(text(startTime), text("2001-08-02T22:59:00.000+0000")))
+                .put(HOUR, new Range(text("2001-08-02T23:00:00.000+0000")))
+                .put(DAY, new Range(text("2001-08-03T00:00:00.000+0000"), text("2001-08-04T00:00:00.000+0000")))
+                .put(HOUR, new Range(text("2001-08-05T00:00:00.000+0000"), text("2001-08-05T01:00:00.000+0000")))
+                .put(MINUTE, new Range(text("2001-08-05T02:00:00.000+0000")))
+                .put(SECOND, new Range(text("2001-08-05T02:01:00.000+0000"), text("2001-08-05T02:01:58.000+0000")))
+                .put(MILLISECOND, new Range(text("2001-08-05T02:01:59.000+0000"), text("2001-08-05T02:01:59.999+0000")));
+        Multimap<TimestampPrecision, Range> expected = builder.build();
+
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeInfiniteEnd()
+    {
+        String startTime = "2001-08-02T00:30:05.321+0000";
+        Range splitRange = new Range(text(startTime), null);
+        Multimap<TimestampPrecision, Range> expected = ImmutableMultimap.of(MILLISECOND, splitRange);
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test
+    public void testSplitTimestampRangeInfiniteStart()
+    {
+        String endTime = "2001-08-07T00:32:07.456+0000";
+        Range splitRange = new Range(null, text(endTime));
+        Multimap<TimestampPrecision, Range> expected = ImmutableMultimap.of(MILLISECOND, splitRange);
+        Multimap<TimestampPrecision, Range> splitRanges = splitTimestampRange(splitRange);
+        assertEquals(splitRanges, expected);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testSplitTimestampRangeRangeNull()
+    {
+        splitTimestampRange(null);
+    }
+
+    private Text text(String v)
+    {
+        return new Text(SERIALIZER.encode(TimestampType.TIMESTAMP, ts(v).getTime()));
+    }
+
+    private static Timestamp ts(String date)
+    {
+        return new Timestamp(PARSER.parseDateTime(date).getMillis());
+    }
+}

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/io/TestPrestoBatchWriter.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/io/TestPrestoBatchWriter.java
@@ -307,7 +307,7 @@ public class TestPrestoBatchWriter
 
         PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, connector.securityOperations().getUserAuthorizations("root"), table);
         prestoBatchWriter.addRows(ImmutableList.of(r1, r2, r3));
-        prestoBatchWriter.flush();
+        prestoBatchWriter.close();
 
         Scanner scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
         Iterator<Entry<Key, Value>> iter = scan.iterator();

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/io/TestPrestoBatchWriter.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/io/TestPrestoBatchWriter.java
@@ -98,7 +98,7 @@ public class TestPrestoBatchWriter
 
         connector = AccumuloQueryRunner.getAccumuloConnector();
         connector.securityOperations().changeUserAuthorizations("root", new Authorizations("private", "moreprivate", "foo", "bar", "xyzzy"));
-        metricsStorage = MetricsStorage.getDefault(connector, CONFIG);
+        metricsStorage = MetricsStorage.getDefault(connector);
 
         AccumuloColumnHandle c1 = new AccumuloColumnHandle("id", Optional.empty(), Optional.empty(), VARCHAR, 0, "", false);
         AccumuloColumnHandle c2 = new AccumuloColumnHandle("age", Optional.of("cf"), Optional.of("age"), BIGINT, 1, "", true);
@@ -169,7 +169,7 @@ public class TestPrestoBatchWriter
         connector.tableOperations().create(table.getIndexTableName());
         metricsStorage.create(table);
 
-        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, connector.securityOperations().getUserAuthorizations("root"), table);
         prestoBatchWriter.addRow(r1);
         prestoBatchWriter.flush();
 
@@ -305,7 +305,7 @@ public class TestPrestoBatchWriter
         connector.tableOperations().create(table.getIndexTableName());
         metricsStorage.create(table);
 
-        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, connector.securityOperations().getUserAuthorizations("root"), table);
         prestoBatchWriter.addRows(ImmutableList.of(r1, r2, r3));
         prestoBatchWriter.flush();
 
@@ -368,7 +368,7 @@ public class TestPrestoBatchWriter
         connector.tableOperations().create(table.getIndexTableName());
         metricsStorage.create(table);
 
-        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, connector.securityOperations().getUserAuthorizations("root"), table);
         prestoBatchWriter.addMutation(m1);
         prestoBatchWriter.flush();
 
@@ -507,7 +507,7 @@ public class TestPrestoBatchWriter
         connector.tableOperations().create(table.getIndexTableName());
         metricsStorage.create(table);
 
-        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, connector.securityOperations().getUserAuthorizations("root"), table);
         prestoBatchWriter.addMutations(ImmutableList.of(m1, m2v, m3v));
         prestoBatchWriter.close();
 
@@ -568,7 +568,7 @@ public class TestPrestoBatchWriter
     {
         testAddMutations();
 
-        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, connector.securityOperations().getUserAuthorizations("root"), table);
         prestoBatchWriter.updateColumnByName("row2", "age", 28L);
         prestoBatchWriter.flush();
 
@@ -744,7 +744,7 @@ public class TestPrestoBatchWriter
     {
         testAddMutations();
 
-        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, connector.securityOperations().getUserAuthorizations("root"), table);
         prestoBatchWriter.updateColumnByName("row2", ImmutableMap.of(Pair.of("age", new ColumnVisibility("moreprivate")), 28L, Pair.of("firstname", new ColumnVisibility("moreprivate")), "dave", Pair.of("arr", new ColumnVisibility("moreprivate")), ImmutableList.of("jkl", "mno", "pqr")));
         prestoBatchWriter.close();
 
@@ -808,7 +808,7 @@ public class TestPrestoBatchWriter
         // Populate the table with data
         testAddMutation();
 
-        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, connector.securityOperations().getUserAuthorizations("root"), table);
         prestoBatchWriter.deleteRow("row1");
         prestoBatchWriter.flush();
 
@@ -917,7 +917,7 @@ public class TestPrestoBatchWriter
     {
         testAddMutations();
 
-        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, connector.securityOperations().getUserAuthorizations("root"), table);
         prestoBatchWriter.deleteRows(ImmutableList.of("row1", "row2", "row3"));
         prestoBatchWriter.close();
 

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/io/TestPrestoBatchWriter.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/io/TestPrestoBatchWriter.java
@@ -1,0 +1,989 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.io;
+
+import com.facebook.presto.accumulo.AccumuloQueryRunner;
+import com.facebook.presto.accumulo.conf.AccumuloConfig;
+import com.facebook.presto.accumulo.index.metrics.MetricCacheKey;
+import com.facebook.presto.accumulo.index.metrics.MetricsStorage;
+import com.facebook.presto.accumulo.metadata.AccumuloTable;
+import com.facebook.presto.accumulo.model.AccumuloColumnHandle;
+import com.facebook.presto.accumulo.model.Row;
+import com.facebook.presto.accumulo.serializers.LexicoderRowSerializer;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.ArrayType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.io.Text;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import static com.facebook.presto.accumulo.serializers.AccumuloRowSerializer.getBlockFromArray;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestPrestoBatchWriter
+{
+    private static final LexicoderRowSerializer SERIALIZER = new LexicoderRowSerializer();
+
+    private static final AccumuloConfig CONFIG = new AccumuloConfig();
+
+    private static final byte[] ROW_ID_COLUMN = PrestoBatchWriter.ROW_ID_COLUMN.copyBytes();
+    private static final byte[] AGE = bytes("age");
+    private static final byte[] CF = bytes("cf");
+    private static final byte[] FIRSTNAME = bytes("firstname");
+    private static final byte[] SENDERS = bytes("arr");
+
+    private static final byte[] M1_ROWID = encode(VARCHAR, "row1");
+    private static final byte[] AGE_VALUE = encode(BIGINT, 27L);
+    private static final byte[] UPDATED_AGE_VALUE = encode(BIGINT, 28L);
+    private static final byte[] M1_FNAME_VALUE = encode(VARCHAR, "alice");
+    private static final byte[] M1_ARR_VALUE = encode(new ArrayType(VARCHAR), getBlockFromArray(VARCHAR, ImmutableList.of("abc", "def", "ghi")));
+
+    private static final byte[] M2_ROWID = encode(VARCHAR, "row2");
+    private static final byte[] M2_FNAME_VALUE = encode(VARCHAR, "bob");
+    private static final byte[] UPDATED_M2_FNAME_VALUE = encode(VARCHAR, "dave");
+    private static final byte[] M2_ARR_VALUE = encode(new ArrayType(VARCHAR), getBlockFromArray(VARCHAR, ImmutableList.of("ghi", "mno", "abc")));
+
+    private static final byte[] M3_ROWID = encode(VARCHAR, "row3");
+    private static final byte[] M3_FNAME_VALUE = encode(VARCHAR, "carol");
+    private static final byte[] M3_ARR_VALUE = encode(new ArrayType(VARCHAR), getBlockFromArray(VARCHAR, ImmutableList.of("def", "ghi", "jkl")));
+
+    private Row r1 = null;
+    private Row r2 = null;
+    private Row r3 = null;
+    private Mutation m1 = null;
+    private Mutation m2v = null;
+    private Mutation m3v = null;
+    private AccumuloTable table;
+    private Connector connector;
+    private MetricsStorage metricsStorage;
+
+    @BeforeClass
+    public void setupClass()
+            throws Exception
+    {
+        CONFIG.setUsername("root");
+        CONFIG.setPassword("secret");
+
+        connector = AccumuloQueryRunner.getAccumuloConnector();
+        connector.securityOperations().changeUserAuthorizations("root", new Authorizations("private", "moreprivate", "foo", "bar", "xyzzy"));
+        metricsStorage = MetricsStorage.getDefault(connector, CONFIG);
+
+        AccumuloColumnHandle c1 = new AccumuloColumnHandle("id", Optional.empty(), Optional.empty(), VARCHAR, 0, "", false);
+        AccumuloColumnHandle c2 = new AccumuloColumnHandle("age", Optional.of("cf"), Optional.of("age"), BIGINT, 1, "", true);
+        AccumuloColumnHandle c3 = new AccumuloColumnHandle("firstname", Optional.of("cf"), Optional.of("firstname"), VARCHAR, 2, "", true);
+        AccumuloColumnHandle c4 = new AccumuloColumnHandle("arr", Optional.of("cf"), Optional.of("arr"), new ArrayType(VARCHAR), 3, "", true);
+
+        table = new AccumuloTable("default", "presto_batch_writer_test_table", ImmutableList.of(c1, c2, c3, c4), "id", false, LexicoderRowSerializer.class.getCanonicalName(), null, Optional.empty(), false);
+
+        m1 = new Mutation(M1_ROWID);
+        m1.put(ROW_ID_COLUMN, ROW_ID_COLUMN, M1_ROWID);
+        m1.put(CF, AGE, AGE_VALUE);
+        m1.put(CF, FIRSTNAME, M1_FNAME_VALUE);
+        m1.put(CF, SENDERS, M1_ARR_VALUE);
+
+        r1 = new Row()
+                .addField("row1", VARCHAR)
+                .addField(27L, BIGINT)
+                .addField("alice", VARCHAR)
+                .addField(getBlockFromArray(VARCHAR, ImmutableList.of("abc", "def", "ghi")), new ArrayType(VARCHAR));
+
+        ColumnVisibility visibility1 = new ColumnVisibility("private");
+        m2v = new Mutation(M2_ROWID);
+        m2v.put(ROW_ID_COLUMN, ROW_ID_COLUMN, M2_ROWID);
+        m2v.put(CF, AGE, visibility1, AGE_VALUE);
+        m2v.put(CF, FIRSTNAME, visibility1, M2_FNAME_VALUE);
+        m2v.put(CF, SENDERS, visibility1, M2_ARR_VALUE);
+
+        r2 = new Row()
+                .addField("row2", VARCHAR)
+                .addField(27L, BIGINT)
+                .addField("bob", VARCHAR)
+                .addField(getBlockFromArray(VARCHAR, ImmutableList.of("ghi", "mno", "abc")), new ArrayType(VARCHAR));
+
+        ColumnVisibility visibility2 = new ColumnVisibility("moreprivate");
+        m3v = new Mutation(M3_ROWID);
+        m3v.put(ROW_ID_COLUMN, ROW_ID_COLUMN, M3_ROWID);
+        m3v.put(CF, AGE, visibility2, AGE_VALUE);
+        m3v.put(CF, FIRSTNAME, visibility2, M3_FNAME_VALUE);
+        m3v.put(CF, SENDERS, visibility2, M3_ARR_VALUE);
+
+        r3 = new Row()
+                .addField("row3", VARCHAR)
+                .addField(27L, BIGINT)
+                .addField("carol", VARCHAR)
+                .addField(getBlockFromArray(VARCHAR, ImmutableList.of("def", "ghi", "jkl")), new ArrayType(VARCHAR));
+    }
+
+    @AfterMethod
+    public void cleanup()
+            throws Exception
+    {
+        if (connector.tableOperations().exists(table.getFullTableName())) {
+            connector.tableOperations().delete(table.getFullTableName());
+        }
+
+        if (connector.tableOperations().exists(table.getIndexTableName())) {
+            connector.tableOperations().delete(table.getIndexTableName());
+        }
+
+        metricsStorage.drop(table);
+    }
+
+    @Test
+    public void testAddRow()
+            throws Exception
+    {
+        connector.tableOperations().create(table.getFullTableName());
+        connector.tableOperations().create(table.getIndexTableName());
+        metricsStorage.create(table);
+
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        prestoBatchWriter.addRow(r1);
+        prestoBatchWriter.flush();
+
+        Scanner scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        Iterator<Entry<Key, Value>> iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row1"), "___ROW___", "___ROW___", "row1");
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "arr", M1_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "firstname", M1_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations());
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row1", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi")), 1);
+
+        prestoBatchWriter.addRow(r2);
+        prestoBatchWriter.flush();
+
+        scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row1"), "___ROW___", "___ROW___", "row1");
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "arr", M1_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "firstname", M1_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "___ROW___", "___ROW___", "row2");
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "arr", M2_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "firstname", M2_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations());
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row1", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row2", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row2", "");
+        assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "row1", "");
+        assertKeyValuePair(iter.next(), M2_FNAME_VALUE, "cf_firstname", "row2", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row2", "");
+        assertKeyValuePair(iter.next(), bytes("mno"), "cf_arr", "row2", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE)), 2);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno")), 1);
+
+        prestoBatchWriter.addRow(r3);
+        prestoBatchWriter.close();
+
+        scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row1"), "___ROW___", "___ROW___", "row1");
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "arr", M1_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "firstname", M1_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "___ROW___", "___ROW___", "row2");
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "arr", M2_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "firstname", M2_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "___ROW___", "___ROW___", "row3");
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "arr", M3_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "firstname", M3_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations());
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row1", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row2", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row3", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row2", "");
+        assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "row1", "");
+        assertKeyValuePair(iter.next(), M2_FNAME_VALUE, "cf_firstname", "row2", "");
+        assertKeyValuePair(iter.next(), M3_FNAME_VALUE, "cf_firstname", "row3", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row3", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row2", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row3", "");
+        assertKeyValuePair(iter.next(), bytes("jkl"), "cf_arr", "row3", "");
+        assertKeyValuePair(iter.next(), bytes("mno"), "cf_arr", "row2", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE)), 3);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M3_FNAME_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi")), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "jkl")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno")), 1);
+    }
+
+    @Test
+    public void testAddRows()
+            throws Exception
+    {
+        connector.tableOperations().create(table.getFullTableName());
+        connector.tableOperations().create(table.getIndexTableName());
+        metricsStorage.create(table);
+
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        prestoBatchWriter.addRows(ImmutableList.of(r1, r2, r3));
+        prestoBatchWriter.flush();
+
+        Scanner scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        Iterator<Entry<Key, Value>> iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row1"), "___ROW___", "___ROW___", "row1");
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "arr", M1_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "firstname", M1_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "___ROW___", "___ROW___", "row2");
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "arr", M2_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "firstname", M2_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "___ROW___", "___ROW___", "row3");
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "arr", M3_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "firstname", M3_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations());
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row1", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row2", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row3", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row2", "");
+        assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "row1", "");
+        assertKeyValuePair(iter.next(), M2_FNAME_VALUE, "cf_firstname", "row2", "");
+        assertKeyValuePair(iter.next(), M3_FNAME_VALUE, "cf_firstname", "row3", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row3", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row2", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row3", "");
+        assertKeyValuePair(iter.next(), bytes("jkl"), "cf_arr", "row3", "");
+        assertKeyValuePair(iter.next(), bytes("mno"), "cf_arr", "row2", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE)), 3);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M3_FNAME_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi")), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "jkl")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno")), 1);
+    }
+
+    @Test
+    public void testAddMutation()
+            throws Exception
+    {
+        connector.tableOperations().create(table.getFullTableName());
+        connector.tableOperations().create(table.getIndexTableName());
+        metricsStorage.create(table);
+
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        prestoBatchWriter.addMutation(m1);
+        prestoBatchWriter.flush();
+
+        Scanner scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        Iterator<Entry<Key, Value>> iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row1"), "___ROW___", "___ROW___", "row1");
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "arr", M1_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "firstname", M1_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row1", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi", "private", "moreprivate")), 1);
+
+        prestoBatchWriter.addMutation(m2v);
+        prestoBatchWriter.flush();
+
+        scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row1"), "___ROW___", "___ROW___", "row1");
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "arr", M1_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "firstname", M1_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "___ROW___", "___ROW___", "row2");
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "arr", M2_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "firstname", M2_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row1", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row2", "private", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row2", "private", "");
+        assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "row1", "");
+        assertKeyValuePair(iter.next(), M2_FNAME_VALUE, "cf_firstname", "row2", "private", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row2", "private", "");
+        assertKeyValuePair(iter.next(), bytes("mno"), "cf_arr", "row2", "private", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE, "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 1);
+
+        prestoBatchWriter.addMutation(m3v);
+        prestoBatchWriter.close();
+
+        scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row1"), "___ROW___", "___ROW___", "row1");
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "arr", M1_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "firstname", M1_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "___ROW___", "___ROW___", "row2");
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "arr", M2_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "firstname", M2_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "___ROW___", "___ROW___", "row3");
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "arr", M3_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "firstname", M3_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row1", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row2", "private", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row2", "private", "");
+        assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "row1", "");
+        assertKeyValuePair(iter.next(), M2_FNAME_VALUE, "cf_firstname", "row2", "private", "");
+        assertKeyValuePair(iter.next(), M3_FNAME_VALUE, "cf_firstname", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row2", "private", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("jkl"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("mno"), "cf_arr", "row2", "private", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE, "private", "moreprivate")), 3);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M3_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi", "private", "moreprivate")), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "jkl", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 1);
+    }
+
+    @Test
+    public void testAddMutations()
+            throws Exception
+    {
+        connector.tableOperations().create(table.getFullTableName());
+        connector.tableOperations().create(table.getIndexTableName());
+        metricsStorage.create(table);
+
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        prestoBatchWriter.addMutations(ImmutableList.of(m1, m2v, m3v));
+        prestoBatchWriter.close();
+
+        Scanner scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        Iterator<Entry<Key, Value>> iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row1"), "___ROW___", "___ROW___", "row1");
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "arr", M1_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "firstname", M1_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "___ROW___", "___ROW___", "row2");
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "arr", M2_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "firstname", M2_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "___ROW___", "___ROW___", "row3");
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "arr", M3_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "firstname", M3_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row1", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row2", "private", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row2", "private", "");
+        assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "row1", "");
+        assertKeyValuePair(iter.next(), M2_FNAME_VALUE, "cf_firstname", "row2", "private", "");
+        assertKeyValuePair(iter.next(), M3_FNAME_VALUE, "cf_firstname", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row2", "private", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("jkl"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("mno"), "cf_arr", "row2", "private", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE, "private", "moreprivate")), 3);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M3_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi", "private", "moreprivate")), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "jkl", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 1);
+    }
+
+    @Test
+    public void testUpdateColumn()
+            throws Exception
+    {
+        testAddMutations();
+
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        prestoBatchWriter.updateColumnByName("row2", "age", 28L);
+        prestoBatchWriter.flush();
+
+        Scanner scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        Iterator<Entry<Key, Value>> iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row1"), "___ROW___", "___ROW___", "row1");
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "arr", M1_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "firstname", M1_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "___ROW___", "___ROW___", "row2");
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "age", encode(BIGINT, 28L));
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "arr", M2_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "firstname", M2_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "___ROW___", "___ROW___", "row3");
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "arr", M3_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "firstname", M3_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row1", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), UPDATED_AGE_VALUE, "cf_age", "row2", "", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row2", "private", "");
+        assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "row1", "");
+        assertKeyValuePair(iter.next(), M2_FNAME_VALUE, "cf_firstname", "row2", "private", "");
+        assertKeyValuePair(iter.next(), M3_FNAME_VALUE, "cf_firstname", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row2", "private", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("jkl"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("mno"), "cf_arr", "row2", "private", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE, "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", UPDATED_AGE_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M3_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi", "private", "moreprivate")), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "jkl", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 1);
+
+        prestoBatchWriter.updateColumnByName("row2", "firstname", new ColumnVisibility("moreprivate"), "dave");
+        prestoBatchWriter.flush();
+
+        scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row1"), "___ROW___", "___ROW___", "row1");
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "arr", M1_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "firstname", M1_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "___ROW___", "___ROW___", "row2");
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "age", encode(BIGINT, 28L));
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "arr", M2_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "firstname", "dave");
+        assertKeyValuePair(iter.next(), bytes("row3"), "___ROW___", "___ROW___", "row3");
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "arr", M3_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "firstname", M3_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row1", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), UPDATED_AGE_VALUE, "cf_age", "row2", "", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row2", "private", "");
+        assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "row1", "");
+        assertKeyValuePair(iter.next(), M3_FNAME_VALUE, "cf_firstname", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), UPDATED_M2_FNAME_VALUE, "cf_firstname", "row2", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row2", "private", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("jkl"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("mno"), "cf_arr", "row2", "private", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE, "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", UPDATED_AGE_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M3_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", UPDATED_M2_FNAME_VALUE)), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", UPDATED_M2_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi", "private", "moreprivate")), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "jkl", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 1);
+
+        prestoBatchWriter.updateColumnByName("row2", "arr", new ColumnVisibility("moreprivate"), ImmutableList.of("jkl", "mno", "pqr"));
+        prestoBatchWriter.close();
+
+        scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row1"), "___ROW___", "___ROW___", "row1");
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "arr", M1_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "firstname", M1_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "___ROW___", "___ROW___", "row2");
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "age", encode(BIGINT, 28L));
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "arr", encode(new ArrayType(VARCHAR), getBlockFromArray(VARCHAR, ImmutableList.of("jkl", "mno", "pqr"))));
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "firstname", "dave");
+        assertKeyValuePair(iter.next(), bytes("row3"), "___ROW___", "___ROW___", "row3");
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "arr", M3_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "firstname", M3_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row1", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), UPDATED_AGE_VALUE, "cf_age", "row2", "", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "row1", "");
+        assertKeyValuePair(iter.next(), M3_FNAME_VALUE, "cf_firstname", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), UPDATED_M2_FNAME_VALUE, "cf_firstname", "row2", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("jkl"), "cf_arr", "row2", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("jkl"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("mno"), "cf_arr", "row2", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("pqr"), "cf_arr", "row2", "moreprivate", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE, "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", UPDATED_AGE_VALUE)), 1);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M3_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", UPDATED_M2_FNAME_VALUE)), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", UPDATED_M2_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "jkl", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 1);
+    }
+
+    @Test
+    public void testUpdateColumns()
+            throws Exception
+    {
+        testAddMutations();
+
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        prestoBatchWriter.updateColumnByName("row2", ImmutableMap.of(Pair.of("age", new ColumnVisibility("moreprivate")), 28L, Pair.of("firstname", new ColumnVisibility("moreprivate")), "dave", Pair.of("arr", new ColumnVisibility("moreprivate")), ImmutableList.of("jkl", "mno", "pqr")));
+        prestoBatchWriter.close();
+
+        Scanner scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        Iterator<Entry<Key, Value>> iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row1"), "___ROW___", "___ROW___", "row1");
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "arr", M1_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row1"), "cf", "firstname", M1_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "___ROW___", "___ROW___", "row2");
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "age", encode(BIGINT, 28L));
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "arr", encode(new ArrayType(VARCHAR), getBlockFromArray(VARCHAR, ImmutableList.of("jkl", "mno", "pqr"))));
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "firstname", "dave");
+        assertKeyValuePair(iter.next(), bytes("row3"), "___ROW___", "___ROW___", "row3");
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "arr", M3_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "firstname", M3_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row1", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), UPDATED_AGE_VALUE, "cf_age", "row2", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), M1_FNAME_VALUE, "cf_firstname", "row1", "");
+        assertKeyValuePair(iter.next(), M3_FNAME_VALUE, "cf_firstname", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), UPDATED_M2_FNAME_VALUE, "cf_firstname", "row2", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row1", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("jkl"), "cf_arr", "row2", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("jkl"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("mno"), "cf_arr", "row2", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("pqr"), "cf_arr", "row2", "moreprivate", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE, "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 3);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M3_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", UPDATED_M2_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "jkl", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 1);
+    }
+
+    @Test
+    public void testDeleteMutation()
+            throws Exception
+    {
+        // Populate the table with data
+        testAddMutation();
+
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        prestoBatchWriter.deleteRow("row1");
+        prestoBatchWriter.flush();
+
+        Scanner scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        Iterator<Entry<Key, Value>> iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row2"), "___ROW___", "___ROW___", "row2");
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "arr", M2_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row2"), "cf", "firstname", M2_FNAME_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "___ROW___", "___ROW___", "row3");
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "arr", M3_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "firstname", M3_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row2", "private", "");
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("abc"), "cf_arr", "row2", "private", "");
+        assertKeyValuePair(iter.next(), M2_FNAME_VALUE, "cf_firstname", "row2", "private", "");
+        assertKeyValuePair(iter.next(), M3_FNAME_VALUE, "cf_firstname", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row2", "private", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("jkl"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("mno"), "cf_arr", "row2", "private", "");
+        assertFalse(iter.hasNext());
+
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE, "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M3_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi", "private", "moreprivate")), 2);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "jkl", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 1);
+
+        prestoBatchWriter.deleteRow("row2");
+        prestoBatchWriter.flush();
+
+        scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), bytes("row3"), "___ROW___", "___ROW___", "row3");
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "age", AGE_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "arr", M3_ARR_VALUE);
+        assertKeyValuePair(iter.next(), bytes("row3"), "cf", "firstname", M3_FNAME_VALUE);
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertTrue(iter.hasNext());
+        assertKeyValuePair(iter.next(), AGE_VALUE, "cf_age", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), M3_FNAME_VALUE, "cf_firstname", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("def"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("ghi"), "cf_arr", "row3", "moreprivate", "");
+        assertKeyValuePair(iter.next(), bytes("jkl"), "cf_arr", "row3", "moreprivate", "");
+        assertFalse(iter.hasNext());
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc", "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M3_FNAME_VALUE, "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "jkl", "private", "moreprivate")), 1);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 0);
+
+        prestoBatchWriter.deleteRow("row3");
+        prestoBatchWriter.close();
+
+        scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertFalse(iter.hasNext());
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc", "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M3_FNAME_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def", "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi", "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "jkl", "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 0);
+    }
+
+    @Test
+    public void testDeleteMutations()
+            throws Exception
+    {
+        testAddMutations();
+
+        PrestoBatchWriter prestoBatchWriter = new PrestoBatchWriter(connector, CONFIG, connector.securityOperations().getUserAuthorizations("root"), table);
+        prestoBatchWriter.deleteRows(ImmutableList.of("row1", "row2", "row3"));
+        prestoBatchWriter.close();
+
+        Scanner scan = connector.createScanner(table.getFullTableName(), new Authorizations("private", "moreprivate"));
+        Iterator<Entry<Key, Value>> iter = scan.iterator();
+        assertFalse(iter.hasNext());
+
+        scan = connector.createScanner(table.getIndexTableName(), new Authorizations("private", "moreprivate"));
+        iter = scan.iterator();
+        assertFalse(iter.hasNext());
+        scan.close();
+
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "age", AGE_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getNumRowsInTable(table.getSchema(), table.getTable()), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "abc", "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M1_FNAME_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M2_FNAME_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "firstname", M3_FNAME_VALUE, "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "def", "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "ghi", "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "jkl", "private", "moreprivate")), 0);
+        assertEquals(metricsStorage.newReader().getCardinality(mck("cf", "arr", "mno", "private", "moreprivate")), 0);
+    }
+
+    private static byte[] encode(Type type, Object v)
+    {
+        return SERIALIZER.encode(type, v);
+    }
+
+    private MetricCacheKey mck(String family, String qualifier, String range, String... auths)
+    {
+        return mck(family, qualifier, range.getBytes(UTF_8), auths);
+    }
+
+    private MetricCacheKey mck(String family, String qualifier, byte[] range, String... auths)
+    {
+        return new MetricCacheKey(metricsStorage, table.getSchema(), table.getTable(), family, qualifier, false, new Authorizations(auths), new Range(new Text(range)));
+    }
+
+    private void assertKeyValuePair(Entry<Key, Value> e, byte[] row, String cf, String cq, String value)
+    {
+        assertEquals(e.getKey().getRow().copyBytes(), row);
+        assertEquals(e.getKey().getColumnFamily().toString(), cf);
+        assertEquals(e.getKey().getColumnQualifier().toString(), cq);
+        assertEquals(e.getValue().toString(), value);
+    }
+
+    private void assertKeyValuePair(Entry<Key, Value> e, byte[] row, String cf, String cq, byte[] value)
+    {
+        assertEquals(e.getKey().getRow().copyBytes(), row);
+        assertEquals(e.getKey().getColumnFamily().toString(), cf);
+        assertEquals(e.getKey().getColumnQualifier().toString(), cq);
+        assertEquals(e.getValue().get(), value);
+    }
+
+    private void assertKeyValuePair(Entry<Key, Value> e, byte[] row, String cf, String cq, String cv, String value)
+    {
+        assertEquals(e.getKey().getRow().copyBytes(), row);
+        assertEquals(e.getKey().getColumnFamily().toString(), cf);
+        assertEquals(e.getKey().getColumnQualifier().toString(), cq);
+        assertEquals(e.getKey().getColumnVisibility().toString(), cv);
+        assertEquals(e.getValue().toString(), value);
+    }
+
+    private static byte[] bytes(String s)
+    {
+        return s.getBytes(UTF_8);
+    }
+}

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/io/TestSortedEntryIterator.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/io/TestSortedEntryIterator.java
@@ -34,7 +34,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 
-import static com.facebook.presto.accumulo.io.SortedEntryIterator.FILL_SIZE;
 import static java.lang.Math.abs;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -47,6 +46,8 @@ import static org.testng.AssertJUnit.assertTrue;
 
 public class TestSortedEntryIterator
 {
+    private static final int FILL_SIZE = 100;
+
     @Test
     public void testEmpty()
             throws Exception
@@ -118,7 +119,7 @@ public class TestSortedEntryIterator
     private void assertScan(List<Entry<Key, Value>> entries)
             throws Exception
     {
-        SortedEntryIterator iterator = new SortedEntryIterator(entries.iterator());
+        SortedEntryIterator iterator = new SortedEntryIterator(FILL_SIZE, entries.iterator());
 
         if (entries.isEmpty()) {
             assertFalse(iterator.hasNext());

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/iterators/TestValueSummingIterator.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/iterators/TestValueSummingIterator.java
@@ -1,0 +1,429 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.iterators;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
+import io.airlift.log.Logger;
+import org.apache.accumulo.core.client.BatchScanner;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.LongCombiner.FixedLenEncoder;
+import org.apache.accumulo.core.iterators.LongCombiner.StringEncoder;
+import org.apache.accumulo.core.iterators.LongCombiner.Type;
+import org.apache.accumulo.core.iterators.LongCombiner.VarLenEncoder;
+import org.apache.accumulo.core.iterators.TypedValueCombiner.Encoder;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.minicluster.MiniAccumuloCluster;
+import org.apache.hadoop.io.Text;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestValueSummingIterator
+{
+    private static final String TABLE_NAME = "testvaluesummingiterator";
+    public static final Encoder<Long> FIXED_LEN_ENCODER = new FixedLenEncoder();
+    public static final Encoder<Long> VAR_LEN_ENCODER = new VarLenEncoder();
+    public static final Encoder<Long> STRING_ENCODER = new StringEncoder();
+
+    private Connector conn = null;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        File tmpDir = Files.createTempDir().getAbsoluteFile();
+        Logger.get(getClass()).info("MAC directory is " + tmpDir);
+        MiniAccumuloCluster mac = new MiniAccumuloCluster(tmpDir, "secret");
+        mac.start();
+        conn = mac.getConnector("root", "secret");
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                mac.stop();
+            }
+            catch (IOException | InterruptedException e) {
+                e.printStackTrace();
+            }
+        }));
+    }
+
+    @AfterMethod
+    public void cleanup()
+            throws Exception
+    {
+        if (conn.tableOperations().exists(TABLE_NAME)) {
+            conn.tableOperations().delete(TABLE_NAME);
+        }
+    }
+
+    @Test
+    public void testNoData()
+            throws Exception
+    {
+        conn.tableOperations().create(TABLE_NAME);
+
+        Scanner scanner = conn.createScanner(TABLE_NAME, new Authorizations());
+        IteratorSetting setting = new IteratorSetting(Integer.MAX_VALUE, ValueSummingIterator.class);
+        long expectedSum = 0;
+
+        ValueSummingIterator.setEncodingType(setting, Type.STRING);
+        scanner.addScanIterator(setting);
+
+        long sum = 0;
+        for (Map.Entry<Key, Value> entry : scanner) {
+            System.out.println(entry);
+            sum += STRING_ENCODER.decode(entry.getValue().get());
+        }
+
+        assertEquals(sum, expectedSum);
+    }
+
+    @Test
+    public void testNoDataInColumn()
+            throws Exception
+    {
+        conn.tableOperations().create(TABLE_NAME);
+        BatchWriter writer = conn.createBatchWriter(TABLE_NAME, new BatchWriterConfig());
+
+        Mutation m1 = new Mutation("foo1");
+        m1.put(b("cf2"), b("cq1"), STRING_ENCODER.encode(1L));
+        m1.put(b("cf2"), b("cq2"), STRING_ENCODER.encode(1L));
+        writer.addMutation(m1);
+
+        writer.close();
+
+        Scanner scanner = conn.createScanner(TABLE_NAME, new Authorizations());
+        scanner.fetchColumnFamily(t("cf1"));
+        IteratorSetting setting = new IteratorSetting(Integer.MAX_VALUE, ValueSummingIterator.class);
+        long expectedSum = 0;
+
+        ValueSummingIterator.setEncodingType(setting, Type.STRING);
+        scanner.addScanIterator(setting);
+
+        long sum = 0;
+        for (Map.Entry<Key, Value> entry : scanner) {
+            System.out.println(entry);
+            sum += STRING_ENCODER.decode(entry.getValue().get());
+        }
+
+        assertEquals(sum, expectedSum);
+    }
+
+    @Test
+    public void testSumAllFixedLenEncoder()
+            throws Exception
+    {
+        testSum(FIXED_LEN_ENCODER, Type.FIXEDLEN);
+    }
+
+    @Test
+    public void testSumBatchAllFixedLenEncoder()
+            throws Exception
+    {
+        testSumBatch(FIXED_LEN_ENCODER, Type.FIXEDLEN);
+    }
+
+    @Test
+    public void testSumAllStringEncoder()
+            throws Exception
+    {
+        testSum(STRING_ENCODER, Type.STRING);
+    }
+
+    @Test
+    public void testSumBatchllStringEncoder()
+            throws Exception
+    {
+        testSumBatch(STRING_ENCODER, Type.STRING);
+    }
+
+    @Test
+    public void testSumAllVarLenEncoder()
+            throws Exception
+    {
+        testSum(VAR_LEN_ENCODER, Type.VARLEN);
+    }
+
+    @Test
+    public void testSumBatchAllVarLenEncoder()
+            throws Exception
+    {
+        testSumBatch(VAR_LEN_ENCODER, Type.VARLEN);
+    }
+
+    @Test
+    public void testSumFamilyFixedLenEncoder()
+            throws Exception
+    {
+        testSum(FIXED_LEN_ENCODER, Type.FIXEDLEN, true);
+    }
+
+    @Test
+    public void testSumBatchFamilyFixedLenEncoder()
+            throws Exception
+    {
+        testSumBatch(FIXED_LEN_ENCODER, Type.FIXEDLEN, true);
+    }
+
+    @Test
+    public void testSumFamilyStringEncoder()
+            throws Exception
+    {
+        testSum(STRING_ENCODER, Type.STRING, true);
+    }
+
+    @Test
+    public void testSumBatchFamilyStringEncoder()
+            throws Exception
+    {
+        testSumBatch(STRING_ENCODER, Type.STRING, true);
+    }
+
+    @Test
+    public void testSumFamilyVarLenEncoder()
+            throws Exception
+    {
+        testSum(VAR_LEN_ENCODER, Type.VARLEN, true);
+    }
+
+    @Test
+    public void testSumBatchFamilyVarLenEncoder()
+            throws Exception
+    {
+        testSumBatch(VAR_LEN_ENCODER, Type.VARLEN, true);
+    }
+
+    @Test
+    public void testSumColumnFixedLenEncoder()
+            throws Exception
+    {
+        testSum(FIXED_LEN_ENCODER, Type.FIXEDLEN, true, true);
+    }
+
+    @Test
+    public void testSumBatchColumnFixedLenEncoder()
+            throws Exception
+    {
+        testSumBatch(FIXED_LEN_ENCODER, Type.FIXEDLEN, true, true);
+    }
+
+    @Test
+    public void testSumColumnStringEncoder()
+            throws Exception
+    {
+        testSum(STRING_ENCODER, Type.STRING, true, true);
+    }
+
+    @Test
+    public void testSumBatchColumnStringEncoder()
+            throws Exception
+    {
+        testSumBatch(STRING_ENCODER, Type.STRING, true, true);
+    }
+
+    @Test
+    public void testSumColumnVarLenEncoder()
+            throws Exception
+    {
+        testSum(VAR_LEN_ENCODER, Type.VARLEN, true, true);
+    }
+
+    @Test
+    public void testSumBatchColumnVarLenEncoder()
+            throws Exception
+    {
+        testSumBatch(VAR_LEN_ENCODER, Type.VARLEN, true, true);
+    }
+
+    private void testSum(Encoder<Long> encoder, Type type)
+            throws Exception
+    {
+        testSum(encoder, type, false, false);
+    }
+
+    private void testSum(Encoder<Long> encoder, Type type, boolean fetchColumn)
+            throws Exception
+    {
+        testSum(encoder, type, fetchColumn, false);
+    }
+
+    private void testSum(Encoder<Long> encoder, Type type, boolean fetchColumn, boolean fetchQualifier)
+            throws Exception
+    {
+        conn.tableOperations().create(TABLE_NAME);
+        BatchWriter writer = conn.createBatchWriter(TABLE_NAME, new BatchWriterConfig());
+
+        Mutation m1 = new Mutation("foo1");
+        m1.put(b("cf1"), b("cq1"), encoder.encode(1L));
+        m1.put(b("cf1"), b("cq2"), encoder.encode(1L));
+        m1.put(b("cf2"), b("cq1"), encoder.encode(1L));
+        m1.put(b("cf2"), b("cq2"), encoder.encode(1L));
+        writer.addMutation(m1);
+
+        Mutation m2 = new Mutation("foo2");
+        m2.put(b("cf1"), b("cq1"), encoder.encode(2L));
+        m2.put(b("cf1"), b("cq2"), encoder.encode(2L));
+        m2.put(b("cf2"), b("cq1"), encoder.encode(2L));
+        m2.put(b("cf2"), b("cq2"), encoder.encode(2L));
+        writer.addMutation(m2);
+
+        Mutation m3 = new Mutation("foo3");
+        m3.put(b("cf1"), b("cq1"), encoder.encode(3L));
+        m3.put(b("cf1"), b("cq2"), encoder.encode(3L));
+        m3.put(b("cf2"), b("cq1"), encoder.encode(3L));
+        m3.put(b("cf2"), b("cq2"), encoder.encode(3L));
+        writer.addMutation(m3);
+
+        writer.close();
+
+        Scanner scanner = conn.createScanner(TABLE_NAME, new Authorizations());
+        IteratorSetting setting = new IteratorSetting(Integer.MAX_VALUE, ValueSummingIterator.class);
+        long expectedSum;
+        if (fetchColumn) {
+            if (fetchQualifier) {
+                scanner.fetchColumn(t("cf1"), t("cq1"));
+                expectedSum = 6;
+            }
+            else {
+                scanner.fetchColumnFamily(t("cf1"));
+                expectedSum = 12;
+            }
+        }
+        else {
+            expectedSum = 24;
+        }
+
+        ValueSummingIterator.setEncodingType(setting, type);
+        scanner.addScanIterator(setting);
+
+        long sum = 0;
+        for (Map.Entry<Key, Value> entry : scanner) {
+            System.out.println(entry);
+            sum += encoder.decode(entry.getValue().get());
+        }
+
+        assertEquals(sum, expectedSum);
+    }
+
+    private void testSumBatch(Encoder<Long> encoder, Type type)
+            throws Exception
+    {
+        testSumBatch(encoder, type, false, false);
+    }
+
+    private void testSumBatch(Encoder<Long> encoder, Type type, boolean fetchColumn)
+            throws Exception
+    {
+        testSumBatch(encoder, type, fetchColumn, false);
+    }
+
+    private void testSumBatch(Encoder<Long> encoder, Type type, boolean fetchColumn, boolean fetchQualifier)
+            throws Exception
+    {
+        conn.tableOperations().create(TABLE_NAME);
+        BatchWriter writer = conn.createBatchWriter(TABLE_NAME, new BatchWriterConfig());
+
+        Mutation m1 = new Mutation("foo1");
+        m1.put(b("cf1"), b("cq1"), encoder.encode(1L));
+        m1.put(b("cf1"), b("cq2"), encoder.encode(1L));
+        m1.put(b("cf2"), b("cq1"), encoder.encode(1L));
+        m1.put(b("cf2"), b("cq2"), encoder.encode(1L));
+        writer.addMutation(m1);
+
+        Mutation m2 = new Mutation("foo2");
+        m2.put(b("cf1"), b("cq1"), encoder.encode(2L));
+        m2.put(b("cf1"), b("cq2"), encoder.encode(2L));
+        m2.put(b("cf2"), b("cq1"), encoder.encode(2L));
+        m2.put(b("cf2"), b("cq2"), encoder.encode(2L));
+        writer.addMutation(m2);
+
+        Mutation m3 = new Mutation("foo3");
+        m3.put(b("cf1"), b("cq1"), encoder.encode(3L));
+        m3.put(b("cf1"), b("cq2"), encoder.encode(3L));
+        m3.put(b("cf2"), b("cq1"), encoder.encode(3L));
+        m3.put(b("cf2"), b("cq2"), encoder.encode(3L));
+        writer.addMutation(m3);
+
+        writer.close();
+
+        BatchScanner scanner = conn.createBatchScanner(TABLE_NAME, new Authorizations(), 10);
+        IteratorSetting setting = new IteratorSetting(Integer.MAX_VALUE, ValueSummingIterator.class);
+        scanner.setRanges(ImmutableList.of(new Range("foo0", "foo1"), new Range("foo2"), new Range("foo3"), new Range("foo4")));
+
+        long expectedSum;
+        if (fetchColumn) {
+            if (fetchQualifier) {
+                scanner.fetchColumn(t("cf1"), t("cq1"));
+                expectedSum = 6;
+            }
+            else {
+                scanner.fetchColumnFamily(t("cf1"));
+                expectedSum = 12;
+            }
+        }
+        else {
+            expectedSum = 24;
+        }
+
+        ValueSummingIterator.setEncodingType(setting, type);
+        scanner.addScanIterator(setting);
+
+        long sum = 0;
+        for (Map.Entry<Key, Value> entry : scanner) {
+            System.out.println(entry);
+            sum += encoder.decode(entry.getValue().get());
+        }
+        Logger.get(getClass()).info(format("%s %s", sum, expectedSum));
+        assertEquals(sum, expectedSum);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testTypeNotSet()
+            throws Exception
+    {
+        conn.tableOperations().create(TABLE_NAME);
+        Scanner scanner = conn.createScanner(TABLE_NAME, new Authorizations());
+        IteratorSetting setting = new IteratorSetting(Integer.MAX_VALUE, ValueSummingIterator.class);
+        scanner.addScanIterator(setting);
+        scanner.iterator().next();
+    }
+
+    private static byte[] b(String s)
+    {
+        return s.getBytes(UTF_8);
+    }
+
+    private static Text t(String s)
+    {
+        return new Text(b(s));
+    }
+}

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/iterators/TestValueSummingIterator.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/iterators/TestValueSummingIterator.java
@@ -15,7 +15,6 @@ package com.facebook.presto.accumulo.iterators;
 
 import com.facebook.presto.accumulo.AccumuloQueryRunner;
 import com.google.common.collect.ImmutableList;
-import io.airlift.log.Logger;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
@@ -39,7 +38,6 @@ import org.testng.annotations.Test;
 
 import java.util.Map;
 
-import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 
@@ -84,11 +82,12 @@ public class TestValueSummingIterator
 
         long sum = 0;
         for (Map.Entry<Key, Value> entry : scanner) {
-            System.out.println(entry);
             sum += STRING_ENCODER.decode(entry.getValue().get());
         }
 
         assertEquals(sum, expectedSum);
+
+        scanner.close();
     }
 
     @Test
@@ -115,11 +114,12 @@ public class TestValueSummingIterator
 
         long sum = 0;
         for (Map.Entry<Key, Value> entry : scanner) {
-            System.out.println(entry);
             sum += STRING_ENCODER.decode(entry.getValue().get());
         }
 
         assertEquals(sum, expectedSum);
+
+        scanner.close();
     }
 
     @Test
@@ -311,11 +311,12 @@ public class TestValueSummingIterator
 
         long sum = 0;
         for (Map.Entry<Key, Value> entry : scanner) {
-            System.out.println(entry);
             sum += encoder.decode(entry.getValue().get());
         }
 
         assertEquals(sum, expectedSum);
+
+        scanner.close();
     }
 
     private void testSumBatch(Encoder<Long> encoder, Type type)
@@ -383,11 +384,12 @@ public class TestValueSummingIterator
 
         long sum = 0;
         for (Map.Entry<Key, Value> entry : scanner) {
-            System.out.println(entry);
             sum += encoder.decode(entry.getValue().get());
         }
-        Logger.get(getClass()).info(format("%s %s", sum, expectedSum));
+
         assertEquals(sum, expectedSum);
+
+        scanner.close();
     }
 
     @Test(expectedExceptions = RuntimeException.class)
@@ -399,6 +401,7 @@ public class TestValueSummingIterator
         IteratorSetting setting = new IteratorSetting(Integer.MAX_VALUE, ValueSummingIterator.class);
         scanner.addScanIterator(setting);
         scanner.iterator().next();
+        scanner.close();
     }
 
     private static byte[] b(String s)

--- a/presto-docs/src/main/sphinx/connector/accumulo.rst
+++ b/presto-docs/src/main/sphinx/connector/accumulo.rst
@@ -12,8 +12,6 @@ Overview
 The Accumulo connector supports reading and writing data from Apache Accumulo.
 Please read this page thoroughly to understand the capabilities and features of the connector.
 
-<<<<<<< b369d8c1c3a4a51e2271764b649287e0b889052a
-=======
 Table of Contents
 ~~~~~~~~~~~~~~~~~
 #. `Dependencies <#dependencies>`__
@@ -41,7 +39,6 @@ Dependencies
 -  Accumulo
 -  *presto-accumulo-iterators*, from `https://github.com/bloomberg/presto-accumulo <https://github.com/bloomberg/presto-accumulo>`_
 
->>>>>>> Refactor metrics storage and add timestamp truncates
 Installing the Iterator Dependency
 ----------------------------------
 
@@ -502,7 +499,7 @@ Property Name            Default Value    Description
 ``scan_auths``           (user auths)     Scan-time authorizations set on the batch scanner.
 ``metrics_storage``      ``default``      Metrics storage to use for this table.  Can either be 'default', 'accumulo', or a Java class name
 ``truncate_timestamps``  ``false``        True to enable truncating of timestamp-type column metrics                                                                                                                                                                       |
-
+======================== ================ ======================================================================================================
 
 Session Properties
 ------------------
@@ -531,6 +528,7 @@ Property Name                                 Default Value Description
 ``scan_username``                             (config)      User to impersonate when scanning the tables. This property trumps the ``scan_auths`` table property
 ``index_short_circuit_cardinality_fetch``     ``true``      Short circuit the retrieval of index metrics once any column is less than the lowest cardinality threshold
 ``index_cardinality_cache_polling_duration``  ``10ms``      Sets the cardinality cache polling duration for short circuit retrieval of index metrics
+============================================= ============= =======================================================================================================
 
 Adding Columns
 --------------

--- a/presto-docs/src/main/sphinx/connector/accumulo.rst
+++ b/presto-docs/src/main/sphinx/connector/accumulo.rst
@@ -480,6 +480,7 @@ Note that session properties are prefixed with the catalog name::
 
     SET SESSION accumulo.column_filter_optimizations_enabled = false;
 
+<<<<<<< 58d6adaada98a8f605337c3904f9ddf0350a580d
 ============================================= ============= =======================================================================================================
 Property Name                                 Default Value Description
 ============================================= ============= =======================================================================================================
@@ -489,8 +490,12 @@ Property Name                                 Default Value Description
 ``index_rows_per_split``                      ``10000``     The number of Accumulo row IDs that are packed into a single Presto split
 ``index_threshold``                           ``0.2``       The ratio between number of rows to be scanned based on the index over the total number of rows
                                                             If the ratio is below this threshold, the index will be used.
-``index_lowest_cardinality_threshold``        ``0.01``      The threshold where the column with the lowest cardinality will be used instead of computing an
-                                                            intersection of ranges in the index. Secondary index must be enabled
+``index_lowest_cardinality_threshold``        ``0.01``      The threshold (as a percentage) where the column with the lowest cardinality will be used instead
+                                                            of computing an intersection of ranges in the secondary index. The minimum value of this value times
+                                                            the number of rows in the table and the row threshold will be used. Secondary index must be enabled
+``index_lowest_cardinality_row_threshold``    ``50000``     The threshold (as number of rows) where the column with the lowest cardinality will be used instead
+                                                            of computing an intersection of ranges in the secondary index. The minimum value of this value and
+                                                            the percentage threshold will be used. Secondary index must be enabled
 ``index_metrics_enabled``                     ``true``      Set to true to enable usage of the metrics table to optimize usage of the index
 ``scan_username``                             (config)      User to impersonate when scanning the tables. This property trumps the ``scan_auths`` table property
 ``index_short_circuit_cardinality_fetch``     ``true``      Short circuit the retrieval of index metrics once any column is less than the lowest cardinality threshold

--- a/presto-docs/src/main/sphinx/connector/accumulo.rst
+++ b/presto-docs/src/main/sphinx/connector/accumulo.rst
@@ -480,20 +480,21 @@ Note that session properties are prefixed with the catalog name::
 
     SET SESSION accumulo.column_filter_optimizations_enabled = false;
 
-======================================== ============= =======================================================================================================
-Property Name                            Default Value Description
-======================================== ============= =======================================================================================================
-``optimize_locality_enabled``            ``true``      Set to true to enable data locality for non-indexed scans
-``optimize_split_ranges_enabled``        ``true``      Set to true to split non-indexed queries by tablet splits. Should generally be true.
-``optimize_index_enabled``               ``true``      Set to true to enable usage of the secondary index on query
-``index_rows_per_split``                 ``10000``     The number of Accumulo row IDs that are packed into a single Presto split
-``index_threshold``                      ``0.2``       The ratio between number of rows to be scanned based on the index over the total number of rows.
-                                                       If the ratio is below this threshold, the index will be used.
-``index_lowest_cardinality_threshold``   ``0.01``      The threshold where the column with the lowest cardinality will be used instead of computing an
-                                                       intersection of ranges in the index. Secondary index must be enabled.
-``index_metrics_enabled``                ``true``      Set to true to enable usage of the metrics table to optimize usage of the index
-``scan_username``                        (config)      User to impersonate when scanning the tables. This property trumps the ``scan_auths`` table property.
-======================================== ============= =======================================================================================================
+============================================= ============= =======================================================================================================
+Property Name                                 Default Value Description
+============================================= ============= =======================================================================================================
+``optimize_locality_enabled``                 ``true``      Set to true to enable data locality for non-indexed scans
+``optimize_split_ranges_enabled``             ``true``      Set to true to split non-indexed queries by tablet splits. Should generally be true.
+``optimize_index_enabled``                    ``true``      Set to true to enable usage of the secondary index on query
+``index_rows_per_split``                      ``10000``     The number of Accumulo row IDs that are packed into a single Presto split
+``index_threshold``                           ``0.2``       The ratio between number of rows to be scanned based on the index over the total number of rows
+                                                            If the ratio is below this threshold, the index will be used.
+``index_lowest_cardinality_threshold``        ``0.01``      The threshold where the column with the lowest cardinality will be used instead of computing an
+                                                            intersection of ranges in the index. Secondary index must be enabled
+``index_metrics_enabled``                     ``true``      Set to true to enable usage of the metrics table to optimize usage of the index
+``scan_username``                             (config)      User to impersonate when scanning the tables. This property trumps the ``scan_auths`` table property
+``index_short_circuit_cardinality_fetch``     ``true``      Short circuit the retrieval of index metrics once any column is less than the lowest cardinality threshold
+``index_cardinality_cache_polling_duration``  ``10ms``      Sets the cardinality cache polling duration for short circuit retrieval of index metrics
 
 Adding Columns
 --------------


### PR DESCRIPTION
- Add ExecutorServices for index/metric retrieval
- Add short circuit feature for metrics fetch
- Add row-based threshold for lowest cardinality usage
- Add a new `ValueSummingIterator` to sum metrics on the server side
- Remove unused tracking of first and last row ID
- Improve ingestion API via a PrestoBatchWriter
- Refactor and create abstract metrics storage
- Add timestamp truncation feature
- Add a maximum limit to the index lookup