### PR TITLE
Fix NPE at MongoDB type signature guessing

### DIFF
--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -505,6 +505,10 @@ public class MongoSession
 
     private Optional<TypeSignature> guessFieldType(Object value)
     {
+        if (value == null) {
+            return Optional.empty();
+        }
+
         TypeSignature typeSignature = null;
         if (value instanceof String) {
             typeSignature = createUnboundedVarcharType().getTypeSignature();


### PR DESCRIPTION
When a field value is null or contains null, there's no way to guess it's type. This would solve #5721.