### PR TITLE
Fix Hive INSERT statement in tests to work with EMR

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/AllSimpleTypesTableDefinitions.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/AllSimpleTypesTableDefinitions.java
@@ -111,7 +111,7 @@ public final class AllSimpleTypesTableDefinitions
 
     public static void populateDataToHiveTable(String tableName)
     {
-        onHive().executeQuery(format("INSERT INTO %s SELECT * FROM %s",
+        onHive().executeQuery(format("INSERT INTO TABLE %s SELECT * FROM %s",
                 tableName,
                 format(tableNameFormat, "textfile")));
     }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestExternalHiveTable.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestExternalHiveTable.java
@@ -91,7 +91,7 @@ public class TestExternalHiveTable
     private void insertNationPartition(TableInstance nation, int partition)
     {
         onHive().executeQuery(
-                "INSERT INTO " + EXTERNAL_TABLE_NAME + " PARTITION (p_regionkey=" + partition + ")"
+                "INSERT INTO TABLE " + EXTERNAL_TABLE_NAME + " PARTITION (p_regionkey=" + partition + ")"
                         + " SELECT p_nationkey, p_name, p_comment FROM " + nation.getNameInDatabase()
                         + " WHERE p_regionkey=" + partition);
     }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveCoercion.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveCoercion.java
@@ -214,7 +214,7 @@ public class TestHiveCoercion
     {
         String tableName = mutableTableInstanceOf(tableDefinition).getNameInDatabase();
 
-        executeHiveQuery(format("INSERT INTO %s " +
+        executeHiveQuery(format("INSERT INTO TABLE %s " +
                 "PARTITION (id=1) " +
                 "VALUES" +
                 "(-1, 2, -3, 100, -101, 2323, 12345, '-1025', 0.5)," +


### PR DESCRIPTION
This is required because older versions of hive in EMR does not support INSERT statements without a TABLE clause