### PR TITLE
Create symlink for configuration

### DIFF
--- a/presto-server-rpm/pom.xml
+++ b/presto-server-rpm/pom.xml
@@ -65,7 +65,7 @@
             <plugin>
                 <groupId>com.teradata</groupId>
                 <artifactId>redlinerpm-maven-plugin-td</artifactId>
-                <version>2.1.3</version>
+                <version>2.1.4</version>
                 <extensions>true</extensions>
 
                 <configuration>
@@ -98,6 +98,13 @@
                                     <name>/usr/sbin/groupadd</name>
                                 </dependency>
                             </dependencies>
+
+                            <links>
+                                <link>
+                                    <path>/usr/lib/presto/etc</path>
+                                    <target>/etc/presto</target>
+                                </link>
+                            </links>
 
                             <rules>
                                 <rule>


### PR DESCRIPTION
Presto expects to find some of its configuration files in
/usr/lib/presto/etc; create a symlink to /etc/presto in that location
so we can configure the following plug-ins:
- SystemAccessControl access-control.properties
- EventListener event-listener.properties
- ResourceGroups resource-groups.properties