### PR TITLE
Fix potentially invalid plans

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushTableWriteThroughUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushTableWriteThroughUnion.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -92,11 +93,14 @@ public class PushTableWriteThroughUnion
                     mappings.put(outputSymbol, newSymbol);
                 }
 
+                int index = i;
                 rewrittenSources.add(new TableWriterNode(
                         idAllocator.getNextId(),
                         unionOriginalSource,
                         node.getTarget(),
-                        unionNode.sourceOutputLayout(i),
+                        node.getColumns().stream()
+                            .map(column -> unionNode.getSymbolMapping().get(column).get(index))
+                            .collect(Collectors.toList()),
                         node.getColumnNames(),
                         newSymbols.build(),
                         node.getPartitioningScheme()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
@@ -127,7 +127,7 @@ public class ExchangeNode
                 scope,
                 partitioningScheme,
                 ImmutableList.of(child),
-                ImmutableList.of(child.getOutputSymbols()));
+                ImmutableList.of(partitioningScheme.getOutputLayout()));
     }
 
     public static ExchangeNode replicatedExchange(PlanNodeId id, Scope scope, PlanNode child)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
@@ -31,7 +31,6 @@ import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HAS
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE;
-import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
@@ -151,19 +150,6 @@ public class ExchangeNode
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), child.getOutputSymbols()),
                 ImmutableList.of(child),
                 ImmutableList.of(child.getOutputSymbols()));
-    }
-
-    public static ExchangeNode gatheringExchange(PlanNodeId id, Scope scope, List<Symbol> outputLayout, List<PlanNode> children)
-    {
-        return new ExchangeNode(
-                id,
-                ExchangeNode.Type.GATHER,
-                scope,
-                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), outputLayout),
-                children,
-                children.stream()
-                        .map(PlanNode::getOutputSymbols)
-                        .collect(toImmutableList()));
     }
 
     @JsonProperty


### PR DESCRIPTION
There are a couple of places in optimizers that make wrong assumptions about column ordering. This was uncovered by #7088, which is more aggressive at removing identity projections that may change the order of columns.