### PR TITLE
Search for subquery projection only above AggregationNode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
@@ -201,6 +201,7 @@ public class TransformCorrelatedScalarAggregationToJoin
 
             Optional<ProjectNode> subqueryProjection = searchFrom(applyNode.getSubquery())
                     .where(ProjectNode.class::isInstance)
+                    .skipOnlyWhen(EnforceSingleRowNode.class::isInstance)
                     .findFirst();
 
             if (subqueryProjection.isPresent()) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6486,6 +6486,24 @@ public abstract class AbstractTestQueries
                         "WHERE 100 < (SELECT * " +
                         "FROM (SELECT (SELECT avg(i.orderkey) FROM orders i WHERE o.orderkey < i.orderkey AND i.orderkey % 10000 = 0)))",
                 "VALUES 14999"); // h2 is slow
+
+        // consecutive correlated subqueries with scalar aggregation
+        assertQuery("SELECT " +
+                "(SELECT avg(regionkey) " +
+                " FROM nation n2" +
+                " WHERE n2.nationkey = n1.nationkey)," +
+                "(SELECT avg(regionkey)" +
+                " FROM nation n3" +
+                " WHERE n3.nationkey = n1.nationkey)" +
+                "FROM nation n1");
+        assertQuery("SELECT" +
+                "(SELECT avg(regionkey)" +
+                " FROM nation n2 " +
+                " WHERE n2.nationkey = n1.nationkey)," +
+                "(SELECT avg(regionkey)+1 " +
+                " FROM nation n3 " +
+                " WHERE n3.nationkey = n1.nationkey)" +
+                "FROM nation n1");
     }
 
     @Test


### PR DESCRIPTION
Previously subquery ProjectNode was found below AggregationNode in
TransformCorrelatedScalarAggregationToJoin, which caused
a new ProjectNode to be created with unsatisfied symbols.

Fixes: https://github.com/prestodb/presto/issues/7064