### PR TITLE
Feature prune join output followup

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -299,10 +299,6 @@ class RelationPlanner
                 leftPlanBuilder.getRoot(),
                 rightPlanBuilder.getRoot(),
                 equiClauses.build(),
-                ImmutableList.<Symbol>builder()
-                        .addAll(leftPlanBuilder.getRoot().getOutputSymbols())
-                        .addAll(rightPlanBuilder.getRoot().getOutputSymbols())
-                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -335,10 +331,6 @@ class RelationPlanner
                     leftPlanBuilder.getRoot(),
                     rightPlanBuilder.getRoot(),
                     equiClauses.build(),
-                    ImmutableList.<Symbol>builder()
-                            .addAll(leftPlanBuilder.getRoot().getOutputSymbols())
-                            .addAll(rightPlanBuilder.getRoot().getOutputSymbols())
-                            .build(),
                     Optional.of(rewritenFilterCondition),
                     Optional.empty(),
                     Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -835,10 +835,6 @@ public class AddExchanges
                     left.getNode(),
                     right.getNode(),
                     node.getCriteria(),
-                    ImmutableList.<Symbol>builder()
-                            .addAll(left.getNode().getOutputSymbols())
-                            .addAll(right.getNode().getOutputSymbols())
-                            .build(),
                     node.getFilter(),
                     node.getLeftHashSymbol(),
                     node.getRightHashSymbol());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/EliminateCrossJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/EliminateCrossJoins.java
@@ -181,10 +181,6 @@ public class EliminateCrossJoins
                         result,
                         rightNode,
                         criteria.build(),
-                        ImmutableList.<Symbol>builder()
-                                .addAll(result.getOutputSymbols())
-                                .addAll(rightNode.getOutputSymbols())
-                                .build(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -179,7 +179,7 @@ public class IndexJoinOptimizer
             }
 
             if (leftRewritten != node.getLeft() || rightRewritten != node.getRight()) {
-                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
             }
             return node;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -70,7 +70,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.expressionOrNullSymbols;
@@ -83,7 +82,6 @@ import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
-import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.equalTo;
@@ -405,12 +403,7 @@ public class PredicatePushDown
                 leftSource = new ProjectNode(idAllocator.getNextId(), leftSource, leftProjections.build());
                 rightSource = new ProjectNode(idAllocator.getNextId(), rightSource, rightProjections.build());
 
-                List<Symbol> expectedOutputSymbols = node.getOutputSymbols();
-                List<Symbol> outputSymbols = Stream.concat(leftSource.getOutputSymbols().stream(), rightSource.getOutputSymbols().stream())
-                        .filter(expectedOutputSymbols::contains)
-                        .collect(toImmutableList());
-
-                output = new JoinNode(node.getId(), node.getType(), leftSource, rightSource, joinConditionBuilder.build(), outputSymbols, newJoinFilter, node.getLeftHashSymbol(), node.getRightHashSymbol());
+                output = new JoinNode(node.getId(), node.getType(), leftSource, rightSource, joinConditionBuilder.build(), newJoinFilter, node.getLeftHashSymbol(), node.getRightHashSymbol());
             }
             if (!postJoinPredicate.equals(BooleanLiteral.TRUE_LITERAL)) {
                 output = new FilterNode(idAllocator.getNextId(), output, postJoinPredicate);
@@ -704,11 +697,11 @@ public class PredicatePushDown
                     return node;
                 }
                 if (canConvertToLeftJoin && canConvertToRightJoin) {
-                    return new JoinNode(node.getId(), INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+                    return new JoinNode(node.getId(), INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
                 }
                 else {
                     return new JoinNode(node.getId(), canConvertToLeftJoin ? LEFT : RIGHT,
-                            node.getLeft(), node.getRight(), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+                            node.getLeft(), node.getRight(), node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
                 }
             }
 
@@ -716,7 +709,7 @@ public class PredicatePushDown
                     node.getType() == JoinNode.Type.RIGHT && !canConvertOuterToInner(node.getLeft().getOutputSymbols(), inheritedPredicate)) {
                 return node;
             }
-            return new JoinNode(node.getId(), JoinNode.Type.INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+            return new JoinNode(node.getId(), JoinNode.Type.INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
         }
 
         private boolean canConvertOuterToInner(List<Symbol> innerSymbolsForOuterJoin, Expression inheritedPredicate)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
@@ -186,10 +186,6 @@ public class TransformCorrelatedScalarAggregationToJoin
                     inputWithUniqueColumns,
                     scalarAggregationSource,
                     ImmutableList.of(),
-                    ImmutableList.<Symbol>builder()
-                            .addAll(inputWithUniqueColumns.getOutputSymbols())
-                            .addAll(scalarAggregationSource.getOutputSymbols())
-                            .build(),
                     joinExpression,
                     Optional.empty(),
                     Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedScalarToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedScalarToJoin.java
@@ -59,10 +59,6 @@ public class TransformUncorrelatedScalarToJoin
                         rewrittenNode.getInput(),
                         rewrittenNode.getSubquery(),
                         ImmutableList.of(),
-                        ImmutableList.<Symbol>builder()
-                                .addAll(rewrittenNode.getInput().getOutputSymbols())
-                                .addAll(rewrittenNode.getSubquery().getOutputSymbols())
-                                .build(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -507,7 +507,6 @@ public class UnaliasSymbolReferences
             PlanNode right = context.rewrite(node.getRight());
 
             List<JoinNode.EquiJoinClause> canonicalCriteria = canonicalizeJoinCriteria(node.getCriteria());
-            List<Symbol> canonicalOutputSymbols = canonicalizeAndDistinct(node.getOutputSymbols());
             Optional<Expression> canonicalFilter = node.getFilter().map(this::canonicalize);
             Optional<Symbol> canonicalLeftHashSymbol = canonicalize(node.getLeftHashSymbol());
             Optional<Symbol> canonicalRightHashSymbol = canonicalize(node.getRightHashSymbol());
@@ -519,7 +518,7 @@ public class UnaliasSymbolReferences
                         .forEach(clause -> map(clause.getRight(), clause.getLeft()));
             }
 
-            return new JoinNode(node.getId(), node.getType(), left, right, canonicalCriteria, canonicalOutputSymbols, canonicalFilter, canonicalLeftHashSymbol, canonicalRightHashSymbol);
+            return new JoinNode(node.getId(), node.getType(), left, right, canonicalCriteria, canonicalFilter, canonicalLeftHashSymbol, canonicalRightHashSymbol);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -89,6 +89,29 @@ public class JoinNode
         checkArgument(!isCrossJoin() || inputSymbols.equals(outputSymbols), "Cross join does not support output symbols pruning or reordering");
     }
 
+    public JoinNode(PlanNodeId id,
+            Type type,
+            PlanNode left,
+            PlanNode right,
+            List<EquiJoinClause> criteria,
+            Optional<Expression> filter,
+            Optional<Symbol> leftHashSymbol,
+            Optional<Symbol> rightHashSymbol)
+    {
+        this(id,
+                type,
+                left,
+                right,
+                criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(left.getOutputSymbols())
+                        .addAll(right.getOutputSymbols())
+                        .build(),
+                filter,
+                leftHashSymbol,
+                rightHashSymbol);
+    }
+
     public enum Type
     {
         INNER("InnerJoin"),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -19,14 +19,12 @@ import com.facebook.presto.sql.tree.Join;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
@@ -74,12 +72,6 @@ public class JoinNode
         requireNonNull(leftHashSymbol, "leftHashSymbol is null");
         requireNonNull(rightHashSymbol, "rightHashSymbol is null");
 
-        Set<Symbol> inputSymbols = ImmutableSet.<Symbol>builder()
-                .addAll(left.getOutputSymbols())
-                .addAll(right.getOutputSymbols())
-                .build();
-        checkArgument(inputSymbols.containsAll(outputSymbols), "Left and right join inputs do not contain all output symbols");
-
         this.type = type;
         this.left = left;
         this.right = right;
@@ -88,6 +80,13 @@ public class JoinNode
         this.filter = filter;
         this.leftHashSymbol = leftHashSymbol;
         this.rightHashSymbol = rightHashSymbol;
+
+        List<Symbol> inputSymbols = ImmutableList.<Symbol>builder()
+                .addAll(left.getOutputSymbols())
+                .addAll(right.getOutputSymbols())
+                .build();
+        checkArgument(inputSymbols.containsAll(outputSymbols), "Left and right join inputs do not contain all output symbols");
+        checkArgument(!isCrossJoin() || inputSymbols.equals(outputSymbols), "Cross join does not support output symbols pruning or reordering");
     }
 
     public enum Type

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -194,7 +194,6 @@ public class TestPhasedExecutionSchedule
                 tableScan,
                 new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of()),
                 ImmutableList.of(),
-                tableScan.getOutputSymbols(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -209,7 +208,6 @@ public class TestPhasedExecutionSchedule
                 joinType,
                 new RemoteSourceNode(new PlanNodeId("probe_id"), probeFragment.getId(), ImmutableList.of()),
                 new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of()),
-                ImmutableList.of(),
                 ImmutableList.of(),
                 Optional.empty(),
                 Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -439,7 +439,6 @@ public class TestSourcePartitionedScheduler
                                 null),
                         new RemoteSourceNode(new PlanNodeId("remote_id"), new PlanFragmentId("plan_fragment_id"), ImmutableList.of()),
                         ImmutableList.of(),
-                        ImmutableList.of(symbol),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty()),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -452,10 +452,6 @@ public class TestEffectivePredicateExtractor
                                 equals(DE, EE),
                                 lessThan(FE, bigintLiteral(100)))),
                 criteria,
-                ImmutableList.<Symbol>builder()
-                    .addAll(leftScan.getOutputSymbols())
-                    .addAll(rightScan.getOutputSymbols())
-                    .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -515,10 +511,6 @@ public class TestEffectivePredicateExtractor
                                 equals(DE, EE),
                                 lessThan(FE, bigintLiteral(100)))),
                 criteria,
-                ImmutableList.<Symbol>builder()
-                        .addAll(leftScan.getOutputSymbols())
-                        .addAll(rightScan.getOutputSymbols())
-                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -572,10 +564,6 @@ public class TestEffectivePredicateExtractor
                                 equals(GE, bigintLiteral(10)))),
                 filter(rightScan, FALSE_LITERAL),
                 criteria,
-                ImmutableList.<Symbol>builder()
-                        .addAll(leftScan.getOutputSymbols())
-                        .addAll(rightScan.getOutputSymbols())
-                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -632,10 +620,6 @@ public class TestEffectivePredicateExtractor
                                 equals(DE, EE),
                                 lessThan(FE, bigintLiteral(100)))),
                 criteria,
-                ImmutableList.<Symbol>builder()
-                        .addAll(leftScan.getOutputSymbols())
-                        .addAll(rightScan.getOutputSymbols())
-                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -688,10 +672,6 @@ public class TestEffectivePredicateExtractor
                                 equals(DE, EE),
                                 lessThan(FE, bigintLiteral(100)))),
                 criteria,
-                ImmutableList.<Symbol>builder()
-                        .addAll(leftScan.getOutputSymbols())
-                        .addAll(rightScan.getOutputSymbols())
-                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateCrossJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateCrossJoins.java
@@ -203,10 +203,6 @@ public class TestEliminateCrossJoins
                 left,
                 right,
                 criteria.build(),
-                ImmutableList.<Symbol>builder()
-                        .addAll(left.getOutputSymbols())
-                        .addAll(right.getOutputSymbols())
-                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());


### PR DESCRIPTION
Thanks for merging https://github.com/prestodb/presto/pull/6501. This is small followup that occurred to me today.

1. BUG potentially: `replaceChildren` must reshuffle output symbols for cross joins since input node output symbols order might have changed
2. Assertion is added that cross joins don't have pruned or reordered output symbols
3. Refactor to make sure that only `PruneUnreferencedOutputs` does prune join output symbols (so other optimizers won't mess join output symbols)
4. Simplification of `HashGenerationOptimizer` join with no-equi conditions handling