### PR TITLE
Document escaping commas in jmx history

### DIFF
--- a/presto-docs/src/main/sphinx/connector/jmx.rst
+++ b/presto-docs/src/main/sphinx/connector/jmx.rst
@@ -25,6 +25,7 @@ To enable periodical dumps, define following properties:
 
 .. code-block:: none
 
+    connector.name=jmx
     jmx.dump-tables=java.lang:type=Runtime,com.facebook.presto.execution.scheduler:name=NodeScheduler
     jmx.dump-period=10s
     jmx.max-entries=86400
@@ -33,6 +34,15 @@ To enable periodical dumps, define following properties:
 which MBeans will be sampled and stored in memory every ``dump-period``.
 History will have limited size of ``max-entries`` of entries. Both ``dump-period``
 and ``max-entries`` have default values of ``10s`` and ``86400`` accordingly.
+
+Commas in MBean names should be escaped in following manner:
+
+.. code-block:: none
+
+    connector.name=jmx
+    jmx.dump-tables=com.facebook.presto.memory:type=memorypool\\,name=general,\
+       com.facebook.presto.memory:type=memorypool\\,name=system,\
+       com.facebook.presto.memory:type=memorypool\\,name=reserved
 
 Querying JMX
 ------------


### PR DESCRIPTION
Missing documentation to recent PR https://github.com/prestodb/presto/pull/6843 