### PR TITLE
Document region specific S3 endpoint

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -205,7 +205,9 @@ Property Name                                Description
 
 ``hive.s3.endpoint``                         The S3 storage endpoint server. This can be used to
                                              connect to an S3-compatible storage system instead
-                                             of AWS.
+                                             of AWS. When using V4 signatures, it is recommended to
+                                             set this to the AWS region-specific endpoint
+                                             (e.g. http[s]://<bucket>.s3-<AWS-region>.amazonaws.com).
 
 ``hive.s3.signer-type``                      Specify a different signer type for S3-compatible storage.
                                              Example: ``S3SignerType`` for v2 signer type


### PR DESCRIPTION
Change the description of the `hive.s3.endpoint` to document the fact that we can use it to set AWS region specific endpoints. This is useful for the case when you're accessing S3 buckets that lie in a region different than that of the EC2 instances where Presto is running.

We saw a customer case where this would have been helpful. Their attempt to access S3 buckets with ORC data was failing with a "400 Bad Request".  Additionally, the following warning appears in the logs:
```WARNING: Attempting to re-send the request to testv4signatures-eu-central-1.s3-external-1.amazonaws.com with AWS V4 authentication. To avoid this warning in the future, please use region-specific endpoint to access buckets located in regions that require V4 signing.```

According to https://github.com/aws/aws-sdk-java/issues/360, this might happen in a case when region is not set. 