### PR TITLE
Add jitter to hive retry driver

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/RetryDriver.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RetryDriver.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -149,8 +150,9 @@ public class RetryDriver
                 log.debug("Failed on executing %s with attempt %d, will retry. Exception: %s", callableName, attempt, e.getMessage());
 
                 int delayInMs = (int) Math.min(minSleepTime.toMillis() * Math.pow(scaleFactor, attempt - 1), maxSleepTime.toMillis());
+                int jitter = ThreadLocalRandom.current().nextInt(Math.max(1, (int) (delayInMs * 0.1)));
                 try {
-                    TimeUnit.MILLISECONDS.sleep(delayInMs);
+                    TimeUnit.MILLISECONDS.sleep(delayInMs + jitter);
                 }
                 catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();


### PR DESCRIPTION
I have recently seen that querying tables with small splits increases the likelihood of getting throttled by S3. Since we don't have any jitter in the retry driver, after backoff threads can wake up at roughly same times and start hammering S3 again. This PR adds some jitter to that process. 

For now I set the jitter to depend on the sleep time (`delayInMs`) as I guess when things go really bad and we have high sleep times it may help to spread the requests a little bit more.