### PR TITLE
Add ExecutorService for metric retrieval

### DIFF
--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -317,5 +317,11 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloModule.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloModule.java
@@ -16,6 +16,8 @@ package com.facebook.presto.accumulo;
 import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.conf.AccumuloSessionProperties;
 import com.facebook.presto.accumulo.conf.AccumuloTableProperties;
+import com.facebook.presto.accumulo.index.ColumnCardinalityCache;
+import com.facebook.presto.accumulo.index.IndexLookup;
 import com.facebook.presto.accumulo.io.AccumuloPageSinkProvider;
 import com.facebook.presto.accumulo.io.AccumuloRecordSetProvider;
 import com.facebook.presto.accumulo.metadata.AccumuloTable;
@@ -96,6 +98,8 @@ public class AccumuloModule
         binder.bind(AccumuloTableProperties.class).in(Scopes.SINGLETON);
         binder.bind(ZooKeeperMetadataManager.class).in(Scopes.SINGLETON);
         binder.bind(AccumuloTableManager.class).in(Scopes.SINGLETON);
+        binder.bind(IndexLookup.class).in(Scopes.SINGLETON);
+        binder.bind(ColumnCardinalityCache.class).in(Scopes.SINGLETON);
         binder.bind(Connector.class).toProvider(ConnectorProvider.class);
 
         configBinder(binder).bindConfig(AccumuloConfig.class);

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloSessionProperties.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloSessionProperties.java
@@ -16,6 +16,7 @@ package com.facebook.presto.accumulo.conf;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.Duration;
 
 import javax.inject.Inject;
 
@@ -25,6 +26,7 @@ import static com.facebook.presto.spi.session.PropertyMetadata.booleanSessionPro
 import static com.facebook.presto.spi.session.PropertyMetadata.doubleSessionProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.integerSessionProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringSessionProperty;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 
 /**
  * Class contains all session-based properties for the Accumulo connector.
@@ -44,6 +46,8 @@ public final class AccumuloSessionProperties
     private static final String INDEX_LOWEST_CARDINALITY_THRESHOLD = "index_lowest_cardinality_threshold";
     private static final String INDEX_METRICS_ENABLED = "index_metrics_enabled";
     private static final String SCAN_USERNAME = "scan_username";
+    private static final String INDEX_SHORT_CIRCUIT_CARDINALITY_FETCH = "index_short_circuit_cardinality_fetch";
+    private static final String INDEX_CARDINALITY_CACHE_POLLING_DURATION = "index_cardinality_cache_polling_duration";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -94,7 +98,22 @@ public final class AccumuloSessionProperties
                 true,
                 false);
 
-        sessionProperties = ImmutableList.of(s1, s2, s3, s4, s5, s6, s7, s8);
+        PropertyMetadata<Boolean> s9 = booleanSessionProperty(
+                INDEX_SHORT_CIRCUIT_CARDINALITY_FETCH,
+                "Short circuit the retrieval of index metrics once any column is less than the lowest cardinality threshold. Default true",
+                true,
+                false);
+
+        PropertyMetadata<String> s10 = new PropertyMetadata<>(
+                INDEX_CARDINALITY_CACHE_POLLING_DURATION,
+                "Sets the cardinality cache polling duration for short circuit retrieval of index metrics. Default 10ms",
+                VARCHAR, String.class,
+                "10ms",
+                false,
+                duration -> Duration.valueOf(duration.toString()).toString(),
+                object -> object);
+
+        sessionProperties = ImmutableList.of(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10);
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -132,6 +151,11 @@ public final class AccumuloSessionProperties
         return session.getProperty(INDEX_LOWEST_CARDINALITY_THRESHOLD, Double.class);
     }
 
+    public static Duration getIndexCardinalityCachePollingDuration(ConnectorSession session)
+    {
+        return Duration.valueOf(session.getProperty(INDEX_CARDINALITY_CACHE_POLLING_DURATION, String.class));
+    }
+
     public static boolean isIndexMetricsEnabled(ConnectorSession session)
     {
         return session.getProperty(INDEX_METRICS_ENABLED, Boolean.class);
@@ -140,5 +164,10 @@ public final class AccumuloSessionProperties
     public static String getScanUsername(ConnectorSession session)
     {
         return session.getProperty(SCAN_USERNAME, String.class);
+    }
+
+    public static boolean isIndexShortCircuitEnabled(ConnectorSession session)
+    {
+        return session.getProperty(INDEX_SHORT_CIRCUIT_CARDINALITY_FETCH, Boolean.class);
     }
 }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
@@ -14,39 +14,63 @@
 package com.facebook.presto.accumulo.index;
 
 import com.facebook.presto.accumulo.conf.AccumuloConfig;
-import com.facebook.presto.accumulo.metadata.AccumuloTable;
 import com.facebook.presto.accumulo.model.AccumuloColumnConstraint;
+import com.facebook.presto.spi.PrestoException;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
+import com.google.common.collect.MultimapBuilder;
+import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.io.Text;
 
-import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.Nonnull;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.accumulo.AccumuloErrorCode.UNEXPECTED_ACCUMULO_ERROR;
+import static com.facebook.presto.accumulo.index.Indexer.CARDINALITY_CQ_AS_TEXT;
+import static com.facebook.presto.accumulo.index.Indexer.getIndexColumnFamily;
+import static com.facebook.presto.accumulo.index.Indexer.getMetricsTableName;
+import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.Streams.stream;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.lang.Long.parseLong;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * This class is an indexing utility to cache the cardinality of a column value for every table.
@@ -57,40 +81,34 @@ import static java.util.Objects.requireNonNull;
  */
 public class ColumnCardinalityCache
 {
-    private final Authorizations auths;
     private static final Logger LOG = Logger.get(ColumnCardinalityCache.class);
     private final Connector connector;
-    private final int size;
-    private final Duration expireDuration;
+    private final ExecutorService coreExecutor;
+    private final BoundedExecutor executorService;
+    private final LoadingCache<CacheKey, Long> cache;
 
-    @GuardedBy("this")
-    private final Map<String, TableColumnCache> tableToCache = new HashMap<>();
-
-    public ColumnCardinalityCache(
-            Connector connector,
-            AccumuloConfig config,
-            Authorizations auths)
+    @Inject
+    public ColumnCardinalityCache(Connector connector, AccumuloConfig config)
     {
         this.connector = requireNonNull(connector, "connector is null");
-        this.size = requireNonNull(config, "config is null").getCardinalityCacheSize();
-        this.expireDuration = config.getCardinalityCacheExpiration();
-        this.auths = requireNonNull(auths, "auths is null");
+        int size = requireNonNull(config, "config is null").getCardinalityCacheSize();
+        Duration expireDuration = config.getCardinalityCacheExpiration();
+
+        // Create a bounded executor with a pool size at 4x number of processors
+        this.coreExecutor = newCachedThreadPool(daemonThreadsNamed("cardinality-lookup-%s"));
+        this.executorService = new BoundedExecutor(coreExecutor, 4 * Runtime.getRuntime().availableProcessors());
+
+        LOG.debug("Created new cache size %d expiry %s", size, expireDuration);
+        cache = CacheBuilder.newBuilder()
+                .maximumSize(size)
+                .expireAfterWrite(expireDuration.toMillis(), MILLISECONDS)
+                .build(new CardinalityCacheLoader());
     }
 
-    /**
-     * Deletes any cache for the given table, no-op of table does not exist in the cache
-     *
-     * @param schema Schema name
-     * @param table Table name
-     */
-    public synchronized void deleteCache(String schema, String table)
+    @PreDestroy
+    public void shutdown()
     {
-        LOG.debug("Deleting cache for %s.%s", schema, table);
-        if (tableToCache.containsKey(table)) {
-            // clear the cache and remove it
-            getTableCache(schema, table).clear();
-            tableToCache.remove(table);
-        }
+        coreExecutor.shutdownNow();
     }
 
     /**
@@ -99,161 +117,208 @@ public class ColumnCardinalityCache
      *
      * @param schema Schema name
      * @param table Table name
+     * @param auths Scan authorizations
      * @param idxConstraintRangePairs Mapping of all ranges for a given constraint
+     * @param earlyReturnThreshold Smallest acceptable cardinality to return early while other tasks complete
+     * @param pollingDuration Duration for polling the cardinality completion service
      * @return An immutable multimap of cardinality to column constraint, sorted by cardinality from smallest to largest
      * @throws TableNotFoundException If the metrics table does not exist
      * @throws ExecutionException If another error occurs; I really don't even know anymore.
      */
-    public Multimap<Long, AccumuloColumnConstraint> getCardinalities(String schema, String table, Multimap<AccumuloColumnConstraint, Range> idxConstraintRangePairs)
+    public Multimap<Long, AccumuloColumnConstraint> getCardinalities(String schema, String table, Authorizations auths, Multimap<AccumuloColumnConstraint, Range> idxConstraintRangePairs, long earlyReturnThreshold, Duration pollingDuration)
             throws ExecutionException, TableNotFoundException
     {
-        // Create a multi map sorted by cardinality, sort columns by name
-        TreeMultimap<Long, AccumuloColumnConstraint> cardinalityToConstraints = TreeMultimap.create(
-                Long::compare,
-                (AccumuloColumnConstraint o1, AccumuloColumnConstraint o2) -> o1.getName().compareTo(o2.getName()));
+        // Submit tasks to the executor to fetch column cardinality, adding it to the Guava cache if necessary
+        CompletionService<Pair<Long, AccumuloColumnConstraint>> executor = new ExecutorCompletionService<>(executorService);
+        idxConstraintRangePairs.asMap().forEach((key, value) -> executor.submit(() -> {
+                    long cardinality = getColumnCardinality(schema, table, auths, key.getFamily(), key.getQualifier(), value);
+                    LOG.debug("Cardinality for column %s is %s", key.getName(), cardinality);
+                    return Pair.of(cardinality, key);
+                }
+        ));
 
-        for (Entry<AccumuloColumnConstraint, Collection<Range>> entry : idxConstraintRangePairs.asMap().entrySet()) {
-            long card = getColumnCardinality(schema, table, entry.getKey(), entry.getValue());
-            LOG.debug("Cardinality for column %s is %s", entry.getKey().getName(), card);
-            cardinalityToConstraints.put(card, entry.getKey());
+        // Create a multi map sorted by cardinality
+        ListMultimap<Long, AccumuloColumnConstraint> cardinalityToConstraints = MultimapBuilder.treeKeys().arrayListValues().build();
+        try {
+            boolean earlyReturn = false;
+            int numTasks = idxConstraintRangePairs.asMap().entrySet().size();
+            do {
+                // Sleep for the polling duration to allow concurrent tasks to run for this time
+                Thread.sleep(pollingDuration.toMillis());
+
+                // Poll each task, retrieving the result if it is done
+                for (int i = 0; i < numTasks; ++i) {
+                    Future<Pair<Long, AccumuloColumnConstraint>> futureCardinality = executor.poll();
+                    if (futureCardinality != null && futureCardinality.isDone()) {
+                        Pair<Long, AccumuloColumnConstraint> columnCardinality = futureCardinality.get();
+                        cardinalityToConstraints.put(columnCardinality.getLeft(), columnCardinality.getRight());
+                    }
+                }
+
+                // If the smallest cardinality is present and below the threshold, set the earlyReturn flag
+                Optional<Entry<Long, AccumuloColumnConstraint>> smallestCardinality = cardinalityToConstraints.entries().stream().findFirst();
+                if (smallestCardinality.isPresent()) {
+                    if (smallestCardinality.get().getKey() <= earlyReturnThreshold) {
+                        LOG.info("Cardinality %s, is below threshold. Returning early while other tasks finish", smallestCardinality);
+                        earlyReturn = true;
+                    }
+                }
+            }
+            while (!earlyReturn && cardinalityToConstraints.entries().size() < numTasks);
+        }
+        catch (ExecutionException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PrestoException(UNEXPECTED_ACCUMULO_ERROR, "Exception when getting cardinality", e);
         }
 
+        // Create a copy of the cardinalities
         return ImmutableMultimap.copyOf(cardinalityToConstraints);
     }
 
     /**
-     * Gets the cardinality for the given column constraint with the given Ranges.
-     * Ranges can be exact values or a range of values.
+     * Gets the column cardinality for all of the given range values. May reach out to the
+     * metrics table in Accumulo to retrieve new cache elements.
      *
-     * @param schema Schema name
+     * @param schema Table schema
      * @param table Table name
-     * @param columnConstraint Mapping of all ranges for a given constraint
-     * @param indexRanges Ranges for each exact or ranged value of the column constraint
-     * @return The cardinality for the column
-     * @throws TableNotFoundException If the metrics table does not exist
-     * @throws ExecutionException If another error occurs; I really don't even know anymore.
+     * @param auths Scan authorizations
+     * @param family Accumulo column family
+     * @param qualifier Accumulo column qualifier
+     * @param colValues All range values to summarize for the cardinality
+     * @return The cardinality of the column
      */
-    private long getColumnCardinality(String schema, String table, AccumuloColumnConstraint columnConstraint, Collection<Range> indexRanges)
-            throws ExecutionException, TableNotFoundException
+    public long getColumnCardinality(String schema, String table, Authorizations auths, String family, String qualifier, Collection<Range> colValues)
+            throws ExecutionException
     {
-        return getTableCache(schema, table)
-                .getColumnCardinality(
-                        columnConstraint.getName(),
-                        columnConstraint.getFamily(),
-                        columnConstraint.getQualifier(),
-                        indexRanges);
-    }
+        LOG.debug("Getting cardinality for %s:%s", family, qualifier);
 
-    /**
-     * Gets the {@link TableColumnCache} for the given table, creating a new one if necessary.
-     *
-     * @param schema Schema name
-     * @param table Table name
-     * @return An existing or new TableColumnCache
-     */
-    private synchronized TableColumnCache getTableCache(String schema, String table)
-    {
-        String fullName = AccumuloTable.getFullTableName(schema, table);
-        TableColumnCache cache = tableToCache.get(fullName);
-        if (cache == null) {
-            LOG.debug("Creating new TableColumnCache for %s.%s %s", schema, table, this);
-            cache = new TableColumnCache(schema, table);
-            tableToCache.put(fullName, cache);
-        }
-        return cache;
-    }
+        // Collect all exact Accumulo Ranges, i.e. single value entries vs. a full scan
+        Collection<CacheKey> exactRanges = colValues.stream()
+                .filter(ColumnCardinalityCache::isExact)
+                .map(range -> new CacheKey(schema, table, family, qualifier, range, auths))
+                .collect(Collectors.toList());
 
-    /**
-     * Internal class for holding the mapping of column names to the LoadingCache
-     */
-    private class TableColumnCache
-    {
-        private final Map<String, LoadingCache<Range, Long>> columnToCache = new HashMap<>();
-        private final String schema;
-        private final String table;
+        LOG.debug("Column values contain %s exact ranges of %s", exactRanges.size(), colValues.size());
 
-        public TableColumnCache(String schema,
-                String table)
-        {
-            this.schema = schema;
-            this.table = table;
-        }
+        // Sum the cardinalities for the exact-value Ranges
+        // This is where the reach-out to Accumulo occurs for all Ranges that have not
+        // previously been fetched
+        long sum = cache.getAll(exactRanges).values().stream().mapToLong(Long::longValue).sum();
 
-        /**
-         * Clears and removes all caches as if the object had been first created
-         */
-        public void clear()
-        {
-            columnToCache.values().forEach(LoadingCache::invalidateAll);
-            columnToCache.clear();
-        }
-
-        /**
-         * Gets the column cardinality for all of the given range values.
-         * May reach out to the metrics table in Accumulo to retrieve new cache elements.
-         *
-         * @param column Presto column name
-         * @param family Accumulo column family
-         * @param qualifier Accumulo column qualifier
-         * @param colValues All range values to summarize for the cardinality
-         * @return The cardinality of the column
-         */
-        public long getColumnCardinality(String column, String family, String qualifier, Collection<Range> colValues)
-                throws ExecutionException, TableNotFoundException
-        {
-            // Get the column cache for this column, creating a new one if necessary
-            LoadingCache<Range, Long> cache = columnToCache.get(column);
-            if (cache == null) {
-                cache = newCache(schema, table, family, qualifier);
-                columnToCache.put(column, cache);
-            }
-
-            // Collect all exact Accumulo Ranges, i.e. single value entries vs. a full scan
-            Collection<Range> exactRanges = colValues.stream().filter(this::isExact).collect(Collectors.toList());
-            LOG.debug("Column values contain %s exact ranges of %s", exactRanges.size(), colValues.size());
-
-            // Sum the cardinalities for the exact-value Ranges
-            // This is where the reach-out to Accumulo occurs for all Ranges that have not previously been fetched
-            long sum = 0;
-            for (Long value : cache.getAll(exactRanges).values()) {
-                sum += value;
-            }
-
-            // If these collection sizes are not equal, then there is at least one non-exact range
-            if (exactRanges.size() != colValues.size()) {
-                // for each range in the column value
-                for (Range range : colValues) {
-                    // if this range is not exact
-                    if (!isExact(range)) {
-                        // Then get the value for this range using the single-value cache lookup
-                        long value = cache.get(range);
-
-                        // add our value to the cache and our sum
-                        cache.put(range, value);
-                        sum += value;
-                    }
+        // If these collection sizes are not equal,
+        // then there is at least one non-exact range
+        if (exactRanges.size() != colValues.size()) {
+            // for each range in the column value
+            for (Range range : colValues) {
+                // if this range is not exact
+                if (!isExact(range)) {
+                    // Then get the value for this range using the single-value cache lookup
+                    sum += cache.get(new CacheKey(schema, table, family, qualifier, range, auths));
                 }
             }
-
-            LOG.debug("Cache stats : size=%s, %s", cache.size(), cache.stats());
-            return sum;
         }
 
-        private boolean isExact(Range range)
+        return sum;
+    }
+
+    private static boolean isExact(Range range)
+    {
+        return !range.isInfiniteStartKey() && !range.isInfiniteStopKey() &&
+                range.getStartKey().followingKey(PartialKey.ROW).equals(range.getEndKey());
+    }
+
+    /**
+     * Complex key for the CacheLoader
+     */
+    private static class CacheKey
+    {
+        private final String schema;
+        private final String table;
+        private final String family;
+        private final String qualifier;
+        private final Range range;
+        private final Authorizations auths;
+
+        public CacheKey(
+                String schema,
+                String table,
+                String family,
+                String qualifier,
+                Range range,
+                Authorizations auths)
         {
-            return !range.isInfiniteStartKey()
-                    && !range.isInfiniteStopKey()
-                    && range.getStartKey().followingKey(PartialKey.ROW).equals(range.getEndKey());
+            this.schema = requireNonNull(schema, "schema is null");
+            this.table = requireNonNull(table, "table is null");
+            this.family = requireNonNull(family, "family is null");
+            this.qualifier = requireNonNull(qualifier, "qualifier is null");
+            this.range = requireNonNull(range, "range is null");
+            this.auths = requireNonNull(auths, "auths is null");
         }
 
-        private LoadingCache<Range, Long> newCache(String schema, String table, String family, String qualifier)
+        public String getSchema()
         {
-            LOG.debug("Created new cache for %s.%s, column %s:%s, size %s expiry %s", schema, table, family, qualifier, size, expireDuration);
-            return CacheBuilder
-                    .newBuilder()
-                    .maximumSize(size)
-                    .expireAfterWrite(expireDuration.toMillis(), TimeUnit.MILLISECONDS)
-                    .build(new CardinalityCacheLoader(schema, table, family, qualifier));
+            return schema;
+        }
+
+        public String getTable()
+        {
+            return table;
+        }
+
+        public String getFamily()
+        {
+            return family;
+        }
+
+        public String getQualifier()
+        {
+            return qualifier;
+        }
+
+        public Range getRange()
+        {
+            return range;
+        }
+
+        public Authorizations getAuths()
+        {
+            return auths;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(schema, table, family, qualifier, range);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+
+            if ((obj == null) || (getClass() != obj.getClass())) {
+                return false;
+            }
+
+            CacheKey other = (CacheKey) obj;
+            return Objects.equals(this.schema, other.schema)
+                    && Objects.equals(this.table, other.table)
+                    && Objects.equals(this.family, other.family)
+                    && Objects.equals(this.qualifier, other.qualifier)
+                    && Objects.equals(this.range, other.range);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("schema", schema)
+                    .add("table", table)
+                    .add("family", family)
+                    .add("qualifier", qualifier)
+                    .add("range", range).toString();
         }
     }
 
@@ -261,23 +326,8 @@ public class ColumnCardinalityCache
      * Internal class for loading the cardinality from Accumulo
      */
     private class CardinalityCacheLoader
-            extends CacheLoader<Range, Long>
+            extends CacheLoader<CacheKey, Long>
     {
-        private final String metricsTable;
-        private final Text columnFamily;
-
-        public CardinalityCacheLoader(
-                String schema,
-                String table,
-                String family,
-                String qualifier)
-        {
-            this.metricsTable = Indexer.getMetricsTableName(schema, table);
-
-            // Create the column family for our scanners
-            this.columnFamily = new Text(Indexer.getIndexColumnFamily(family.getBytes(UTF_8), qualifier.getBytes(UTF_8)).array());
-        }
-
         /**
          * Loads the cardinality for the given Range. Uses a BatchScanner and sums the cardinality for all values that encapsulate the Range.
          *
@@ -285,64 +335,77 @@ public class ColumnCardinalityCache
          * @return The cardinality of the column, which would be zero if the value does not exist
          */
         @Override
-        public Long load(Range key)
+        public Long load(@Nonnull CacheKey key)
                 throws Exception
         {
-            // Create a BatchScanner against our metrics table, setting the value range and fetching the appropriate column
-            BatchScanner scanner = connector.createBatchScanner(metricsTable, auths, 10);
-            scanner.setRanges(ImmutableList.of(key));
-            scanner.fetchColumn(columnFamily, Indexer.CARDINALITY_CQ_AS_TEXT);
+            LOG.debug("Loading a non-exact range from Accumulo: %s", key);
+            // Get metrics table name and the column family for the scanner
+            String metricsTable = getMetricsTableName(key.getSchema(), key.getTable());
+            Text columnFamily = new Text(getIndexColumnFamily(key.getFamily().getBytes(UTF_8), key.getQualifier().getBytes(UTF_8)).array());
 
-            // Sum all those entries!
-            long sum = 0;
-            for (Entry<Key, Value> entry : scanner) {
-                sum += Long.parseLong(entry.getValue().toString());
+            // Create scanner for querying the range
+            Scanner scanner = connector.createScanner(metricsTable, key.getAuths());
+            scanner.setRange(key.getRange());
+            scanner.fetchColumn(columnFamily, CARDINALITY_CQ_AS_TEXT);
+
+            try {
+                return stream(scanner)
+                        .map(Entry::getValue)
+                        .map(Value::toString)
+                        .mapToLong(Long::parseLong)
+                        .sum();
             }
-
-            scanner.close();
-            return sum;
+            finally {
+                scanner.close();
+            }
         }
 
-        @SuppressWarnings("unchecked")
         @Override
-        public Map<Range, Long> loadAll(Iterable<? extends Range> keys)
+        public Map<CacheKey, Long> loadAll(@Nonnull Iterable<? extends CacheKey> keys)
                 throws Exception
         {
-            LOG.debug("Loading %s exact ranges from Accumulo", ((Collection<Range>) keys).size());
-
-            // Create batch scanner for querying all ranges
-            BatchScanner scanner = connector.createBatchScanner(metricsTable, auths, 10);
-            scanner.setRanges((Collection<Range>) keys);
-            scanner.fetchColumn(columnFamily, Indexer.CARDINALITY_CQ_AS_TEXT);
-
-            // Create a new map to hold our cardinalities for each range, returning a default of zero for each non-existent Key
-            Map<Range, Long> rangeValues = new MapDefaultZero();
-            for (Entry<Key, Value> entry : scanner) {
-                rangeValues.put(
-                        Range.exact(entry.getKey().getRow()),
-                        Long.parseLong(entry.getValue().toString()));
+            int size = Iterables.size(keys);
+            if (size == 0) {
+                return ImmutableMap.of();
             }
 
-            scanner.close();
-            return rangeValues;
-        }
+            LOG.debug("Loading %s exact ranges from Accumulo", size);
 
-        /**
-         * We extend HashMap here and override get to return a value of zero if the key is not in the map.
-         * This mitigates the CacheLoader InvalidCacheLoadException if loadAll fails to return a value for a given key,
-         * which occurs when there is no key in Accumulo.
-         */
-        public class MapDefaultZero
-                extends HashMap<Range, Long>
-        {
-            @Override
-            public Long get(Object key)
-            {
-                // Get the key from our map overlord
-                Long value = super.get(key);
+            // In order to simplify the implementation, we are making a (safe) assumption
+            // that the CacheKeys will all contain the same combination of schema/table/family/qualifier
+            // This is asserted with the below implementation error just to make sure
+            CacheKey anyKey = stream(keys).findAny().get();
+            if (stream(keys).anyMatch(k -> !k.getSchema().equals(anyKey.getSchema()) || !k.getTable().equals(anyKey.getTable()) || !k.getFamily().equals(anyKey.getFamily()) || !k.getQualifier().equals(anyKey.getQualifier()))) {
+                throw new PrestoException(FUNCTION_IMPLEMENTATION_ERROR, "loadAll called with a non-homogeneous collection of cache keys");
+            }
 
-                // Return zero if null
-                return value == null ? 0 : value;
+            Map<Range, CacheKey> rangeToKey = stream(keys).collect(Collectors.toMap(CacheKey::getRange, Function.identity()));
+            LOG.debug("rangeToKey size is " + rangeToKey.size());
+
+            // Get metrics table name and the column family for the scanner
+            String metricsTable = getMetricsTableName(anyKey.getSchema(), anyKey.getTable());
+            Text columnFamily = new Text(getIndexColumnFamily(anyKey.getFamily().getBytes(UTF_8), anyKey.getQualifier().getBytes(UTF_8)).array());
+
+            BatchScanner scanner = connector.createBatchScanner(metricsTable, anyKey.getAuths(), 10);
+            try {
+                scanner.setRanges(stream(keys).map(CacheKey::getRange).collect(Collectors.toList()));
+                scanner.fetchColumn(columnFamily, CARDINALITY_CQ_AS_TEXT);
+
+                // Create a new map to hold our cardinalities for each range, returning a default of
+                // Zero for each non-existent Key
+                Map<CacheKey, Long> rangeValues = new HashMap<>();
+                stream(keys).forEach(key -> rangeValues.put(key, 0L));
+
+                for (Entry<Key, Value> entry : scanner) {
+                    rangeValues.put(rangeToKey.get(Range.exact(entry.getKey().getRow())), parseLong(entry.getValue().toString()));
+                }
+
+                return rangeValues;
+            }
+            finally {
+                if (scanner != null) {
+                    scanner.close();
+                }
             }
         }
     }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
@@ -13,9 +13,6 @@
  */
 package com.facebook.presto.accumulo.index;
 
-import com.facebook.presto.accumulo.AccumuloClient;
-import com.facebook.presto.accumulo.conf.AccumuloConfig;
-import com.facebook.presto.accumulo.conf.AccumuloSessionProperties;
 import com.facebook.presto.accumulo.model.AccumuloColumnConstraint;
 import com.facebook.presto.accumulo.model.TabletSplitMetadata;
 import com.facebook.presto.accumulo.serializers.AccumuloRowSerializer;
@@ -26,6 +23,7 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import io.airlift.log.Logger;
+import io.airlift.units.Duration;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchScanner;
@@ -38,13 +36,30 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
 
+import javax.inject.Inject;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.accumulo.AccumuloClient.getRangesFromDomain;
+import static com.facebook.presto.accumulo.conf.AccumuloSessionProperties.getIndexCardinalityCachePollingDuration;
+import static com.facebook.presto.accumulo.conf.AccumuloSessionProperties.getIndexSmallCardThreshold;
+import static com.facebook.presto.accumulo.conf.AccumuloSessionProperties.getIndexThreshold;
+import static com.facebook.presto.accumulo.conf.AccumuloSessionProperties.getNumIndexRowsPerSplit;
+import static com.facebook.presto.accumulo.conf.AccumuloSessionProperties.isIndexMetricsEnabled;
+import static com.facebook.presto.accumulo.conf.AccumuloSessionProperties.isIndexShortCircuitEnabled;
+import static com.facebook.presto.accumulo.conf.AccumuloSessionProperties.isOptimizeIndexEnabled;
+import static com.facebook.presto.accumulo.index.Indexer.CARDINALITY_CQ_AS_TEXT;
+import static com.facebook.presto.accumulo.index.Indexer.METRICS_TABLE_ROWID_AS_TEXT;
+import static com.facebook.presto.accumulo.index.Indexer.METRICS_TABLE_ROWS_CF_AS_TEXT;
+import static com.facebook.presto.accumulo.index.Indexer.getIndexColumnFamily;
+import static com.facebook.presto.accumulo.index.Indexer.getIndexTableName;
+import static com.facebook.presto.accumulo.index.Indexer.getMetricsTableName;
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -59,22 +74,15 @@ import static java.util.Objects.requireNonNull;
 public class IndexLookup
 {
     private static final Logger LOG = Logger.get(IndexLookup.class);
-    private static final Range METRICS_TABLE_ROWID_RANGE = new Range(Indexer.METRICS_TABLE_ROWID_AS_TEXT);
+    private static final Range METRICS_TABLE_ROWID_RANGE = new Range(METRICS_TABLE_ROWID_AS_TEXT);
     private final ColumnCardinalityCache cardinalityCache;
     private final Connector connector;
 
-    public IndexLookup(
-            Connector connector,
-            AccumuloConfig config,
-            Authorizations auths)
+    @Inject
+    public IndexLookup(Connector connector, ColumnCardinalityCache cardinalityCache)
     {
         this.connector = requireNonNull(connector, "connector is null");
-        this.cardinalityCache = new ColumnCardinalityCache(connector, requireNonNull(config, "config is null"), auths);
-    }
-
-    public void dropCache(String schema, String table)
-    {
-        cardinalityCache.deleteCache(schema, table);
+        this.cardinalityCache = requireNonNull(cardinalityCache, "cardinalityCache is null");
     }
 
     /**
@@ -111,7 +119,7 @@ public class IndexLookup
             throws Exception
     {
         // Early out if index is disabled
-        if (!AccumuloSessionProperties.isOptimizeIndexEnabled(session)) {
+        if (!isOptimizeIndexEnabled(session)) {
             LOG.debug("Secondary index is disabled");
             return false;
         }
@@ -128,14 +136,14 @@ public class IndexLookup
         }
 
         // If metrics are not enabled
-        if (!AccumuloSessionProperties.isIndexMetricsEnabled(session)) {
+        if (!isIndexMetricsEnabled(session)) {
             LOG.debug("Use of index metrics is disabled");
             // Get the ranges via the index table
-            List<Range> indexRanges = getIndexRanges(Indexer.getIndexTableName(schema, table), constraintRanges, rowIdRanges, auths);
+            List<Range> indexRanges = getIndexRanges(getIndexTableName(schema, table), constraintRanges, rowIdRanges, auths);
 
             if (!indexRanges.isEmpty()) {
                 // Bin the ranges into TabletMetadataSplits and return true to use the tablet splits
-                binRanges(AccumuloSessionProperties.getNumIndexRowsPerSplit(session), indexRanges, tabletSplits);
+                binRanges(getNumIndexRowsPerSplit(session), indexRanges, tabletSplits);
                 LOG.debug("Number of splits for %s.%s is %d with %d ranges", schema, table, tabletSplits.size(), indexRanges.size());
             }
             else {
@@ -157,14 +165,12 @@ public class IndexLookup
         ImmutableListMultimap.Builder<AccumuloColumnConstraint, Range> builder = ImmutableListMultimap.builder();
         for (AccumuloColumnConstraint columnConstraint : constraints) {
             if (columnConstraint.isIndexed()) {
-                for (Range range : AccumuloClient.getRangesFromDomain(columnConstraint.getDomain(), serializer)) {
+                for (Range range : getRangesFromDomain(columnConstraint.getDomain(), serializer)) {
                     builder.put(columnConstraint, range);
                 }
             }
             else {
-                LOG.warn(
-                        "Query containts constraint on non-indexed column %s. Is it worth indexing?",
-                        columnConstraint.getName());
+                LOG.warn("Query containts constraint on non-indexed column %s. Is it worth indexing?", columnConstraint.getName());
             }
         }
         return builder.build();
@@ -180,18 +186,33 @@ public class IndexLookup
             Authorizations auths)
             throws Exception
     {
+        String metricsTable = getMetricsTableName(schema, table);
+        long numRows = getNumRowsInTable(metricsTable, auths);
+
         // Get the cardinalities from the metrics table
-        Multimap<Long, AccumuloColumnConstraint> cardinalities = cardinalityCache.getCardinalities(schema, table, constraintRanges);
+        Multimap<Long, AccumuloColumnConstraint> cardinalities;
+        if (isIndexShortCircuitEnabled(session)) {
+            cardinalities = cardinalityCache.getCardinalities(
+                    schema,
+                    table,
+                    auths,
+                    constraintRanges,
+                    (long) (numRows * getIndexSmallCardThreshold(session)),
+                    getIndexCardinalityCachePollingDuration(session));
+        }
+        else {
+            // disable short circuit using 0
+            cardinalities = cardinalityCache.getCardinalities(schema, table, auths, constraintRanges, 0, new Duration(0, TimeUnit.MILLISECONDS));
+        }
+
         Optional<Entry<Long, AccumuloColumnConstraint>> entry = cardinalities.entries().stream().findFirst();
         if (!entry.isPresent()) {
             return false;
         }
 
         Entry<Long, AccumuloColumnConstraint> lowestCardinality = entry.get();
-        String indexTable = Indexer.getIndexTableName(schema, table);
-        String metricsTable = Indexer.getMetricsTableName(schema, table);
-        long numRows = getNumRowsInTable(metricsTable, auths);
-        double threshold = AccumuloSessionProperties.getIndexThreshold(session);
+        String indexTable = getIndexTableName(schema, table);
+        double threshold = getIndexThreshold(session);
         List<Range> indexRanges;
 
         // If the smallest cardinality in our list is above the lowest cardinality threshold,
@@ -235,7 +256,7 @@ public class IndexLookup
         // If the percentage of scanned rows, the ratio, less than the configured threshold
         if (ratio < threshold) {
             // Bin the ranges into TabletMetadataSplits and return true to use the tablet splits
-            binRanges(AccumuloSessionProperties.getNumIndexRowsPerSplit(session), indexRanges, tabletSplits);
+            binRanges(getNumIndexRowsPerSplit(session), indexRanges, tabletSplits);
             LOG.debug("Number of splits for %s.%s is %d with %d ranges", schema, table, tabletSplits.size(), indexRanges.size());
             return true;
         }
@@ -248,7 +269,7 @@ public class IndexLookup
     private static boolean smallestCardAboveThreshold(ConnectorSession session, long numRows, long smallestCardinality)
     {
         double ratio = ((double) smallestCardinality / (double) numRows);
-        double threshold = AccumuloSessionProperties.getIndexSmallCardThreshold(session);
+        double threshold = getIndexSmallCardThreshold(session);
         LOG.debug("Smallest cardinality is %d, num rows is %d, ratio is %2f with threshold of %f", smallestCardinality, numRows, ratio, threshold);
         return ratio > threshold;
     }
@@ -259,7 +280,7 @@ public class IndexLookup
         // Create scanner against the metrics table, pulling the special column and the rows column
         Scanner scanner = connector.createScanner(metricsTable, auths);
         scanner.setRange(METRICS_TABLE_ROWID_RANGE);
-        scanner.fetchColumn(Indexer.METRICS_TABLE_ROWS_CF_AS_TEXT, Indexer.CARDINALITY_CQ_AS_TEXT);
+        scanner.fetchColumn(METRICS_TABLE_ROWS_CF_AS_TEXT, CARDINALITY_CQ_AS_TEXT);
 
         // Scan the entry and get the number of rows
         long numRows = -1;
@@ -286,10 +307,7 @@ public class IndexLookup
             scanner.setRanges(constraintEntry.getValue());
 
             // Fetch the column family for this specific column
-            Text family = new Text(
-                    Indexer.getIndexColumnFamily(
-                            constraintEntry.getKey().getFamily().getBytes(UTF_8),
-                            constraintEntry.getKey().getQualifier().getBytes(UTF_8)).array());
+            Text family = new Text(getIndexColumnFamily(constraintEntry.getKey().getFamily().getBytes(UTF_8), constraintEntry.getKey().getQualifier().getBytes(UTF_8)).array());
             scanner.fetchColumnFamily(family);
 
             // For each entry in the scanner

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloClient.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloClient.java
@@ -15,6 +15,8 @@ package com.facebook.presto.accumulo;
 
 import com.facebook.presto.accumulo.conf.AccumuloConfig;
 import com.facebook.presto.accumulo.conf.AccumuloTableProperties;
+import com.facebook.presto.accumulo.index.ColumnCardinalityCache;
+import com.facebook.presto.accumulo.index.IndexLookup;
 import com.facebook.presto.accumulo.metadata.AccumuloTable;
 import com.facebook.presto.accumulo.metadata.ZooKeeperMetadataManager;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -47,7 +49,7 @@ public class TestAccumuloClient
         Connector connector = AccumuloQueryRunner.getAccumuloConnector();
         config.setZooKeepers(connector.getInstance().getZooKeepers());
         zooKeeperMetadataManager = new ZooKeeperMetadataManager(config, new TypeRegistry());
-        client = new AccumuloClient(connector, config, zooKeeperMetadataManager, new AccumuloTableManager(connector));
+        client = new AccumuloClient(connector, config, zooKeeperMetadataManager, new AccumuloTableManager(connector), new IndexLookup(connector, new ColumnCardinalityCache(connector, config)));
     }
 
     @Test

--- a/presto-docs/src/main/sphinx/connector/accumulo.rst
+++ b/presto-docs/src/main/sphinx/connector/accumulo.rst
@@ -480,20 +480,22 @@ Note that session properties are prefixed with the catalog name::
 
     SET SESSION accumulo.column_filter_optimizations_enabled = false;
 
-======================================== ============= =======================================================================================================
-Property Name                            Default Value Description
-======================================== ============= =======================================================================================================
-``optimize_locality_enabled``            ``true``      Set to true to enable data locality for non-indexed scans
-``optimize_split_ranges_enabled``        ``true``      Set to true to split non-indexed queries by tablet splits. Should generally be true.
-``optimize_index_enabled``               ``true``      Set to true to enable usage of the secondary index on query
-``index_rows_per_split``                 ``10000``     The number of Accumulo row IDs that are packed into a single Presto split
-``index_threshold``                      ``0.2``       The ratio between number of rows to be scanned based on the index over the total number of rows.
-                                                       If the ratio is below this threshold, the index will be used.
-``index_lowest_cardinality_threshold``   ``0.01``      The threshold where the column with the lowest cardinality will be used instead of computing an
-                                                       intersection of ranges in the index. Secondary index must be enabled.
-``index_metrics_enabled``                ``true``      Set to true to enable usage of the metrics table to optimize usage of the index
-``scan_username``                        (config)      User to impersonate when scanning the tables. This property trumps the ``scan_auths`` table property.
-======================================== ============= =======================================================================================================
+============================================= ============= =======================================================================================================
+Property Name                                 Default Value Description
+============================================= ============= =======================================================================================================
+``optimize_locality_enabled``                 ``true``      Set to true to enable data locality for non-indexed scans
+``optimize_split_ranges_enabled``             ``true``      Set to true to split non-indexed queries by tablet splits. Should generally be true.
+``optimize_index_enabled``                    ``true``      Set to true to enable usage of the secondary index on query
+``index_rows_per_split``                      ``10000``     The number of Accumulo row IDs that are packed into a single Presto split
+``index_threshold``                           ``0.2``       The ratio between number of rows to be scanned based on the index over the total number of rows
+                                                            If the ratio is below this threshold, the index will be used.
+``index_lowest_cardinality_threshold``        ``0.01``      The threshold where the column with the lowest cardinality will be used instead of computing an
+                                                            intersection of ranges in the index. Secondary index must be enabled
+``index_metrics_enabled``                     ``true``      Set to true to enable usage of the metrics table to optimize usage of the index
+``scan_username``                             (config)      User to impersonate when scanning the tables. This property trumps the ``scan_auths`` table property
+``index_short_circuit_cardinality_fetch``     ``true``      Short circuit the retrieval of index metrics once any column is less than the lowest cardinality threshold
+``index_cardinality_cache_polling_duration``  ``10ms``      Sets the cardinality cache polling duration for short circuit retrieval of index metrics
+============================================= ============= =======================================================================================================
 
 Adding Columns
 --------------


### PR DESCRIPTION
This service will add parallelism to the retrieval of metrics
from the index metrics table, decreasing the overall planning time.
A new property, index_short_circuit_cardinality_fetch, is used to enable
a new feature which causes the metrics retrieval to return early if one
of the cardinalities retrieved is less than a given threshold.  The
remaining tasks will complete as planned, caching the results in the
Guava cache, but the connector can use the smallest cardinality
column in the meantime.

We also add a polling duration because some cached results are
returned a few milliseconds before a significantly lower result.
By adding a sleep prior to polling the tasks, we are adding 'waves'
of result retrieval.  The results of any completed tasks are taken
and the smallest cardinality, if below the threshold, is used while
the other tasks complete.