### PR TITLE
Fix wrong results for nested except

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SetFlatteningOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SetFlatteningOptimizer.java
@@ -96,8 +96,9 @@ public class SetFlatteningOptimizer
                 PlanNode rewrittenSource = context.rewrite(subplan, context.get());
 
                 Class<?> setOperationClass = node.getClass();
-                if (setOperationClass.isInstance(rewrittenSource)) {
+                if (setOperationClass.isInstance(rewrittenSource) && (!setOperationClass.equals(ExceptNode.class) || i == 0)) {
                     // Absorb source's subplans if it is also a SetOperation of the same type
+                    // ExceptNodes can only flatten their first source because except is not associative
                     SetOperationNode rewrittenSetOperation = (SetOperationNode) rewrittenSource;
                     flattenedSources.addAll(rewrittenSetOperation.getSources());
                     for (Map.Entry<Symbol, Collection<Symbol>> entry : node.getSymbolMapping().asMap().entrySet()) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
@@ -67,6 +67,18 @@ public class BasePlanTest
         });
     }
 
+    protected void assertPlanWithOptimizers(String sql, PlanMatchPattern pattern, List<PlanOptimizer> optimizers)
+    {
+        queryRunner.inTransaction(transactionSession -> {
+            FeaturesConfig featuresConfig = new FeaturesConfig()
+                    .setDistributedIndexJoinsEnabled(false)
+                    .setOptimizeHashGeneration(true);
+            Plan actualPlan = queryRunner.createPlan(transactionSession, sql, featuresConfig, optimizers, LogicalPlanner.Stage.OPTIMIZED);
+            PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), actualPlan, pattern);
+            return null;
+        });
+    }
+
     protected void assertMinimallyOptimizedPlan(@Language("SQL") String sql, PlanMatchPattern pattern)
     {
         LocalQueryRunner queryRunner = getQueryRunner();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -21,14 +21,17 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.ExceptNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.planner.plan.IntersectNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.Expression;
@@ -201,6 +204,21 @@ public final class PlanMatchPattern
                         joinType,
                         expectedEquiCriteria,
                         expectedFilter.map(predicate -> rewriteQualifiedNamesToSymbolReferences(new SqlParser().createExpression(predicate)))));
+    }
+
+    public static PlanMatchPattern union(PlanMatchPattern... sources)
+    {
+        return node(UnionNode.class, sources);
+    }
+
+    public static PlanMatchPattern intersect(PlanMatchPattern... sources)
+    {
+        return node(IntersectNode.class, sources);
+    }
+
+    public static PlanMatchPattern except(PlanMatchPattern... sources)
+    {
+        return node(ExceptNode.class, sources);
     }
 
     public static ExpectedValueProvider<JoinNode.EquiJoinClause> equiJoinClause(String left, String right)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSetFlatteningOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSetFlatteningOptimizer.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.except;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.intersect;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.union;
+
+public class TestSetFlatteningOptimizer
+        extends BasePlanTest
+{
+    @Test
+    public void testFlattensUnion()
+    {
+        assertPlan(
+                "(SELECT * FROM nation UNION SELECT * FROM nation)" +
+                        "UNION (SELECT * FROM nation UNION SELECT * FROM nation)",
+                anyTree(
+                        union(
+                                tableScan("nation"),
+                                tableScan("nation"),
+                                tableScan("nation"),
+                                tableScan("nation"))));
+    }
+
+    @Test
+    public void testFlattensUnionAll()
+    {
+        assertPlan(
+                "(SELECT * FROM nation UNION ALL SELECT * FROM nation)" +
+                        "UNION ALL (SELECT * FROM nation UNION ALL SELECT * FROM nation)",
+                anyTree(
+                        union(
+                                tableScan("nation"),
+                                tableScan("nation"),
+                                tableScan("nation"),
+                                tableScan("nation"))));
+    }
+
+    @Test
+    public void testFlattensUnionAndUnionAllWhenAllowed()
+    {
+        assertPlan(
+                "SELECT * FROM nation " +
+                        "UNION ALL (SELECT * FROM nation " +
+                        "UNION (SELECT * FROM nation UNION ALL select * FROM nation))",
+                anyTree(
+                        union(
+                                tableScan("nation"),
+                                anyTree(
+                                        union(
+                                                tableScan("nation"),
+                                                tableScan("nation"),
+                                                tableScan("nation"))))));
+    }
+
+    @Test
+    public void testFlattensIntersect()
+    {
+        assertPlan(
+                "(SELECT * FROM nation INTERSECT SELECT * FROM nation)" +
+                        "INTERSECT (SELECT * FROM nation INTERSECT SELECT * FROM nation)",
+                anyTree(
+                        intersect(
+                                tableScan("nation"),
+                                tableScan("nation"),
+                                tableScan("nation"),
+                                tableScan("nation"))));
+    }
+
+    @Test
+    public void testFlattensOnlyFirstInputOfExcept()
+    {
+        assertPlan(
+                "(SELECT * FROM nation EXCEPT SELECT * FROM nation)" +
+                        "EXCEPT (SELECT * FROM nation EXCEPT SELECT * FROM nation)",
+                anyTree(
+                        except(
+                                tableScan("nation"),
+                                tableScan("nation"),
+                                except(
+                                        tableScan("nation"),
+                                        tableScan("nation")))));
+    }
+
+    @Test
+    public void testDoesNotFlattenDifferentSetOperations()
+    {
+        assertPlan(
+                "(SELECT * FROM nation EXCEPT SELECT * FROM nation)" +
+                        "UNION (SELECT * FROM nation INTERSECT SELECT * FROM nation)",
+                anyTree(
+                        union(
+                                except(
+                                        tableScan("nation"),
+                                        tableScan("nation")),
+                                intersect(
+                                        tableScan("nation"),
+                                        tableScan("nation")))));
+    }
+
+    public void assertPlan(String sql, PlanMatchPattern pattern)
+    {
+        List<PlanOptimizer> optimizers = ImmutableList.of(
+                new UnaliasSymbolReferences(),
+                new PruneUnreferencedOutputs(),
+                new PruneIdentityProjections(),
+                new SetFlatteningOptimizer());
+        assertPlanWithOptimizers(sql, pattern, optimizers);
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1738,6 +1738,9 @@ public abstract class AbstractTestQueries
                 "SELECT * FROM (VALUES 1, 2) " +
                         "EXCEPT SELECT * FROM (VALUES 3.0, 2)");
 
+        assertQuery(
+                "(SELECT * FROM (VALUES 1) EXCEPT SELECT * FROM (VALUES 0))" +
+                        "EXCEPT (SELECT * FROM (VALUES 1) EXCEPT SELECT * FROM (VALUES 1))");
         MaterializedResult emptyResult = computeActual("SELECT 0 EXCEPT (SELECT regionkey FROM nation WHERE nationkey <10)");
         assertEquals(emptyResult.getMaterializedRows().size(), 0);
     }


### PR DESCRIPTION
Fixes #6757 

While writing tests I noticed that we don't prune unreferenced outputs for intersect and except nodes, so I fixed that too.