### PR TITLE
Advise to use -XX:+ExitOnOutOfMemoryError in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See the [User Manual](https://prestodb.io/docs/current/) for deployment instruct
 ## Requirements
 
 * Mac OS X or Linux
-* Java 8 Update 60 or higher (8u60+), 64-bit
+* Java 8 Update 92 or higher (8u92+), 64-bit
 * Maven 3.3.9+ (for building)
 * Python 2.4+ (for running with the launcher script)
 

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -66,8 +66,7 @@ The JVM config file, ``etc/jvm.config``, contains a list of command line
 options used for launching the Java Virtual Machine. The format of the file
 is a list of options, one per line. These options are not interpreted by
 the shell, so options containing spaces or other special characters should
-not be quoted (as demonstrated by the ``OnOutOfMemoryError`` option in the
-example below).
+not be quoted.
 
 The following provides a good starting point for creating ``etc/jvm.config``:
 
@@ -80,7 +79,7 @@ The following provides a good starting point for creating ``etc/jvm.config``:
     -XX:+UseGCOverheadLimit
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
-    -XX:OnOutOfMemoryError=kill -9 %p
+    -XX:+ExitOnOutOfMemoryError
 
 Because an ``OutOfMemoryError`` will typically leave the JVM in an
 inconsistent state, we write a heap dump (for debugging) and forcibly

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
@@ -87,7 +87,7 @@ final class PrestoSystemRequirements
         }
 
         JavaVersion version = JavaVersion.parse(javaVersion);
-        if (version.getMajor() == 8 && version.getUpdate().isPresent() && version.getUpdate().getAsInt() >= 60) {
+        if (version.getMajor() == 8 && version.getUpdate().isPresent() && version.getUpdate().getAsInt() >= 92) {
             return;
         }
 
@@ -95,7 +95,7 @@ final class PrestoSystemRequirements
             return;
         }
 
-        failRequirement("Presto requires Java 8u60+ (found %s)", javaVersion);
+        failRequirement("Presto requires Java 8u92+ (found %s)", javaVersion);
     }
 
     private static void verifyUsingG1Gc()

--- a/presto-product-tests/conf/presto/etc/jvm.config
+++ b/presto-product-tests/conf/presto/etc/jvm.config
@@ -13,7 +13,7 @@
 -XX:+CMSClassUnloadingEnabled
 -XX:+AggressiveOpts
 -XX:+HeapDumpOnOutOfMemoryError
--XX:OnOutOfMemoryError=kill -9 %p
+-XX:+ExitOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=150M
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=UTC

--- a/presto-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/presto-server-rpm/src/main/resources/dist/config/jvm.config
@@ -5,5 +5,5 @@
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:+UseGCOverheadLimit
--XX:OnOutOfMemoryError=kill -9 %p
+-XX:+ExitOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=512M

--- a/presto-server-rpm/src/main/rpm/preinstall
+++ b/presto-server-rpm/src/main/rpm/preinstall
@@ -31,7 +31,7 @@ check_if_correct_java_version() {
   JAVA_VERSION=$(java_version "$1")
   JAVA_VENDOR=$(java_vendor "$1")
   JAVA_UPDATE=$(echo $JAVA_VERSION | cut -d'_' -f2)
-  if [[ ("$JAVA_VERSION" > "1.8") && ($JAVA_UPDATE -ge 60) && ("$JAVA_VENDOR" = "Oracle Corporation") ]]; then
+  if [[ ("$JAVA_VERSION" > "1.8") && ($JAVA_UPDATE -ge 92) && ("$JAVA_VENDOR" = "Oracle Corporation") ]]; then
     echo "JAVA8_HOME=$1" > /tmp/presto_env.sh
     return 0
   else
@@ -39,7 +39,7 @@ check_if_correct_java_version() {
   fi
 }
 
-# if Java version of $JAVA_HOME is not 1.8 update 60 (8u60) and is not Oracle Java, then try to find it again below
+# if Java version of $JAVA_HOME is not 1.8 update 92 (8u92) and is not Oracle Java, then try to find it again below
 if ! check_if_correct_java_version "$JAVA8_HOME" && ! check_if_correct_java_version "$JAVA_HOME"; then
   java_found=false
   for candidate in \
@@ -71,7 +71,7 @@ if [ "$java_found" = false ]; then
 | Please download the latest Oracle JDK/JRE from the Java web site     |
 |       > http://www.oracle.com/technetwork/java/javase/downloads <    |
 |                                                                      |
-| Presto requires Java 1.8 update 60 (8u60)                            |
+| Presto requires Java 1.8 update 92 (8u92)                            |
 | NOTE: This script will attempt to find Java whether you install      |
 |       using the binary or the RPM based installer.                   |
 +======================================================================+


### PR DESCRIPTION
The flag is available since JDK 8u92. This is 9 months old already, so
it's safe to use.