### PR TITLE
Preserve relative order of conjuncts

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Iterables;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
@@ -43,7 +44,6 @@ import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpressionType.IS_DISTINCT_FROM;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
-import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -105,11 +105,54 @@ public final class ExpressionUtils
         requireNonNull(expressions, "expressions is null");
         Preconditions.checkArgument(!expressions.isEmpty(), "expressions is empty");
 
-        // build balanced tree for efficient recursive processing
+        // Build balanced tree for efficient recursive processing that
+        // preserves the evaluation order of the input expressions.
+        //
+        // The tree is built bottom up by combining pairs of elements into
+        // binary AND expressions.
+        //
+        // Example:
+        //
+        // Initial state:
+        //  a b c d e
+        //
+        // First iteration:
+        //
+        //  /\    /\   e
+        // a  b  c  d
+        //
+        // Second iteration:
+        //
+        //    / \    e
+        //  /\   /\
+        // a  b c  d
+        //
+        //
+        // Last iteration:
+        //
+        //      / \
+        //    / \  e
+        //  /\   /\
+        // a  b c  d
+
         Queue<Expression> queue = new ArrayDeque<>(expressions);
         while (queue.size() > 1) {
-            queue.add(new LogicalBinaryExpression(type, queue.remove(), queue.remove()));
+            Queue<Expression> buffer = new ArrayDeque<>();
+
+            // combine pairs of elements
+            while (queue.size() >= 2) {
+                buffer.add(new LogicalBinaryExpression(type, queue.remove(), queue.remove()));
+            }
+
+            // if there's and odd number of elements, just append the last one
+            if (!queue.isEmpty()) {
+                buffer.add(queue.remove());
+            }
+
+            // continue processing the pairs that were just built
+            queue = buffer;
         }
+
         return queue.remove();
     }
 
@@ -222,22 +265,26 @@ public final class ExpressionUtils
         };
     }
 
+    /**
+     * Removes duplicate deterministic expressions. Preserves the relative order
+     * of the expressions in the list.
+     */
     private static List<Expression> removeDuplicates(List<Expression> expressions)
     {
-        // Capture all non-deterministic predicates
-        List<Expression> nonDeterministicDisjuncts = expressions.stream()
-                .filter(e -> !DeterminismEvaluator.isDeterministic(e))
-                .collect(toImmutableList());
+        Set<Expression> seen = new HashSet<>();
 
-        // Capture and de-dupe all deterministic predicates
-        Set<Expression> deterministicDisjuncts = expressions.stream()
-                .filter(DeterminismEvaluator::isDeterministic)
-                .collect(toImmutableSet());
+        ImmutableList.Builder<Expression> result = ImmutableList.builder();
+        for (Expression expression : expressions) {
+            if (!DeterminismEvaluator.isDeterministic(expression)) {
+                result.add(expression);
+            }
+            else if (!seen.contains(expression)) {
+                result.add(expression);
+                seen.add(expression);
+            }
+        }
 
-        return ImmutableList.<Expression>builder()
-                .addAll(nonDeterministicDisjuncts)
-                .addAll(deterministicDisjuncts)
-                .build();
+        return result.build();
     }
 
     public static Expression normalize(Expression expression)

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionUtils.java
@@ -17,6 +17,7 @@ import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.IsNullPredicate;
 import com.facebook.presto.sql.tree.LikePredicate;
+import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -32,6 +33,25 @@ import static org.testng.Assert.assertEquals;
 
 public class TestExpressionUtils
 {
+    @Test
+    public void testAnd()
+            throws Exception
+    {
+        Expression a = name("a");
+        Expression b = name("b");
+        Expression c = name("c");
+        Expression d = name("d");
+        Expression e = name("e");
+
+        assertEquals(
+                ExpressionUtils.and(a, b, c, d, e),
+                and(and(and(a, b), and(c, d)), e));
+
+        assertEquals(
+                ExpressionUtils.combineConjuncts(a, b, a, c, d, c, e),
+                and(and(and(a, b), and(c, d)), e));
+    }
+
     @Test
     public void testNormalize()
             throws Exception
@@ -62,5 +82,10 @@ public class TestExpressionUtils
     private static QualifiedNameReference name(String name)
     {
         return new QualifiedNameReference(QualifiedName.of(name));
+    }
+
+    private LogicalBinaryExpression and(Expression left, Expression right)
+    {
+        return new LogicalBinaryExpression(LogicalBinaryExpression.Type.AND, left, right);
     }
 }


### PR DESCRIPTION
ExpressionUtils.and() and ExpressionUtils.combineConjuncts()
try to build a balanced tree of terms. Due to the way the code
was written, for odd-numbered expressions, the algorithm places
the last term as the first term in the tree. For example:

    and(a, b, c, d, e) -> and(e, and(and(a, b), and(c, d)))

This can cause the predicate pushdown optimizer to reorder terms
that are sensitive to evaluation order.

Additionally, combineConjuncts attempts to remove duplicate terms,
but it does not preserve the relative ordering of the terms in the
input.