### PR TITLE
Document note about enabling authorization without authentication

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive-security.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-security.rst
@@ -39,6 +39,8 @@ Property Value                                     Description
                                                    :doc:`/sql/revoke` commands.
 ================================================== ============================================================
 
+Ensure that authentication has been enabled when enabling authorization checks.
+
 Authentication
 ==============
 

--- a/presto-docs/src/main/sphinx/sql/grant.rst
+++ b/presto-docs/src/main/sphinx/sql/grant.rst
@@ -26,6 +26,10 @@ The optional ``WITH GRANT OPTION`` clause allows the grantee to grant these same
 
 For ``GRANT`` statement to succeed, the user executing it should possess the specified privileges as well as the ``GRANT OPTION`` for those privileges.
 
+.. note::
+
+    Ensure that authentication has been enabled before running any of the authorization commands.
+
 Examples
 --------
 

--- a/presto-docs/src/main/sphinx/sql/revoke.rst
+++ b/presto-docs/src/main/sphinx/sql/revoke.rst
@@ -26,6 +26,10 @@ The optional ``GRANT OPTION FOR`` clause also revokes the privileges to grant th
 
 For ``REVOKE`` statement to succeed, the user executing it should possess the specified privileges as well as the ``GRANT OPTION`` for those privileges.
 
+.. note::
+
+    Ensure that authentication has been enabled before running any of the authorization commands.
+
 Examples
 --------
 


### PR DESCRIPTION
Running authorization commands without authentication is a bad security practice. Users should be warned against doing it.

TD review: https://github.com/Teradata/presto/pull/463