### PR TITLE
Bind the resource of ui on another port

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorUIHttpServerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorUIHttpServerModule.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.transaction.TransactionManager;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.discovery.client.AnnouncementHttpServerInfo;
+import io.airlift.discovery.server.DynamicAnnouncementResource;
+import io.airlift.discovery.server.ServiceResource;
+import io.airlift.event.client.EventClient;
+import io.airlift.http.server.HttpRequestEvent;
+import io.airlift.http.server.HttpServer;
+import io.airlift.http.server.HttpServerConfig;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.HttpServerProvider;
+import io.airlift.http.server.LocalAnnouncementHttpServerInfo;
+import io.airlift.http.server.RequestStats;
+import io.airlift.http.server.TheAdminServlet;
+import io.airlift.http.server.TheServlet;
+import io.airlift.json.JsonCodecFactory;
+import io.airlift.node.NodeConfig;
+import io.airlift.node.NodeInfo;
+
+import javax.servlet.Filter;
+
+import java.util.UUID;
+
+import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
+import static io.airlift.event.client.EventBinder.eventBinder;
+import static io.airlift.http.server.HttpServerBinder.HttpResourceBinding;
+import static io.airlift.http.server.HttpServerBinder.httpServerBinder;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static java.util.Objects.requireNonNull;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class CoordinatorUIHttpServerModule
+        extends AbstractConfigurationAwareModule
+{
+    private final Injector injector;
+
+    public CoordinatorUIHttpServerModule(Injector injector)
+    {
+        this.injector = requireNonNull(injector, "injector is null");
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        binder.disableCircularProxies();
+
+        ServerConfig serverConfig = injector.getInstance(ServerConfig.class);
+        HttpServerConfig httpServerConfig = injector.getInstance(HttpServerConfig.class)
+                                          .setHttpPort(serverConfig.getUIHttpPort());
+        binder.bind(HttpServerConfig.class).toInstance(httpServerConfig);
+
+        binder.bind(HttpServerInfo.class).in(Scopes.SINGLETON);
+        binder.bind(EventClient.class).toInstance(injector.getInstance(EventClient.class));
+        binder.bind(HttpServer.class).toProvider(HttpServerProvider.class).in(Scopes.SINGLETON);
+
+        Multibinder.newSetBinder(binder, Filter.class, TheServlet.class);
+        Multibinder.newSetBinder(binder, Filter.class, TheAdminServlet.class);
+        Multibinder.newSetBinder(binder, HttpResourceBinding.class, TheServlet.class);
+        newExporter(binder).export(HttpServer.class).withGeneratedName();
+        binder.bind(RequestStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(RequestStats.class).withGeneratedName();
+        eventBinder(binder).bindEventClient(HttpRequestEvent.class);
+
+        NodeConfig nodeConfig = injector.getInstance(NodeConfig.class);
+        nodeConfig.setNodeId(UUID.randomUUID().toString());
+        binder.bind(NodeInfo.class).toInstance(new NodeInfo(nodeConfig));
+        binder.bind(AnnouncementHttpServerInfo.class).to(LocalAnnouncementHttpServerInfo.class).in(Scopes.SINGLETON);
+        binder.bind(BlockEncodingSerde.class).toInstance(injector.getInstance(BlockEncodingSerde.class));
+        binder.bind(TypeManager.class).toInstance(injector.getInstance(TypeManager.class));
+        binder.bind(SqlParser.class).toInstance(injector.getInstance(SqlParser.class));
+        binder.bind(TransactionManager.class).toInstance(injector.getInstance(TransactionManager.class));
+
+        binder.bind(ObjectMapper.class).toInstance(injector.getInstance(ObjectMapper.class));
+        binder.bind(JsonCodecFactory.class).toInstance(injector.getInstance(JsonCodecFactory.class));
+
+        resourceBinding(binder);
+    }
+
+    protected void resourceBinding(Binder binder)
+    {
+        // bind webapp
+        httpServerBinder(binder).bindResource("/", "webapp").withWelcomeFile("index.html");
+        // presto coordinator ui announcement
+        discoveryBinder(binder).bindHttpAnnouncement("presto-coordinator-ui");
+        // accept presto worker's announcement
+        jaxrsBinder(binder).bindInstance(injector.getInstance(DynamicAnnouncementResource.class));
+        // service info
+        jaxrsBinder(binder).bindInstance(injector.getInstance(ServiceResource.class));
+        // query execution visualizer
+        jaxrsBinder(binder).bindInstance(injector.getInstance(QueryExecutionResource.class));
+        // query manager
+        jaxrsBinder(binder).bindInstance(injector.getInstance(QueryResource.class));
+        // cluster statistics
+        jaxrsBinder(binder).bindInstance(injector.getInstance(ClusterStatsResource.class));
+        // server info resource
+        jaxrsBinder(binder).bindInstance(injector.getInstance(ServerInfoResource.class));
+        // server node resource
+        jaxrsBinder(binder).bindInstance(injector.getInstance(NodeResource.class));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -132,6 +132,18 @@ public class PrestoServer
 
             injector.getInstance(Announcer.class).start();
 
+            ServerConfig serverConfig = injector.getInstance(ServerConfig.class);
+
+            if (serverConfig.isCoordinator() && serverConfig.isEnabledUIonSecondaryPort()) {
+                Bootstrap uIApp = new Bootstrap(new DiscoveryModule(),
+                                                new JaxrsModule(true),
+                                                new CoordinatorUIHttpServerModule(injector));
+                Injector uIInjector = uIApp.doNotInitializeLogging().initialize();
+                log.info("UI runs on a seperate port: %d", serverConfig.getUIHttpPort());
+
+                uIInjector.getInstance(Announcer.class).start();
+            }
+
             log.info("======== SERVER STARTED ========");
         }
         catch (Throwable e) {

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -25,6 +25,8 @@ public class ServerConfig
     private String dataSources;
     private boolean includeExceptionInResponse = true;
     private Duration gracePeriod = new Duration(2, MINUTES);
+    private boolean enabledUIonSecondaryPort = false;
+    private int uIHttpPort = 0;
 
     public boolean isCoordinator()
     {
@@ -85,6 +87,30 @@ public class ServerConfig
     public ServerConfig setGracePeriod(Duration gracePeriod)
     {
         this.gracePeriod = gracePeriod;
+        return this;
+    }
+
+    public boolean isEnabledUIonSecondaryPort()
+    {
+        return enabledUIonSecondaryPort;
+    }
+
+    @Config("http-server.ui.secondary.port.enabled")
+    public ServerConfig setEnabledUIonSecondaryPort(boolean enabledUIonSecondaryPort)
+    {
+        this.enabledUIonSecondaryPort = enabledUIonSecondaryPort;
+        return this;
+    }
+
+    public int getUIHttpPort()
+    {
+        return uIHttpPort;
+    }
+
+    @Config("http-server.ui.http.port")
+    public ServerConfig setUIHttpPort(int uIHttpPort)
+    {
+        this.uIHttpPort = uIHttpPort;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
@@ -34,7 +34,9 @@ public class TestServerConfig
                 .setPrestoVersion(null)
                 .setDataSources(null)
                 .setIncludeExceptionInResponse(true)
-                .setGracePeriod(new Duration(2, MINUTES)));
+                .setGracePeriod(new Duration(2, MINUTES))
+                .setEnabledUIonSecondaryPort(false)
+                .setUIHttpPort(0));
     }
 
     @Test
@@ -46,6 +48,8 @@ public class TestServerConfig
                 .put("datasources", "jmx")
                 .put("http.include-exception-in-response", "false")
                 .put("shutdown.grace-period", "5m")
+                .put("http-server.ui.secondary.port.enabled", "true")
+                .put("http-server.ui.http.port", "8080")
                 .build();
 
         ServerConfig expected = new ServerConfig()
@@ -53,7 +57,9 @@ public class TestServerConfig
                 .setPrestoVersion("test")
                 .setDataSources("jmx")
                 .setIncludeExceptionInResponse(false)
-                .setGracePeriod(new Duration(5, MINUTES));
+                .setGracePeriod(new Duration(5, MINUTES))
+                .setEnabledUIonSecondaryPort(true)
+                .setUIHttpPort(8080);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This pull request is addressing the issue #7027. 
- Added a module to launch the UI on another port and binding related resources. 
- Launch the UI module in a new bootstrap after the main bootstrap initialized.