### PR TITLE
Change maven central repository to .apache.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,31 @@
         <tag>HEAD</tag>
     </scm>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>http://repo1.maven.apache.org/maven2/</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+      <pluginRepository>
+          <id>central</id>
+          <url>http://repo1.maven.apache.org/maven2/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+      </pluginRepository>
+    </pluginRepositories>
+
     <properties>
         <air.main.basedir>${project.basedir}</air.main.basedir>
 


### PR DESCRIPTION
This is a workaround for a certificate problem with repo.maven.org

https://issues.sonatype.org/browse/MVNCENTRAL-1369