### PR TITLE
Validate S3 key length

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -99,6 +99,7 @@ import static java.nio.file.Files.createDirectories;
 import static java.nio.file.Files.createTempFile;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_REQUESTED_RANGE_NOT_SATISFIABLE;
@@ -551,6 +552,7 @@ public class PrestoS3FileSystem
                                     case SC_NOT_FOUND:
                                         return null;
                                     case SC_FORBIDDEN:
+                                    case SC_BAD_REQUEST:
                                         throw new UnrecoverableS3OperationException(path, e);
                                 }
                             }
@@ -889,6 +891,7 @@ public class PrestoS3FileSystem
                                             return new ByteArrayInputStream(new byte[0]);
                                         case SC_FORBIDDEN:
                                         case SC_NOT_FOUND:
+                                        case SC_BAD_REQUEST:
                                             throw new UnrecoverableS3OperationException(path, e);
                                     }
                                 }


### PR DESCRIPTION
With an `INSERT` query that has a huge value for a `varchar` partition key I have seen that the S3 backend responded with HTTP 400 as the key is too long. According to the S3 [docs](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html) a valid key is a sequence of Unicode characters whose UTF-8 encoding is at most 1024 bytes long. This PR adds validation for that when creating keys from paths.