### PR TITLE
Fix NPE when Like node has no escape

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/LikePredicate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/LikePredicate.java
@@ -73,7 +73,15 @@ public class LikePredicate
     @Override
     public List<Node> getChildren()
     {
-        return ImmutableList.of(value, pattern, escape);
+        ImmutableList.Builder<Node> result = ImmutableList.<Node>builder()
+                .add(value)
+                .add(pattern);
+
+        if (escape != null) {
+            result.add(escape);
+        }
+
+        return result.build();
     }
 
     @Override

--- a/presto-parser/src/test/java/com/facebook/presto/sql/tree/TestLikePredicate.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/tree/TestLikePredicate.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestLikePredicate
+{
+    @Test
+    public void testGetChildren()
+            throws Exception
+    {
+        StringLiteral value = new StringLiteral("a");
+        StringLiteral pattern = new StringLiteral("b");
+        StringLiteral escape = new StringLiteral("c");
+
+        assertEquals(new LikePredicate(value, pattern, escape).getChildren(), ImmutableList.of(value, pattern, escape));
+        assertEquals(new LikePredicate(value, pattern, null).getChildren(), ImmutableList.of(value, pattern));
+    }
+}


### PR DESCRIPTION
This was a regression introduced by 24407ce9de51c8d567990648d30d57e86e8a4e68
and a8d0940df0e777adf8b7bcd7c1e34546c7ffbeb2.

LikePredicate.getNodes() was not handling the case where the escape is
missing (null), and it was trying to add a null to an ImmutableList.