### PR TITLE
Process expression instead of group reference

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -108,8 +108,7 @@ public class IterativeOptimizer
                 Optional<PlanNode> transformed = rule.apply(node, context.getLookup(), context.getIdAllocator(), context.getSymbolAllocator());
 
                 if (transformed.isPresent()) {
-                    context.getMemo().replace(group, transformed.get(), rule.getClass().getName());
-                    node = transformed.get();
+                    node = context.getMemo().replace(group, transformed.get(), rule.getClass().getName());
 
                     done = false;
                     progress = true;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
@@ -97,7 +97,7 @@ public class Memo
         return node.replaceChildren(children);
     }
 
-    public void replace(int group, PlanNode node, String reason)
+    public PlanNode replace(int group, PlanNode node, String reason)
     {
         PlanNode old = membership.get(group);
 
@@ -117,6 +117,8 @@ public class Memo
         incrementReferenceCounts(node);
         membership.put(group, node);
         decrementReferenceCounts(old);
+
+        return node;
     }
 
     private void incrementReferenceCounts(PlanNode node)


### PR DESCRIPTION
When the result of applying a rule is a GroupReference
(e.g., in the case where a node is being removed, such as
for X->Y->(1) ==> X->(1)), make sure the loop continues
processing the expression contained in the target group.

Currently, the loop would try to continue processing
the GroupReference, which is non-sensical, since rules
can't match it.