### PR TITLE
Fix README.md VM options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After opening the project in IntelliJ, double check that the Java SDK is properl
 Presto comes with sample configuration that should work out-of-the-box for development. Use the following options to create a run configuration:
 
 * Main Class: `com.facebook.presto.server.PrestoServer`
-* VM Options: `-ea -Xmx2G -Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties`
+* VM Options: `-ea -XX:+UseG1GC  -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -Xmx2G -Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties`
 * Working directory: `$MODULE_DIR$`
 * Use classpath of module: `presto-main`
 


### PR DESCRIPTION
Use recommended configuration from Deploying Presto chapter in presto-docs.
Without this settings some of the TPC-DS product tests are failing.