### PR TITLE
cassandra 3.x - support for SMALLINT, TINYINT, DATE

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
@@ -107,6 +107,8 @@ public class CassandraRecordCursor
                 return currentRow.getLong(i);
             case TIMESTAMP:
                 return currentRow.getTimestamp(i).getTime();
+            case DATE:
+                return (long) currentRow.getDate(i).getDaysSinceEpoch();
             case FLOAT:
                 return floatToRawIntBits(currentRow.getFloat(i));
             default:

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
@@ -98,6 +98,10 @@ public class CassandraRecordCursor
         switch (getCassandraType(i)) {
             case INT:
                 return currentRow.getInt(i);
+            case SMALLINT:
+                return currentRow.getShort(i);
+            case TINYINT:
+                return currentRow.getByte(i);
             case BIGINT:
             case COUNTER:
                 return currentRow.getLong(i);

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordSink.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordSink.java
@@ -31,6 +31,8 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Float.intBitsToFloat;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -116,6 +118,12 @@ public class CassandraRecordSink
         }
         else if (REAL.equals(columnTypes.get(field))) {
             append(intBitsToFloat((int) value));
+        }
+        else if (SMALLINT.equals(columnTypes.get(field))) {
+            append(((Number) value).shortValue());
+        }
+        else if (TINYINT.equals(columnTypes.get(field))) {
+            append(((Number) value).byteValue());
         }
         else {
             append(value);

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
@@ -25,7 +25,9 @@ import com.facebook.presto.spi.type.DateType;
 import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.IntegerType;
 import com.facebook.presto.spi.type.RealType;
+import com.facebook.presto.spi.type.SmallintType;
 import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.TinyintType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarbinaryType;
 import com.google.common.annotations.VisibleForTesting;
@@ -74,7 +76,9 @@ public enum CassandraType
     VARINT(createUnboundedVarcharType(), BigInteger.class),
     LIST(createUnboundedVarcharType(), null),
     MAP(createUnboundedVarcharType(), null),
-    SET(createUnboundedVarcharType(), null);
+    SET(createUnboundedVarcharType(), null),
+    SMALLINT(SmallintType.SMALLINT, Short.class),
+    TINYINT(TinyintType.TINYINT, Byte.class);
 
     private static class Constants
     {
@@ -143,12 +147,16 @@ public enum CassandraType
                 return MAP;
             case SET:
                 return SET;
+            case SMALLINT:
+                return SMALLINT;
             case TEXT:
                 return TEXT;
             case TIMESTAMP:
                 return TIMESTAMP;
             case TIMEUUID:
                 return TIMEUUID;
+            case TINYINT:
+                return TINYINT;
             case UUID:
                 return UUID;
             case VARCHAR:
@@ -180,6 +188,10 @@ public enum CassandraType
                     return NullableValue.of(nativeType, utf8Slice(row.getString(i)));
                 case INT:
                     return NullableValue.of(nativeType, (long) row.getInt(i));
+                case SMALLINT:
+                    return NullableValue.of(nativeType, row.getShort(i));
+                case TINYINT:
+                    return NullableValue.of(nativeType, row.getByte(i));
                 case BIGINT:
                 case COUNTER:
                     return NullableValue.of(nativeType, row.getLong(i));
@@ -301,6 +313,10 @@ public enum CassandraType
                     return CassandraCqlUtils.quoteStringLiteral(row.getString(i));
                 case INT:
                     return Integer.toString(row.getInt(i));
+                case SMALLINT:
+                    return Short.toString(row.getShort(i));
+                case TINYINT:
+                    return Byte.toString(row.getByte(i));
                 case BIGINT:
                 case COUNTER:
                     return Long.toString(row.getLong(i));
@@ -355,6 +371,8 @@ public enum CassandraType
             case DOUBLE:
             case FLOAT:
             case DECIMAL:
+            case SMALLINT:
+            case TINYINT:
                 return object.toString();
             default:
                 throw new IllegalStateException("Handling of type " + elemType + " is not implemented");
@@ -396,6 +414,8 @@ public enum CassandraType
             case BOOLEAN:
             case DOUBLE:
             case COUNTER:
+            case SMALLINT:
+            case TINYINT:
                 return nativeValue;
             case INET:
                 return InetAddresses.forString(((Slice) nativeValue).toStringUtf8());
@@ -438,6 +458,8 @@ public enum CassandraType
             case DOUBLE:
             case INET:
             case INT:
+            case SMALLINT:
+            case TINYINT:
             case FLOAT:
             case DECIMAL:
             case TIMESTAMP:
@@ -453,7 +475,7 @@ public enum CassandraType
             case MAP:
             default:
                 // todo should we just skip partition pruning instead of throwing an exception?
-                throw new PrestoException(NOT_SUPPORTED, "Unsupport partition key type: " + this);
+                throw new PrestoException(NOT_SUPPORTED, "Unsupported partition key type: " + this);
         }
     }
 
@@ -497,6 +519,12 @@ public enum CassandraType
         }
         else if (type.equals(IntegerType.INTEGER)) {
             return INT;
+        }
+        else if (type.equals(SmallintType.SMALLINT)) {
+            return SMALLINT;
+        }
+        else if (type.equals(TinyintType.TINYINT)) {
+            return TINYINT;
         }
         else if (type.equals(DoubleType.DOUBLE)) {
             return DOUBLE;

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/util/CassandraCqlUtils.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/util/CassandraCqlUtils.java
@@ -39,7 +39,7 @@ public final class CassandraCqlUtils
     private static final String[] KEYWORDS = {"ADD", "ALL", "ALLOW", "ALTER", "AND", "APPLY",
             "ASC", "ASCII", "AUTHORIZE", "BATCH", "BEGIN", "BIGINT", "BLOB", "BOOLEAN", "BY",
             "CLUSTERING", "COLUMNFAMILY", "COMPACT", "COUNT", "COUNTER", "CREATE", "DECIMAL",
-            "DELETE", "DESC", "DOUBLE", "DROP", "FILTERING", "FLOAT", "FROM", "GRANT", "IN",
+            "DATE", "DELETE", "DESC", "DOUBLE", "DROP", "FILTERING", "FLOAT", "FROM", "GRANT", "IN",
             "INDEX", "INET", "INSERT", "INT", "INTO", "KEY", "KEYSPACE", "KEYSPACES", "LIMIT",
             "LIST", "MAP", "MODIFY", "NORECURSIVE", "NOSUPERUSER", "OF", "ON", "ORDER", "PASSWORD",
             "PERMISSION", "PERMISSIONS", "PRIMARY", "RENAME", "REVOKE", "SCHEMA", "SELECT", "SET", "SMALLINT",

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/util/CassandraCqlUtils.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/util/CassandraCqlUtils.java
@@ -42,8 +42,8 @@ public final class CassandraCqlUtils
             "DELETE", "DESC", "DOUBLE", "DROP", "FILTERING", "FLOAT", "FROM", "GRANT", "IN",
             "INDEX", "INET", "INSERT", "INT", "INTO", "KEY", "KEYSPACE", "KEYSPACES", "LIMIT",
             "LIST", "MAP", "MODIFY", "NORECURSIVE", "NOSUPERUSER", "OF", "ON", "ORDER", "PASSWORD",
-            "PERMISSION", "PERMISSIONS", "PRIMARY", "RENAME", "REVOKE", "SCHEMA", "SELECT", "SET",
-            "STORAGE", "SUPERUSER", "TABLE", "TEXT", "TIMESTAMP", "TIMEUUID", "TO", "TOKEN",
+            "PERMISSION", "PERMISSIONS", "PRIMARY", "RENAME", "REVOKE", "SCHEMA", "SELECT", "SET", "SMALLINT",
+            "STORAGE", "SUPERUSER", "TABLE", "TEXT", "TIMESTAMP", "TIMEUUID", "TINYINT", "TO", "TOKEN",
             "TRUNCATE", "TTL", "TYPE", "UNLOGGED", "UPDATE", "USE", "USER", "USERS", "USING",
             "UUID", "VALUES", "VARCHAR", "VARINT", "WHERE", "WITH", "WRITETIME"};
 

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraTestingUtils.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraTestingUtils.java
@@ -119,6 +119,8 @@ public class CassandraTestingUtils
                 " typeuuid uuid, " +
                 " typeinteger int, " +
                 " typelong bigint, " +
+                " typesmallint smallint, " +
+                " typetinyint tinyint, " +
                 " typebytes blob, " +
                 " typetimestamp timestamp, " +
                 " typeansi ascii, " +
@@ -146,6 +148,8 @@ public class CassandraTestingUtils
                 " typeuuid uuid, " +
                 " typeinteger int, " +
                 " typelong bigint, " +
+                " typesmallint smallint, " +
+                " typetinyint tinyint, " +
                 " typebytes blob, " +
                 " typetimestamp timestamp, " +
                 " typeansi ascii, " +
@@ -165,6 +169,8 @@ public class CassandraTestingUtils
                 "   typeuuid, " +
                 "   typeinteger, " +
                 "   typelong, " +
+                "   typesmallint, " +
+                "   typetinyint, " +
                 // TODO: NOT YET SUPPORTED AS A PARTITION KEY
                 // "   typebytes, " +
                 "   typetimestamp, " +
@@ -197,6 +203,8 @@ public class CassandraTestingUtils
                     .value("typeuuid", UUID.fromString(String.format("00000000-0000-0000-0000-%012d", rowNumber)))
                     .value("typeinteger", rowNumber)
                     .value("typelong", rowNumber.longValue() + 1000)
+                    .value("typesmallint", rowNumber.shortValue())
+                    .value("typetinyint", rowNumber.byteValue())
                     .value("typebytes", ByteBuffer.wrap(Ints.toByteArray(rowNumber)).asReadOnlyBuffer())
                     .value("typetimestamp", date)
                     .value("typeansi", "ansi " + rowNumber)

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -42,7 +42,9 @@ import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
@@ -85,6 +87,8 @@ public class TestCassandraIntegrationSmokeTest
                 " AND typeuuid = '00000000-0000-0000-0000-000000000007'" +
                 " AND typeinteger = 7" +
                 " AND typelong = 1007" +
+                " AND typesmallint = 7" +
+                " AND typetinyint = 7" +
                 " AND typebytes = from_hex('" + toRawHexString(ByteBuffer.wrap(toByteArray(7))) + "')" +
                 " AND typetimestamp = TIMESTAMP '1970-01-01 03:04:05'" +
                 " AND typeansi = 'ansi 7'" +
@@ -205,6 +209,8 @@ public class TestCassandraIntegrationSmokeTest
                 " typeuuid, " +
                 " typeinteger, " +
                 " typelong, " +
+                " typesmallint, " +
+                " typetinyint, " +
                 " typebytes, " +
                 " typetimestamp, " +
                 " typeansi, " +
@@ -230,6 +236,8 @@ public class TestCassandraIntegrationSmokeTest
                 uuidType,
                 INTEGER,
                 BIGINT,
+                SMALLINT,
+                TINYINT,
                 VARBINARY,
                 TIMESTAMP,
                 createUnboundedVarcharType(),
@@ -256,6 +264,8 @@ public class TestCassandraIntegrationSmokeTest
                     String.format("00000000-0000-0000-0000-%012d", rowNumber),
                     rowNumber,
                     rowNumber + 1000L,
+                    rowNumber,
+                    rowNumber,
                     ByteBuffer.wrap(toByteArray(rowNumber)),
                     TIMESTAMP_LOCAL,
                     "ansi " + rowNumber,

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraType.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraType.java
@@ -32,6 +32,8 @@ public class TestCassandraType
         assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList(1, 2, 3), CassandraType.INT)));
         assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList(100000L, 200000000L, 3000000000L), CassandraType.BIGINT)));
         assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList(1.0, 2.0, 3.0), CassandraType.DOUBLE)));
+        assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList((short) -32768, (short) 0, (short) 32767), CassandraType.SMALLINT)));
+        assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList((byte) -128, (byte) 0, (byte) 127), CassandraType.TINYINT)));
     }
 
     private static void continueWhileNotNull(JsonParser parser, JsonToken token)


### PR DESCRIPTION
With the 3.0 release of Cassandra, there have been added some new data types: `tinyint` and `smallint` (https://docs.datastax.com/en/cql/3.1/cql/cql_reference/cql_data_types_c.html).

If you tried to use prestodb to work with a Cassandra 3.x table that has columns of that new types, you would run into a `NullPointerException: cassandraType is null`.

This PR adds support for these two types.

This little test scenario might come in handy:
```
cqlsh> create table test.presto_types (id text, small smallint, tiny tinyint, PRIMARY KEY(id));

presto:test> select * from test.presto_types;

Query 20170117_135445_00006_68jce failed: cassandraType is null
java.lang.NullPointerException: cassandraType is null
	at java.util.Objects.requireNonNull(Objects.java:228)
	at com.facebook.presto.cassandra.CassandraColumnHandle.<init>(CassandraColumnHandle.java:62)
```
