### PR TITLE
Trim product tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
   - |
     if [[ -v PRODUCT_TESTS ]]; then
       presto-product-tests/bin/run_on_docker.sh \
-        multinode -x quarantine,big_query,storage_formats,profile_specific_tests
+        multinode -x quarantine,big_query,storage_formats,profile_specific_tests,tpch
     fi
   - |
     if [[ -v PRODUCT_TESTS ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,11 +67,6 @@ script:
         multinode -x quarantine,big_query,storage_formats,profile_specific_tests,tpch
     fi
   - |
-    if [[ -v PRODUCT_TESTS ]]; then
-      presto-product-tests/bin/run_on_docker.sh \
-        singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation,authorization
-    fi
-  - |
     if [[ -v HIVE_TESTS ]]; then
       presto-hive-hadoop2/bin/run_on_docker.sh
     fi


### PR DESCRIPTION
This should shorten the product test build by several minutes each build, while sacrificing little-to-no confidence in presto's correctness. The tests excluded by this pull request are run every 3 hours for the latest build of prestodb:master, by the [presto-checks](https://travis-ci.org/Teradata/presto-checks/builds).

If there's interest in that, we could set up additional notifications from presto-checks:master branch.