### PR TITLE
Separate docs and example in Queue docs

### DIFF
--- a/presto-docs/src/main/sphinx/admin/queue.rst
+++ b/presto-docs/src/main/sphinx/admin/queue.rst
@@ -23,6 +23,9 @@ to the source submitting the query. The source name can be set as follows:
 
   * JDBC: set the ``ApplicationName`` client info property on the ``Connection`` instance.
 
+Example
+-------
+
 There are three rules that define which queries go into which queues:
 
   * The first rule makes ``bob`` an admin.


### PR DESCRIPTION
Make it clear where general documentation ends and an example begins.