### PR TITLE
Remove exclamation marks from queued query errors

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryQueueManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryQueueManager.java
@@ -67,7 +67,7 @@ public class SqlQueryQueueManager
             if (!queue.reserve(queryExecution)) {
                 // Reject query if we couldn't acquire a permit to enter the queue.
                 // The permits will be released when this query fails.
-                queryExecution.fail(new PrestoException(QUERY_QUEUE_FULL, "Too many queued queries!"));
+                queryExecution.fail(new PrestoException(QUERY_QUEUE_FULL, "Too many queued queries"));
                 return;
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -412,7 +412,7 @@ public class InternalResourceGroup
                 group = group.parent.get();
             }
             if (!canQueue && !canRun) {
-                query.fail(new PrestoException(QUERY_QUEUE_FULL, format("Too many queued queries for \"%s\"!", id)));
+                query.fail(new PrestoException(QUERY_QUEUE_FULL, format("Too many queued queries for \"%s\"", id)));
                 return;
             }
             if (canRun) {

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
@@ -62,7 +62,7 @@ public class TestResourceGroups
         MockQueryExecution query3 = new MockQueryExecution(0);
         root.run(query3);
         assertEquals(query3.getState(), FAILED);
-        assertEquals(query3.getFailureCause().getMessage(), "Too many queued queries for \"root\"!");
+        assertEquals(query3.getFailureCause().getMessage(), "Too many queued queries for \"root\"");
     }
 
     @Test(timeOut = 10_000)


### PR DESCRIPTION
We don't need to shout in error messages.