### PR TITLE
Fix null-handling bug in min_by/max_by

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxBy.java
@@ -33,6 +33,7 @@ import static com.facebook.presto.metadata.Signature.orderableTypeParameter;
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.NULLABLE_BLOCK_INPUT_CHANNEL;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
@@ -95,7 +96,7 @@ public abstract class AbstractMinMaxBy
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type value, Type key)
     {
-        return ImmutableList.of(new ParameterMetadata(STATE), new ParameterMetadata(NULLABLE_BLOCK_INPUT_CHANNEL, value), new ParameterMetadata(NULLABLE_BLOCK_INPUT_CHANNEL, key), new ParameterMetadata(BLOCK_INDEX));
+        return ImmutableList.of(new ParameterMetadata(STATE), new ParameterMetadata(NULLABLE_BLOCK_INPUT_CHANNEL, value), new ParameterMetadata(BLOCK_INPUT_CHANNEL, key), new ParameterMetadata(BLOCK_INDEX));
     }
 
     public static void input(boolean min, Type keyType, MaxOrMinByState state, Block value, Block key, int position)

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMinMaxByAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMinMaxByAggregation.java
@@ -102,6 +102,11 @@ public class TestMinMaxByAggregation
                 1.0,
                 createDoublesBlock(1.0, null),
                 createDoublesBlock(1.0, 2.0));
+        assertAggregation(
+                function,
+                10.0,
+                createDoublesBlock(10.0, 9.0, 8.0, 11.0),
+                createDoublesBlock(1.0, null, 2.0, null));
     }
 
     @Test
@@ -114,6 +119,11 @@ public class TestMinMaxByAggregation
                 null,
                 createDoublesBlock(1.0, null),
                 createDoublesBlock(1.0, 2.0));
+        assertAggregation(
+                function,
+                10.0,
+                createDoublesBlock(8.0, 9.0, 10.0, 11.0),
+                createDoublesBlock(-2.0, null, -1.0, null));
     }
 
     @Test


### PR DESCRIPTION
Null keys were previously incorrectly handled. They were effectively treated as default value of the type for comparison in the input function.