### PR TITLE
Add PooledHiveMetastoreClientFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -644,6 +644,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-pool2</artifactId>
+                <version>2.4.2</version>
+            </dependency>
+
+            <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>1.9</version>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -177,6 +177,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
+         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -101,6 +101,7 @@ public class HiveClientModule
         newExporter(binder).export(NamenodeStats.class).as(generatedNameOf(NamenodeStats.class));
 
         binder.bind(HiveMetastoreClientFactory.class).in(Scopes.SINGLETON);
+        binder.bind(PooledHiveMetastoreClientFactory.class).in(Scopes.SINGLETON);
         binder.bind(HiveCluster.class).to(StaticHiveCluster.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(StaticMetastoreConfig.class);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PooledHiveMetastoreClientFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PooledHiveMetastoreClientFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.authentication.HiveMetastoreAuthentication;
+import com.facebook.presto.hive.metastore.HiveMetastoreClient;
+import com.facebook.presto.hive.thrift.PooledTTransportFactory;
+import com.facebook.presto.hive.thrift.TTransportPool;
+import com.google.common.net.HostAndPort;
+import com.google.common.primitives.Ints;
+import io.airlift.units.Duration;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class PooledHiveMetastoreClientFactory
+    extends HiveMetastoreClientFactory
+{
+    private final HostAndPort socksProxy;
+    private final int timeoutMillis;
+    private final HiveMetastoreAuthentication metastoreAuthentication;
+    private final TTransportPool transportPool;
+
+    public PooledHiveMetastoreClientFactory(@Nullable HostAndPort socksProxy, Duration timeout, HiveMetastoreAuthentication metastoreAuthentication)
+    {
+        super(socksProxy, timeout, metastoreAuthentication);
+        this.socksProxy = socksProxy;
+        this.timeoutMillis = Ints.checkedCast(timeout.toMillis());
+        this.metastoreAuthentication = requireNonNull(metastoreAuthentication, "metastoreAuthentication is null");
+        this.transportPool = new TTransportPool();
+    }
+
+    @Inject
+    public PooledHiveMetastoreClientFactory(HiveClientConfig config, HiveMetastoreAuthentication metastoreAuthentication)
+    {
+        this(config.getMetastoreSocksProxy(), config.getMetastoreTimeout(), metastoreAuthentication);
+    }
+
+    @Override
+    public HiveMetastoreClient create(String host, int port)
+            throws TTransportException
+    {
+        try {
+            TTransport transport = transportPool.borrowObject(host, port);
+            if (transport == null) {
+                transport = transportPool.borrowObject(host, port, new PooledTTransportFactory(transportPool, host, port, socksProxy, timeoutMillis, metastoreAuthentication));
+            }
+            return new ThriftHiveMetastoreClient(transport);
+        }
+        catch (Exception e) {
+            throw new TTransportException(String.format("%s: %s", host, e.getMessage()), e.getCause());
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StaticHiveCluster.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StaticHiveCluster.java
@@ -45,7 +45,7 @@ public class StaticHiveCluster
     @Inject
     public StaticHiveCluster(StaticMetastoreConfig config, HiveMetastoreClientFactory clientFactory, PooledHiveMetastoreClientFactory pooledClientFactory)
     {
-        this(config.getMetastoreUris(), config.useTransportPool(), clientFactory, pooledClientFactory);
+        this(config.getMetastoreUris(), config.isEnableTransportPool(), clientFactory, pooledClientFactory);
     }
 
     public StaticHiveCluster(List<URI> metastoreUris, HiveMetastoreClientFactory clientFactory)
@@ -59,7 +59,7 @@ public class StaticHiveCluster
         this.clientFactory = requireNonNull(clientFactory, "clientFactory is null");
     }
 
-    public StaticHiveCluster(List<URI> metastoreUris, boolean useTransportPool, HiveMetastoreClientFactory clientFactory, PooledHiveMetastoreClientFactory pooledClientFactory)
+    public StaticHiveCluster(List<URI> metastoreUris, boolean enableTransportPool, HiveMetastoreClientFactory clientFactory, PooledHiveMetastoreClientFactory pooledClientFactory)
     {
         requireNonNull(metastoreUris, "metastoreUris is null");
         checkArgument(!metastoreUris.isEmpty(), "metastoreUris must specify at least one URI");
@@ -67,7 +67,7 @@ public class StaticHiveCluster
                 .map(StaticHiveCluster::checkMetastoreUri)
                 .map(uri -> HostAndPort.fromParts(uri.getHost(), uri.getPort()))
                 .collect(toList());
-        if (useTransportPool) {
+        if (enableTransportPool) {
             this.clientFactory = requireNonNull(pooledClientFactory, "clientFactory is null");
         }
         else {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StaticMetastoreConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StaticMetastoreConfig.java
@@ -30,6 +30,7 @@ public class StaticMetastoreConfig
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
     private List<URI> metastoreUris;
+    private boolean enableTransportPool;
 
     @NotNull
     public List<URI> getMetastoreUris()
@@ -47,6 +48,18 @@ public class StaticMetastoreConfig
         }
 
         this.metastoreUris = ImmutableList.copyOf(transform(SPLITTER.split(uris), URI::create));
+        return this;
+    }
+
+    public boolean useTransportPool()
+    {
+        return enableTransportPool;
+    }
+
+    @Config("hive.metastore.enable-transport-pool")
+    public StaticMetastoreConfig setEnableTransportPool(boolean enableTransportPool)
+    {
+        this.enableTransportPool = enableTransportPool;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StaticMetastoreConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StaticMetastoreConfig.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.net.URI;
@@ -31,6 +32,10 @@ public class StaticMetastoreConfig
 
     private List<URI> metastoreUris;
     private boolean enableTransportPool;
+    private int maxTransport = 128;
+    private long transportIdleTimeout = 300_000L;
+    private long transportEvictInterval = 10_000L;
+    private int transportEvictNumTests = 3;
 
     @NotNull
     public List<URI> getMetastoreUris()
@@ -51,7 +56,7 @@ public class StaticMetastoreConfig
         return this;
     }
 
-    public boolean useTransportPool()
+    public boolean isEnableTransportPool()
     {
         return enableTransportPool;
     }
@@ -60,6 +65,56 @@ public class StaticMetastoreConfig
     public StaticMetastoreConfig setEnableTransportPool(boolean enableTransportPool)
     {
         this.enableTransportPool = enableTransportPool;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxTransport()
+    {
+        return maxTransport;
+    }
+
+    @Config("hive.metastore.max-transport-num-per-endpoint")
+    public StaticMetastoreConfig setMaxTransport(int maxTransport)
+    {
+        this.maxTransport = maxTransport;
+        return this;
+    }
+
+    public long getTransportIdleTimeout()
+    {
+        return transportIdleTimeout;
+    }
+
+    @Config("hive.metastore.transport-idle-timeout")
+    public StaticMetastoreConfig setTransportIdleTimeout(long transportIdleTimeout)
+    {
+        this.transportIdleTimeout = transportIdleTimeout;
+        return this;
+    }
+
+    public long getTransportEvictInterval()
+    {
+        return transportEvictInterval;
+    }
+
+    @Config("hive.metastore.transport-eviction-interval")
+    public StaticMetastoreConfig setTransportEvictInterval(long transportEvictInterval)
+    {
+        this.transportEvictInterval = transportEvictInterval;
+        return this;
+    }
+
+    @Min(0)
+    public int getTransportEvictNumTests()
+    {
+        return transportEvictNumTests;
+    }
+
+    @Config("hive.metastore.transport-eviction-num-tests")
+    public StaticMetastoreConfig setTransportEvictNumTests(int transportEvictNumTests)
+    {
+        this.transportEvictNumTests = transportEvictNumTests;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/thrift/PooledTTransportFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/thrift/PooledTTransportFactory.java
@@ -54,9 +54,22 @@ public class PooledTTransportFactory
     }
 
     @Override
+    public void activateObject(PooledObject<TTransport> pooledObject)
+        throws Exception
+    {
+        pooledObject.getObject().flush();
+    }
+
+    @Override
     public boolean validateObject(PooledObject<TTransport> pooledObject)
     {
-        return pooledObject.getObject().isOpen();
+        try {
+            return (pooledObject.getObject().isOpen() &&
+                ((PooledTTransport) pooledObject.getObject()).isReachable(timeoutMillis));
+        }
+        catch (Exception e) {
+            return false;
+        }
     }
 
     @Override
@@ -143,6 +156,12 @@ public class PooledTTransportFactory
             return transport;
         }
 
+        public boolean isReachable(int timeoutMillis)
+            throws ClassCastException, IOException
+        {
+            return ((TSocket) transport).getSocket().getInetAddress().isReachable(timeoutMillis);
+        }
+
         @Override
         public void close()
         {
@@ -192,42 +211,42 @@ public class PooledTTransportFactory
 
         @Override
         public void open()
-                throws TTransportException
+            throws TTransportException
         {
             transport.open();
         }
 
         @Override
         public int readAll(byte[] bytes, int off, int len)
-                throws TTransportException
+            throws TTransportException
         {
             return transport.readAll(bytes, off, len);
         }
 
         @Override
         public int read(byte[] bytes, int off, int len)
-                throws TTransportException
+            throws TTransportException
         {
             return transport.read(bytes, off, len);
         }
 
         @Override
         public void write(byte[] bytes)
-                throws TTransportException
+            throws TTransportException
         {
             transport.write(bytes);
         }
 
         @Override
         public void write(byte[] bytes, int off, int len)
-                throws TTransportException
+            throws TTransportException
         {
             transport.write(bytes, off, len);
         }
 
         @Override
         public void flush()
-                throws TTransportException
+            throws TTransportException
         {
             transport.flush();
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/thrift/PooledTTransportFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/thrift/PooledTTransportFactory.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.thrift;
+
+import com.facebook.presto.hive.authentication.HiveMetastoreAuthentication;
+import com.google.common.net.HostAndPort;
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+
+import static java.util.Objects.requireNonNull;
+
+public class PooledTTransportFactory
+    extends BasePooledObjectFactory<TTransport>
+{
+    private final TTransportPool pool;
+    private final String host;
+    private final int port;
+    private final HostAndPort socksProxy;
+    private final int timeoutMillis;
+    private final HiveMetastoreAuthentication metastoreAuthentication;
+
+    public PooledTTransportFactory(TTransportPool pool, String host, int port, @Nullable HostAndPort socksProxy, int timeoutMillis, HiveMetastoreAuthentication metastoreAuthentication)
+    {
+        this.pool = requireNonNull(pool, "pool is null");
+        this.host = requireNonNull(host, "host is null");
+        this.port = port;
+        this.socksProxy = socksProxy;
+        this.timeoutMillis = timeoutMillis;
+        this.metastoreAuthentication = requireNonNull(metastoreAuthentication, "metastoreAuthentication is null");
+    }
+
+    @Override
+    public boolean validateObject(PooledObject<TTransport> pooledObject)
+    {
+        return pooledObject.getObject().isOpen();
+    }
+
+    @Override
+    public TTransport create()
+        throws Exception
+    {
+        TTransport transport;
+        if (socksProxy == null) {
+            transport = new TSocket(host, port, timeoutMillis);
+        }
+        else {
+            SocketAddress address = InetSocketAddress.createUnresolved(socksProxy.getHostText(), socksProxy.getPort());
+            Socket socket = new Socket(new Proxy(Proxy.Type.SOCKS, address));
+            try {
+                socket.connect(InetSocketAddress.createUnresolved(host, port), timeoutMillis);
+                socket.setSoTimeout(timeoutMillis);
+                transport = new TSocket(socket);
+            }
+            catch (SocketException e) {
+                if (socket.isConnected()) {
+                    try {
+                        socket.close();
+                    }
+                    catch (IOException ioException) {
+                        // ignored
+                    }
+                }
+                throw e;
+            }
+        }
+        TTransport authenticatedTransport = metastoreAuthentication.authenticate(transport, host);
+        if (!authenticatedTransport.isOpen()) {
+            authenticatedTransport.open();
+        }
+
+        return new PooledTTransport(authenticatedTransport, pool, HostAndPort.fromParts(host, port).toString());
+    }
+
+    @Override
+    public void destroyObject(PooledObject<TTransport> pooledObject)
+    {
+        try {
+            ((PooledTTransport) pooledObject.getObject()).getTTransport().close();
+        }
+        catch (ClassCastException e) {
+            // ignore
+        }
+        pooledObject.invalidate();
+    }
+
+    @Override
+    public PooledObject<TTransport> wrap(TTransport transport)
+    {
+        return new DefaultPooledObject<TTransport>(transport);
+    }
+
+    @Override
+    public void passivateObject(PooledObject<TTransport> pooledObject)
+    {
+        try {
+            pooledObject.getObject().flush();
+        }
+        catch (TTransportException e) {
+            destroyObject(pooledObject);
+        }
+    }
+
+    private static class PooledTTransport
+        extends TTransport
+    {
+        private final String remote;
+        private final TTransportPool pool;
+        private final TTransport transport;
+
+        public PooledTTransport(TTransport transport, TTransportPool pool, String remote)
+        {
+            this.transport = transport;
+            this.pool = pool;
+            this.remote = remote;
+        }
+
+        public TTransport getTTransport()
+        {
+            return transport;
+        }
+
+        @Override
+        public void close()
+        {
+            try {
+                pool.returnObject(remote, this, transport);
+            }
+            catch (Exception e) {
+                transport.close();
+            }
+        }
+
+        @Override
+        public boolean isOpen()
+        {
+            return transport.isOpen();
+        }
+
+        @Override
+        public boolean peek()
+        {
+            return transport.peek();
+        }
+
+        @Override
+        public byte[] getBuffer()
+        {
+            return transport.getBuffer();
+        }
+
+        @Override
+        public int getBufferPosition()
+        {
+            return transport.getBufferPosition();
+        }
+
+        @Override
+        public int getBytesRemainingInBuffer()
+        {
+            return transport.getBytesRemainingInBuffer();
+        }
+
+        @Override
+        public void consumeBuffer(int len)
+        {
+            transport.consumeBuffer(len);
+        }
+
+        @Override
+        public void open()
+                throws TTransportException
+        {
+            transport.open();
+        }
+
+        @Override
+        public int readAll(byte[] bytes, int off, int len)
+                throws TTransportException
+        {
+            return transport.readAll(bytes, off, len);
+        }
+
+        @Override
+        public int read(byte[] bytes, int off, int len)
+                throws TTransportException
+        {
+            return transport.read(bytes, off, len);
+        }
+
+        @Override
+        public void write(byte[] bytes)
+                throws TTransportException
+        {
+            transport.write(bytes);
+        }
+
+        @Override
+        public void write(byte[] bytes, int off, int len)
+                throws TTransportException
+        {
+            transport.write(bytes, off, len);
+        }
+
+        @Override
+        public void flush()
+                throws TTransportException
+        {
+            transport.flush();
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/thrift/TTransportPool.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/thrift/TTransportPool.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.thrift;
+
+import com.google.common.net.HostAndPort;
+import io.airlift.units.Duration;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.PooledObjectFactory;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.apache.thrift.transport.TTransport;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+public class TTransportPool
+{
+    private static final int MIN_IDLE = 0;
+    private static final int MAX_TOTAL = 128;
+    private static final int NUM_TESTS = 3;
+    private static final Duration IDLE_TIMEOUT = new Duration(300, TimeUnit.SECONDS);
+    private static final Duration EVICTION_INTERVEL = new Duration(10, TimeUnit.SECONDS);
+    private final ConcurrentMap<String, ObjectPool<TTransport>> pools = new ConcurrentHashMap();
+    private GenericObjectPoolConfig poolConfig;
+
+    public TTransportPool()
+    {
+        poolConfig = new GenericObjectPoolConfig();
+        poolConfig.setMaxIdle(MAX_TOTAL);
+        poolConfig.setMinIdle(MIN_IDLE);
+        poolConfig.setMaxTotal(MAX_TOTAL);
+        poolConfig.setMinEvictableIdleTimeMillis(IDLE_TIMEOUT.toMillis());
+        poolConfig.setTimeBetweenEvictionRunsMillis(EVICTION_INTERVEL.toMillis());
+        poolConfig.setNumTestsPerEvictionRun(NUM_TESTS);
+    }
+
+    public TTransportPool(GenericObjectPoolConfig poolConfig)
+    {
+        this.poolConfig = poolConfig;
+    }
+
+    private void add(String remote, PooledObjectFactory transportFactory)
+    {
+        pools.put(remote, new GenericObjectPool<TTransport>(transportFactory, poolConfig));
+    }
+
+    protected TTransport get(String remote, PooledObjectFactory transportFactory)
+        throws Exception
+    {
+        ObjectPool<TTransport> pool = pools.get(remote);
+        if (pool == null) {
+            add(remote, transportFactory);
+            pool = pools.get(remote);
+        }
+        return pool.borrowObject();
+    }
+
+    protected TTransport get(String remote)
+        throws Exception
+    {
+        ObjectPool<TTransport> pool = pools.get(remote);
+        if (pool == null) {
+            return null;
+        }
+        return pool.borrowObject();
+    }
+
+    public TTransport borrowObject(String host, int port, PooledObjectFactory transportFactory)
+        throws Exception
+    {
+        return get(HostAndPort.fromParts(host, port).toString(), transportFactory);
+    }
+
+    public TTransport borrowObject(String host, int port)
+        throws Exception
+    {
+        return get(HostAndPort.fromParts(host, port).toString());
+    }
+
+    public void returnObject(String remote, TTransport pooledTransport, TTransport transport)
+    {
+        if (remote == null) {
+            transport.close();
+            return;
+        }
+        ObjectPool<TTransport> pool = pools.get(remote);
+        if (pool == null) {
+            transport.close();
+            return;
+        }
+        try {
+            pool.returnObject(pooledTransport);
+        }
+        catch (Exception e) {
+            transport.close();
+        }
+    }
+
+    public void returnObject(TTransport transport)
+    {
+        transport.close();
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestStaticMetastoreConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestStaticMetastoreConfig.java
@@ -31,7 +31,12 @@ public class TestStaticMetastoreConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(StaticMetastoreConfig.class)
-                .setMetastoreUris(null));
+                .setMetastoreUris(null)
+                .setEnableTransportPool(false)
+                .setMaxTransport(128)
+                .setTransportIdleTimeout(300_000L)
+                .setTransportEvictInterval(10_000L)
+                .setTransportEvictNumTests(3));
     }
 
     @Test
@@ -39,10 +44,20 @@ public class TestStaticMetastoreConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("hive.metastore.uri", "thrift://localhost:9083")
+                .put("hive.metastore.enable-transport-pool", "true")
+                .put("hive.metastore.max-transport-num-per-endpoint", "64")
+                .put("hive.metastore.transport-idle-timeout", "10000")
+                .put("hive.metastore.transport-eviction-interval", "1000")
+                .put("hive.metastore.transport-eviction-num-tests", "10")
                 .build();
 
         StaticMetastoreConfig expected = new StaticMetastoreConfig()
-                .setMetastoreUris("thrift://localhost:9083");
+                .setMetastoreUris("thrift://localhost:9083")
+                .setEnableTransportPool(true)
+                .setMaxTransport(64)
+                .setTransportIdleTimeout(10_000L)
+                .setTransportEvictInterval(1_000L)
+                .setTransportEvictNumTests(10);
 
         assertFullMapping(properties, expected);
         assertEquals(expected.getMetastoreUris(), ImmutableList.of(URI.create("thrift://localhost:9083")));
@@ -53,10 +68,20 @@ public class TestStaticMetastoreConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("hive.metastore.uri", "thrift://localhost:9083,thrift://192.0.2.3:8932")
+                .put("hive.metastore.enable-transport-pool", "true")
+                .put("hive.metastore.max-transport-num-per-endpoint", "64")
+                .put("hive.metastore.transport-idle-timeout", "10000")
+                .put("hive.metastore.transport-eviction-interval", "1000")
+                .put("hive.metastore.transport-eviction-num-tests", "10")
                 .build();
 
         StaticMetastoreConfig expected = new StaticMetastoreConfig()
-                .setMetastoreUris("thrift://localhost:9083,thrift://192.0.2.3:8932");
+                .setMetastoreUris("thrift://localhost:9083,thrift://192.0.2.3:8932")
+                .setEnableTransportPool(true)
+                .setMaxTransport(64)
+                .setTransportIdleTimeout(10_000L)
+                .setTransportEvictInterval(1_000L)
+                .setTransportEvictNumTests(10);
 
         assertFullMapping(properties, expected);
         assertEquals(expected.getMetastoreUris(), ImmutableList.of(


### PR DESCRIPTION
HiveMetastoreClientFactory can create unbounded connections to Hive metastore instance. In practice, we noticed local cache(partitionCache) can create a large number of connections to a single instance during its background refresh, which exceeded the local ports(Mesos default ephemeral port limit which is 1024) when only limited Hive metastore instances are available. As a result, queries failed with "Cannot assign requested address". This PR supports a transport pool to limit the maximum total connections to each metastore instance.