### PR TITLE
"Error opening Hive split" caused by "Request is a replay" error fixed with retries.

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -71,6 +71,7 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_MISSING_DATA;
 import static com.facebook.presto.hive.HiveUtil.closeWithSuppression;
 import static com.facebook.presto.hive.HiveUtil.getDecimalType;
+import static com.facebook.presto.hive.RetryDriver.retry;
 import static com.facebook.presto.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getParquetType;
 import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.buildParquetPredicate;
@@ -329,7 +330,10 @@ public class ParquetHiveRecordCursor
         try {
             FileSystem fileSystem = hdfsEnvironment.getFileSystem(sessionUser, path, configuration);
             dataSource = buildHdfsParquetDataSource(fileSystem, path, start, length);
-            ParquetMetadata parquetMetadata = hdfsEnvironment.doAs(sessionUser, () -> ParquetFileReader.readFooter(configuration, path, NO_FILTER));
+            ParquetMetadata parquetMetadata = retry()
+                    .stopOnIllegalExceptions()
+                    .run("createParquetRecordReaderReadFooter", () -> hdfsEnvironment.doAs(
+                            sessionUser, () -> ParquetFileReader.readFooter(configuration, path, NO_FILTER)));
             List<BlockMetaData> blocks = parquetMetadata.getBlocks();
             FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
@@ -365,12 +369,8 @@ public class ParquetHiveRecordCursor
             ParquetInputSplit split = new ParquetInputSplit(path, start, start + length, length, null, offsets.toLongArray());
 
             TaskAttemptContext taskContext = ContextUtil.newTaskAttemptContext(configuration, new TaskAttemptID());
-
-            return hdfsEnvironment.doAs(sessionUser, () -> {
-                ParquetRecordReader<FakeParquetRecord> realReader = new PrestoParquetRecordReader(readSupport);
-                realReader.initialize(split, taskContext);
-                return realReader;
-            });
+            return retry().stopOnIllegalExceptions().run("createParquetRecordReaderInitializeRealReader",
+                    () -> hdfsEnvironment.doAs(sessionUser, () -> initializeRealReader(readSupport, split, taskContext)));
         }
         catch (Exception e) {
             Throwables.propagateIfInstanceOf(e, PrestoException.class);
@@ -393,6 +393,16 @@ public class ParquetHiveRecordCursor
                 }
             }
         }
+    }
+
+    private ParquetRecordReader<FakeParquetRecord> initializeRealReader(PrestoReadSupport readSupport,
+                                                                        ParquetInputSplit split,
+                                                                        TaskAttemptContext taskContext)
+            throws IOException, InterruptedException
+    {
+        ParquetRecordReader<FakeParquetRecord> realReader = new PrestoParquetRecordReader(readSupport);
+        realReader.initialize(split, taskContext);
+        return realReader;
     }
 
     public class PrestoParquetRecordReader

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/HiveFileIterator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/HiveFileIterator.java
@@ -114,7 +114,8 @@ public class HiveFileIterator
         try (TimeStat.BlockTimer ignored = namenodeStats.getListLocatedStatus().time()) {
             return retry()
                     .stopOnIllegalExceptions()
-                    .run("getLocatedFileStatusRemoteIterator", () -> directoryLister.list(fileSystem, path));
+                    .run("getLocatedFileStatusRemoteIterator", 
+                            () -> directoryLister.list(fileSystem, path));
         }
         catch (IOException | RuntimeException e) {
             namenodeStats.getListLocatedStatus().recordException(e);


### PR DESCRIPTION
Hello again. 

I accidentally messed up PR #6896 so let me create new one (I've closed the old one).

We've tested this on master with orc, parquet, avro and json file formats and everything is working fine. Performance overhead added in the second commit to previous pull request is not occurring this time.

Let me know if something could be better here :)

> 
> This pull request probably fixes #5709 - at least for my case (mentioned in the issue’s comment) and maybe also #6186 but I have not tested that.
> 
> Our setup consists of kerberized hadoop 2.6-cdh5.8.0 cluster connected with ActiveDirectory, 2 namenodes in HA and some datanodes acting also as presto workers. One of the datanodes is presto coordinator. During the tests we noticed that first few queries after starting coordinator and workers fails with everyone’s favourite „GSS initiate failed” exception.
> Investigation in the code led us to the [CachingKerberosHadoopAuthentication][1] class. Forcing condition in 47th line to be always true fixes the problem but that kind of solution had a drawback of few request for each file (that ought to be read from HDFS) made to the KDC instance so we investigated it a bit deeper and found that "Request is a replay" message is returned by KDC.
> We've also found that in [HiveServer2][2] this issue is fixed by simply retrying failing operation so this is the change we've also made.

[1]: https://github.com/prestodb/presto/blob/master/presto-hive/src/main/java/com/facebook/presto/hive/authentication/CachingKerberosHadoopAuthentication.java
[2]: https://issues.apache.org/jira/browse/HIVE-12481