### PR TITLE
Change failure info in query info

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.SessionRepresentation;
-import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.ErrorType;
 import com.facebook.presto.spi.QueryId;
@@ -28,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+import javax.validation.constraints.NotNull;
 
 import java.net.URI;
 import java.util.List;
@@ -59,7 +59,7 @@ public class QueryInfo
     private final boolean clearTransactionId;
     private final String updateType;
     private final Optional<StageInfo> outputStage;
-    private final FailureInfo failureInfo;
+    private final Optional<TaskFailureInfo> taskFailureInfo;
     private final ErrorType errorType;
     private final ErrorCode errorCode;
     private final Set<Input> inputs;
@@ -86,7 +86,7 @@ public class QueryInfo
             @JsonProperty("clearTransactionId") boolean clearTransactionId,
             @JsonProperty("updateType") String updateType,
             @JsonProperty("outputStage") Optional<StageInfo> outputStage,
-            @JsonProperty("failureInfo") FailureInfo failureInfo,
+            @JsonProperty("taskFailureInfo") Optional<TaskFailureInfo> taskFailureInfo,
             @JsonProperty("errorCode") ErrorCode errorCode,
             @JsonProperty("inputs") Set<Input> inputs,
             @JsonProperty("output") Optional<Output> output,
@@ -106,6 +106,7 @@ public class QueryInfo
         requireNonNull(startedTransactionId, "startedTransactionId is null");
         requireNonNull(query, "query is null");
         requireNonNull(outputStage, "outputStage is null");
+        requireNonNull(taskFailureInfo, "taskFailureInfo is null");
         requireNonNull(inputs, "inputs is null");
         requireNonNull(output, "output is null");
         requireNonNull(resourceGroupName, "resourceGroupName is null");
@@ -127,7 +128,7 @@ public class QueryInfo
         this.clearTransactionId = clearTransactionId;
         this.updateType = updateType;
         this.outputStage = outputStage;
-        this.failureInfo = failureInfo;
+        this.taskFailureInfo = taskFailureInfo;
         this.errorType = errorCode == null ? null : errorCode.getType();
         this.errorCode = errorCode;
         this.inputs = ImmutableSet.copyOf(inputs);
@@ -239,14 +240,13 @@ public class QueryInfo
         return outputStage;
     }
 
-    @Nullable
+    @NotNull
     @JsonProperty
-    public FailureInfo getFailureInfo()
+    public Optional<TaskFailureInfo> getTaskFailureInfo()
     {
-        return failureInfo;
+        return taskFailureInfo;
     }
 
-    @Nullable
     @JsonProperty
     public ErrorType getErrorType()
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskFailureInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskFailureInfo.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.client.ErrorLocation;
+import com.facebook.presto.client.FailureInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.validation.constraints.NotNull;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class TaskFailureInfo
+{
+    private final FailureInfo failureInfo;
+    private final Optional<String> failureTask;
+    private final Optional<URI>  failureTaskUri;
+    private final Optional<String> failureHost;
+    private final Optional<Integer> failurePort;
+
+    @JsonCreator
+    public TaskFailureInfo(
+            @JsonProperty("type") String type,
+            @JsonProperty("message") String message,
+            @JsonProperty("cause") FailureInfo cause,
+            @JsonProperty("suppressed") List<FailureInfo> suppressed,
+            @JsonProperty("stack") List<String> stack,
+            @JsonProperty("errorLocation") @Nullable ErrorLocation errorLocation,
+            @JsonProperty("task") Optional<String> task,
+            @JsonProperty("uri") Optional<URI> uri,
+            @JsonProperty("host") Optional<String> host,
+            @JsonProperty("port") Optional<Integer> port)
+    {
+        requireNonNull(uri, "uri is null");
+        requireNonNull(task, "task is null");
+        requireNonNull(host, "host is null");
+        requireNonNull(port, "port is null");
+
+        this.failureInfo = new FailureInfo(type, message, cause, suppressed, stack, errorLocation);
+        this.failureTask = task;
+        this.failureTaskUri = uri;
+        this.failureHost = host;
+        this.failurePort = port;
+    }
+
+    public TaskFailureInfo(FailureInfo failureInfo)
+    {
+        requireNonNull(failureInfo, "failureInfo is null");
+
+        this.failureInfo = failureInfo;
+        this.failureTask = Optional.empty();
+        this.failureTaskUri = Optional.empty();
+        this.failureHost = Optional.empty();
+        this.failurePort = Optional.empty();
+    }
+
+    public TaskFailureInfo(FailureInfo failureInfo, Optional<String> task, Optional<URI> uri, Optional<String> host, Optional<Integer> port)
+    {
+        requireNonNull(failureInfo, "failureInfo is null");
+        requireNonNull(task, "task is null");
+        requireNonNull(uri, "uri is null");
+        requireNonNull(host, "host is null");
+        requireNonNull(port, "port is null");
+
+        this.failureInfo = failureInfo;
+        this.failureTask = task;
+        this.failureTaskUri = uri;
+        this.failureHost = host;
+        this.failurePort = port;
+    }
+
+    @NotNull
+    @JsonProperty
+    public String getType()
+    {
+        return failureInfo.getType();
+    }
+
+    @Nullable
+    @JsonProperty
+    public String getMessage()
+    {
+        return failureInfo.getMessage();
+    }
+
+    @Nullable
+    @JsonProperty
+    public FailureInfo getCause()
+    {
+        return failureInfo.getCause();
+    }
+
+    @NotNull
+    @JsonProperty
+    public List<FailureInfo> getSuppressed()
+    {
+        return failureInfo.getSuppressed();
+    }
+
+    @NotNull
+    @JsonProperty
+    public List<String> getStack()
+    {
+        return failureInfo.getStack();
+    }
+
+    @Nullable
+    @JsonProperty
+    public ErrorLocation getErrorLocation()
+    {
+        return failureInfo.getErrorLocation();
+    }
+
+    @NotNull
+    @JsonProperty
+    public Optional<String> getTask()
+    {
+        return failureTask;
+    }
+
+    @NotNull
+    @JsonProperty
+    public Optional<URI> getUri()
+    {
+        return failureTaskUri;
+    }
+
+   @NotNull
+    @JsonProperty
+    public Optional<String> getHost()
+    {
+        return failureHost;
+    }
+
+    @NotNull
+    @JsonProperty
+    public Optional<Integer> getPort()
+    {
+        return failurePort;
+    }
+
+    @NotNull
+    public FailureInfo getFailureInfo()
+    {
+        return failureInfo;
+    }
+}

--- a/presto-main/src/main/resources/webapp/assets/query.js
+++ b/presto-main/src/main/resources/webapp/assets/query.js
@@ -892,11 +892,21 @@ var QueryDetail = React.createClass({
     },
     renderFailureInfo: function() {
         var query = this.state.query;
-        if (query.failureInfo) {
+        if (query.taskFailureInfo) {
+            var taskInfo = "N/A";
+            if (query.taskFailureInfo.task != null) {
+                var task = query.taskFailureInfo.task;
+                 taskInfo = (
+                     <a href={ query.taskFailureInfo.uri + "?pretty" }>
+                         { getTaskIdSuffix(task)}
+                     </a>
+                     );
+                }
+            }
             return (
                 <div className="row">
                     <div className="col-xs-12">
-                        <h3>Error Information</h3>
+                        <h3>Failure Information</h3>
                         <table className="table">
                             <tbody>
                                 <tr>
@@ -917,11 +927,27 @@ var QueryDetail = React.createClass({
                                 </tr>
                                 <tr>
                                     <td className="info-title">
+                                        Task
+                                    </td>
+                                    <td className="info-text">
+                                        { taskInfo }
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Host
+                                    </td>
+                                    <td className="info-text">
+                                        { query.taskFailureInfo.host ? query.taskFailureInfo.host : "N/A" }
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
                                         Stack Trace
                                     </td>
                                     <td className="info-text">
                                         <pre className="stack-trace">
-                                            { formatStackTrace(query.failureInfo) }
+                                            { formatStackTrace(query.taskFailureInfo) }
                                         </pre>
                                     </td>
                                 </tr>

--- a/presto-main/src/main/resources/webapp/old/query.html
+++ b/presto-main/src/main/resources/webapp/old/query.html
@@ -252,8 +252,8 @@ d3.json('/v1/query/' + queryId, function (query) {
         button.attr('disabled', 'disabled');
     }
 
-    if (query.failureInfo) {
-        var s = formatStackTrace(query.failureInfo);
+    if (query.taskFailureInfo) {
+        var s = formatStackTrace(query.taskFailureInfo);
         d3.select('#failureMessage').html("<pre>" + htmlEscape(s) + "</pre>");
     }
     else {

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -98,7 +98,7 @@ public class MockQueryExecution
                 false,
                 "",
                 Optional.empty(),
-                null,
+                Optional.empty(),
                 null,
                 ImmutableSet.of(),
                 Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.security.AccessControl;
@@ -380,9 +379,9 @@ public class TestQueryStateMachine
         assertEquals(stateMachine.isDone(), expectedState.isDone());
 
         if (expectedState == FAILED) {
-            FailureInfo failure = queryInfo.getFailureInfo();
-            assertNotNull(failure);
-            assertEquals(failure.getType(), expectedException.getClass().getName());
+            Optional<TaskFailureInfo> failure = queryInfo.getTaskFailureInfo();
+            assertTrue(failure.isPresent());
+            assertEquals(failure.get().getType(), expectedException.getClass().getName());
             if (expectedException instanceof PrestoException) {
                 assertEquals(queryInfo.getErrorCode(), ((PrestoException) expectedException).getErrorCode());
             }
@@ -391,7 +390,7 @@ public class TestQueryStateMachine
             }
         }
         else {
-            assertNull(queryInfo.getFailureInfo());
+            assertFalse(queryInfo.getTaskFailureInfo().isPresent());
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -92,7 +92,7 @@ public class TestBasicQueryInfo
                         false,
                         "33",
                         Optional.empty(),
-                        null,
+                        Optional.empty(),
                         StandardErrorCode.ABANDONED_QUERY.toErrorCode(),
                         ImmutableSet.of(),
                         Optional.empty(),


### PR DESCRIPTION
This is for issue #6545.

So, basically:
1) QueryInfo  is updated to contain optional TaskFailureInfo which contains FailureInfo and two additional field( task and host ).
2) QueryStateMachine is now filling these two fields. So that we don't wait until the last moment(queryCompleteEvent) to check the Task List which can be released before that.  
3) UI is updated to consume it:
![image](https://cloud.githubusercontent.com/assets/4419959/22275815/1741d534-e264-11e6-9004-3755b2f6f3d2.png)


4) Two additional test cases are added in TestServer to test if a query fails as supposed to. 

