### PR TITLE
Store test results and logs for all job runs in S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,9 +116,19 @@ after_script:
     sudo pip install awscli
     export AWS_ACCESS_KEY_ID=${DEPLOY_S3_ACCESS_KEY}
     export AWS_SECRET_ACCESS_KEY=${DEPLOY_S3_SECRET_KEY}
+
     JOB_ARTIFACTS_URL_PREFIX=s3://${DEPLOY_S3_BUCKET}/${ARTIFACTS_UPLOAD_PATH}/travis_jobs/${TRAVIS_JOB_NUMBER}-run
     JOB_RUN_ATTEMPTS=$( aws s3 ls ${JOB_ARTIFACTS_URL_PREFIX} | wc -l | tr -d '[:space:]' )
     JOB_STATUS=$( [ "$TRAVIS_TEST_RESULT" == "0" ] && echo SUCCESS || echo FAILURE )
-    wget https://api.travis-ci.org/jobs/${TRAVIS_JOB_ID}/log.txt?deansi=true -O /tmp/log.txt
-    aws s3 cp /tmp/log.txt ${JOB_ARTIFACTS_URL_PREFIX}_$((JOB_RUN_ATTEMPTS + 1))-${JOB_STATUS}/log.txt
+
+    mkdir -p /tmp/job_artifacts/
+    rsync -av -m \
+      --include='**/' \
+      --include='**/surefire-reports/**.xml' \
+      --include='**/surefire-reports/emailable-report.html' \
+      --exclude='*' \
+      . /tmp/job_artifacts/
+    wget https://api.travis-ci.org/jobs/${TRAVIS_JOB_ID}/log.txt?deansi=true -O /tmp/job_artifacts/log.txt
+
+    aws s3 sync /tmp/job_artifacts ${JOB_ARTIFACTS_URL_PREFIX}_$((JOB_RUN_ATTEMPTS + 1))-${JOB_STATUS}
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,5 +106,5 @@ deploy:
   bucket: ${DEPLOY_S3_BUCKET}
   skip_cleanup: true
   local-dir: /tmp/artifacts
-  upload-dir: travis_build_artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_JOB_NUMBER}
+  upload-dir: travis_build_artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}
   acl: public_read

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,6 @@ script:
     if [[ -v HIVE_TESTS ]]; then
       presto-hive-hadoop2/bin/run_on_docker.sh
     fi
-  - |
-    # Build presto-server-rpm for later artifact upload
-    if [[ -v DEPLOY_S3_ACCESS_KEY && -v PRODUCT_TESTS ]]; then
-       ./mvnw install $MAVEN_FAST_INSTALL -pl presto-server-rpm
-    fi
 
 before_cache:
   # Make the cache stable between builds by removing build output
@@ -104,7 +99,7 @@ before_deploy:
 deploy:
   on:
     all_branches: true
-    condition: -v DEPLOY_S3_ACCESS_KEY && -v PRODUCT_TESTS
+    condition: -v DEPLOY_S3_ACCESS_KEY && -v MAVEN_CHECKS
   provider: s3
   access_key_id: ${DEPLOY_S3_ACCESS_KEY}
   secret_access_key: ${DEPLOY_S3_SECRET_KEY}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
     - MAVEN_OPTS="-Xmx512M -XX:+ExitOnOutOfMemoryError"
     - MAVEN_SKIP_CHECKS_AND_DOCS="-Dair.check.skip-all=true -Dmaven.javadoc.skip=true"
     - MAVEN_FAST_INSTALL="-DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1"
+    - ARTIFACTS_UPLOAD_PATH=travis_build_artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}
   matrix:
     - MAVEN_CHECKS=true
     - TEST_SPECIFIC_MODULES=presto-tests
@@ -106,5 +107,18 @@ deploy:
   bucket: ${DEPLOY_S3_BUCKET}
   skip_cleanup: true
   local-dir: /tmp/artifacts
-  upload-dir: travis_build_artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}
+  upload-dir: ${ARTIFACTS_UPLOAD_PATH}
   acl: public_read
+
+after_script:
+- |
+  if [[ -v DEPLOY_S3_ACCESS_KEY ]]; then
+    sudo pip install awscli
+    export AWS_ACCESS_KEY_ID=${DEPLOY_S3_ACCESS_KEY}
+    export AWS_SECRET_ACCESS_KEY=${DEPLOY_S3_SECRET_KEY}
+    JOB_ARTIFACTS_URL_PREFIX=s3://${DEPLOY_S3_BUCKET}/${ARTIFACTS_UPLOAD_PATH}/travis_jobs/${TRAVIS_JOB_NUMBER}-run
+    JOB_RUN_ATTEMPTS=$( aws s3 ls ${JOB_ARTIFACTS_URL_PREFIX} | wc -l | tr -d '[:space:]' )
+    JOB_STATUS=$( [ "$TRAVIS_TEST_RESULT" == "0" ] && echo SUCCESS || echo FAILURE )
+    wget https://api.travis-ci.org/jobs/${TRAVIS_JOB_ID}/log.txt?deansi=true -O /tmp/log.txt
+    aws s3 cp /tmp/log.txt ${JOB_ARTIFACTS_URL_PREFIX}_$((JOB_RUN_ATTEMPTS + 1))-${JOB_STATUS}/log.txt
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 env:
   global:
     - MAVEN_OPTS="-Xmx512M -XX:+ExitOnOutOfMemoryError"
-    - MAVEN_SKIP_CHECKS_AND_DOCS="-Dair.check.skip-all=true -Dmaven.javadoc.skip=true"
+    - MAVEN_SKIP_CHECKS_AND_DOCS="-Dair.check.skip-all=true -Dair.check.skip-checkstyle=true -Dmaven.javadoc.skip=true"
     - MAVEN_FAST_INSTALL="-DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1"
     - ARTIFACTS_UPLOAD_PATH=travis_build_artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}
   matrix:


### PR DESCRIPTION
Gathering this data will allow for:

1) diagnosing non-deterministic build failures after the build gets restarted and the log is gone
2) analysing test stability, durations and their trends (this PR sets up data gathering for that)
3) taking more informed decisions on which tests are worth running every build and which could be run periodically.

This PR also changes the artifact upload layout so that it's possible in the future to reuse main presto build's `target` output in other builds (say: [presto-checks](https://travis-ci.org/Teradata/presto-checks/builds)).