### PR TITLE
Add option to make Hive plugin respect inputFormat.getSplits()

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.google.common.base.Splitter;
 import com.google.common.base.StandardSystemProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
@@ -31,7 +32,9 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
@@ -59,6 +62,7 @@ public class HiveClientConfig
     private int domainCompactionThreshold = 100;
     private boolean forceLocalScheduling;
     private boolean recursiveDirWalkerEnabled;
+    private Set<String> respectSplitsInputFormats;
 
     private int maxConcurrentFileRenames = 20;
 
@@ -217,6 +221,25 @@ public class HiveClientConfig
     public boolean getRecursiveDirWalkerEnabled()
     {
         return recursiveDirWalkerEnabled;
+    }
+
+    public Set<String> getRespectSplitsInputFormats()
+    {
+        return respectSplitsInputFormats;
+    }
+
+    @Config("hive.respect-splits.input-formats")
+    @ConfigDescription("Comma Separated List of Input Format Classnames which Presto should simply honor InputFormat.getSplits() to determine the splits")
+    public HiveClientConfig setRespectSplitsInputFormats(String inputFormatList)
+    {
+        this.respectSplitsInputFormats = (inputFormatList == null) ? null : new HashSet<>(SPLITTER.splitToList(inputFormatList));
+        return this;
+    }
+
+    public HiveClientConfig setRespectSplitsInputFormats(Set<String> inputFormats)
+    {
+        this.respectSplitsInputFormats = (inputFormats == null) ? null : ImmutableSet.copyOf(inputFormats);
+        return this;
     }
 
     public DateTimeZone getDateTimeZone()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -83,6 +84,7 @@ public class HiveSplitManager
     private final int maxPartitionBatchSize;
     private final int maxInitialSplits;
     private final boolean recursiveDfsWalkerEnabled;
+    private final Set<String> respectSplitsInputFormats;
 
     @Inject
     public HiveSplitManager(
@@ -106,7 +108,8 @@ public class HiveSplitManager
                 hiveClientConfig.getMinPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionBatchSize(),
                 hiveClientConfig.getMaxInitialSplits(),
-                hiveClientConfig.getRecursiveDirWalkerEnabled()
+                hiveClientConfig.getRecursiveDirWalkerEnabled(),
+                hiveClientConfig.getRespectSplitsInputFormats()
         );
     }
 
@@ -122,7 +125,8 @@ public class HiveSplitManager
             int minPartitionBatchSize,
             int maxPartitionBatchSize,
             int maxInitialSplits,
-            boolean recursiveDfsWalkerEnabled)
+            boolean recursiveDfsWalkerEnabled,
+            Set<String> respectSplitsInputFormats)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
         this.metastoreProvider = requireNonNull(metastoreProvider, "metastore is null");
@@ -137,6 +141,7 @@ public class HiveSplitManager
         this.maxPartitionBatchSize = maxPartitionBatchSize;
         this.maxInitialSplits = maxInitialSplits;
         this.recursiveDfsWalkerEnabled = recursiveDfsWalkerEnabled;
+        this.respectSplitsInputFormats = respectSplitsInputFormats;
     }
 
     @Override
@@ -177,7 +182,8 @@ public class HiveSplitManager
                 executor,
                 maxPartitionBatchSize,
                 maxInitialSplits,
-                recursiveDfsWalkerEnabled);
+                recursiveDfsWalkerEnabled,
+                respectSplitsInputFormats);
 
         HiveSplitSource splitSource = new HiveSplitSource(maxOutstandingSplits, hiveSplitLoader, executor);
         hiveSplitLoader.start(splitSource);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -558,7 +558,8 @@ public abstract class AbstractTestHiveClient
                 hiveClientConfig.getMinPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionBatchSize(),
                 hiveClientConfig.getMaxInitialSplits(),
-                false
+                false,
+                null
         );
         pageSinkProvider = new HivePageSinkProvider(hdfsEnvironment, metastoreClient, new GroupByHashPageIndexerFactory(), typeManager, new HiveClientConfig(), locationService, partitionUpdateCodec);
         pageSourceProvider = new HivePageSourceProvider(hiveClientConfig, hdfsEnvironment, getDefaultHiveRecordCursorProvider(hiveClientConfig), getDefaultHiveDataStreamFactories(hiveClientConfig), TYPE_MANAGER);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -195,7 +195,8 @@ public abstract class AbstractTestHiveClientS3
                 hiveClientConfig.getMinPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionBatchSize(),
                 hiveClientConfig.getMaxInitialSplits(),
-                hiveClientConfig.getRecursiveDirWalkerEnabled());
+                hiveClientConfig.getRecursiveDirWalkerEnabled(),
+                null);
         pageSinkProvider = new HivePageSinkProvider(hdfsEnvironment, metastoreClient, new GroupByHashPageIndexerFactory(), typeManager, new HiveClientConfig(), locationService, partitionUpdateCodec);
         pageSourceProvider = new HivePageSourceProvider(hiveClientConfig, hdfsEnvironment, getDefaultHiveRecordCursorProvider(hiveClientConfig), getDefaultHiveDataStreamFactories(hiveClientConfig), TYPE_MANAGER);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.google.common.base.StandardSystemProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import io.airlift.configuration.testing.ConfigAssertions;
 import io.airlift.units.DataSize;
@@ -53,6 +54,7 @@ public class TestHiveClientConfig
                 .setMaxPartitionBatchSize(100)
                 .setMaxInitialSplits(200)
                 .setMaxInitialSplitSize(new DataSize(32, Unit.MEGABYTE))
+                .setRespectSplitsInputFormats((String) null)
                 .setDomainCompactionThreshold(100)
                 .setForceLocalScheduling(false)
                 .setMaxConcurrentFileRenames(20)
@@ -142,6 +144,7 @@ public class TestHiveClientConfig
                 .put("hive.config.resources", "/foo.xml,/bar.xml")
                 .put("hive.max-initial-splits", "10")
                 .put("hive.max-initial-split-size", "16MB")
+                .put("hive.respect-splits.input-formats", "InputFormat1,InputFormat2")
                 .put("hive.domain-compaction-threshold", "42")
                 .put("hive.recursive-directories", "true")
                 .put("hive.storage-format", "SEQUENCEFILE")
@@ -226,6 +229,7 @@ public class TestHiveClientConfig
                 .setResourceConfigFiles(ImmutableList.of("/foo.xml", "/bar.xml"))
                 .setHiveStorageFormat(HiveStorageFormat.SEQUENCEFILE)
                 .setHiveCompressionCodec(HiveCompressionCodec.NONE)
+                .setRespectSplitsInputFormats(ImmutableSet.of("InputFormat1", "InputFormat2"))
                 .setRespectTableFormat(false)
                 .setImmutablePartitions(true)
                 .setMaxPartitionsPerWriter(222)


### PR DESCRIPTION
Add option to make Hive plugin respect inputFormat.getSplits() to obtain files in a partition

 - Contributing back feature added at Uber, to support queries on fresher data (https://github.com/uber/hoodie)
 - Running in production for 3 months

Happy to add any edits as suggested. 
