### PR TITLE
Principal error in Hive Kerberos Authentication

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosAuthentication.java
@@ -52,7 +52,7 @@ public class KerberosAuthentication
         checkArgument(exists(keytabPath), "keytab does not exist: " + keytabLocation);
         checkArgument(isReadable(keytabPath), "keytab is not readable: " + keytabLocation);
         this.principal = createKerberosPrincipal(principal);
-        this.configuration = createConfiguration(principal, keytabLocation);
+        this.configuration = createConfiguration(this.principal.getName(), keytabLocation);
     }
 
     public Subject getSubject()


### PR DESCRIPTION
The principal like 'user/_HOST@REALM.COM' will convert to 'user/host@REALM.COM'. However, the replaced principal didn't passed into configuration, made kerberos authentication failed.