### PR TITLE
Remove dead code from PluginManager

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -31,7 +31,6 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
-import io.airlift.configuration.ConfigurationFactory;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.log.Logger;
 import io.airlift.node.NodeInfo;
@@ -91,7 +90,6 @@ public class PluginManager
             HttpServerInfo httpServerInfo,
             PluginManagerConfig config,
             ConnectorManager connectorManager,
-            ConfigurationFactory configurationFactory,
             Metadata metadata,
             ResourceGroupManager resourceGroupManager,
             AccessControlManager accessControlManager,
@@ -102,7 +100,6 @@ public class PluginManager
         requireNonNull(nodeInfo, "nodeInfo is null");
         requireNonNull(httpServerInfo, "httpServerInfo is null");
         requireNonNull(config, "config is null");
-        requireNonNull(configurationFactory, "configurationFactory is null");
 
         installedPluginsDir = config.getInstalledPluginsDir();
         if (config.getPlugins() == null) {

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -119,11 +119,6 @@ public class PluginManager
         this.typeRegistry = requireNonNull(typeRegistry, "typeRegistry is null");
     }
 
-    public boolean arePluginsLoaded()
-    {
-        return pluginsLoaded.get();
-    }
-
     public void loadPlugins()
             throws Exception
     {


### PR DESCRIPTION
I left commits separately (though can be squashed) because `arePluginsLoaded` (c0a6fb2) seemed to be not used from the beginning. Maybe there's a reason to keep it anyway but I don't think it's worth to keep dead code in repo. If one needs the functionality of checking if plugins are loaded, he can add it then.