### PR TITLE
Support Integer, Smallint, Tinyint Parquet Predicate Pushdown

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/TupleDomainParquetPredicate.java
@@ -44,7 +44,10 @@ import java.util.function.Function;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -139,7 +142,7 @@ public class TupleDomainParquetPredicate<C>
                 return Domain.create(ValueSet.of(type, false), hasNullValue);
             }
         }
-        else if (type.equals(BIGINT) && (statistics instanceof LongStatistics || statistics instanceof IntStatistics)) {
+        else if ((type.equals(BIGINT) || type.equals(TINYINT) || type.equals(SMALLINT) || type.equals(INTEGER)) && (statistics instanceof LongStatistics || statistics instanceof IntStatistics)) {
             ParquetIntegerStatistics parquetIntegerStatistics;
             if (statistics instanceof LongStatistics) {
                 LongStatistics longStatistics = (LongStatistics) statistics;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestTupleDomainParquetPredicate.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestTupleDomainParquetPredicate.java
@@ -19,6 +19,7 @@ import parquet.column.statistics.BinaryStatistics;
 import parquet.column.statistics.BooleanStatistics;
 import parquet.column.statistics.DoubleStatistics;
 import parquet.column.statistics.FloatStatistics;
+import parquet.column.statistics.IntStatistics;
 import parquet.column.statistics.LongStatistics;
 import parquet.io.api.Binary;
 
@@ -30,7 +31,10 @@ import static com.facebook.presto.spi.predicate.Range.range;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Float.floatToRawIntBits;
@@ -73,6 +77,46 @@ public class TestTupleDomainParquetPredicate
         LongStatistics statistics = new LongStatistics();
         statistics.setMinMax(minimum, maximum);
         return statistics;
+    }
+
+    @Test
+    public void testInteger()
+            throws Exception
+    {
+        assertEquals(getDomain(INTEGER, 0, null), all(INTEGER));
+
+        assertEquals(getDomain(INTEGER, 10, intColumnStats(100, 100)), singleValue(INTEGER, 100L));
+
+        assertEquals(getDomain(INTEGER, 10, intColumnStats(0, 100)), create(ValueSet.ofRanges(range(INTEGER, 0L, true, 100L, true)), false));
+    }
+
+    private static IntStatistics intColumnStats(int minimum, int maximum)
+    {
+        IntStatistics statistics = new IntStatistics();
+        statistics.setMinMax(minimum, maximum);
+        return statistics;
+    }
+
+    @Test
+    public void testSmallint()
+            throws Exception
+    {
+        assertEquals(getDomain(SMALLINT, 0, null), all(SMALLINT));
+
+        assertEquals(getDomain(SMALLINT, 10, intColumnStats(100, 100)), singleValue(SMALLINT, 100L));
+
+        assertEquals(getDomain(SMALLINT, 10, intColumnStats(0, 100)), create(ValueSet.ofRanges(range(SMALLINT, 0L, true, 100L, true)), false));
+    }
+
+    @Test
+    public void testTinyint()
+            throws Exception
+    {
+        assertEquals(getDomain(TINYINT, 0, null), all(TINYINT));
+
+        assertEquals(getDomain(TINYINT, 10, intColumnStats(100, 100)), singleValue(TINYINT, 100L));
+
+        assertEquals(getDomain(TINYINT, 10, intColumnStats(0, 100)), create(ValueSet.ofRanges(range(TINYINT, 0L, true, 100L, true)), false));
     }
 
     @Test


### PR DESCRIPTION
add missing Parquet TupleDomain support for Integer, Smallint, and Tinyint @dain @nezihyigitbasi 