### PR TITLE
Fix planning issue when ORDER BY clause contains aggregations

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -790,7 +790,12 @@ class StatementAnalyzer
         List<Expression> orderByExpressions = analyzeOrderBy(node, sourceScope, outputScope, outputExpressions);
         analyzeHaving(node, sourceScope);
 
-        analyzeAggregations(node, sourceScope, groupByExpressions, outputExpressions, orderByExpressions, analysis.getColumnReferences());
+        List<Expression> expressions = new ArrayList<>();
+        expressions.addAll(outputExpressions);
+        expressions.addAll(orderByExpressions);
+        node.getHaving().ifPresent(expressions::add);
+
+        analyzeAggregations(node, sourceScope, groupByExpressions, analysis.getColumnReferences(), expressions);
         analyzeWindowFunctions(node, outputExpressions, orderByExpressions);
 
         return outputScope;
@@ -1434,7 +1439,7 @@ class StatementAnalyzer
             computedGroupingSets = computeGroupingSetsCrossProduct(enumeratedGroupingSets, node.getGroupBy().get().isDistinct());
             checkState(!computedGroupingSets.isEmpty(), "computed grouping sets cannot be empty");
         }
-        else if (!extractAggregates(node).isEmpty()) {
+        else if (hasAggregates(node)) {
             // if there are aggregates, but no group by, create a grand total grouping set (global aggregation)
             computedGroupingSets = ImmutableList.of(ImmutableSet.of());
         }
@@ -1647,11 +1652,14 @@ class StatementAnalyzer
             QuerySpecification node,
             Scope scope,
             List<List<Expression>> groupingSets,
-            List<Expression> outputExpressions,
-            List<Expression> orderByExpressions,
-            Set<Expression> columnReferences)
+            Set<Expression> columnReferences,
+            List<Expression> expressions)
     {
-        extractAggregates(node);
+        AggregateExtractor extractor = new AggregateExtractor(metadata);
+        for (Expression expression : expressions) {
+            extractor.process(expression);
+        }
+        analysis.setAggregates(node, extractor.getAggregates());
 
         // is this an aggregation query?
         if (!groupingSets.isEmpty()) {
@@ -1665,37 +1673,28 @@ class StatementAnalyzer
                     .distinct()
                     .collect(toImmutableList());
 
-            for (Expression expression : Iterables.concat(outputExpressions, orderByExpressions)) {
+            for (Expression expression : expressions) {
                 verifyAggregations(distinctGroupingColumns, scope, expression, columnReferences);
-            }
-
-            if (node.getHaving().isPresent()) {
-                verifyAggregations(distinctGroupingColumns, scope, node.getHaving().get(), columnReferences);
             }
         }
     }
 
-    private List<FunctionCall> extractAggregates(QuerySpecification node)
+    private boolean hasAggregates(QuerySpecification node)
     {
         AggregateExtractor extractor = new AggregateExtractor(metadata);
-        for (SelectItem item : node.getSelect().getSelectItems()) {
-            if (item instanceof SingleColumn) {
-                extractor.process(((SingleColumn) item).getExpression(), null);
-            }
-        }
 
-        for (SortItem item : node.getOrderBy()) {
-            extractor.process(item.getSortKey(), null);
-        }
+        node.getSelect()
+                .getSelectItems().stream()
+                .filter(SingleColumn.class::isInstance)
+                .forEach(extractor::process);
 
-        if (node.getHaving().isPresent()) {
-            extractor.process(node.getHaving().get(), null);
-        }
+        node.getOrderBy().stream()
+                .forEach(extractor::process);
 
-        List<FunctionCall> aggregates = extractor.getAggregates();
-        analysis.setAggregates(node, aggregates);
+        node.getHaving()
+                .ifPresent(extractor::process);
 
-        return aggregates;
+        return !extractor.getAggregates().isEmpty();
     }
 
     private void verifyAggregations(

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -17,6 +17,11 @@ import javax.annotation.Nullable;
 
 public abstract class AstVisitor<R, C>
 {
+    public R process(Node node)
+    {
+        return process(node, null);
+    }
+
     public R process(Node node, @Nullable C context)
     {
         return node.accept(this, context);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1011,6 +1011,18 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testOrderByWithAggregation()
+            throws Exception
+    {
+        assertQuery("" +
+                "SELECT x, sum(cast(x AS double))\n" +
+                "FROM (VALUES '1.0') t(x)\n" +
+                "GROUP BY x\n" +
+                "ORDER BY sum(cast(x AS double))",
+                "VALUES ('1.0', 1.0)");
+    }
+
+    @Test
     public void testGroupByOrderByLimit()
     {
         assertQueryOrdered("SELECT custkey, SUM(totalprice) FROM ORDERS GROUP BY custkey ORDER BY SUM(totalprice) DESC LIMIT 10");


### PR DESCRIPTION
A recent commit (ec2e8976ba9cd59f3990b8e46288b8a728065b07) changed
the way ORDER BY expressions are handled in a way that causes certain
expression to not be "analyzed" and their types be recorded in the
Analysis object.

extractAggregates() looks for aggregations in node.getOrderBy()
and records them for later use by the planner. The new ORDER BY
analyzer process the rewritten expressions, which have a different
object identity. As a result, the aggregates don't have associated
type and implicit coercion information for the planner to use.

This change makes it so that the aggregates are extracted from
the rewritten expressions.

Fixes https://github.com/prestodb/presto/issues/6882