### PR TITLE
Fix improper reuse of length vector in ORC list reader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapStreamReader.java
@@ -33,7 +33,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;


### PR DESCRIPTION
Allocate a new length vector for each ORC list reader bock, since the numeric
readers do skip null positions, and there is code that assumes the nulls have
zero length.