### PR TITLE
Fix partial aggregation push down through union

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionRewriter;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class SymbolMapper
+{
+    private final Map<Symbol, Symbol> mapping;
+
+    public SymbolMapper(Map<Symbol, Symbol> mapping)
+    {
+        this.mapping = ImmutableMap.copyOf(requireNonNull(mapping, "mapping is null"));
+    }
+
+    public Symbol map(Symbol symbol)
+    {
+        Symbol canonical = symbol;
+        while (mapping.containsKey(canonical) && !mapping.get(canonical).equals(canonical)) {
+            canonical = mapping.get(canonical);
+        }
+        return canonical;
+    }
+
+    public Expression map(Expression value)
+    {
+        return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
+        {
+            @Override
+            public Expression rewriteSymbolReference(SymbolReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                Symbol canonical = map(Symbol.from(node));
+                return canonical.toSymbolReference();
+            }
+        }, value);
+    }
+
+    public AggregationNode map(AggregationNode node, PlanNode source)
+    {
+        ImmutableMap.Builder<Symbol, Signature> functionInfos = ImmutableMap.builder();
+        ImmutableMap.Builder<Symbol, FunctionCall> functionCalls = ImmutableMap.builder();
+        ImmutableMap.Builder<Symbol, Symbol> masks = ImmutableMap.builder();
+        for (Map.Entry<Symbol, FunctionCall> entry : node.getAggregations().entrySet()) {
+            Symbol symbol = entry.getKey();
+            Symbol canonical = map(symbol);
+            FunctionCall canonicalCall = (FunctionCall) map(entry.getValue());
+            functionCalls.put(canonical, canonicalCall);
+            functionInfos.put(canonical, node.getFunctions().get(symbol));
+        }
+        for (Map.Entry<Symbol, Symbol> entry : node.getMasks().entrySet()) {
+            masks.put(map(entry.getKey()), map(entry.getValue()));
+        }
+
+        List<List<Symbol>> groupingSets = node.getGroupingSets().stream()
+                .map(this::mapAndDistinct)
+                .collect(toImmutableList());
+
+        return new AggregationNode(
+                node.getId(),
+                source,
+                functionCalls.build(),
+                functionInfos.build(),
+                masks.build(),
+                groupingSets,
+                node.getStep(),
+                node.getHashSymbol().map(this::map),
+                node.getGroupIdSymbol().map(this::map));
+    }
+
+    private List<Symbol> mapAndDistinct(List<Symbol> outputs)
+    {
+        Set<Symbol> added = new HashSet<>();
+        ImmutableList.Builder<Symbol> builder = ImmutableList.builder();
+        for (Symbol symbol : outputs) {
+            Symbol canonical = map(symbol);
+            if (added.add(canonical)) {
+                builder.add(canonical);
+            }
+        }
+        return builder.build();
+    }
+
+    public static SymbolMapper.Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static class Builder
+    {
+        private ImmutableMap.Builder<Symbol, Symbol> mappings = ImmutableMap.builder();
+
+        public SymbolMapper build()
+        {
+            return new SymbolMapper(mappings.build());
+        }
+
+        public void put(Symbol from, Symbol to)
+        {
+            mappings.put(from, to);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -129,35 +129,9 @@ public class UnaliasSymbolReferences
         public PlanNode visitAggregation(AggregationNode node, RewriteContext<Void> context)
         {
             PlanNode source = context.rewrite(node.getSource());
-
-            ImmutableMap.Builder<Symbol, Signature> functionInfos = ImmutableMap.builder();
-            ImmutableMap.Builder<Symbol, FunctionCall> functionCalls = ImmutableMap.builder();
-            ImmutableMap.Builder<Symbol, Symbol> masks = ImmutableMap.builder();
-            for (Map.Entry<Symbol, FunctionCall> entry : node.getAggregations().entrySet()) {
-                Symbol symbol = entry.getKey();
-                Symbol canonical = canonicalize(symbol);
-                FunctionCall canonicalCall = (FunctionCall) canonicalize(entry.getValue());
-                functionCalls.put(canonical, canonicalCall);
-                functionInfos.put(canonical, node.getFunctions().get(symbol));
-            }
-            for (Map.Entry<Symbol, Symbol> entry : node.getMasks().entrySet()) {
-                masks.put(canonicalize(entry.getKey()), canonicalize(entry.getValue()));
-            }
-
-            List<List<Symbol>> groupingSets = node.getGroupingSets().stream()
-                    .map(this::canonicalizeAndDistinct)
-                    .collect(toImmutableList());
-
-            return new AggregationNode(
-                    node.getId(),
-                    source,
-                    functionCalls.build(),
-                    functionInfos.build(),
-                    masks.build(),
-                    groupingSets,
-                    node.getStep(),
-                    canonicalize(node.getHashSymbol()),
-                    canonicalize(node.getGroupIdSymbol()));
+            //TODO: use mapper in other methods
+            SymbolMapper mapper = new SymbolMapper(mapping);
+            return mapper.map(node, source);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -645,6 +645,11 @@ public class LocalQueryRunner
 
     public Plan createPlan(Session session, @Language("SQL") String sql, LogicalPlanner.Stage stage)
     {
+        return createPlan(session, sql, stage, true);
+    }
+
+    public Plan createPlan(Session session, @Language("SQL") String sql, LogicalPlanner.Stage stage, boolean forceSingleNode)
+    {
         Statement statement = unwrapExecuteStatement(sqlParser.createStatement(sql), sqlParser, session);
 
         assertFormattedSql(sqlParser, statement);
@@ -652,7 +657,7 @@ public class LocalQueryRunner
         FeaturesConfig featuresConfig = new FeaturesConfig()
                 .setDistributedIndexJoinsEnabled(false)
                 .setOptimizeHashGeneration(true);
-        PlanOptimizers planOptimizers = new PlanOptimizers(metadata, sqlParser, featuresConfig, true, new MBeanExporter(new TestingMBeanServer()));
+        PlanOptimizers planOptimizers = new PlanOptimizers(metadata, sqlParser, featuresConfig, forceSingleNode, new MBeanExporter(new TestingMBeanServer()));
         return createPlan(session, sql, planOptimizers.get(), stage);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
@@ -34,7 +34,7 @@ import static org.testng.Assert.fail;
 
 public class BasePlanTest
 {
-    private final LocalQueryRunner queryRunner;
+    protected final LocalQueryRunner queryRunner;
 
     public BasePlanTest()
     {
@@ -106,8 +106,13 @@ public class BasePlanTest
 
     protected Plan plan(String sql, LogicalPlanner.Stage stage)
     {
+        return plan(sql, stage, true);
+    }
+
+    protected Plan plan(String sql, LogicalPlanner.Stage stage, boolean forceSingleNode)
+    {
         try {
-            return queryRunner.inTransaction(transactionSession -> queryRunner.createPlan(transactionSession, sql, stage));
+            return queryRunner.inTransaction(transactionSession -> queryRunner.createPlan(transactionSession, sql, stage, forceSingleNode));
         }
         catch (RuntimeException ex) {
             fail("Invalid SQL: " + sql, ex);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnion.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnion.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.sql.planner.LogicalPlanner;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE;
+import static java.util.stream.Collectors.toList;
+import static org.testng.Assert.assertFalse;
+
+public class TestUnion
+        extends BasePlanTest
+{
+    @Test
+    public void testPartialAggregationsWithUnion()
+    {
+        Plan plan = plan(
+                "SELECT orderstatus, sum(orderkey) FROM (SELECT orderkey, orderstatus FROM orders UNION ALL SELECT orderkey, orderstatus FROM orders) x GROUP BY (orderstatus)",
+                LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED,
+                false);
+        assertAtMostOneAggregationBetweenRemoteExchanges(plan);
+    }
+
+    @Test
+    public void testPartialRollupAggregationsWithUnion()
+    {
+        Plan plan = plan(
+                "SELECT orderstatus, sum(orderkey) FROM (SELECT orderkey, orderstatus FROM orders UNION ALL SELECT orderkey, orderstatus FROM orders) x GROUP BY ROLLUP (orderstatus)",
+                LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED,
+                false);
+        assertAtMostOneAggregationBetweenRemoteExchanges(plan);
+    }
+
+    private static void assertAtMostOneAggregationBetweenRemoteExchanges(Plan plan)
+    {
+        List<PlanNode> fragments = searchFrom(plan.getRoot())
+                .where(TestUnion::isRemoteExchange)
+                .findAll()
+                .stream()
+                .flatMap(exchangeNode -> exchangeNode.getSources().stream())
+                .collect(toList());
+
+        for (PlanNode fragment : fragments) {
+            List<PlanNode> aggregations = searchFrom(fragment)
+                    .where(AggregationNode.class::isInstance)
+                    .skipOnlyWhen(TestUnion::isNotRemoteExchange)
+                    .findAll();
+
+            assertFalse(aggregations.size() > 1, "More than a single AggregationNode between remote exchanges");
+        }
+    }
+
+    private static boolean isNotRemoteExchange(PlanNode planNode)
+    {
+        return !isRemoteExchange(planNode);
+    }
+
+    private static boolean isRemoteExchange(PlanNode planNode)
+    {
+        return (planNode instanceof ExchangeNode) && ((ExchangeNode) planNode).getScope().equals(REMOTE);
+    }
+}


### PR DESCRIPTION
It seems like a regression caused by @martint, because couple months ago there was this pr https://github.com/prestodb/presto/pull/5981

Problem was that `PartialAggregationPushDown` was not able to push aggregation through more then one `ExchangeNode`. When it found plan: `Aggregation -> Exchange -> Exchange`, it was transforming it to `Aggregation Final -> Exchange -> Aggregation Partial -> Project -> Exchange`. This projection was making it unable to push partial aggregation further down. 

Alternative fix to that, would be to run `PartialAggregationPushDown`, `UnaliasSymbolReferences` and `PruneIdentiyProjection` until some fix point would be reached (however currently `UnaliasSymbolReferences` can not be used after  `AddLocalExchanges`).

Query plan before fix:

```
presto:tiny> explain (type distributed) SELECT orderstatus, sum(orderkey) FROM (SELECT orderkey, orderstatus FROM orders UNION ALL SELECT orderkey, orderstatus FROM orders) x GROUP BY (orderstatus);
                                                                      Query Plan                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
 Fragment 0 [SINGLE]                                                                                                                                  
     Output layout: [orderstatus_19, sum]                                                                                                             
     Output partitioning: SINGLE []                                                                                                                   
     - Output[orderstatus, _col1] => [orderstatus_19:varchar(1), sum:bigint]                                                                          
             orderstatus := orderstatus_19                                                                                                            
             _col1 := sum                                                                                                                             
         - RemoteSource[1] => [orderstatus_19:varchar(1), sum:bigint]                                                                                 
                                                                                                                                                      
 Fragment 1 [HASH]                                                                                                                                    
     Output layout: [orderstatus_19, sum]                                                                                                             
     Output partitioning: SINGLE []                                                                                                                   
     - Project[] => [orderstatus_19:varchar(1), sum:bigint]                                                                                           
         - Aggregate(FINAL)[orderstatus_19][$hashvalue] => [orderstatus_19:varchar(1), $hashvalue:bigint, sum:bigint]                                 
                 sum := "sum"("sum_37")                                                                                                               
             - LocalExchange[HASH][$hashvalue] ("orderstatus_19") => orderstatus_19:varchar(1), sum_37:bigint, $hashvalue:bigint                      
                 - Aggregate(PARTIAL)[orderstatus_19][$hashvalue_40] => [orderstatus_19:varchar(1), $hashvalue_40:bigint, sum_37:bigint]              
                         sum_37 := "sum"("orderkey_18")                                                                                               
                     - Project[] => [orderkey_18:bigint, orderstatus_19:varchar(1), $hashvalue_40:bigint]                                             
                             $hashvalue_40 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("orderstatus_19"), 0))                        
                         - Project[] => [orderkey_18:bigint, orderstatus_19:varchar(1), $hashvalue_38:bigint]                                         
                                 orderkey_18 := "orderkey"                                                                                            
                                 orderstatus_19 := "orderstatus"                                                                                      
                             - RemoteSource[2] => [orderkey:bigint, orderstatus:varchar(1), $hashvalue_38:bigint]                                     
                 - Aggregate(PARTIAL)[orderstatus_19][$hashvalue_43] => [orderstatus_19:varchar(1), $hashvalue_43:bigint, sum_37:bigint]              
                         sum_37 := "sum"("orderkey_18")                                                                                               
                     - Project[] => [orderkey_18:bigint, orderstatus_19:varchar(1), $hashvalue_43:bigint]                                             
                             $hashvalue_43 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("orderstatus_19"), 0))                        
                         - Project[] => [orderkey_18:bigint, orderstatus_19:varchar(1), $hashvalue_41:bigint]                                         
                                 orderkey_18 := "orderkey_4"                                                                                          
                                 orderstatus_19 := "orderstatus_6"                                                                                    
                             - RemoteSource[3] => [orderkey_4:bigint, orderstatus_6:varchar(1), $hashvalue_41:bigint]                                 
                                                                                                                                                      
 Fragment 2 [tpch:orders:15000]                                                                                                                       
     Output layout: [orderkey, orderstatus, $hashvalue_39]                                                                                            
     Output partitioning: HASH [orderstatus][$hashvalue_39]                                                                                           
     - ScanProject[table = tpch:tpch:orders:sf0.01, originalConstraint = true] => [orderkey:bigint, orderstatus:varchar(1), $hashvalue_39:bigint]     
             $hashvalue_39 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("orderstatus"), 0))                                           
             orderkey := tpch:orderkey                                                                                                                
             orderstatus := tpch:orderstatus                                                                                                          
                                                                                                                                                      
 Fragment 3 [tpch:orders:15000]                                                                                                                       
     Output layout: [orderkey_4, orderstatus_6, $hashvalue_42]                                                                                        
     Output partitioning: HASH [orderstatus_6][$hashvalue_42]                                                                                         
     - ScanProject[table = tpch:tpch:orders:sf0.01, originalConstraint = true] => [orderkey_4:bigint, orderstatus_6:varchar(1), $hashvalue_42:bigint] 
             $hashvalue_42 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("orderstatus_6"), 0))                                         
             orderkey_4 := tpch:orderkey                                                                                                              
             orderstatus_6 := tpch:orderstatus                                                                                                        
```

and after fix:

```
presto:tiny> explain (type distributed) SELECT orderstatus, sum(orderkey) FROM (SELECT orderkey, orderstatus FROM orders UNION ALL SELECT orderkey, orderstatus FROM orders) x GROUP BY (orderstatus);
                                                                        Query Plan                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------
 Fragment 0 [SINGLE]                                                                                                                                      
     Output layout: [orderstatus_19, sum]                                                                                                                 
     Output partitioning: SINGLE []                                                                                                                       
     - Output[orderstatus, _col1] => [orderstatus_19:varchar(1), sum:bigint]                                                                              
             orderstatus := orderstatus_19                                                                                                                
             _col1 := sum                                                                                                                                 
         - RemoteSource[1] => [orderstatus_19:varchar(1), sum:bigint]                                                                                     
                                                                                                                                                          
 Fragment 1 [HASH]                                                                                                                                        
     Output layout: [orderstatus_19, sum]                                                                                                                 
     Output partitioning: SINGLE []                                                                                                                       
     - Project[] => [orderstatus_19:varchar(1), sum:bigint]                                                                                               
         - Aggregate(FINAL)[orderstatus_19][$hashvalue] => [orderstatus_19:varchar(1), $hashvalue:bigint, sum:bigint]                                     
                 sum := "sum"("sum_37")                                                                                                                   
             - LocalExchange[HASH][$hashvalue] ("orderstatus_19") => orderstatus_19:varchar(1), sum_37:bigint, $hashvalue:bigint                          
                 - Project[] => [orderstatus_19:varchar(1), sum_37:bigint, $hashvalue_40:bigint]                                                          
                         $hashvalue_40 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("orderstatus_19"), 0))                                
                     - Project[] => [orderstatus_19:varchar(1), sum_37:bigint, $hashvalue_38:bigint]                                                      
                             orderstatus_19 := "orderstatus"                                                                                              
                         - RemoteSource[2] => [orderstatus:varchar(1), sum_37:bigint, $hashvalue_38:bigint]                                               
                 - Project[] => [orderstatus_19:varchar(1), sum_37:bigint, $hashvalue_43:bigint]                                                          
                         $hashvalue_43 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("orderstatus_19"), 0))                                
                     - Project[] => [orderstatus_19:varchar(1), sum_37:bigint, $hashvalue_41:bigint]                                                      
                             orderstatus_19 := "orderstatus_6"                                                                                            
                         - RemoteSource[3] => [orderstatus_6:varchar(1), sum_37:bigint, $hashvalue_41:bigint]                                             
                                                                                                                                                          
 Fragment 2 [tpch:orders:15000]                                                                                                                           
     Output layout: [orderstatus, sum_37, $hashvalue_39]                                                                                                  
     Output partitioning: HASH [orderstatus][$hashvalue_39]                                                                                               
     - Aggregate(PARTIAL)[orderstatus][$hashvalue_39] => [orderstatus:varchar(1), $hashvalue_39:bigint, sum_37:bigint]                                    
             sum_37 := "sum"("orderkey")                                                                                                                  
         - ScanProject[table = tpch:tpch:orders:sf0.01, originalConstraint = true] => [orderkey:bigint, orderstatus:varchar(1), $hashvalue_39:bigint]     
                 $hashvalue_39 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("orderstatus"), 0))                                           
                 orderkey := tpch:orderkey                                                                                                                
                 orderstatus := tpch:orderstatus                                                                                                          
                                                                                                                                                          
 Fragment 3 [tpch:orders:15000]                                                                                                                           
     Output layout: [orderstatus_6, sum_37, $hashvalue_42]                                                                                                
     Output partitioning: HASH [orderstatus_6][$hashvalue_42]                                                                                             
     - Aggregate(PARTIAL)[orderstatus_6][$hashvalue_42] => [orderstatus_6:varchar(1), $hashvalue_42:bigint, sum_37:bigint]                                
             sum_37 := "sum"("orderkey_4")                                                                                                                
         - ScanProject[table = tpch:tpch:orders:sf0.01, originalConstraint = true] => [orderkey_4:bigint, orderstatus_6:varchar(1), $hashvalue_42:bigint] 
                 $hashvalue_42 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("orderstatus_6"), 0))                                         
                 orderkey_4 := tpch:orderkey                                                                                                              
                 orderstatus_6 := tpch:orderstatus                    
```