### PR TITLE
Fix DSL matching for Aggregation and GroupId nodes

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/GroupIdMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/GroupIdMatcher.java
@@ -28,15 +28,17 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 
 public class GroupIdMatcher
-    implements Matcher
+        implements Matcher
 {
-    private final List<List<Symbol>> groups;
-    private final Map<Symbol, Symbol> identityMappings;
+    private final List<List<String>> groups;
+    private final Map<String, String> identityMappings;
+    private final String groupIdAlias;
 
-    public GroupIdMatcher(List<List<Symbol>> groups, Map<Symbol, Symbol> identityMappings)
+    public GroupIdMatcher(List<List<String>> groups, Map<String, String> identityMappings, String groupIdAlias)
     {
         this.groups = groups;
         this.identityMappings = identityMappings;
+        this.groupIdAlias = groupIdAlias;
     }
 
     @Override
@@ -59,16 +61,16 @@ public class GroupIdMatcher
         }
 
         for (int i = 0; i < actualGroups.size(); i++) {
-            if (!AggregationMatcher.matches(actualGroups.get(i), groups.get(i))) {
+            if (!AggregationMatcher.matches(groups.get(i), actualGroups.get(i), symbolAliases)) {
                 return NO_MATCH;
             }
         }
 
-        if (!AggregationMatcher.matches(identityMappings.keySet(), actualArgumentMappings.keySet())) {
+        if (!AggregationMatcher.matches(identityMappings.keySet(), actualArgumentMappings.keySet(), symbolAliases)) {
             return NO_MATCH;
         }
 
-        return match();
+        return match(groupIdAlias, groudIdNode.getGroupIdSymbol().toSymbolReference());
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -141,7 +141,7 @@ public final class PlanMatchPattern
     }
 
     public static PlanMatchPattern aggregation(
-            List<List<Symbol>> groupingSets,
+            List<List<String>> groupingSets,
             Map<Optional<String>, ExpectedValueProvider<FunctionCall>> aggregations,
             Map<Symbol, Symbol> masks,
             Optional<Symbol> groupId,
@@ -275,9 +275,9 @@ public final class PlanMatchPattern
         return result;
     }
 
-    public static PlanMatchPattern groupingSet(List<List<Symbol>> groups, PlanMatchPattern source)
+    public static PlanMatchPattern groupingSet(List<List<String>> groups, String groupIdAlias, PlanMatchPattern source)
     {
-        return node(GroupIdNode.class, source).with(new GroupIdMatcher(groups, ImmutableMap.of()));
+        return node(GroupIdNode.class, source).with(new GroupIdMatcher(groups, ImmutableMap.of(), groupIdAlias));
     }
 
     public static PlanMatchPattern values(Map<String, Integer> values)


### PR DESCRIPTION
Use symbol aliases rather than symbols when looking for a match.