### PR TITLE
Enable support date and string statistics for file and stripe

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReader.java
@@ -21,6 +21,7 @@ import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.orc.metadata.MetadataReader;
 import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
+import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
 import com.facebook.presto.orc.metadata.StripeInformation;
 import com.facebook.presto.orc.metadata.StripeStatistics;
 import com.facebook.presto.orc.reader.StreamReader;
@@ -100,6 +101,7 @@ public class OrcRecordReader
             int bufferSize,
             int rowsInRowGroup,
             DateTimeZone hiveStorageTimeZone,
+            HiveWriterVersion hiveWriterVersion,
             MetadataReader metadataReader,
             DataSize maxMergeDistance,
             DataSize maxReadSize,
@@ -188,6 +190,7 @@ public class OrcRecordReader
                 this.presentColumns,
                 rowsInRowGroup,
                 predicate,
+                hiveWriterVersion,
                 metadataReader);
 
         streamReaders = createStreamReaders(orcDataSource, types, hiveStorageTimeZone, presentColumnsAndTypes.build());

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/MetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/MetadataReader.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.orc.metadata;
 
+import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -22,16 +24,16 @@ public interface MetadataReader
     PostScript readPostScript(byte[] data, int offset, int length)
             throws IOException;
 
-    Metadata readMetadata(InputStream inputStream)
+    Metadata readMetadata(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
             throws IOException;
 
-    Footer readFooter(InputStream inputStream)
+    Footer readFooter(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
             throws IOException;
 
-    StripeFooter readStripeFooter(List<OrcType> types, InputStream inputStream)
+    StripeFooter readStripeFooter(HiveWriterVersion hiveWriterVersion, List<OrcType> types, InputStream inputStream)
             throws IOException;
 
-    List<RowGroupIndex> readRowIndexes(InputStream inputStream)
+    List<RowGroupIndex> readRowIndexes(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
             throws IOException;
 
     List<HiveBloomFilter> readBloomFilterIndexes(InputStream inputStream)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc.metadata;
 import com.facebook.presto.hive.protobuf.CodedInputStream;
 import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
 import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
+import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -38,6 +39,8 @@ import java.util.Optional;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static com.facebook.presto.orc.metadata.CompressionKind.UNCOMPRESSED;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZLIB;
+import static com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion.ORC_HIVE_8732;
+import static com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion.ORIGINAL;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Character.MIN_SURROGATE;
 
@@ -59,30 +62,39 @@ public class OrcMetadataReader
                 postScript.getFooterLength(),
                 postScript.getMetadataLength(),
                 toCompression(postScript.getCompression()),
-                postScript.getCompressionBlockSize());
+                postScript.getCompressionBlockSize(),
+                toHiveWriterVersion(postScript.getWriterVersion()));
+    }
+
+    private static HiveWriterVersion toHiveWriterVersion(int writerVersion)
+    {
+        if (writerVersion >= 1) {
+            return ORC_HIVE_8732;
+        }
+        return ORIGINAL;
     }
 
     @Override
-    public Metadata readMetadata(InputStream inputStream)
+    public Metadata readMetadata(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
             throws IOException
     {
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
         OrcProto.Metadata metadata = OrcProto.Metadata.parseFrom(input);
-        return new Metadata(toStripeStatistics(metadata.getStripeStatsList()));
+        return new Metadata(toStripeStatistics(hiveWriterVersion, metadata.getStripeStatsList()));
     }
 
-    private static List<StripeStatistics> toStripeStatistics(List<OrcProto.StripeStatistics> types)
+    private static List<StripeStatistics> toStripeStatistics(HiveWriterVersion hiveWriterVersion, List<OrcProto.StripeStatistics> types)
     {
-        return ImmutableList.copyOf(Iterables.transform(types, OrcMetadataReader::toStripeStatistics));
+        return ImmutableList.copyOf(Iterables.transform(types, stripeStatistics -> toStripeStatistics(hiveWriterVersion, stripeStatistics)));
     }
 
-    private static StripeStatistics toStripeStatistics(OrcProto.StripeStatistics stripeStatistics)
+    private static StripeStatistics toStripeStatistics(HiveWriterVersion hiveWriterVersion, OrcProto.StripeStatistics stripeStatistics)
     {
-        return new StripeStatistics(toColumnStatistics(stripeStatistics.getColStatsList(), false));
+        return new StripeStatistics(toColumnStatistics(hiveWriterVersion, stripeStatistics.getColStatsList(), false));
     }
 
     @Override
-    public Footer readFooter(InputStream inputStream)
+    public Footer readFooter(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
             throws IOException
     {
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
@@ -92,7 +104,7 @@ public class OrcMetadataReader
                 footer.getRowIndexStride(),
                 toStripeInformation(footer.getStripesList()),
                 toType(footer.getTypesList()),
-                toColumnStatistics(footer.getStatisticsList(), false),
+                toColumnStatistics(hiveWriterVersion, footer.getStatisticsList(), false),
                 toUserMetadata(footer.getMetadataList()));
     }
 
@@ -112,7 +124,7 @@ public class OrcMetadataReader
     }
 
     @Override
-    public StripeFooter readStripeFooter(List<OrcType> types, InputStream inputStream)
+    public StripeFooter readStripeFooter(HiveWriterVersion hiveWriterVersion, List<OrcType> types, InputStream inputStream)
             throws IOException
     {
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
@@ -141,12 +153,12 @@ public class OrcMetadataReader
     }
 
     @Override
-    public List<RowGroupIndex> readRowIndexes(InputStream inputStream)
+    public List<RowGroupIndex> readRowIndexes(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
             throws IOException
     {
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
         OrcProto.RowIndex rowIndex = OrcProto.RowIndex.parseFrom(input);
-        return ImmutableList.copyOf(Iterables.transform(rowIndex.getEntryList(), OrcMetadataReader::toRowGroupIndex));
+        return ImmutableList.copyOf(Iterables.transform(rowIndex.getEntryList(), rowIndexEntry -> toRowGroupIndex(hiveWriterVersion, rowIndexEntry)));
     }
 
     @Override
@@ -163,7 +175,7 @@ public class OrcMetadataReader
         return builder.build();
     }
 
-    private static RowGroupIndex toRowGroupIndex(RowIndexEntry rowIndexEntry)
+    private static RowGroupIndex toRowGroupIndex(HiveWriterVersion hiveWriterVersion, RowIndexEntry rowIndexEntry)
     {
         List<Long> positionsList = rowIndexEntry.getPositionsList();
         ImmutableList.Builder<Integer> positions = ImmutableList.builder();
@@ -175,28 +187,28 @@ public class OrcMetadataReader
 
             positions.add(intPosition);
         }
-        return new RowGroupIndex(positions.build(), toColumnStatistics(rowIndexEntry.getStatistics(), true));
+        return new RowGroupIndex(positions.build(), toColumnStatistics(hiveWriterVersion, rowIndexEntry.getStatistics(), true));
     }
 
-    private static ColumnStatistics toColumnStatistics(OrcProto.ColumnStatistics statistics, boolean isRowGroup)
+    private static ColumnStatistics toColumnStatistics(HiveWriterVersion hiveWriterVersion, OrcProto.ColumnStatistics statistics, boolean isRowGroup)
     {
         return new ColumnStatistics(
                 statistics.getNumberOfValues(),
                 toBooleanStatistics(statistics.getBucketStatistics()),
                 toIntegerStatistics(statistics.getIntStatistics()),
                 toDoubleStatistics(statistics.getDoubleStatistics()),
-                toStringStatistics(statistics.getStringStatistics(), isRowGroup),
-                toDateStatistics(statistics.getDateStatistics(), isRowGroup),
+                toStringStatistics(hiveWriterVersion, statistics.getStringStatistics(), isRowGroup),
+                toDateStatistics(hiveWriterVersion, statistics.getDateStatistics(), isRowGroup),
                 toDecimalStatistics(statistics.getDecimalStatistics()),
                 null);
     }
 
-    private static List<ColumnStatistics> toColumnStatistics(List<OrcProto.ColumnStatistics> columnStatistics, final boolean isRowGroup)
+    private static List<ColumnStatistics> toColumnStatistics(HiveWriterVersion hiveWriterVersion, List<OrcProto.ColumnStatistics> columnStatistics, boolean isRowGroup)
     {
         if (columnStatistics == null) {
             return ImmutableList.of();
         }
-        return ImmutableList.copyOf(Iterables.transform(columnStatistics, statistics -> toColumnStatistics(statistics, isRowGroup)));
+        return ImmutableList.copyOf(Iterables.transform(columnStatistics, statistics -> toColumnStatistics(hiveWriterVersion, statistics, isRowGroup)));
     }
 
     private Map<String, Slice> toUserMetadata(List<OrcProto.UserMetadataItem> metadataList)
@@ -247,10 +259,9 @@ public class OrcMetadataReader
                 doubleStatistics.hasMaximum() ? doubleStatistics.getMaximum() : null);
     }
 
-    private static StringStatistics toStringStatistics(OrcProto.StringStatistics stringStatistics, boolean isRowGroup)
+    private static StringStatistics toStringStatistics(HiveWriterVersion hiveWriterVersion, OrcProto.StringStatistics stringStatistics, boolean isRowGroup)
     {
-        // TODO remove this when string statistics in ORC are fixed https://issues.apache.org/jira/browse/HIVE-8732
-        if (!isRowGroup) {
+        if (hiveWriterVersion == ORIGINAL && !isRowGroup) {
             return null;
         }
 
@@ -350,10 +361,9 @@ public class OrcMetadataReader
         return slice;
     }
 
-    private static DateStatistics toDateStatistics(OrcProto.DateStatistics dateStatistics, boolean isRowGroup)
+    private static DateStatistics toDateStatistics(HiveWriterVersion hiveWriterVersion, OrcProto.DateStatistics dateStatistics, boolean isRowGroup)
     {
-        // TODO remove this when date statistics in ORC are fixed https://issues.apache.org/jira/browse/HIVE-8732
-        if (!isRowGroup) {
+        if (hiveWriterVersion == ORIGINAL && !isRowGroup) {
             return null;
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/PostScript.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/PostScript.java
@@ -22,19 +22,26 @@ import static java.util.Objects.requireNonNull;
 
 public class PostScript
 {
+    public enum HiveWriterVersion
+    {
+        ORIGINAL, ORC_HIVE_8732;
+    }
+
     private final List<Integer> version;
     private final long footerLength;
     private final long metadataLength;
     private final CompressionKind compression;
     private final long compressionBlockSize;
+    private final HiveWriterVersion hiveWriterVersion;
 
-    public PostScript(List<Integer> version, long footerLength, long metadataLength, CompressionKind compression, long compressionBlockSize)
+    public PostScript(List<Integer> version, long footerLength, long metadataLength, CompressionKind compression, long compressionBlockSize, HiveWriterVersion hiveWriterVersion)
     {
         this.version = ImmutableList.copyOf(requireNonNull(version, "version is null"));
         this.footerLength = footerLength;
         this.metadataLength = metadataLength;
         this.compression = requireNonNull(compression, "compressionKind is null");
         this.compressionBlockSize = compressionBlockSize;
+        this.hiveWriterVersion = requireNonNull(hiveWriterVersion, "hiveWriterVersion is null");
     }
 
     public List<Integer> getVersion()
@@ -62,6 +69,11 @@ public class PostScript
         return compressionBlockSize;
     }
 
+    public HiveWriterVersion getHiveWriterVersion()
+    {
+        return hiveWriterVersion;
+    }
+
     @Override
     public String toString()
     {
@@ -71,6 +83,7 @@ public class PostScript
                 .add("metadataLength", metadataLength)
                 .add("compressionKind", compression)
                 .add("compressionBlockSize", compressionBlockSize)
+                .add("hiveWriterVersion", hiveWriterVersion)
                 .toString();
     }
 }


### PR DESCRIPTION
Check ORC post script to determine if the file was written with a version
that fixes date and string statics at the file and stripe level