### PR TITLE
Include message in 403 response from coordinator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceUtil.java
@@ -92,7 +92,11 @@ final class ResourceUtil
             accessControl.checkCanSetUser(principal, user);
         }
         catch (AccessDeniedException e) {
-            throw new WebApplicationException(e.getMessage(), Status.FORBIDDEN);
+            throw new WebApplicationException(
+                    e,
+                    Response.status(Status.FORBIDDEN)
+                            .entity("Access denied: " + e.getMessage())
+                            .build());
         }
 
         Identity identity = new Identity(user, Optional.ofNullable(principal));


### PR DESCRIPTION
Jax-rs' WebApplicationException produces a canned response
that doesn't include the provided message unless the Response
object is passed explicitly during construction.

This change provides a more user-friendly message in the HTTP
response body in case of an "access denied" error.