### PR TITLE
Deterministic query plans

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -34,6 +34,7 @@ import com.facebook.presto.sql.tree.SampledRelation;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.SubqueryExpression;
 import com.facebook.presto.sql.tree.Table;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
@@ -46,14 +47,13 @@ import javax.annotation.concurrent.Immutable;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Sets.newIdentityHashSet;
+import static java.util.Collections.newSetFromMap;
 import static java.util.Objects.requireNonNull;
 
 public class Analysis
@@ -62,37 +62,37 @@ public class Analysis
     private final List<Expression> parameters;
     private String updateType;
 
-    private final IdentityHashMap<Table, Query> namedQueries = new IdentityHashMap<>();
+    private final IdentityLinkedHashMap<Table, Query> namedQueries = new IdentityLinkedHashMap<>();
 
-    private final IdentityHashMap<Node, Scope> scopes = new IdentityHashMap<>();
-    private final Set<Expression> columnReferences = newIdentityHashSet();
+    private final IdentityLinkedHashMap<Node, Scope> scopes = new IdentityLinkedHashMap<>();
+    private final Set<Expression> columnReferences = newSetFromMap(new IdentityLinkedHashMap<>());
 
-    private final IdentityHashMap<QuerySpecification, List<FunctionCall>> aggregates = new IdentityHashMap<>();
-    private final IdentityHashMap<QuerySpecification, List<List<Expression>>> groupByExpressions = new IdentityHashMap<>();
-    private final IdentityHashMap<Node, Expression> where = new IdentityHashMap<>();
-    private final IdentityHashMap<QuerySpecification, Expression> having = new IdentityHashMap<>();
-    private final IdentityHashMap<Node, List<Expression>> orderByExpressions = new IdentityHashMap<>();
-    private final IdentityHashMap<Node, List<Expression>> outputExpressions = new IdentityHashMap<>();
-    private final IdentityHashMap<QuerySpecification, List<FunctionCall>> windowFunctions = new IdentityHashMap<>();
+    private final IdentityLinkedHashMap<QuerySpecification, List<FunctionCall>> aggregates = new IdentityLinkedHashMap<>();
+    private final IdentityLinkedHashMap<QuerySpecification, List<List<Expression>>> groupByExpressions = new IdentityLinkedHashMap<>();
+    private final IdentityLinkedHashMap<Node, Expression> where = new IdentityLinkedHashMap<>();
+    private final IdentityLinkedHashMap<QuerySpecification, Expression> having = new IdentityLinkedHashMap<>();
+    private final IdentityLinkedHashMap<Node, List<Expression>> orderByExpressions = new IdentityLinkedHashMap<>();
+    private final IdentityLinkedHashMap<Node, List<Expression>> outputExpressions = new IdentityLinkedHashMap<>();
+    private final IdentityLinkedHashMap<QuerySpecification, List<FunctionCall>> windowFunctions = new IdentityLinkedHashMap<>();
 
-    private final IdentityHashMap<Join, Expression> joins = new IdentityHashMap<>();
+    private final IdentityLinkedHashMap<Join, Expression> joins = new IdentityLinkedHashMap<>();
     private final ListMultimap<Node, InPredicate> inPredicatesSubqueries = ArrayListMultimap.create();
     private final ListMultimap<Node, SubqueryExpression> scalarSubqueries = ArrayListMultimap.create();
     private final ListMultimap<Node, ExistsPredicate> existsSubqueries = ArrayListMultimap.create();
     private final ListMultimap<Node, QuantifiedComparisonExpression> quantifiedComparisonSubqueries = ArrayListMultimap.create();
 
-    private final IdentityHashMap<Table, TableHandle> tables = new IdentityHashMap<>();
+    private final IdentityLinkedHashMap<Table, TableHandle> tables = new IdentityLinkedHashMap<>();
 
-    private final IdentityHashMap<Expression, Type> types = new IdentityHashMap<>();
-    private final IdentityHashMap<Expression, Type> coercions = new IdentityHashMap<>();
-    private final Set<Expression> typeOnlyCoercions = newIdentityHashSet();
-    private final IdentityHashMap<Relation, Type[]> relationCoercions = new IdentityHashMap<>();
-    private final IdentityHashMap<FunctionCall, Signature> functionSignature = new IdentityHashMap<>();
-    private final IdentityHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences = new IdentityHashMap<>();
+    private final IdentityLinkedHashMap<Expression, Type> types = new IdentityLinkedHashMap<>();
+    private final IdentityLinkedHashMap<Expression, Type> coercions = new IdentityLinkedHashMap<>();
+    private final Set<Expression> typeOnlyCoercions = newSetFromMap(new IdentityLinkedHashMap<>());
+    private final IdentityLinkedHashMap<Relation, Type[]> relationCoercions = new IdentityLinkedHashMap<>();
+    private final IdentityLinkedHashMap<FunctionCall, Signature> functionSignature = new IdentityLinkedHashMap<>();
+    private final IdentityLinkedHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences = new IdentityLinkedHashMap<>();
 
-    private final IdentityHashMap<Field, ColumnHandle> columns = new IdentityHashMap<>();
+    private final IdentityLinkedHashMap<Field, ColumnHandle> columns = new IdentityLinkedHashMap<>();
 
-    private final IdentityHashMap<SampledRelation, Double> sampleRatios = new IdentityHashMap<>();
+    private final IdentityLinkedHashMap<SampledRelation, Double> sampleRatios = new IdentityLinkedHashMap<>();
 
     // for create table
     private Optional<QualifiedObjectName> createTableDestination = Optional.empty();
@@ -162,9 +162,9 @@ public class Analysis
         return aggregates.get(query);
     }
 
-    public IdentityHashMap<Expression, Type> getTypes()
+    public IdentityLinkedHashMap<Expression, Type> getTypes()
     {
-        return new IdentityHashMap<>(types);
+        return new IdentityLinkedHashMap<>(types);
     }
 
     public Type getType(Expression expression)
@@ -192,7 +192,7 @@ public class Analysis
         relationCoercions.put(relation, types);
     }
 
-    public IdentityHashMap<Expression, Type> getCoercions()
+    public IdentityLinkedHashMap<Expression, Type> getCoercions()
     {
         return coercions;
     }
@@ -202,7 +202,7 @@ public class Analysis
         return coercions.get(expression);
     }
 
-    public void addLambdaArgumentReferences(IdentityHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences)
+    public void addLambdaArgumentReferences(IdentityLinkedHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences)
     {
         this.lambdaArgumentReferences.putAll(lambdaArgumentReferences);
     }
@@ -391,7 +391,7 @@ public class Analysis
         return functionSignature.get(function);
     }
 
-    public void addFunctionSignatures(IdentityHashMap<FunctionCall, Signature> infos)
+    public void addFunctionSignatures(IdentityLinkedHashMap<FunctionCall, Signature> infos)
     {
         functionSignature.putAll(infos);
     }
@@ -401,7 +401,7 @@ public class Analysis
         return ImmutableSet.copyOf(columnReferences);
     }
 
-    public void addTypes(IdentityHashMap<Expression, Type> types)
+    public void addTypes(IdentityLinkedHashMap<Expression, Type> types)
     {
         this.types.putAll(types);
     }
@@ -414,7 +414,7 @@ public class Analysis
         }
     }
 
-    public void addCoercions(IdentityHashMap<Expression, Type> coercions, Set<Expression> typeOnlyCoercions)
+    public void addCoercions(IdentityLinkedHashMap<Expression, Type> coercions, Set<Expression> typeOnlyCoercions)
     {
         this.coercions.putAll(coercions);
         this.typeOnlyCoercions.addAll(typeOnlyCoercions);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
@@ -21,17 +21,17 @@ import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.facebook.presto.sql.tree.SubqueryExpression;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.IdentityHashMap;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
 public class ExpressionAnalysis
 {
-    private final IdentityHashMap<Expression, Type> expressionTypes;
-    private final IdentityHashMap<Expression, Type> expressionCoercions;
+    private final IdentityLinkedHashMap<Expression, Type> expressionTypes;
+    private final IdentityLinkedHashMap<Expression, Type> expressionCoercions;
     private final Set<Expression> typeOnlyCoercions;
     private final Set<Expression> columnReferences;
     private final Set<InPredicate> subqueryInPredicates;
@@ -39,18 +39,18 @@ public class ExpressionAnalysis
     private final Set<ExistsPredicate> existsSubqueries;
     private final Set<QuantifiedComparisonExpression> quantifiedComparisons;
     // For lambda argument references, maps each QualifiedNameReference to the referenced LambdaArgumentDeclaration
-    private final IdentityHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences;
+    private final IdentityLinkedHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences;
 
     public ExpressionAnalysis(
-            IdentityHashMap<Expression, Type> expressionTypes,
-            IdentityHashMap<Expression, Type> expressionCoercions,
+            IdentityLinkedHashMap<Expression, Type> expressionTypes,
+            IdentityLinkedHashMap<Expression, Type> expressionCoercions,
             Set<InPredicate> subqueryInPredicates,
             Set<SubqueryExpression> scalarSubqueries,
             Set<ExistsPredicate> existsSubqueries,
             Set<Expression> columnReferences,
             Set<Expression> typeOnlyCoercions,
             Set<QuantifiedComparisonExpression> quantifiedComparisons,
-            IdentityHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences)
+            IdentityLinkedHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences)
     {
         this.expressionTypes = requireNonNull(expressionTypes, "expressionTypes is null");
         this.expressionCoercions = requireNonNull(expressionCoercions, "expressionCoercions is null");
@@ -68,7 +68,7 @@ public class ExpressionAnalysis
         return expressionTypes.get(expression);
     }
 
-    public IdentityHashMap<Expression, Type> getExpressionTypes()
+    public IdentityLinkedHashMap<Expression, Type> getExpressionTypes()
     {
         return expressionTypes;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -110,6 +110,7 @@ import com.facebook.presto.sql.tree.WithQuery;
 import com.facebook.presto.type.ArrayType;
 import com.facebook.presto.type.MapType;
 import com.facebook.presto.type.RowType;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -122,7 +123,6 @@ import com.google.common.collect.Multimap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -760,15 +760,15 @@ class StatementAnalyzer
                 throw new SemanticException(NON_NUMERIC_SAMPLE_PERCENTAGE, relation.getSamplePercentage(), "Sample percentage cannot contain column references");
             }
 
-            IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(
-                    session,
-                    metadata,
-                    sqlParser,
-                    ImmutableMap.of(),
-                    relation.getSamplePercentage(),
-                    analysis.getParameters(),
-                    analysis.isDescribe());
-            ExpressionInterpreter samplePercentageEval = expressionOptimizer(relation.getSamplePercentage(), metadata, session, expressionTypes);
+        IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypes(
+                session,
+                metadata,
+                sqlParser,
+                ImmutableMap.of(),
+                relation.getSamplePercentage(),
+                analysis.getParameters(),
+                analysis.isDescribe());
+        ExpressionInterpreter samplePercentageEval = expressionOptimizer(relation.getSamplePercentage(), metadata, session, expressionTypes);
 
             Object samplePercentageObject = samplePercentageEval.optimize(symbol -> {
                 throw new SemanticException(NON_NUMERIC_SAMPLE_PERCENTAGE, relation.getSamplePercentage(), "Sample percentage cannot contain column references");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DesugaringRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DesugaringRewriter.java
@@ -21,9 +21,8 @@ import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
-
-import java.util.IdentityHashMap;
 
 import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
@@ -34,9 +33,9 @@ import static java.util.Objects.requireNonNull;
 public class DesugaringRewriter
         extends ExpressionRewriter<Void>
 {
-    private final IdentityHashMap<Expression, Type> expressionTypes;
+    private final IdentityLinkedHashMap<Expression, Type> expressionTypes;
 
-    public DesugaringRewriter(IdentityHashMap<Expression, Type> expressionTypes)
+    public DesugaringRewriter(IdentityLinkedHashMap<Expression, Type> expressionTypes)
     {
         this.expressionTypes = requireNonNull(expressionTypes, "expressionTypes is null");
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
@@ -46,6 +46,7 @@ import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.PeekingIterator;
@@ -53,7 +54,6 @@ import com.google.common.collect.PeekingIterator;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -453,7 +453,7 @@ public final class DomainTranslator
          */
         private Optional<NormalizedSimpleComparison> toNormalizedSimpleComparison(ComparisonExpression comparison)
         {
-            IdentityHashMap<Expression, Type> expressionTypes = analyzeExpression(comparison);
+            IdentityLinkedHashMap<Expression, Type> expressionTypes = analyzeExpression(comparison);
             Object left = ExpressionInterpreter.expressionOptimizer(comparison.getLeft(), metadata, session, expressionTypes).optimize(NoOpSymbolResolver.INSTANCE);
             Object right = ExpressionInterpreter.expressionOptimizer(comparison.getRight(), metadata, session, expressionTypes).optimize(NoOpSymbolResolver.INSTANCE);
 
@@ -486,11 +486,11 @@ public final class DomainTranslator
 
         private boolean isImplicitCoercion(Cast cast)
         {
-            IdentityHashMap<Expression, Type> expressionTypes = analyzeExpression(cast);
+            IdentityLinkedHashMap<Expression, Type> expressionTypes = analyzeExpression(cast);
             return metadata.getTypeManager().canCoerce(expressionTypes.get(cast.getExpression()), expressionTypes.get(cast));
         }
 
-        private IdentityHashMap<Expression, Type> analyzeExpression(Expression expression)
+        private IdentityLinkedHashMap<Expression, Type> analyzeExpression(Expression expression)
         {
             return ExpressionAnalyzer.getExpressionTypes(session, metadata, new SqlParser(), types, expression, emptyList() /* parameters already replaced */);
         }
@@ -748,7 +748,7 @@ public final class DomainTranslator
 
     private static Type typeOf(Expression expression, Session session, Metadata metadata, Map<Symbol, Type> types)
     {
-        IdentityHashMap<Expression, Type> expressionTypes = ExpressionAnalyzer.getExpressionTypes(session, metadata, new SqlParser(), types, expression, emptyList() /* parameters already replaced */);
+        IdentityLinkedHashMap<Expression, Type> expressionTypes = ExpressionAnalyzer.getExpressionTypes(session, metadata, new SqlParser(), types, expression, emptyList() /* parameters already replaced */);
         return expressionTypes.get(expression);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
@@ -62,7 +62,7 @@ public class EqualityInference
             // Current cost heuristic:
             // 1) Prefer fewer input symbols
             // 2) Prefer smaller expression trees
-            // 3) Ordering.arbitrary() - creates a stable consistent ordering (extremely useful for unit testing)
+            // 3) Sort the expressions alphabetically - creates a stable consistent ordering (extremely useful for unit testing)
             // TODO: be more precise in determining the cost of an expression
             return ComparisonChain.start()
                     .compare(DependencyExtractor.extractAll(expression1).size(), DependencyExtractor.extractAll(expression2).size())

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -88,6 +88,7 @@ import com.facebook.presto.type.RowType;
 import com.facebook.presto.type.RowType.RowField;
 import com.facebook.presto.util.Failures;
 import com.facebook.presto.util.FastutilSetHelper;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Defaults;
 import com.google.common.base.Functions;
@@ -102,7 +103,6 @@ import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -134,15 +134,15 @@ public class ExpressionInterpreter
     private final Metadata metadata;
     private final ConnectorSession session;
     private final boolean optimize;
-    private final IdentityHashMap<Expression, Type> expressionTypes;
+    private final IdentityLinkedHashMap<Expression, Type> expressionTypes;
 
     private final Visitor visitor;
 
     // identity-based cache for LIKE expressions with constant pattern and escape char
-    private final IdentityHashMap<LikePredicate, Regex> likePatternCache = new IdentityHashMap<>();
-    private final IdentityHashMap<InListExpression, Set<?>> inListCache = new IdentityHashMap<>();
+    private final IdentityLinkedHashMap<LikePredicate, Regex> likePatternCache = new IdentityLinkedHashMap<>();
+    private final IdentityLinkedHashMap<InListExpression, Set<?>> inListCache = new IdentityLinkedHashMap<>();
 
-    public static ExpressionInterpreter expressionInterpreter(Expression expression, Metadata metadata, Session session, IdentityHashMap<Expression, Type> expressionTypes)
+    public static ExpressionInterpreter expressionInterpreter(Expression expression, Metadata metadata, Session session, IdentityLinkedHashMap<Expression, Type> expressionTypes)
     {
         requireNonNull(expression, "expression is null");
         requireNonNull(metadata, "metadata is null");
@@ -151,7 +151,7 @@ public class ExpressionInterpreter
         return new ExpressionInterpreter(expression, metadata, session, expressionTypes, false);
     }
 
-    public static ExpressionInterpreter expressionOptimizer(Expression expression, Metadata metadata, Session session, IdentityHashMap<Expression, Type> expressionTypes)
+    public static ExpressionInterpreter expressionOptimizer(Expression expression, Metadata metadata, Session session, IdentityLinkedHashMap<Expression, Type> expressionTypes)
     {
         requireNonNull(expression, "expression is null");
         requireNonNull(metadata, "metadata is null");
@@ -172,7 +172,7 @@ public class ExpressionInterpreter
                     actualType.getTypeSignature()));
         }
 
-        IdentityHashMap<Expression, Type> coercions = new IdentityHashMap<>();
+        IdentityLinkedHashMap<Expression, Type> coercions = new IdentityLinkedHashMap<>();
         coercions.putAll(analyzer.getExpressionCoercions());
         coercions.put(expression, expectedType);
         return evaluateConstantExpression(expression, coercions, metadata, session, ImmutableSet.of(), parameters);
@@ -180,7 +180,7 @@ public class ExpressionInterpreter
 
     public static Object evaluateConstantExpression(
             Expression expression,
-            IdentityHashMap<Expression, Type> coercions,
+            IdentityLinkedHashMap<Expression, Type> coercions,
             Metadata metadata, Session session,
             Set<Expression> columnReferences,
             List<Expression> parameters)
@@ -235,7 +235,7 @@ public class ExpressionInterpreter
         new ConstantExpressionVerifierVisitor(columnReferences, expression).process(expression, null);
     }
 
-    private ExpressionInterpreter(Expression expression, Metadata metadata, Session session, IdentityHashMap<Expression, Type> expressionTypes, boolean optimize)
+    private ExpressionInterpreter(Expression expression, Metadata metadata, Session session, IdentityLinkedHashMap<Expression, Type> expressionTypes, boolean optimize)
     {
         this.expression = expression;
         this.metadata = metadata;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/InterpretedInternalFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/InterpretedInternalFilterFunction.java
@@ -22,10 +22,10 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -55,7 +55,7 @@ public class InterpretedInternalFilterFunction
         for (Map.Entry<Symbol, Integer> entry : symbolToInputMappings.entrySet()) {
             inputTypes.put(entry.getValue(), symbolTypes.get(entry.getKey()));
         }
-        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(session, metadata, sqlParser, inputTypes.build(), rewritten, emptyList() /* parameters already rewritten */);
+        IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(session, metadata, sqlParser, inputTypes.build(), rewritten, emptyList() /* parameters already rewritten */);
 
         evaluator = ExpressionInterpreter.expressionInterpreter(rewritten, metadata, session, expressionTypes);
         InputReferenceExtractor inputReferenceExtractor = new InputReferenceExtractor();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/InterpretedProjectionFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/InterpretedProjectionFunction.java
@@ -22,10 +22,10 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 
-import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -57,7 +57,7 @@ public class InterpretedProjectionFunction
         for (Map.Entry<Symbol, Integer> entry : symbolToInputMappings.entrySet()) {
             inputTypes.put(entry.getValue(), symbolTypes.get(entry.getKey()));
         }
-        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(session, metadata, sqlParser, inputTypes.build(), rewritten, emptyList() /* parameters already replaced */);
+        IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(session, metadata, sqlParser, inputTypes.build(), rewritten, emptyList() /* parameters already replaced */);
         this.type = requireNonNull(expressionTypes.get(rewritten), "type is null");
 
         evaluator = ExpressionInterpreter.expressionInterpreter(rewritten, metadata, session, expressionTypes);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -145,6 +145,7 @@ import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -167,7 +168,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -1022,7 +1022,7 @@ public class LocalExecutionPlanner
                 rewrittenProjections.add(symbolToInputRewriter.rewrite(assignments.get(symbol)));
             }
 
-            IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(
+            IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(
                     context.getSession(),
                     metadata,
                     sqlParser,
@@ -1126,7 +1126,7 @@ public class LocalExecutionPlanner
             }
         }
 
-        private RowExpression toRowExpression(Expression expression, IdentityHashMap<Expression, Type> types)
+        private RowExpression toRowExpression(Expression expression, IdentityLinkedHashMap<Expression, Type> types)
         {
             return SqlToRowExpressionTranslator.translate(expression, SCALAR, types, metadata.getFunctionRegistry(), metadata.getTypeManager(), session, true);
         }
@@ -1175,7 +1175,7 @@ public class LocalExecutionPlanner
             PageBuilder pageBuilder = new PageBuilder(outputTypes);
             for (List<Expression> row : node.getRows()) {
                 pageBuilder.declarePosition();
-                IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(
+                IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypes(
                         context.getSession(),
                         metadata,
                         sqlParser,
@@ -1569,7 +1569,7 @@ public class LocalExecutionPlanner
 
             Expression rewrittenFilter = new SymbolToInputRewriter(joinSourcesLayout).rewrite(filterExpression);
 
-            IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(
+            IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(
                     session,
                     metadata,
                     sqlParser,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -51,11 +51,11 @@ import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayList;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -381,9 +381,9 @@ public class LogicalPlanner
         return columns.build();
     }
 
-    private static IdentityHashMap<LambdaArgumentDeclaration, Symbol> buildLambdaDeclarationToSymbolMap(Analysis analysis, SymbolAllocator symbolAllocator)
+    private static IdentityLinkedHashMap<LambdaArgumentDeclaration, Symbol> buildLambdaDeclarationToSymbolMap(Analysis analysis, SymbolAllocator symbolAllocator)
     {
-        IdentityHashMap<LambdaArgumentDeclaration, Symbol> resultMap = new IdentityHashMap<>();
+        IdentityLinkedHashMap<LambdaArgumentDeclaration, Symbol> resultMap = new IdentityLinkedHashMap<>();
         for (Map.Entry<Expression, Type> entry : analysis.getTypes().entrySet()) {
             if (!(entry.getKey() instanceof LambdaArgumentDeclaration)) {
                 continue;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -58,6 +58,7 @@ import com.facebook.presto.sql.tree.SortItem.Ordering;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.sql.tree.Window;
 import com.facebook.presto.sql.tree.WindowFrame;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -66,7 +67,6 @@ import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -89,7 +89,7 @@ class QueryPlanner
     private final Analysis analysis;
     private final SymbolAllocator symbolAllocator;
     private final PlanNodeIdAllocator idAllocator;
-    private final IdentityHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap;
+    private final IdentityLinkedHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap;
     private final Metadata metadata;
     private final Session session;
     private final SubqueryPlanner subqueryPlanner;
@@ -98,7 +98,7 @@ class QueryPlanner
             Analysis analysis,
             SymbolAllocator symbolAllocator,
             PlanNodeIdAllocator idAllocator,
-            IdentityHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap,
+            IdentityLinkedHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap,
             Metadata metadata,
             Session session)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -67,6 +67,7 @@ import com.facebook.presto.sql.tree.Unnest;
 import com.facebook.presto.sql.tree.Values;
 import com.facebook.presto.type.ArrayType;
 import com.facebook.presto.type.MapType;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -75,7 +76,6 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.UnmodifiableIterator;
 
 import java.util.ArrayList;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -96,7 +96,7 @@ class RelationPlanner
     private final Analysis analysis;
     private final SymbolAllocator symbolAllocator;
     private final PlanNodeIdAllocator idAllocator;
-    private final IdentityHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap;
+    private final IdentityLinkedHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap;
     private final Metadata metadata;
     private final Session session;
     private final SubqueryPlanner subqueryPlanner;
@@ -105,7 +105,7 @@ class RelationPlanner
             Analysis analysis,
             SymbolAllocator symbolAllocator,
             PlanNodeIdAllocator idAllocator,
-            IdentityHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap,
+            IdentityLinkedHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap,
             Metadata metadata,
             Session session)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -41,12 +41,12 @@ import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression.Quantifier;
 import com.facebook.presto.sql.tree.SubqueryExpression;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -70,7 +70,7 @@ class SubqueryPlanner
     private final Analysis analysis;
     private final SymbolAllocator symbolAllocator;
     private final PlanNodeIdAllocator idAllocator;
-    private final IdentityHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap;
+    private final IdentityLinkedHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap;
     private final Metadata metadata;
     private final Session session;
     private final List<Expression> parameters;
@@ -79,7 +79,7 @@ class SubqueryPlanner
             Analysis analysis,
             SymbolAllocator symbolAllocator,
             PlanNodeIdAllocator idAllocator,
-            IdentityHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap,
+            IdentityLinkedHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap,
             Metadata metadata,
             Session session,
             List<Expression> parameters)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslationMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslationMap.java
@@ -25,10 +25,10 @@ import com.facebook.presto.sql.tree.FieldReference;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
 import com.facebook.presto.sql.tree.LambdaExpression;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
 
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -45,7 +45,7 @@ class TranslationMap
     // all expressions are rewritten in terms of fields declared by this relation plan
     private final RelationPlan rewriteBase;
     private final Analysis analysis;
-    private final IdentityHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap;
+    private final IdentityLinkedHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap;
 
     // current mappings of underlying field -> symbol for translating direct field references
     private final Symbol[] fieldSymbols;
@@ -54,7 +54,7 @@ class TranslationMap
     private final Map<Expression, Symbol> expressionToSymbols = new HashMap<>();
     private final Map<Expression, Expression> expressionToExpressions = new HashMap<>();
 
-    public TranslationMap(RelationPlan rewriteBase, Analysis analysis, IdentityHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap)
+    public TranslationMap(RelationPlan rewriteBase, Analysis analysis, IdentityLinkedHashMap<LambdaArgumentDeclaration, Symbol> lambdaDeclarationToSymbolMap)
     {
         this.rewriteBase = requireNonNull(rewriteBase, "rewriteBase is null");
         this.analysis = requireNonNull(analysis, "analysis is null");
@@ -73,7 +73,7 @@ class TranslationMap
         return analysis;
     }
 
-    public IdentityHashMap<LambdaArgumentDeclaration, Symbol> getLambdaDeclarationToSymbolMap()
+    public IdentityLinkedHashMap<LambdaArgumentDeclaration, Symbol> getLambdaDeclarationToSymbolMap()
     {
         return lambdaDeclarationToSymbolMap;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -71,6 +71,7 @@ import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -90,7 +91,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -660,7 +660,7 @@ public class AddExchanges
         private boolean shouldPrune(Expression predicate, Map<Symbol, ColumnHandle> assignments, Map<ColumnHandle, NullableValue> bindings, List<Symbol> correlations)
         {
             List<Expression> conjuncts = extractConjuncts(predicate);
-            IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(
+            IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypes(
                     session,
                     metadata,
                     parser,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DesugaringOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DesugaringOptimizer.java
@@ -30,8 +30,8 @@ import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 
-import java.util.IdentityHashMap;
 import java.util.Map;
 
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
@@ -114,7 +114,7 @@ public class DesugaringOptimizer
             if (expression instanceof SymbolReference) {
                 return expression;
             }
-            IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(session, metadata, sqlParser, types, expression, emptyList() /* parameters already replaced */);
+            IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypes(session, metadata, sqlParser, types, expression, emptyList() /* parameters already replaced */);
             return ExpressionTreeRewriter.rewriteWith(new DesugaringRewriter(expressionTypes), expression);
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
@@ -28,6 +28,7 @@ import com.facebook.presto.sql.relational.RowExpression;
 import com.facebook.presto.sql.relational.RowExpressionVisitor;
 import com.facebook.presto.sql.relational.VariableReferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -37,7 +38,6 @@ import io.airlift.slice.Slice;
 
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -100,7 +100,7 @@ public class ExpressionEquivalence
         Expression expressionWithInputReferences = new SymbolToInputRewriter(symbolInput).rewrite(expression);
 
         // determine the type of every expression
-        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(
+        IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(
                 session,
                 metadata,
                 sqlParser,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -53,6 +53,7 @@ import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -62,7 +63,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -782,7 +782,7 @@ public class PredicatePushDown
         // Temporary implementation for joins because the SimplifyExpressions optimizers can not run properly on join clauses
         private Expression simplifyExpression(Expression expression)
         {
-            IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(
+            IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypes(
                     session,
                     metadata,
                     sqlParser,
@@ -798,7 +798,7 @@ public class PredicatePushDown
          */
         private Object nullInputEvaluator(final Collection<Symbol> nullSymbols, Expression expression)
         {
-            IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(
+            IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypes(
                     session,
                     metadata,
                     sqlParser,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -63,6 +63,7 @@ import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -71,7 +72,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -502,7 +502,7 @@ class PropertyDerivations
             for (Map.Entry<Symbol, Expression> assignment : node.getAssignments().entrySet()) {
                 Expression expression = assignment.getValue();
 
-                IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(session, metadata, parser, types, expression, emptyList() /* parameters already replaced */);
+                IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypes(session, metadata, parser, types, expression, emptyList() /* parameters already replaced */);
                 Type type = requireNonNull(expressionTypes.get(expression));
                 ExpressionInterpreter optimizer = ExpressionInterpreter.expressionOptimizer(expression, metadata, session, expressionTypes);
                 // TODO:

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyExpressions.java
@@ -38,12 +38,12 @@ import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import java.util.Collection;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -150,7 +150,7 @@ public class SimplifyExpressions
             }
             expression = ExpressionTreeRewriter.rewriteWith(new PushDownNegationsExpressionRewriter(), expression);
             expression = ExpressionTreeRewriter.rewriteWith(new ExtractCommonPredicatesExpressionRewriter(), expression, NodeContext.ROOT_NODE);
-            IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(session, metadata, sqlParser, types, expression, emptyList() /* parameters already replaced */);
+            IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypes(session, metadata, sqlParser, types, expression, emptyList() /* parameters already replaced */);
             ExpressionInterpreter interpreter = ExpressionInterpreter.expressionOptimizer(expression, metadata, session, expressionTypes);
             return LiteralInterpreter.toExpression(interpreter.optimize(NoOpSymbolResolver.INSTANCE), expressionTypes.get(expression));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -69,10 +69,10 @@ import com.facebook.presto.sql.tree.WhenClause;
 import com.facebook.presto.type.RowType;
 import com.facebook.presto.type.RowType.RowField;
 import com.facebook.presto.type.UnknownType;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-import java.util.IdentityHashMap;
 import java.util.List;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
@@ -130,7 +130,7 @@ public final class SqlToRowExpressionTranslator
     public static RowExpression translate(
             Expression expression,
             FunctionKind functionKind,
-            IdentityHashMap<Expression, Type> types,
+            IdentityLinkedHashMap<Expression, Type> types,
             FunctionRegistry functionRegistry,
             TypeManager typeManager,
             Session session,
@@ -152,11 +152,11 @@ public final class SqlToRowExpressionTranslator
             extends AstVisitor<RowExpression, Void>
     {
         private final FunctionKind functionKind;
-        private final IdentityHashMap<Expression, Type> types;
+        private final IdentityLinkedHashMap<Expression, Type> types;
         private final TypeManager typeManager;
         private final TimeZoneKey timeZoneKey;
 
-        private Visitor(FunctionKind functionKind, IdentityHashMap<Expression, Type> types, TypeManager typeManager, TimeZoneKey timeZoneKey)
+        private Visitor(FunctionKind functionKind, IdentityLinkedHashMap<Expression, Type> types, TypeManager typeManager, TimeZoneKey timeZoneKey)
         {
             this.functionKind = functionKind;
             this.types = types;

--- a/presto-main/src/main/java/com/facebook/presto/util/maps/IdentityLinkedHashMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/maps/IdentityLinkedHashMap.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util.maps;
+
+import com.google.common.base.Equivalence;
+
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.unmodifiableCollection;
+
+public class IdentityLinkedHashMap<K, V>
+        implements Map<K, V>
+{
+    private final Map<Equivalence.Wrapper<K>, V> delegate = new LinkedHashMap<>();
+    private final Equivalence<Object> equivalence = Equivalence.identity();
+
+    public IdentityLinkedHashMap()
+    {
+    }
+
+    public IdentityLinkedHashMap(IdentityLinkedHashMap<K, V> map)
+    {
+        putAll(map);
+    }
+
+    @Override
+    public int size()
+    {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key)
+    {
+        return delegate.containsKey(equivalence.wrap(key));
+    }
+
+    @Override
+    public boolean containsValue(Object value)
+    {
+        return delegate.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key)
+    {
+        return delegate.get(equivalence.wrap(key));
+    }
+
+    @Override
+    public V put(K key, V value)
+    {
+        return delegate.put(equivalence.wrap(key), value);
+    }
+
+    @Override
+    public V remove(Object key)
+    {
+        return delegate.remove(equivalence.wrap(key));
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> map)
+    {
+        map.entrySet().forEach(e -> delegate.put(equivalence.wrap(e.getKey()), e.getValue()));
+    }
+
+    @Override
+    public void clear()
+    {
+        delegate.clear();
+    }
+
+    @Override
+    public Set<K> keySet()
+    {
+        return new AbstractSet<K>()
+        {
+            @Override
+            public Iterator<K> iterator()
+            {
+                return delegate.keySet().stream().map(Equivalence.Wrapper::get).iterator();
+            }
+
+            @Override
+            public int size()
+            {
+                return delegate.size();
+            }
+        };
+    }
+
+    @Override
+    public Collection<V> values()
+    {
+        return unmodifiableCollection(delegate.values());
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet()
+    {
+        return new AbstractSet<Entry<K, V>>()
+        {
+            @Override
+            public Iterator<Entry<K, V>> iterator()
+            {
+                return delegate.entrySet().stream().map(e -> {
+                    K key = e.getKey().get();
+                    return (Entry<K, V>) new AbstractMap.SimpleEntry<>(key, e.getValue());
+                }).iterator();
+            }
+
+            @Override
+            public int size()
+            {
+                return delegate.size();
+            }
+        };
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -65,6 +65,7 @@ import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.TestingTransactionHandle;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -76,7 +77,6 @@ import org.joda.time.DateTimeZone;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -584,7 +584,7 @@ public final class FunctionAssertions
     {
         filter = new SymbolToInputRewriter(ImmutableMap.of()).rewrite(filter);
 
-        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, metadata, SQL_PARSER, INPUT_TYPES, ImmutableList.of(filter), emptyList());
+        IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, metadata, SQL_PARSER, INPUT_TYPES, ImmutableList.of(filter), emptyList());
 
         try {
             Supplier<PageProcessor> processor = compiler.compilePageProcessor(toRowExpression(filter, expressionTypes), ImmutableList.of());
@@ -604,7 +604,7 @@ public final class FunctionAssertions
         filter = new SymbolToInputRewriter(INPUT_MAPPING).rewrite(filter);
         projection = new SymbolToInputRewriter(INPUT_MAPPING).rewrite(projection);
 
-        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, metadata,
+        IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, metadata,
                 SQL_PARSER, INPUT_TYPES, ImmutableList.of(filter, projection), emptyList());
 
         try {
@@ -626,7 +626,7 @@ public final class FunctionAssertions
         filter = new SymbolToInputRewriter(INPUT_MAPPING).rewrite(filter);
         projection = new SymbolToInputRewriter(INPUT_MAPPING).rewrite(projection);
 
-        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, metadata,
+        IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, metadata,
                 SQL_PARSER, INPUT_TYPES, ImmutableList.of(filter, projection), emptyList());
 
         try {
@@ -657,7 +657,7 @@ public final class FunctionAssertions
         }
     }
 
-    private RowExpression toRowExpression(Expression projection, IdentityHashMap<Expression, Type> expressionTypes)
+    private RowExpression toRowExpression(Expression projection, IdentityLinkedHashMap<Expression, Type> expressionTypes)
     {
         return SqlToRowExpressionTranslator.translate(projection, SCALAR, expressionTypes, metadata.getFunctionRegistry(), metadata.getTypeManager(), session, false);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -31,6 +31,7 @@ import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.StringLiteral;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -43,7 +44,6 @@ import org.joda.time.LocalDate;
 import org.joda.time.LocalTime;
 import org.testng.annotations.Test;
 
-import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -1250,7 +1250,7 @@ public class TestExpressionInterpreter
 
         Expression parsedExpression = FunctionAssertions.createExpression(expression, METADATA, SYMBOL_TYPES);
 
-        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, SYMBOL_TYPES, parsedExpression, emptyList());
+        IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, SYMBOL_TYPES, parsedExpression, emptyList());
         ExpressionInterpreter interpreter = expressionOptimizer(parsedExpression, METADATA, TEST_SESSION, expressionTypes);
         return interpreter.optimize(symbol -> {
             switch (symbol.getName().toLowerCase(ENGLISH)) {
@@ -1297,7 +1297,7 @@ public class TestExpressionInterpreter
 
     private static Object evaluate(Expression expression)
     {
-        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, SYMBOL_TYPES, expression, emptyList());
+        IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, SYMBOL_TYPES, expression, emptyList());
         ExpressionInterpreter interpreter = expressionInterpreter(expression, METADATA, TEST_SESSION, expressionTypes);
 
         return interpreter.evaluate((RecordCursor) null);

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
@@ -23,9 +23,8 @@ import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.type.TypeRegistry;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import org.testng.annotations.Test;
-
-import java.util.IdentityHashMap;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
@@ -40,7 +39,7 @@ public class TestSqlToRowExpressionTranslator
     public void testPossibleExponentialOptimizationTime()
     {
         Expression expression = new LongLiteral("1");
-        IdentityHashMap<Expression, Type> types = new IdentityHashMap<>();
+        IdentityLinkedHashMap<Expression, Type> types = new IdentityLinkedHashMap<>();
         types.put(expression, BIGINT);
         for (int i = 0; i < 100; i++) {
             expression = new CoalesceExpression(expression);

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/PageProcessorBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/PageProcessorBenchmark.java
@@ -27,6 +27,7 @@ import com.facebook.presto.sql.relational.RowExpression;
 import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.testing.TestingSession;
+import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -47,7 +48,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -170,7 +170,7 @@ public class PageProcessorBenchmark
         }
         Map<Integer, Type> types = builder.build();
 
-        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, METADATA, SQL_PARSER, types, inputReferenceExpression, emptyList());
+        IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, METADATA, SQL_PARSER, types, inputReferenceExpression, emptyList());
         return SqlToRowExpressionTranslator.translate(inputReferenceExpression, SCALAR, expressionTypes, METADATA.getFunctionRegistry(), METADATA.getTypeManager(), TEST_SESSION, true);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/util/maps/IdentityLinkedHashMapTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/maps/IdentityLinkedHashMapTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util.maps;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.IntStream.range;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertTrue;
+
+public class IdentityLinkedHashMapTest
+{
+    @Test
+    public void testUsesIdentityAsEquivalenceForKeys()
+    {
+        String key = "foo";
+        String otherKey = new String(key);
+        assertEquals(key, otherKey);
+        assertNotSame(key, otherKey);
+
+        IdentityLinkedHashMap<String, Integer> map = new IdentityLinkedHashMap<>();
+        assertTrue(map.isEmpty());
+
+        int value = 1;
+        int otherValue = 2;
+
+        map.put(key, value);
+        assertEquals(map, ImmutableMap.of(key, value));
+        assertTrue(map.containsKey(key));
+        assertFalse(map.containsKey(otherKey));
+        assertTrue(map.containsValue(value));
+
+        map.put(otherKey, otherValue);
+        assertEquals(map.get(key), Integer.valueOf(value));
+        assertEquals(map.get(otherKey), Integer.valueOf(otherValue));
+
+        assertEquals(map.size(), otherValue);
+        map.remove(key);
+        assertEquals(map.size(), value);
+        map.remove(otherKey);
+        assertTrue(map.isEmpty());
+
+        Set<String> keys = ImmutableSet.of("a", "aa");
+        Map<String, Integer> expectedMap = ImmutableMap.of("a", value, "aa", otherValue);
+
+        map.putAll(Maps.asMap(keys, String::length));
+        assertEquals(expectedMap, map);
+
+        map.clear();
+        assertTrue(map.isEmpty());
+    }
+
+    @Test
+    public void testStableIterationOrder()
+    {
+        Set<String> keys = ImmutableSet.of("All", "your", "base", "are", "belong", "to", "us");
+        Map<String, Integer> expectedMap = Maps.asMap(keys, String::length);
+
+        range(0, 10).forEach(attempt -> {
+            IdentityLinkedHashMap<String, Integer> map = new IdentityLinkedHashMap<>();
+
+            keys.forEach(i -> map.put(i, i.length()));
+
+            assertEquals(map.keySet(), keys);
+            assertEquals(map.values(), expectedMap.values());
+            assertEquals(map.entrySet(), expectedMap.entrySet());
+        });
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/PlanDeterminismChecker.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/PlanDeterminismChecker.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.sql.planner.LogicalPlanner;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.PlanPrinter;
+import com.facebook.presto.testing.LocalQueryRunner;
+
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import static org.testng.Assert.assertEquals;
+
+public class PlanDeterminismChecker
+{
+    private static final int MINIMUM_SUBSEQUENT_SAME_PLANS = 10;
+
+    private final LocalQueryRunner localQueryRunner;
+    private final Function<String, String> planEquivalenceFunction;
+
+    public PlanDeterminismChecker(LocalQueryRunner localQueryRunner)
+    {
+        this(localQueryRunner, Function.identity());
+    }
+
+    public PlanDeterminismChecker(LocalQueryRunner localQueryRunner, Function<String, String> planEquivalenceFunction)
+    {
+        this.localQueryRunner = localQueryRunner;
+        this.planEquivalenceFunction = planEquivalenceFunction;
+    }
+
+    public void checkPlanIsDeterministic(String sql)
+    {
+        IntStream.range(1, MINIMUM_SUBSEQUENT_SAME_PLANS)
+                .mapToObj(attempt -> getPlanText(sql))
+                .map(planEquivalenceFunction)
+                .reduce((previous, current) -> {
+                    assertEquals(previous, current);
+                    return current;
+                });
+    }
+
+    private String getPlanText(String sql)
+    {
+        return localQueryRunner.inTransaction(session -> {
+            Plan plan = localQueryRunner.createPlan(session, sql, LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED);
+            return PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), localQueryRunner.getMetadata(), session);
+        });
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.TestingAccessControlManager;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
+
+import java.util.List;
+
+import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+
+public class TestQueryPlanDeterminism
+        extends AbstractTestQueries
+{
+    private final PlanDeterminismChecker determinismChecker;
+
+    protected TestQueryPlanDeterminism()
+    {
+        super(createLocalQueryRunner());
+        determinismChecker = new PlanDeterminismChecker((LocalQueryRunner) queryRunner);
+    }
+
+    public static LocalQueryRunner createLocalQueryRunner()
+    {
+        Session defaultSession = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema(TINY_SCHEMA_NAME)
+                .build();
+
+        LocalQueryRunner localQueryRunner = new LocalQueryRunner(defaultSession);
+
+        // add the tpch catalog
+        // local queries run directly against the generator
+        localQueryRunner.createCatalog(
+                defaultSession.getCatalog().get(),
+                new TpchConnectorFactory(1),
+                ImmutableMap.<String, String>of());
+
+        localQueryRunner.getMetadata().addFunctions(CUSTOM_FUNCTIONS);
+
+        SessionPropertyManager sessionPropertyManager = localQueryRunner.getMetadata().getSessionPropertyManager();
+        sessionPropertyManager.addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);
+        sessionPropertyManager.addConnectorSessionProperties(new ConnectorId(TESTING_CATALOG), TEST_CATALOG_PROPERTIES);
+
+        return localQueryRunner;
+    }
+
+    @Override
+    protected MaterializedResult computeActual(@Language("SQL") String sql)
+    {
+        determinismChecker.checkPlanIsDeterministic(sql);
+        return super.computeActual(sql);
+    }
+
+    @Override
+    protected MaterializedResult computeActual(Session session, @Language("SQL") String sql)
+    {
+        determinismChecker.checkPlanIsDeterministic(session, sql);
+        return super.computeActual(session, sql);
+    }
+
+    @Override
+    protected void assertQuery(@Language("SQL") String sql)
+    {
+        determinismChecker.checkPlanIsDeterministic(sql);
+    }
+
+    @Override
+    protected void assertQuery(Session session, @Language("SQL") String sql)
+    {
+        determinismChecker.checkPlanIsDeterministic(session, sql);
+    }
+
+    @Override
+    public void assertQueryOrdered(@Language("SQL") String sql)
+    {
+        determinismChecker.checkPlanIsDeterministic(sql);
+    }
+
+    @Override
+    protected void assertQuery(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        determinismChecker.checkPlanIsDeterministic(actual);
+    }
+
+    @Override
+    protected void assertQuery(Session session, @Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        determinismChecker.checkPlanIsDeterministic(session, actual);
+    }
+
+    @Override
+    protected void assertQueryOrdered(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        determinismChecker.checkPlanIsDeterministic(actual);
+    }
+
+    @Override
+    protected void assertQueryOrdered(Session session, @Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        determinismChecker.checkPlanIsDeterministic(session, actual);
+    }
+
+    @Override
+    protected void assertUpdate(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        determinismChecker.checkPlanIsDeterministic(actual);
+    }
+
+    @Override
+    protected void assertUpdate(Session session, @Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        determinismChecker.checkPlanIsDeterministic(session, actual);
+    }
+
+    @Override
+    protected void assertUpdate(@Language("SQL") String sql)
+    {
+        determinismChecker.checkPlanIsDeterministic(sql);
+    }
+
+    @Override
+    protected void assertUpdate(Session session, @Language("SQL") String sql)
+    {
+        determinismChecker.checkPlanIsDeterministic(session, sql);
+   }
+
+    @Override
+    protected void assertUpdate(@Language("SQL") String sql, long count)
+    {
+        determinismChecker.checkPlanIsDeterministic(sql);
+    }
+
+    @Override
+    protected void assertUpdate(Session session, @Language("SQL") String sql, long count)
+    {
+        determinismChecker.checkPlanIsDeterministic(session, sql);
+    }
+
+    @Override
+    protected void assertQueryFails(@Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
+    {
+        super.assertQueryFails(sql, expectedMessageRegExp);
+    }
+
+    @Override
+    protected void assertQueryFails(Session session, @Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
+    {
+        super.assertQueryFails(session, sql, expectedMessageRegExp);
+    }
+
+    @Override
+    protected void assertAccessAllowed(@Language("SQL") String sql, TestingAccessControlManager.TestingPrivilege... deniedPrivileges)
+    {
+    }
+
+    @Override
+    protected void assertAccessAllowed(Session session, @Language("SQL") String sql, TestingAccessControlManager.TestingPrivilege... deniedPrivileges)
+    {
+    }
+
+    @Override
+    protected void assertAccessDenied(@Language("SQL") String sql, @Language("RegExp") String exceptionsMessageRegExp, TestingAccessControlManager.TestingPrivilege... deniedPrivileges)
+    {
+    }
+
+    @Override
+    protected void assertAccessDenied(Session session, @Language("SQL") String sql, @Language("RegExp") String exceptionsMessageRegExp, TestingAccessControlManager.TestingPrivilege... deniedPrivileges)
+    {
+    }
+
+    @Override
+    protected void assertTableColumnNames(String tableName, String... columnNames)
+    {
+    }
+
+    @Override
+    protected MaterializedResult computeExpected(@Language("SQL") String sql, List<? extends Type> resultTypes)
+    {
+        determinismChecker.checkPlanIsDeterministic(sql);
+        return super.computeExpected(sql, resultTypes);
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlansDeterministic.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlansDeterministic.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+
+public class TestQueryPlansDeterministic
+{
+    private PlanDeterminismChecker determinismChecker = new PlanDeterminismChecker(createLocalQueryRunner());
+
+    private static LocalQueryRunner createLocalQueryRunner()
+    {
+        Session defaultSession = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema(TINY_SCHEMA_NAME)
+                .build();
+
+        LocalQueryRunner localQueryRunner = new LocalQueryRunner(defaultSession);
+
+        // add the tpch catalog
+        // local queries run directly against the generator
+        localQueryRunner.createCatalog(
+                defaultSession.getCatalog().get(),
+                new TpchConnectorFactory(1),
+                ImmutableMap.of());
+
+        return localQueryRunner;
+    }
+
+    @Test
+    public void testTpchQ9deterministic()
+            throws Exception
+    {
+        //This uses a modified version of TPC-H Q9, because the tpch connector uses non-standard column names
+        determinismChecker.checkPlanIsDeterministic("SELECT\n" +
+                "  nation,\n" +
+                "  o_year,\n" +
+                "  sum(amount) AS sum_profit\n" +
+                "FROM (\n" +
+                "       SELECT\n" +
+                "         n.name                                                          AS nation,\n" +
+                "         extract(YEAR FROM o.orderdate)                                  AS o_year,\n" +
+                "         l.extendedprice * (1 - l.discount) - ps.supplycost * l.quantity AS amount\n" +
+                "       FROM\n" +
+                "         part p,\n" +
+                "         supplier s,\n" +
+                "         lineitem l,\n" +
+                "         partsupp ps,\n" +
+                "         orders o,\n" +
+                "         nation n\n" +
+                "       WHERE\n" +
+                "         s.suppkey = l.suppkey\n" +
+                "         AND ps.suppkey = l.suppkey\n" +
+                "         AND ps.partkey = l.partkey\n" +
+                "         AND p.partkey = l.partkey\n" +
+                "         AND o.orderkey = l.orderkey\n" +
+                "         AND s.nationkey = n.nationkey\n" +
+                "         AND p.name LIKE '%green%'\n" +
+                "     ) AS profit\n" +
+                "GROUP BY\n" +
+                "  nation,\n" +
+                "  o_year\n" +
+                "ORDER BY\n" +
+                "  nation,\n" +
+                "  o_year DESC\n");
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlansDeterministic.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlansDeterministic.java
@@ -24,7 +24,7 @@ import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 
 public class TestQueryPlansDeterministic
 {
-    private PlanDeterminismChecker determinismChecker = new PlanDeterminismChecker(createLocalQueryRunner());
+    private final PlanDeterminismChecker determinismChecker = new PlanDeterminismChecker(createLocalQueryRunner());
 
     private static LocalQueryRunner createLocalQueryRunner()
     {
@@ -81,5 +81,24 @@ public class TestQueryPlansDeterministic
                 "ORDER BY\n" +
                 "  nation,\n" +
                 "  o_year DESC\n");
+    }
+
+    @Test
+    public void testTpcdsQ6deterministic()
+            throws Exception
+    {
+        //This is a query inspired on TPC-DS Q6 that reproduces its plan nondeterminism problems
+        determinismChecker.checkPlanIsDeterministic("SELECT orderdate " +
+                "FROM orders o,\n" +
+                "     lineitem i\n" +
+                "WHERE o.orderdate =\n" +
+                "    (SELECT DISTINCT (orderdate)\n" +
+                "     FROM orders\n" +
+                "     WHERE totalprice > 2)\n" +
+                "  AND i.quantity > 1.2 *\n" +
+                "    (SELECT avg(j.quantity)\n" +
+                "     FROM lineitem j\n" +
+                "    )\n"
+        );
     }
 }

--- a/src/checkstyle/checks.xml
+++ b/src/checkstyle/checks.xml
@@ -164,5 +164,9 @@
                 jdk.nashorn.internal,
                 jdk.internal" />
         </module>
+
+        <module name="ImportControl">
+            <property name="file" value="src/checkstyle/import-control.xml"/>
+        </module>
     </module>
 </module>

--- a/src/checkstyle/import-control.xml
+++ b/src/checkstyle/import-control.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE import-control PUBLIC
+        "-//Puppy Crawl//DTD Import Control 1.2//EN"
+        "http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd">
+<import-control pkg=".*" regex="true">
+    <allow pkg=".*" regex="true"/>
+    <subpackage name="com.facebook.presto">
+        <subpackage name="sql\.(planner|analyzer)" regex="true">
+            <!--
+            IdentityHashMap is a potential source of query plan non-determinism
+            due to non-deterministic iteration order.
+            Use com.facebook.presto.util.maps.IdentityLinkedHashMap instead.
+            -->
+            <disallow class="java.util.IdentityHashMap"/>
+        </subpackage>
+    </subpackage>
+</import-control>


### PR DESCRIPTION
This PR addresses non-determinism in query planning, as mentioned in #6579. The non-determinism severely impacts users' ability to monitor performance and tune Presto, not to mention our ability in reproducing and fixing bugs. 

So far, two non-determinism sources have been identified and fixed:
 - use of `Ordering.arbitrary()` in EqualityInference
 - use of IdentityHashMap for iteration

Lots of instances of HashMap's in `planner` and `analyzer` have been spotted, but so far none of those has been proven to cause non-determinism (maybe they're not used for iteration?). Since queries from AbstractTestQueries did not spot any more non-determinism, I'd like to treat this PR as complete and probably add tests asserting plan determinism for all TPC-H and TPC-DS queries later.

Internal review was conducted [here](https://github.com/Teradata/presto/pull/413)