### PR TITLE
Fix incorrect pruning of join output columns

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -297,6 +297,10 @@ class RelationPlanner
                 leftPlanBuilder.getRoot(),
                 rightPlanBuilder.getRoot(),
                 equiClauses.build(),
+                ImmutableList.<Symbol>builder()
+                        .addAll(leftPlanBuilder.getRoot().getOutputSymbols())
+                        .addAll(rightPlanBuilder.getRoot().getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -329,6 +333,10 @@ class RelationPlanner
                     leftPlanBuilder.getRoot(),
                     rightPlanBuilder.getRoot(),
                     equiClauses.build(),
+                    ImmutableList.<Symbol>builder()
+                            .addAll(leftPlanBuilder.getRoot().getOutputSymbols())
+                            .addAll(rightPlanBuilder.getRoot().getOutputSymbols())
+                            .build(),
                     Optional.of(rewritenFilterCondition),
                     Optional.empty(),
                     Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -835,6 +835,7 @@ public class AddExchanges
                     left.getNode(),
                     right.getNode(),
                     node.getCriteria(),
+                    node.getOutputSymbols(),
                     node.getFilter(),
                     node.getLeftHashSymbol(),
                     node.getRightHashSymbol());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.IndexSourceNode;
@@ -140,12 +141,12 @@ public class IndexJoinOptimizer
                 switch (node.getType()) {
                     case INNER:
                         // Prefer the right candidate over the left candidate
-                        IndexJoinNode indexJoinNode = null;
+                        PlanNode indexJoinNode = null;
                         if (rightIndexCandidate.isPresent()) {
-                            indexJoinNode = new IndexJoinNode(idAllocator.getNextId(), IndexJoinNode.Type.INNER, leftRewritten, rightIndexCandidate.get(), createEquiJoinClause(leftJoinSymbols, rightJoinSymbols), Optional.empty(), Optional.empty());
+                            indexJoinNode = createIndexJoinWithExpectedOutputs(node.getOutputSymbols(), IndexJoinNode.Type.INNER, leftRewritten, rightIndexCandidate.get(), createEquiJoinClause(leftJoinSymbols, rightJoinSymbols), idAllocator);
                         }
                         else if (leftIndexCandidate.isPresent()) {
-                            indexJoinNode = new IndexJoinNode(idAllocator.getNextId(), IndexJoinNode.Type.INNER, rightRewritten, leftIndexCandidate.get(), createEquiJoinClause(rightJoinSymbols, leftJoinSymbols), Optional.empty(), Optional.empty());
+                            indexJoinNode = createIndexJoinWithExpectedOutputs(node.getOutputSymbols(), IndexJoinNode.Type.INNER, rightRewritten, leftIndexCandidate.get(), createEquiJoinClause(rightJoinSymbols, leftJoinSymbols), idAllocator);
                         }
 
                         if (indexJoinNode != null) {
@@ -159,14 +160,14 @@ public class IndexJoinOptimizer
                     case LEFT:
                         // We cannot use indices for outer joins until index join supports in-line filtering
                         if (!node.getFilter().isPresent() && rightIndexCandidate.isPresent()) {
-                            return new IndexJoinNode(idAllocator.getNextId(), IndexJoinNode.Type.SOURCE_OUTER, leftRewritten, rightIndexCandidate.get(), createEquiJoinClause(leftJoinSymbols, rightJoinSymbols), Optional.empty(), Optional.empty());
+                            return createIndexJoinWithExpectedOutputs(node.getOutputSymbols(), IndexJoinNode.Type.SOURCE_OUTER, leftRewritten, rightIndexCandidate.get(), createEquiJoinClause(leftJoinSymbols, rightJoinSymbols), idAllocator);
                         }
                         break;
 
                     case RIGHT:
                         // We cannot use indices for outer joins until index join supports in-line filtering
                         if (!node.getFilter().isPresent() && leftIndexCandidate.isPresent()) {
-                            return new IndexJoinNode(idAllocator.getNextId(), IndexJoinNode.Type.SOURCE_OUTER, rightRewritten, leftIndexCandidate.get(), createEquiJoinClause(rightJoinSymbols, leftJoinSymbols), Optional.empty(), Optional.empty());
+                            return createIndexJoinWithExpectedOutputs(node.getOutputSymbols(), IndexJoinNode.Type.SOURCE_OUTER, rightRewritten, leftIndexCandidate.get(), createEquiJoinClause(rightJoinSymbols, leftJoinSymbols), idAllocator);
                         }
                         break;
 
@@ -179,9 +180,21 @@ public class IndexJoinOptimizer
             }
 
             if (leftRewritten != node.getLeft() || rightRewritten != node.getRight()) {
-                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
+                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol());
             }
             return node;
+        }
+
+        private static PlanNode createIndexJoinWithExpectedOutputs(List<Symbol> expectedOutputs, IndexJoinNode.Type type, PlanNode probe, PlanNode index, List<IndexJoinNode.EquiJoinClause> equiJoinClause, PlanNodeIdAllocator idAllocator)
+        {
+            PlanNode result = new IndexJoinNode(idAllocator.getNextId(), type, probe, index, equiJoinClause, Optional.empty(), Optional.empty());
+            if (!result.getOutputSymbols().equals(expectedOutputs)) {
+                result = new ProjectNode(
+                        idAllocator.getNextId(),
+                        result,
+                        Assignments.identity(expectedOutputs));
+            }
+            return result;
         }
 
         private static List<IndexJoinNode.EquiJoinClause> createEquiJoinClause(List<Symbol> probeSymbols, List<Symbol> indexSymbols)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
@@ -186,6 +186,10 @@ public class TransformCorrelatedScalarAggregationToJoin
                     inputWithUniqueColumns,
                     scalarAggregationSource,
                     ImmutableList.of(),
+                    ImmutableList.<Symbol>builder()
+                            .addAll(inputWithUniqueColumns.getOutputSymbols())
+                            .addAll(scalarAggregationSource.getOutputSymbols())
+                            .build(),
                     joinExpression,
                     Optional.empty(),
                     Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedScalarToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedScalarToJoin.java
@@ -59,6 +59,10 @@ public class TransformUncorrelatedScalarToJoin
                         rewrittenNode.getInput(),
                         rewrittenNode.getSubquery(),
                         ImmutableList.of(),
+                        ImmutableList.<Symbol>builder()
+                                .addAll(rewrittenNode.getInput().getOutputSymbols())
+                                .addAll(rewrittenNode.getSubquery().getOutputSymbols())
+                                .build(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -518,7 +518,7 @@ public class UnaliasSymbolReferences
                         .forEach(clause -> map(clause.getRight(), clause.getLeft()));
             }
 
-            return new JoinNode(node.getId(), node.getType(), left, right, canonicalCriteria, canonicalFilter, canonicalLeftHashSymbol, canonicalRightHashSymbol);
+            return new JoinNode(node.getId(), node.getType(), left, right, canonicalCriteria, canonicalizeAndDistinct(node.getOutputSymbols()), canonicalFilter, canonicalLeftHashSymbol, canonicalRightHashSymbol);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -89,29 +89,6 @@ public class JoinNode
         checkArgument(!isCrossJoin() || inputSymbols.equals(outputSymbols), "Cross join does not support output symbols pruning or reordering");
     }
 
-    public JoinNode(PlanNodeId id,
-            Type type,
-            PlanNode left,
-            PlanNode right,
-            List<EquiJoinClause> criteria,
-            Optional<Expression> filter,
-            Optional<Symbol> leftHashSymbol,
-            Optional<Symbol> rightHashSymbol)
-    {
-        this(id,
-                type,
-                left,
-                right,
-                criteria,
-                ImmutableList.<Symbol>builder()
-                        .addAll(left.getOutputSymbols())
-                        .addAll(right.getOutputSymbols())
-                        .build(),
-                filter,
-                leftHashSymbol,
-                rightHashSymbol);
-    }
-
     public enum Type
     {
         INNER("InnerJoin"),

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -188,12 +188,17 @@ public class TestPhasedExecutionSchedule
                 TupleDomain.all(),
                 null);
 
+        RemoteSourceNode remote = new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of());
         PlanNode join = new JoinNode(
                 new PlanNodeId(name + "_id"),
                 INNER,
                 tableScan,
-                new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of()),
+                remote,
                 ImmutableList.of(),
+                ImmutableList.<Symbol>builder()
+                        .addAll(tableScan.getOutputSymbols())
+                        .addAll(remote.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -203,12 +208,18 @@ public class TestPhasedExecutionSchedule
 
     private static PlanFragment createJoinPlanFragment(JoinNode.Type joinType, String name, PlanFragment buildFragment, PlanFragment probeFragment)
     {
+        RemoteSourceNode probe = new RemoteSourceNode(new PlanNodeId("probe_id"), probeFragment.getId(), ImmutableList.of());
+        RemoteSourceNode build = new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of());
         PlanNode planNode = new JoinNode(
                 new PlanNodeId(name + "_id"),
                 joinType,
-                new RemoteSourceNode(new PlanNodeId("probe_id"), probeFragment.getId(), ImmutableList.of()),
-                new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of()),
+                probe,
+                build,
                 ImmutableList.of(),
+                ImmutableList.<Symbol>builder()
+                        .addAll(probe.getOutputSymbols())
+                        .addAll(build.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -425,20 +425,27 @@ public class TestSourcePartitionedScheduler
 
         // table scan with splitCount splits
         PlanNodeId tableScanNodeId = new PlanNodeId("plan_id");
+        TableScanNode tableScan = new TableScanNode(
+                tableScanNodeId,
+                new TableHandle(CONNECTOR_ID, new TestingTableHandle()),
+                ImmutableList.of(symbol),
+                ImmutableMap.of(symbol, new TestingColumnHandle("column")),
+                Optional.empty(),
+                TupleDomain.all(),
+                null);
+
+        RemoteSourceNode remote = new RemoteSourceNode(new PlanNodeId("remote_id"), new PlanFragmentId("plan_fragment_id"), ImmutableList.of());
         PlanFragment testFragment = new PlanFragment(
                 new PlanFragmentId("plan_id"),
                 new JoinNode(new PlanNodeId("join_id"),
                         INNER,
-                        new TableScanNode(
-                                tableScanNodeId,
-                                new TableHandle(CONNECTOR_ID, new TestingTableHandle()),
-                                ImmutableList.of(symbol),
-                                ImmutableMap.of(symbol, new TestingColumnHandle("column")),
-                                Optional.empty(),
-                                TupleDomain.all(),
-                                null),
-                        new RemoteSourceNode(new PlanNodeId("remote_id"), new PlanFragmentId("plan_fragment_id"), ImmutableList.of()),
+                        tableScan,
+                        remote,
                         ImmutableList.of(),
+                        ImmutableList.<Symbol>builder()
+                                .addAll(tableScan.getOutputSymbols())
+                                .addAll(remote.getOutputSymbols())
+                                .build(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty()),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -440,18 +440,25 @@ public class TestEffectivePredicateExtractor
                 null
         );
 
+        FilterNode left = filter(leftScan,
+                and(
+                        lessThan(BE, AE),
+                        lessThan(CE, bigintLiteral(10)),
+                        equals(GE, bigintLiteral(10))));
+        FilterNode right = filter(rightScan,
+                and(
+                        equals(DE, EE),
+                        lessThan(FE, bigintLiteral(100))));
+
         PlanNode node = new JoinNode(newId(),
                 JoinNode.Type.INNER,
-                filter(leftScan,
-                        and(
-                                lessThan(BE, AE),
-                                lessThan(CE, bigintLiteral(10)),
-                                equals(GE, bigintLiteral(10)))),
-                filter(rightScan,
-                        and(
-                                equals(DE, EE),
-                                lessThan(FE, bigintLiteral(100)))),
+                left,
+                right,
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(left.getOutputSymbols())
+                        .addAll(right.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -499,18 +506,24 @@ public class TestEffectivePredicateExtractor
                 null
         );
 
+        FilterNode left = filter(leftScan,
+                and(
+                        lessThan(BE, AE),
+                        lessThan(CE, bigintLiteral(10)),
+                        equals(GE, bigintLiteral(10))));
+        FilterNode right = filter(rightScan,
+                and(
+                        equals(DE, EE),
+                        lessThan(FE, bigintLiteral(100))));
         PlanNode node = new JoinNode(newId(),
                 JoinNode.Type.LEFT,
-                filter(leftScan,
-                        and(
-                                lessThan(BE, AE),
-                                lessThan(CE, bigintLiteral(10)),
-                                equals(GE, bigintLiteral(10)))),
-                filter(rightScan,
-                        and(
-                                equals(DE, EE),
-                                lessThan(FE, bigintLiteral(100)))),
+                left,
+                right,
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(left.getOutputSymbols())
+                        .addAll(right.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -555,15 +568,21 @@ public class TestEffectivePredicateExtractor
                 null
         );
 
+        FilterNode left = filter(leftScan,
+                and(
+                        lessThan(BE, AE),
+                        lessThan(CE, bigintLiteral(10)),
+                        equals(GE, bigintLiteral(10))));
+        FilterNode right = filter(rightScan, FALSE_LITERAL);
         PlanNode node = new JoinNode(newId(),
                 JoinNode.Type.LEFT,
-                filter(leftScan,
-                        and(
-                                lessThan(BE, AE),
-                                lessThan(CE, bigintLiteral(10)),
-                                equals(GE, bigintLiteral(10)))),
-                filter(rightScan, FALSE_LITERAL),
+                left,
+                right,
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(left.getOutputSymbols())
+                        .addAll(right.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -608,18 +627,24 @@ public class TestEffectivePredicateExtractor
                 null
         );
 
+        FilterNode left = filter(leftScan,
+                and(
+                        lessThan(BE, AE),
+                        lessThan(CE, bigintLiteral(10)),
+                        equals(GE, bigintLiteral(10))));
+        FilterNode right = filter(rightScan,
+                and(
+                        equals(DE, EE),
+                        lessThan(FE, bigintLiteral(100))));
         PlanNode node = new JoinNode(newId(),
                 JoinNode.Type.RIGHT,
-                filter(leftScan,
-                        and(
-                                lessThan(BE, AE),
-                                lessThan(CE, bigintLiteral(10)),
-                                equals(GE, bigintLiteral(10)))),
-                filter(rightScan,
-                        and(
-                                equals(DE, EE),
-                                lessThan(FE, bigintLiteral(100)))),
+                left,
+                right,
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(left.getOutputSymbols())
+                        .addAll(right.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
@@ -664,14 +689,20 @@ public class TestEffectivePredicateExtractor
                 null
         );
 
+        FilterNode left = filter(leftScan, FALSE_LITERAL);
+        FilterNode right = filter(rightScan,
+                and(
+                        equals(DE, EE),
+                        lessThan(FE, bigintLiteral(100))));
         PlanNode node = new JoinNode(newId(),
                 JoinNode.Type.RIGHT,
-                filter(leftScan, FALSE_LITERAL),
-                filter(rightScan,
-                        and(
-                                equals(DE, EE),
-                                lessThan(FE, bigintLiteral(100)))),
+                left,
+                right,
                 criteria,
+                ImmutableList.<Symbol>builder()
+                        .addAll(left.getOutputSymbols())
+                        .addAll(right.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateCrossJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateCrossJoins.java
@@ -203,6 +203,10 @@ public class TestEliminateCrossJoins
                 left,
                 right,
                 criteria.build(),
+                ImmutableList.<Symbol>builder()
+                        .addAll(left.getOutputSymbols())
+                        .addAll(right.getOutputSymbols())
+                        .build(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty());

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -985,6 +985,12 @@ public abstract class AbstractTestQueries
                 "LIMIT 10");
         assertQuery("SELECT COUNT(*) FROM (SELECT DISTINCT orderstatus, custkey FROM orders LIMIT 10)");
         assertQuery("SELECT DISTINCT custkey, orderstatus FROM orders WHERE custkey = 1268 LIMIT 2");
+
+        assertQuery("" +
+                "SELECT DISTINCT x " +
+                "FROM (VALUES 1) t(x) JOIN (VALUES 10, 20) u(a) ON t.x < u.a " +
+                "LIMIT 100",
+                "SELECT 1");
     }
 
     @Test


### PR DESCRIPTION
Some nodes are sensitive to which columns are produced by
their children (e.g., DistinctLimitNode). The change to
add support for pruning join columns did not correctly
deal with this, which results in queries like this one
to produce incorrect results:

    SELECT DISTINCT x
    FROM (VALUES 1) t(x) JOIN (VALUES 10, 20) u(a) ON t.x < u.a
    LIMIT 100

Additionally, the constructor in JoinNode that derives
the output columns from the children is error-prone, since
it lends to misuse in places that expect the outputs not to
 change.

This change fixes the issue by making the specification of
join output columns explicit in every place that constructs
a Join node.

This is a candidate "fix" for https://github.com/prestodb/presto/issues/7111. 