### PR TITLE
Add SortedEntryIterator wrapper to Accumulo connector

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloConfig.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloConfig.java
@@ -34,6 +34,7 @@ public class AccumuloConfig
     public static final String ZOOKEEPER_METADATA_ROOT = "accumulo.zookeeper.metadata.root";
     public static final String CARDINALITY_CACHE_SIZE = "accumulo.cardinality.cache.size";
     public static final String CARDINALITY_CACHE_EXPIRE_DURATION = "accumulo.cardinality.cache.expire.duration";
+    public static final String RECORD_CURSOR_BUFFER_SIZE = "accumulo.record.cursor.buffer.size";
 
     private String instance;
     private String zooKeepers;
@@ -42,6 +43,7 @@ public class AccumuloConfig
     private String zkMetadataRoot = "/presto-accumulo";
     private int cardinalityCacheSize = 100_000;
     private Duration cardinalityCacheExpiration = new Duration(5, TimeUnit.MINUTES);
+    private int recordCursorBufferSize = 1_000_000;
 
     @NotNull
     public String getInstance()
@@ -137,5 +139,18 @@ public class AccumuloConfig
     public void setCardinalityCacheExpiration(Duration cardinalityCacheExpiration)
     {
         this.cardinalityCacheExpiration = cardinalityCacheExpiration;
+    }
+
+    @NotNull
+    public int getRecordCursorBufferSize()
+    {
+        return recordCursorBufferSize;
+    }
+
+    @Config(RECORD_CURSOR_BUFFER_SIZE)
+    @ConfigDescription("Sets the number of entries buffered in the record cursor to re-order entries as they are read from Accumulo")
+    public void setRecordCursorBufferSize(int recordCursorBufferSize)
+    {
+        this.recordCursorBufferSize = recordCursorBufferSize;
     }
 }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
@@ -33,7 +33,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.io.Text;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -67,7 +66,7 @@ public class AccumuloRecordCursor
     private final List<AccumuloColumnHandle> columnHandles;
     private final String[] fieldToColumnName;
     private final BatchScanner scanner;
-    private final Iterator<Entry<Key, Value>> iterator;
+    private final SortedEntryIterator iterator;
     private final AccumuloRowSerializer serializer;
     private final Text prevRowID = new Text();
     private final Text rowID = new Text();
@@ -82,7 +81,8 @@ public class AccumuloRecordCursor
             BatchScanner scanner,
             String rowIdName,
             List<AccumuloColumnHandle> columnHandles,
-            List<AccumuloColumnConstraint> constraints)
+            List<AccumuloColumnConstraint> constraints,
+            int bufferSize)
     {
         this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
         this.scanner = requireNonNull(scanner, "scanner is null");
@@ -131,7 +131,7 @@ public class AccumuloRecordCursor
             }
         }
 
-        iterator = this.scanner.iterator();
+        iterator = new SortedEntryIterator(bufferSize, this.scanner.iterator());
     }
 
     @Override
@@ -322,6 +322,10 @@ public class AccumuloRecordCursor
     @Override
     public void close()
     {
+        // Interrupt iterator thread to avoid a logging 'error' on race condition
+        // between reading the last entry, closing the scanner, and then hasNext()
+        // on the scanner's iterator
+        iterator.close();
         scanner.close();
         nanoEnd = System.nanoTime();
     }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordSet.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordSet.java
@@ -59,18 +59,21 @@ public class AccumuloRecordSet
     private final AccumuloRowSerializer serializer;
     private final BatchScanner scanner;
     private final String rowIdName;
+    private final int bufferSize;
 
     public AccumuloRecordSet(
             Connector connector,
             ConnectorSession session,
             AccumuloSplit split,
             String username,
-            List<AccumuloColumnHandle> columnHandles)
+            List<AccumuloColumnHandle> columnHandles,
+            int bufferSize)
     {
         requireNonNull(session, "session is null");
         requireNonNull(split, "split is null");
         requireNonNull(username, "username is null");
         constraints = requireNonNull(split.getConstraints(), "constraints is null");
+        this.bufferSize = bufferSize;
 
         rowIdName = split.getRowId();
 
@@ -145,6 +148,6 @@ public class AccumuloRecordSet
     @Override
     public RecordCursor cursor()
     {
-        return new AccumuloRecordCursor(serializer, scanner, rowIdName, columnHandles, constraints);
+        return new AccumuloRecordCursor(serializer, scanner, rowIdName, columnHandles, constraints, bufferSize);
     }
 }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordSetProvider.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordSetProvider.java
@@ -46,6 +46,7 @@ public class AccumuloRecordSetProvider
     private final Connector connector;
     private final String connectorId;
     private final String username;
+    private final int bufferSize;
 
     @Inject
     public AccumuloRecordSetProvider(
@@ -56,6 +57,7 @@ public class AccumuloRecordSetProvider
         this.connector = requireNonNull(connector, "connector is null");
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
         this.username = requireNonNull(config, "config is null").getUsername();
+        this.bufferSize = config.getRecordCursorBufferSize();
     }
 
     @Override
@@ -75,6 +77,6 @@ public class AccumuloRecordSetProvider
         }
 
         // Return new record set
-        return new AccumuloRecordSet(connector, session, accSplit, username, handles.build());
+        return new AccumuloRecordSet(connector, session, accSplit, username, handles.build(), bufferSize);
     }
 }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/BoundedPriorityBlockingQueue.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/BoundedPriorityBlockingQueue.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.io;
+
+import javax.annotation.Nonnull;
+
+import java.util.AbstractQueue;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.PriorityQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class BoundedPriorityBlockingQueue<E>
+        extends AbstractQueue<E>
+        implements BlockingQueue<E>
+{
+    private final PriorityQueue<E> queue;
+    private final int maxCapacity;
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Condition notFull = lock.newCondition();
+    private final Condition notEmpty = lock.newCondition();
+
+    public BoundedPriorityBlockingQueue(int initialCapacity, Comparator<? super E> comparator, int maxCapacity)
+    {
+        queue = new PriorityQueue<>(initialCapacity, comparator);
+        this.maxCapacity = maxCapacity;
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<E> iterator()
+    {
+        lock.lock();
+        try {
+            return new PriorityQueue<>(queue).iterator();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public int size()
+    {
+        lock.lock();
+        try {
+            return queue.size();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public void put(E element)
+            throws InterruptedException
+    {
+        lock.lockInterruptibly();
+        try {
+            try {
+                while (queue.size() == maxCapacity) {
+                    notFull.await();
+                }
+            }
+            catch (InterruptedException e) {
+                notFull.signal();
+                throw e;
+            }
+            offer(element);
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean offer(E element, long timeout, @Nonnull TimeUnit unit)
+            throws InterruptedException
+    {
+        lock.lockInterruptibly();
+        try {
+            if (queue.size() < maxCapacity) {
+                return offer(element);
+            }
+            notEmpty.await(timeout, unit);
+            return offer(element);
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public E take()
+            throws InterruptedException
+    {
+        lock.lockInterruptibly();
+        try {
+            try {
+                while (queue.size() == 0) {
+                    notEmpty.await();
+                }
+            }
+            catch (InterruptedException e) {
+                notEmpty.signal();
+                throw e;
+            }
+            return poll();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public E poll(long timeout, @Nonnull TimeUnit unit)
+            throws InterruptedException
+    {
+        lock.lockInterruptibly();
+        try {
+            E element = poll();
+            if (element != null) {
+                return element;
+            }
+            notEmpty.await(timeout, unit);
+            return poll();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public int remainingCapacity()
+    {
+        lock.lock();
+        try {
+            return maxCapacity - queue.size();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public int drainTo(@Nonnull Collection<? super E> objects)
+    {
+        requireNonNull(objects, "objects is null");
+        checkArgument(objects != this, "collection cannot be 'this'");
+
+        lock.lock();
+        try {
+            int numAdded = 0;
+            while (size() > 0) {
+                objects.add(poll());
+                ++numAdded;
+            }
+            return numAdded;
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public int drainTo(@Nonnull Collection<? super E> objects, int maxElements)
+    {
+        requireNonNull(objects, "objects is null");
+        checkArgument(objects != this, "collection cannot be 'this'");
+
+        lock.lock();
+        try {
+            int numAdded = 0;
+            while (size() > 0 && numAdded < maxElements) {
+                objects.add(poll());
+                ++numAdded;
+            }
+            return numAdded;
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean offer(@Nonnull E element)
+    {
+        lock.lock();
+        try {
+            if (queue.size() == maxCapacity) {
+                return false;
+            }
+            queue.offer(element);
+            notEmpty.signal();
+            return true;
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public E poll()
+    {
+        lock.lock();
+        try {
+            E element = queue.poll();
+            if (element != null) {
+                notFull.signal();
+            }
+            return element;
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public E peek()
+    {
+        lock.lock();
+        try {
+            return queue.peek();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean contains(Object o)
+    {
+        lock.lock();
+        try {
+            return queue.contains(o);
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    @Nonnull
+    @Override
+    public <T> T[] toArray(@Nonnull T[] ts)
+    {
+        lock.lock();
+        try {
+            return queue.toArray(ts);
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        lock.lock();
+        try {
+            return queue.toString();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void clear()
+    {
+        lock.lock();
+        try {
+            queue.clear();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean remove(Object o)
+    {
+        lock.lock();
+        try {
+            return queue.remove(o);
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+}

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/SortedEntryIterator.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/SortedEntryIterator.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo.io;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+
+import java.io.Closeable;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Objects.requireNonNull;
+
+public class SortedEntryIterator
+        implements Iterator<Entry<Key, Value>>, Closeable
+{
+    private final BlockingQueue<Entry<Key, Value>> orderedEntries;
+    private final AtomicBoolean finishedScan = new AtomicBoolean(false);
+    private final int bufferSize;
+    private final IteratorTask iteratorTask = new IteratorTask();
+    private final Thread iteratorThread = new Thread(iteratorTask);
+    private final Iterator<Entry<Key, Value>> parent;
+
+    public SortedEntryIterator(int bufferSize, Iterator<Entry<Key, Value>> parent)
+    {
+        this.parent = requireNonNull(parent, "parent iterator is null");
+        this.bufferSize = bufferSize;
+        this.orderedEntries = new BoundedPriorityBlockingQueue<>(bufferSize, new KeyValueEntryComparator(), (int) (bufferSize * 1.25));
+
+        // Begin reading from the parent iterator, adding entries to the queue
+        this.iteratorThread.start();
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        // Wait for the scan to finish or there are at least FILL_SIZE entries
+        // This will guarantee ordering of the last FILL_SIZE entries that were put in the queue
+        while (!finishedScan.get() && orderedEntries.size() < bufferSize) {
+            try {
+                // Say there are no more entries if this thread has been interrupted
+                if (Thread.currentThread().isInterrupted()) {
+                    return false;
+                }
+
+                Thread.sleep(1);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+
+        return !orderedEntries.isEmpty() || !finishedScan.get();
+    }
+
+    @Override
+    public Entry<Key, Value> next()
+    {
+        // This won't block due to the behavior of hasNext
+        return orderedEntries.poll();
+    }
+
+    @Override
+    public void close()
+    {
+        // Alert the task to stop reading entries
+        iteratorTask.stop();
+
+        // Block until thread has finished reading
+        // Avoids race condition between closing the scanner and
+        // reading the next entry from the parent iterator
+        // (which causes Accumulo to log an error message)
+        while (iteratorThread.isAlive()) {
+            try {
+                Thread.sleep(1);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        // Drop all entries in the queue
+        orderedEntries.clear();
+    }
+
+    private static class KeyValueEntryComparator
+            implements Comparator<Entry<Key, Value>>
+    {
+        @Override
+        public int compare(Entry<Key, Value> o1, Entry<Key, Value> o2)
+        {
+            return o1.getKey().compareTo(o2.getKey());
+        }
+    }
+
+    private class IteratorTask
+            implements Runnable
+    {
+        private final AtomicBoolean stop = new AtomicBoolean(false);
+
+        @Override
+        public void run()
+        {
+            while (!stop.get() && parent.hasNext()) {
+                try {
+                    orderedEntries.put(parent.next());
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+
+            finishedScan.set(true);
+        }
+
+        public void stop()
+        {
+            this.stop.set(true);
+        }
+    }
+}

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/AccumuloQueryRunner.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/AccumuloQueryRunner.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.accumulo;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.serializers.LexicoderRowSerializer;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.spi.PrestoException;
@@ -43,6 +42,12 @@ import java.util.Map;
 
 import static com.facebook.presto.accumulo.AccumuloErrorCode.MINI_ACCUMULO;
 import static com.facebook.presto.accumulo.AccumuloErrorCode.UNEXPECTED_ACCUMULO_ERROR;
+import static com.facebook.presto.accumulo.conf.AccumuloConfig.INSTANCE;
+import static com.facebook.presto.accumulo.conf.AccumuloConfig.PASSWORD;
+import static com.facebook.presto.accumulo.conf.AccumuloConfig.RECORD_CURSOR_BUFFER_SIZE;
+import static com.facebook.presto.accumulo.conf.AccumuloConfig.USERNAME;
+import static com.facebook.presto.accumulo.conf.AccumuloConfig.ZOOKEEPERS;
+import static com.facebook.presto.accumulo.conf.AccumuloConfig.ZOOKEEPER_METADATA_ROOT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
@@ -73,11 +78,12 @@ public final class AccumuloQueryRunner
         queryRunner.installPlugin(new AccumuloPlugin());
         Map<String, String> accumuloProperties =
                 ImmutableMap.<String, String>builder()
-                        .put(AccumuloConfig.INSTANCE, connector.getInstance().getInstanceName())
-                        .put(AccumuloConfig.ZOOKEEPERS, connector.getInstance().getZooKeepers())
-                        .put(AccumuloConfig.USERNAME, MAC_USER)
-                        .put(AccumuloConfig.PASSWORD, MAC_PASSWORD)
-                        .put(AccumuloConfig.ZOOKEEPER_METADATA_ROOT, "/presto-accumulo-test")
+                        .put(INSTANCE, connector.getInstance().getInstanceName())
+                        .put(ZOOKEEPERS, connector.getInstance().getZooKeepers())
+                        .put(USERNAME, MAC_USER)
+                        .put(PASSWORD, MAC_PASSWORD)
+                        .put(ZOOKEEPER_METADATA_ROOT, "/presto-accumulo-test")
+                        .put(RECORD_CURSOR_BUFFER_SIZE, "10000")
                         .build();
 
         queryRunner.createCatalog("accumulo", "accumulo", accumuloProperties);

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestSortedEntryIterator.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestSortedEntryIterator.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.accumulo;
+
+import com.facebook.presto.accumulo.io.SortedEntryIterator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.accumulo.core.client.lexicoder.IntegerLexicoder;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.io.Text;
+import org.testng.annotations.Test;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static java.lang.Math.abs;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertFalse;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+public class TestSortedEntryIterator
+{
+    private static final int FILL_SIZE = 100_000;
+
+    @Test
+    public void testEmpty()
+            throws Exception
+    {
+        assertScan(ImmutableList.of());
+    }
+
+    @Test
+    public void testNumEntriesIsFillSize()
+            throws Exception
+    {
+        List<Entry<Key, Value>> entries = new ArrayList<>();
+        for (int i = 0; i < FILL_SIZE; ++i) {
+            entries.add(new SimpleEntry<>(new Key(
+                    new Text(uuid()),
+                    new Text(uuid()),
+                    new Text(uuid()),
+                    new Text(uuid()),
+                    0L),
+                    new Value(uuid().getBytes(UTF_8))));
+        }
+
+        assertScan(entries);
+    }
+
+    @Test
+    public void testNumEntriesIsLessThanFillSize()
+            throws Exception
+    {
+        List<Entry<Key, Value>> entries = new ArrayList<>();
+        for (int i = 0; i < FILL_SIZE / 10; ++i) {
+            entries.add(new SimpleEntry<>(new Key(
+                    new Text(uuid()),
+                    new Text(uuid()),
+                    new Text(uuid()),
+                    new Text(uuid()),
+                    0L),
+                    new Value(uuid().getBytes(UTF_8))));
+        }
+
+        assertScan(entries);
+    }
+
+    @Test
+    public void testNumEntriesIsGreaterThanFillSize()
+            throws Exception
+    {
+        int numTasks = 10;
+        // Generate random data from ten threads
+        // Each thread generates keys that are increasing by row ID,
+        // simulating how a BatchScanner reads data from multiple threads
+        List<Entry<Key, Value>> entries = Collections.synchronizedList(new ArrayList<>());
+        ExecutorService service = MoreExecutors.getExitingExecutorService(
+                new ThreadPoolExecutor(
+                        numTasks,
+                        numTasks,
+                        0,
+                        SECONDS,
+                        new SynchronousQueue<>()
+                ));
+
+        for (Future<Void> task : service.invokeAll(Collections.nCopies(numTasks, new GenerateOrderedData(entries)))) {
+            task.get();
+        }
+
+        assertScan(entries);
+    }
+
+    private void assertScan(List<Entry<Key, Value>> entries)
+            throws Exception
+    {
+        SortedEntryIterator iterator = new SortedEntryIterator(FILL_SIZE, entries.iterator());
+
+        if (entries.isEmpty()) {
+            assertFalse(iterator.hasNext());
+        }
+        else {
+            assertTrue(iterator.hasNext());
+            Entry<Key, Value> previousEntry = iterator.next();
+            long numEntries = 1;
+            while (iterator.hasNext()) {
+                Entry<Key, Value> entry = iterator.next();
+                assertTrue(
+                        format("Entries are not correctly ordered, %s %s", previousEntry, entry),
+                        previousEntry.getKey().compareTo(entry.getKey()) < 0);
+                ++numEntries;
+            }
+
+            assertEquals(entries.size(), numEntries);
+        }
+    }
+
+    private static class GenerateOrderedData
+            implements Callable<Void>
+    {
+        private final List<Entry<Key, Value>> entries;
+
+        public GenerateOrderedData(List<Entry<Key, Value>> entries)
+        {
+            this.entries = requireNonNull(entries, "entries is null");
+        }
+
+        @Override
+        public Void call()
+                throws Exception
+        {
+            // Append monotonically increasing rows to the given list
+            Random random = new Random();
+            IntegerLexicoder lexicoder = new IntegerLexicoder();
+            for (int i = 0; i < FILL_SIZE; ++i) {
+                entries.add(new SimpleEntry<>(new Key(
+                        new Text(lexicoder.encode(i)),
+                        new Text(uuid()),
+                        new Text(uuid()),
+                        new Text(uuid()),
+                        abs(random.nextLong())),
+                        new Value(uuid().getBytes(UTF_8))));
+            }
+            return null;
+        }
+    }
+
+    private static String uuid()
+    {
+        return randomUUID().toString();
+    }
+}


### PR DESCRIPTION
This wrapper fixes an issue where some results returned by the
AccumuloRecordCursor were incomplete.  Due to the use of a BatchScanner,
the entries returned could span multiple rows, causing incorrect
results.  By wrapping the BatchScanner's Iterator in this new iterator,
we re-order the stream of results to fix the functionality of the
RecordCursor.