### PR TITLE
Create failed query when session is invalid

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.execution;
 
-import com.facebook.presto.Session;
+import com.facebook.presto.server.SessionSupplier;
 import com.facebook.presto.spi.QueryId;
 import io.airlift.units.Duration;
 
@@ -33,7 +33,7 @@ public interface QueryManager
 
     void recordHeartbeat(QueryId queryId);
 
-    QueryInfo createQuery(Session session, String query);
+    QueryInfo createQuery(SessionSupplier sessionSupplier, String query);
 
     void cancelQuery(QueryId queryId);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/SessionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionSupplier.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.transaction.TransactionManager;
+
+public interface SessionSupplier
+{
+    Identity getIdentity();
+
+    Session createSession(
+            QueryId queryId,
+            TransactionManager transactionManager,
+            AccessControl accessControl,
+            SessionPropertyManager sessionPropertyManager);
+}

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
@@ -220,7 +220,7 @@ public class TestQueues
 
     private static QueryId createQuery(DistributedQueryRunner queryRunner, Session session, String sql)
     {
-        return queryRunner.getCoordinator().getQueryManager().createQuery(session, sql).getQueryId();
+        return queryRunner.getCoordinator().getQueryManager().createQuery(new TestingSessionFactory(session), sql).getQueryId();
     }
 
     private static void cancelQuery(DistributedQueryRunner queryRunner, QueryId queryId)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestingSessionFactory.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestingSessionFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.server.SessionSupplier;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.transaction.TransactionManager;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestingSessionFactory
+        implements SessionSupplier
+{
+    private final Session session;
+
+    public TestingSessionFactory(Session session)
+    {
+        this.session = requireNonNull(session, "session is null");
+    }
+
+    @Override
+    public Identity getIdentity()
+    {
+        return session.getIdentity();
+    }
+
+    @Override
+    public Session createSession(QueryId queryId, TransactionManager transactionManager, AccessControl accessControl, SessionPropertyManager sessionPropertyManager)
+    {
+        return session;
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueues.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution.resourceGroups.db;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.QueryState;
+import com.facebook.presto.execution.TestingSessionFactory;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupInfo;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.resourceGroups.db.DbResourceGroupConfig;
@@ -230,7 +231,7 @@ public class TestQueues
 
     private static QueryId createQuery(DistributedQueryRunner queryRunner, Session session, String sql)
     {
-        return queryRunner.getCoordinator().getQueryManager().createQuery(session, sql).getQueryId();
+        return queryRunner.getCoordinator().getQueryManager().createQuery(new TestingSessionFactory(session), sql).getQueryId();
     }
 
     private static void cancelQuery(DistributedQueryRunner queryRunner, QueryId queryId)


### PR DESCRIPTION
When the server recieves a properly formed Session but the contents are
invalid, create a failed query instead of returning an HTTP error response.
This allows clients to report errors using the normal failed query system.