### PR TITLE
Report non-GROUP BY columns in select's Subquery

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -342,10 +342,10 @@ class AggregationAnalyzer
                 }
             }
             else if (node.getFilter().isPresent()) {
-                    throw new SemanticException(MUST_BE_AGGREGATION_FUNCTION,
-                            node,
-                            "Filter is only valid for aggregation functions",
-                            node);
+                throw new SemanticException(MUST_BE_AGGREGATION_FUNCTION,
+                        node,
+                        "Filter is only valid for aggregation functions",
+                        node);
             }
 
             if (node.getWindow().isPresent() && !process(node.getWindow().get(), context)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -87,7 +87,7 @@ import static java.util.Objects.requireNonNull;
 class AggregationAnalyzer
 {
     // fields and expressions in the group by clause
-    private final List<Integer> fieldIndexes;
+    private final Set<Integer> groupingFields;
     private final List<Expression> expressions;
 
     private final Analysis analysis;
@@ -116,9 +116,9 @@ class AggregationAnalyzer
         this.expressions = groupByExpressions.stream()
                 .map(e -> ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(parameters), e))
                 .collect(toImmutableList());
-        ImmutableList.Builder<Integer> fieldIndexes = ImmutableList.builder();
+        ImmutableSet.Builder<Integer> groupingFields = ImmutableSet.builder();
 
-        fieldIndexes.addAll(groupByExpressions.stream()
+        groupingFields.addAll(groupByExpressions.stream()
                 .filter(FieldReference.class::isInstance)
                 .map(FieldReference.class::cast)
                 .map(FieldReference::getFieldIndex)
@@ -141,10 +141,10 @@ class AggregationAnalyzer
 
             if (fields.size() == 1) {
                 Field field = Iterables.getOnlyElement(fields);
-                fieldIndexes.add(scope.getRelationType().indexOf(field));
+                groupingFields.add(scope.getRelationType().indexOf(field));
             }
         }
-        this.fieldIndexes = fieldIndexes.build();
+        this.groupingFields = groupingFields.build();
     }
 
     public void analyze(Expression expression)
@@ -192,7 +192,7 @@ class AggregationAnalyzer
                 // Not our scope, not our responsibility
                 return;
             }
-            if (!fieldIndexes.contains(resolvedField.getFieldIndex())) {
+            if (!groupingFields.contains(resolvedField.getFieldIndex())) {
                 throw new SemanticException(MUST_BE_AGGREGATE_OR_GROUP_BY, referenceExpression,
                         "Subquery uses '%s' which must appear in GROUP BY clause", referenceExpression);
             }
@@ -434,13 +434,13 @@ class AggregationAnalyzer
             checkState(fields.size() <= 1, "Found more than one field for name '%s': %s", qualifiedName, fields);
 
             Field field = Iterables.getOnlyElement(fields);
-            return fieldIndexes.contains(scope.getRelationType().indexOf(field));
+            return groupingFields.contains(scope.getRelationType().indexOf(field));
         }
 
         @Override
         protected Boolean visitFieldReference(FieldReference node, Void context)
         {
-            boolean inGroup = fieldIndexes.contains(node.getFieldIndex());
+            boolean inGroup = groupingFields.contains(node.getFieldIndex());
             if (!inGroup) {
                 Field field = scope.getRelationType().getFieldByIndex(node.getFieldIndex());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1723,7 +1723,15 @@ class StatementAnalyzer
             Expression expression,
             Set<Expression> columnReferences)
     {
-        AggregationAnalyzer analyzer = new AggregationAnalyzer(groupByExpressions, metadata, scope, columnReferences, analysis.getParameters(), analysis.isDescribe());
+        AggregationAnalyzer analyzer = new AggregationAnalyzer(
+                analysis,
+                groupByExpressions,
+                metadata,
+                scope,
+                columnReferences,
+                analysis.getParameters(),
+                analysis.isDescribe());
+
         analyzer.analyze(expression);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -217,6 +217,17 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testGroupByWithSubquerySelectExpression()
+            throws Exception
+    {
+        // u.a is not GROUP-ed BY and it is used in select Subquery expression
+        assertFails(MUST_BE_AGGREGATE_OR_GROUP_BY, "SELECT (SELECT 1 FROM t1 WHERE a = u.a) FROM t1 u GROUP BY b");
+
+        // u.a is not GROUP-ed BY but select Subquery expression is using a different u.a
+        analyze("SELECT (SELECT 1 FROM t1 u WHERE a = u.a) FROM t1 u GROUP BY b");
+    }
+
+    @Test
     public void testOrderByInvalidOrdinal()
             throws Exception
     {


### PR DESCRIPTION
Find and report column references within a Subquery in a select
expression that not part of the GROUP BY and therefore should not be
used. Such queries now cause a SemanticException, previously they would
fail with a RuntimeException when building a plan.

Outstanding work:

* allow un-GROUP-ed-BY columns within a select's Subquery if they appear
    in an aggregation, e.g.

        WITH t(a,b) as (VALUES (1,2))
        SELECT (SELECT count(a)) FROM t GROUP BY b;

        WITH t(a,b) as (VALUES (1,2))
        SELECT (SELECT 1 FROM t WHERE t.a = count(u.a)) FROM t u GROUP BY b;

* in case of GROUP BY <expression>, allow the expression in a select's
    Subquery, e.g.

        WITH t(a,b) as (VALUES (1,2))
        SELECT (SELECT b+1) FROM t GROUP BY b+1;
