### PR TITLE
retrofitting changes from PR#4939 to HiveCoercionPolicy

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionPolicy.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionPolicy.java
@@ -16,8 +16,13 @@ package com.facebook.presto.hive;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.VarcharType;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 
 import javax.inject.Inject;
+
+import java.util.ArrayList;
 
 import static com.facebook.presto.hive.HiveType.HIVE_BYTE;
 import static com.facebook.presto.hive.HiveType.HIVE_DOUBLE;
@@ -61,7 +66,21 @@ public class HiveCoercionPolicy
         if (fromHiveType.equals(HIVE_FLOAT)) {
             return toHiveType.equals(HIVE_DOUBLE);
         }
-
+        if (isStruct(fromHiveType) && isStruct(toHiveType)) {
+            ArrayList<TypeInfo> tableFieldTypes     = getStructFields(fromHiveType);
+            ArrayList<TypeInfo> partitionFieldTypes = getStructFields(toHiveType);
+            return tableFieldTypes.subList(0, partitionFieldTypes.size()).equals(partitionFieldTypes);
+        }
         return false;
+    }
+
+    private static boolean isStruct(HiveType type)
+    {
+        return type.getCategory() == ObjectInspector.Category.STRUCT;
+    }
+
+    private static ArrayList<TypeInfo> getStructFields(HiveType structHiveType)
+    {
+        return ((StructTypeInfo) structHiveType.getTypeInfo()).getAllStructFieldTypeInfos();
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -741,7 +741,7 @@ public class ParquetHiveRecordCursor
             List<Type> prestoTypeParameters = prestoType.getTypeParameters();
             List<parquet.schema.Type> fieldTypes = entryType.getFields();
             checkArgument(
-                    prestoTypeParameters.size() == fieldTypes.size(),
+                    prestoTypeParameters.size() >= fieldTypes.size(),
                     "Schema mismatch, metastore schema for row column %s has %s fields but parquet schema has %s fields",
                     columnName,
                     prestoTypeParameters.size(),
@@ -751,7 +751,7 @@ public class ParquetHiveRecordCursor
             this.fieldIndex = fieldIndex;
 
             ImmutableList.Builder<BlockConverter> converters = ImmutableList.builder();
-            for (int i = 0; i < prestoTypeParameters.size(); i++) {
+            for (int i = 0; i < fieldTypes.size(); i++) {
                 parquet.schema.Type fieldType = fieldTypes.get(i);
                 converters.add(createConverter(prestoTypeParameters.get(i), columnName + "." + fieldType.getName(), fieldType, i));
             }
@@ -796,7 +796,7 @@ public class ParquetHiveRecordCursor
             for (BlockConverter converter : converters) {
                 converter.afterValue();
             }
-            while (currentEntryBuilder.getPositionCount() < converters.size()) {
+            while (currentEntryBuilder.getPositionCount() < rowType.getTypeParameters().size()) {
                 currentEntryBuilder.appendNull();
             }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -77,6 +77,7 @@ import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.facebook.presto.type.ArrayType;
 import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.RowType;
 import com.facebook.presto.type.TypeRegistry;
 import com.facebook.presto.util.ImmutableCollectors;
 import com.google.common.collect.ImmutableList;
@@ -2728,6 +2729,21 @@ public abstract class AbstractTestHiveClient
                     }
                 }
 
+                index = columnIndex.get("t_struct");
+                if (index != null) {
+                    if ((rowNumber % 31) == 0) {
+                        assertNull(row.getField(index));
+                    }
+                    else {
+                        assertTrue(row.getField(index) instanceof List);
+                        List values = (List) row.getField(index);
+                        assertEquals(values.size(), 3);
+                        assertEquals(values.get(0), "test abc");
+                        assertEquals(values.get(1), 0.1);
+                        assertNull(values.get(2));
+                    }
+                }
+
                 // MAP<INT, ARRAY<STRUCT<s_string: STRING, s_double:DOUBLE>>>
                 index = columnIndex.get("t_complex");
                 if (index != null) {
@@ -2961,7 +2977,7 @@ public abstract class AbstractTestHiveClient
                 else if (DATE.equals(column.getType())) {
                     assertInstanceOf(value, SqlDate.class);
                 }
-                else if (column.getType() instanceof ArrayType) {
+                else if (column.getType() instanceof ArrayType || column.getType() instanceof RowType) {
                     assertInstanceOf(value, List.class);
                 }
                 else if (column.getType() instanceof MapType) {

--- a/presto-hive/src/test/sql/create-test-hive13.sql
+++ b/presto-hive/src/test/sql/create-test-hive13.sql
@@ -82,8 +82,6 @@ SELECT * FROM presto_test_types_textfile
 ;
 
 
--- Parquet fails when trying to use complex nested types.
--- Parquet is missing TIMESTAMP and BINARY.
 CREATE TABLE presto_test_types_parquet (
   t_string STRING
 , t_varchar VARCHAR(50)
@@ -98,12 +96,15 @@ CREATE TABLE presto_test_types_parquet (
 , t_binary BINARY
 , t_map MAP<STRING, STRING>
 , t_array_string ARRAY<STRING>
-, t_array_struct ARRAY<STRUCT<s_string: STRING, s_double:DOUBLE>>
+, t_array_struct ARRAY<STRUCT<s_string:STRING, s_double:DOUBLE>>
+, t_struct STRUCT<s_string:STRING, s_double:DOUBLE>
 )
+PARTITIONED BY (dummy INT)
 STORED AS PARQUET
 ;
 
 INSERT INTO TABLE presto_test_types_parquet
+PARTITION (dummy=0)
 SELECT
   t_string
 , t_varchar
@@ -119,9 +120,12 @@ SELECT
 , t_map
 , t_array_string
 , t_array_struct
+, t_array_struct[0]
 FROM presto_test_types_textfile
 ;
 
+ALTER TABLE presto_test_types_parquet
+CHANGE COLUMN t_struct t_struct STRUCT<s_string:STRING, s_double:DOUBLE, s_boolean:BOOLEAN>;
 
 ALTER TABLE presto_test_types_textfile ADD COLUMNS (new_column INT);
 ALTER TABLE presto_test_types_sequencefile ADD COLUMNS (new_column INT);


### PR DESCRIPTION
This PR takes schema evolution support from PR#4939 and retrofits it into a coercion policy