### PR TITLE
Fix NPE when scheduling non-remotely accessible splits

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -43,6 +43,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -306,8 +307,12 @@ public class NodeScheduler
         List<CompletableFuture<?>> blockedFutures = blockedNodes.stream()
                 .map(Node::getNodeIdentifier)
                 .map(nodeToTaskMap::get)
+                .filter(Objects::nonNull)
                 .map(remoteTask -> remoteTask.whenSplitQueueHasSpace(spaceThreshold))
                 .collect(toImmutableList());
+        if (blockedFutures.isEmpty()) {
+            return completedFuture(null);
+        }
         return firstCompletedFuture(blockedFutures, true);
     }
 


### PR DESCRIPTION
When scheduling a large initial batch of non-remotely accessible splits,
the split queue could fill up before the RemoteTask was created. This
causes a NPE when attempting to get the queue space future from the
task.
Instead, we just skip these nodes as the RemoteTask will be created
immediately after split scheduling.