### PR TITLE
Fix typo in hive connector documentation

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -400,7 +400,7 @@ existing data in S3::
 Drop the external table ``request_logs``. This only drops the metadata
 for the table. The referenced data directory is not deleted::
 
-    DROP hive.web.request_logs
+    DROP TABLE hive.web.request_logs
 
 Drop a schema::
 


### PR DESCRIPTION
Fix type about DROP TABLE in hive connector documentation.
It is pointed out at [groups](https://groups.google.com/forum/#!searchin/presto-users/drop$20table$20typo%7Csort:relevance/presto-users/NmYo85jh28Y/1weaiUBYCQAJ)