### PR TITLE
Fix Integer overflow at encodePartitionedJoinPosition

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
@@ -154,7 +154,7 @@ public class PartitionedLookupSource
 
     private long encodePartitionedJoinPosition(int partition, int joinPosition)
     {
-        return (joinPosition << shiftSize) | (partition);
+        return (((long) joinPosition) << shiftSize) | (partition);
     }
 
     private static class PartitionedLookupOuterPositionIterator


### PR DESCRIPTION
We had an issue of data inconsistency when the right side table is large in JOIN clause. By changing JOIN table orders, query returned expected result but we've been struggled to find out the root cause. The cause was an integer overflow at `encodePartitionedJoinPosition` in `PartitionedLookupSource`. Some records were missed by returning negative value after the encoding of a large integer value. 

The simplest fix for this issue the following, but it requires lots of type casting and comparison for `toIntExact`
```
@@ -154,7 +154,7 @@ public class PartitionedLookupSource

     private long encodePartitionedJoinPosition(int partition, int joinPosition)
     {
-        return (joinPosition << shiftSize) | (partition);
+        return (((long) joinPosition) << shiftSize) | (partition);
     }
```

The PR tries minimizing type casting also. 