### PR TITLE
Make access-control.config-path configurable

### DIFF
--- a/presto-docs/src/main/sphinx/develop/system-access-control.rst
+++ b/presto-docs/src/main/sphinx/develop/system-access-control.rst
@@ -34,9 +34,8 @@ Configuration
 
 After a plugin that implements ``SystemAccessControl`` and
 ``SystemAccessControlFactory`` has been installed on the coordinator, it is
-configured using an ``etc/access-control.properties`` file. All of the properties
-other than ``access-control.name`` are specific to the ``SystemAccessControl``
-implementation.
+configured using a file specified in ``access-control.config-path`` property of ``config.properties`` (by default it points to ``etc/access-control.properties`` file).
+All of the properties other than ``access-control.name`` are specific to the ``SystemAccessControl`` implementation.
 
 The ``access-control.name`` property is used by Presto to find a registered
 ``SystemAccessControlFactory`` based on the name returned by

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.security;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+import javax.validation.constraints.NotNull;
+
+public class AccessControlConfig
+{
+    private String accessControlConfigPath = "etc/access-control.properties";
+
+    @NotNull
+    public String getAccessControlConfigPath()
+    {
+        return accessControlConfigPath;
+    }
+
+    @Config("access-control.config-path")
+    @ConfigDescription("Path with filename to access control properties")
+    public AccessControlConfig setAccessControlConfigPath(String configPath)
+    {
+        this.accessControlConfigPath = configPath;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -57,12 +57,12 @@ public class AccessControlManager
         implements AccessControl
 {
     private static final Logger log = Logger.get(AccessControlManager.class);
-    private static final File ACCESS_CONTROL_CONFIGURATION = new File("etc/access-control.properties");
     private static final String ACCESS_CONTROL_PROPERTY_NAME = "access-control.name";
 
     public static final String ALLOW_ALL_ACCESS_CONTROL = "allow-all";
 
     private final TransactionManager transactionManager;
+    private final File configurationFile;
     private final Map<String, SystemAccessControlFactory> systemAccessControlFactories = new ConcurrentHashMap<>();
     private final Map<ConnectorId, CatalogAccessControlEntry> connectorAccessControl = new ConcurrentHashMap<>();
 
@@ -75,9 +75,10 @@ public class AccessControlManager
     private final CounterStat authorizationFail = new CounterStat();
 
     @Inject
-    public AccessControlManager(TransactionManager transactionManager)
+    public AccessControlManager(TransactionManager transactionManager, AccessControlConfig config)
     {
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.configurationFile = new File(config.getAccessControlConfigPath());
         systemAccessControlFactories.put(ALLOW_ALL_ACCESS_CONTROL, new SystemAccessControlFactory()
         {
             @Override
@@ -121,12 +122,12 @@ public class AccessControlManager
     public void loadSystemAccessControl()
             throws Exception
     {
-        if (ACCESS_CONTROL_CONFIGURATION.exists()) {
-            Map<String, String> properties = new HashMap<>(loadProperties(ACCESS_CONTROL_CONFIGURATION));
+        if (configurationFile.exists()) {
+            Map<String, String> properties = new HashMap<>(loadProperties(configurationFile));
 
             String accessControlName = properties.remove(ACCESS_CONTROL_PROPERTY_NAME);
             checkArgument(!isNullOrEmpty(accessControlName),
-                    "Access control configuration %s does not contain %s", ACCESS_CONTROL_CONFIGURATION.getAbsoluteFile(), ACCESS_CONTROL_PROPERTY_NAME);
+                    "Access control configuration %s does not contain %s", configurationFile.getAbsoluteFile(), ACCESS_CONTROL_PROPERTY_NAME);
 
             setSystemAccessControl(accessControlName, properties);
         }

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlModule.java
@@ -14,17 +14,20 @@
 package com.facebook.presto.security;
 
 import com.google.inject.Binder;
-import com.google.inject.Module;
 import com.google.inject.Scopes;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
 
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class AccessControlModule
-    implements Module
+    extends AbstractConfigurationAwareModule
 {
     @Override
-    public void configure(Binder binder)
+    protected void setup(Binder binder)
     {
+        configBinder(binder).bindConfig(AccessControlConfig.class);
+
         binder.bind(AccessControlManager.class).in(Scopes.SINGLETON);
         binder.bind(AccessControl.class).to(AccessControlManager.class).in(Scopes.SINGLETON);
         newExporter(binder).export(AccessControlManager.class).withGeneratedName();

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -80,6 +80,7 @@ import com.facebook.presto.operator.ProjectionFunction;
 import com.facebook.presto.operator.ProjectionFunctions;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
+import com.facebook.presto.security.AccessControlConfig;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorPageSource;
@@ -272,7 +273,7 @@ public class LocalQueryRunner
                 new SchemaPropertyManager(),
                 new TablePropertyManager(),
                 transactionManager);
-        this.accessControl = new TestingAccessControlManager(transactionManager);
+        this.accessControl = new TestingAccessControlManager(transactionManager, new AccessControlConfig());
         this.eventListener = new TestingEventListenerManager();
         this.pageSourceManager = new PageSourceManager();
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.testing;
 
 import com.facebook.presto.metadata.QualifiedObjectName;
+import com.facebook.presto.security.AccessControlConfig;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.spi.CatalogSchemaName;
 import com.facebook.presto.spi.security.Identity;
@@ -74,9 +75,9 @@ public class TestingAccessControlManager
     private final Set<TestingPrivilege> denyPrivileges = new HashSet<>();
 
     @Inject
-    public TestingAccessControlManager(TransactionManager transactionManager)
+    public TestingAccessControlManager(TransactionManager transactionManager, AccessControlConfig config)
     {
-        super(transactionManager);
+        super(transactionManager, config);
         setSystemAccessControl(ALLOW_ALL_ACCESS_CONTROL, ImmutableMap.of());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCommitTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCommitTask.java
@@ -18,6 +18,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.Session.SessionBuilder;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.security.AccessControlConfig;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.spi.PrestoException;
@@ -63,7 +64,7 @@ public class TestCommitTask
             throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
 
         Session session = sessionBuilder()
                 .setTransactionId(transactionManager.beginTransaction(false))
@@ -84,7 +85,7 @@ public class TestCommitTask
             throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
 
         Session session = sessionBuilder()
                 .build();
@@ -113,7 +114,7 @@ public class TestCommitTask
             throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
 
         Session session = sessionBuilder()
                 .setTransactionId(TransactionId.create()) // Use a random transaction ID that is unknown to the system

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestDeallocateTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestDeallocateTask.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution;
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.security.AccessControlConfig;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.spi.PrestoException;
@@ -79,7 +80,7 @@ public class TestDeallocateTask
     private Set<String> executeDeallocate(String statementName, String sqlString, Session session)
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), sqlString, session, URI.create("fake://uri"), false, transactionManager, accessControl, executor);
         Deallocate deallocate = new Deallocate(statementName);
         new DeallocateTask().execute(deallocate, transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList());

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestPrepareTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestPrepareTask.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution;
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.security.AccessControlConfig;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.spi.PrestoException;
@@ -102,7 +103,7 @@ public class TestPrepareTask
     private Map<String, String> executePrepare(String statementName, Statement statement, String sqlString, Session session)
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), sqlString, session, URI.create("fake://uri"), false, transactionManager, accessControl, executor);
         Prepare prepare = new Prepare(statementName, statement);
         new PrepareTask(new SqlParser()).execute(prepare, transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList());

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -18,6 +18,7 @@ import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.security.AccessControlConfig;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
@@ -403,7 +404,7 @@ public class TestQueryStateMachine
     private QueryStateMachine createQueryStateMachineWithTicker(Ticker ticker)
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
         QueryStateMachine stateMachine = QueryStateMachine.beginWithTicker(QUERY_ID, QUERY, TEST_SESSION, LOCATION, false, transactionManager, accessControl, executor, ticker);
         stateMachine.setInputs(INPUTS);
         stateMachine.setOutput(OUTPUT);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestRollbackTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestRollbackTask.java
@@ -18,6 +18,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.Session.SessionBuilder;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.security.AccessControlConfig;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.spi.PrestoException;
@@ -62,7 +63,7 @@ public class TestRollbackTask
             throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
 
         Session session = sessionBuilder()
                 .setTransactionId(transactionManager.beginTransaction(false))
@@ -83,7 +84,7 @@ public class TestRollbackTask
             throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
 
         Session session = sessionBuilder()
                 .build();
@@ -112,7 +113,7 @@ public class TestRollbackTask
             throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
 
         Session session = sessionBuilder()
                 .setTransactionId(TransactionId.create()) // Use a random transaction ID that is unknown to the system

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStartTransactionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStartTransactionTask.java
@@ -18,6 +18,7 @@ import com.facebook.presto.Session.SessionBuilder;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.security.AccessControlConfig;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.spi.PrestoException;
@@ -78,7 +79,7 @@ public class TestStartTransactionTask
     {
         Session session = sessionBuilder().build();
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
@@ -105,7 +106,7 @@ public class TestStartTransactionTask
             throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
 
         Session session = sessionBuilder()
                 .setTransactionId(TransactionId.create())
@@ -139,7 +140,7 @@ public class TestStartTransactionTask
                 .setClientTransactionSupport()
                 .build();
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
@@ -160,7 +161,7 @@ public class TestStartTransactionTask
                 .setClientTransactionSupport()
                 .build();
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
@@ -189,7 +190,7 @@ public class TestStartTransactionTask
                 .setClientTransactionSupport()
                 .build();
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
@@ -225,7 +226,7 @@ public class TestStartTransactionTask
                 .setClientTransactionSupport()
                 .build();
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
@@ -267,7 +268,7 @@ public class TestStartTransactionTask
                 scheduledExecutor,
                 new CatalogManager(),
                 executor);
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -59,7 +59,7 @@ public class TestAccessControlManager
     public void testInitializing()
             throws Exception
     {
-        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager());
+        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager(), new AccessControlConfig());
         accessControlManager.checkCanSetUser(null, "foo");
     }
 
@@ -67,7 +67,7 @@ public class TestAccessControlManager
     public void testNoneSystemAccessControl()
             throws Exception
     {
-        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager());
+        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager(), new AccessControlConfig());
         accessControlManager.setSystemAccessControl(ALLOW_ALL_ACCESS_CONTROL, ImmutableMap.<String, String>of());
         accessControlManager.checkCanSetUser(null, USER_NAME);
     }
@@ -76,7 +76,7 @@ public class TestAccessControlManager
     public void testSetAccessControl()
             throws Exception
     {
-        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager());
+        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager(), new AccessControlConfig());
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
@@ -92,7 +92,7 @@ public class TestAccessControlManager
             throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = new AccessControlManager(transactionManager, new AccessControlConfig());
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
@@ -110,7 +110,7 @@ public class TestAccessControlManager
     {
         CatalogManager catalogManager = new CatalogManager();
         TransactionManager transactionManager = createTestTransactionManager(catalogManager);
-        AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = new AccessControlManager(transactionManager, new AccessControlConfig());
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
@@ -131,7 +131,7 @@ public class TestAccessControlManager
     {
         CatalogManager catalogManager = new CatalogManager();
         TransactionManager transactionManager = createTestTransactionManager(catalogManager);
-        AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = new AccessControlManager(transactionManager, new AccessControlConfig());
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -31,6 +31,7 @@ import com.facebook.presto.metadata.TablePropertyManager;
 import com.facebook.presto.metadata.TestingMetadata;
 import com.facebook.presto.metadata.ViewDefinition;
 import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.security.AccessControlConfig;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -1044,7 +1045,7 @@ public class TestAnalyzer
         TypeManager typeManager = new TypeRegistry();
         CatalogManager catalogManager = new CatalogManager();
         transactionManager = createTestTransactionManager(catalogManager);
-        accessControl = new AccessControlManager(transactionManager);
+        accessControl = new AccessControlManager(transactionManager, new AccessControlConfig());
 
         metadata = new MetadataManager(
                 new FeaturesConfig(),


### PR DESCRIPTION
This is to avoid hard coded path for configuration and allow some flexibility for the user deploying Presto.