### PR TITLE
Push aggregations below outer joins

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -71,6 +71,7 @@ public final class SystemSessionProperties
     public static final String ITERATIVE_OPTIMIZER_TIMEOUT = "iterative_optimizer_timeout";
     public static final String EXCHANGE_COMPRESSION = "exchange_compression";
     public static final String ENABLE_INTERMEDIATE_AGGREGATIONS = "enable_intermediate_aggregations";
+    public static final String PUSH_AGGREGATION_THROUGH_JOIN = "push_aggregation_through_join";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -306,6 +307,11 @@ public final class SystemSessionProperties
                         ENABLE_INTERMEDIATE_AGGREGATIONS,
                         "Enable the use of intermediate aggregations",
                         featuresConfig.isEnableIntermediateAggregations(),
+                        false),
+                booleanSessionProperty(
+                        PUSH_AGGREGATION_THROUGH_JOIN,
+                        "Allow pushing aggregations below joins",
+                        featuresConfig.isPushAggregationThroughJoin(),
                         false));
     }
 
@@ -476,5 +482,10 @@ public final class SystemSessionProperties
     public static boolean isEnableIntermediateAggregations(Session session)
     {
         return session.getSystemProperty(ENABLE_INTERMEDIATE_AGGREGATIONS, Boolean.class);
+    }
+
+    public static boolean shouldPushAggregationThroughJoin(Session session)
+    {
+        return session.getSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -68,6 +68,7 @@ public class FeaturesConfig
     private int spillerThreads = 4;
     private double spillMaxUsedSpaceThreshold = 0.9;
     private boolean iterativeOptimizerEnabled = true;
+    private boolean pushAggregationThroughJoin = true;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
 
@@ -410,6 +411,18 @@ public class FeaturesConfig
     public FeaturesConfig setEnableIntermediateAggregations(boolean enableIntermediateAggregations)
     {
         this.enableIntermediateAggregations = enableIntermediateAggregations;
+        return this;
+    }
+
+    public boolean isPushAggregationThroughJoin()
+    {
+        return pushAggregationThroughJoin;
+    }
+
+    @Config("optimizer.push-aggregation-through-join")
+    public FeaturesConfig setPushAggregationThroughJoin(boolean value)
+    {
+        this.pushAggregationThroughJoin = value;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PushAggregationThroughOuterJoin;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughProject;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughSemiJoin;
@@ -174,6 +175,11 @@ public class PlanOptimizers
                 new TransformUncorrelatedScalarToJoin(),
                 new TransformCorrelatedScalarAggregationToJoin(metadata),
                 new PredicatePushDown(metadata, sqlParser),
+                new PruneUnreferencedOutputs(),
+                new IterativeOptimizer(
+                        stats,
+                        ImmutableSet.of(new RemoveRedundantIdentityProjections(), new PushAggregationThroughOuterJoin())
+                ),
                 inlineProjections,
                 new SimplifyExpressions(metadata, sqlParser), // Re-run the SimplifyExpressions to simplify any recomposed expressions from other optimizations
                 new ProjectionPushDown(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.ExpressionSymbolInliner;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.tree.CoalesceExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.shouldPushAggregationThroughJoin;
+import static com.facebook.presto.sql.planner.optimizations.DistinctOutputQueryUtil.isDistinct;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+/**
+ * This optimizer pushes aggregations below outer joins when: the aggregation
+ * is on top of the outer join, it groups by all columns in the outer table, and
+ * the outer rows are guaranteed to be distinct.
+ * <p>
+ * When the aggregation is pushed down, we still need to perform aggregations
+ * on the null values that come out of the absent values in an outer
+ * join. We add a cross join with a row of aggregations on null literals,
+ * and coalesce the aggregation that results from the left outer join with
+ * the result of the aggregation over nulls.
+ * <p>
+ * Example:
+ * <pre>
+ * - Filter ("nationkey" > "avg")
+ *  - Aggregate(Group by: all columns from the left table, aggregation:
+ *    avg("n2.nationkey"))
+ *      - LeftJoin("regionkey" = "regionkey")
+ *          - AssignUniqueId (nation)
+ *              - Tablescan (nation)
+ *          - Tablescan (nation)
+ * </pre>
+ * </p>
+ * Is rewritten to:
+ * <pre>
+ * - Filter ("nationkey" > "avg")
+ *  - project(regionkey, coalesce("avg", "avg_over_null")
+ *      - CrossJoin
+ *          - LeftJoin("regionkey" = "regionkey")
+ *              - AssignUniqueId (nation)
+ *                  - Tablescan (nation)
+ *              - Aggregate(Group by: regionkey, aggregation:
+ *                avg(nationkey))
+ *                  - Tablescan (nation)
+ *          - Aggregate
+ *            avg(null_literal)
+ *              - Values (null_literal)
+ * </pre>
+ */
+public class PushAggregationThroughOuterJoin
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        if (!shouldPushAggregationThroughJoin(session)) {
+            return Optional.empty();
+        }
+
+        if (!(node instanceof AggregationNode)) {
+            return Optional.empty();
+        }
+
+        AggregationNode aggregation = (AggregationNode) node;
+        PlanNode source = lookup.resolve(aggregation.getSource());
+        if (!(source instanceof JoinNode)) {
+            return Optional.empty();
+        }
+        JoinNode join = (JoinNode) source;
+        if (join.getFilter().isPresent()
+                || !(join.getType() == JoinNode.Type.LEFT || join.getType() == JoinNode.Type.RIGHT)
+                || !groupsOnAllOuterTableColumns(aggregation, lookup.resolve(getOuterTable(join)))
+                || !isDistinct(lookup.resolve(getOuterTable(join)), lookup::resolve)) {
+            return Optional.empty();
+        }
+
+        List<Symbol> groupingKeys = join.getCriteria().stream()
+                .map(join.getType() == JoinNode.Type.RIGHT ? JoinNode.EquiJoinClause::getLeft : JoinNode.EquiJoinClause::getRight)
+                .collect(toImmutableList());
+        AggregationNode rewrittenAggregation = new AggregationNode(
+                node.getId(),
+                getInnerTable(join),
+                aggregation.getAssignments(),
+                ImmutableList.of(groupingKeys),
+                aggregation.getStep(),
+                aggregation.getHashSymbol(),
+                aggregation.getGroupIdSymbol());
+
+        JoinNode rewrittenJoin;
+        if (join.getType() == JoinNode.Type.LEFT) {
+            rewrittenJoin = new JoinNode(
+                    join.getId(),
+                    join.getType(),
+                    join.getLeft(),
+                    rewrittenAggregation,
+                    join.getCriteria(),
+                    ImmutableList.<Symbol>builder()
+                            .addAll(join.getLeft().getOutputSymbols())
+                            .addAll(rewrittenAggregation.getAssignments().keySet())
+                            .build(),
+                    join.getFilter(),
+                    join.getLeftHashSymbol(),
+                    join.getRightHashSymbol(),
+                    join.getDistributionType());
+        }
+        else {
+            rewrittenJoin = new JoinNode(
+                    join.getId(),
+                    join.getType(),
+                    rewrittenAggregation,
+                    join.getRight(),
+                    join.getCriteria(),
+                    ImmutableList.<Symbol>builder()
+                            .addAll(rewrittenAggregation.getAssignments().keySet())
+                            .addAll(join.getRight().getOutputSymbols())
+                            .build(),
+                    join.getFilter(),
+                    join.getLeftHashSymbol(),
+                    join.getRightHashSymbol(),
+                    join.getDistributionType());
+        }
+
+        return Optional.of(coalesceWithNullAggregation(rewrittenAggregation, rewrittenJoin, symbolAllocator, idAllocator, lookup));
+    }
+
+    private static PlanNode getInnerTable(JoinNode join)
+    {
+        checkState(join.getType() == JoinNode.Type.LEFT || join.getType() == JoinNode.Type.RIGHT, "expected LEFT or RIGHT JOIN");
+        PlanNode innerNode;
+        if (join.getType().equals(JoinNode.Type.LEFT)) {
+            innerNode = join.getRight();
+        }
+        else {
+            innerNode = join.getLeft();
+        }
+        return innerNode;
+    }
+
+    private static PlanNode getOuterTable(JoinNode join)
+    {
+        checkState(join.getType() == JoinNode.Type.LEFT || join.getType() == JoinNode.Type.RIGHT, "expected LEFT or RIGHT JOIN");
+        PlanNode outerNode;
+        if (join.getType().equals(JoinNode.Type.LEFT)) {
+            outerNode = join.getLeft();
+        }
+        else {
+            outerNode = join.getRight();
+        }
+        return outerNode;
+    }
+
+    private static boolean groupsOnAllOuterTableColumns(AggregationNode node, PlanNode outerTable)
+    {
+        return new HashSet<>(node.getGroupingKeys()).equals(new HashSet<>(outerTable.getOutputSymbols()));
+    }
+
+    // When the aggregation is done after the join, there will be a null value that gets aggregated over
+    // where rows did not exist in the inner table.  For some aggregate functions, such as count, the result
+    // of an aggregation over a single null row is one or zero rather than null. In order to ensure correct results,
+    // we add a coalesce function with the output of the new outer join and the agggregation performed over a single
+    // null row.
+    private PlanNode coalesceWithNullAggregation(AggregationNode aggregationNode, PlanNode outerJoin, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, Lookup lookup)
+    {
+        // Create an aggregation node over a row of nulls.
+        MappedAggregationInfo aggregationOverNullInfo = createAggregationOverNull(aggregationNode, symbolAllocator, idAllocator, lookup);
+        AggregationNode aggregationOverNull = aggregationOverNullInfo.getAggregation();
+        Map<Symbol, Symbol> sourceAggregationToOverNullMapping = aggregationOverNullInfo.getSymbolMapping();
+
+        // Do a cross join with the aggregation over null
+        JoinNode crossJoin = new JoinNode(
+                idAllocator.getNextId(),
+                JoinNode.Type.INNER,
+                outerJoin,
+                aggregationOverNull,
+                ImmutableList.of(),
+                ImmutableList.<Symbol>builder()
+                        .addAll(outerJoin.getOutputSymbols())
+                        .addAll(aggregationOverNull.getOutputSymbols())
+                        .build(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+
+        // Add coalesce expressions for all aggregation functions
+        Assignments.Builder assignmentsBuilder = Assignments.builder();
+        for (Symbol symbol : outerJoin.getOutputSymbols()) {
+            if (aggregationNode.getAssignments().containsKey(symbol)) {
+                assignmentsBuilder.put(symbol, new CoalesceExpression(symbol.toSymbolReference(), sourceAggregationToOverNullMapping.get(symbol).toSymbolReference()));
+            }
+            else {
+                assignmentsBuilder.put(symbol, symbol.toSymbolReference());
+            }
+        }
+        return new ProjectNode(idAllocator.getNextId(), crossJoin, assignmentsBuilder.build());
+    }
+
+    private MappedAggregationInfo createAggregationOverNull(AggregationNode referenceAggregation, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, Lookup lookup)
+    {
+        // Create a values node that consists of a single row of nulls.
+        // Map the output symbols from the referenceAggregation's source
+        // to symbol references for the new values node.
+        NullLiteral nullLiteral = new NullLiteral();
+        ImmutableList.Builder<Symbol> nullSymbols = ImmutableList.builder();
+        ImmutableList.Builder<Expression> nullLiterals = ImmutableList.builder();
+        ImmutableMap.Builder<Symbol, SymbolReference> sourcesSymbolMappingBuilder = ImmutableMap.builder();
+        for (Symbol sourceSymbol : lookup.resolve(referenceAggregation.getSource()).getOutputSymbols()) {
+            nullLiterals.add(nullLiteral);
+            Symbol nullSymbol = symbolAllocator.newSymbol(nullLiteral, symbolAllocator.getTypes().get(sourceSymbol));
+            nullSymbols.add(nullSymbol);
+            sourcesSymbolMappingBuilder.put(sourceSymbol, nullSymbol.toSymbolReference());
+        }
+        ValuesNode nullRow = new ValuesNode(
+                idAllocator.getNextId(),
+                nullSymbols.build(),
+                ImmutableList.of(nullLiterals.build()));
+        Map<Symbol, SymbolReference> sourcesSymbolMapping = sourcesSymbolMappingBuilder.build();
+
+        // For each aggregation function in the reference node, create a corresponding aggregation function
+        // that points to the nullRow. Map the symbols from the aggregations in referenceAggregation to the
+        // symbols in these new aggregations.
+        ImmutableMap.Builder<Symbol, Symbol> aggregationsSymbolMappingBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<Symbol, AggregationNode.Aggregation> aggregationsOverNullBuilder = ImmutableMap.builder();
+        for (Map.Entry<Symbol, AggregationNode.Aggregation> entry : referenceAggregation.getAssignments().entrySet()) {
+            Symbol aggregationSymbol = entry.getKey();
+            AggregationNode.Aggregation aggregation = entry.getValue();
+            AggregationNode.Aggregation overNullAggregation = new AggregationNode.Aggregation(
+                    (FunctionCall) new ExpressionSymbolInliner(sourcesSymbolMapping).rewrite(aggregation.getCall()),
+                    aggregation.getSignature(),
+                    aggregation.getMask().map(x -> Symbol.from(sourcesSymbolMapping.get(x))));
+            Symbol overNullSymbol = symbolAllocator.newSymbol(overNullAggregation.getCall(), symbolAllocator.getTypes().get(aggregationSymbol));
+            aggregationsOverNullBuilder.put(overNullSymbol, overNullAggregation);
+            aggregationsSymbolMappingBuilder.put(aggregationSymbol, overNullSymbol);
+        }
+        Map<Symbol, Symbol> aggregationsSymbolMapping = aggregationsSymbolMappingBuilder.build();
+
+        // create an aggregation node whose source is the null row.
+        AggregationNode aggregationOverNullRow = new AggregationNode(
+                idAllocator.getNextId(),
+                nullRow,
+                aggregationsOverNullBuilder.build(),
+                ImmutableList.of(ImmutableList.of()),
+                AggregationNode.Step.SINGLE,
+                Optional.empty(),
+                Optional.empty()
+        );
+        return new MappedAggregationInfo(aggregationOverNullRow, aggregationsSymbolMapping);
+    }
+
+    private static class MappedAggregationInfo
+    {
+        private final AggregationNode aggregationNode;
+        private final Map<Symbol, Symbol> symbolMapping;
+
+        public MappedAggregationInfo(AggregationNode aggregationNode, Map<Symbol, Symbol> symbolMapping)
+        {
+            this.aggregationNode = aggregationNode;
+            this.symbolMapping = symbolMapping;
+        }
+
+        public Map<Symbol, Symbol> getSymbolMapping()
+        {
+            return symbolMapping;
+        }
+
+        public AggregationNode getAggregation()
+        {
+            return aggregationNode;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DistinctOutputQueryUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DistinctOutputQueryUtil.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.AssignUniqueId;
+import com.facebook.presto.sql.planner.plan.DistinctLimitNode;
+import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
+import com.facebook.presto.sql.planner.plan.ExceptNode;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.IntersectNode;
+import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanVisitor;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+
+import java.util.function.Function;
+
+import static java.util.function.Function.identity;
+
+public final class DistinctOutputQueryUtil
+{
+    private DistinctOutputQueryUtil() {}
+
+    public static boolean isDistinct(PlanNode node)
+    {
+        return node.accept(new IsDistinctPlanVisitor(identity()), null);
+    }
+
+    public static boolean isDistinct(PlanNode node, Function<PlanNode, PlanNode> lookupFunction)
+    {
+        return node.accept(new IsDistinctPlanVisitor(lookupFunction), null);
+    }
+
+    private static final class IsDistinctPlanVisitor
+            extends PlanVisitor<Void, Boolean>
+    {
+        /*
+        With the iterative optimizer, plan nodes are replaced with
+        GroupReference nodes. This requires the rules that look deeper
+        in the tree than the rewritten node and its immediate sources
+        to use Lookup for resolving the nodes corresponding to the
+        GroupReferences.
+        */
+        private final Function<PlanNode, PlanNode> lookupFunction;
+
+        private IsDistinctPlanVisitor(Function<PlanNode, PlanNode> lookupFunction)
+        {
+            this.lookupFunction = lookupFunction;
+        }
+
+        @Override
+        protected Boolean visitPlan(PlanNode node, Void context)
+        {
+            return false;
+        }
+
+        @Override
+        public Boolean visitAggregation(AggregationNode node, Void context)
+        {
+            return true;
+        }
+
+        @Override
+        public Boolean visitAssignUniqueId(AssignUniqueId node, Void context)
+        {
+            return true;
+        }
+
+        @Override
+        public Boolean visitDistinctLimit(DistinctLimitNode node, Void context)
+        {
+            return true;
+        }
+
+        @Override
+        public Boolean visitEnforceSingleRow(EnforceSingleRowNode node, Void context)
+        {
+            return true;
+        }
+
+        @Override
+        public Boolean visitExcept(ExceptNode node, Void context)
+        {
+            return true;
+        }
+
+        @Override
+        public Boolean visitFilter(FilterNode node, Void context)
+        {
+            return lookupFunction.apply(node.getSource()).accept(this, null);
+        }
+
+        @Override
+        public Boolean visitIntersect(IntersectNode node, Void context)
+        {
+            return true;
+        }
+
+        @Override
+        public Boolean visitProject(ProjectNode node, Void context)
+        {
+            return node.isIdentity() && lookupFunction.apply(node.getSource()).accept(this, null);
+        }
+
+        @Override
+        public Boolean visitValues(ValuesNode node, Void context)
+        {
+            return node.getRows().size() == 1;
+        }
+
+        @Override
+        public Boolean visitLimit(LimitNode node, Void context)
+        {
+            return node.getCount() <= 1;
+        }
+
+        @Override
+        public Boolean visitTopN(TopNNode node, Void context)
+        {
+            return node.getCount() <= 1;
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -62,7 +62,8 @@ public class TestFeaturesConfig
                 .setIterativeOptimizerEnabled(true)
                 .setIterativeOptimizerTimeout(new Duration(3, MINUTES))
                 .setExchangeCompressionEnabled(false)
-                .setEnableIntermediateAggregations(false));
+                .setEnableIntermediateAggregations(false)
+                .setPushAggregationThroughJoin(true));
     }
 
     @Test
@@ -87,6 +88,7 @@ public class TestFeaturesConfig
                 .put("optimizer.optimize-mixed-distinct-aggregations", "true")
                 .put("optimizer.push-table-write-through-union", "false")
                 .put("optimizer.dictionary-aggregation", "true")
+                .put("optimizer.push-aggregation-through-join", "false")
                 .put("regex-library", "RE2J")
                 .put("re2j.dfa-states-limit", "42")
                 .put("re2j.dfa-retries", "42")
@@ -117,6 +119,7 @@ public class TestFeaturesConfig
                 .put("optimizer.optimize-mixed-distinct-aggregations", "true")
                 .put("optimizer.push-table-write-through-union", "false")
                 .put("optimizer.dictionary-aggregation", "true")
+                .put("optimizer.push-aggregation-through-join", "false")
                 .put("regex-library", "RE2J")
                 .put("re2j.dfa-states-limit", "42")
                 .put("re2j.dfa-retries", "42")
@@ -145,6 +148,7 @@ public class TestFeaturesConfig
                 .setOptimizeMixedDistinctAggregations(true)
                 .setPushTableWriteThroughUnion(false)
                 .setDictionaryAggregation(true)
+                .setPushAggregationThroughJoin(false)
                 .setLegacyArrayAgg(true)
                 .setLegacyMapSubscript(true)
                 .setRegexLibrary(RE2J)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPlanMatchingFramework.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPlanMatchingFramework.java
@@ -250,14 +250,6 @@ public class TestPlanMatchingFramework
                                         tableScan("lineitem").withAlias("ORDERS_OK", columnReference("lineitem", "orderkey"))))));
     }
 
-    @Test(expectedExceptions = {IllegalStateException.class}, expectedExceptionsMessageRegExp = ".*already bound in.*")
-    public void testBindMultipleAliasesSameExpression()
-    {
-        assertMinimallyOptimizedPlan("SELECT orderkey FROM lineitem",
-                output(ImmutableList.of("ORDERKEY", "TWO"),
-                        tableScan("lineitem", ImmutableMap.of("FIRST", "orderkey", "SECOND", "orderkey"))));
-    }
-
     @Test(expectedExceptions = {IllegalStateException.class}, expectedExceptionsMessageRegExp = "missing expression for alias .*")
     public void testProjectLimitsScope()
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolAliases.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolAliases.java
@@ -206,7 +206,6 @@ public final class SymbolAliases
             }
 
             checkState(!bindings.containsKey(alias), "Alias '%s' already bound to expression '%s'. Tried to rebind to '%s'", alias, bindings.get(alias), symbolReference);
-            checkState(!bindings.values().contains(symbolReference), "Expression '%s' is already bound in %s. Tried to rebind as '%s'.", symbolReference, bindings, alias);
             bindings.put(alias, symbolReference);
             return this;
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expressions;
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.SINGLE;
+
+public class TestPushAggregationThroughOuterJoin
+{
+    @Test
+    public void testPushesAggregationThroughLeftJoin()
+    {
+        FunctionCall averageFunctionCall = new FunctionCall(QualifiedName.of("avg"), ImmutableList.of(new SymbolReference("COL2")));
+        Signature avgSignature = new Signature(
+                "avg",
+                FunctionKind.AGGREGATE,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                DOUBLE.getTypeSignature(),
+                ImmutableList.of(DOUBLE.getTypeSignature()),
+                false);
+        new RuleTester().assertThat(new PushAggregationThroughOuterJoin())
+                .on(p ->
+                        p.aggregation(
+                                p.join(
+                                        JoinNode.Type.LEFT,
+                                        p.values(ImmutableList.of(p.symbol("COL1", BIGINT)), ImmutableList.of(expressions("10"))),
+                                        p.values(p.symbol("COL2", BIGINT)),
+                                        ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("COL1", BIGINT), p.symbol("COL2", BIGINT))),
+                                        ImmutableList.of(p.symbol("COL1", BIGINT), p.symbol("COL2", BIGINT)),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty()
+                                ),
+                                ImmutableMap.of(p.symbol("AVG", DOUBLE),
+                                        new AggregationNode.Aggregation(averageFunctionCall, avgSignature, Optional.empty())),
+                                ImmutableList.of(ImmutableList.of(p.symbol("COL1", BIGINT))),
+                                SINGLE,
+                                Optional.empty(),
+                                Optional.empty())
+                )
+                .matches(
+                        project(ImmutableMap.of(
+                                "COL1", expression("COL1"),
+                                "COALESCE", expression("coalesce(AVG, AVG_NULL)")),
+                                join(JoinNode.Type.INNER, ImmutableList.of(),
+                                        join(JoinNode.Type.LEFT, ImmutableList.of(equiJoinClause("COL1", "COL2")),
+                                                values(ImmutableMap.of("COL1", 0)),
+                                                aggregation(
+                                                        ImmutableList.of(ImmutableList.of("COL2")),
+                                                        ImmutableMap.of(Optional.of("AVG"), functionCall("avg", ImmutableList.of("COL2"))),
+                                                        ImmutableMap.of(),
+                                                        Optional.empty(),
+                                                        SINGLE,
+                                                        values(ImmutableMap.of("COL2", 0)))),
+                                        aggregation(
+                                                ImmutableList.of(ImmutableList.of()),
+                                                ImmutableMap.of(Optional.of("AVG_NULL"), functionCall("avg", ImmutableList.of("null_literal"))),
+                                                ImmutableMap.of(),
+                                                Optional.empty(),
+                                                SINGLE,
+                                                values(ImmutableMap.of("null_literal", 0))))));
+    }
+
+    @Test
+    public void testPushesAggregationThroughRightJoin()
+    {
+        FunctionCall averageFunctionCall = new FunctionCall(QualifiedName.of("avg"), ImmutableList.of(new SymbolReference("COL2")));
+        Signature avgSignature = new Signature(
+                "avg",
+                FunctionKind.AGGREGATE,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                DOUBLE.getTypeSignature(),
+                ImmutableList.of(DOUBLE.getTypeSignature()),
+                false);
+        new RuleTester().assertThat(new PushAggregationThroughOuterJoin())
+                .on(p ->
+                        p.aggregation(
+                                p.join(
+                                        JoinNode.Type.RIGHT,
+                                        p.values(p.symbol("COL2", BIGINT)),
+                                        p.values(ImmutableList.of(p.symbol("COL1", BIGINT)), ImmutableList.of(expressions("10"))),
+                                        ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("COL2", BIGINT), p.symbol("COL1", BIGINT))),
+                                        ImmutableList.of(p.symbol("COL2", BIGINT), p.symbol("COL1", BIGINT)),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty()
+                                ),
+                                ImmutableMap.of(p.symbol("AVG", DOUBLE), new AggregationNode.Aggregation(averageFunctionCall, avgSignature, Optional.empty())),
+                                ImmutableList.of(ImmutableList.of(p.symbol("COL1", BIGINT))),
+                                SINGLE,
+                                Optional.empty(),
+                                Optional.empty())
+                )
+                .matches(
+                        project(ImmutableMap.of(
+                                "COALESCE", expression("coalesce(AVG, AVG_NULL)"),
+                                "COL1", expression("COL1")),
+                                join(JoinNode.Type.INNER, ImmutableList.of(),
+                                        join(JoinNode.Type.RIGHT, ImmutableList.of(equiJoinClause("COL2", "COL1")),
+                                                aggregation(
+                                                        ImmutableList.of(ImmutableList.of("COL2")),
+                                                        ImmutableMap.of(Optional.of("AVG"), functionCall("avg", ImmutableList.of("COL2"))),
+                                                        ImmutableMap.of(),
+                                                        Optional.empty(),
+                                                        SINGLE,
+                                                        values(ImmutableMap.of("COL2", 0))),
+                                                values(ImmutableMap.of("COL1", 0))),
+                                        aggregation(
+                                                ImmutableList.of(ImmutableList.of()),
+                                                ImmutableMap.of(
+                                                        Optional.of("AVG_NULL"), functionCall("avg", ImmutableList.of("null_literal"))),
+                                                ImmutableMap.of(),
+                                                Optional.empty(),
+                                                SINGLE,
+                                                values(ImmutableMap.of("null_literal", 0))))));
+    }
+
+    @Test
+    public void testDoesNotFireWhenNotDistinct()
+    {
+        FunctionCall averageFunctionCall = new FunctionCall(QualifiedName.of("avg"), ImmutableList.of(new SymbolReference("COL2")));
+        Signature avgSignature = new Signature(
+                "avg",
+                FunctionKind.AGGREGATE,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                DOUBLE.getTypeSignature(),
+                ImmutableList.of(DOUBLE.getTypeSignature()),
+                false);
+        new RuleTester().assertThat(new PushAggregationThroughOuterJoin())
+                .on(p ->
+                        p.aggregation(
+                                p.join(
+                                        JoinNode.Type.LEFT,
+                                        p.values(ImmutableList.of(p.symbol("COL1", BIGINT)), ImmutableList.of(expressions("10"), expressions("11"))),
+                                        p.values(new Symbol("COL2")),
+                                        ImmutableList.of(new JoinNode.EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
+                                        ImmutableList.of(new Symbol("COL1"), new Symbol("COL2")),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty()
+                                ),
+                                ImmutableMap.of(new Symbol("AVG"),
+                                        new AggregationNode.Aggregation(averageFunctionCall, avgSignature, Optional.empty())),
+                                ImmutableList.of(ImmutableList.of(new Symbol("COL1"))),
+                                SINGLE,
+                                Optional.empty(),
+                                Optional.empty())
+                )
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenGroupingOnInner()
+    {
+        FunctionCall averageFunctionCall = new FunctionCall(QualifiedName.of("avg"), ImmutableList.of(new SymbolReference("COL2")));
+        Signature avgSignature = new Signature(
+                "avg",
+                FunctionKind.AGGREGATE,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                DOUBLE.getTypeSignature(),
+                ImmutableList.of(DOUBLE.getTypeSignature()),
+                false);
+        new RuleTester().assertThat(new PushAggregationThroughOuterJoin())
+                .on(p ->
+                        p.aggregation(
+                                p.join(
+                                        JoinNode.Type.LEFT,
+                                        p.values(ImmutableList.of(p.symbol("COL1", BIGINT)), ImmutableList.of(expressions("10"))),
+                                        p.values(new Symbol("COL2"), new Symbol("COL3")),
+                                        ImmutableList.of(new JoinNode.EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
+                                        ImmutableList.of(new Symbol("COL1"), new Symbol("COL2")),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty()
+                                ),
+                                ImmutableMap.of(new Symbol("AVG"),
+                                        new AggregationNode.Aggregation(averageFunctionCall, avgSignature, Optional.empty())),
+                                ImmutableList.of(ImmutableList.of(new Symbol("COL1"), new Symbol("COL3"))),
+                                SINGLE,
+                                Optional.empty(),
+                                Optional.empty())
+                )
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -37,6 +37,7 @@ import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.DeleteNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
@@ -321,6 +322,30 @@ public class PlanBuilder
         {
             return new ExchangeNode(idAllocator.getNextId(), type, scope, partitioningScheme, sources, inputs);
         }
+    }
+
+    public AggregationNode aggregation(
+            PlanNode source,
+            Map<Symbol, AggregationNode.Aggregation> assignments,
+            List<List<Symbol>> groupingSets,
+            AggregationNode.Step step,
+            Optional<Symbol> hashSymbol,
+            Optional<Symbol> groupIdSymbol)
+    {
+        return new AggregationNode(idAllocator.getNextId(), source, assignments, groupingSets, step, hashSymbol, groupIdSymbol);
+    }
+
+    public JoinNode join(
+            JoinNode.Type type,
+            PlanNode left,
+            PlanNode right,
+            List<JoinNode.EquiJoinClause> criteria,
+            List<Symbol> outputSymbols,
+            Optional<Expression> filter,
+            Optional<Symbol> leftHashSymbol,
+            Optional<Symbol> rightHashSymbol)
+    {
+        return new JoinNode(idAllocator.getNextId(), type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, Optional.empty());
     }
 
     public Symbol symbol(String name, Type type)


### PR DESCRIPTION
This rewrite pushes aggregations below outer joins when the grouping keys contain all columns in the outer table, and the outer table's rows are unique.  It is particularly useful for correlated scalar aggregations, which are rewritten to an aggregation above a left outer join.

Fixes https://github.com/prestodb/presto/issues/6988
The first commit is from https://github.com/prestodb/presto/pull/7048 so there can be planner tests.