### PR TITLE
Add Avro to list of supported file types

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -31,6 +31,7 @@ The following file types are supported for the Hive connector:
 
 * ORC
 * Parquet
+* Avro
 * RCFile
 * SequenceFile
 * Text


### PR DESCRIPTION
Avro has been added to the supported file types with Presto 0.155. This change has not been reflected in the documentation, yet.