### PR TITLE
Fix NPE in MappedPageSource

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/split/MappedPageSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/MappedPageSource.java
@@ -64,6 +64,9 @@ public class MappedPageSource
     public Page getNextPage()
     {
         Page nextPage = delegate.getNextPage();
+        if (nextPage == null) {
+            return null;
+        }
         Block[] blocks = Arrays.stream(delegateFieldIndex)
                 .mapToObj(nextPage::getBlock)
                 .toArray(Block[]::new);


### PR DESCRIPTION
With a brand new raptor test environment I got a NPE when querying `system` tables. It seems that `MappedPageSource` doesn't handle the case where `delegate` is finished and returns a null page. This PR fixes that.

```
presto:system> select * from table_stats;

Query 20161213_221846_00023_nggki, FAILED, 1 node
http://localhost:8080/query.html?20161213_221846_00023_nggki
Splits: 2 total, 0 done (0.00%)
CPU Time: 0.0s total,     0 rows/s,     0B/s, 0% active
Per Node: 0.0 parallelism,     0 rows/s,     0B/s
Parallelism: 0.0
0:05 [0 rows, 0B] [0 rows/s, 0B/s]

Query 20161213_221846_00023_nggki failed: null
java.lang.NullPointerException
	at com.facebook.presto.split.MappedPageSource.getNextPage(MappedPageSource.java:67)
	at com.facebook.presto.operator.TableScanOperator.getOutput(TableScanOperator.java:256)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:378)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:301)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:622)
	at com.facebook.presto.execution.TaskExecutor$PrioritizedSplitRunner.process(TaskExecutor.java:534)
	at com.facebook.presto.execution.TaskExecutor$Runner.run(TaskExecutor.java:670)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```