### PR TITLE
Fix BlackholePageSink

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorPageSink.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorPageSink.java
@@ -29,6 +29,13 @@ public interface ConnectorPageSink
      */
     CompletableFuture<?> appendPage(Page page);
 
+    /**
+     * Notifies the connector that no more pages will be appended and returns
+     * connector-specific information that will be sent to the coordinator to
+     * complete the write operation. This method may be called immediately
+     * after the previous call to {@link #appendPage} (even if the returned
+     * future is not complete).
+     */
     CompletableFuture<Collection<Slice>> finish();
 
     void abort();


### PR DESCRIPTION
Presto may call `PageSink#finish()` before the latest write is finished.
Connector should take care of such situation itself, returning the same
blocked future that write is waiting on.