### PR TITLE
pass existing connection to buildSql(), don't leak resources

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -257,12 +257,12 @@ public class BaseJdbcClient
     }
 
     @Override
-    public PreparedStatement buildSql(JdbcSplit split, List<JdbcColumnHandle> columnHandles)
+    public PreparedStatement buildSql(Connection connection, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
             throws SQLException
     {
         return new QueryBuilder(identifierQuote).buildSql(
                 this,
-                getConnection(split),
+                connection,
                 split.getCatalogName(),
                 split.getSchemaName(),
                 split.getTableName(),

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -41,7 +41,7 @@ public interface JdbcClient
     Connection getConnection(JdbcSplit split)
             throws SQLException;
 
-    PreparedStatement buildSql(JdbcSplit split, List<JdbcColumnHandle> columnHandles)
+    PreparedStatement buildSql(Connection connection, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
             throws SQLException;
 
     JdbcOutputTableHandle beginCreateTable(ConnectorTableMetadata tableMetadata);

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
@@ -73,7 +73,7 @@ public class JdbcRecordCursor
 
         try {
             connection = jdbcClient.getConnection(split);
-            statement = jdbcClient.buildSql(split, columnHandles);
+            statement = jdbcClient.buildSql(connection, split, columnHandles);
             log.debug("Executing: %s", statement.toString());
             resultSet = statement.executeQuery();
         }


### PR DESCRIPTION
Presto was leaking JDBC connections when executing `SELECT` statements, leaving transactions open and causing our workflow to stall. This changes the behavior of `buildSql()` to not open a new connection, because that connection wasn't being cleaned up by anything.