### PR TITLE
Fix Mongo case-sensitive schema

### DIFF
--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -33,6 +33,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.mongodb.MongoClient;
 import com.mongodb.client.FindIterable;
@@ -67,6 +68,7 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -106,6 +108,7 @@ public class MongoSession
     private final int cursorBatchSize;
 
     private final LoadingCache<SchemaTableName, MongoTable> tableCache;
+    private final LoadingCache<String, Map<String, String>> schemaNamesCache;
     private final String implicitPrefix;
 
     public MongoSession(TypeManager typeManager, MongoClient client, MongoClientConfig config)
@@ -128,6 +131,18 @@ public class MongoSession
                         return loadTableSchema(key);
                     }
                 });
+
+        this.schemaNamesCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(1, HOURS)
+                .refreshAfterWrite(1, MINUTES)
+                .build(new CacheLoader<String, Map<String, String>>()
+                {
+                    @Override
+                    public Map<String, String> load(String key) throws Exception
+                    {
+                        return loadAllSchemas();
+                    }
+                });
     }
 
     public void shutdown()
@@ -137,7 +152,13 @@ public class MongoSession
 
     public List<String> getAllSchemas()
     {
-        return ImmutableList.copyOf(client.listDatabaseNames());
+        return ImmutableList.copyOf(getCacheValue(schemaNamesCache, "", RuntimeException.class).keySet());
+    }
+
+    private Map<String, String> loadAllSchemas()
+            throws Exception
+    {
+        return Maps.uniqueIndex(client.listDatabaseNames(), MongoSession::toLowerCase);
     }
 
     public Set<String> getAllTables(String schema)
@@ -145,11 +166,13 @@ public class MongoSession
     {
         ImmutableSet.Builder<String> builder = ImmutableSet.builder();
 
-        builder.addAll(ImmutableList.copyOf(client.getDatabase(schema).listCollectionNames()).stream()
+        String caseSensitiveSchemaName = getCaseSensitiveSchemaName(schema);
+
+        builder.addAll(ImmutableList.copyOf(client.getDatabase(caseSensitiveSchemaName).listCollectionNames()).stream()
                             .filter(name -> !name.equals(schemaCollection))
                             .filter(name -> !SYSTEM_TABLES.contains(name))
                             .collect(toSet()));
-        builder.addAll(getTableMetadataNames(schema));
+        builder.addAll(getTableMetadataNames(caseSensitiveSchemaName));
 
         return builder.build();
     }
@@ -172,6 +195,17 @@ public class MongoSession
         getCollection(tableName).drop();
 
         tableCache.invalidate(tableName);
+    }
+
+    public String getCaseSensitiveSchemaName(String caseInsensitiveName)
+    {
+        String caseSensitiveSchemaName = getCacheValue(schemaNamesCache, "", RuntimeException.class).get(caseInsensitiveName.toLowerCase(ENGLISH));
+        return caseSensitiveSchemaName == null ? caseInsensitiveName : caseSensitiveSchemaName;
+    }
+
+    private static String toLowerCase(String value)
+    {
+        return value.toLowerCase(ENGLISH);
     }
 
     private MongoTable loadTableSchema(SchemaTableName tableName)


### PR DESCRIPTION
We have some problem with case-sensitive schema name where we have our database named like this `camelCase`. 

We thought that we would do something like https://github.com/prestodb/presto/blob/master/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CachingCassandraSchemaProvider.java#L113

Where the names are cached so it can be mapped later. We solved that problem already however. As I'm new to the codebase and the project but would like to contribute to the project. Not sure if this is something that the community would want?