### PR TITLE
correct spelling of type 'timestamp with time zone' in JDBC connector

### DIFF
--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>
@@ -123,12 +128,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.presto</groupId>
-            <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -18,11 +18,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.facebook.presto</groupId>
-            <artifactId>presto-main</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>
@@ -128,6 +123,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -90,9 +90,9 @@ public class BaseJdbcClient
             .put(VARBINARY, "varbinary")
             .put(DATE, "date")
             .put(TIME, "time")
-            .put(TIME_WITH_TIME_ZONE, "time with timezone")
+            .put(TIME_WITH_TIME_ZONE, "time with time zone")
             .put(TIMESTAMP, "timestamp")
-            .put(TIMESTAMP_WITH_TIME_ZONE, "timestamp with timezone")
+            .put(TIMESTAMP_WITH_TIME_ZONE, "timestamp with time zone")
             .build();
 
     protected final String connectorId;

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -205,7 +205,7 @@ public class BaseJdbcClient
                 boolean found = false;
                 while (resultSet.next()) {
                     found = true;
-                    Type columnType = toPrestoType(resultSet.getInt("DATA_TYPE"), resultSet.getInt("COLUMN_SIZE"));
+                    Type columnType = toPrestoType(resultSet.getInt("DATA_TYPE"), resultSet.getInt("COLUMN_SIZE"), resultSet.getString("TYPE_NAME"));
                     // skip unsupported column types
                     if (columnType != null) {
                         String columnName = resultSet.getString("COLUMN_NAME");
@@ -462,7 +462,7 @@ public class BaseJdbcClient
         }
     }
 
-    protected Type toPrestoType(int jdbcType, int columnSize)
+    protected Type toPrestoType(int jdbcType, int columnSize, String typeName)
     {
         switch (jdbcType) {
             case Types.BIT:
@@ -498,9 +498,9 @@ public class BaseJdbcClient
             case Types.DATE:
                 return DATE;
             case Types.TIME:
-                return TIME;
+                return "timetz".equalsIgnoreCase(typeName) ? TIME_WITH_TIME_ZONE : TIME;
             case Types.TIMESTAMP:
-                return TIMESTAMP;
+                return "timestamptz".equalsIgnoreCase(typeName) ? TIMESTAMP_WITH_TIME_ZONE : TIMESTAMP;
         }
         return null;
     }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
@@ -17,12 +17,15 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.CharType;
+import com.facebook.presto.spi.type.DateTimeEncoding;
 import com.facebook.presto.spi.type.DateType;
 import com.facebook.presto.spi.type.IntegerType;
 import com.facebook.presto.spi.type.RealType;
 import com.facebook.presto.spi.type.SmallintType;
 import com.facebook.presto.spi.type.TimeType;
+import com.facebook.presto.spi.type.TimeWithTimeZoneType;
 import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.TimestampWithTimeZoneType;
 import com.facebook.presto.spi.type.TinyintType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarbinaryType;
@@ -170,9 +173,17 @@ public class JdbcRecordCursor
                 Time time = resultSet.getTime(field + 1);
                 return UTC_CHRONOLOGY.millisOfDay().get(time.getTime());
             }
+            if (type.equals(TimeWithTimeZoneType.TIME_WITH_TIME_ZONE)) {
+                Time time = resultSet.getTime(field + 1);
+                return DateTimeEncoding.packDateTimeWithZone(UTC_CHRONOLOGY.millisOfDay().get(time.getTime()), -time.getTimezoneOffset());
+            }
             if (type.equals(TimestampType.TIMESTAMP)) {
                 Timestamp timestamp = resultSet.getTimestamp(field + 1);
                 return timestamp.getTime();
+            }
+            if (type.equals(TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE)) {
+                Timestamp timestamp = resultSet.getTimestamp(field + 1);
+                return DateTimeEncoding.packDateTimeWithZone(timestamp.getTime(), -timestamp.getTimezoneOffset());
             }
             throw new PrestoException(GENERIC_INTERNAL_ERROR, "Unhandled type for long: " + type.getTypeSignature());
         }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordSink.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordSink.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.TimestampWithTimeZoneType;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.util.DateTimeZoneIndex;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import org.joda.time.DateTimeZone;
@@ -150,7 +149,7 @@ public class JdbcRecordSink
             else if (TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE.equals(columnTypes.get(field))) {
                 long utcMillis = DateTimeEncoding.unpackMillisUtc(value);
                 TimeZoneKey tz = DateTimeEncoding.unpackZoneKey(value);
-                Calendar cal = GregorianCalendar.getInstance(DateTimeZoneIndex.getDateTimeZone(tz).toTimeZone());
+                Calendar cal = GregorianCalendar.getInstance(DateTimeZone.forID(tz.getId()).toTimeZone());
                 cal.setTimeInMillis(utcMillis);
                 statement.setTimestamp(next(), new Timestamp(cal.getTimeInMillis()), cal);
             }
@@ -160,7 +159,7 @@ public class JdbcRecordSink
             else if (TimeWithTimeZoneType.TIME_WITH_TIME_ZONE.equals(columnTypes.get(field))) {
                 long utcMillis = DateTimeEncoding.unpackMillisUtc(value);
                 TimeZoneKey tz = DateTimeEncoding.unpackZoneKey(value);
-                Calendar cal = GregorianCalendar.getInstance(DateTimeZoneIndex.getDateTimeZone(tz).toTimeZone());
+                Calendar cal = GregorianCalendar.getInstance(DateTimeZone.forID(tz.getId()).toTimeZone());
                 cal.setTimeInMillis(utcMillis);
                 statement.setTime(next(), new Time(cal.getTimeInMillis()), cal);
             }

--- a/presto-main/src/main/java/com/facebook/presto/type/TimeOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimeOperators.java
@@ -35,6 +35,7 @@ import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static com.facebook.presto.util.DateTimeUtils.parseTimeWithTimeZone;
 import static com.facebook.presto.util.DateTimeUtils.parseTimeWithoutTimeZone;
 import static com.facebook.presto.util.DateTimeUtils.printTimeWithoutTimeZone;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -133,6 +134,19 @@ public final class TimeOperators
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to time: " + value.toStringUtf8(), e);
+        }
+    }
+
+    @ScalarOperator(CAST)
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.TIME_WITH_TIME_ZONE)
+    public static long castFromSliceWithTimeZone(ConnectorSession session, @SqlType("varchar(x)") Slice value)
+    {
+        try {
+            return parseTimeWithTimeZone(value.toStringUtf8());
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to time with time zone: " + value.toStringUtf8(), e);
         }
     }
 

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -55,12 +55,51 @@ public class TestPostgreSqlIntegrationSmokeTest
     }
 
     @Test
+    public void testTimestampTz()
+            throws Exception
+    {
+        queryRunner.execute("CREATE TABLE tpch.test_timestamptz AS SELECT CAST('2016-12-07 00:00:00-03:00' AS TIMESTAMP WITH TIME ZONE) as sometime");
+        assertQuery("SELECT * FROM test_timestamptz", "SELECT CAST('2016-12-07 00:00:00-03:00' AS TIMESTAMP)");
+    }
+
+    @Test
+    public void testTimestamp()
+            throws Exception
+    {
+        queryRunner.execute("CREATE TABLE tpch.test_timestamp AS SELECT CAST('2016-12-07 00:00:00' AS TIMESTAMP) as sometime");
+        assertQuery("SELECT * FROM test_timestamp", "SELECT CAST('2016-12-07 00:00:00' AS TIMESTAMP)");
+    }
+
+    @Test
+    public void testTimeTz()
+            throws Exception
+    {
+        queryRunner.execute("CREATE TABLE tpch.test_timetz AS SELECT CAST('00:00:00-03:00' AS TIME WITH TIME ZONE) as sometime");
+        assertQuery("SELECT * FROM test_timetz", "SELECT CAST(CAST('1970-01-01 00:00:00-03:00' AS TIMESTAMP) AS TIME)");
+    }
+    @Test
+    public void testTime()
+            throws Exception
+    {
+        queryRunner.execute("CREATE TABLE tpch.test_time AS SELECT CAST('00:00:00' AS TIME) as sometime");
+        assertQuery("SELECT * FROM test_time", "SELECT CAST('00:00:00' AS TIME)");
+    }
+
+    @Test
+    public void testDate()
+            throws Exception
+    {
+        queryRunner.execute("CREATE TABLE tpch.test_date AS SELECT CAST('2016-12-07' AS DATE) as sometime");
+        assertQuery("SELECT * FROM test_date", "SELECT CAST('2016-12-07' AS DATE)");
+    }
+
+    @Test
     public void testInsert()
             throws Exception
     {
-        execute("CREATE TABLE tpch.test_insert (x bigint, y varchar(100))");
-        assertUpdate("INSERT INTO test_insert VALUES (123, 'test')", 1);
-        assertQuery("SELECT * FROM test_insert", "SELECT 123 x, 'test' y");
+        execute("CREATE TABLE tpch.test_insert (x bigint, y varchar(100), z timestamp with time zone)");
+        assertUpdate("INSERT INTO test_insert VALUES (123, 'test', CAST('2016-12-07 12:34:56-07:00' AS TIMESTAMP WITH TIME ZONE))", 1);
+        assertQuery("SELECT * FROM test_insert", "SELECT 123 x, 'test' y, CAST('2016-12-07 12:34:56-07:00' AS TIMESTAMP)");
         assertUpdate("DROP TABLE test_insert");
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -31,6 +31,7 @@ import com.google.common.base.Joiner;
 import io.airlift.tpch.TpchTable;
 import org.intellij.lang.annotations.Language;
 import org.joda.time.DateTimeZone;
+import org.joda.time.chrono.ISOChronology;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.PreparedBatch;
@@ -267,7 +268,9 @@ public class H2QueryRunner
                         }
                     }
                     else if (TIME.equals(type) || TIME_WITH_TIME_ZONE.equals(type)) {
-                        Time timeValue = resultSet.getTime(i);
+                        long positiveOrNegativeOffset = resultSet.getTime(i).getTime();
+                        int positiveOffset = ISOChronology.getInstanceUTC().millisOfDay().get(positiveOrNegativeOffset);
+                        Time timeValue = new Time(positiveOffset);
                         if (resultSet.wasNull()) {
                             row.add(null);
                         }


### PR DESCRIPTION
[`BaseJdbcClient.java`](../tree/master/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java#L95) has a typo in the name of the SQL type 'timestamp with time zone'. To reproduce, try to make a table containing a timestamp in a PostgreSQL database via JDBC:

```sql
CREATE TABLE postgresql.public.foo AS SELECT now() as rightnow
```

PostgreSQL will complain about an unexpected `with` token since Presto translates this query into something like this:

```sql
CREATE TABLE "temp_abcdef" ("rightnow" timestamp with timezone)
```

It should instead be:


```sql
CREATE TABLE "temp_abcdef" ("rightnow" timestamp with time zone)
```

The type map appears to be in the `BaseJdbcClient` class. There is another reference to this spelling in the MySQL code, but this PR doesn't modify that code.