### PR TITLE
Implement SUM and AVG on interval types #6966

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -26,6 +26,10 @@ General Aggregate Functions
 
     Returns the average (arithmetic mean) of all input values.
 
+.. function:: avg(time interval type) -> time interval type
+
+    Returns the average interval length of all input values.
+
 .. function:: bool_and(boolean) -> boolean
 
     Returns ``TRUE`` if every input value is ``TRUE``, otherwise ``FALSE``.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -37,7 +37,9 @@ import com.facebook.presto.operator.aggregation.DoubleRegressionAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
 import com.facebook.presto.operator.aggregation.GeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.operator.aggregation.IntervalDayToSecondAverageAggregation;
 import com.facebook.presto.operator.aggregation.IntervalDayToSecondSumAggregation;
+import com.facebook.presto.operator.aggregation.IntervalYearToMonthAverageAggregation;
 import com.facebook.presto.operator.aggregation.IntervalYearToMonthSumAggregation;
 import com.facebook.presto.operator.aggregation.LongSumAggregation;
 import com.facebook.presto.operator.aggregation.MergeHyperLogLogAggregation;
@@ -415,6 +417,8 @@ public class FunctionRegistry
                 .aggregate(IntervalYearToMonthSumAggregation.class)
                 .aggregate(AverageAggregations.class)
                 .aggregate(RealAverageAggregation.class)
+                .aggregate(IntervalDayToSecondAverageAggregation.class)
+                .aggregate(IntervalYearToMonthAverageAggregation.class)
                 .aggregate(GeometricMeanAggregations.class)
                 .aggregate(RealGeometricMeanAggregations.class)
                 .aggregate(ApproximateCountDistinctAggregations.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -37,6 +37,8 @@ import com.facebook.presto.operator.aggregation.DoubleRegressionAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
 import com.facebook.presto.operator.aggregation.GeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.operator.aggregation.IntervalDayToSecondSumAggregation;
+import com.facebook.presto.operator.aggregation.IntervalYearToMonthSumAggregation;
 import com.facebook.presto.operator.aggregation.LongSumAggregation;
 import com.facebook.presto.operator.aggregation.MergeHyperLogLogAggregation;
 import com.facebook.presto.operator.aggregation.RealAverageAggregation;
@@ -409,6 +411,8 @@ public class FunctionRegistry
                 .aggregate(DoubleSumAggregation.class)
                 .aggregate(RealSumAggregation.class)
                 .aggregate(LongSumAggregation.class)
+                .aggregate(IntervalDayToSecondSumAggregation.class)
+                .aggregate(IntervalYearToMonthSumAggregation.class)
                 .aggregate(AverageAggregations.class)
                 .aggregate(RealAverageAggregation.class)
                 .aggregate(GeometricMeanAggregations.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/IntervalDayToSecondAverageAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/IntervalDayToSecondAverageAggregation.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.LongAndDoubleState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+
+import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+import static java.lang.Math.round;
+
+@AggregationFunction("avg")
+public final class IntervalDayToSecondAverageAggregation
+{
+    private IntervalDayToSecondAverageAggregation() {}
+
+    @InputFunction
+    public static void input(LongAndDoubleState state, @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long value)
+    {
+        state.setLong(state.getLong() + 1);
+        state.setDouble(state.getDouble() + value);
+    }
+
+    @CombineFunction
+    public static void combine(LongAndDoubleState state, LongAndDoubleState otherState)
+    {
+        state.setLong(state.getLong() + otherState.getLong());
+        state.setDouble(state.getDouble() + otherState.getDouble());
+    }
+
+    @OutputFunction(StandardTypes.INTERVAL_DAY_TO_SECOND)
+    public static void output(LongAndDoubleState state, BlockBuilder out)
+    {
+        long count = state.getLong();
+        if (count == 0) {
+            out.appendNull();
+        }
+        else {
+            double value = state.getDouble();
+            INTERVAL_DAY_TIME.writeLong(out, round(value / count));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/IntervalDayToSecondSumAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/IntervalDayToSecondSumAggregation.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.NullableLongState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.type.BigintOperators;
+
+import static com.facebook.presto.spi.type.StandardTypes.INTERVAL_DAY_TO_SECOND;
+import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+
+@AggregationFunction("sum")
+public final class IntervalDayToSecondSumAggregation
+{
+    private IntervalDayToSecondSumAggregation() {}
+
+    @InputFunction
+    public static void sum(NullableLongState state, @SqlType(INTERVAL_DAY_TO_SECOND) long value)
+    {
+        state.setNull(false);
+        state.setLong(BigintOperators.add(state.getLong(), value));
+    }
+
+    @CombineFunction
+    public static void combine(NullableLongState state, NullableLongState otherState)
+    {
+        if (state.isNull()) {
+            state.setNull(false);
+            state.setLong(otherState.getLong());
+            return;
+        }
+
+        state.setLong(BigintOperators.add(state.getLong(), otherState.getLong()));
+    }
+
+    @OutputFunction(INTERVAL_DAY_TO_SECOND)
+    public static void output(NullableLongState state, BlockBuilder out)
+    {
+        NullableLongState.write(INTERVAL_DAY_TIME, state, out);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/IntervalYearToMonthAverageAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/IntervalYearToMonthAverageAggregation.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.LongAndDoubleState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+
+import static com.facebook.presto.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+import static java.lang.Math.round;
+
+@AggregationFunction("avg")
+public final class IntervalYearToMonthAverageAggregation
+{
+    private IntervalYearToMonthAverageAggregation() {}
+
+    @InputFunction
+    public static void input(LongAndDoubleState state, @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long value)
+    {
+        state.setLong(state.getLong() + 1);
+        state.setDouble(state.getDouble() + value);
+    }
+
+    @CombineFunction
+    public static void combine(LongAndDoubleState state, LongAndDoubleState otherState)
+    {
+        state.setLong(state.getLong() + otherState.getLong());
+        state.setDouble(state.getDouble() + otherState.getDouble());
+    }
+
+    @OutputFunction(StandardTypes.INTERVAL_YEAR_TO_MONTH)
+    public static void output(LongAndDoubleState state, BlockBuilder out)
+    {
+        long count = state.getLong();
+        if (count == 0) {
+            out.appendNull();
+        }
+        else {
+            double value = state.getDouble();
+            INTERVAL_YEAR_MONTH.writeLong(out, round(value / count));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/IntervalYearToMonthSumAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/IntervalYearToMonthSumAggregation.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.NullableLongState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.type.BigintOperators;
+
+import static com.facebook.presto.spi.type.StandardTypes.INTERVAL_YEAR_TO_MONTH;
+import static com.facebook.presto.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+
+@AggregationFunction("sum")
+public final class IntervalYearToMonthSumAggregation
+{
+    private IntervalYearToMonthSumAggregation() {}
+
+    @InputFunction
+    public static void sum(NullableLongState state, @SqlType(INTERVAL_YEAR_TO_MONTH) long value)
+    {
+        state.setNull(false);
+        state.setLong(BigintOperators.add(state.getLong(), value));
+    }
+
+    @CombineFunction
+    public static void combine(NullableLongState state, NullableLongState otherState)
+    {
+        if (state.isNull()) {
+            state.setNull(false);
+            state.setLong(otherState.getLong());
+            return;
+        }
+
+        state.setLong(BigintOperators.add(state.getLong(), otherState.getLong()));
+    }
+
+    @OutputFunction(INTERVAL_YEAR_TO_MONTH)
+    public static void output(NullableLongState state, BlockBuilder out)
+    {
+        NullableLongState.write(INTERVAL_YEAR_MONTH, state, out);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondAverageAggregation.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlIntervalDayTime;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+import static java.lang.Math.round;
+
+public class TestIntervalDayToSecondAverageAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_DAY_TIME.writeLong(blockBuilder, i * 250);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public SqlIntervalDayTime getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double sum = 0;
+        for (int i = start; i < start + length; i++) {
+            sum += i * 250;
+        }
+        return new SqlIntervalDayTime(round(sum / length));
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "avg";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_DAY_TO_SECOND);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondSumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondSumAggregation.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlIntervalDayTime;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+
+public class TestIntervalDayToSecondSumAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_DAY_TIME.writeLong(blockBuilder, i * 1000);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public SqlIntervalDayTime getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        long sum = 0;
+        for (int i = start; i < start + length; i++) {
+            sum += i * 1000;
+        }
+        return new SqlIntervalDayTime(sum);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "sum";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_DAY_TO_SECOND);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthAverageAggregation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlIntervalYearMonth;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+import static java.lang.Math.round;
+import static java.lang.Math.toIntExact;
+
+public class TestIntervalYearToMonthAverageAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_YEAR_MONTH.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public SqlIntervalYearMonth getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        double sum = 0;
+        for (int i = start; i < start + length; i++) {
+            sum += i;
+        }
+        return new SqlIntervalYearMonth(toIntExact(round(sum / length)));
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "avg";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_YEAR_TO_MONTH);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthSumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthSumAggregation.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlIntervalYearMonth;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+
+public class TestIntervalYearToMonthSumAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(new BlockBuilderStatus(), length);
+        for (int i = start; i < start + length; i++) {
+            INTERVAL_YEAR_MONTH.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public SqlIntervalYearMonth getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        int sum = 0;
+        for (int i = start; i < start + length; i++) {
+            sum += i;
+        }
+        return new SqlIntervalYearMonth(sum);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "sum";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTERVAL_YEAR_TO_MONTH);
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5225,7 +5225,7 @@ public abstract class AbstractTestQueries
         });
 
         assertTrue(functions.containsKey("avg"), "Expected function names " + functions + " to contain 'avg'");
-        assertEquals(functions.get("avg").asList().size(), 4);
+        assertEquals(functions.get("avg").asList().size(), 6);
         assertEquals(functions.get("avg").asList().get(0).getField(1), "decimal(p,s)");
         assertEquals(functions.get("avg").asList().get(0).getField(2), "decimal(p,s)");
         assertEquals(functions.get("avg").asList().get(0).getField(3), "aggregate");
@@ -5235,9 +5235,15 @@ public abstract class AbstractTestQueries
         assertEquals(functions.get("avg").asList().get(2).getField(1), "double");
         assertEquals(functions.get("avg").asList().get(2).getField(2), "double");
         assertEquals(functions.get("avg").asList().get(2).getField(3), "aggregate");
-        assertEquals(functions.get("avg").asList().get(3).getField(1), "real");
-        assertEquals(functions.get("avg").asList().get(3).getField(2), "real");
+        assertEquals(functions.get("avg").asList().get(3).getField(1), "interval day to second");
+        assertEquals(functions.get("avg").asList().get(3).getField(2), "interval day to second");
         assertEquals(functions.get("avg").asList().get(3).getField(3), "aggregate");
+        assertEquals(functions.get("avg").asList().get(4).getField(1), "interval year to month");
+        assertEquals(functions.get("avg").asList().get(4).getField(2), "interval year to month");
+        assertEquals(functions.get("avg").asList().get(4).getField(3), "aggregate");
+        assertEquals(functions.get("avg").asList().get(5).getField(1), "real");
+        assertEquals(functions.get("avg").asList().get(5).getField(2), "real");
+        assertEquals(functions.get("avg").asList().get(5).getField(3), "aggregate");
 
         assertTrue(functions.containsKey("abs"), "Expected function names " + functions + " to contain 'abs'");
         assertEquals(functions.get("abs").asList().get(0).getField(3), "scalar");


### PR DESCRIPTION
Simple implementation based on already existing SUM and AVG variants, but provided for Interval types as requested in #6966 issue.
I think there is no reason not to provide those variants and they seem very useful.