### PR TITLE
Make DiscretePredicates support lazy generation

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartition.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartition.java
@@ -69,11 +69,6 @@ public class HivePartition
         return partitionId;
     }
 
-    public TupleDomain<ColumnHandle> getTupleDomain()
-    {
-        return TupleDomain.fromFixedValues(keys);
-    }
-
     public Map<ColumnHandle, NullableValue> getKeys()
     {
         return keys;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -945,7 +945,6 @@ public abstract class AbstractTestHiveClient
             assertEquals(actualPartition.getKeys(), expectedPartition.getKeys());
             assertEquals(actualPartition.getTableName(), expectedPartition.getTableName());
             assertEquals(actualPartition.getBuckets(), expectedPartition.getBuckets());
-            assertEquals(actualPartition.getTupleDomain(), expectedPartition.getTupleDomain());
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/DiscretePredicates.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/DiscretePredicates.java
@@ -24,16 +24,17 @@ import static java.util.Objects.requireNonNull;
 public final class DiscretePredicates
 {
     private final List<ColumnHandle> columns;
-    private final List<TupleDomain<ColumnHandle>> predicates;
+    private final Iterable<TupleDomain<ColumnHandle>> predicates;
 
-    public DiscretePredicates(List<ColumnHandle> columns, List<TupleDomain<ColumnHandle>> predicates)
+    public DiscretePredicates(List<ColumnHandle> columns, Iterable<TupleDomain<ColumnHandle>> predicates)
     {
         requireNonNull(columns, "columns is null");
         if (columns.isEmpty()) {
             throw new IllegalArgumentException("columns is empty");
         }
         this.columns = unmodifiableList(new ArrayList<>(columns));
-        this.predicates = unmodifiableList(new ArrayList<>(requireNonNull(predicates, "predicates is null")));
+        // do not copy predicates because it may be lazy
+        this.predicates = requireNonNull(predicates, "predicates is null");
     }
 
     public List<ColumnHandle> getColumns()
@@ -41,7 +42,7 @@ public final class DiscretePredicates
         return columns;
     }
 
-    public List<TupleDomain<ColumnHandle>> getPredicates()
+    public Iterable<TupleDomain<ColumnHandle>> getPredicates()
     {
         return predicates;
     }


### PR DESCRIPTION
Some Hive tables have a huge numbers of partitions, and generating
a tuple domain for each one can stress the GC.  Since DiscretePredicates
is rarely used, it is better to delay creation of the tuple domains
until necessary, and it is better to use an iterator so all tuple
domains do not have to be in memory at the same time.

Additionally, add an optimized `columnWiseUnion` which does not require all `TupleDomains` to be in memory at the same time.