### PR TITLE
Guarantee all queries are expired

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -401,7 +401,7 @@ public class QueryStateMachine
                 outputPositions,
                 operatorStatsSummary.build());
 
-        return new QueryInfo(queryId,
+        QueryInfo queryInfo =  new QueryInfo(queryId,
                 session.toSessionRepresentation(),
                 state,
                 memoryPool.get().getId(),
@@ -424,6 +424,10 @@ public class QueryStateMachine
                 output.get(),
                 completeInfo,
                 getResourceGroup());
+        if (queryInfo.isFinalQueryInfo()) {
+            finalQueryInfo.compareAndSet(Optional.empty(), Optional.of(queryInfo));
+        }
+        return queryInfo;
     }
 
     public VersionedMemoryPoolId getMemoryPool()
@@ -699,15 +703,6 @@ public class QueryStateMachine
     public Optional<QueryInfo> getFinalQueryInfo()
     {
         return finalQueryInfo.get();
-    }
-
-    public QueryInfo updateQueryInfo(Optional<StageInfo> stageInfo)
-    {
-        QueryInfo queryInfo = getQueryInfo(stageInfo);
-        if (queryInfo.isFinalQueryInfo()) {
-            finalQueryInfo.compareAndSet(Optional.empty(), Optional.of(queryInfo));
-        }
-        return queryInfo;
     }
 
     public void pruneQueryInfo()

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -472,7 +472,7 @@ public final class SqlQueryExecution
             stageInfo = Optional.ofNullable(scheduler.getStageInfo());
         }
 
-        QueryInfo queryInfo = stateMachine.updateQueryInfo(stageInfo);
+        QueryInfo queryInfo = stateMachine.getQueryInfo(stageInfo);
         if (queryInfo.isFinalQueryInfo()) {
             // capture the final query state and drop reference to the scheduler
             queryScheduler.set(null);


### PR DESCRIPTION
Updated transitionTo functions to guarantee that finalQueryInfo listeners are fired. This fixes #6747