### PR TITLE
Add FORMAT statement

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -77,6 +77,7 @@ import com.facebook.presto.sql.tree.DropSchema;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
 import com.facebook.presto.sql.tree.Explain;
+import com.facebook.presto.sql.tree.Format;
 import com.facebook.presto.sql.tree.Grant;
 import com.facebook.presto.sql.tree.Insert;
 import com.facebook.presto.sql.tree.Prepare;
@@ -216,6 +217,7 @@ public class CoordinatorModule
         binder.bind(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(Query.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(Explain.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
+        executionBinder.addBinding(Format.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(ShowCreate.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(ShowColumns.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(ShowPartitions.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/sql/Serialization.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/Serialization.java
@@ -41,7 +41,7 @@ public final class Serialization
         public void serialize(Expression expression, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
                 throws IOException
         {
-            jsonGenerator.writeString(ExpressionFormatter.formatExpression(expression, false, Optional.empty()));
+            jsonGenerator.writeString(ExpressionFormatter.formatExpression(expression, Optional.empty(), 0));
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -1284,10 +1284,12 @@ public class TestExpressionInterpreter
         return evaluate(parsedExpression);
     }
 
-    private static void assertRoundTrip(String expression)
+    private static void assertRoundTrip(String expressionSql)
     {
-        assertEquals(SQL_PARSER.createExpression(expression),
-                SQL_PARSER.createExpression(formatExpression(SQL_PARSER.createExpression(expression), Optional.empty())));
+        Expression expression = SQL_PARSER.createExpression(expressionSql);
+        assertEquals(
+                expression,
+                SQL_PARSER.createExpression(formatExpression(expression, Optional.empty(), 0)));
     }
 
     private static Object evaluate(Expression expression)

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -61,6 +61,7 @@ statement
         ON TABLE? qualifiedName FROM grantee=identifier                #revoke
     | EXPLAIN ANALYZE?
         ('(' explainOption (',' explainOption)* ')')? statement        #explain
+    | FORMAT statement                                                 #format
     | SHOW CREATE TABLE qualifiedName                                  #showCreateTable
     | SHOW CREATE VIEW qualifiedName                                   #showCreateView
     | SHOW TABLES ((FROM | IN) qualifiedName)? (LIKE pattern=STRING)?  #showTables

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -97,16 +97,11 @@ public final class ExpressionFormatter
 
     public static String formatExpression(Expression expression, Optional<List<Expression>> parameters)
     {
-        return formatExpression(expression, true, parameters);
-    }
-
-    public static String formatExpression(Expression expression, boolean unmangleNames, Optional<List<Expression>> parameters)
-    {
-        return new Formatter(parameters).process(expression, unmangleNames);
+        return new Formatter(parameters).process(expression, null);
     }
 
     public static class Formatter
-            extends AstVisitor<String, Boolean>
+            extends AstVisitor<String, Void>
     {
         private final Optional<List<Expression>> parameters;
 
@@ -116,27 +111,27 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitNode(Node node, Boolean unmangleNames)
+        protected String visitNode(Node node, Void context)
         {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        protected String visitRow(Row node, Boolean unmangleNames)
+        protected String visitRow(Row node, Void context)
         {
             return "ROW (" + Joiner.on(", ").join(node.getItems().stream()
-                    .map((child) -> process(child, unmangleNames))
+                    .map((child) -> process(child, context))
                     .collect(toList())) + ")";
         }
 
         @Override
-        protected String visitExpression(Expression node, Boolean unmangleNames)
+        protected String visitExpression(Expression node, Void context)
         {
             throw new UnsupportedOperationException(format("not yet implemented: %s.visit%s", getClass().getName(), node.getClass().getSimpleName()));
         }
 
         @Override
-        protected String visitAtTimeZone(AtTimeZone node, Boolean context)
+        protected String visitAtTimeZone(AtTimeZone node, Void context)
         {
             return new StringBuilder()
                     .append(process(node.getValue(), context))
@@ -145,7 +140,7 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitCurrentTime(CurrentTime node, Boolean unmangleNames)
+        protected String visitCurrentTime(CurrentTime node, Void context)
         {
             StringBuilder builder = new StringBuilder();
 
@@ -161,105 +156,105 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitExtract(Extract node, Boolean unmangleNames)
+        protected String visitExtract(Extract node, Void context)
         {
-            return "EXTRACT(" + node.getField() + " FROM " + process(node.getExpression(), unmangleNames) + ")";
+            return "EXTRACT(" + node.getField() + " FROM " + process(node.getExpression(), context) + ")";
         }
 
         @Override
-        protected String visitBooleanLiteral(BooleanLiteral node, Boolean unmangleNames)
+        protected String visitBooleanLiteral(BooleanLiteral node, Void context)
         {
             return String.valueOf(node.getValue());
         }
 
         @Override
-        protected String visitStringLiteral(StringLiteral node, Boolean unmangleNames)
+        protected String visitStringLiteral(StringLiteral node, Void context)
         {
             return formatStringLiteral(node.getValue());
         }
 
         @Override
-        protected String visitCharLiteral(CharLiteral node, Boolean unmangleNames)
+        protected String visitCharLiteral(CharLiteral node, Void context)
         {
             return "CHAR " + formatStringLiteral(node.getValue());
         }
 
         @Override
-        protected String visitBinaryLiteral(BinaryLiteral node, Boolean unmangleNames)
+        protected String visitBinaryLiteral(BinaryLiteral node, Void context)
         {
             return "X'" + node.toHexString() + "'";
         }
 
         @Override
-        protected String visitParameter(Parameter node, Boolean unmangleNames)
+        protected String visitParameter(Parameter node, Void context)
         {
             if (parameters.isPresent()) {
                 checkArgument(node.getPosition() < parameters.get().size(), "Invalid parameter number %s.  Max value is %s", node.getPosition(), parameters.get().size() - 1);
-                return process(parameters.get().get(node.getPosition()), unmangleNames);
+                return process(parameters.get().get(node.getPosition()), context);
             }
             return "?";
         }
 
         @Override
-        protected String visitArrayConstructor(ArrayConstructor node, Boolean unmangleNames)
+        protected String visitArrayConstructor(ArrayConstructor node, Void context)
         {
             ImmutableList.Builder<String> valueStrings = ImmutableList.builder();
             for (Expression value : node.getValues()) {
-                valueStrings.add(formatSql(value, unmangleNames, parameters));
+                valueStrings.add(formatSql(value, parameters));
             }
             return "ARRAY[" + Joiner.on(",").join(valueStrings.build()) + "]";
         }
 
         @Override
-        protected String visitSubscriptExpression(SubscriptExpression node, Boolean unmangleNames)
+        protected String visitSubscriptExpression(SubscriptExpression node, Void context)
         {
-            return formatSql(node.getBase(), unmangleNames, parameters) + "[" + formatSql(node.getIndex(), unmangleNames, parameters) + "]";
+            return formatSql(node.getBase(), parameters) + "[" + formatSql(node.getIndex(), parameters) + "]";
         }
 
         @Override
-        protected String visitLongLiteral(LongLiteral node, Boolean unmangleNames)
+        protected String visitLongLiteral(LongLiteral node, Void context)
         {
             return Long.toString(node.getValue());
         }
 
         @Override
-        protected String visitDoubleLiteral(DoubleLiteral node, Boolean unmangleNames)
+        protected String visitDoubleLiteral(DoubleLiteral node, Void context)
         {
             return Double.toString(node.getValue());
         }
 
         @Override
-        protected String visitDecimalLiteral(DecimalLiteral node, Boolean unmangleNames)
+        protected String visitDecimalLiteral(DecimalLiteral node, Void context)
         {
             return "DECIMAL '" + node.getValue() + "'";
         }
 
         @Override
-        protected String visitGenericLiteral(GenericLiteral node, Boolean unmangleNames)
+        protected String visitGenericLiteral(GenericLiteral node, Void context)
         {
             return node.getType() + " " + formatStringLiteral(node.getValue());
         }
 
         @Override
-        protected String visitTimeLiteral(TimeLiteral node, Boolean unmangleNames)
+        protected String visitTimeLiteral(TimeLiteral node, Void context)
         {
             return "TIME '" + node.getValue() + "'";
         }
 
         @Override
-        protected String visitTimestampLiteral(TimestampLiteral node, Boolean unmangleNames)
+        protected String visitTimestampLiteral(TimestampLiteral node, Void context)
         {
             return "TIMESTAMP '" + node.getValue() + "'";
         }
 
         @Override
-        protected String visitNullLiteral(NullLiteral node, Boolean unmangleNames)
+        protected String visitNullLiteral(NullLiteral node, Void context)
         {
             return "null";
         }
 
         @Override
-        protected String visitIntervalLiteral(IntervalLiteral node, Boolean unmangleNames)
+        protected String visitIntervalLiteral(IntervalLiteral node, Void context)
         {
             String sign = (node.getSign() == IntervalLiteral.Sign.NEGATIVE) ? "- " : "";
             StringBuilder builder = new StringBuilder()
@@ -275,39 +270,39 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitSubqueryExpression(SubqueryExpression node, Boolean unmangleNames)
+        protected String visitSubqueryExpression(SubqueryExpression node, Void context)
         {
-            return "(" + formatSql(node.getQuery(), unmangleNames, parameters) + ")";
+            return "(" + formatSql(node.getQuery(), parameters) + ")";
         }
 
         @Override
-        protected String visitExists(ExistsPredicate node, Boolean unmangleNames)
+        protected String visitExists(ExistsPredicate node, Void context)
         {
-            return "(EXISTS (" + formatSql(node.getSubquery(), unmangleNames, parameters) + "))";
+            return "(EXISTS (" + formatSql(node.getSubquery(), parameters) + "))";
         }
 
         @Override
-        protected String visitQualifiedNameReference(QualifiedNameReference node, Boolean unmangleNames)
+        protected String visitQualifiedNameReference(QualifiedNameReference node, Void context)
         {
             return formatQualifiedName(node.getName());
         }
 
         @Override
-        protected String visitLambdaArgumentDeclaration(LambdaArgumentDeclaration node, Boolean context)
+        protected String visitLambdaArgumentDeclaration(LambdaArgumentDeclaration node, Void context)
         {
             return formatIdentifier(node.getName());
         }
 
         @Override
-        protected String visitSymbolReference(SymbolReference node, Boolean context)
+        protected String visitSymbolReference(SymbolReference node, Void context)
         {
             return formatIdentifier(node.getName());
         }
 
         @Override
-        protected String visitDereferenceExpression(DereferenceExpression node, Boolean unmangleNames)
+        protected String visitDereferenceExpression(DereferenceExpression node, Void context)
         {
-            String baseString = process(node.getBase(), unmangleNames);
+            String baseString = process(node.getBase(), context);
             return baseString + "." + formatIdentifier(node.getFieldName());
         }
 
@@ -321,18 +316,18 @@ public final class ExpressionFormatter
         }
 
         @Override
-        public String visitFieldReference(FieldReference node, Boolean unmangleNames)
+        public String visitFieldReference(FieldReference node, Void context)
         {
             // add colon so this won't parse
             return ":input(" + node.getFieldIndex() + ")";
         }
 
         @Override
-        protected String visitFunctionCall(FunctionCall node, Boolean unmangleNames)
+        protected String visitFunctionCall(FunctionCall node, Void context)
         {
             StringBuilder builder = new StringBuilder();
 
-            String arguments = joinExpressions(node.getArguments(), unmangleNames);
+            String arguments = joinExpressions(node.getArguments());
             if (node.getArguments().isEmpty() && "count".equalsIgnoreCase(node.getName().getSuffix())) {
                 arguments = "*";
             }
@@ -344,96 +339,96 @@ public final class ExpressionFormatter
                     .append('(').append(arguments).append(')');
 
             if (node.getFilter().isPresent()) {
-                builder.append(" FILTER ").append(visitFilter(node.getFilter().get(), unmangleNames));
+                builder.append(" FILTER ").append(visitFilter(node.getFilter().get(), context));
             }
 
             if (node.getWindow().isPresent()) {
-                builder.append(" OVER ").append(visitWindow(node.getWindow().get(), unmangleNames));
+                builder.append(" OVER ").append(visitWindow(node.getWindow().get(), context));
             }
 
             return builder.toString();
         }
 
         @Override
-        protected String visitLambdaExpression(LambdaExpression node, Boolean unmangleNames)
+        protected String visitLambdaExpression(LambdaExpression node, Void context)
         {
             StringBuilder builder = new StringBuilder();
 
             builder.append('(');
             Joiner.on(", ").appendTo(builder, node.getArguments());
             builder.append(") -> ");
-            builder.append(process(node.getBody(), unmangleNames));
+            builder.append(process(node.getBody(), context));
             return builder.toString();
         }
 
         @Override
-        protected String visitLogicalBinaryExpression(LogicalBinaryExpression node, Boolean unmangleNames)
+        protected String visitLogicalBinaryExpression(LogicalBinaryExpression node, Void context)
         {
-            return formatBinaryExpression(node.getType().toString(), node.getLeft(), node.getRight(), unmangleNames);
+            return formatBinaryExpression(node.getType().toString(), node.getLeft(), node.getRight());
         }
 
         @Override
-        protected String visitNotExpression(NotExpression node, Boolean unmangleNames)
+        protected String visitNotExpression(NotExpression node, Void context)
         {
-            return "(NOT " + process(node.getValue(), unmangleNames) + ")";
+            return "(NOT " + process(node.getValue(), context) + ")";
         }
 
         @Override
-        protected String visitComparisonExpression(ComparisonExpression node, Boolean unmangleNames)
+        protected String visitComparisonExpression(ComparisonExpression node, Void context)
         {
-            return formatBinaryExpression(node.getType().getValue(), node.getLeft(), node.getRight(), unmangleNames);
+            return formatBinaryExpression(node.getType().getValue(), node.getLeft(), node.getRight());
         }
 
         @Override
-        protected String visitIsNullPredicate(IsNullPredicate node, Boolean unmangleNames)
+        protected String visitIsNullPredicate(IsNullPredicate node, Void context)
         {
-            return "(" + process(node.getValue(), unmangleNames) + " IS NULL)";
+            return "(" + process(node.getValue(), context) + " IS NULL)";
         }
 
         @Override
-        protected String visitIsNotNullPredicate(IsNotNullPredicate node, Boolean unmangleNames)
+        protected String visitIsNotNullPredicate(IsNotNullPredicate node, Void context)
         {
-            return "(" + process(node.getValue(), unmangleNames) + " IS NOT NULL)";
+            return "(" + process(node.getValue(), context) + " IS NOT NULL)";
         }
 
         @Override
-        protected String visitNullIfExpression(NullIfExpression node, Boolean unmangleNames)
+        protected String visitNullIfExpression(NullIfExpression node, Void context)
         {
-            return "NULLIF(" + process(node.getFirst(), unmangleNames) + ", " + process(node.getSecond(), unmangleNames) + ')';
+            return "NULLIF(" + process(node.getFirst(), context) + ", " + process(node.getSecond(), context) + ')';
         }
 
         @Override
-        protected String visitIfExpression(IfExpression node, Boolean unmangleNames)
+        protected String visitIfExpression(IfExpression node, Void context)
         {
             StringBuilder builder = new StringBuilder();
             builder.append("IF(")
-                    .append(process(node.getCondition(), unmangleNames))
+                    .append(process(node.getCondition(), context))
                     .append(", ")
-                    .append(process(node.getTrueValue(), unmangleNames));
+                    .append(process(node.getTrueValue(), context));
             if (node.getFalseValue().isPresent()) {
                 builder.append(", ")
-                        .append(process(node.getFalseValue().get(), unmangleNames));
+                        .append(process(node.getFalseValue().get(), context));
             }
             builder.append(")");
             return builder.toString();
         }
 
         @Override
-        protected String visitTryExpression(TryExpression node, Boolean unmangleNames)
+        protected String visitTryExpression(TryExpression node, Void context)
         {
-            return "TRY(" + process(node.getInnerExpression(), unmangleNames) + ")";
+            return "TRY(" + process(node.getInnerExpression(), context) + ")";
         }
 
         @Override
-        protected String visitCoalesceExpression(CoalesceExpression node, Boolean unmangleNames)
+        protected String visitCoalesceExpression(CoalesceExpression node, Void context)
         {
-            return "COALESCE(" + joinExpressions(node.getOperands(), unmangleNames) + ")";
+            return "COALESCE(" + joinExpressions(node.getOperands()) + ")";
         }
 
         @Override
-        protected String visitArithmeticUnary(ArithmeticUnaryExpression node, Boolean unmangleNames)
+        protected String visitArithmeticUnary(ArithmeticUnaryExpression node, Void context)
         {
-            String value = process(node.getValue(), unmangleNames);
+            String value = process(node.getValue(), context);
 
             switch (node.getSign()) {
                 case MINUS:
@@ -448,24 +443,24 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitArithmeticBinary(ArithmeticBinaryExpression node, Boolean unmangleNames)
+        protected String visitArithmeticBinary(ArithmeticBinaryExpression node, Void context)
         {
-            return formatBinaryExpression(node.getType().getValue(), node.getLeft(), node.getRight(), unmangleNames);
+            return formatBinaryExpression(node.getType().getValue(), node.getLeft(), node.getRight());
         }
 
         @Override
-        protected String visitLikePredicate(LikePredicate node, Boolean unmangleNames)
+        protected String visitLikePredicate(LikePredicate node, Void context)
         {
             StringBuilder builder = new StringBuilder();
 
             builder.append('(')
-                    .append(process(node.getValue(), unmangleNames))
+                    .append(process(node.getValue(), context))
                     .append(" LIKE ")
-                    .append(process(node.getPattern(), unmangleNames));
+                    .append(process(node.getPattern(), context));
 
             if (node.getEscape() != null) {
                 builder.append(" ESCAPE ")
-                        .append(process(node.getEscape(), unmangleNames));
+                        .append(process(node.getEscape(), context));
             }
 
             builder.append(')');
@@ -474,7 +469,7 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitAllColumns(AllColumns node, Boolean unmangleNames)
+        protected String visitAllColumns(AllColumns node, Void context)
         {
             if (node.getPrefix().isPresent()) {
                 return node.getPrefix().get() + ".*";
@@ -484,23 +479,23 @@ public final class ExpressionFormatter
         }
 
         @Override
-        public String visitCast(Cast node, Boolean unmangleNames)
+        public String visitCast(Cast node, Void context)
         {
             return (node.isSafe() ? "TRY_CAST" : "CAST") +
-                    "(" + process(node.getExpression(), unmangleNames) + " AS " + node.getType() + ")";
+                    "(" + process(node.getExpression(), context) + " AS " + node.getType() + ")";
         }
 
         @Override
-        protected String visitSearchedCaseExpression(SearchedCaseExpression node, Boolean unmangleNames)
+        protected String visitSearchedCaseExpression(SearchedCaseExpression node, Void context)
         {
             ImmutableList.Builder<String> parts = ImmutableList.builder();
             parts.add("CASE");
             for (WhenClause whenClause : node.getWhenClauses()) {
-                parts.add(process(whenClause, unmangleNames));
+                parts.add(process(whenClause, context));
             }
 
             node.getDefaultValue()
-                    .ifPresent((value) -> parts.add("ELSE").add(process(value, unmangleNames)));
+                    .ifPresent((value) -> parts.add("ELSE").add(process(value, context)));
 
             parts.add("END");
 
@@ -508,19 +503,19 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitSimpleCaseExpression(SimpleCaseExpression node, Boolean unmangleNames)
+        protected String visitSimpleCaseExpression(SimpleCaseExpression node, Void context)
         {
             ImmutableList.Builder<String> parts = ImmutableList.builder();
 
             parts.add("CASE")
-                    .add(process(node.getOperand(), unmangleNames));
+                    .add(process(node.getOperand(), context));
 
             for (WhenClause whenClause : node.getWhenClauses()) {
-                parts.add(process(whenClause, unmangleNames));
+                parts.add(process(whenClause, context));
             }
 
             node.getDefaultValue()
-                    .ifPresent((value) -> parts.add("ELSE").add(process(value, unmangleNames)));
+                    .ifPresent((value) -> parts.add("ELSE").add(process(value, context)));
 
             parts.add("END");
 
@@ -528,55 +523,55 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitWhenClause(WhenClause node, Boolean unmangleNames)
+        protected String visitWhenClause(WhenClause node, Void context)
         {
-            return "WHEN " + process(node.getOperand(), unmangleNames) + " THEN " + process(node.getResult(), unmangleNames);
+            return "WHEN " + process(node.getOperand(), context) + " THEN " + process(node.getResult(), context);
         }
 
         @Override
-        protected String visitBetweenPredicate(BetweenPredicate node, Boolean unmangleNames)
+        protected String visitBetweenPredicate(BetweenPredicate node, Void context)
         {
-            return "(" + process(node.getValue(), unmangleNames) + " BETWEEN " +
-                    process(node.getMin(), unmangleNames) + " AND " + process(node.getMax(), unmangleNames) + ")";
+            return "(" + process(node.getValue(), context) + " BETWEEN " +
+                    process(node.getMin(), context) + " AND " + process(node.getMax(), context) + ")";
         }
 
         @Override
-        protected String visitInPredicate(InPredicate node, Boolean unmangleNames)
+        protected String visitInPredicate(InPredicate node, Void context)
         {
-            return "(" + process(node.getValue(), unmangleNames) + " IN " + process(node.getValueList(), unmangleNames) + ")";
+            return "(" + process(node.getValue(), context) + " IN " + process(node.getValueList(), context) + ")";
         }
 
         @Override
-        protected String visitInListExpression(InListExpression node, Boolean unmangleNames)
+        protected String visitInListExpression(InListExpression node, Void context)
         {
-            return "(" + joinExpressions(node.getValues(), unmangleNames) + ")";
+            return "(" + joinExpressions(node.getValues()) + ")";
         }
 
-        private String visitFilter(Expression node, Boolean unmangleNames)
+        private String visitFilter(Expression node, Void context)
         {
-            return "(WHERE " + process(node, unmangleNames) + ')';
+            return "(WHERE " + process(node, context) + ')';
         }
 
         @Override
-        public String visitWindow(Window node, Boolean unmangleNames)
+        public String visitWindow(Window node, Void context)
         {
             List<String> parts = new ArrayList<>();
 
             if (!node.getPartitionBy().isEmpty()) {
-                parts.add("PARTITION BY " + joinExpressions(node.getPartitionBy(), unmangleNames));
+                parts.add("PARTITION BY " + joinExpressions(node.getPartitionBy()));
             }
             if (!node.getOrderBy().isEmpty()) {
-                parts.add("ORDER BY " + formatSortItems(node.getOrderBy(), unmangleNames, parameters));
+                parts.add("ORDER BY " + formatSortItems(node.getOrderBy(), parameters));
             }
             if (node.getFrame().isPresent()) {
-                parts.add(process(node.getFrame().get(), unmangleNames));
+                parts.add(process(node.getFrame().get(), context));
             }
 
             return '(' + Joiner.on(' ').join(parts) + ')';
         }
 
         @Override
-        public String visitWindowFrame(WindowFrame node, Boolean unmangleNames)
+        public String visitWindowFrame(WindowFrame node, Void context)
         {
             StringBuilder builder = new StringBuilder();
 
@@ -584,29 +579,29 @@ public final class ExpressionFormatter
 
             if (node.getEnd().isPresent()) {
                 builder.append("BETWEEN ")
-                        .append(process(node.getStart(), unmangleNames))
+                        .append(process(node.getStart(), context))
                         .append(" AND ")
-                        .append(process(node.getEnd().get(), unmangleNames));
+                        .append(process(node.getEnd().get(), context));
             }
             else {
-                builder.append(process(node.getStart(), unmangleNames));
+                builder.append(process(node.getStart(), context));
             }
 
             return builder.toString();
         }
 
         @Override
-        public String visitFrameBound(FrameBound node, Boolean unmangleNames)
+        public String visitFrameBound(FrameBound node, Void context)
         {
             switch (node.getType()) {
                 case UNBOUNDED_PRECEDING:
                     return "UNBOUNDED PRECEDING";
                 case PRECEDING:
-                    return process(node.getValue().get(), unmangleNames) + " PRECEDING";
+                    return process(node.getValue().get(), context) + " PRECEDING";
                 case CURRENT_ROW:
                     return "CURRENT ROW";
                 case FOLLOWING:
-                    return process(node.getValue().get(), unmangleNames) + " FOLLOWING";
+                    return process(node.getValue().get(), context) + " FOLLOWING";
                 case UNBOUNDED_FOLLOWING:
                     return "UNBOUNDED FOLLOWING";
             }
@@ -614,28 +609,28 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, Boolean unmangleNames)
+        protected String visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, Void context)
         {
             return new StringBuilder()
-                    .append(process(node.getValue(), unmangleNames))
+                    .append(process(node.getValue(), context))
                     .append(' ')
                     .append(node.getComparisonType().getValue())
                     .append(' ')
                     .append(node.getQuantifier().toString())
                     .append(' ')
-                    .append(process(node.getSubquery(), unmangleNames))
+                    .append(process(node.getSubquery(), context))
                     .toString();
         }
 
-        private String formatBinaryExpression(String operator, Expression left, Expression right, boolean unmangleNames)
+        private String formatBinaryExpression(String operator, Expression left, Expression right)
         {
-            return '(' + process(left, unmangleNames) + ' ' + operator + ' ' + process(right, unmangleNames) + ')';
+            return '(' + process(left, null) + ' ' + operator + ' ' + process(right, null) + ')';
         }
 
-        private String joinExpressions(List<Expression> expressions, boolean unmangleNames)
+        private String joinExpressions(List<Expression> expressions)
         {
             return Joiner.on(", ").join(expressions.stream()
-                    .map((e) -> process(e, unmangleNames))
+                    .map((e) -> process(e, null))
                     .iterator());
         }
 
@@ -653,14 +648,14 @@ public final class ExpressionFormatter
 
     static String formatSortItems(List<SortItem> sortItems, Optional<List<Expression>> parameters)
     {
-        return formatSortItems(sortItems, true, parameters);
+        return Joiner.on(", ").join(sortItems.stream()
+                .map(sortItemFormatterFunction(parameters))
+                .iterator());
     }
 
-    static String formatSortItems(List<SortItem> sortItems, boolean unmangleNames, Optional<List<Expression>> parameters)
+    static String formatGroupBy(List<GroupingElement> groupingElements)
     {
-        return Joiner.on(", ").join(sortItems.stream()
-                .map(sortItemFormatterFunction(unmangleNames, parameters))
-                .iterator());
+        return formatGroupBy(groupingElements, Optional.empty());
     }
 
     static String formatGroupBy(List<GroupingElement> groupingElements, Optional<List<Expression>> parameters)
@@ -707,12 +702,12 @@ public final class ExpressionFormatter
         return format("(%s)", Joiner.on(", ").join(groupingSet));
     }
 
-    private static Function<SortItem, String> sortItemFormatterFunction(boolean unmangleNames, Optional<List<Expression>> parameters)
+    private static Function<SortItem, String> sortItemFormatterFunction(Optional<List<Expression>> parameters)
     {
         return input -> {
             StringBuilder builder = new StringBuilder();
 
-            builder.append(formatExpression(input.getSortKey(), unmangleNames, parameters));
+            builder.append(formatExpression(input.getSortKey(), parameters));
 
             switch (input.getOrdering()) {
                 case ASCENDING:

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -115,14 +115,7 @@ public final class SqlFormatter
     public static String formatSql(Node root, Optional<List<Expression>> parameters)
     {
         StringBuilder builder = new StringBuilder();
-        new Formatter(builder, true, parameters).process(root, 0);
-        return builder.toString();
-    }
-
-    public static String formatSql(Node root, boolean unmangleNames, Optional<List<Expression>> parameters)
-    {
-        StringBuilder builder = new StringBuilder();
-        new Formatter(builder, unmangleNames, parameters).process(root, 0);
+        new Formatter(builder, parameters).process(root, 0);
         return builder.toString();
     }
 
@@ -130,13 +123,11 @@ public final class SqlFormatter
             extends AstVisitor<Void, Integer>
     {
         private final StringBuilder builder;
-        private final boolean unmangledNames;
         private final Optional<List<Expression>> parameters;
 
-        public Formatter(StringBuilder builder, boolean unmangleNames, Optional<List<Expression>> parameters)
+        public Formatter(StringBuilder builder, Optional<List<Expression>> parameters)
         {
             this.builder = builder;
-            this.unmangledNames = unmangleNames;
             this.parameters = parameters;
         }
 
@@ -150,7 +141,7 @@ public final class SqlFormatter
         protected Void visitExpression(Expression node, Integer indent)
         {
             checkArgument(indent == 0, "visitExpression should only be called at root");
-            builder.append(formatExpression(node, unmangledNames, parameters));
+            builder.append(formatExpression(node, parameters));
             return null;
         }
 
@@ -268,7 +259,7 @@ public final class SqlFormatter
             }
 
             if (node.getGroupBy().isPresent()) {
-                append(indent, "GROUP BY " + (node.getGroupBy().get().isDistinct() ? " DISTINCT " : "") + formatGroupBy(node.getGroupBy().get().getGroupingElements(), parameters)).append('\n');
+                append(indent, "GROUP BY " + (node.getGroupBy().get().isDistinct() ? " DISTINCT " : "") + formatGroupBy(node.getGroupBy().get().getGroupingElements())).append('\n');
             }
 
             if (node.getHaving().isPresent()) {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -39,6 +39,7 @@ import com.facebook.presto.sql.tree.ExplainFormat;
 import com.facebook.presto.sql.tree.ExplainOption;
 import com.facebook.presto.sql.tree.ExplainType;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Format;
 import com.facebook.presto.sql.tree.Grant;
 import com.facebook.presto.sql.tree.Insert;
 import com.facebook.presto.sql.tree.Intersect;
@@ -562,6 +563,16 @@ public final class SqlFormatter
             }
 
             builder.append("\n");
+
+            process(node.getStatement(), indent);
+
+            return null;
+        }
+
+        @Override
+        protected Void visitFormat(Format node, Integer indent)
+        {
+            builder.append("FORMAT ");
 
             process(node.getStatement(), indent);
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -114,8 +114,13 @@ public final class SqlFormatter
 
     public static String formatSql(Node root, Optional<List<Expression>> parameters)
     {
+        return formatSql(root, parameters, 0);
+    }
+
+    public static String formatSql(Node root, Optional<List<Expression>> parameters, int indent)
+    {
         StringBuilder builder = new StringBuilder();
-        new Formatter(builder, parameters).process(root, 0);
+        new Formatter(builder, parameters).process(root, indent);
         return builder.toString();
     }
 
@@ -487,6 +492,7 @@ public final class SqlFormatter
                 processRelation(relations.next(), indent);
 
                 if (relations.hasNext()) {
+                    builder.append(indentString(indent));
                     builder.append("INTERSECT ");
                     if (!node.isDistinct()) {
                         builder.append("ALL ");
@@ -1073,11 +1079,11 @@ public final class SqlFormatter
             return builder.append(indentString(indent))
                     .append(value);
         }
+    }
 
-        private static String indentString(int indent)
-        {
-            return Strings.repeat(INDENT, indent);
-        }
+    public static String indentString(int indent)
+    {
+        return Strings.repeat(INDENT, indent);
     }
 
     private static void appendAliasColumns(StringBuilder builder, List<String> columns)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -59,6 +59,7 @@ import com.facebook.presto.sql.tree.ExplainOption;
 import com.facebook.presto.sql.tree.ExplainType;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Extract;
+import com.facebook.presto.sql.tree.Format;
 import com.facebook.presto.sql.tree.FrameBound;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GenericLiteral;
@@ -597,6 +598,12 @@ class AstBuilder
     public Node visitExplain(SqlBaseParser.ExplainContext context)
     {
         return new Explain(getLocation(context), context.ANALYZE() != null, (Statement) visit(context.statement()), visit(context.explainOption(), ExplainOption.class));
+    }
+
+    @Override
+    public Node visitFormat(SqlBaseParser.FormatContext context)
+    {
+        return new Format(getLocation(context), (Statement) visit(context.statement()));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -122,6 +122,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitFormat(Format node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitShowTables(ShowTables node, C context)
     {
         return visitStatement(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Expression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Expression.java
@@ -37,6 +37,6 @@ public abstract class Expression
     @Override
     public final String toString()
     {
-        return ExpressionFormatter.formatExpression(this, Optional.empty()); // This will not replace parameters, but we don't have access to them here
+        return ExpressionFormatter.formatExpression(this, Optional.empty(), 0); // This will not replace parameters, but we don't have access to them here
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Format.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Format.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class Format
+        extends Statement
+{
+    private final Statement statement;
+
+    public Format(Statement statement)
+    {
+        this(Optional.empty(), statement);
+    }
+
+    public Format(NodeLocation location, Statement statement)
+    {
+        this(Optional.of(location), statement);
+    }
+
+    private Format(Optional<NodeLocation> location, Statement statement)
+    {
+        super(location);
+        this.statement = requireNonNull(statement, "statement is null");
+    }
+
+    public Statement getStatement()
+    {
+        return statement;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitFormat(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(statement);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        Format o = (Format) obj;
+        return Objects.equals(statement, o.statement);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("statement", statement)
+                .toString();
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -51,6 +51,7 @@ import com.facebook.presto.sql.tree.Explain;
 import com.facebook.presto.sql.tree.ExplainFormat;
 import com.facebook.presto.sql.tree.ExplainType;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Format;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GenericLiteral;
 import com.facebook.presto.sql.tree.Grant;
@@ -1382,6 +1383,13 @@ public class TestSqlParser
     {
         assertStatement("EXPLAIN ANALYZE SELECT * FROM t",
                 new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), true, ImmutableList.of()));
+    }
+
+    @Test
+    public void testFormat()
+            throws Exception
+    {
+        assertStatement("FORMAT SELECT * FROM t", new Format(simpleQuery(selectList(new AllColumns()))));
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7744,4 +7744,10 @@ public abstract class AbstractTestQueries
                         "WHERE a = 1)",
                 "VALUES 3008750");
     }
+
+    @Test
+    public void testFormat()
+    {
+        assertQuery("FORMAT SElect * FRom NAtion", "SELECT 'SELECT *\nFROM\n  \"NAtion\"\n'");
+    }
 }


### PR DESCRIPTION
Add FORMAT statement syntax. Format returns formatted statement. It is useful utility to canonicalize bunch of queries to same format. I used that for to format TPC-DS queries in https://github.com/prestodb/presto/pull/6636.

See some result examples:
https://github.com/Teradata/presto/blob/feature_tpcds_product_tests/presto-product-tests/src/main/resources/sql-tests/testcases/tpcds/q03.sql
https://github.com/Teradata/presto/blob/feature_tpcds_product_tests/presto-product-tests/src/main/resources/sql-tests/testcases/tpcds/q06.sql
https://github.com/Teradata/presto/blob/feature_tpcds_product_tests/presto-product-tests/src/main/resources/sql-tests/testcases/tpcds/q13.sql
