### PR TITLE
Fix test failure at adding queryIds and cpuUsage to ResourceGroupInfo

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupInfo.java
@@ -13,11 +13,14 @@
  */
 package com.facebook.presto.execution.resourceGroups;
 
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 
 import java.util.List;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -30,7 +33,9 @@ public class ResourceGroupInfo
     private final int maxQueuedQueries;
     private final int runningQueries;
     private final int queuedQueries;
+    private final long cpuUsage;
     private final DataSize memoryUsage;
+    private final Set<QueryId> queryIds;
     private final List<ResourceGroupInfo> subGroups;
 
     public ResourceGroupInfo(
@@ -40,7 +45,9 @@ public class ResourceGroupInfo
             int maxQueuedQueries,
             int runningQueries,
             int queuedQueries,
+            long cpuUsage,
             DataSize memoryUsage,
+            Set<QueryId> queryIds,
             List<ResourceGroupInfo> subGroups)
     {
         this.id = id;
@@ -49,7 +56,9 @@ public class ResourceGroupInfo
         this.maxQueuedQueries = maxQueuedQueries;
         this.runningQueries = runningQueries;
         this.queuedQueries = queuedQueries;
+        this.cpuUsage = cpuUsage;
         this.memoryUsage = requireNonNull(memoryUsage, "memoryUsage is null");
+        this.queryIds = ImmutableSet.copyOf(requireNonNull(queryIds, "queryIds is null"));
         this.subGroups = ImmutableList.copyOf(requireNonNull(subGroups, "subGroups is null"));
     }
 
@@ -88,8 +97,18 @@ public class ResourceGroupInfo
         return queuedQueries;
     }
 
+    public long getCpuUsage()
+    {
+        return cpuUsage;
+    }
+
     public DataSize getMemoryUsage()
     {
         return memoryUsage;
+    }
+
+    public Set<QueryId> getQueryIds()
+    {
+        return queryIds;
     }
 }

--- a/presto-tests/src/test/resources/resource_groups_info.json
+++ b/presto-tests/src/test/resources/resource_groups_info.json
@@ -1,0 +1,21 @@
+{
+  "rootGroups": [
+    {
+      "name": "global",
+      "softMemoryLimit": "50%",
+      "hardCpuLimit": "5m",
+      "softCpuLimit": "30s",
+      "maxRunning": 100,
+      "maxQueued": 1000,
+      "subGroups": [
+      ]
+    }
+  ],
+  "selectors": [
+    {
+      "group": "global"
+    }
+  ],
+  "cpuQuotaPeriod": "1ms"
+}
+


### PR DESCRIPTION
This reverts commit c030a101e0b4036b5f9c6f443966836d8b50f7c8.

Also `queryIds` include all subGroups' as like other properties do.