### PR TITLE
Support _HOST placeholder in kerberos principal in Hive connector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosAuthentication.java
@@ -52,7 +52,7 @@ public class KerberosAuthentication
         checkArgument(exists(keytabPath), "keytab does not exist: " + keytabLocation);
         checkArgument(isReadable(keytabPath), "keytab is not readable: " + keytabLocation);
         this.principal = createKerberosPrincipal(principal);
-        this.configuration = createConfiguration(principal, keytabLocation);
+        this.configuration = createConfiguration(this.principal.getName(), keytabLocation);
     }
 
     public Subject getSubject()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosAuthentication.java
@@ -71,7 +71,7 @@ public class KerberosAuthentication
     private static KerberosPrincipal createKerberosPrincipal(String principal)
     {
         try {
-            return new KerberosPrincipal(getServerPrincipal(principal, InetAddress.getLocalHost().getHostName()));
+            return new KerberosPrincipal(getServerPrincipal(principal, InetAddress.getLocalHost().getCanonicalHostName()));
         }
         catch (IOException e) {
             throw Throwables.propagate(e);

--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -23,7 +23,7 @@ function export_canonical_path() {
 
 source ${BASH_SOURCE%/*}/../../../bin/locations.sh
 
-export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-10}
+export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-12}
 export HADOOP_MASTER_IMAGE=${HADOOP_MASTER_IMAGE:-"teradatalabs/cdh5-hive:${DOCKER_IMAGES_VERSION}"}
 
 # The following variables are defined to enable running product tests with arbitrary/downloaded jars

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
@@ -12,13 +12,13 @@ hive.metastore-cache-ttl=0s
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM
-hive.metastore.client.principal=hive/hadoop-master@LABS.TERADATA.COM
-hive.metastore.client.keytab=/etc/hive/conf/hive.keytab
+hive.metastore.client.principal=hive/_HOST@LABS.TERADATA.COM
+hive.metastore.client.keytab=/etc/presto/conf/hive-presto-master.keytab
 
 hive.hdfs.authentication.type=KERBEROS
 hive.hdfs.impersonation.enabled=true
-hive.hdfs.presto.principal=hdfs/hadoop-master@LABS.TERADATA.COM
-hive.hdfs.presto.keytab=/etc/hadoop/conf/hdfs.keytab
+hive.hdfs.presto.principal=presto-server/_HOST@LABS.TERADATA.COM
+hive.hdfs.presto.keytab=/etc/presto/conf/presto-server.keytab
 hive.fs.cache.max-size=10
 
 #required for testGrantRevoke() product test

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
@@ -9,10 +9,14 @@ databases:
   hive:
     host: hadoop-master
     jdbc_url: jdbc:hive2://${databases.hive.host}:10000/default;principal=hive/hadoop-master@LABS.TERADATA.COM;auth=kerberos;kerberosAuthType=fromSubject;
-    jdbc_user: hive/hadoop-master@LABS.TERADATA.COM
+    jdbc_user: hdfs # Note: databases.hive.jdbc_user is not being used in kerberized environment as of now
     jdbc_password: na
-    kerberos_principal: hive/hadoop-master@LABS.TERADATA.COM
-    kerberos_keytab: /etc/hive/conf/hive.keytab
+
+    # The primary part in kerberos_principal should be "hdfs" in order to pass the Hive authorization.
+    # The reason being this user, which is used by Tempto to run CREATE TABLE queries in Hive, should match
+    # the user that owns the "/product-test" directory in HDFS (i.e. the "hdfs" user).
+    kerberos_principal: hdfs/hadoop-master@LABS.TERADATA.COM
+    kerberos_keytab: /etc/hadoop/conf/hdfs.keytab
 
   presto:
     host: presto-master
@@ -20,7 +24,12 @@ databases:
     server_address: https://${databases.presto.host}:${databases.presto.port}
     # Use the HTTP interface in JDBC, as Kerberos authentication is not yet supported in there.
     jdbc_url: jdbc:presto://${databases.presto.host}:8080/hive/${databases.hive.schema}
-    jdbc_user: hive
+
+    # jdbc_user in here should satisfy two requirements in order to pass SQL standard access control checks in Presto:
+    #   1) It should belong to the "admin" role in hive
+    #   2) It should have the required privileges (such as SELECT) on Hive tables (such as hive.default.nation)
+    jdbc_user: hdfs
+
     https_keystore_path: /etc/presto/conf/keystore.jks
     https_keystore_password: password
     cli_authentication: true


### PR DESCRIPTION
Product test has been added.

@supersedes https://github.com/prestodb/presto/pull/6861

Must be merged after https://github.com/Teradata/docker-images/pull/9 is merged and released, and the version is changed from `latest` to `12` in `compose-commons.sh`