### PR TITLE
Fix isBlocked() behaviour in TableWriterOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
@@ -37,6 +37,7 @@ import static com.facebook.presto.sql.planner.plan.TableWriterNode.CreateHandle;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.InsertHandle;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static java.util.Objects.requireNonNull;
@@ -120,8 +121,8 @@ public class TableWriterOperator
     private final ConnectorPageSink pageSink;
     private final List<Integer> inputChannels;
 
-    private ListenableFuture<?> blocked = NOT_BLOCKED;
-    private CompletableFuture<Collection<Slice>> finishFuture;
+    private ListenableFuture<?> appendFuture = NOT_BLOCKED;
+    private ListenableFuture<Collection<Slice>> finishFuture = immediateFuture(null);
     private State state = State.RUNNING;
     private long rowCount;
     private boolean committed;
@@ -153,37 +154,32 @@ public class TableWriterOperator
     {
         if (state == State.RUNNING) {
             state = State.FINISHING;
-            finishFuture = pageSink.finish();
-            blocked = toListenableFuture(finishFuture);
+            finishFuture = toListenableFuture(pageSink.finish());
         }
     }
 
     @Override
     public boolean isFinished()
     {
-        updateBlockedIfNecessary();
-        return state == State.FINISHED && blocked == NOT_BLOCKED;
+        return state == State.FINISHED;
     }
 
     @Override
     public ListenableFuture<?> isBlocked()
     {
-        updateBlockedIfNecessary();
-        return blocked;
+        if (!appendFuture.isDone()) {
+            return appendFuture;
+        }
+        if (!finishFuture.isDone()) {
+            return finishFuture;
+        }
+        return NOT_BLOCKED;
     }
 
     @Override
     public boolean needsInput()
     {
-        updateBlockedIfNecessary();
-        return state == State.RUNNING && blocked == NOT_BLOCKED;
-    }
-
-    private void updateBlockedIfNecessary()
-    {
-        if (blocked != NOT_BLOCKED && blocked.isDone()) {
-            blocked = NOT_BLOCKED;
-        }
+        return state == State.RUNNING && isBlocked() == NOT_BLOCKED;
     }
 
     @Override
@@ -199,7 +195,7 @@ public class TableWriterOperator
 
         CompletableFuture<?> future = pageSink.appendPage(new Page(blocks));
         if (!future.isDone()) {
-            this.blocked = toListenableFuture(future);
+            this.appendFuture = toListenableFuture(future);
         }
         rowCount += page.getPositionCount();
     }
@@ -207,7 +203,7 @@ public class TableWriterOperator
     @Override
     public Page getOutput()
     {
-        if (state != State.FINISHING || !blocked.isDone()) {
+        if (state != State.FINISHING || !isBlocked().isDone()) {
             return null;
         }
         state = State.FINISHED;


### PR DESCRIPTION
Operator#finish() is called when source operator is completed. So, it may be called
before Operator#addInput() is finished on the destination operator. In such situation
the destination operator must still be in a BLOCKED state, until the addInput() operation
is completed.

Instead of overwriting the addInput() future with the finish() future it is needed to
keep them both. isBlocked() must return one that is not yet completed.