### PR TITLE
Pass custom HttpClientConfig to QueryRunner

### DIFF
--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -95,6 +95,12 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
@@ -53,20 +53,22 @@ public class QueryRunner
             Optional<String> kerberosPrincipal,
             Optional<String> kerberosRemoteServiceName,
             boolean authenticationEnabled,
-            KerberosConfig kerberosConfig)
+            KerberosConfig kerberosConfig,
+            Optional<HttpClientConfig> httpClientConfig)
     {
         this.session = new AtomicReference<>(requireNonNull(session, "session is null"));
         this.queryResultsCodec = requireNonNull(queryResultsCodec, "queryResultsCodec is null");
         this.httpClient = new JettyHttpClient(
-                getHttpClientConfig(
-                        socksProxy,
-                        keystorePath,
-                        keystorePassword,
-                        truststorePath,
-                        truststorePassword,
-                        kerberosPrincipal,
-                        kerberosRemoteServiceName,
-                        authenticationEnabled),
+                httpClientConfig.isPresent() ? httpClientConfig.get() :
+                        getHttpClientConfig(
+                                socksProxy,
+                                keystorePath,
+                                keystorePassword,
+                                truststorePath,
+                                truststorePassword,
+                                kerberosPrincipal,
+                                kerberosRemoteServiceName,
+                                authenticationEnabled),
                 kerberosConfig,
                 Optional.<JettyIoPool>empty(),
                 ImmutableList.<HttpRequestFilter>of());
@@ -110,6 +112,32 @@ public class QueryRunner
             boolean authenticationEnabled,
             KerberosConfig kerberosConfig)
     {
+        return create(session,
+                socksProxy,
+                keystorePath,
+                keystorePassword,
+                truststorePath,
+                truststorePassword,
+                kerberosPrincipal,
+                kerberosRemoteServiceName,
+                authenticationEnabled,
+                kerberosConfig,
+                Optional.empty());
+    }
+
+    public static QueryRunner create(
+            ClientSession session,
+            Optional<HostAndPort> socksProxy,
+            Optional<String> keystorePath,
+            Optional<String> keystorePassword,
+            Optional<String> truststorePath,
+            Optional<String> truststorePassword,
+            Optional<String> kerberosPrincipal,
+            Optional<String> kerberosRemoteServiceName,
+            boolean authenticationEnabled,
+            KerberosConfig kerberosConfig,
+            Optional<HttpClientConfig> httpClientConfig)
+    {
         return new QueryRunner(
                 session,
                 jsonCodec(QueryResults.class),
@@ -121,7 +149,8 @@ public class QueryRunner
                 kerberosPrincipal,
                 kerberosRemoteServiceName,
                 authenticationEnabled,
-                kerberosConfig);
+                kerberosConfig,
+                httpClientConfig);
     }
 
     private static HttpClientConfig getHttpClientConfig(

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestQueryRunner.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cli;
+
+import com.facebook.presto.client.ClientSession;
+import com.google.common.net.HostAndPort;
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestQueryRunner
+{
+    @Test
+    public void testGivenHttpClientConfig()
+    {
+        ClientSession session = new ClientOptions().toClientSession();
+        HttpClientConfig mockConfig = spy(new HttpClientConfig());
+        when(mockConfig.getConnectTimeout()).thenReturn(new Duration(4, TimeUnit.SECONDS));
+        QueryRunner runner = QueryRunner.create(session,
+                Optional.<HostAndPort>empty(),
+                Optional.<String>empty(),
+                Optional.<String>empty(),
+                Optional.<String>empty(),
+                Optional.<String>empty(),
+                Optional.<String>empty(),
+                Optional.<String>empty(),
+                false,
+                null,
+                Optional.of(mockConfig)
+                );
+
+        // Configs are fetched from a given HttpClientConfig.
+        verify(mockConfig, atLeast(1)).getConnectTimeout();
+        verify(mockConfig, atLeast(1)).getRequestTimeout();
+    }
+}


### PR DESCRIPTION
Current `QueryRunner` hard code connect timeout and request timeout of Jetty http client config. This cause unnecessary timeout especially non-powerful environment like unit test or CI environment. We can mitigate the situation by passing custom `HttpClientConfig` to `QueryRunner`.

It can mitigate this type of situation: https://github.com/prestodb/presto/issues/6723

