### PR TITLE
Fix potential resource group starvation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -536,6 +536,7 @@ public class InternalResourceGroup
                     subGroup.internalRefreshStats();
                     cachedMemoryUsageBytes += subGroup.cachedMemoryUsageBytes;
                     if (!subGroup.isDirty()) {
+                        subGroup.updateEligiblility(); // final check if there's QUEUED queries
                         iterator.remove();
                     }
                 }


### PR DESCRIPTION
We found a case that all queries were QUEUED in a subgroup. I guess the situation has something to do with `cachedMemoryUsageBytes`

It's not always easy to reproduce the issue but the symptom occurred on the following condition

* There're already QUEUED queries by hitting maxRunningQueries (or else) (it was 1 in our case)
* `queryFinished` called by the single running queries at the end of query
* But the subgroup is not `eligibleToStartNext` because its `cachedMemoryUsageBytes` exceeds `softMemoryLimitBytes` (the value is not updated yet). So it fails to register under parent's `eligibleSubGroups`
* `internalRefreshStats` finally set the cachedMemoryUsageBytes to zero, but it's too late to tell its parent the eligibility
* All queries are QUEUED and no query is running until new query comes in.
