### PR TITLE
[WIP] Iterative optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -67,6 +67,7 @@ public final class SystemSessionProperties
     public static final String OPTIMIZE_DISTINCT_AGGREGATIONS = "optimize_mixed_distinct_aggregations";
     public static final String LEGACY_ORDER_BY = "legacy_order_by";
     public static final String REORDER_WINDOWS = "reorder_windows";
+    public static final String NEW_OPTIMIZER = "new_optimizer_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -271,6 +272,11 @@ public final class SystemSessionProperties
                         REORDER_WINDOWS,
                         "Allow reordering window functions in query",
                         featuresConfig.isReorderWindows(),
+                        false),
+                booleanSessionProperty(
+                        NEW_OPTIMIZER,
+                        "Experimental: enable new optimizer",
+                        featuresConfig.isNewOptimizerEnabled(),
                         false));
     }
 
@@ -426,5 +432,10 @@ public final class SystemSessionProperties
     public static boolean isLegacyOrderByEnabled(Session session)
     {
         return session.getSystemProperty(LEGACY_ORDER_BY, Boolean.class);
+    }
+
+    public static boolean isNewOptimizerEnabled(Session session)
+    {
+        return session.getSystemProperty(NEW_OPTIMIZER, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -68,6 +68,7 @@ public class FeaturesConfig
     private DataSize operatorMemoryLimitBeforeSpill = new DataSize(4, DataSize.Unit.MEGABYTE);
     private Path spillerSpillPath = Paths.get(System.getProperty("java.io.tmpdir"), "presto", "spills");
     private int spillerThreads = 4;
+    private boolean newOptimizerEnabled;
 
     public boolean isResourceGroupsEnabled()
     {
@@ -301,6 +302,18 @@ public class FeaturesConfig
     public FeaturesConfig setSpillEnabled(boolean spillEnabled)
     {
         this.spillEnabled = spillEnabled;
+        return this;
+    }
+
+    public boolean isNewOptimizerEnabled()
+    {
+        return newOptimizerEnabled;
+    }
+
+    @Config("experimental.new-optimizer-enabled")
+    public FeaturesConfig setNewOptimizerEnabled(boolean value)
+    {
+        this.newOptimizerEnabled = value;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -272,7 +272,7 @@ public class LogicalPlanner
         PlanNode source = plan.getRoot();
 
         if (!analysis.isCreateTableAsSelectWithData()) {
-            source = new LimitNode(idAllocator.getNextId(), source, 0L, false);
+            source = new LimitNode(idAllocator.getNextId(), source, 0L, LimitNode.Step.SINGLE);
         }
 
         // todo this should be checked in analysis

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAs
 import com.facebook.presto.sql.planner.iterative.rule.ImplementIntersectAndExcept;
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
 import com.facebook.presto.sql.planner.iterative.rule.MergeIntersections;
+import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
 import com.facebook.presto.sql.planner.iterative.rule.MergeUnions;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
@@ -123,7 +124,8 @@ public class PlanOptimizers
                         new PruneTableScanColumns(),
                         new PruneValuesColumns(),
 
-                        new PushLimitThroughProject()
+                        new PushLimitThroughProject(),
+                        new MergeLimits()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -25,6 +25,7 @@ import com.facebook.presto.sql.planner.iterative.rule.UnaliasMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasOutput;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasProject;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasSort;
+import com.facebook.presto.sql.planner.iterative.rule.UnaliasTopN;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
 import com.facebook.presto.sql.planner.optimizations.BeginTableWrite;
@@ -97,7 +98,8 @@ public class PlanOptimizers
                         new UnaliasOutput(),
                         new UnaliasSort(),
                         new UnaliasGroupId(),
-                        new UnaliasMarkDistinct()
+                        new UnaliasMarkDistinct(),
+                        new UnaliasTopN()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantProjections;
+import com.facebook.presto.sql.planner.iterative.rule.SingleMarkDistinctToGroupBy;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasFilter;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasGroupId;
@@ -106,7 +107,8 @@ public class PlanOptimizers
                         new UnaliasSetOperation(),
 
                         new RemoveRedundantProjections(),
-                        new InlineProjections()
+                        new InlineProjections(),
+                        new SingleMarkDistinctToGroupBy()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeIntersections;
 import com.facebook.presto.sql.planner.iterative.rule.MergeUnions;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughProject;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantProjections;
 import com.facebook.presto.sql.planner.iterative.rule.SingleMarkDistinctToGroupBy;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
@@ -120,7 +121,9 @@ public class PlanOptimizers
                         new MergeIntersections(),
 
                         new PruneTableScanColumns(),
-                        new PruneValuesColumns()
+                        new PruneValuesColumns(),
+
+                        new PushLimitThroughProject()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.planner.iterative.rule.UnaliasGroupId;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasOutput;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasProject;
+import com.facebook.presto.sql.planner.iterative.rule.UnaliasSetOperation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasSort;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasTopN;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
@@ -99,7 +100,8 @@ public class PlanOptimizers
                         new UnaliasSort(),
                         new UnaliasGroupId(),
                         new UnaliasMarkDistinct(),
-                        new UnaliasTopN()
+                        new UnaliasTopN(),
+                        new UnaliasSetOperation()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -44,6 +44,7 @@ import com.facebook.presto.sql.planner.iterative.rule.UnaliasProject;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasSetOperation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasSort;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasTopN;
+import com.facebook.presto.sql.planner.iterative.rule.UnaliasUnnest;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
 import com.facebook.presto.sql.planner.optimizations.BeginTableWrite;
@@ -120,6 +121,7 @@ public class PlanOptimizers
                         new UnaliasMarkDistinct(),
                         new UnaliasTopN(),
                         new UnaliasSetOperation(),
+                        new UnaliasUnnest(),
 
                         new RemoveRedundantProjections(),
                         new InlineProjections(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementIntersectAndExcept;
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
+import com.facebook.presto.sql.planner.iterative.rule.MergeIntersections;
 import com.facebook.presto.sql.planner.iterative.rule.MergeUnions;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
@@ -116,6 +117,7 @@ public class PlanOptimizers
                         new SingleMarkDistinctToGroupBy(),
 
                         new MergeUnions(),
+                        new MergeIntersections(),
 
                         new PruneTableScanColumns(),
                         new PruneValuesColumns()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
+import com.facebook.presto.sql.planner.iterative.rule.UnaliasProject;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
 import com.facebook.presto.sql.planner.optimizations.BeginTableWrite;
@@ -82,7 +83,9 @@ public class PlanOptimizers
                 new CanonicalizeExpressions(),
                 new IterativeOptimizer(ImmutableSet.of(
                         new com.facebook.presto.sql.planner.iterative.rule.ImplementFilteredAggregations(),
-                        new ImplementBernoulliSampleAsFilter()
+                        new ImplementBernoulliSampleAsFilter(),
+
+                        new UnaliasProject()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
+import com.facebook.presto.sql.planner.iterative.rule.ImplementIntersectAndExcept;
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
@@ -97,6 +98,7 @@ public class PlanOptimizers
                 new IterativeOptimizer(ImmutableSet.of(
                         new com.facebook.presto.sql.planner.iterative.rule.ImplementFilteredAggregations(),
                         new ImplementBernoulliSampleAsFilter(),
+                        new ImplementIntersectAndExcept(),
 
                         new UnaliasProject(),
                         new UnaliasFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -30,6 +30,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughProject;
+import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughSemiJoin;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantProjections;
 import com.facebook.presto.sql.planner.iterative.rule.SingleMarkDistinctToGroupBy;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
@@ -130,6 +131,7 @@ public class PlanOptimizers
 
                         new PushLimitThroughProject(),
                         new PushLimitThroughMarkDistinct(),
+                        new PushLimitThroughSemiJoin(),
                         new MergeLimits(),
                         new MergeLimitWithDistinct(),
                         new MergeLimitWithTopN(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
 import com.facebook.presto.sql.planner.optimizations.BeginTableWrite;
@@ -56,6 +57,7 @@ import com.facebook.presto.sql.planner.optimizations.TransformUncorrelatedScalar
 import com.facebook.presto.sql.planner.optimizations.UnaliasSymbolReferences;
 import com.facebook.presto.sql.planner.optimizations.WindowFilterPushDown;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 
 import java.util.List;
@@ -77,6 +79,7 @@ public class PlanOptimizers
         builder.add(
                 new DesugaringOptimizer(metadata, sqlParser), // Clean up all the sugar in expressions, e.g. AtTimeZone, must be run before all the other optimizers
                 new CanonicalizeExpressions(),
+                new IterativeOptimizer(ImmutableSet.of()),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),
                 new SimplifyExpressions(metadata, sqlParser),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementIntersectAndExcept;
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
+import com.facebook.presto.sql.planner.iterative.rule.MergeUnions;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantProjections;
@@ -113,6 +114,8 @@ public class PlanOptimizers
                         new RemoveRedundantProjections(),
                         new InlineProjections(),
                         new SingleMarkDistinctToGroupBy(),
+
+                        new MergeUnions(),
 
                         new PruneTableScanColumns(),
                         new PruneValuesColumns()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -17,6 +17,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
+import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
 import com.facebook.presto.sql.planner.optimizations.BeginTableWrite;
@@ -80,7 +81,8 @@ public class PlanOptimizers
                 new DesugaringOptimizer(metadata, sqlParser), // Clean up all the sugar in expressions, e.g. AtTimeZone, must be run before all the other optimizers
                 new CanonicalizeExpressions(),
                 new IterativeOptimizer(ImmutableSet.of(
-                        new com.facebook.presto.sql.planner.iterative.rule.ImplementFilteredAggregations()
+                        new com.facebook.presto.sql.planner.iterative.rule.ImplementFilteredAggregations(),
+                        new ImplementBernoulliSampleAsFilter()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
+import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantProjections;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasFilter;
@@ -104,7 +105,8 @@ public class PlanOptimizers
                         new UnaliasTopN(),
                         new UnaliasSetOperation(),
 
-                        new RemoveRedundantProjections()
+                        new RemoveRedundantProjections(),
+                        new InlineProjections()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAs
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasFilter;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasGroupId;
+import com.facebook.presto.sql.planner.iterative.rule.UnaliasMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasOutput;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasProject;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasSort;
@@ -95,7 +96,8 @@ public class PlanOptimizers
                         new UnaliasAggregation(),
                         new UnaliasOutput(),
                         new UnaliasSort(),
-                        new UnaliasGroupId()
+                        new UnaliasGroupId(),
+                        new UnaliasMarkDistinct()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -46,6 +46,7 @@ import com.facebook.presto.sql.planner.iterative.rule.UnaliasSetOperation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasSort;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasTopN;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasUnnest;
+import com.facebook.presto.sql.planner.iterative.rule.UnaliasWindow;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
 import com.facebook.presto.sql.planner.optimizations.BeginTableWrite;
@@ -124,6 +125,7 @@ public class PlanOptimizers
                         new UnaliasSetOperation(),
                         new UnaliasUnnest(),
                         new UnaliasJoin(),
+                        new UnaliasWindow(),
 
                         new RemoveRedundantProjections(),
                         new InlineProjections(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.planner.iterative.rule.ImplementIntersectAndExcep
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
 import com.facebook.presto.sql.planner.iterative.rule.MergeIntersections;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithDistinct;
+import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithSort;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
 import com.facebook.presto.sql.planner.iterative.rule.MergeUnions;
@@ -131,7 +132,8 @@ public class PlanOptimizers
                         new PushLimitThroughMarkDistinct(),
                         new MergeLimits(),
                         new MergeLimitWithDistinct(),
-                        new MergeLimitWithTopN()
+                        new MergeLimitWithTopN(),
+                        new MergeLimitWithSort()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.planner.iterative.rule.ImplementIntersectAndExcep
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
 import com.facebook.presto.sql.planner.iterative.rule.MergeIntersections;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithDistinct;
+import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
 import com.facebook.presto.sql.planner.iterative.rule.MergeUnions;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
@@ -129,7 +130,8 @@ public class PlanOptimizers
                         new PushLimitThroughProject(),
                         new PushLimitThroughMarkDistinct(),
                         new MergeLimits(),
-                        new MergeLimitWithDistinct()
+                        new MergeLimitWithDistinct(),
+                        new MergeLimitWithTopN()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasFilter;
+import com.facebook.presto.sql.planner.iterative.rule.UnaliasGroupId;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasOutput;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasProject;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasSort;
@@ -93,7 +94,8 @@ public class PlanOptimizers
                         new UnaliasFilter(),
                         new UnaliasAggregation(),
                         new UnaliasOutput(),
-                        new UnaliasSort()
+                        new UnaliasSort(),
+                        new UnaliasGroupId()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
+import com.facebook.presto.sql.planner.iterative.rule.UnaliasFilter;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasProject;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
@@ -85,7 +86,8 @@ public class PlanOptimizers
                         new com.facebook.presto.sql.planner.iterative.rule.ImplementFilteredAggregations(),
                         new ImplementBernoulliSampleAsFilter(),
 
-                        new UnaliasProject()
+                        new UnaliasProject(),
+                        new UnaliasFilter()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasFilter;
+import com.facebook.presto.sql.planner.iterative.rule.UnaliasOutput;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasProject;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
@@ -89,7 +90,8 @@ public class PlanOptimizers
 
                         new UnaliasProject(),
                         new UnaliasFilter(),
-                        new UnaliasAggregation()
+                        new UnaliasAggregation(),
+                        new UnaliasOutput()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughProject;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughSemiJoin;
+import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughUnion;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantProjections;
 import com.facebook.presto.sql.planner.iterative.rule.SingleMarkDistinctToGroupBy;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
@@ -133,6 +134,7 @@ public class PlanOptimizers
                         new PushLimitThroughProject(),
                         new PushLimitThroughMarkDistinct(),
                         new PushLimitThroughSemiJoin(),
+                        new PushLimitThroughUnion(),
                         new MergeLimits(),
                         new MergeLimitWithDistinct(),
                         new MergeLimitWithTopN(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
+import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasFilter;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasProject;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
@@ -87,7 +88,8 @@ public class PlanOptimizers
                         new ImplementBernoulliSampleAsFilter(),
 
                         new UnaliasProject(),
-                        new UnaliasFilter()
+                        new UnaliasFilter(),
+                        new UnaliasAggregation()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -17,6 +17,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
+import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroLimit;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementIntersectAndExcept;
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
@@ -135,7 +136,8 @@ public class PlanOptimizers
                         new MergeLimits(),
                         new MergeLimitWithDistinct(),
                         new MergeLimitWithTopN(),
-                        new MergeLimitWithSort()
+                        new MergeLimitWithSort(),
+                        new EvaluateZeroLimit()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -38,6 +38,7 @@ import com.facebook.presto.sql.planner.iterative.rule.SingleMarkDistinctToGroupB
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasFilter;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasGroupId;
+import com.facebook.presto.sql.planner.iterative.rule.UnaliasJoin;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasOutput;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasProject;
@@ -122,6 +123,7 @@ public class PlanOptimizers
                         new UnaliasTopN(),
                         new UnaliasSetOperation(),
                         new UnaliasUnnest(),
+                        new UnaliasJoin(),
 
                         new RemoveRedundantProjections(),
                         new InlineProjections(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantProjections;
 import com.facebook.presto.sql.planner.iterative.rule.SingleMarkDistinctToGroupBy;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
@@ -111,7 +112,8 @@ public class PlanOptimizers
                         new InlineProjections(),
                         new SingleMarkDistinctToGroupBy(),
 
-                        new PruneTableScanColumns()
+                        new PruneTableScanColumns(),
+                        new PruneValuesColumns()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -34,6 +34,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughProject;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughSemiJoin;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughUnion;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantProjections;
+import com.facebook.presto.sql.planner.iterative.rule.SimplifyCountOverConstant;
 import com.facebook.presto.sql.planner.iterative.rule.SingleMarkDistinctToGroupBy;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasFilter;
@@ -113,6 +114,7 @@ public class PlanOptimizers
                         new com.facebook.presto.sql.planner.iterative.rule.ImplementFilteredAggregations(),
                         new ImplementBernoulliSampleAsFilter(),
                         new ImplementIntersectAndExcept(),
+                        new SimplifyCountOverConstant(),
 
                         new UnaliasProject(),
                         new UnaliasFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -26,6 +26,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
 import com.facebook.presto.sql.planner.iterative.rule.MergeUnions;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughProject;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantProjections;
 import com.facebook.presto.sql.planner.iterative.rule.SingleMarkDistinctToGroupBy;
@@ -126,6 +127,7 @@ public class PlanOptimizers
                         new PruneValuesColumns(),
 
                         new PushLimitThroughProject(),
+                        new PushLimitThroughMarkDistinct(),
                         new MergeLimits(),
                         new MergeLimitWithDistinct()
                 )),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantProjections;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasFilter;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasGroupId;
@@ -101,7 +102,9 @@ public class PlanOptimizers
                         new UnaliasGroupId(),
                         new UnaliasMarkDistinct(),
                         new UnaliasTopN(),
-                        new UnaliasSetOperation()
+                        new UnaliasSetOperation(),
+
+                        new RemoveRedundantProjections()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAs
 import com.facebook.presto.sql.planner.iterative.rule.ImplementIntersectAndExcept;
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
 import com.facebook.presto.sql.planner.iterative.rule.MergeIntersections;
+import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
 import com.facebook.presto.sql.planner.iterative.rule.MergeUnions;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
@@ -125,7 +126,8 @@ public class PlanOptimizers
                         new PruneValuesColumns(),
 
                         new PushLimitThroughProject(),
-                        new MergeLimits()
+                        new MergeLimits(),
+                        new MergeLimitWithDistinct()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasFilter;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasOutput;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasProject;
+import com.facebook.presto.sql.planner.iterative.rule.UnaliasSort;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
 import com.facebook.presto.sql.planner.optimizations.BeginTableWrite;
@@ -91,7 +92,8 @@ public class PlanOptimizers
                         new UnaliasProject(),
                         new UnaliasFilter(),
                         new UnaliasAggregation(),
-                        new UnaliasOutput()
+                        new UnaliasOutput(),
+                        new UnaliasSort()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -79,7 +79,9 @@ public class PlanOptimizers
         builder.add(
                 new DesugaringOptimizer(metadata, sqlParser), // Clean up all the sugar in expressions, e.g. AtTimeZone, must be run before all the other optimizers
                 new CanonicalizeExpressions(),
-                new IterativeOptimizer(ImmutableSet.of()),
+                new IterativeOptimizer(ImmutableSet.of(
+                        new com.facebook.presto.sql.planner.iterative.rule.ImplementFilteredAggregations()
+                )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),
                 new SimplifyExpressions(metadata, sqlParser),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
 import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
+import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantProjections;
 import com.facebook.presto.sql.planner.iterative.rule.SingleMarkDistinctToGroupBy;
 import com.facebook.presto.sql.planner.iterative.rule.UnaliasAggregation;
@@ -108,7 +109,9 @@ public class PlanOptimizers
 
                         new RemoveRedundantProjections(),
                         new InlineProjections(),
-                        new SingleMarkDistinctToGroupBy()
+                        new SingleMarkDistinctToGroupBy(),
+
+                        new PruneTableScanColumns()
                 )),
                 new ImplementFilteredAggregations(),
                 new ImplementSampleAsFilter(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
@@ -500,7 +500,7 @@ public class PlanPrinter
         @Override
         public Void visitLimit(LimitNode node, Integer indent)
         {
-            print(indent, "- Limit%s[%s] => [%s]", node.isPartial() ? "Partial" : "", node.getCount(), formatOutputs(node.getOutputSymbols()));
+            print(indent, "- Limit[%s, %s] => [%s]", node.getStep(), node.getCount(), formatOutputs(node.getOutputSymbols()));
             printStats(indent + 2, node.getId());
             return processChildren(node, indent + 1);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -767,7 +767,7 @@ class QueryPlanner
         if (orderBy.isEmpty() && limit.isPresent()) {
             if (!limit.get().equalsIgnoreCase("all")) {
                 long limitValue = Long.parseLong(limit.get());
-                subPlan = subPlan.withNewRoot(new LimitNode(idAllocator.getNextId(), subPlan.getRoot(), limitValue, false));
+                subPlan = subPlan.withNewRoot(new LimitNode(idAllocator.getNextId(), subPlan.getRoot(), limitValue, LimitNode.Step.SINGLE));
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/GroupReference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/GroupReference.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class GroupReference
+        extends PlanNode
+{
+    private final int groupId;
+    private final List<Symbol> outputs;
+
+    public GroupReference(PlanNodeId id, int groupId, List<Symbol> outputs)
+    {
+        super(id);
+        this.groupId = groupId;
+        this.outputs = ImmutableList.copyOf(outputs);
+    }
+
+    public int getGroupId()
+    {
+        return groupId;
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<Symbol> getOutputSymbols()
+    {
+        return outputs;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class IterativeOptimizer
+        implements PlanOptimizer
+{
+    private final Set<Rule> rules;
+
+    public IterativeOptimizer(Set<Rule> rules)
+    {
+        this.rules = ImmutableSet.copyOf(rules);
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, Map<Symbol, Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        if (!SystemSessionProperties.isNewOptimizerEnabled(session)) {
+            return plan;
+        }
+
+        Memo memo = new Memo(idAllocator, plan);
+
+        Lookup lookup = node -> {
+            if (node instanceof GroupReference) {
+                return memo.getNode(((GroupReference) node).getGroupId());
+            }
+
+            return node;
+        };
+
+        exploreGroup(memo, lookup, idAllocator, symbolAllocator, memo.getRootGroup());
+
+        return memo.extract();
+    }
+
+    private boolean exploreGroup(Memo memo, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, int group)
+    {
+        // tracks whether this group or any children groups change as
+        // this method executes
+        boolean progress = exploreNode(memo, lookup, idAllocator, symbolAllocator, group);
+
+        while (exploreChildren(memo, lookup, idAllocator, symbolAllocator, group)) {
+            progress = true;
+
+            // if children changed, try current group again
+            // in case we can match additional rules
+            if (!exploreNode(memo, lookup, idAllocator, symbolAllocator, group)) {
+                // no additional matches, so bail out
+                break;
+            }
+        }
+
+        return progress;
+    }
+
+    private boolean exploreNode(
+            Memo memo,
+            Lookup lookup,
+            PlanNodeIdAllocator idAllocator,
+            SymbolAllocator symbolAllocator,
+            int group)
+    {
+        PlanNode node = memo.getNode(group);
+
+        boolean done = false;
+        boolean progress = false;
+
+        while (!done) {
+            done = true;
+            for (Rule rule : rules) {
+                Optional<PlanNode> transformed = rule.apply(node, lookup, idAllocator, symbolAllocator);
+
+                if (transformed.isPresent()) {
+                    memo.replace(group, transformed.get(), rule.getClass().getName());
+                    node = transformed.get();
+
+                    done = false;
+                    progress = true;
+                }
+            }
+        }
+
+        return progress;
+    }
+
+    private boolean exploreChildren(Memo memo, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, int group)
+    {
+        boolean progress = false;
+
+        PlanNode expression = memo.getNode(group);
+        for (PlanNode child : expression.getSources()) {
+            checkState(child instanceof GroupReference, "Expected child to be a group reference. Found: " + child.getClass().getName());
+
+            if (exploreGroup(memo, lookup, idAllocator, symbolAllocator, ((GroupReference) child).getGroupId())) {
+                progress = true;
+            }
+        }
+
+        return progress;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Lookup.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Lookup.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative;
+
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+public interface Lookup
+{
+    PlanNode resolve(PlanNode node);
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.plan.ChildReplacer;
+import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+public class Memo
+{
+    private final PlanNodeIdAllocator idAllocator;
+    private final int rootGroup;
+
+    private int nextGroupId;
+
+    private final Map<Integer, PlanNode> membership = new HashMap<>();
+    private final Map<Integer, Integer> referenceCounts = new HashMap<>();
+
+    public Memo(PlanNodeIdAllocator idAllocator, PlanNode plan)
+    {
+        this.idAllocator = idAllocator;
+        rootGroup = insertRecursive(plan);
+        referenceCounts.put(rootGroup, 1);
+    }
+
+    public int getRootGroup()
+    {
+        return rootGroup;
+    }
+
+    public PlanNode getNode(int group)
+    {
+        checkArgument(membership.containsKey(group), "Invalid group: %s", group);
+        return membership.get(group);
+    }
+
+    public PlanNode extract()
+    {
+        return extract(getNode(rootGroup));
+    }
+
+    private PlanNode extract(PlanNode node)
+    {
+        if (node instanceof GroupReference) {
+            return extract(membership.get(((GroupReference) node).getGroupId()));
+        }
+
+        List<PlanNode> children = node.getSources().stream()
+                .map(this::extract)
+                .collect(Collectors.toList());
+
+        return ChildReplacer.replaceChildren(node, children);
+    }
+
+    public void replace(int group, PlanNode node, String rule)
+    {
+        PlanNode old = membership.get(group);
+
+        // output node is special. TODO: we need to get rid of OutputNode. It doesn't add any value
+        checkArgument(node instanceof OutputNode || new HashSet<>(old.getOutputSymbols()).equals(new HashSet<>(node.getOutputSymbols())),
+                "%s: transformed expression doesn't produce same outputs: %s vs %s",
+                rule,
+                old.getOutputSymbols(),
+                node.getOutputSymbols());
+
+        if (node instanceof GroupReference) {
+            node = getNode(((GroupReference) node).getGroupId());
+        }
+        else {
+            node = insertChildrenAndRewrite(node);
+        }
+
+        incrementReferenceCounts(node);
+        membership.put(group, node);
+        decrementReferenceCounts(old);
+    }
+
+    private void incrementReferenceCounts(PlanNode node)
+    {
+        Set<Integer> references = getAllReferences(node);
+
+        for (int group : references) {
+            referenceCounts.compute(group, (g, count) -> count + 1);
+        }
+    }
+
+    private void decrementReferenceCounts(PlanNode node)
+    {
+        Set<Integer> references = getAllReferences(node);
+
+        for (int group : references) {
+            int newCount = referenceCounts.compute(group, (g, count) -> count - 1);
+            checkState(newCount >= 0, "Reference count became negative");
+
+            if (newCount == 0) {
+                PlanNode child = membership.get(group);
+                deleteGroup(group);
+                decrementReferenceCounts(child);
+            }
+        }
+    }
+
+    private Set<Integer> getAllReferences(PlanNode node)
+    {
+        return node.getSources().stream()
+                    .map(GroupReference.class::cast)
+                    .map(GroupReference::getGroupId)
+                    .collect(Collectors.toSet());
+    }
+
+    private void deleteGroup(int group)
+    {
+        membership.remove(group);
+        referenceCounts.remove(group);
+    }
+
+    private PlanNode insertChildrenAndRewrite(PlanNode node)
+    {
+        return ChildReplacer.replaceChildren(
+                node,
+                node.getSources().stream()
+                        .map(child -> new GroupReference(
+                                idAllocator.getNextId(),
+                                insertRecursive(child),
+                                child.getOutputSymbols()))
+                        .collect(Collectors.toList()));
+    }
+
+    private int insertRecursive(PlanNode node)
+    {
+        if (node instanceof GroupReference) {
+            return ((GroupReference) node).getGroupId();
+        }
+
+        int group = nextGroupId();
+        PlanNode rewritten = insertChildrenAndRewrite(node);
+
+        membership.put(group, rewritten);
+        referenceCounts.put(group, 0);
+        incrementReferenceCounts(rewritten);
+
+        return group;
+    }
+
+    private int nextGroupId()
+    {
+        return nextGroupId++;
+    }
+
+    public int getGroupCount()
+    {
+        return membership.size();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Rule.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Rule.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.Optional;
+
+public interface Rule
+{
+    Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator);
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EvaluateZeroLimit.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EvaluateZeroLimit.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+public class EvaluateZeroLimit
+    implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof LimitNode)) {
+            return Optional.empty();
+        }
+
+        LimitNode limit = (LimitNode) node;
+
+        if (limit.getCount() != 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new ValuesNode(limit.getId(), limit.getOutputSymbols(), ImmutableList.of()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementBernoulliSampleAsFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementBernoulliSampleAsFilter.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.SampleNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.ComparisonExpressionType;
+import com.facebook.presto.sql.tree.DoubleLiteral;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+/**
+ * Transforms:
+ *
+ * <pre>
+ * - Sample(BERNOULLI, p)
+ *     - X
+ * </pre>
+ *
+ * Into:
+ *
+ * <pre>
+ * - Filter (rand() < p)
+ *     - X
+ * </pre>
+ */
+public class ImplementBernoulliSampleAsFilter
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof SampleNode)) {
+            return Optional.empty();
+        }
+
+        SampleNode sample = (SampleNode) node;
+
+        if (sample.getSampleType() != SampleNode.Type.BERNOULLI) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new FilterNode(
+                node.getId(),
+                sample.getSource(),
+                new ComparisonExpression(
+                        ComparisonExpressionType.LESS_THAN,
+                        new FunctionCall(QualifiedName.of("rand"), ImmutableList.<Expression>of()),
+                        new DoubleLiteral(Double.toString(sample.getSampleRatio())))));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementFilteredAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementFilteredAggregations.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+
+/**
+ * Implements filtered aggregations by transforming plans of the following shape:
+ *
+ * <pre>
+ * - Aggregation
+ *        F1(...) FILTER (WHERE C1(...)),
+ *        F2(...) FILTER (WHERE C2(...))
+ *     - X
+ * </pre>
+ *
+ * into
+ *
+ * <pre>
+ * - Aggregation
+ *        F1(...) mask ($0)
+ *        F2(...) mask ($1)
+ *     - Project
+ *            &lt;identity projections for existing fields&gt;
+ *            $0 = C1(...)
+ *            $1 = C2(...)
+ *         - X
+ * </pre>
+ */
+public class ImplementFilteredAggregations
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof AggregationNode)) {
+            return Optional.empty();
+        }
+
+        AggregationNode aggregation = (AggregationNode) node;
+
+        boolean hasFilters = aggregation.getAggregations()
+                .entrySet().stream()
+                .anyMatch(e -> e.getValue().getFilter().isPresent() &&
+                        !aggregation.getMasks().containsKey(e.getKey())); // can't handle filtered aggregations with DISTINCT (conservatively, if they have a mask)
+
+        if (!hasFilters) {
+            return Optional.empty();
+        }
+
+        Assignments.Builder newAssignments = Assignments.builder();
+        ImmutableMap.Builder<Symbol, Symbol> masks = ImmutableMap.<Symbol, Symbol>builder()
+                .putAll(aggregation.getMasks());
+
+        for (Map.Entry<Symbol, FunctionCall> entry : aggregation.getAggregations().entrySet()) {
+            Symbol output = entry.getKey();
+            if (entry.getValue().getFilter().isPresent()) {
+                Expression filter = entry.getValue().getFilter().get();
+                Symbol symbol = symbolAllocator.newSymbol(filter, BOOLEAN);
+                newAssignments.put(symbol, filter);
+                masks.put(output, symbol);
+            }
+        }
+
+        // identity projection for all existing inputs
+        newAssignments.putIdentities(aggregation.getSource().getOutputSymbols());
+
+        // strip the filters
+        ImmutableMap.Builder<Symbol, FunctionCall> calls = ImmutableMap.builder();
+        for (Map.Entry<Symbol, FunctionCall> entry : aggregation.getAggregations().entrySet()) {
+            FunctionCall call = entry.getValue();
+            calls.put(entry.getKey(), new FunctionCall(
+                    call.getName(),
+                    call.getWindow(),
+                    Optional.empty(),
+                    call.isDistinct(),
+                    call.getArguments()));
+        }
+
+        return Optional.of(
+                new AggregationNode(
+                        idAllocator.getNextId(),
+                        new ProjectNode(
+                                idAllocator.getNextId(),
+                                aggregation.getSource(),
+                                newAssignments.build()),
+                        calls.build(),
+                        aggregation.getFunctions(),
+                        masks.build(),
+                        aggregation.getGroupingSets(),
+                        aggregation.getStep(),
+                        aggregation.getHashSymbol(),
+                        aggregation.getGroupIdSymbol()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementIntersectAndExcept.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementIntersectAndExcept.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.ExpressionUtils;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.ExceptNode;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.IntersectNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.SetOperationNode;
+import com.facebook.presto.sql.planner.plan.UnionNode;
+import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GenericLiteral;
+import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
+import static com.google.common.collect.Iterables.concat;
+
+public class ImplementIntersectAndExcept
+        implements Rule
+{
+    private static final String MARKER = "marker";
+    private static final Signature COUNT_AGGREGATION = new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BOOLEAN));
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof IntersectNode) && !(node instanceof ExceptNode)) {
+            return Optional.empty();
+        }
+
+        SetOperationNode setOperation = (SetOperationNode) node;
+
+        List<Symbol> markers = allocateSymbols(symbolAllocator, node.getSources().size(), MARKER, BOOLEAN);
+
+        // identity projection for all the fields in each of the sources plus marker columns
+        List<PlanNode> withMarkers = appendMarkers(markers, setOperation.getSources(), setOperation, idAllocator, symbolAllocator);
+
+        // add a union over all the rewritten sources. The outputs of the union have the same name as the
+        // original intersect node
+        List<Symbol> outputs = setOperation.getOutputSymbols();
+        UnionNode union = union(withMarkers, ImmutableList.copyOf(concat(outputs, markers)), idAllocator);
+
+        // add count aggregations and filter rows where any of the counts is >= 1
+        List<Symbol> aggregationOutputs = allocateSymbols(symbolAllocator, markers.size(), "count", BIGINT);
+        AggregationNode aggregation = computeCounts(union, outputs, markers, aggregationOutputs, idAllocator);
+
+        FilterNode filterNode;
+        if (node instanceof IntersectNode) {
+            filterNode = addFilterForIntersect(aggregation, idAllocator);
+        }
+        else if (node instanceof ExceptNode) {
+            filterNode = addFilterForExcept(aggregation, aggregationOutputs.get(0), aggregationOutputs.subList(1, aggregationOutputs.size()), idAllocator);
+        }
+        else {
+            throw new IllegalStateException("Unexpected node type: " + node.getClass().getName());
+        }
+
+        return Optional.of(
+                new ProjectNode(
+                        idAllocator.getNextId(),
+                        filterNode,
+                        identityAssignments(outputs)));
+    }
+
+    private List<Symbol> allocateSymbols(SymbolAllocator allocator, int count, String nameHint, Type type)
+    {
+        ImmutableList.Builder<Symbol> symbolsBuilder = ImmutableList.builder();
+        for (int i = 0; i < count; i++) {
+            symbolsBuilder.add(allocator.newSymbol(nameHint, type));
+        }
+        return symbolsBuilder.build();
+    }
+
+    private List<PlanNode> appendMarkers(List<Symbol> markers, List<PlanNode> nodes, SetOperationNode node, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        ImmutableList.Builder<PlanNode> result = ImmutableList.builder();
+        for (int i = 0; i < nodes.size(); i++) {
+            result.add(appendMarkers(nodes.get(i), i, markers, node.sourceSymbolMap(i), idAllocator, symbolAllocator));
+        }
+        return result.build();
+    }
+
+    private PlanNode appendMarkers(
+            PlanNode source,
+            int markerIndex,
+            List<Symbol> markers,
+            Map<Symbol, SymbolReference> projections,
+            PlanNodeIdAllocator idAllocator,
+            SymbolAllocator symbolAllocator)
+    {
+        Assignments.Builder assignments = Assignments.builder();
+        // add existing intersect symbols to projection
+        for (Map.Entry<Symbol, SymbolReference> entry : projections.entrySet()) {
+            Symbol symbol = symbolAllocator.newSymbol(entry.getKey().getName(), symbolAllocator.getTypes().get(entry.getKey()));
+            assignments.put(symbol, entry.getValue());
+        }
+
+        // add extra marker fields to the projection
+        for (int i = 0; i < markers.size(); ++i) {
+            Expression expression = (i == markerIndex) ? TRUE_LITERAL : new Cast(new NullLiteral(), StandardTypes.BOOLEAN);
+            assignments.put(symbolAllocator.newSymbol(markers.get(i).getName(), BOOLEAN), expression);
+        }
+
+        return new ProjectNode(idAllocator.getNextId(), source, assignments.build());
+    }
+
+    private UnionNode union(List<PlanNode> nodes, List<Symbol> outputs, PlanNodeIdAllocator idAllocator)
+    {
+        ImmutableListMultimap.Builder<Symbol, Symbol> outputsToInputs = ImmutableListMultimap.builder();
+        for (PlanNode source : nodes) {
+            for (int i = 0; i < source.getOutputSymbols().size(); i++) {
+                outputsToInputs.put(outputs.get(i), source.getOutputSymbols().get(i));
+            }
+        }
+
+        return new UnionNode(idAllocator.getNextId(), nodes, outputsToInputs.build(), outputs);
+    }
+
+    private AggregationNode computeCounts(UnionNode sourceNode, List<Symbol> originalColumns, List<Symbol> markers, List<Symbol> aggregationOutputs, PlanNodeIdAllocator idAllocator)
+    {
+        ImmutableMap.Builder<Symbol, Signature> signatures = ImmutableMap.builder();
+        ImmutableMap.Builder<Symbol, FunctionCall> aggregations = ImmutableMap.builder();
+
+        for (int i = 0; i < markers.size(); i++) {
+            Symbol output = aggregationOutputs.get(i);
+            aggregations.put(output, new FunctionCall(QualifiedName.of("count"), ImmutableList.of(markers.get(i).toSymbolReference())));
+            signatures.put(output, COUNT_AGGREGATION);
+        }
+
+        return new AggregationNode(
+                idAllocator.getNextId(),
+                sourceNode,
+                aggregations.build(),
+                signatures.build(),
+                ImmutableMap.of(),
+                ImmutableList.of(originalColumns),
+                AggregationNode.Step.SINGLE,
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private FilterNode addFilterForExcept(AggregationNode aggregation, Symbol firstSource, List<Symbol> remainingSources, PlanNodeIdAllocator idAllocator)
+    {
+        ImmutableList.Builder<Expression> predicatesBuilder = ImmutableList.builder();
+        predicatesBuilder.add(new ComparisonExpression(GREATER_THAN_OR_EQUAL, firstSource.toSymbolReference(), new GenericLiteral("BIGINT", "1")));
+        for (Symbol symbol : remainingSources) {
+            predicatesBuilder.add(new ComparisonExpression(EQUAL, symbol.toSymbolReference(), new GenericLiteral("BIGINT", "0")));
+        }
+
+        return new FilterNode(idAllocator.getNextId(), aggregation, ExpressionUtils.and(predicatesBuilder.build()));
+    }
+
+    private FilterNode addFilterForIntersect(AggregationNode aggregation, PlanNodeIdAllocator idAllocator)
+    {
+        ImmutableList<Expression> predicates = aggregation.getAggregations().keySet().stream()
+                .map(column -> new ComparisonExpression(GREATER_THAN_OR_EQUAL, column.toSymbolReference(), new GenericLiteral("BIGINT", "1")))
+                .collect(toImmutableList());
+        return new FilterNode(idAllocator.getNextId(), aggregation, ExpressionUtils.and(predicates));
+    }
+
+    private static Assignments identityAssignments(Collection<Symbol> columns)
+    {
+        return Assignments.copyOf(
+                columns.stream()
+                        .distinct()
+                        .collect(Collectors.toMap(Function.identity(), Symbol::toSymbolReference)));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/InlineProjections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/InlineProjections.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.DependencyExtractor;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionRewriter;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.sql.tree.TryExpression;
+import com.google.common.collect.Sets;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Inlines expressions from a child project node into a parent project node
+ * as long as they are referenced only once (to avoid introducing duplicate
+ * computation), and that the references don't appear within a TRY block
+ * (to avoid changing semantics).
+ */
+public class InlineProjections
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode parent = (ProjectNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode child = (ProjectNode) source;
+
+        // find the references that appear just once across all
+        // expressions in the parent project node
+        Set<Symbol> singletonInputs = parent.getAssignments()
+                .getExpressions().stream()
+                .flatMap(e -> DependencyExtractor.extractAll(e).stream())
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
+                .entrySet().stream()
+                .filter(e -> e.getValue() == 1)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+
+        if (singletonInputs.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // exclude any inputs to TRY expression. Inlining them would potentially
+        // change the semantics of those expressions
+        Set<Symbol> tryArguments = parent.getAssignments()
+                .getExpressions().stream()
+                .flatMap(e -> extractTryArguments(e).stream())
+                .collect(Collectors.toSet());
+
+        Set<Symbol> candidates = Sets.difference(singletonInputs, tryArguments);
+
+        // see if any assignments for those inputs is *not* an identity projection
+        boolean allIdentities = child.getAssignments()
+                .entrySet().stream()
+                .filter(e -> candidates.contains(e.getKey()))
+                .allMatch(e -> e.getValue() instanceof SymbolReference &&
+                        e.getKey().getName().equals(((SymbolReference) e.getValue()).getName()));
+        if (allIdentities) {
+            return Optional.empty();
+        }
+
+        // inline the expressions
+        Assignments.Builder parentAssignments = Assignments.builder();
+        for (Map.Entry<Symbol, Expression> entry : parent.getAssignments().entrySet()) {
+            Expression inlined = ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Object>()
+            {
+                @Override
+                public Expression rewriteSymbolReference(SymbolReference reference, Object context, ExpressionTreeRewriter treeRewriter)
+                {
+                    Symbol symbol = Symbol.from(reference);
+                    if (candidates.contains(symbol)) {
+                        return child.getAssignments().get(symbol);
+                    }
+
+                    return reference;
+                }
+            }, entry.getValue());
+
+            parentAssignments.put(entry.getKey(), inlined);
+        }
+
+        // derive identity assignments for the inputs of expressions that were inlined
+        Set<Symbol> inputs = child.getAssignments()
+                .entrySet().stream()
+                .filter(e -> candidates.contains(e.getKey()))
+                .map(Map.Entry::getValue)
+                .flatMap(e -> DependencyExtractor.extractAll(e).stream())
+                .collect(Collectors.toSet());
+
+        Assignments.Builder childAssignments = Assignments.builder();
+        for (Map.Entry<Symbol, Expression> assignment : child.getAssignments().entrySet()) {
+            if (!candidates.contains(assignment.getKey())) {
+                childAssignments.put(assignment.getKey(), assignment.getValue());
+            }
+        }
+        for (Symbol input : inputs) {
+            childAssignments.put(input, input.toSymbolReference());
+        }
+
+        return Optional.of(
+                new ProjectNode(
+                        parent.getId(),
+                        new ProjectNode(
+                                child.getId(),
+                                child.getSource(),
+                                childAssignments.build()),
+                        parentAssignments.build()));
+    }
+
+    private Set<Symbol> extractTryArguments(Expression expression)
+    {
+        Set<Symbol> result = new HashSet<>();
+
+        new DefaultTraversalVisitor<Void, Void>()
+        {
+            @Override
+            protected Void visitTryExpression(TryExpression node, Void context)
+            {
+                result.addAll(DependencyExtractor.extractUnique(node));
+                return null;
+            }
+        }.process(expression, null);
+
+        return result;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeIntersections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeIntersections.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.IntersectNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Iterables;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class MergeIntersections
+    implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof IntersectNode)) {
+            return Optional.empty();
+        }
+
+        List<PlanNode> children = node.getSources()
+                .stream()
+                .map(lookup::resolve)
+                .collect(Collectors.toList());
+
+        if (children.stream().noneMatch(IntersectNode.class::isInstance)) {
+            return Optional.empty();
+        }
+
+        IntersectNode parent = (IntersectNode) node;
+
+        List<PlanNode> newChildren = new ArrayList<>();
+        ImmutableListMultimap.Builder<Symbol, Symbol> newMappings = ImmutableListMultimap.builder();
+        for (int i = 0; i < children.size(); i++) {
+            PlanNode source = children.get(i);
+
+            if (source instanceof IntersectNode) {
+                IntersectNode child = (IntersectNode) source;
+                newChildren.addAll(child.getSources());
+                for (Map.Entry<Symbol, Collection<Symbol>> entry : parent.getSymbolMapping().asMap().entrySet()) {
+                    Symbol inputSymbol = Iterables.get(entry.getValue(), i);
+                    newMappings.putAll(entry.getKey(), child.getSymbolMapping().get(inputSymbol));
+                }
+            }
+            else {
+                newChildren.add(source);
+                for (Map.Entry<Symbol, Collection<Symbol>> entry : parent.getSymbolMapping().asMap().entrySet()) {
+                    newMappings.put(entry.getKey(), Iterables.get(entry.getValue(), i));
+                }
+            }
+        }
+
+        return Optional.of(
+                new IntersectNode(
+                        parent.getId(),
+                        newChildren,
+                        newMappings.build(),
+                        parent.getOutputSymbols()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithDistinct.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.DistinctLimitNode;
+import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.Optional;
+
+public class MergeLimitWithDistinct
+    implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof LimitNode)) {
+            return Optional.empty();
+        }
+
+        LimitNode parent = (LimitNode) node;
+
+        PlanNode input = lookup.resolve(parent.getSource());
+        if (!(input instanceof AggregationNode)) {
+            return Optional.empty();
+        }
+
+        AggregationNode child = (AggregationNode) input;
+
+        if (!child.getAggregations().isEmpty() ||
+                child.getOutputSymbols().size() != child.getGroupingKeys().size() ||
+                !child.getOutputSymbols().containsAll(child.getGroupingKeys())) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                new DistinctLimitNode(
+                        parent.getId(),
+                        child.getSource(),
+                        parent.getCount(),
+                        false,
+                        child.getHashSymbol()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithSort.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithSort.java
@@ -54,6 +54,6 @@ public class MergeLimitWithSort
                         parent.getCount(),
                         child.getOrderBy(),
                         child.getOrderings(),
-                        parent.isPartial()));
+                        parent.getStep() == LimitNode.Step.PARTIAL));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithSort.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithSort.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.SortNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
+
+import java.util.Optional;
+
+public class MergeLimitWithSort
+    implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof LimitNode)) {
+            return Optional.empty();
+        }
+
+        LimitNode parent = (LimitNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof SortNode)) {
+            return Optional.empty();
+        }
+
+        SortNode child = (SortNode) source;
+
+        if (parent.getCount() < 1) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                new TopNNode(
+                        parent.getId(),
+                        child.getSource(),
+                        parent.getCount(),
+                        child.getOrderBy(),
+                        child.getOrderings(),
+                        parent.isPartial()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithTopN.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithTopN.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
+
+import java.util.Optional;
+
+public class MergeLimitWithTopN
+    implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof LimitNode)) {
+            return Optional.empty();
+        }
+
+        LimitNode parent = (LimitNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof TopNNode)) {
+            return Optional.empty();
+        }
+
+        TopNNode child = (TopNNode) source;
+
+        if (parent.getCount() < 1) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                new TopNNode(
+                        parent.getId(),
+                        child.getSource(),
+                        Math.min(parent.getCount(), child.getCount()),
+                        child.getOrderBy(),
+                        child.getOrderings(),
+                        parent.isPartial()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimits.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimits.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.Optional;
+
+public class MergeLimits
+    implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof LimitNode)) {
+            return Optional.empty();
+        }
+
+        LimitNode parent = (LimitNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof LimitNode)) {
+            return Optional.empty();
+        }
+
+        LimitNode child = (LimitNode) source;
+
+        return Optional.of(
+                new LimitNode(
+                        parent.getId(),
+                        child.getSource(),
+                        Math.min(parent.getCount(), child.getCount()),
+                        parent.isPartial()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimits.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimits.java
@@ -46,6 +46,6 @@ public class MergeLimits
                         parent.getId(),
                         child.getSource(),
                         Math.min(parent.getCount(), child.getCount()),
-                        parent.isPartial()));
+                        parent.getStep()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeUnions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeUnions.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.UnionNode;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Iterables;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class MergeUnions
+    implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof UnionNode)) {
+            return Optional.empty();
+        }
+
+        List<PlanNode> children = node.getSources()
+                .stream()
+                .map(lookup::resolve)
+                .collect(Collectors.toList());
+
+        if (children.stream().noneMatch(UnionNode.class::isInstance)) {
+            return Optional.empty();
+        }
+
+        UnionNode parent = (UnionNode) node;
+
+        List<PlanNode> newChildren = new ArrayList<>();
+        ImmutableListMultimap.Builder<Symbol, Symbol> newMappings = ImmutableListMultimap.builder();
+        for (int i = 0; i < children.size(); i++) {
+            PlanNode source = children.get(i);
+
+            if (source instanceof UnionNode) {
+                UnionNode child = (UnionNode) source;
+                newChildren.addAll(child.getSources());
+                for (Map.Entry<Symbol, Collection<Symbol>> entry : parent.getSymbolMapping().asMap().entrySet()) {
+                    Symbol inputSymbol = Iterables.get(entry.getValue(), i);
+                    newMappings.putAll(entry.getKey(), child.getSymbolMapping().get(inputSymbol));
+                }
+            }
+            else {
+                newChildren.add(source);
+                for (Map.Entry<Symbol, Collection<Symbol>> entry : parent.getSymbolMapping().asMap().entrySet()) {
+                    newMappings.put(entry.getKey(), Iterables.get(entry.getValue(), i));
+                }
+            }
+        }
+
+        return Optional.of(
+                new UnionNode(
+                        parent.getId(),
+                        newChildren,
+                        newMappings.build(),
+                        parent.getOutputSymbols()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTableScanColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTableScanColumns.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.DependencyExtractor;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class PruneTableScanColumns
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode parent = (ProjectNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof TableScanNode)) {
+            return Optional.empty();
+        }
+
+        TableScanNode child = (TableScanNode) source;
+
+        Set<Symbol> dependencies = DependencyExtractor.extractUnique(parent.getAssignments().getExpressions());
+        if (dependencies.equals(new HashSet<>(child.getOutputSymbols()))) {
+            return Optional.empty();
+        }
+
+        List<Symbol> newOutputs = ImmutableList.copyOf(dependencies);
+        return Optional.of(
+                new ProjectNode(
+                        parent.getId(),
+                        new TableScanNode(
+                                child.getId(),
+                                child.getTable(),
+                                newOutputs,
+                                newOutputs.stream()
+                                        .collect(Collectors.toMap(Function.identity(), e -> child.getAssignments().get(e))),
+                                child.getLayout(),
+                                child.getCurrentConstraint(),
+                                child.getOriginalConstraint()),
+                        parent.getAssignments()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneValuesColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneValuesColumns.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.DependencyExtractor;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class PruneValuesColumns
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode parent = (ProjectNode) node;
+
+        PlanNode child = lookup.resolve(parent.getSource());
+        if (!(child instanceof ValuesNode)) {
+            return Optional.empty();
+        }
+
+        ValuesNode values = (ValuesNode) child;
+
+        Set<Symbol> childOutputs = new HashSet<>(child.getOutputSymbols());
+
+        // we need to compute the intersection in case some dependencies are symbols from
+        // the outer scope (i.e., correlated queries)
+        Set<Symbol> dependencies = Sets.intersection(DependencyExtractor.extractUnique(parent.getAssignments().getExpressions()), childOutputs);
+        if (dependencies.equals(childOutputs)) {
+            return Optional.empty();
+        }
+
+        List<Symbol> newOutputs = ImmutableList.copyOf(dependencies);
+
+        // for each output of project, the corresponding column in the values node
+        int[] mapping = new int[newOutputs.size()];
+        for (int i = 0; i < mapping.length; i++) {
+            mapping[i] = values.getOutputSymbols().indexOf(newOutputs.get(i));
+        }
+
+        ImmutableList.Builder<List<Expression>> rowsBuilder = ImmutableList.builder();
+        for (List<Expression> row : values.getRows()) {
+            rowsBuilder.add(Arrays.stream(mapping)
+                    .mapToObj(row::get)
+                    .collect(Collectors.toList()));
+        }
+
+        return Optional.of(
+                new ProjectNode(
+                        parent.getId(),
+                        new ValuesNode(values.getId(), newOutputs, rowsBuilder.build()),
+                        parent.getAssignments()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitThroughMarkDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitThroughMarkDistinct.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+
+public class PushLimitThroughMarkDistinct
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof LimitNode)) {
+            return Optional.empty();
+        }
+
+        LimitNode parent = (LimitNode) node;
+
+        PlanNode child = lookup.resolve(parent.getSource());
+        if (!(child instanceof MarkDistinctNode)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                replaceChildren(child, ImmutableList.of(
+                        replaceChildren(parent, child.getSources()))));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitThroughProject.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitThroughProject.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+
+public class PushLimitThroughProject
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof LimitNode)) {
+            return Optional.empty();
+        }
+
+        LimitNode parent = (LimitNode) node;
+
+        PlanNode child = lookup.resolve(parent.getSource());
+        if (!(child instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                replaceChildren(child, ImmutableList.of(
+                        replaceChildren(parent, child.getSources()))));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitThroughSemiJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitThroughSemiJoin.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+
+public class PushLimitThroughSemiJoin
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof LimitNode)) {
+            return Optional.empty();
+        }
+
+        LimitNode parent = (LimitNode) node;
+
+        PlanNode child = lookup.resolve(parent.getSource());
+        if (!(child instanceof SemiJoinNode)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                replaceChildren(child, ImmutableList.of(
+                        replaceChildren(parent, child.getSources()))));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantProjections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantProjections.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Optional;
+
+/**
+ * Removes projection nodes that only perform non-renaming identity projections
+ */
+public class RemoveRedundantProjections
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode project = (ProjectNode) node;
+
+        if (!project.isIdentity()) {
+            return Optional.empty();
+        }
+
+        if (!ImmutableSet.copyOf(project.getOutputSymbols()).equals(ImmutableSet.copyOf(project.getSource().getOutputSymbols()))) {
+            return Optional.empty();
+        }
+
+        return Optional.of(project.getSource());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/Renamer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/Renamer.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionRewriter;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+class Renamer
+{
+    private final Map<Symbol, Symbol> renames;
+
+    public static Renamer from(ProjectNode node)
+    {
+        ImmutableMap.Builder<Symbol, Symbol> result = ImmutableMap.builder();
+
+        for (Map.Entry<Symbol, Expression> entry : node.getAssignments().entrySet()) {
+            Symbol symbol = entry.getKey();
+            Expression value = entry.getValue();
+
+            if (value instanceof SymbolReference && !((SymbolReference) value).getName().equals(symbol.getName())) {
+                result.put(symbol, Symbol.from(value));
+            }
+        }
+
+        return new Renamer(result.build());
+    }
+
+    private Renamer(Map<Symbol, Symbol> renames)
+    {
+        this.renames = renames;
+    }
+
+    public boolean hasRenames()
+    {
+        return !renames.isEmpty();
+    }
+
+    public Symbol rename(Symbol symbol)
+    {
+        return renames.getOrDefault(symbol, symbol);
+    }
+
+    public Expression rename(Expression expression)
+    {
+        return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Object>()
+        {
+            @Override
+            public Expression rewriteSymbolReference(SymbolReference reference, Object context, ExpressionTreeRewriter treeRewriter)
+            {
+                return rename(Symbol.from(reference)).toSymbolReference();
+            }
+        }, expression);
+    }
+
+    public ProjectNode renameOutputs(ProjectNode node)
+    {
+        Assignments.Builder assignments = Assignments.builder();
+        for (Map.Entry<Symbol, Expression> assignment : node.getAssignments().entrySet()) {
+            assignments.put(
+                    rename(assignment.getKey()),
+                    assignment.getValue());
+        }
+
+        return new ProjectNode(node.getId(), node.getSource(), assignments.build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/Renamer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/Renamer.java
@@ -49,6 +49,14 @@ class Renamer
         return new Renamer(result.build());
     }
 
+    public static Renamer merge(Renamer first, Renamer second)
+    {
+        return new Renamer(ImmutableMap.<Symbol, Symbol>builder()
+                .putAll(first.renames)
+                .putAll(second.renames)
+                .build());
+    }
+
     private Renamer(Map<Symbol, Symbol> renames)
     {
         this.renames = renames;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/Renamer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/Renamer.java
@@ -28,6 +28,11 @@ class Renamer
 {
     private final Map<Symbol, Symbol> renames;
 
+    public static Renamer empty()
+    {
+        return new Renamer(ImmutableMap.of());
+    }
+
     public static Renamer from(ProjectNode node)
     {
         ImmutableMap.Builder<Symbol, Symbol> result = ImmutableMap.builder();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/Renamer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/Renamer.java
@@ -22,7 +22,10 @@ import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 class Renamer
 {
@@ -65,6 +68,20 @@ class Renamer
     public boolean hasRenames()
     {
         return !renames.isEmpty();
+    }
+
+    public List<Symbol> renameAll(List<Symbol> symbols)
+    {
+        return symbols.stream()
+                .map(this::rename)
+                .collect(Collectors.toList());
+    }
+
+    public Set<Symbol> renameAll(Set<Symbol> symbols)
+    {
+        return symbols.stream()
+                .map(this::rename)
+                .collect(Collectors.toSet());
     }
 
     public Symbol rename(Symbol symbol)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Literal;
+import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.collect.ImmutableList;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+
+public class SimplifyCountOverConstant
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof AggregationNode)) {
+            return Optional.empty();
+        }
+
+        AggregationNode parent = (AggregationNode) node;
+
+        PlanNode input = lookup.resolve(parent.getSource());
+        if (!(input instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode child = (ProjectNode) input;
+
+        boolean changed = false;
+        Map<Symbol, FunctionCall> aggregations = new LinkedHashMap<>(parent.getAggregations());
+        Map<Symbol, Signature> functions = new LinkedHashMap<>(parent.getFunctions());
+
+        for (Entry<Symbol, FunctionCall> entry : parent.getAggregations().entrySet()) {
+            Symbol symbol = entry.getKey();
+            FunctionCall functionCall = entry.getValue();
+            Signature signature = parent.getFunctions().get(symbol);
+
+            if (isCountOverConstant(functionCall, signature, child.getAssignments())) {
+                changed = true;
+                aggregations.put(symbol, new FunctionCall(
+                        functionCall.getName(),
+                        functionCall.getWindow(),
+                        functionCall.getFilter(),
+                        functionCall.isDistinct(),
+                        ImmutableList.of()));
+
+                functions.put(symbol, new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT)));
+            }
+        }
+
+        if (!changed) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new AggregationNode(
+                node.getId(),
+                child,
+                aggregations,
+                functions,
+                parent.getMasks(),
+                parent.getGroupingSets(),
+                parent.getStep(),
+                parent.getHashSymbol(),
+                parent.getGroupIdSymbol()));
+    }
+
+    private static boolean isCountOverConstant(FunctionCall function, Signature signature, Assignments inputs)
+    {
+        if (!signature.getName().equals("count") || signature.getArgumentTypes().size() != 1) {
+            return false;
+        }
+
+        Expression argument = function.getArguments().get(0);
+        if (argument instanceof SymbolReference) {
+            argument = inputs.get(Symbol.from(argument));
+        }
+
+        return argument instanceof Literal && !(argument instanceof NullLiteral);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SingleMarkDistinctToGroupBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SingleMarkDistinctToGroupBy.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.SINGLE;
+
+/**
+ * Converts Single Distinct Aggregation into GroupBy
+ *
+ * Rewrite if and only if
+ *  1 all aggregation functions have a single common distinct mask symbol
+ *  2 all aggregation functions have mask
+ *
+ * Rewrite MarkDistinctNode into AggregationNode(use DistinctSymbols as GroupBy)
+ * Remove Distincts in the original AggregationNode
+ */
+public class SingleMarkDistinctToGroupBy
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof AggregationNode)) {
+            return Optional.empty();
+        }
+
+        AggregationNode parent = (AggregationNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof MarkDistinctNode)) {
+            return Optional.empty();
+        }
+
+        MarkDistinctNode child = (MarkDistinctNode) source;
+
+        boolean hasFilters = parent.getAggregations()
+                .values().stream()
+                .map(FunctionCall::getFilter)
+                .anyMatch(Optional::isPresent);
+
+        if (hasFilters) {
+            return Optional.empty();
+        }
+
+        // optimize if and only if
+        // all aggregation functions have a single common distinct mask symbol
+        // AND all aggregation functions have mask
+        Set<Symbol> masks = ImmutableSet.copyOf(parent.getMasks().values());
+        if (masks.size() != 1 || parent.getMasks().size() != parent.getAggregations().size()) {
+            return Optional.empty();
+        }
+
+        Symbol mask = Iterables.getOnlyElement(masks);
+
+        if (!child.getMarkerSymbol().equals(mask)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                new AggregationNode(
+                        idAllocator.getNextId(),
+                        new AggregationNode(
+                                idAllocator.getNextId(),
+                                child.getSource(),
+                                Collections.emptyMap(),
+                                Collections.emptyMap(),
+                                Collections.emptyMap(),
+                                ImmutableList.of(child.getDistinctSymbols()),
+                                SINGLE,
+                                child.getHashSymbol(),
+                                Optional.empty()),
+                        // remove DISTINCT flag from function calls
+                        parent.getAggregations()
+                                .entrySet().stream()
+                                .collect(Collectors.toMap(Map.Entry::getKey, e ->
+                                        new FunctionCall(e.getValue().getName(), e.getValue().getWindow(), false, e.getValue().getArguments()))),
+                        parent.getFunctions(),
+                        Collections.emptyMap(),
+                        parent.getGroupingSets(),
+                        parent.getStep(),
+                        parent.getHashSymbol(),
+                        parent.getGroupIdSymbol()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasAggregation.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.tree.FunctionCall;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class UnaliasAggregation
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof AggregationNode)) {
+            return Optional.empty();
+        }
+
+        AggregationNode parent = (AggregationNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode child = (ProjectNode) source;
+
+        Renamer renamer = Renamer.from(child);
+
+        if (!renamer.hasRenames()) {
+            return Optional.empty();
+        }
+
+        Map<Symbol, FunctionCall> rewrittenAggregations = parent.getAggregations()
+                .entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> renamer.rename(e.getKey()),
+                        e -> (FunctionCall) renamer.rename(e.getValue())));
+
+        Map<Symbol, Signature> rewrittenFunctions = parent.getFunctions()
+                .entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> renamer.rename(e.getKey()),
+                        Map.Entry::getValue));
+
+        Map<Symbol, Symbol> rewrittenMasks = parent.getMasks()
+                .entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> renamer.rename(e.getKey()),
+                        e -> renamer.rename(e.getValue())));
+
+        List<List<Symbol>> rewrittenGroupingSets = parent.getGroupingSets().stream()
+                .map(g -> g.stream()
+                        .map(renamer::rename)
+                        .collect(Collectors.toList()))
+                .collect(Collectors.toList());
+
+        AggregationNode rewrittenAggregation = new AggregationNode(
+                parent.getId(),
+                renamer.renameOutputs(child),
+                rewrittenAggregations,
+                rewrittenFunctions,
+                rewrittenMasks,
+                rewrittenGroupingSets,
+                parent.getStep(),
+                parent.getHashSymbol().map(renamer::rename),
+                parent.getGroupIdSymbol().map(renamer::rename));
+
+        return Optional.of(
+                new ProjectNode(
+                        idAllocator.getNextId(),
+                        rewrittenAggregation,
+                        // compute assignments to preserve original output names
+                        Assignments.copyOf(
+                                parent.getOutputSymbols().stream()
+                                        .collect(Collectors.toMap(
+                                                Function.identity(),
+                                                symbol -> renamer.rename(symbol).toSymbolReference())))));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasFilter.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Given:
+ * <pre>
+ * - Filter :: [x1, ..., xn, y1, ..., ym]
+ *         f1(x1, ..., xn, y1, ..., ym)
+ *         ...
+ *     - Project :: [x1, ..., xn, y1, ..., ym]
+ *             x1 = k1
+ *             ...
+ *             xn = kn
+ *             y1 = g1(k1, ..., kn)
+ *             ...
+ *             ym = gm(k1, ..., kn)
+ *         - X ::= [k1, ..., kn]
+ * </pre>
+ * <p>
+ * Where x1, ..., xn are simple renames in the child projection, into:
+ * <p>
+ * <pre>
+ * - Project :: [x1, ..., xn, y1, ..., ym]
+ *         x1 = k1
+ *         ...
+ *         xn = kn
+ *         y1 = y1
+ *         ...
+ *         yn = ym
+ *     - Filter
+ *             f1(k1, ... kn, y1, ..., ym)
+ *             ...
+ *         - Project [k1, ..., kn, y1, ..., ym]
+ *                 k1 = k1
+ *                 ...
+ *                 kn = kn
+ *                 y1 = g1(k1, ..., kn)
+ *                 ...
+ *                 ym = gm(k1, ..., kn)
+ *             - X
+ * </pre>
+ */
+public class UnaliasFilter
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof FilterNode)) {
+            return Optional.empty();
+        }
+
+        FilterNode parent = (FilterNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode child = (ProjectNode) source;
+
+        Renamer renamer = Renamer.from(child);
+
+        if (!renamer.hasRenames()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                new ProjectNode(
+                        idAllocator.getNextId(),
+                        new FilterNode(
+                                parent.getId(),
+                                renamer.renameOutputs(child),
+                                renamer.rename(parent.getPredicate())),
+                        // compute assignments to preserve original output names
+                        Assignments.copyOf(
+                                parent.getOutputSymbols().stream()
+                                        .collect(Collectors.toMap(
+                                                Function.identity(),
+                                                symbol -> renamer.rename(symbol).toSymbolReference())))));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasGroupId.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasGroupId.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class UnaliasGroupId
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof GroupIdNode)) {
+            return Optional.empty();
+        }
+
+        GroupIdNode parent = (GroupIdNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode child = (ProjectNode) source;
+
+        Renamer renamer = Renamer.from(child);
+
+        if (!renamer.hasRenames()) {
+            return Optional.empty();
+        }
+
+        List<List<Symbol>> rewrittenGroupingSets = parent.getGroupingSets().stream()
+                .map(s -> s.stream()
+                        .map(renamer::rename)
+                        .collect(Collectors.toList()))
+                .collect(Collectors.toList());
+
+        Map<Symbol, Symbol> rewrittenArgumentMappings = parent.getArgumentMappings()
+                .entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> renamer.rename(e.getValue())));
+
+        Map<Symbol, Symbol> rewrittenGroupingSetMappings = parent.getGroupingSetMappings()
+                .entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> renamer.rename(e.getValue())));
+
+        GroupIdNode rewrittenNode = new GroupIdNode(
+                parent.getId(),
+                renamer.renameOutputs(child),
+                rewrittenGroupingSets,
+                rewrittenGroupingSetMappings,
+                rewrittenArgumentMappings,
+                parent.getGroupIdSymbol());
+
+        return Optional.of(
+                new ProjectNode(
+                        idAllocator.getNextId(),
+                        rewrittenNode,
+                        // compute assignments to preserve original output names
+                        Assignments.copyOf(
+                                parent.getOutputSymbols().stream()
+                                        .collect(Collectors.toMap(
+                                                Function.identity(),
+                                                symbol -> renamer.rename(symbol).toSymbolReference())))));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasJoin.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class UnaliasJoin
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof JoinNode)) {
+            return Optional.empty();
+        }
+
+        JoinNode parent = (JoinNode) node;
+
+        PlanNode left = lookup.resolve(parent.getLeft());
+        PlanNode right = lookup.resolve(parent.getRight());
+        if (!(left instanceof ProjectNode) && !(right instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        Renamer leftRenames = Renamer.empty();
+        if (left instanceof ProjectNode) {
+            ProjectNode project = (ProjectNode) left;
+            leftRenames = Renamer.from(project);
+            left = leftRenames.renameOutputs(project);
+        }
+
+        Renamer rightRenames = Renamer.empty();
+        if (right instanceof ProjectNode) {
+            ProjectNode project = (ProjectNode) right;
+            rightRenames = Renamer.from(project);
+            right = rightRenames.renameOutputs(project);
+        }
+
+        Renamer renames = Renamer.merge(leftRenames, rightRenames);
+
+        if (!renames.hasRenames()) {
+            return Optional.empty();
+        }
+
+        JoinNode rewrittenJoin = new JoinNode(
+                parent.getId(),
+                parent.getType(),
+                left,
+                right,
+                parent.getCriteria().stream()
+                        .map(c -> new JoinNode.EquiJoinClause(
+                                renames.rename(c.getLeft()),
+                                renames.rename(c.getRight())))
+                        .collect(Collectors.toList()),
+                parent.getFilter().map(renames::rename),
+                parent.getLeftHashSymbol().map(renames::rename),
+                parent.getRightHashSymbol().map(renames::rename));
+
+        // compute assignments to preserve original output names
+        Assignments.Builder finalAssignments = Assignments.builder();
+        for (Symbol symbol : parent.getOutputSymbols()) {
+            finalAssignments.put(symbol, renames.rename(symbol).toSymbolReference());
+        }
+
+        return Optional.of(new ProjectNode(idAllocator.getNextId(), rewrittenJoin, finalAssignments.build()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasMarkDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasMarkDistinct.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class UnaliasMarkDistinct
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof MarkDistinctNode)) {
+            return Optional.empty();
+        }
+
+        MarkDistinctNode parent = (MarkDistinctNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode child = (ProjectNode) source;
+
+        Renamer renamer = Renamer.from(child);
+
+        if (!renamer.hasRenames()) {
+            return Optional.empty();
+        }
+
+        MarkDistinctNode rewrittenMarkDistinct = new MarkDistinctNode(
+                parent.getId(),
+                renamer.renameOutputs(child),
+                renamer.rename(parent.getMarkerSymbol()),
+                parent.getDistinctSymbols().stream()
+                        .map(renamer::rename)
+                        .collect(Collectors.toList()),
+                parent.getHashSymbol().map(renamer::rename));
+
+        // compute assignments to preserve original output names
+        Assignments.Builder finalAssignments = Assignments.builder();
+        for (Symbol symbol : parent.getOutputSymbols()) {
+            finalAssignments.put(symbol, renamer.rename(symbol).toSymbolReference());
+        }
+
+        return Optional.of(
+                new ProjectNode(
+                        idAllocator.getNextId(),
+                        rewrittenMarkDistinct,
+                        finalAssignments.build()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasOutput.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasOutput.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class UnaliasOutput
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof OutputNode)) {
+            return Optional.empty();
+        }
+
+        OutputNode parent = (OutputNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode child = (ProjectNode) source;
+
+        Renamer renamer = Renamer.from(child);
+
+        if (!renamer.hasRenames()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                new OutputNode(
+                        parent.getId(),
+                        renamer.renameOutputs(child),
+                        parent.getColumnNames(),
+                        parent.getOutputSymbols().stream()
+                                .map(renamer::rename)
+                                .collect(Collectors.toList())));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasProject.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasProject.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Given:
+ * <pre>
+ * - Project
+ *         c1 = f1(x1, ..., xn, y1, ..., ym)
+ *         c2 = f2(x1, ..., xn, y1, ..., ym)
+ *         ...
+ *     - Project :: [x1, ..., xn, y1, ..., ym]
+ *             x1 = k1
+ *             ...
+ *             xn = kn
+ *             y1 = g1(k1, ..., kn)
+ *             ...
+ *             ym = gm(k1, ..., kn)
+ *         - X ::= [k1, ..., kn]
+ * </pre>
+ *
+ * Where x1, ..., xn are simple renames in the child projection, into:
+ *
+ * <pre>
+ * - Project
+ *         c1 = f1(k1, ... kn, y1, ..., ym)
+ *         c2 = f2(k1, ... kn, y1, ..., ym)
+ *         ...
+ *     - Project [k1, ..., kn, y1, ..., ym]
+ *             k1 = k1
+ *             ...
+ *             kn = kn
+ *             y1 = g1(k1, ..., kn)
+ *             ...
+ *             ym = gm(k1, ..., kn)
+ *         - X
+ * </pre>
+ */
+public class UnaliasProject
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode parent = (ProjectNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode child = (ProjectNode) source;
+
+        Renamer renamer = Renamer.from(child);
+
+        if (!renamer.hasRenames()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                new ProjectNode(
+                        parent.getId(),
+                        renamer.renameOutputs(child),
+                        Assignments.copyOf(
+                                parent.getAssignments()
+                                        .entrySet().stream()
+                                        .collect(Collectors.toMap(
+                                                Map.Entry::getKey,
+                                                e -> renamer.rename(e.getValue()))))));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasSetOperation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasSetOperation.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.ExceptNode;
+import com.facebook.presto.sql.planner.plan.IntersectNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.SetOperationNode;
+import com.facebook.presto.sql.planner.plan.UnionNode;
+import com.google.common.collect.ImmutableListMultimap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class UnaliasSetOperation
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof UnionNode) && !(node instanceof IntersectNode) && !(node instanceof ExceptNode)) {
+            return Optional.empty();
+        }
+
+        SetOperationNode parent = (SetOperationNode) node;
+
+        List<PlanNode> newChildren = new ArrayList<>();
+        ImmutableListMultimap.Builder<Symbol, Symbol> mappings = ImmutableListMultimap.builder();
+
+        boolean changed = false;
+        for (int childIndex = 0; childIndex < parent.getSources().size(); childIndex++) {
+            PlanNode child = lookup.resolve(parent.getSources().get(childIndex));
+
+            Renamer renamer = Renamer.empty();
+            if (child instanceof ProjectNode) {
+                ProjectNode project = (ProjectNode) child;
+                renamer = Renamer.from(project);
+
+                if (renamer.hasRenames()) {
+                    changed = true;
+                }
+
+                child = renamer.renameOutputs(project);
+            }
+
+            for (Symbol output : parent.getOutputSymbols()) {
+                Symbol input = parent.getSymbolMapping().get(output).get(childIndex);
+                mappings.put(output, renamer.rename(input));
+            }
+
+            newChildren.add(child);
+        }
+
+        if (!changed) {
+            return Optional.empty();
+        }
+
+        PlanNode result;
+        if (node instanceof UnionNode) {
+            result = new UnionNode(parent.getId(), newChildren, mappings.build(), parent.getOutputSymbols());
+        }
+        else if (node instanceof IntersectNode) {
+            result = new IntersectNode(parent.getId(), newChildren, mappings.build(), parent.getOutputSymbols());
+        }
+        else if (node instanceof ExceptNode) {
+            result = new ExceptNode(parent.getId(), newChildren, mappings.build(), parent.getOutputSymbols());
+        }
+        else {
+            throw new UnsupportedOperationException("Unsupported set operation node type: " + node.getClass().getName());
+        }
+
+        return Optional.of(result);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasSort.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasSort.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.SortNode;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class UnaliasSort
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof SortNode)) {
+            return Optional.empty();
+        }
+
+        SortNode parent = (SortNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode child = (ProjectNode) source;
+
+        Renamer renamer = Renamer.from(child);
+
+        if (!renamer.hasRenames()) {
+            return Optional.empty();
+        }
+
+        SortNode rewrittenNode = new SortNode(
+                parent.getId(),
+                renamer.renameOutputs(child),
+                parent.getOrderBy().stream()
+                        .map(renamer::rename)
+                        .collect(Collectors.toList()),
+                parent.getOrderings()
+                        .entrySet().stream()
+                        .collect(Collectors.toMap(
+                                e -> renamer.rename(e.getKey()),
+                                Map.Entry::getValue)));
+
+        // compute assignments to preserve original output names
+        Assignments.Builder finalAssignments = Assignments.builder();
+        for (Symbol symbol : parent.getOutputSymbols()) {
+            finalAssignments.put(symbol, renamer.rename(symbol).toSymbolReference());
+        }
+
+        return Optional.of(new ProjectNode(idAllocator.getNextId(), rewrittenNode, finalAssignments.build()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasTopN.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasTopN.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class UnaliasTopN
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof TopNNode)) {
+            return Optional.empty();
+        }
+
+        TopNNode parent = (TopNNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode child = (ProjectNode) source;
+
+        Renamer renamer = Renamer.from(child);
+
+        if (!renamer.hasRenames()) {
+            return Optional.empty();
+        }
+
+        TopNNode rewrittenNode = new TopNNode(
+                parent.getId(),
+                renamer.renameOutputs(child),
+                parent.getCount(),
+                parent.getOrderBy().stream()
+                        .map(renamer::rename)
+                        .collect(Collectors.toList()),
+                parent.getOrderings()
+                        .entrySet().stream()
+                        .collect(Collectors.toMap(
+                                e -> renamer.rename(e.getKey()),
+                                Map.Entry::getValue)),
+                parent.isPartial());
+
+        // compute assignments to preserve original output names
+        Assignments.Builder finalAssignments = Assignments.builder();
+        for (Symbol symbol : parent.getOutputSymbols()) {
+            finalAssignments.put(symbol, renamer.rename(symbol).toSymbolReference());
+        }
+
+        return Optional.of(new ProjectNode(idAllocator.getNextId(), rewrittenNode, finalAssignments.build()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasUnnest.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasUnnest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.UnnestNode;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class UnaliasUnnest
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof UnnestNode)) {
+            return Optional.empty();
+        }
+
+        UnnestNode parent = (UnnestNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode child = (ProjectNode) source;
+
+        Renamer renamer = Renamer.from(child);
+
+        if (!renamer.hasRenames()) {
+            return Optional.empty();
+        }
+
+        UnnestNode rewrittenNode = new UnnestNode(
+                parent.getId(),
+                renamer.renameOutputs(child),
+                parent.getReplicateSymbols().stream()
+                        .map(renamer::rename)
+                        .collect(Collectors.toList()),
+                parent.getUnnestSymbols()
+                        .entrySet().stream()
+                        .collect(Collectors.toMap(
+                                e-> renamer.rename(e.getKey()),
+                                Map.Entry::getValue)),
+                parent.getOrdinalitySymbol());
+
+        // compute assignments to preserve original output names
+        Assignments.Builder finalAssignments = Assignments.builder();
+        for (Symbol symbol : parent.getOutputSymbols()) {
+            finalAssignments.put(symbol, renamer.rename(symbol).toSymbolReference());
+        }
+
+        return Optional.of(new ProjectNode(idAllocator.getNextId(), rewrittenNode, finalAssignments.build()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasWindow.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/UnaliasWindow.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.FunctionCall;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class UnaliasWindow
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof WindowNode)) {
+            return Optional.empty();
+        }
+
+        WindowNode parent = (WindowNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+
+        ProjectNode child = (ProjectNode) source;
+
+        Renamer renamer = Renamer.from(child);
+
+        if (!renamer.hasRenames()) {
+            return Optional.empty();
+        }
+
+        WindowNode rewrittenNode = new WindowNode(
+                parent.getId(),
+                renamer.renameOutputs(child),
+                new WindowNode.Specification(
+                        renamer.renameAll(parent.getSpecification().getPartitionBy()),
+                        renamer.renameAll(parent.getSpecification().getOrderBy()),
+                        parent.getSpecification().getOrderings()
+                                .entrySet().stream()
+                                .collect(Collectors.toMap(
+                                        e -> renamer.rename(e.getKey()),
+                                        Map.Entry::getValue))),
+                parent.getWindowFunctions()
+                        .entrySet().stream()
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                e -> renameFunction(renamer, e.getValue()))),
+                parent.getHashSymbol().map(renamer::rename),
+                renamer.renameAll(parent.getPrePartitionedInputs()),
+                parent.getPreSortedOrderPrefix());
+
+        // compute assignments to preserve original output names
+        Assignments.Builder finalAssignments = Assignments.builder();
+        for (Symbol symbol : parent.getOutputSymbols()) {
+            finalAssignments.put(symbol, renamer.rename(symbol).toSymbolReference());
+        }
+
+        return Optional.of(new ProjectNode(idAllocator.getNextId(), rewrittenNode, finalAssignments.build()));
+    }
+
+    private WindowNode.Function renameFunction(Renamer renamer, WindowNode.Function function)
+    {
+        WindowNode.Frame frame = function.getFrame();
+
+        return new WindowNode.Function(
+                (FunctionCall) renamer.rename(function.getFunctionCall()),
+                function.getSignature(),
+                new WindowNode.Frame(
+                        frame.getType(),
+                        frame.getStartType(),
+                        frame.getStartValue().map(renamer::rename),
+                        frame.getEndType(),
+                        frame.getEndValue().map(renamer::rename)));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -495,15 +495,20 @@ public class AddExchanges
 
             if (!child.getProperties().isSingleNode()) {
                 child = withDerivedProperties(
-                        new LimitNode(idAllocator.getNextId(), child.getNode(), node.getCount(), true),
+                        new LimitNode(idAllocator.getNextId(), child.getNode(), node.getCount(), LimitNode.Step.PARTIAL),
                         child.getProperties());
 
                 child = withDerivedProperties(
                         gatheringExchange(idAllocator.getNextId(), REMOTE, child.getNode()),
                         child.getProperties());
-            }
 
-            return rebaseAndDeriveProperties(node, child);
+                return withDerivedProperties(
+                        new LimitNode(idAllocator.getNextId(), child.getNode(), node.getCount(), LimitNode.Step.FINAL),
+                        child.getProperties());
+            }
+            else {
+                return rebaseAndDeriveProperties(node, child);
+            }
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -187,7 +187,7 @@ public class AddLocalExchanges
         @Override
         public PlanWithProperties visitLimit(LimitNode node, StreamPreferredProperties parentPreferences)
         {
-            if (node.isPartial()) {
+            if (node.getStep() == LimitNode.Step.PARTIAL) {
                 return planAndEnforceChildren(
                         node,
                         parentPreferences.withoutPreference().withDefaultParallelism(session),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CountConstantOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CountConstantOptimizer.java
@@ -39,6 +39,7 @@ import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static java.util.Objects.requireNonNull;
 
+@Deprecated
 public class CountConstantOptimizer
         implements PlanOptimizer
 {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementFilteredAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementFilteredAggregations.java
@@ -56,6 +56,7 @@ import static java.util.Objects.requireNonNull;
  *         - X
  * </pre>
  */
+@Deprecated
 public class ImplementFilteredAggregations
         implements PlanOptimizer
 {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
@@ -98,6 +98,7 @@ import static java.util.stream.Collectors.toList;
  * GROUP BY a) T2
  * WHERE foo_cnt >= 1 AND bar_cnt = 0;
  */
+@Deprecated
 public class ImplementIntersectAndExceptAsUnion
         implements PlanOptimizer
 {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementSampleAsFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementSampleAsFilter.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
+@Deprecated
 public class ImplementSampleAsFilter
         implements PlanOptimizer
 {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+@Deprecated
 public class LimitPushDown
         implements PlanOptimizer
 {
@@ -104,7 +105,7 @@ public class LimitPushDown
             LimitContext limit = context.get();
             if (limit != null) {
                 // Drop in a LimitNode b/c we cannot push our limit down any further
-                rewrittenNode = new LimitNode(idAllocator.getNextId(), rewrittenNode, limit.getCount(), limit.isPartial());
+                rewrittenNode = new LimitNode(idAllocator.getNextId(), rewrittenNode, limit.getCount(), limit.isPartial() ? LimitNode.Step.PARTIAL : LimitNode.Step.SINGLE);
             }
             return rewrittenNode;
         }
@@ -143,7 +144,7 @@ public class LimitPushDown
             PlanNode rewrittenNode = context.defaultRewrite(node);
             if (limit != null) {
                 // Drop in a LimitNode b/c limits cannot be pushed through aggregations
-                rewrittenNode = new LimitNode(idAllocator.getNextId(), rewrittenNode, limit.getCount(), limit.isPartial());
+                rewrittenNode = new LimitNode(idAllocator.getNextId(), rewrittenNode, limit.getCount(), limit.isPartial() ? LimitNode.Step.PARTIAL : LimitNode.Step.SINGLE);
             }
             return rewrittenNode;
         }
@@ -213,7 +214,7 @@ public class LimitPushDown
 
             PlanNode output = new UnionNode(node.getId(), sources, node.getSymbolMapping(), node.getOutputSymbols());
             if (limit != null) {
-                output = new LimitNode(idAllocator.getNextId(), output, limit.getCount(), limit.isPartial());
+                output = new LimitNode(idAllocator.getNextId(), output, limit.getCount(), limit.isPartial() ? LimitNode.Step.PARTIAL : LimitNode.Step.SINGLE);
             }
             return output;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeProjections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeProjections.java
@@ -37,6 +37,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Merges chains of consecutive projections
  */
+@Deprecated
 public class MergeProjections
         implements PlanOptimizer
 {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -513,7 +513,7 @@ public class PruneUnreferencedOutputs
             ImmutableSet.Builder<Symbol> expectedInputs = ImmutableSet.<Symbol>builder()
                     .addAll(context.get());
             PlanNode source = context.rewrite(node.getSource(), expectedInputs.build());
-            return new LimitNode(node.getId(), source, node.getCount(), node.isPartial());
+            return new LimitNode(node.getId(), source, node.getCount(), node.getStep());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SetFlatteningOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SetFlatteningOptimizer.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
+@Deprecated
 public class SetFlatteningOptimizer
         implements PlanOptimizer
 {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SingleDistinctOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SingleDistinctOptimizer.java
@@ -52,6 +52,7 @@ import static java.util.Objects.requireNonNull;
  * All unused mask will be removed by PruneUnreferencedOutputs
  * Remove Distincts in the original AggregationNode
  */
+@Deprecated
 public class SingleDistinctOptimizer
         implements PlanOptimizer
 {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformExistsApplyToScalarApply.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformExistsApplyToScalarApply.java
@@ -101,7 +101,7 @@ public class TransformExistsApplyToScalarApply
             PlanNode input = context.rewrite(node.getInput());
             PlanNode subquery = context.rewrite(node.getSubquery());
 
-            subquery = new LimitNode(idAllocator.getNextId(), subquery, 1, false);
+            subquery = new LimitNode(idAllocator.getNextId(), subquery, 1, LimitNode.Step.FINAL);
 
             FunctionRegistry functionRegistry = metadata.getFunctionRegistry();
             QualifiedName countFunction = QualifiedName.of("count");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ChildReplacer.java
@@ -52,7 +52,7 @@ public class ChildReplacer
     @Override
     public PlanNode visitLimit(LimitNode node, List<PlanNode> newChildren)
     {
-        return new LimitNode(node.getId(), Iterables.getOnlyElement(newChildren), node.getCount(), node.isPartial());
+        return new LimitNode(node.getId(), Iterables.getOnlyElement(newChildren), node.getCount(), node.getStep());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/LimitNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/LimitNode.java
@@ -31,23 +31,30 @@ public class LimitNode
 {
     private final PlanNode source;
     private final long count;
-    private final boolean partial;
+    private final Step step;
+
+    public enum Step
+    {
+        PARTIAL,
+        FINAL,
+        SINGLE
+    }
 
     @JsonCreator
     public LimitNode(
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
             @JsonProperty("count") long count,
-            @JsonProperty("partial") boolean partial)
+            @JsonProperty("step") Step step)
     {
         super(id);
-        this.partial = partial;
-
         requireNonNull(source, "source is null");
+        requireNonNull(step, "step is null");
         checkArgument(count >= 0, "count must be greater than or equal to zero");
 
         this.source = source;
         this.count = count;
+        this.step = step;
     }
 
     @Override
@@ -69,9 +76,9 @@ public class LimitNode
     }
 
     @JsonProperty
-    public boolean isPartial()
+    public Step getStep()
     {
-        return partial;
+        return step;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -223,7 +223,12 @@ public class LocalQueryRunner
 
     public LocalQueryRunner(Session defaultSession)
     {
-        this(defaultSession, new FeaturesConfig().setOptimizeMixedDistinctAggregations(true), false);
+        this(
+                defaultSession,
+                new FeaturesConfig()
+                        .setOptimizeMixedDistinctAggregations(true)
+                        .setNewOptimizerEnabled(true),
+                false);
     }
 
     public LocalQueryRunner(Session defaultSession, FeaturesConfig featuresConfig)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -259,7 +259,7 @@ public class TestEffectivePredicateExtractor
                                 equals(BE, CE),
                                 lessThan(CE, bigintLiteral(10)))),
                 1,
-                false);
+                LimitNode.Step.SINGLE);
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestMemo.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestMemo.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.tree.BooleanLiteral;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestMemo
+{
+    private PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+
+    @Test
+    public void testInitialization()
+            throws Exception
+    {
+        ProjectNode plan = project(values());
+        Memo memo = new Memo(idAllocator, plan);
+
+        assertEquals(memo.getGroupCount(), 2);
+        assertMatchesStructure(plan, memo.extract());
+    }
+
+    /*
+      From: X -> Y  -> Z
+      To:   X -> Y' -> Z'
+     */
+    @Test
+    public void testReplaceSubtree()
+            throws Exception
+    {
+        PlanNode plan = project(filter(values()));
+
+        Memo memo = new Memo(idAllocator, plan);
+        assertEquals(memo.getGroupCount(), 3);
+
+        // replace child of root node with subtree
+        PlanNode transformed = project(values());
+        memo.replace(getChildGroup(memo, memo.getRootGroup()), transformed, "rule");
+        assertEquals(memo.getGroupCount(), 3);
+        assertMatchesStructure(memo.extract(), project(plan.getId(), transformed));
+    }
+
+    /*
+      From: X -> Y  -> Z  -> W
+      To:   X -> Y' -> Z' -> W
+     */
+    @Test
+    public void testReplaceNonLeafSubtree()
+            throws Exception
+    {
+        PlanNode w = values();
+        PlanNode z = filter(w);
+        PlanNode y = filter(z);
+        PlanNode x = project(y);
+
+        Memo memo = new Memo(idAllocator, x);
+
+        assertEquals(memo.getGroupCount(), 4);
+
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+        int zGroup = getChildGroup(memo, yGroup);
+
+        PlanNode rewrittenW = memo.getNode(zGroup).getSources().get(0);
+
+        ProjectNode newZ = project(rewrittenW);
+        ProjectNode newY = project(newZ);
+
+        memo.replace(yGroup, newY, "rule");
+
+        assertEquals(memo.getGroupCount(), 4);
+
+        assertMatchesStructure(
+                memo.extract(),
+                project(x.getId(),
+                        project(newY.getId(),
+                                project(newZ.getId(),
+                                        values(w.getId())))));
+    }
+
+    /*
+      From: X -> Y -> Z
+      To:   X -> Z
+     */
+    @Test
+    public void testRemoveNode()
+            throws Exception
+    {
+        PlanNode z = values();
+        PlanNode y = filter(z);
+        PlanNode x = project(y);
+
+        Memo memo = new Memo(idAllocator, x);
+
+        assertEquals(memo.getGroupCount(), 3);
+
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+        memo.replace(yGroup, memo.getNode(yGroup).getSources().get(0), "rule");
+
+        assertEquals(memo.getGroupCount(), 2);
+
+        assertMatchesStructure(
+                memo.extract(),
+                project(x.getId(),
+                        values(z.getId())));
+    }
+
+    /*
+       From: X -> Z
+       To:   X -> Y -> Z
+     */
+    @Test
+    public void testInsertNode()
+            throws Exception
+    {
+        PlanNode z = values();
+        PlanNode x = project(z);
+
+        Memo memo = new Memo(idAllocator, x);
+
+        assertEquals(memo.getGroupCount(), 2);
+
+        int zGroup = getChildGroup(memo, memo.getRootGroup());
+        PlanNode y = filter(memo.getNode(zGroup));
+        memo.replace(zGroup, y, "rule");
+
+        assertEquals(memo.getGroupCount(), 3);
+
+        assertMatchesStructure(
+                memo.extract(),
+                project(x.getId(),
+                        filter(y.getId(),
+                                values(z.getId()))));
+    }
+
+    /*
+      From: X -> Y -> Z
+      To:   X --> Y1' --> Z
+              \-> Y2' -/
+     */
+    @Test
+    public void testMultipleReferences()
+            throws Exception
+    {
+        PlanNode z = values();
+        PlanNode y = filter(z);
+        PlanNode x = project(y);
+
+        Memo memo = new Memo(idAllocator, x);
+        assertEquals(memo.getGroupCount(), 3);
+
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+
+        PlanNode rewrittenZ = memo.getNode(yGroup).getSources().get(0);
+        PlanNode y1 = filter(rewrittenZ);
+        PlanNode y2 = project(rewrittenZ);
+
+        PlanNode newX = join(y1, y2);
+        memo.replace(memo.getRootGroup(), newX, "rule");
+        assertEquals(memo.getGroupCount(), 4);
+
+        assertMatchesStructure(
+                memo.extract(),
+                join(newX.getId(),
+                        filter(y1.getId(), values(z.getId())),
+                        project(y2.getId(), values(z.getId()))));
+    }
+
+    private static void assertMatchesStructure(PlanNode actual, PlanNode expected)
+    {
+        assertEquals(actual.getClass(), expected.getClass());
+        assertEquals(actual.getId(), expected.getId());
+        assertEquals(actual.getSources().size(), expected.getSources().size());
+
+        for (int i = 0; i < actual.getSources().size(); i++) {
+            assertMatchesStructure(actual.getSources().get(i), expected.getSources().get(i));
+        }
+    }
+
+    private int getChildGroup(Memo memo, int group)
+    {
+        PlanNode node = memo.getNode(group);
+        GroupReference child = (GroupReference) node.getSources().get(0);
+
+        return child.getGroupId();
+    }
+
+    private JoinNode join(PlanNodeId id, PlanNode left, PlanNode right)
+    {
+        return new JoinNode(id, JoinNode.Type.INNER, left, right, ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    private JoinNode join(PlanNode left, PlanNode right)
+    {
+        return join(idAllocator.getNextId(), left, right);
+    }
+
+    private ProjectNode project(PlanNodeId id, PlanNode source)
+    {
+        return new ProjectNode(id, source, Assignments.of());
+    }
+
+    private ProjectNode project(PlanNode source)
+    {
+        return project(idAllocator.getNextId(), source);
+    }
+
+    private FilterNode filter(PlanNodeId id, PlanNode source)
+    {
+        return new FilterNode(id, source, BooleanLiteral.TRUE_LITERAL);
+    }
+
+    private FilterNode filter(PlanNode source)
+    {
+        return filter(idAllocator.getNextId(), source);
+    }
+
+    private ValuesNode values(PlanNodeId id)
+    {
+        return new ValuesNode(id, ImmutableList.of(), ImmutableList.of());
+    }
+
+    private ValuesNode values()
+    {
+        return values(idAllocator.getNextId());
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -113,6 +113,7 @@ public class DistributedQueryRunner
 
             Map<String, String> extraCoordinatorProperties = ImmutableMap.<String, String>builder()
                     .put("optimizer.optimize-mixed-distinct-aggregations", "true")
+                    .put("experimental.new-optimizer-enabled", "true")
                     .putAll(extraProperties)
                     .putAll(coordinatorProperties)
                     .build();


### PR DESCRIPTION
This is a preview of an iterative version of the current optimizer framework.

It decouples the traversal of the plan tree (`IterativeOptimizer`) from the transformation logic (`Rule`). It's implemented as yet-another `PlanOptimizer`, so it can be inserted in the middle of the existing optimizers sequence.

Some benefits:
* It makes it possible to write targeted transformation rules that will work even if they are not implemented for every node that might appear in the ancestry of a given node.
* Rules can be tested individually.
* The `Memo` structure breaks up the tree and adds a level of indirection that allows for more efficient mutations.
* It implements column pruning and unaliasing in a more principled way.

It's very much work in progress, but I wanted others to see what's coming up (cc @mattsfuller).

- [ ] Rule tests
- [ ] Migrate predicate pushdown rules
- [ ] Migrate prune outputs rules
- [x] Config & session property
- [x] GC unreferenced nodes in Memo