### PR TITLE
Fix broken default for legacy_order_by session property

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -258,8 +258,8 @@ public final class SystemSessionProperties
                 booleanSessionProperty(
                         LEGACY_ORDER_BY,
                         "Use legacy rules for column resolution in ORDER BY clause",
-                        false,
-                        featuresConfig.isLegacyOrderBy()));
+                        featuresConfig.isLegacyOrderBy(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()


### PR DESCRIPTION
The arguments were in the wrong order, so the value from
FeaturesConfig was not being used to control the default value.