### PR TITLE
Improve LocalExchanges concurrency

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -45,6 +45,7 @@ public final class SystemSessionProperties
     public static final String PREFER_STREAMING_OPERATORS = "prefer_streaming_operators";
     public static final String TASK_WRITER_COUNT = "task_writer_count";
     public static final String TASK_CONCURRENCY = "task_concurrency";
+    public static final String LOCAL_EXCHANGE_CONCURRENCY = "local_exchange_concurrency";
     public static final String TASK_SHARE_INDEX_LOADING = "task_share_index_loading";
     public static final String QUERY_MAX_MEMORY = "query_max_memory";
     public static final String QUERY_MAX_RUN_TIME = "query_max_run_time";
@@ -154,6 +155,11 @@ public final class SystemSessionProperties
                             return concurrency;
                         },
                         value -> value),
+                integerSessionProperty(
+                        LOCAL_EXCHANGE_CONCURRENCY,
+                        "Number of local parallel hash partitioners per local exchange",
+                        1,
+                        false),
                 booleanSessionProperty(
                         TASK_SHARE_INDEX_LOADING,
                         "Share index join lookups and caching within a task",
@@ -309,6 +315,11 @@ public final class SystemSessionProperties
     public static int getTaskConcurrency(Session session)
     {
         return session.getSystemProperty(TASK_CONCURRENCY, Integer.class);
+    }
+
+    public static int getLocalExchangeConcurrency(Session session)
+    {
+        return session.getSystemProperty(LOCAL_EXCHANGE_CONCURRENCY, Integer.class);
     }
 
     public static boolean isShareIndexLoading(Session session)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -20,6 +20,7 @@ import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.tpch.TpchConnectorFactory;
 import com.google.common.collect.ImmutableMap;
 
+import static com.facebook.presto.SystemSessionProperties.LOCAL_EXCHANGE_CONCURRENCY;
 import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
@@ -37,6 +38,7 @@ public class TestLocalQueries
         Session defaultSession = testSessionBuilder()
                 .setCatalog("local")
                 .setSchema(TINY_SCHEMA_NAME)
+                .setSystemProperty(LOCAL_EXCHANGE_CONCURRENCY, "2")
                 .build();
 
         LocalQueryRunner localQueryRunner = new LocalQueryRunner(defaultSession);


### PR DESCRIPTION
In some cases higher values of `task_concurrency` doesn't improve performance, because some queries can be bottlenecked on hash partitioning in LocalExchanges.

This PR addresses this issue, by adding random partitioning before hash partitioning and increases number of hash partitioners to desired number.

This issue was was very common before recent improvements in `BigintType` hash calculations. Now it is still visible for:

- very simple queries
- queries with multiple columns in join/aggregation
- queries with multiple long varchar columns in join/aggregation

Tomorrow I will post some benchmark results.

CC @dain 