### PR TITLE
Add connector comment field for SHOW COLUMNS

### DIFF
--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -100,16 +100,16 @@ public class TestCassandraDistributed
     {
         MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
 
-        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR)
-                .row("orderkey", "bigint", "")
-                .row("custkey", "bigint", "")
-                .row("orderstatus", "varchar", "")
-                .row("totalprice", "double", "")
-                .row("orderdate", "varchar", "")
-                .row("orderpriority", "varchar", "")
-                .row("clerk", "varchar", "")
-                .row("shippriority", "integer", "")
-                .row("comment", "varchar", "")
+        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("orderkey", "bigint", "", "")
+                .row("custkey", "bigint", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("totalprice", "double", "", "")
+                .row("orderdate", "varchar", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("clerk", "varchar", "", "")
+                .row("shippriority", "integer", "", "")
+                .row("comment", "varchar", "", "")
                 .build();
 
         assertEquals(actual, expectedParametrizedVarchar);

--- a/presto-docs/src/main/sphinx/connector/accumulo.rst
+++ b/presto-docs/src/main/sphinx/connector/accumulo.rst
@@ -100,12 +100,12 @@ Simply issue a ``CREATE TABLE`` statement to create a new Presto/Accumulo table:
 
 .. code-block:: none
 
-      Column   |  Type   |                      Comment
-    -----------+---------+---------------------------------------------------
-     recordkey | varchar | Accumulo row ID
-     name      | varchar | Accumulo column name:name. Indexed: false
-     age       | bigint  | Accumulo column age:age. Indexed: false
-     birthday  | date    | Accumulo column birthday:birthday. Indexed: false
+      Column   |  Type   | Extra |                      Comment
+    -----------+---------+-------+---------------------------------------------------
+     recordkey | varchar |       | Accumulo row ID
+     name      | varchar |       | Accumulo column name:name. Indexed: false
+     age       | bigint  |       | Accumulo column age:age. Indexed: false
+     birthday  | date    |       | Accumulo column birthday:birthday. Indexed: false
 
 This command will create a new Accumulo table with the ``recordkey`` column
 as the Accumulo row ID. The name, age, and birthday columns are mapped to
@@ -146,12 +146,12 @@ For example:
 
 .. code-block:: none
 
-      Column   |  Type   |                    Comment
-    -----------+---------+-----------------------------------------------
-     recordkey | varchar | Accumulo row ID
-     name      | varchar | Accumulo column metadata:name. Indexed: false
-     age       | bigint  | Accumulo column metadata:age. Indexed: false
-     birthday  | date    | Accumulo column metadata:date. Indexed: false
+      Column   |  Type   | Extra |                    Comment
+    -----------+---------+-------+-----------------------------------------------
+     recordkey | varchar |       | Accumulo row ID
+     name      | varchar |       | Accumulo column metadata:name. Indexed: false
+     age       | bigint  |       | Accumulo column metadata:age. Indexed: false
+     birthday  | date    |       | Accumulo column metadata:date. Indexed: false
 
 You can then issue ``INSERT`` statements to put data into Accumulo.
 
@@ -665,11 +665,11 @@ when creating the external table.
 
 .. code-block:: none
 
-     Column |  Type   |               Comment
-    --------+---------+-------------------------------------
-     a      | varchar | Accumulo row ID
-     b      | bigint  | Accumulo column b:b. Indexed: true
-     c      | date    | Accumulo column c:c. Indexed: true
+     Column |  Type   | Extra |               Comment
+    --------+---------+-------+-------------------------------------
+     a      | varchar |       | Accumulo row ID
+     b      | bigint  |       | Accumulo column b:b. Indexed: true
+     c      | date    |       | Accumulo column c:c. Indexed: true
 
 2. Using the ZooKeeper CLI, delete the corresponding znode.  Note this uses the default ZooKeeper
 metadata root of ``/presto-accumulo``

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -182,11 +182,11 @@ This table can be described in Presto::
 
 .. code-block:: none
 
-     Column  |  Type   | Null | Partition Key | Comment
-    ---------+---------+------+---------------+---------
-     user_id | bigint  | true | true          |
-     fname   | varchar | true | false         |
-     lname   | varchar | true | false         |
+     Column  |  Type   | Extra | Comment
+    ---------+---------+-------+---------
+     user_id | bigint  |       |
+     fname   | varchar |       |
+     lname   | varchar |       |
     (3 rows)
 
 This table can then be queried in Presto::

--- a/presto-docs/src/main/sphinx/connector/kafka-tutorial.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka-tutorial.rst
@@ -150,19 +150,19 @@ built-in ones:
 .. code-block:: none
 
     presto:tpch> DESCRIBE customer;
-          Column       |  Type   | Null | Partition Key |                   Comment
-    -------------------+---------+------+---------------+---------------------------------------------
-     _partition_id     | bigint  | true | false         | Partition Id
-     _partition_offset | bigint  | true | false         | Offset for the message within the partition
-     _segment_start    | bigint  | true | false         | Segment start offset
-     _segment_end      | bigint  | true | false         | Segment end offset
-     _segment_count    | bigint  | true | false         | Running message count per segment
-     _key              | varchar | true | false         | Key text
-     _key_corrupt      | boolean | true | false         | Key data is corrupt
-     _key_length       | bigint  | true | false         | Total number of key bytes
-     _message          | varchar | true | false         | Message text
-     _message_corrupt  | boolean | true | false         | Message data is corrupt
-     _message_length   | bigint  | true | false         | Total number of message bytes
+          Column       |  Type   | Extra |                   Comment
+    -------------------+---------+-------+---------------------------------------------
+     _partition_id     | bigint  |       | Partition Id
+     _partition_offset | bigint  |       | Offset for the message within the partition
+     _segment_start    | bigint  |       | Segment start offset
+     _segment_end      | bigint  |       | Segment end offset
+     _segment_count    | bigint  |       | Running message count per segment
+     _key              | varchar |       | Key text
+     _key_corrupt      | boolean |       | Key data is corrupt
+     _key_length       | bigint  |       | Total number of key bytes
+     _message          | varchar |       | Message text
+     _message_corrupt  | boolean |       | Message data is corrupt
+     _message_length   | bigint  |       | Total number of message bytes
     (11 rows)
 
     presto:tpch> SELECT count(*) FROM customer;
@@ -226,20 +226,20 @@ The customer table now has an additional column: ``kafka_key``.
 .. code-block:: none
 
     presto:tpch> DESCRIBE customer;
-          Column       |  Type   | Null | Partition Key |                   Comment
-    -------------------+---------+------+---------------+---------------------------------------------
-     kafka_key         | bigint  | true | false         |
-     _partition_id     | bigint  | true | false         | Partition Id
-     _partition_offset | bigint  | true | false         | Offset for the message within the partition
-     _segment_start    | bigint  | true | false         | Segment start offset
-     _segment_end      | bigint  | true | false         | Segment end offset
-     _segment_count    | bigint  | true | false         | Running message count per segment
-     _key              | varchar | true | false         | Key text
-     _key_corrupt      | boolean | true | false         | Key data is corrupt
-     _key_length       | bigint  | true | false         | Total number of key bytes
-     _message          | varchar | true | false         | Message text
-     _message_corrupt  | boolean | true | false         | Message data is corrupt
-     _message_length   | bigint  | true | false         | Total number of message bytes
+          Column       |  Type   | Extra |                   Comment
+    -------------------+---------+-------+---------------------------------------------
+     kafka_key         | bigint  |       |
+     _partition_id     | bigint  |       | Partition Id
+     _partition_offset | bigint  |       | Offset for the message within the partition
+     _segment_start    | bigint  |       | Segment start offset
+     _segment_end      | bigint  |       | Segment end offset
+     _segment_count    | bigint  |       | Running message count per segment
+     _key              | varchar |       | Key text
+     _key_corrupt      | boolean |       | Key data is corrupt
+     _key_length       | bigint  |       | Total number of key bytes
+     _message          | varchar |       | Message text
+     _message_corrupt  | boolean |       | Message data is corrupt
+     _message_length   | bigint  |       | Total number of message bytes
     (12 rows)
 
     presto:tpch> SELECT kafka_key FROM customer ORDER BY kafka_key LIMIT 10;
@@ -343,29 +343,29 @@ the sum query from earlier can operate on the ``account_balance`` column directl
 .. code-block:: none
 
     presto:tpch> DESCRIBE customer;
-          Column       |  Type   | Null | Partition Key |                   Comment
-    -------------------+---------+------+---------------+---------------------------------------------
-     kafka_key         | bigint  | true | false         |
-     row_number        | bigint  | true | false         |
-     customer_key      | bigint  | true | false         |
-     name              | varchar | true | false         |
-     address           | varchar | true | false         |
-     nation_key        | bigint  | true | false         |
-     phone             | varchar | true | false         |
-     account_balance   | double  | true | false         |
-     market_segment    | varchar | true | false         |
-     comment           | varchar | true | false         |
-     _partition_id     | bigint  | true | false         | Partition Id
-     _partition_offset | bigint  | true | false         | Offset for the message within the partition
-     _segment_start    | bigint  | true | false         | Segment start offset
-     _segment_end      | bigint  | true | false         | Segment end offset
-     _segment_count    | bigint  | true | false         | Running message count per segment
-     _key              | varchar | true | false         | Key text
-     _key_corrupt      | boolean | true | false         | Key data is corrupt
-     _key_length       | bigint  | true | false         | Total number of key bytes
-     _message          | varchar | true | false         | Message text
-     _message_corrupt  | boolean | true | false         | Message data is corrupt
-     _message_length   | bigint  | true | false         | Total number of message bytes
+          Column       |  Type   | Extra |                   Comment
+    -------------------+---------+-------+---------------------------------------------
+     kafka_key         | bigint  |       |
+     row_number        | bigint  |       |
+     customer_key      | bigint  |       |
+     name              | varchar |       |
+     address           | varchar |       |
+     nation_key        | bigint  |       |
+     phone             | varchar |       |
+     account_balance   | double  |       |
+     market_segment    | varchar |       |
+     comment           | varchar |       |
+     _partition_id     | bigint  |       | Partition Id
+     _partition_offset | bigint  |       | Offset for the message within the partition
+     _segment_start    | bigint  |       | Segment start offset
+     _segment_end      | bigint  |       | Segment end offset
+     _segment_count    | bigint  |       | Running message count per segment
+     _key              | varchar |       | Key text
+     _key_corrupt      | boolean |       | Key data is corrupt
+     _key_length       | bigint  |       | Total number of key bytes
+     _message          | varchar |       | Message text
+     _message_corrupt  | boolean |       | Message data is corrupt
+     _message_length   | bigint  |       | Total number of message bytes
     (21 rows)
 
     presto:tpch> SELECT * FROM customer LIMIT 5;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -105,7 +105,7 @@ import static com.facebook.presto.hive.HiveTableProperties.getPartitionedBy;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.HiveType.toHiveType;
 import static com.facebook.presto.hive.HiveUtil.PRESTO_VIEW_FLAG;
-import static com.facebook.presto.hive.HiveUtil.annotateColumnComment;
+import static com.facebook.presto.hive.HiveUtil.columnExtraInfo;
 import static com.facebook.presto.hive.HiveUtil.decodeViewData;
 import static com.facebook.presto.hive.HiveUtil.encodeViewData;
 import static com.facebook.presto.hive.HiveUtil.hiveColumnHandles;
@@ -1330,7 +1330,8 @@ public class HiveMetadata
         return handle -> new ColumnMetadata(
                 handle.getName(),
                 typeManager.getType(handle.getTypeSignature()),
-                annotateColumnComment(columnComment.get(handle.getName()), handle.isPartitionKey()),
+                columnComment.get(handle.getName()).orElse(null),
+                columnExtraInfo(handle.isPartitionKey()),
                 handle.isHidden());
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -767,18 +767,9 @@ public final class HiveUtil
     }
 
     @Nullable
-    public static String annotateColumnComment(Optional<String> comment, boolean partitionKey)
+    public static String columnExtraInfo(boolean partitionKey)
     {
-        String normalizedComment = comment.orElse("").trim();
-        if (partitionKey) {
-            if (normalizedComment.isEmpty()) {
-                normalizedComment = "Partition Key";
-            }
-            else {
-                normalizedComment = "Partition Key: " + normalizedComment;
-            }
-        }
-        return normalizedComment.isEmpty() ? null : normalizedComment;
+        return partitionKey ? "partition key" : null;
     }
 
     public static List<String> toPartitionValues(String partitionName)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -147,7 +147,7 @@ import static com.facebook.presto.hive.HiveType.HIVE_INT;
 import static com.facebook.presto.hive.HiveType.HIVE_LONG;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.HiveType.toHiveType;
-import static com.facebook.presto.hive.HiveUtil.annotateColumnComment;
+import static com.facebook.presto.hive.HiveUtil.columnExtraInfo;
 import static com.facebook.presto.hive.HiveWriteUtils.createDirectory;
 import static com.facebook.presto.hive.util.Types.checkType;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -1991,7 +1991,8 @@ public abstract class AbstractTestHiveClient
                     .map(column -> new ColumnMetadata(
                             column.getName(),
                             column.getType(),
-                            annotateColumnComment(Optional.ofNullable(column.getComment()), partitionedBy.contains(column.getName())),
+                            column.getComment(),
+                            columnExtraInfo(partitionedBy.contains(column.getName())),
                             false))
                     .collect(toList());
             assertEquals(filterNonHiddenColumnMetadata(tableMetadata.getColumns()), expectedColumns);
@@ -2973,7 +2974,7 @@ public abstract class AbstractTestHiveClient
         assertTrue(map.containsKey(name));
         ColumnMetadata column = map.get(name);
         assertEquals(column.getType(), type, name);
-        assertEquals(column.getComment(), annotateColumnComment(Optional.empty(), partitionKey));
+        assertEquals(column.getExtraInfo(), columnExtraInfo(partitionKey));
     }
 
     protected static ImmutableMap<String, Integer> indexColumns(List<ColumnHandle> columnHandles)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -59,7 +59,7 @@ import static com.facebook.presto.hive.HiveTableProperties.BUCKETED_BY_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.BUCKET_COUNT_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.PARTITIONED_BY_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
-import static com.facebook.presto.hive.HiveUtil.annotateColumnComment;
+import static com.facebook.presto.hive.HiveUtil.columnExtraInfo;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.CharType.createCharType;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
@@ -263,7 +263,7 @@ public class TestHiveIntegrationSmokeTest
         assertEquals(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY), partitionedBy);
         for (ColumnMetadata columnMetadata : tableMetadata.getColumns()) {
             boolean partitionKey = partitionedBy.contains(columnMetadata.getName());
-            assertEquals(columnMetadata.getComment(), annotateColumnComment(Optional.empty(), partitionKey));
+            assertEquals(columnMetadata.getExtraInfo(), columnExtraInfo(partitionKey));
         }
 
         assertColumnType(tableMetadata, "_string", createUnboundedVarcharType());
@@ -356,10 +356,6 @@ public class TestHiveIntegrationSmokeTest
         // Verify the partition keys are correctly created
         List<String> partitionedBy = ImmutableList.of("partition_bigint", "partition_decimal_long");
         assertEquals(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY), partitionedBy);
-        for (ColumnMetadata columnMetadata : tableMetadata.getColumns()) {
-            boolean partitionKey = partitionedBy.contains(columnMetadata.getName());
-            assertEquals(columnMetadata.getComment(), annotateColumnComment(Optional.empty(), partitionKey));
-        }
 
         // Verify the column types
         assertColumnType(tableMetadata, "string_col", createUnboundedVarcharType());
@@ -504,13 +500,7 @@ public class TestHiveIntegrationSmokeTest
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, "test_create_partitioned_table_as");
         assertEquals(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY), storageFormat);
-
-        List<String> partitionedBy = ImmutableList.of("ship_priority", "order_status");
-        assertEquals(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY), partitionedBy);
-        for (ColumnMetadata columnMetadata : tableMetadata.getColumns()) {
-            boolean partitionKey = partitionedBy.contains(columnMetadata.getName());
-            assertEquals(columnMetadata.getComment(), annotateColumnComment(Optional.empty(), partitionKey));
-        }
+        assertEquals(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY), ImmutableList.of("ship_priority", "order_status"));
 
         List<?> partitions = getPartitions("test_create_partitioned_table_as");
         assertEquals(partitions.size(), 3);
@@ -702,13 +692,7 @@ public class TestHiveIntegrationSmokeTest
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
         assertEquals(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY), storageFormat);
 
-        List<String> partitionedBy = ImmutableList.of("orderstatus");
-        assertEquals(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY), partitionedBy);
-        for (ColumnMetadata columnMetadata : tableMetadata.getColumns()) {
-            boolean partitionKey = partitionedBy.contains(columnMetadata.getName());
-            assertEquals(columnMetadata.getComment(), annotateColumnComment(Optional.empty(), partitionKey));
-        }
-
+        assertEquals(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY), ImmutableList.of("orderstatus"));
         assertEquals(tableMetadata.getMetadata().getProperties().get(BUCKETED_BY_PROPERTY), ImmutableList.of("custkey", "custkey2"));
         assertEquals(tableMetadata.getMetadata().getProperties().get(BUCKET_COUNT_PROPERTY), 11);
 
@@ -838,13 +822,7 @@ public class TestHiveIntegrationSmokeTest
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
         assertEquals(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY), storageFormat);
 
-        List<String> partitionedBy = ImmutableList.of("partition_key");
-        assertEquals(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY), partitionedBy);
-        for (ColumnMetadata columnMetadata : tableMetadata.getColumns()) {
-            boolean partitionKey = partitionedBy.contains(columnMetadata.getName());
-            assertEquals(columnMetadata.getComment(), annotateColumnComment(Optional.empty(), partitionKey));
-        }
-
+        assertEquals(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY), ImmutableList.of("partition_key"));
         assertEquals(tableMetadata.getMetadata().getProperties().get(BUCKETED_BY_PROPERTY), ImmutableList.of("bucket_key"));
         assertEquals(tableMetadata.getMetadata().getProperties().get(BUCKET_COUNT_PROPERTY), 11);
 
@@ -1337,14 +1315,14 @@ public class TestHiveIntegrationSmokeTest
 
         MaterializedResult actual = computeActual("SHOW COLUMNS FROM test_show_columns_partition_key");
         MaterializedResult expected = resultBuilder(getSession(), canonicalizeType(createUnboundedVarcharType()), canonicalizeType(createUnboundedVarcharType()), canonicalizeType(createUnboundedVarcharType()))
-                .row("grape", canonicalizeTypeName("bigint"), "")
-                .row("orange", canonicalizeTypeName("bigint"), "")
-                .row("pear", canonicalizeTypeName("varchar(65535)"), "")
-                .row("mango", canonicalizeTypeName("integer"), "")
-                .row("lychee", canonicalizeTypeName("smallint"), "")
-                .row("kiwi", canonicalizeTypeName("tinyint"), "")
-                .row("apple", canonicalizeTypeName("varchar"), "Partition Key")
-                .row("pineapple", canonicalizeTypeName("varchar(65535)"), "Partition Key")
+                .row("grape", canonicalizeTypeName("bigint"), "", "")
+                .row("orange", canonicalizeTypeName("bigint"), "", "")
+                .row("pear", canonicalizeTypeName("varchar(65535)"), "", "")
+                .row("mango", canonicalizeTypeName("integer"), "", "")
+                .row("lychee", canonicalizeTypeName("smallint"), "", "")
+                .row("kiwi", canonicalizeTypeName("tinyint"), "", "")
+                .row("apple", canonicalizeTypeName("varchar"), "partition key", "")
+                .row("pineapple", canonicalizeTypeName("varchar(65535)"), "partition key", "")
                 .build();
         assertEquals(actual, expected);
     }
@@ -1865,7 +1843,7 @@ public class TestHiveIntegrationSmokeTest
             assertEquals(partitionByProperty, partitionKeys);
             for (ColumnMetadata columnMetadata : tableMetadata.getColumns()) {
                 boolean partitionKey = partitionKeys.contains(columnMetadata.getName());
-                assertEquals(columnMetadata.getComment(), annotateColumnComment(Optional.empty(), partitionKey));
+                assertEquals(columnMetadata.getExtraInfo(), columnExtraInfo(partitionKey));
             }
         }
         else {

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
@@ -70,6 +70,7 @@ public class InformationSchemaMetadata
                     .column("is_nullable", createUnboundedVarcharType())
                     .column("data_type", createUnboundedVarcharType())
                     .column("comment", createUnboundedVarcharType())
+                    .column("extra_info", createUnboundedVarcharType())
                     .build())
             .table(tableMetadataBuilder(TABLE_TABLES)
                     .column("table_catalog", createUnboundedVarcharType())

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -169,7 +169,8 @@ public class InformationSchemaPageSourceProvider
                         null,
                         "YES",
                         column.getType().getDisplayName(),
-                        column.getComment());
+                        column.getComment(),
+                        column.getExtraInfo());
                 ordinalPosition++;
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -244,6 +244,7 @@ final class ShowQueriesRewrite
                     selectList(
                             aliasedName("column_name", "Column"),
                             aliasedName("data_type", "Type"),
+                            aliasedNullToEmpty("extra_info", "Extra"),
                             aliasedNullToEmpty("comment", "Comment")),
                     from(tableName.getCatalogName(), TABLE_COLUMNS),
                     logicalAnd(

--- a/presto-main/src/test/java/com/facebook/presto/TestHiddenColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/TestHiddenColumns.java
@@ -46,10 +46,10 @@ public class TestHiddenColumns
     public void testDescribeTable()
             throws Exception
     {
-        MaterializedResult expected = MaterializedResult.resultBuilder(TEST_SESSION, VARCHAR, VARCHAR, VARCHAR)
-                .row("regionkey", "bigint", "")
-                .row("name", "varchar(25)", "")
-                .row("comment", "varchar(152)", "")
+        MaterializedResult expected = MaterializedResult.resultBuilder(TEST_SESSION, VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("regionkey", "bigint", "", "")
+                .row("name", "varchar(25)", "", "")
+                .row("comment", "varchar(152)", "", "")
                 .build();
         assertEquals(runner.execute("DESC REGION"), expected);
     }

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
@@ -188,16 +188,16 @@ public class TestMySqlDistributedQueries
     {
         MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
 
-        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR)
-                .row("orderkey", "bigint", "")
-                .row("custkey", "bigint", "")
-                .row("orderstatus", "varchar(255)", "")
-                .row("totalprice", "double", "")
-                .row("orderdate", "date", "")
-                .row("orderpriority", "varchar(255)", "")
-                .row("clerk", "varchar(255)", "")
-                .row("shippriority", "integer", "")
-                .row("comment", "varchar(255)", "")
+        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("orderkey", "bigint", "", "")
+                .row("custkey", "bigint", "", "")
+                .row("orderstatus", "varchar(255)", "", "")
+                .row("totalprice", "double", "", "")
+                .row("orderdate", "date", "", "")
+                .row("orderpriority", "varchar(255)", "", "")
+                .row("clerk", "varchar(255)", "", "")
+                .row("shippriority", "integer", "", "")
+                .row("comment", "varchar(255)", "", "")
                 .build();
 
         assertEquals(actual, expectedParametrizedVarchar);

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -27,7 +27,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import static com.facebook.presto.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
-import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -64,16 +63,16 @@ public class TestMySqlIntegrationSmokeTest
         MaterializedResult actualColumns = computeActual("DESC ORDERS").toJdbcTypes();
 
         // some connectors don't support dates, and some do not support parametrized varchars, so we check multiple options
-        MaterializedResult expectedColumns = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, VARCHAR, VARCHAR)
-                .row("orderkey", "bigint", "")
-                .row("custkey", "bigint", "")
-                .row("orderstatus", "varchar(255)", "")
-                .row("totalprice", "double", "")
-                .row("orderdate", "date", "")
-                .row("orderpriority", "varchar(255)", "")
-                .row("clerk", "varchar(255)", "")
-                .row("shippriority", "integer", "")
-                .row("comment", "varchar(255)", "")
+        MaterializedResult expectedColumns = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("orderkey", "bigint", "", "")
+                .row("custkey", "bigint", "", "")
+                .row("orderstatus", "varchar(255)", "", "")
+                .row("totalprice", "double", "", "")
+                .row("orderdate", "date", "", "")
+                .row("orderpriority", "varchar(255)", "", "")
+                .row("clerk", "varchar(255)", "", "")
+                .row("shippriority", "integer", "", "")
+                .row("comment", "varchar(255)", "", "")
                 .build();
         assertEquals(actualColumns, expectedColumns);
     }
@@ -121,8 +120,9 @@ public class TestMySqlIntegrationSmokeTest
         execute("CREATE TABLE tpch.mysql_test_tinyint1 (c_tinyint tinyint(1))");
 
         MaterializedResult actual = computeActual("SHOW COLUMNS FROM mysql_test_tinyint1");
-        MaterializedResult expected = MaterializedResult.resultBuilder(getSession(), TINYINT)
-                .row("c_tinyint", "tinyint", "").build();
+        MaterializedResult expected = MaterializedResult.resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("c_tinyint", "tinyint", "", "")
+                .build();
 
         assertEquals(actual, expected);
 

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/catalog/describe.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/catalog/describe.result
@@ -1,5 +1,5 @@
 -- delimiter: |; trimValues:true;
-n_nationkey | bigint  | |
-n_name      | varchar(25) | |
-n_regionkey | bigint  | |
-n_comment   | varchar(152) | |
+n_nationkey | bigint  | | |
+n_name      | varchar(25) | | |
+n_regionkey | bigint  | | |
+n_comment   | varchar(152) | | |

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/catalog/showColumns.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/catalog/showColumns.result
@@ -1,5 +1,5 @@
--- delimiter: |; ignoreOrder: true; ignoreExcessRows:true; trimValues:true; 
- node_id      | varchar |         |
- http_uri     | varchar |         |
- node_version | varchar |         |
- state        | varchar |         |
+-- delimiter: |; ignoreOrder: true; ignoreExcessRows:true; trimValues:true;
+ node_id      | varchar |       |         |
+ http_uri     | varchar |       |         |
+ node_version | varchar |       |         |
+ state        | varchar |       |         |

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/mysql/describe_real_table.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/mysql/describe_real_table.sql
@@ -3,8 +3,8 @@
 describe mysql.test.real_table_mysql
 --!
 -- delimiter: |; trimValues: true; ignoreOrder: true;
-id_employee        | integer     | |
-salary             | double      | |
-bonus              | real        | |
-tip                | real        | |
-tip2               | double      | |
+id_employee        | integer     | | |
+salary             | double      | | |
+bonus              | real        | | |
+tip                | real        | | |
+tip2               | double      | | |

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/mysql/describe_table.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/mysql/describe_table.sql
@@ -3,11 +3,11 @@
 describe mysql.test.workers_mysql
 --!
 -- delimiter: |; trimValues: true; ignoreOrder: true;
-id_employee        | integer     | |
-first_name         | varchar(32) | |
-last_name          | varchar(32) | |
-date_of_employment | date        | |
-department         | tinyint     | |
-id_department      | integer     | |
-name               | varchar(32) | |
-salary             | integer     | |
+id_employee        | integer     | | |
+first_name         | varchar(32) | | |
+last_name          | varchar(32) | | |
+date_of_employment | date        | | |
+department         | tinyint     | | |
+id_department      | integer     | | |
+name               | varchar(32) | | |
+salary             | integer     | | |

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/postgresql/describe_real_table.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/postgresql/describe_real_table.sql
@@ -3,8 +3,8 @@
 describe postgresql.public.real_table_psql
 --!
 -- delimiter: |; trimValues: true; ignoreOrder: true;
-id_employee        | integer     | |
-salary             | real        | |
-bonus              | double      | |
-tip                | real        | |
-tip2               | double      | |
+id_employee        | integer     | | |
+salary             | real        | | |
+bonus              | double      | | |
+tip                | real        | | |
+tip2               | double      | | |

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/postgresql/describe_table.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/postgresql/describe_table.sql
@@ -3,11 +3,11 @@
 describe postgresql.public.workers_psql
 --!
 -- delimiter: |; trimValues: true; ignoreOrder: true;
-id_employee        | integer     | |
-first_name         | varchar(32) | |
-last_name          | varchar(32) | |
-date_of_employment | date        | |
-department         | integer     | |
-id_department      | integer     | |
-name               | varchar(32) | |
-salary             | integer     | |
+id_employee        | integer     | | |
+first_name         | varchar(32) | | |
+last_name          | varchar(32) | | |
+date_of_employment | date        | | |
+department         | integer     | | |
+id_department      | integer     | | |
+name               | varchar(32) | | |
+salary             | integer     | | |

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ColumnMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ColumnMetadata.java
@@ -24,6 +24,7 @@ public class ColumnMetadata
     private final String name;
     private final Type type;
     private final String comment;
+    private final String extraInfo;
     private final boolean hidden;
 
     public ColumnMetadata(String name, Type type)
@@ -32,6 +33,11 @@ public class ColumnMetadata
     }
 
     public ColumnMetadata(String name, Type type, String comment, boolean hidden)
+    {
+        this(name, type, comment, null, hidden);
+    }
+
+    public ColumnMetadata(String name, Type type, String comment, String extraInfo, boolean hidden)
     {
         if (name == null || name.isEmpty()) {
             throw new NullPointerException("name is null or empty");
@@ -43,6 +49,7 @@ public class ColumnMetadata
         this.name = name.toLowerCase(ENGLISH);
         this.type = type;
         this.comment = comment;
+        this.extraInfo = extraInfo;
         this.hidden = hidden;
     }
 
@@ -61,6 +68,11 @@ public class ColumnMetadata
         return comment;
     }
 
+    public String getExtraInfo()
+    {
+        return extraInfo;
+    }
+
     public boolean isHidden()
     {
         return hidden;
@@ -75,6 +87,9 @@ public class ColumnMetadata
         if (comment != null) {
             sb.append(", comment='").append(comment).append('\'');
         }
+        if (extraInfo != null) {
+            sb.append(", extraInfo='").append(extraInfo).append('\'');
+        }
         if (hidden) {
             sb.append(", hidden");
         }
@@ -85,7 +100,7 @@ public class ColumnMetadata
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, type, comment, hidden);
+        return Objects.hash(name, type, comment, extraInfo, hidden);
     }
 
     @Override
@@ -101,6 +116,7 @@ public class ColumnMetadata
         return Objects.equals(this.name, other.name) &&
                 Objects.equals(this.type, other.type) &&
                 Objects.equals(this.comment, other.comment) &&
+                Objects.equals(this.extraInfo, other.extraInfo) &&
                 Objects.equals(this.hidden, other.hidden);
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -687,9 +687,9 @@ public abstract class AbstractTestDistributedQueries
         // test SHOW COLUMNS
         actual = computeActual("SHOW COLUMNS FROM meta_test_view");
 
-        expected = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR)
-                .row("x", "bigint", "")
-                .row("y", "varchar(3)", "")
+        expected = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("x", "bigint", "", "")
+                .row("y", "varchar(3)", "", "")
                 .build();
 
         assertEquals(actual, expected);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -146,29 +146,29 @@ public abstract class AbstractTestIntegrationSmokeTest
             orderDateType = "varchar";
         }
         if (parametrizedVarchar) {
-            return MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, VARCHAR, VARCHAR)
-                    .row("orderkey", "bigint", "")
-                    .row("custkey", "bigint", "")
-                    .row("orderstatus", "varchar", "")
-                    .row("totalprice", "double", "")
-                    .row("orderdate", orderDateType, "")
-                    .row("orderpriority", "varchar", "")
-                    .row("clerk", "varchar", "")
-                    .row("shippriority", "integer", "")
-                    .row("comment", "varchar", "")
+            return MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                    .row("orderkey", "bigint", "", "")
+                    .row("custkey", "bigint", "", "")
+                    .row("orderstatus", "varchar", "", "")
+                    .row("totalprice", "double", "", "")
+                    .row("orderdate", orderDateType, "", "")
+                    .row("orderpriority", "varchar", "", "")
+                    .row("clerk", "varchar", "", "")
+                    .row("shippriority", "integer", "", "")
+                    .row("comment", "varchar", "", "")
                     .build();
         }
         else {
-            return MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, VARCHAR, VARCHAR)
-                    .row("orderkey", "bigint", "")
-                    .row("custkey", "bigint", "")
-                    .row("orderstatus", "varchar(1)", "")
-                    .row("totalprice", "double", "")
-                    .row("orderdate", orderDateType, "")
-                    .row("orderpriority", "varchar(15)", "")
-                    .row("clerk", "varchar(15)", "")
-                    .row("shippriority", "integer", "")
-                    .row("comment", "varchar(79)", "")
+            return MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                    .row("orderkey", "bigint", "", "")
+                    .row("custkey", "bigint", "", "")
+                    .row("orderstatus", "varchar(1)", "", "")
+                    .row("totalprice", "double", "", "")
+                    .row("orderdate", orderDateType, "", "")
+                    .row("orderpriority", "varchar(15)", "", "")
+                    .row("clerk", "varchar(15)", "", "")
+                    .row("shippriority", "integer", "", "")
+                    .row("comment", "varchar(79)", "", "")
                     .build();
         }
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4997,28 +4997,28 @@ public abstract class AbstractTestQueries
     {
         MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
 
-        MaterializedResult expectedUnparametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR)
-                .row("orderkey", "bigint", "")
-                .row("custkey", "bigint", "")
-                .row("orderstatus", "varchar", "")
-                .row("totalprice", "double", "")
-                .row("orderdate", "date", "")
-                .row("orderpriority", "varchar", "")
-                .row("clerk", "varchar", "")
-                .row("shippriority", "integer", "")
-                .row("comment", "varchar", "")
+        MaterializedResult expectedUnparametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("orderkey", "bigint", "", "")
+                .row("custkey", "bigint", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("totalprice", "double", "", "")
+                .row("orderdate", "date", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("clerk", "varchar", "", "")
+                .row("shippriority", "integer", "", "")
+                .row("comment", "varchar", "", "")
                 .build();
 
-        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR)
-                .row("orderkey", "bigint", "")
-                .row("custkey", "bigint", "")
-                .row("orderstatus", "varchar(1)", "")
-                .row("totalprice", "double", "")
-                .row("orderdate", "date", "")
-                .row("orderpriority", "varchar(15)", "")
-                .row("clerk", "varchar(15)", "")
-                .row("shippriority", "integer", "")
-                .row("comment", "varchar(79)", "")
+        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("orderkey", "bigint", "", "")
+                .row("custkey", "bigint", "", "")
+                .row("orderstatus", "varchar(1)", "", "")
+                .row("totalprice", "double", "", "")
+                .row("orderdate", "date", "", "")
+                .row("orderpriority", "varchar(15)", "", "")
+                .row("clerk", "varchar(15)", "", "")
+                .row("shippriority", "integer", "", "")
+                .row("comment", "varchar(79)", "", "")
                 .build();
 
         // Until we migrate all connectors to parametrized varchar we check two options


### PR DESCRIPTION
This allows connectors to provide additional metadata such as
"partition key" without needing to overload the comment field.