### PR TITLE
Don't split non-straddling expressions across join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/RelationType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/RelationType.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Predicate;
 
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -133,9 +132,9 @@ public class RelationType
                 .collect(toImmutableList());
     }
 
-    public Predicate<QualifiedName> canResolvePredicate()
+    public boolean canResolve(QualifiedName name)
     {
-        return input -> !resolveFields(input).isEmpty();
+        return !resolveFields(name).isEmpty();
     }
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -977,11 +977,11 @@ class StatementAnalyzer
 
                     Expression leftExpression = null;
                     Expression rightExpression = null;
-                    if (firstDependencies.stream().allMatch(left.getRelationType().canResolvePredicate()) && secondDependencies.stream().allMatch(right.getRelationType().canResolvePredicate())) {
+                    if (firstDependencies.stream().allMatch(left.getRelationType()::canResolve) && secondDependencies.stream().allMatch(right.getRelationType()::canResolve)) {
                         leftExpression = conjunctFirst;
                         rightExpression = conjunctSecond;
                     }
-                    else if (firstDependencies.stream().allMatch(right.getRelationType().canResolvePredicate()) && secondDependencies.stream().allMatch(left.getRelationType().canResolvePredicate())) {
+                    else if (firstDependencies.stream().allMatch(right.getRelationType()::canResolve) && secondDependencies.stream().allMatch(left.getRelationType()::canResolve)) {
                         leftExpression = conjunctSecond;
                         rightExpression = conjunctFirst;
                     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -242,12 +242,12 @@ class RelationPlanner
                     Set<QualifiedName> firstDependencies = DependencyExtractor.extractNames(firstExpression, analysis.getColumnReferences());
                     Set<QualifiedName> secondDependencies = DependencyExtractor.extractNames(secondExpression, analysis.getColumnReferences());
 
-                    if (firstDependencies.stream().allMatch(left.canResolvePredicate()) && secondDependencies.stream().allMatch(right.canResolvePredicate())) {
+                    if (firstDependencies.stream().allMatch(left::canResolve) && secondDependencies.stream().allMatch(right::canResolve)) {
                         leftComparisonExpressions.add(firstExpression);
                         rightComparisonExpressions.add(secondExpression);
                         joinConditionComparisonTypes.add(comparisonType);
                     }
-                    else if (firstDependencies.stream().allMatch(right.canResolvePredicate()) && secondDependencies.stream().allMatch(left.canResolvePredicate())) {
+                    else if (firstDependencies.stream().allMatch(right::canResolve) && secondDependencies.stream().allMatch(left::canResolve)) {
                         leftComparisonExpressions.add(secondExpression);
                         rightComparisonExpressions.add(firstExpression);
                         joinConditionComparisonTypes.add(comparisonType.flip());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -138,7 +138,7 @@ public class TestLogicalPlanner
                 countOfMatchingNodes(
                         plan("SELECT * FROM orders o1 JOIN orders o2 ON o1.orderkey = (SELECT 1) AND o2.orderkey = (SELECT 1) AND o1.orderkey + o2.orderkey = (SELECT 1)"),
                         EnforceSingleRowNode.class::isInstance),
-                2);
+                1);
 
         // one subquery used for "1 IN (SELECT 1)", one subquery used for "2 IN (SELECT 1)"
         assertEquals(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPlanMatchingFramework.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPlanMatchingFramework.java
@@ -91,7 +91,7 @@ public class TestPlanMatchingFramework
     {
         assertMinimallyOptimizedPlan("SELECT orderkey, 1 + orderkey FROM lineitem",
                 output(ImmutableList.of("ORDERKEY", "EXPRESSION"),
-                        project(ImmutableMap.of("EXPRESSION", expression("1 + ORDERKEY")),
+                        project(ImmutableMap.of("EXPRESSION", expression("CAST(1 AS bigint) + ORDERKEY")),
                                 tableScan("lineitem", ImmutableMap.of("ORDERKEY", "orderkey")))));
     }
 
@@ -100,7 +100,7 @@ public class TestPlanMatchingFramework
     {
         assertMinimallyOptimizedPlan("SELECT orderkey, 1 + orderkey FROM lineitem",
                 output(ImmutableList.of("ORDERKEY", "EXPRESSION"),
-                        project(ImmutableMap.of("ORDERKEY", expression("ORDERKEY"), "EXPRESSION", expression("1 + ORDERKEY")),
+                        project(ImmutableMap.of("ORDERKEY", expression("ORDERKEY"), "EXPRESSION", expression("CAST(1 AS bigint) + ORDERKEY")),
                                 tableScan("lineitem", ImmutableMap.of("ORDERKEY", "orderkey")))));
     }
 
@@ -194,7 +194,7 @@ public class TestPlanMatchingFramework
     {
         assertMinimallyOptimizedPlan("SELECT 1 + orderkey FROM lineitem",
                 output(ImmutableList.of("ORDERKEY"),
-                        project(ImmutableMap.of("EXPRESSION", expression("1 + ORDERKEY")),
+                        project(ImmutableMap.of("EXPRESSION", expression("CAST(1 AS bigint) + ORDERKEY")),
                                 tableScan("lineitem", ImmutableMap.of("ORDERKEY", "orderkey")))));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+
+public class TestPredicatePushdown
+        extends BasePlanTest
+{
+    @Test
+    public void testNonStraddlingJoinExpression()
+    {
+        assertPlan("SELECT * FROM orders JOIN lineitem ON orders.orderkey = lineitem.orderkey AND cast(lineitem.linenumber AS varchar) = '2'",
+                anyTree(
+                        join(INNER, ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
+                                any(
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
+                                anyTree(
+                                        filter("cast(LINEITEM_LINENUMBER as varchar) = cast('2' as varchar)",
+                                                tableScan("lineitem", ImmutableMap.of(
+                                                        "LINEITEM_OK", "orderkey",
+                                                        "LINEITEM_LINENUMBER", "linenumber")))))));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
@@ -79,7 +79,17 @@ final class ExpressionVerifier
     @Override
     protected Boolean visitCast(Cast actual, Expression expectedExpression)
     {
-        return process(actual.getExpression(), expectedExpression);
+        if (!(expectedExpression instanceof Cast)) {
+            return false;
+        }
+
+        Cast expected = (Cast) expectedExpression;
+
+        if (!actual.getType().equals(expected.getType())) {
+            return false;
+        }
+
+        return process(actual.getExpression(), expected.getExpression());
     }
 
     @Override
@@ -154,7 +164,11 @@ final class ExpressionVerifier
     @Override
     protected Boolean visitDoubleLiteral(DoubleLiteral actual, Expression expected)
     {
-        return getValueFromLiteral(actual).equals(getValueFromLiteral(expected));
+        if (expected instanceof DoubleLiteral) {
+            return getValueFromLiteral(actual).equals(getValueFromLiteral(expected));
+        }
+
+        return false;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TestExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TestExpressionVerifier.java
@@ -43,6 +43,20 @@ public class TestExpressionVerifier
         assertFalse(verifier.process(actual, expression("NOT(X = 3 AND X = 3 AND X < 10)")));
     }
 
+    @Test
+    public void testCast()
+            throws Exception
+    {
+        SymbolAliases aliases = SymbolAliases.builder()
+                .put("X", new SymbolReference("orderkey"))
+                .build();
+
+        ExpressionVerifier verifier = new ExpressionVerifier(aliases);
+        assertTrue(verifier.process(expression("CAST('2' AS varchar)"), expression("CAST('2' AS varchar)")));
+        assertFalse(verifier.process(expression("CAST('2' AS varchar)"), expression("CAST('2' AS bigint)")));
+        assertTrue(verifier.process(expression("CAST(orderkey AS varchar)"), expression("CAST(X AS varchar)")));
+    }
+
     private Expression expression(String sql)
     {
         return rewriteQualifiedNamesToSymbolReferences(parser.createExpression(sql));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
@@ -190,7 +190,7 @@ public class TestMergeWindows
                                 ImmutableList.of(functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
                                 window(specificationB,
                                         ImmutableList.of(functionCall("lag", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS, "ONE", "ZERO"))),
-                                        project(ImmutableMap.of("ONE", expression("1"), "ZERO", expression("0.0")),
+                                        project(ImmutableMap.of("ONE", expression("CAST(1 AS bigint)"), "ZERO", expression("0.0")),
                                                 window(specificationA,
                                                         ImmutableList.of(
                                                         functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
@@ -212,7 +212,7 @@ public class TestMergeWindows
                                 ImmutableList.of(
                                 functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS)),
                                 functionCall("lag", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS, "ONE", "ZERO"))),
-                                project(ImmutableMap.of("ONE", expression("1"), "ZERO", expression("0.0")),
+                                project(ImmutableMap.of("ONE", expression("CAST(1 AS bigint)"), "ZERO", expression("0.0")),
                                         window(specificationA,
                                                 ImmutableList.of(
                                                 functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),


### PR DESCRIPTION
The query planner currently splits comparison expressions in
join criteria and pushes each term to a different side of the join.

This causes expressions that can be evaluated entirely on one side
of the tree (e.g., comparisons against constants) to be evaluated
as join conditions instead of being pushed down entirely to either
side of the join.

This fix treats any expression that is not a pure comparison that
straddles the join as a "complex" expression. Predicate pushdown
and other optimizers then take care of moving it to the appropriate
branch of the join.

```sql
SELECT *
FROM (VALUES 1) t(x)
    JOIN (VALUES (1,2)) u(x,y) ON t.x = u.x AND cast(u.y AS varchar) = '2';
```

Before:

```
     - Output[x, x, y] => [field:integer, field:integer, field_2:integer]
             x := field
             x := field
             y := field_2
         - Project => [field:integer, field_2:integer]
             - InnerJoin[("field" = "field_1") AND ("expr_8" = "expr_10")] => [field:integer, expr_8:varchar, expr_10:varchar, field_1:integer, field_2:intege
                 - Project => [field:integer, expr_8:varchar]
                         expr_8 := CAST('2' AS varchar)
                     - Values => [field:integer]
                             (1)
                 - Project => [expr_10:varchar, field_1:integer, field_2:integer]
                         expr_10 := CAST("field_2" AS varchar)
                     - Filter[(CAST("field_2" AS varchar) = CAST('2' AS varchar))] => [field_1:integer, field_2:integer]
                         - Values => [field_1:integer, field_2:integer]
                                 (1, 2)
```

After:

```
     - Output[x, x, y] => [field:integer, field:integer, field_2:integer]
             x := field
             x := field
             y := field_2
         - Project => [field:integer, field_2:integer]
             - InnerJoin[("field" = "field_1")] => [field:integer, field_1:integer, field_2:integer]
                 - Values => [field:integer]
                         (1)
                 - Filter[(CAST("field_2" AS varchar) = CAST('2' AS varchar))] => [field_1:integer, field_2:integer]
                     - Values => [field_1:integer, field_2:integer]
                             (1, 2)
```