### PR TITLE
Respect summarize parameter when DELETE'ing task

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
@@ -210,11 +210,19 @@ public class TaskResource
             @Context UriInfo uriInfo)
     {
         requireNonNull(taskId, "taskId is null");
+        TaskInfo taskInfo;
 
         if (abort) {
-            return taskManager.abortTask(taskId);
+            taskInfo = taskManager.abortTask(taskId);
         }
-        return taskManager.cancelTask(taskId);
+        else {
+            taskInfo = taskManager.cancelTask(taskId);
+        }
+
+        if (shouldSummarize(uriInfo)) {
+            taskInfo = taskInfo.summarize();
+        }
+        return taskInfo;
     }
 
     @GET


### PR DESCRIPTION
A heap dump of the coordinator shows that in a busy cluster these
objects can take up more than half of the heap, and they scale both with
the complexity of the query and size of the cluster