### PR TITLE
Rename SemanticExceptions methods

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -128,7 +128,7 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MULTIPLE_FIELDS
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.STANDALONE_LAMBDA;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TYPE_MISMATCH;
-import static com.facebook.presto.sql.analyzer.SemanticExceptions.throwMissingAttributeException;
+import static com.facebook.presto.sql.analyzer.SemanticExceptions.missingAttributeException;
 import static com.facebook.presto.sql.tree.Extract.Field.TIMEZONE_HOUR;
 import static com.facebook.presto.sql.tree.Extract.Field.TIMEZONE_MINUTE;
 import static com.facebook.presto.type.ArrayParametricType.ARRAY;
@@ -370,7 +370,7 @@ public class ExpressionAnalyzer
                         return handleResolvedField(node, resolvedField.get());
                     }
                     if (!scope.isColumnReference(qualifiedName)) {
-                        throwMissingAttributeException(node, qualifiedName);
+                        throw missingAttributeException(node, qualifiedName);
                     }
                 }
             }
@@ -390,7 +390,7 @@ public class ExpressionAnalyzer
                 }
             }
             if (rowFieldType == null) {
-                throwMissingAttributeException(node);
+                throw missingAttributeException(node);
             }
 
             expressionTypes.put(node, rowFieldType);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -226,13 +226,13 @@ public class ExpressionAnalyzer
 
     public Type analyze(Expression expression, Scope scope)
     {
-        Visitor visitor = new Visitor(scope, symbolTypes);
+        Visitor visitor = new Visitor(scope);
         return visitor.process(expression, new StackableAstVisitor.StackableAstVisitorContext<>(Context.notInLambda()));
     }
 
     private Type analyze(Expression expression, Scope scope, Context context)
     {
-        Visitor visitor = new Visitor(scope, symbolTypes);
+        Visitor visitor = new Visitor(scope);
         return visitor.process(expression, new StackableAstVisitor.StackableAstVisitorContext<>(context));
     }
 
@@ -256,7 +256,7 @@ public class ExpressionAnalyzer
     {
         private final Scope scope;
 
-        private Visitor(Scope scope, Map<Symbol, Type> symbolTypes)
+        private Visitor(Scope scope)
         {
             this.scope = requireNonNull(scope, "scope is null");
         }
@@ -776,7 +776,6 @@ public class ExpressionAnalyzer
             if (node.getFilter().isPresent()) {
                 Expression expression = node.getFilter().get();
                 process(expression, context);
-                Type type = expressionTypes.get(expression);
             }
 
             ImmutableList.Builder<TypeSignatureProvider> argumentTypesBuilder = ImmutableList.builder();

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
@@ -27,8 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.sql.analyzer.SemanticExceptions.throwAmbiguousAttributeException;
-import static com.facebook.presto.sql.analyzer.SemanticExceptions.throwMissingAttributeException;
+import static com.facebook.presto.sql.analyzer.SemanticExceptions.ambiguousAttributeException;
+import static com.facebook.presto.sql.analyzer.SemanticExceptions.missingAttributeException;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Objects.requireNonNull;
@@ -70,7 +70,7 @@ public class Scope
 
     public ResolvedField resolveField(Expression expression, QualifiedName name)
     {
-        return tryResolveField(expression, name).orElseThrow(() -> throwMissingAttributeException(expression, name));
+        return tryResolveField(expression, name).orElseThrow(() -> missingAttributeException(expression, name));
     }
 
     public Optional<ResolvedField> tryResolveField(Expression expression)
@@ -103,7 +103,7 @@ public class Scope
     {
         List<Field> matches = relation.resolveFields(name);
         if (matches.size() > 1) {
-            throwAmbiguousAttributeException(node, name);
+            throw ambiguousAttributeException(node, name);
         }
 
         if (matches.isEmpty()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/SemanticExceptions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/SemanticExceptions.java
@@ -25,26 +25,26 @@ public final class SemanticExceptions
 {
     private SemanticExceptions() {}
 
-    public static SemanticException throwMissingAttributeException(Expression node, QualifiedName name)
+    public static SemanticException missingAttributeException(Expression node, QualifiedName name)
     {
         throw new SemanticException(MISSING_ATTRIBUTE, node, "Column '%s' cannot be resolved", name);
     }
 
     /**
-     * Use {@link #throwMissingAttributeException(Expression, QualifiedName)} instead.
+     * Use {@link #missingAttributeException(Expression, QualifiedName)} instead.
      */
     @Deprecated
-    public static SemanticException throwMissingAttributeException(Expression node)
+    public static SemanticException missingAttributeException(Expression node)
     {
         throw new SemanticException(MISSING_ATTRIBUTE, node, "Column '%s' cannot be resolved", node);
     }
 
-    public static SemanticException throwAmbiguousAttributeException(Expression node, QualifiedName name)
+    public static SemanticException ambiguousAttributeException(Expression node, QualifiedName name)
     {
         throw new SemanticException(AMBIGUOUS_ATTRIBUTE, node, "Column '%s' is ambiguous", name);
     }
 
-    public static SemanticException throwNotSupportedException(Node node, String notSupportedFeatureDescription)
+    public static SemanticException notSupportedException(Node node, String notSupportedFeatureDescription)
     {
         throw new SemanticException(NOT_SUPPORTED, node, notSupportedFeatureDescription + " is not supported");
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -81,7 +81,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.sql.analyzer.SemanticExceptions.throwNotSupportedException;
+import static com.facebook.presto.sql.analyzer.SemanticExceptions.notSupportedException;
 import static com.facebook.presto.sql.planner.ExpressionInterpreter.evaluateConstantExpression;
 import static com.facebook.presto.sql.tree.Join.Type.INNER;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
@@ -197,7 +197,7 @@ class RelationPlanner
                 unnest = (Unnest) node.getRight();
             }
             if (node.getType() != Join.Type.CROSS && node.getType() != Join.Type.IMPLICIT) {
-                throwNotSupportedException(unnest, "UNNEST on other than the right side of CROSS JOIN");
+                throw notSupportedException(unnest, "UNNEST on other than the right side of CROSS JOIN");
             }
             return planCrossJoinUnnest(leftPlan, node, unnest);
         }
@@ -298,7 +298,7 @@ class RelationPlanner
                 Set<InPredicate> inPredicates = subqueryPlanner.collectInPredicateSubqueries(complexExpression, node);
                 if (!inPredicates.isEmpty()) {
                     InPredicate inPredicate = Iterables.getLast(inPredicates);
-                    throwNotSupportedException(inPredicate, "IN with subquery predicate in join condition");
+                    throw notSupportedException(inPredicate, "IN with subquery predicate in join condition");
                 }
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -53,7 +53,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
-import static com.facebook.presto.sql.analyzer.SemanticExceptions.throwNotSupportedException;
+import static com.facebook.presto.sql.analyzer.SemanticExceptions.notSupportedException;
 import static com.facebook.presto.sql.planner.ExpressionNodeInliner.replaceExpression;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
@@ -362,7 +362,7 @@ class SubqueryPlanner
     {
         Map<Expression, Symbol> correlation = extractCorrelation(subPlan, subqueryNode);
         if (!correlationAllowed && !correlation.isEmpty()) {
-            throwNotSupportedException(subquery, "Correlated subquery in given context");
+            throw notSupportedException(subquery, "Correlated subquery in given context");
         }
         subPlan = subPlan.appendProjections(correlation.keySet(), symbolAllocator, idAllocator);
         subqueryNode = replaceExpressionsWithSymbols(subqueryNode, correlation);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/Predicates.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/Predicates.java
@@ -20,7 +20,7 @@ public class Predicates
 {
     private Predicates() {}
 
-    public static Predicate isInstanceOfAny(Class... classes)
+    public static <T> Predicate<T> isInstanceOfAny(Class... classes)
     {
         Predicate predicate = alwaysFalse();
         for (Class clazz : classes) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToScalarApply.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToScalarApply.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.sql.analyzer.SemanticExceptions.throwNotSupportedException;
+import static com.facebook.presto.sql.analyzer.SemanticExceptions.notSupportedException;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
 import static com.facebook.presto.sql.planner.plan.SimplePlanRewriter.rewriteWith;
 import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
@@ -124,7 +124,7 @@ public class TransformQuantifiedComparisonApplyToScalarApply
             Symbol outputColumnSymbol = getOnlyElement(subqueryPlan.getOutputSymbols());
             Type outputColumnType = types.get(outputColumnSymbol);
             if (!outputColumnType.isOrderable()) {
-                throwNotSupportedException(quantifiedComparison, "Quantified comparison '= ALL' or '<> ANY' for unorderable type " + outputColumnType.getDisplayName());
+                throw notSupportedException(quantifiedComparison, "Quantified comparison '= ALL' or '<> ANY' for unorderable type " + outputColumnType.getDisplayName());
             }
 
             List<TypeSignature> outputColumnTypeSignature = ImmutableList.of(outputColumnType.getTypeSignature());


### PR DESCRIPTION
Rename SemanticExceptions methods

Since Intellij raises a warning when a method which always throws an
excepition is not prefixed with `throw` keyword, there is no need to
prefix SemanticExceptions method with 'throw' prefix.

This commit also fixes ralated Intellij warnings.
