### PR TITLE
Skip synchronization of outer positions on writes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinHash.java
@@ -98,4 +98,9 @@ public final class JoinHash
     {
         pagesHash.appendTo(toIntExact(position), pageBuilder, outputChannelOffset);
     }
+
+    @Override
+    public void close()
+    {
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -174,11 +174,11 @@ public class LookupJoinOperator
         closed = true;
         probe = null;
         pageBuilder.reset();
-        onClose.run();
         // closing lookup source is only here for index join
         if (lookupSource != null) {
             lookupSource.close();
         }
+        onClose.run();
     }
 
     private boolean joinCurrentPosition()

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
@@ -45,7 +45,7 @@ public interface LookupSource
 
     // this is only here for index lookup source
     @Override
-    default void close() {}
+    void close();
 
     interface OuterPositionIterator
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
@@ -43,7 +43,6 @@ public interface LookupSource
         return (pageBuilder, outputChannelOffset) -> false;
     }
 
-    // this is only here for index lookup source
     @Override
     void close();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/OuterLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OuterLookupSource.java
@@ -94,6 +94,12 @@ public final class OuterLookupSource
         return outerPositionTracker.getOuterPositionIterator();
     }
 
+    @Override
+    public void close()
+    {
+        lookupSource.close();
+    }
+
     @ThreadSafe
     private static class SharedLookupOuterPositionIterator
             implements OuterPositionIterator

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
@@ -414,5 +414,10 @@ public class IndexLoader
         {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public void close()
+        {
+        }
     }
 }


### PR DESCRIPTION
Addresses this issue: https://github.com/prestodb/presto/issues/6923

Not an ideal solution, better one would be to completely omit synchronization by using one copy of `visitedPosition` per thread and later merge them together, but from benchmarking this already gives significant improvement (this one is still ~30% slower compared to version without synchronization before @dain changes) . 

CC @KBP-TDC 