### PR TITLE
Add specialized addInput function to Accumulator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -265,6 +265,15 @@ public class PagesIndex
         return types.get(channel).getSlice(block, blockPosition);
     }
 
+    public Block getBlock(int channel, int position)
+    {
+        long pageAddress = valueAddresses.getLong(position);
+
+        Block block = channels[channel].get(decodeSliceIndex(pageAddress));
+        int blockPosition = decodePosition(pageAddress);
+        return block.getSingleValueBlock(blockPosition);
+    }
+
     public void sort(List<Integer> sortChannels, List<SortOrder> sortOrders)
     {
         sort(sortChannels, sortOrders, 0, getPositionCount());

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.WindowIndex;
 import com.facebook.presto.spi.type.Type;
 
 public interface Accumulator
@@ -27,6 +28,8 @@ public interface Accumulator
     Type getIntermediateType();
 
     void addInput(Page page);
+
+    void addInput(WindowIndex index, int channel, int position);
 
     void addIntermediate(Block block);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
@@ -31,6 +31,8 @@ public interface Accumulator
 
     void addInput(WindowIndex index, int channel, int position);
 
+    void addInput(int positionCount);
+
     void addIntermediate(Block block);
 
     void evaluateIntermediate(BlockBuilder blockBuilder);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.function.WindowIndex;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.CallSiteBinder;
 import com.facebook.presto.sql.gen.CompilerOperations;
@@ -52,8 +53,10 @@ import static com.facebook.presto.bytecode.CompilerUtils.defineClass;
 import static com.facebook.presto.bytecode.CompilerUtils.makeClassName;
 import static com.facebook.presto.bytecode.Parameter.arg;
 import static com.facebook.presto.bytecode.ParameterizedType.type;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantFalse;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantInt;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantString;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantTrue;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.invokeStatic;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.not;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
@@ -61,6 +64,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.count
 import static com.facebook.presto.sql.gen.BytecodeUtils.invoke;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
 
 public class AccumulatorCompiler
 {
@@ -123,6 +127,7 @@ public class AccumulatorCompiler
 
         // Generate methods
         generateAddInput(definition, stateField, inputChannelsField, maskChannelField, metadata.getInputMetadata(), metadata.getInputFunction(), callSiteBinder, grouped);
+        generateAddInputWindowIndex(definition, stateField, metadata.getInputMetadata(), metadata.getInputFunction(), callSiteBinder);
         generateGetEstimatedSize(definition, stateField);
         generateGetIntermediateType(definition, callSiteBinder, stateSerializer.getSerializedType());
         generateGetFinalType(definition, callSiteBinder, metadata.getOutputType());
@@ -233,6 +238,179 @@ public class AccumulatorCompiler
 
         body.append(block);
         body.ret();
+    }
+
+    private static void generateAddInputWindowIndex(
+            ClassDefinition definition,
+            FieldDefinition stateField,
+            List<ParameterMetadata> parameterMetadatas,
+            MethodHandle inputFunction,
+            CallSiteBinder callSiteBinder)
+    {
+        // TODO: implement masking based on maskChannel field once Window Functions support DISTINCT arguments to the functions.
+
+        Parameter index = arg("index", WindowIndex.class);
+        Parameter channel = arg("channel", int.class);
+        Parameter position = arg("position", int.class);
+
+        MethodDefinition method = definition.declareMethod(a(PUBLIC), "addInput", type(void.class), ImmutableList.of(index, channel, position));
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        scope.declareVariable(int.class, "isNull");
+        scope.declareVariable(Block.class, "block");
+
+        BytecodeBlock block = new BytecodeBlock();
+        block.append(constantFalse())
+                .putVariable(scope.getVariable("isNull"));
+
+        block.append(
+                generateInvokeFunctionOnIndex(scope, inputFunction.type().parameterArray(), parameterMetadatas, stateField));
+
+        BytecodeBlock popBlock = new BytecodeBlock();
+        Class<?>[] parameters = inputFunction.type().parameterArray();
+        for (int i = parameters.length - 1; i >= 0; i--) {
+            popBlock.pop(parameters[i]);
+        }
+
+        block.append(new IfStatement("if (!isNull)")
+                .condition(new BytecodeBlock()
+                        .getVariable(scope.getVariable("isNull")))
+                .ifTrue(popBlock) // clear the stack before return
+                .ifFalse(new BytecodeBlock()
+                        .comment("input()")
+                        .append(invoke(callSiteBinder.bind(inputFunction), "input"))));
+
+        body.append(block);
+        body.ret();
+    }
+
+    private static BytecodeBlock generateInvokeFunctionOnIndex(
+            Scope scope,
+            Class<?>[] parameters,
+            List<ParameterMetadata> parameterMetadatas,
+            FieldDefinition stateField)
+    {
+        BytecodeBlock block = new BytecodeBlock();
+
+        block.comment("Read value from WindowIndex");
+        for (int i = 0; i < parameters.length; i++) {
+            ParameterMetadata parameterMetadata = parameterMetadatas.get(i);
+            switch (parameterMetadata.getParameterType()) {
+                case STATE:
+                    block.append(scope.getThis().getField(stateField));
+                    break;
+                case BLOCK_INDEX:
+                    block.append(constantInt(0)); // index.getBlock(channel, position) generates always a page with only one position
+                    break;
+                case BLOCK_INPUT_CHANNEL:
+                    block.append(generateReadBlockFromIndex(scope));
+                    block.append(checkIsBlockNull(scope));
+                    break;
+                case NULLABLE_BLOCK_INPUT_CHANNEL:
+                    block.append(generateReadBlockFromIndex(scope));
+                    break;
+                case INPUT_CHANNEL:
+                    block.append(generateReadFromIndex(scope, parameters[i]));
+                    break;
+            }
+        }
+
+        return block;
+    }
+
+    // block should be on stack and 'isNull' variable should be available in scope
+    private static BytecodeNode checkIsBlockNull(Scope scope)
+    {
+        BytecodeBlock block = new BytecodeBlock();
+
+        Variable blockVariable = scope.getVariable("block");
+
+        block.putVariable(blockVariable);
+
+        block.append(new IfStatement("if(block.isNull(position))")
+                .condition(new BytecodeBlock()
+                        .getVariable(blockVariable)
+                        .append(constantInt(0)) // WindowIndex.getBlock() generates block with only one position
+                        .invokeInterface(Block.class, "isNull", boolean.class, int.class))
+                .ifTrue(new BytecodeBlock()
+                        .comment("isNull = true")
+                        .append(constantTrue())
+                        .putVariable(scope.getVariable("isNull"))));
+
+        block.getVariable(blockVariable);
+
+        return block;
+    }
+
+    private static BytecodeNode generateReadBlockFromIndex(Scope scope)
+    {
+        BytecodeBlock block = new BytecodeBlock();
+
+        block.comment("index.getBlock(channel, position)")
+                .append(scope.getVariable("index"))
+                .append(scope.getVariable("channel"))
+                .append(scope.getVariable("position"))
+                .invokeInterface(WindowIndex.class, "getBlock", Block.class, int.class, int.class);
+
+        return block;
+    }
+
+    private static BytecodeBlock generateReadFromIndex(Scope scope, Class<?> parameterType)
+    {
+        Variable index = scope.getVariable("index");
+        Variable channel = scope.getVariable("channel");
+        Variable position = scope.getVariable("position");
+
+        BytecodeBlock block = new BytecodeBlock();
+
+        block.append(new IfStatement("if (index.isNull(channel, position)")
+                .condition(new BytecodeBlock()
+                        .append(index)
+                        .append(channel)
+                        .append(position)
+                        .invokeInterface(WindowIndex.class, "isNull", boolean.class, int.class, int.class))
+                .ifTrue(new BytecodeBlock()
+                        .comment("isNull = true")
+                        .append(constantTrue())
+                        .putVariable(scope.getVariable("isNull"))));
+
+        if (parameterType == long.class) {
+            block.comment("index.getLong(channel, position)")
+                    .append(index)
+                    .append(channel)
+                    .append(position)
+                    .invokeInterface(WindowIndex.class, "getLong", long.class, int.class, int.class);
+        }
+        else if (parameterType == double.class) {
+            block.comment("index.getDouble(channel, position)")
+                    .append(index)
+                    .append(channel)
+                    .append(position)
+                    .invokeInterface(WindowIndex.class, "getDouble", double.class, int.class, int.class);
+        }
+        else if (parameterType == boolean.class) {
+            block.comment("index.getBoolean(channel, position)")
+                    .append(index)
+                    .append(channel)
+                    .append(position)
+                    .invokeInterface(WindowIndex.class, "getBoolean", boolean.class, int.class, int.class);
+        }
+        else if (parameterType == Slice.class) {
+            block.comment("index.getSlice(channel, position)")
+                    .append(index)
+                    .append(channel)
+                    .append(position)
+                    .invokeInterface(WindowIndex.class, "getSlice", Slice.class, int.class, int.class);
+        }
+        else if (parameterType == Block.class) {
+            block.append(generateReadBlockFromIndex(scope));
+        }
+        else {
+            throw new IllegalArgumentException(format("Unsupported parameter type: %s", parameterType));
+        }
+
+        return block;
     }
 
     private static BytecodeBlock generateInputForLoop(

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
@@ -17,7 +17,6 @@ import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.aggregation.Accumulator;
 import com.facebook.presto.operator.aggregation.AccumulatorFactory;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
-import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.WindowFunction;
 import com.facebook.presto.spi.function.WindowIndex;
@@ -81,7 +80,7 @@ public class AggregateWindowFunction
     private void accumulate(int start, int end)
     {
         if (function.getParameterTypes().size() == 0) {
-            accumulator.addInput(new Page(end - start + 1));
+            accumulator.addInput(end - start + 1);
         }
         else {
             for (int position = start; position <= end; position++) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/PagesWindowIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/PagesWindowIndex.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.operator.window;
 
 import com.facebook.presto.operator.PagesIndex;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.WindowIndex;
 import io.airlift.slice.Slice;
 
@@ -77,6 +79,14 @@ public class PagesWindowIndex
     public Slice getSlice(int channel, int position)
     {
         return pagesIndex.getSlice(channel, position(position));
+    }
+
+    @Override
+    public Block getBlock(int channel, int position)
+    {
+        BlockBuilder builder = pagesIndex.getType(channel).createBlockBuilder(new BlockBuilderStatus(), 1);
+        pagesIndex.appendTo(channel, position, builder);
+        return builder.build();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/PagesWindowIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/PagesWindowIndex.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.window;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.WindowIndex;
 import io.airlift.slice.Slice;
 
@@ -84,9 +83,7 @@ public class PagesWindowIndex
     @Override
     public Block getBlock(int channel, int position)
     {
-        BlockBuilder builder = pagesIndex.getType(channel).createBlockBuilder(new BlockBuilderStatus(), 1);
-        pagesIndex.appendTo(channel, position, builder);
-        return builder.build();
+        return pagesIndex.getBlock(channel, position);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CompilerOperations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CompilerOperations.java
@@ -13,12 +13,14 @@
  */
 package com.facebook.presto.sql.gen;
 
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 
 import javax.annotation.Nullable;
 
 import java.util.Set;
 
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 
 // This methods are statically bound by the compiler
@@ -70,5 +72,10 @@ public final class CompilerOperations
             return BOOLEAN.getBoolean(masks, index);
         }
         return true;
+    }
+
+    public static void throwStandardPrestoException(String message)
+    {
+        throw new PrestoException(GENERIC_INTERNAL_ERROR, message);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/WindowIndex.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/WindowIndex.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import io.airlift.slice.Slice;
 
@@ -70,6 +71,14 @@ public interface WindowIndex
      * @param position row within the partition, starting at zero
      */
     Slice getSlice(int channel, int position);
+
+    /**
+     * Gets a value stored as a {@link Block}.
+     * @param channel argument number
+     * @param position row within the partition, starting at zero
+     * @return
+     */
+    Block getBlock(int channel, int position);
 
     /**
      * Outputs a value from the index. This is useful for "value"

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3689,6 +3689,36 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testWindowFunctionWithoutParameters()
+    {
+        MaterializedResult actual = computeActual("SELECT count() over(partition by custkey) from orders where custkey < 3 order by custkey");
+
+        MaterializedResult expected = resultBuilder(getSession(), BIGINT)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .build();
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
     public void testHaving()
     {
         assertQuery("SELECT orderstatus, sum(totalprice) FROM orders GROUP BY orderstatus HAVING orderstatus = 'O'");


### PR DESCRIPTION
Avoid building pages unnecessarily while data is stored in `WindowIndex`.

Limitations:
1. functions taking `Block` as an argument will fall back to building `Page` (and extracting `Block` from it) - similarly to what we had before this patch
2. `maskChannel` is not taken into account here because the only use case I'm aware of is a window function taking a DISTINCT argument (i.e. `SELECT X(DISTINCT Y) OVER(...)` where `X` is a window function and Y is a column argument). The implementation of accumulator should be extended to take into account `maskChannel` once `DISTINCT` is supported (for now window functions with `DISTINCT` arguments are disallowed: `Query failed: line 1:1: DISTINCT in window function parameters not yet supported: "sum"(DISTINCT "x") OVER ()`).

---
Benchmarking:
This patch was tested on sf1 and sf10 TPCH-based internal benchmark suite based on real customer use cases.
Results vary from 0x up to 17x performance boost.

Some results with example anonymized queries:
17x gain observed on below query:
```sql
select count(*), max(foo), max(bar), max(baz), max(oof) from (
select *
, case when partkey=0
or (orderkey<0 and partkey>0)
or (orderkey>0 and partkey<0)
or day(shipdate)=1
then day(shipdate) else 0 end Period_Start_1a
, case when suppkey=0
or (linenumber<0 and suppkey>0)
or (linenumber>0 and suppkey<0)
or day(commitdate)=1
then day(commitdate) else 0 end Period_Start_2a
, case when orderkey=0
or (suppkey<0 and orderkey>0)
or (suppkey>0 and orderkey<0)
or day(receiptdate)=1
then day(receiptdate) else 0 end Period_Start_1b
, case when linenumber=0
or (partkey<0 and linenumber>0)
or (partkey>0 and linenumber<0)
or tax=1
then tax else 0 end Period_Start_2b
, sum (quantity) over (partition by orderkey) foo
, sum (discount) over (partition by linenumber) bar
, sum (tax) over (partition by returnflag) baz
, sum (linenumber) over (partition by linestatus) oof
from hive.${schema}.lineitem);
```

5x:
```sql
select count(*), max(foo), max(bar), max(baz), max(oof), max(zab), max(rab),
 max(foo2), max(bar2), max(baz2), max(oof2),
 max(zab2), max(rab2), max(foo3), max(bar3),
 max(baz3), max(oof3), max(zab3), max(rab3),
 max(foo4), max(bar4), max(baz4), max(oof4),
 max(foo5), max(bar5), max(baz5), max(zab5),
 max(rab5), max(oof5), max(foo6), max(bar6)
 from (
select *
,sum(quantity) over (partition by suppkey order by partkey rows between unbounded preceding and current row) foo 
,sum(discount) over (partition by suppkey order by partkey rows between unbounded preceding and current row) bar 
,sum(quantity) over (partition by orderkey order by shipdate rows between UNBOUNDED preceding and CURRENT ROW) baz 
,sum(discount) over (partition by linenumber order by commitdate rows between UNBOUNDED preceding and CURRENT ROW) oof 
,sum(quantity) over (partition by returnflag order by receiptdate rows between UNBOUNDED preceding and CURRENT ROW) zab 
,sum(discount) over (partition by linestatus order by tax rows between UNBOUNDED preceding and CURRENT ROW) rab 

,sum(extendedprice) over (partition by orderkey order by shipdate rows between UNBOUNDED preceding and CURRENT ROW) foo2 
,sum(tax) over (partition by orderkey order by shipdate rows between UNBOUNDED preceding and CURRENT ROW) zab2 
,max(shipdate) over (partition by orderkey) baz3 
,lag(cast(extendedprice as double),1,0) over (partition by orderkey order by shipdate) foo4 
,lag(comment,1,comment) over (partition by orderkey order by shipdate) foo5 
,lead(comment,1,comment) over (partition by orderkey order by shipdate) rab5 

,sum(quantity) over (partition by linenumber order by commitdate rows between UNBOUNDED preceding and CURRENT ROW) baz2 
,sum(tax) over (partition by linenumber order by commitdate rows between UNBOUNDED preceding and CURRENT ROW) foo3 
,max(commitdate) over (partition by linenumber) zab3 
,lag(cast(extendedprice as double),1,0) over (partition by linenumber order by commitdate) baz4 
,lag(comment,1,comment) over (partition by linenumber order by commitdate) baz5 
,lead(comment,1,comment) over (partition by linenumber order by commitdate) bar6 

,sum(discount) over (partition by returnflag order by receiptdate rows between UNBOUNDED preceding and CURRENT ROW) bar2 
,sum(linenumber) over (partition by returnflag order by receiptdate rows between UNBOUNDED preceding and CURRENT ROW) rab2 
,max(receiptdate) over (partition by returnflag) oof3 
,lag(cast(extendedprice as double),1,0) over (partition by returnflag order by receiptdate) bar4 
,lag(extendedprice,1,extendedprice) over (partition by returnflag order by receiptdate) bar5 
,lead(extendedprice,1,extendedprice) over (partition by returnflag order by receiptdate) oof5 

,sum(quantity) over (partition by linestatus order by tax rows between UNBOUNDED preceding and CURRENT ROW) oof2
,sum(extendedprice) over (partition by linestatus order by tax rows between UNBOUNDED preceding and CURRENT ROW) bar3 
,max(tax) over (partition by linestatus) rab3 
,lag(cast(extendedprice as double),1,0) over (partition by linestatus order by tax) oof4 
,lag(comment,1,comment) over (partition by linestatus order by tax) zab5 
,lead(comment,1,comment) over (partition by linestatus order by tax) foo6 
from hive.${schema}.lineitem);
```

Most of the time saved is visible on CPU time usage.
In case of the latter query (5x boost), CPU time was reduced from 9h 34min to 1h 35min.