### PR TITLE
Support Parquet TupleDomain using ColumnDescriptor

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
@@ -14,6 +14,16 @@
 package com.facebook.presto.hive.parquet;
 
 import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.RealType;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarcharType;
 import parquet.column.ColumnDescriptor;
 import parquet.column.Encoding;
 import parquet.io.ColumnIO;
@@ -21,14 +31,24 @@ import parquet.io.ColumnIOFactory;
 import parquet.io.InvalidRecordException;
 import parquet.io.ParquetDecodingException;
 import parquet.io.PrimitiveColumnIO;
+import parquet.schema.DecimalMetadata;
 import parquet.schema.MessageType;
-import parquet.schema.Type;
 
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Optional.empty;
+import static parquet.schema.OriginalType.DECIMAL;
+import static parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
+import static parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
+import static parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+import static parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
 
 public final class ParquetTypeUtils
 {
@@ -44,27 +64,68 @@ public final class ParquetTypeUtils
     public static Optional<RichColumnDescriptor> getDescriptor(MessageType fileSchema, MessageType requestedSchema, List<String> path)
     {
         checkArgument(path.size() >= 1, "Parquet nested path should have at least one component");
-        int level = path.size();
-        for (PrimitiveColumnIO columnIO : getColumns(fileSchema, requestedSchema)) {
-            ColumnIO[] fields = columnIO.getPath();
-            if (fields.length <= level) {
+        int index = getPathIndex(fileSchema, requestedSchema, path);
+        return getDescriptor(fileSchema, requestedSchema, index);
+    }
+
+    public static Optional<RichColumnDescriptor> getDescriptor(MessageType fileSchema, MessageType requestedSchema, int index)
+    {
+        if (index == -1) {
+            return empty();
+        }
+        PrimitiveColumnIO columnIO = getColumns(fileSchema, requestedSchema).get(index);
+        ColumnDescriptor descriptor = columnIO.getColumnDescriptor();
+        return Optional.of(new RichColumnDescriptor(descriptor.getPath(), columnIO.getType().asPrimitiveType(), descriptor.getMaxRepetitionLevel(), descriptor.getMaxDefinitionLevel()));
+    }
+
+    private static int getPathIndex(MessageType fileSchema, MessageType requestedSchema, List<String> path)
+    {
+        int maxLevel = path.size();
+        List<PrimitiveColumnIO> columns = getColumns(fileSchema, requestedSchema);
+        int index = -1;
+        for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+            ColumnIO[] fields = columns.get(columnIndex).getPath();
+            if (fields.length <= maxLevel) {
                 continue;
             }
-            if (fields[level].getName().equalsIgnoreCase(path.get(level - 1))) {
+            if (fields[maxLevel].getName().equalsIgnoreCase(path.get(maxLevel - 1))) {
                 boolean match = true;
-                for (int i = 0; i < level - 1; i++) {
-                    if (!fields[i + 1].getName().equalsIgnoreCase(path.get(i))) {
+                for (int level = 0; level < maxLevel - 1; level++) {
+                    if (!fields[level + 1].getName().equalsIgnoreCase(path.get(level))) {
                         match = false;
                     }
                 }
 
                 if (match) {
-                    ColumnDescriptor descriptor = columnIO.getColumnDescriptor();
-                    return Optional.of(new RichColumnDescriptor(descriptor.getPath(), columnIO.getType().asPrimitiveType(), descriptor.getMaxRepetitionLevel(), descriptor.getMaxDefinitionLevel()));
+                    index = columnIndex;
                 }
             }
         }
-        return empty();
+        return index;
+    }
+
+    public static Type getPrestoType(RichColumnDescriptor descriptor)
+    {
+        switch (descriptor.getType()) {
+            case BOOLEAN:
+                return BooleanType.BOOLEAN;
+            case BINARY:
+                return createDecimalType(descriptor).orElse(VarcharType.VARCHAR);
+            case FLOAT:
+                return RealType.REAL;
+            case DOUBLE:
+                return DoubleType.DOUBLE;
+            case INT32:
+                return createDecimalType(descriptor).orElse(IntegerType.INTEGER);
+            case INT64:
+                return createDecimalType(descriptor).orElse(BigintType.BIGINT);
+            case INT96:
+                return TimestampType.TIMESTAMP;
+            case FIXED_LEN_BYTE_ARRAY:
+                return createDecimalType(descriptor).orElseThrow(() -> new PrestoException(NOT_SUPPORTED, "Parquet type FIXED_LEN_BYTE_ARRAY supported as DECIMAL; got " + descriptor.getPrimitiveType().getOriginalType()));
+            default:
+                throw new PrestoException(NOT_SUPPORTED, "Unsupported parquet type: " + descriptor.getType());
+        }
     }
 
     public static int getFieldIndex(MessageType fileSchema, String name)
@@ -73,7 +134,7 @@ public final class ParquetTypeUtils
             return fileSchema.getFieldIndex(name);
         }
         catch (InvalidRecordException e) {
-            for (Type type : fileSchema.getFields()) {
+            for (parquet.schema.Type type : fileSchema.getFields()) {
                 if (type.getName().equalsIgnoreCase(name)) {
                     return fileSchema.getFieldIndex(type.getName());
                 }
@@ -125,12 +186,21 @@ public final class ParquetTypeUtils
         }
         // parquet is case-sensitive, but hive is not. all hive columns get converted to lowercase
         // check for direct match above but if no match found, try case-insensitive match
-        for (Type type : messageType.getFields()) {
+        for (parquet.schema.Type type : messageType.getFields()) {
             if (type.getName().equalsIgnoreCase(columnName)) {
                 return type;
             }
         }
 
         return null;
+    }
+
+    public static Optional<Type> createDecimalType(RichColumnDescriptor descriptor)
+    {
+        if (descriptor.getPrimitiveType().getOriginalType() != DECIMAL) {
+            return Optional.empty();
+        }
+        DecimalMetadata decimalMetadata = descriptor.getPrimitiveType().getDecimalMetadata();
+        return Optional.of(DecimalType.createDecimalType(decimalMetadata.getPrecision(), decimalMetadata.getScale()));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/ParquetPredicate.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/ParquetPredicate.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.parquet.predicate;
 
+import parquet.column.ColumnDescriptor;
 import parquet.column.statistics.Statistics;
 
 import java.util.Map;
@@ -22,13 +23,13 @@ public interface ParquetPredicate
     ParquetPredicate TRUE = new ParquetPredicate()
     {
         @Override
-        public boolean matches(long numberOfRows, Map<Integer, Statistics<?>> statisticsByColumnIndex)
+        public boolean matches(long numberOfRows, Map<ColumnDescriptor, Statistics<?>> statistics)
         {
             return true;
         }
 
         @Override
-        public boolean matches(Map<Integer, ParquetDictionaryDescriptor> dictionariesByColumnIndex)
+        public boolean matches(Map<ColumnDescriptor, ParquetDictionaryDescriptor> dictionaries)
         {
             return true;
         }
@@ -39,16 +40,14 @@ public interface ParquetPredicate
      *
      * @param numberOfRows the number of rows in the segment; this can be used with
      * Statistics to determine if a column is only null
-     * @param statisticsByColumnIndex statistics for column by ordinal position
-     * in the file; this will match the field order from the hive metastore
+     * @param statistics column statistics
      */
-    boolean matches(long numberOfRows, Map<Integer, Statistics<?>> statisticsByColumnIndex);
+    boolean matches(long numberOfRows, Map<ColumnDescriptor, Statistics<?>> statistics);
 
     /**
      * Should the Parquet Reader process a file section with the specified dictionary.
      *
-     * @param dictionariesByColumnIndex dictionaries for column by ordinal position
-     * in the file; this will match the field order from the hive metastore
+     * @param dictionaries dictionaries per column
      */
-    boolean matches(Map<Integer, ParquetDictionaryDescriptor> dictionariesByColumnIndex);
+    boolean matches(Map<ColumnDescriptor, ParquetDictionaryDescriptor> dictionaries);
 }


### PR DESCRIPTION
Currently Parquet TupleDomain is constructed based on HiveColumnHandle. This would not work if Nested predicate are pushed down, e.g.
```
select s.a
from t
where s.b > 10
```
This patch construct Parquet TupleDomain with Parquet's ColumnDescriptor, so that it could work with nested predicate pushdown
