### PR TITLE
Add strictOutput matching to plan matching framework

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BaseStrictSymbolsMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BaseStrictSymbolsMatcher.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public abstract class BaseStrictSymbolsMatcher
+        implements Matcher
+{
+    private final Function<PlanNode, Set<Symbol>> getActual;
+
+    public BaseStrictSymbolsMatcher(Function<PlanNode, Set<Symbol>> getActual)
+    {
+        this.getActual = requireNonNull(getActual, "getActual is null");
+    }
+
+    public boolean shapeMatches(PlanNode node)
+    {
+        try {
+            getActual.apply(node);
+            return true;
+        }
+        catch (ClassCastException e) {
+            return false;
+        }
+    }
+
+    public MatchResult detailMatches(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+
+        Set<Symbol> expected = getExpectedSymbols(node, session, metadata, symbolAliases);
+
+        return new MatchResult(getActual.apply(node).equals(getExpectedSymbols(node, session, metadata, symbolAliases)));
+    }
+
+    protected abstract Set<Symbol> getExpectedSymbols(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases);
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import static com.facebook.presto.sql.ExpressionUtils.rewriteQualifiedNamesToSymbolReferences;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.facebook.presto.sql.planner.assertions.StrictSymbolsMatcher.actualOutputs;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableMap;
 import static com.google.common.base.Preconditions.checkState;
@@ -172,6 +173,11 @@ public final class PlanMatchPattern
         PlanMatchPattern result = output(source);
         result.withOutputs(outputs);
         return result;
+    }
+
+    public static PlanMatchPattern strictOutput(List<String> outputs, PlanMatchPattern source)
+    {
+        return output(outputs, source).with(new StrictSymbolsMatcher(actualOutputs(), outputs));
     }
 
     public static PlanMatchPattern project(PlanMatchPattern source)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -38,11 +38,13 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.WindowFrame;
+import com.facebook.presto.util.ImmutableCollectors;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,6 +52,7 @@ import java.util.Optional;
 import static com.facebook.presto.sql.ExpressionUtils.rewriteQualifiedNamesToSymbolReferences;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.facebook.presto.sql.planner.assertions.StrictAssignedSymbolsMatcher.actualAssignments;
 import static com.facebook.presto.sql.planner.assertions.StrictSymbolsMatcher.actualOutputs;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableMap;
@@ -98,6 +101,14 @@ public final class PlanMatchPattern
     {
         PlanMatchPattern result = tableScan(expectedTableName);
         return result.addColumnReferences(expectedTableName, columnReferences);
+    }
+
+    public static PlanMatchPattern strictTableScan(String expectedTableName, Map<String, String> columnReferences)
+    {
+        return tableScan(expectedTableName, columnReferences)
+                .withExactAssignedOutputs(columnReferences.values().stream()
+                        .map(columnName -> columnReference(expectedTableName, columnName))
+                        .collect(ImmutableCollectors.toImmutableList()));
     }
 
     public static PlanMatchPattern constrainedTableScan(String expectedTableName, Map<String, Domain> constraint)
@@ -177,7 +188,7 @@ public final class PlanMatchPattern
 
     public static PlanMatchPattern strictOutput(List<String> outputs, PlanMatchPattern source)
     {
-        return output(outputs, source).with(new StrictSymbolsMatcher(actualOutputs(), outputs));
+        return output(outputs, source).withExactOutputs(outputs);
     }
 
     public static PlanMatchPattern project(PlanMatchPattern source)
@@ -191,6 +202,17 @@ public final class PlanMatchPattern
         assignments.entrySet().forEach(
                 assignment -> result.withAlias(assignment.getKey(), assignment.getValue()));
         return result;
+    }
+
+    public static PlanMatchPattern strictProject(Map<String, ExpressionMatcher> assignments, PlanMatchPattern source)
+    {
+        /*
+         * Under the current implementation of project, all of the outputs are also in the assignment.
+         * If the implementation changes, this will need to change too.
+         */
+        return project(assignments, source)
+                .withExactAssignedOutputs(assignments.values())
+                .withExactAssignments(assignments.values());
     }
 
     public static PlanMatchPattern semiJoin(String sourceSymbolAlias, String filteringSymbolAlias, String outputAlias, PlanMatchPattern source, PlanMatchPattern filtering)
@@ -319,6 +341,35 @@ public final class PlanMatchPattern
     public PlanMatchPattern withAlias(Optional<String> alias, RvalueMatcher matcher)
     {
         matchers.add(new Alias(alias, matcher));
+        return this;
+    }
+
+    /*
+     * This is useful if you already know the bindings for the aliases you expect to find
+     * in the outputs. This is the case for symbols that are produced by a direct or indirect
+     * source of the node you're applying this to.
+     */
+    public PlanMatchPattern withExactOutputs(List<String> expectedAliases)
+    {
+        matchers.add(new StrictSymbolsMatcher(actualOutputs(), expectedAliases));
+        return this;
+    }
+
+    /*
+     * withExactAssignments and withExactAssignedOutputs are needed for matching symbols
+     * that are produced in the node that you're matching. The name of the symbol bound to
+     * the alias is *not* known when the Matcher is run, and so you need to match by what
+     * is being assigned to it.
+     */
+    public PlanMatchPattern withExactAssignedOutputs(Collection<? extends RvalueMatcher> expectedAliases)
+    {
+        matchers.add(new StrictAssignedSymbolsMatcher(actualOutputs(), expectedAliases));
+        return this;
+    }
+
+    public PlanMatchPattern withExactAssignments(Collection<? extends RvalueMatcher> expectedAliases)
+    {
+        matchers.add(new StrictAssignedSymbolsMatcher(actualAssignments(), expectedAliases));
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StrictAssignedSymbolsMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StrictAssignedSymbolsMatcher.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class StrictAssignedSymbolsMatcher
+        extends BaseStrictSymbolsMatcher
+{
+    private final Collection<? extends RvalueMatcher> getExpected;
+
+    public StrictAssignedSymbolsMatcher(Function<PlanNode, Set<Symbol>> getActual, Collection<? extends RvalueMatcher> getExpected)
+    {
+        super(getActual);
+        this.getExpected = requireNonNull(getExpected, "getExpected is null");
+    }
+
+    @Override
+    protected Set<Symbol> getExpectedSymbols(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        ImmutableSet.Builder<Symbol> expected = ImmutableSet.builder();
+        for (RvalueMatcher matcher : getExpected) {
+            Optional<Symbol> assigned = matcher.getAssignedSymbol(node, session, metadata, symbolAliases);
+            if (!assigned.isPresent()) {
+                return null;
+            }
+
+            expected.add(assigned.get());
+        }
+
+        return expected.build();
+    }
+
+    public static Function<PlanNode, Set<Symbol>> actualAssignments()
+    {
+        return node -> ((ProjectNode) node).getAssignments().keySet();
+    }
+
+    public static Function<PlanNode, Set<Symbol>> actualSubqueryAssignments()
+    {
+        return node -> ((ApplyNode) node).getSubqueryAssignments().keySet();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("exact assignments", getExpected)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StrictSymbolsMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StrictSymbolsMatcher.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.util.ImmutableCollectors;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class StrictSymbolsMatcher
+        extends BaseStrictSymbolsMatcher
+{
+    private final List<String> expectedAliases;
+
+    public StrictSymbolsMatcher(Function<PlanNode, Set<Symbol>> getActual, List<String> expectedAliases)
+    {
+        super(getActual);
+        this.expectedAliases = requireNonNull(expectedAliases, "expectedAliases is null");
+    }
+
+    @Override
+    protected Set<Symbol> getExpectedSymbols(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        return expectedAliases.stream()
+                .map(symbolAliases::get)
+                .map(Symbol::from)
+                .collect(ImmutableCollectors.toImmutableSet());
+    }
+
+    public static Function<PlanNode, Set<Symbol>> actualOutputs()
+    {
+        return node -> ImmutableSet.copyOf(node.getOutputSymbols());
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("exact outputs", expectedAliases)
+                .toString();
+    }
+}


### PR DESCRIPTION
Some tests require being able to ensure that the set of outputs for a node is
exactly what is expected, rather than a superset.