### PR TITLE
Set the local language during test

### DIFF
--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbResourceGroupConfigurationManager.java
@@ -21,6 +21,7 @@ import io.airlift.units.Duration;
 import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.testng.annotations.Test;
 
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -39,6 +40,9 @@ public class TestDbResourceGroupConfigurationManager
 {
     static H2DaoProvider setup(String prefix)
     {
+        //  Set the language for test as some exception messages use the language specified in locale. See #6655 for details.
+        Locale.setDefault(new Locale("en", "US"));
+
         DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_" + prefix + System.nanoTime());
         return new H2DaoProvider(config);
     }


### PR DESCRIPTION
Some exception messages use the language specified in locale.
This will cause test case fail under different locale settings as
the exception message is not matched.

Fixes: https://github.com/prestodb/presto/issues/6655