### PR TITLE
Add config option and session property to restore legacy ORDER BY behavior

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -64,6 +64,7 @@ public final class SystemSessionProperties
     public static final String SPILL_ENABLED = "spill_enabled";
     public static final String OPERATOR_MEMORY_LIMIT_BEFORE_SPILL = "operator_memory_limit_before_spill";
     public static final String OPTIMIZE_DISTINCT_AGGREGATIONS = "optimize_mixed_distinct_aggregations";
+    public static final String LEGACY_ORDER_BY = "legacy_order_by";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -253,7 +254,12 @@ public final class SystemSessionProperties
                         OPTIMIZE_DISTINCT_AGGREGATIONS,
                         "Optimize mixed non-distinct and distinct aggregations",
                         featuresConfig.isOptimizeMixedDistinctAggregations(),
-                        false));
+                        false),
+                booleanSessionProperty(
+                        LEGACY_ORDER_BY,
+                        "Use legacy rules for column resolution in ORDER BY clause",
+                        false,
+                        featuresConfig.isLegacyOrderBy()));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -393,5 +399,10 @@ public final class SystemSessionProperties
     public static boolean isOptimizeDistinctAggregationEnabled(Session session)
     {
         return session.getSystemProperty(OPTIMIZE_DISTINCT_AGGREGATIONS, Boolean.class);
+    }
+
+    public static boolean isLegacyOrderByEnabled(Session session)
+    {
+        return session.getSystemProperty(LEGACY_ORDER_BY, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -52,6 +52,7 @@ public class FeaturesConfig
     private boolean optimizeSingleDistinct = true;
     private boolean pushTableWriteThroughUnion = true;
     private boolean legacyArrayAgg;
+    private boolean legacyOrderBy;
     private boolean optimizeMixedDistinctAggregations;
 
     private String processingOptimization = ProcessingOptimization.DISABLED;
@@ -105,6 +106,18 @@ public class FeaturesConfig
     public boolean isLegacyArrayAgg()
     {
         return legacyArrayAgg;
+    }
+
+    @Config("deprecated.legacy-order-by")
+    public FeaturesConfig setLegacyOrderBy(boolean value)
+    {
+        this.legacyOrderBy = value;
+        return this;
+    }
+
+    public boolean isLegacyOrderBy()
+    {
+        return legacyOrderBy;
     }
 
     @Config("distributed-joins-enabled")

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -54,7 +54,8 @@ public class TestFeaturesConfig
                 .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("4MB"))
                 .setSpillerSpillPath(Paths.get(System.getProperty("java.io.tmpdir"), "presto", "spills").toString())
                 .setSpillerThreads(4)
-                .setOptimizeMixedDistinctAggregations(false));
+                .setOptimizeMixedDistinctAggregations(false)
+                .setLegacyOrderBy(false));
     }
 
     @Test
@@ -63,6 +64,7 @@ public class TestFeaturesConfig
         Map<String, String> propertiesLegacy = new ImmutableMap.Builder<String, String>()
                 .put("experimental.resource-groups-enabled", "true")
                 .put("deprecated.legacy-array-agg", "true")
+                .put("deprecated.legacy-order-by", "true")
                 .put("distributed-index-joins-enabled", "true")
                 .put("distributed-joins-enabled", "false")
                 .put("colocated-joins-enabled", "true")
@@ -85,6 +87,7 @@ public class TestFeaturesConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("experimental.resource-groups-enabled", "true")
                 .put("deprecated.legacy-array-agg", "true")
+                .put("deprecated.legacy-order-by", "true")
                 .put("distributed-index-joins-enabled", "true")
                 .put("distributed-joins-enabled", "false")
                 .put("colocated-joins-enabled", "true")
@@ -125,7 +128,8 @@ public class TestFeaturesConfig
                 .setSpillEnabled(true)
                 .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("100MB"))
                 .setSpillerSpillPath("/tmp/custom/spill/path")
-                .setSpillerThreads(42);
+                .setSpillerThreads(42)
+                .setLegacyOrderBy(true);
 
         assertFullMapping(properties, expected);
         assertDeprecatedEquivalence(FeaturesConfig.class, properties, propertiesLegacy);


### PR DESCRIPTION
We recently made a change to the column resolution rules for ORDER BY to
make them compliant with ANSI SQL. In order to ease the transition from
the old semantics, we now add a config option and session property that
controls the behavior.

The session property is "legacy_order_by". The config option is
"deprecated.legacy-order-by".

This will be removed in a not-too-distant version.

Fixes #6867