### PR TITLE
Fix reporting for errors in ORDER BY expression

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -406,6 +406,8 @@ public class TestAnalyzer
             throws Exception
     {
         assertFails(AMBIGUOUS_ATTRIBUTE, "SELECT a x, b x FROM t1 ORDER BY x");
+        assertFails(AMBIGUOUS_ATTRIBUTE, "SELECT a x, a x FROM t1 ORDER BY x");
+        assertFails(AMBIGUOUS_ATTRIBUTE, "SELECT a, a FROM t1 ORDER BY a");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1005,9 +1005,8 @@ public abstract class AbstractTestQueries
         assertQueryOrdered("SELECT a, a* -2 AS b FROM (VALUES -1, 0, 2) t(a) ORDER BY a + b", "VALUES (2, -4), (0, 0), (-1, 2)");
         assertQueryOrdered("SELECT a as b, a* -2 AS a FROM (VALUES -1, 0, 2) t(a) ORDER BY a + b", "VALUES (2, -4), (0, 0), (-1, 2)");
         assertQueryOrdered("SELECT a* -2 AS a FROM (VALUES -1, 0, 2) t(a) ORDER BY a + t.a", "VALUES -4, 0, 2");
-        assertQueryOrdered("SELECT a* -2 AS a, a* -2 AS a FROM (VALUES -1, 0, 2) t(a) ORDER BY a", "VALUES (-4, -4), (0, 0), (2, 2)");
 
-        assertQueryFails("SELECT a, a* -1 AS a FROM (VALUES -1, 0, 2) t(a) ORDER BY a", ".*'a' in ORDER BY is ambiguous");
+        assertQueryFails("SELECT a, a* -1 AS a FROM (VALUES -1, 0, 2) t(a) ORDER BY a", ".*'a' is ambiguous");
     }
 
     @Test
@@ -3260,13 +3259,6 @@ public abstract class AbstractTestQueries
     public void testOrderByMultipleFields()
     {
         assertQueryOrdered("SELECT custkey, orderstatus FROM orders ORDER BY custkey DESC, orderstatus");
-    }
-
-    @Test
-    public void testOrderByDuplicateFields()
-    {
-        assertQueryOrdered("SELECT custkey, custkey FROM orders ORDER BY custkey, custkey");
-        assertQueryOrdered("SELECT custkey, custkey FROM orders ORDER BY custkey ASC, custkey DESC");
     }
 
     @Test


### PR DESCRIPTION
Due to ec2e8976ba9cd59f3990b8e46288b8a728065b07, when analysis fails for certain
expressions, the error is misreported as happening in the SELECT clause
instead of in the ORDER BY clause. This is because the analyzer processes
the rewritten expressions, which contain inlined SELECT expressions and their
original locations.

This change fixes the issue by analyzing the original unmodified expressions
with a synthetic scope built from the output of the SELECT clause
that can delegate resolution to the source scope for missing names (essentially,
it implements the resolution rules per the SQL spec).

One side-effect of this change is that queries whose ORDER BY clause reference
columns that appear multiple times in the SELECT clause are now considered
invalid due to ambiguous references -- this matches the expected behavior
according to the ANSI spec.

Fixes https://github.com/prestodb/presto/issues/6883

(First commit is part of https://github.com/prestodb/presto/pull/6885)