### PR TITLE
Improve URL function `url_extract_parameter` and `url_extract_query`

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/UrlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/UrlFunctions.java
@@ -95,7 +95,7 @@ public final class UrlFunctions
     public static Slice urlExtractQuery(@SqlType(StandardTypes.VARCHAR) Slice url)
     {
         URI uri = parseUrl(url);
-        return (uri == null) ? null : slice(uri.getQuery());
+        return (uri == null) ? null : slice(uri.getRawQuery());
     }
 
     @SqlNullable
@@ -115,11 +115,11 @@ public final class UrlFunctions
     public static Slice urlExtractParameter(@SqlType(StandardTypes.VARCHAR) Slice url, @SqlType(StandardTypes.VARCHAR) Slice parameterName)
     {
         URI uri = parseUrl(url);
-        if ((uri == null) || (uri.getQuery() == null)) {
+        if ((uri == null) || (uri.getRawQuery() == null)) {
             return null;
         }
 
-        Slice query = slice(uri.getQuery());
+        Slice query = slice(uri.getRawQuery());
         String parameter = parameterName.toStringUtf8();
         Iterable<String> queryArgs = QUERY_SPLITTER.split(query.toStringUtf8());
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUrlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUrlFunctions.java
@@ -33,6 +33,7 @@ public class TestUrlFunctions
         validateUrlExtract("mailto:test@example.com", "mailto", "", null, "", "", "");
         validateUrlExtract("foo", "", "", null, "foo", "", "");
         validateUrlExtract("http://example.com/^", null, null, null, null, null, null);
+        validateUrlExtract("http://example.com/path1/p.php?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1#Ref1", "http", "example.com", null, "/path1/p.php", "source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1", "Ref1");
     }
 
     @Test
@@ -47,6 +48,7 @@ public class TestUrlFunctions
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k1&k1=v1&k1&k1#Ref1', 'k1')", VARCHAR, "");
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k=a=b=c&x=y#Ref1', 'k')", VARCHAR, "a=b=c");
         assertFunction("url_extract_parameter('foo', 'k1')", VARCHAR, null);
+        assertFunction("url_extract_parameter('http://example.com/path1/p.php?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1', 'source_url')", VARCHAR, "http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar");
     }
 
     @Test


### PR DESCRIPTION
use `getRawQuery()` instead of `getQuery()` in `urlExtractParameter` and `urlExtractQuery`
method. to awoid decode query parameters.

for example:

```
presto:log> select url_extract_parameter('http://foo.com?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar',
'source_url');
_col0
----------------------
http://bar.com?a=foo
```
the expectation output is `http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar`

and also in `url_extract_query` function

```
presto:log> select url_extract_query('http://foo.com?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar');
_col0
-------------------------------------
source_url=http://bar.com?a=foo&b=bar
```
and expectation output is `source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar`