### PR TITLE
Add specialized addInput function to Accumulator - continuation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -305,6 +305,19 @@ public class PagesIndex
         return types.get(channel).getSlice(block, blockPosition);
     }
 
+    public Block getObject(int channel, int position)
+    {
+        long pageAddress = valueAddresses.getLong(position);
+
+        Block block = channels[channel].get(decodeSliceIndex(pageAddress));
+        int blockPosition = decodePosition(pageAddress);
+        Object result = types.get(channel).getObject(block, blockPosition);
+        if (!(result instanceof Block)) {
+            throw new IllegalStateException("Object has to be of type Block");
+        }
+        return (Block) result;
+    }
+
     public Block getSingleValueBlock(int channel, int position)
     {
         long pageAddress = valueAddresses.getLong(position);

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -305,6 +305,15 @@ public class PagesIndex
         return types.get(channel).getSlice(block, blockPosition);
     }
 
+    public Block getSingleValueBlock(int channel, int position)
+    {
+        long pageAddress = valueAddresses.getLong(position);
+
+        Block block = channels[channel].get(decodeSliceIndex(pageAddress));
+        int blockPosition = decodePosition(pageAddress);
+        return block.getSingleValueBlock(blockPosition);
+    }
+
     public void sort(List<Integer> sortChannels, List<SortOrder> sortOrders)
     {
         sort(sortChannels, sortOrders, 0, getPositionCount());

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.WindowIndex;
 import com.facebook.presto.spi.type.Type;
 
 public interface Accumulator
@@ -27,6 +28,8 @@ public interface Accumulator
     Type getIntermediateType();
 
     void addInput(Page page);
+
+    void addInput(WindowIndex index, int channel, int position);
 
     void addIntermediate(Block block);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
@@ -31,6 +31,8 @@ public interface Accumulator
 
     void addInput(WindowIndex index, int channel, int position);
 
+    void addInput(int positionCount);
+
     void addIntermediate(Block block);
 
     void evaluateIntermediate(BlockBuilder blockBuilder);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
@@ -19,6 +19,8 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.WindowIndex;
 import com.facebook.presto.spi.type.Type;
 
+import java.util.List;
+
 public interface Accumulator
 {
     long getEstimatedSize();
@@ -29,7 +31,7 @@ public interface Accumulator
 
     void addInput(Page page);
 
-    void addInput(WindowIndex index, int channel, int startPosition, int endPosition);
+    void addInput(WindowIndex index, List<Integer> channels, int startPosition, int endPosition);
 
     void addInput(int positionCount);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
@@ -29,7 +29,7 @@ public interface Accumulator
 
     void addInput(Page page);
 
-    void addInput(WindowIndex index, int channel, int position);
+    void addInput(WindowIndex index, int channel, int startPosition, int endPosition);
 
     void addInput(int positionCount);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.WindowFunction;
 import com.facebook.presto.spi.function.WindowIndex;
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Ints;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,7 +31,7 @@ public class AggregateWindowFunction
         implements WindowFunction
 {
     private final InternalAggregationFunction function;
-    private final int[] argumentChannels;
+    private final List<Integer> argumentChannels;
     private final AccumulatorFactory accumulatorFactory;
 
     private WindowIndex windowIndex;
@@ -43,7 +42,7 @@ public class AggregateWindowFunction
     private AggregateWindowFunction(InternalAggregationFunction function, List<Integer> argumentChannels)
     {
         this.function = requireNonNull(function, "function is null");
-        this.argumentChannels = Ints.toArray(argumentChannels);
+        this.argumentChannels = ImmutableList.copyOf(argumentChannels);
         this.accumulatorFactory = function.bind(createArgs(function), Optional.empty());
     }
 
@@ -83,9 +82,7 @@ public class AggregateWindowFunction
             accumulator.addInput(end - start + 1);
         }
         else {
-            for (int i = 0; i < function.getParameterTypes().size(); ++i) {
-                accumulator.addInput(windowIndex, argumentChannels[i], start, end);
-            }
+            accumulator.addInput(windowIndex, argumentChannels, start, end);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
@@ -17,7 +17,6 @@ import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.aggregation.Accumulator;
 import com.facebook.presto.operator.aggregation.AccumulatorFactory;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
-import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.WindowFunction;
 import com.facebook.presto.spi.function.WindowIndex;
@@ -81,7 +80,7 @@ public class AggregateWindowFunction
     private void accumulate(int start, int end)
     {
         if (function.getParameterTypes().size() == 0) {
-            accumulator.addInput(new Page(end - start + 1));
+            accumulator.addInput(end - start + 1);
         }
         else {
             for (int position = start; position <= end; position++) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
@@ -83,10 +83,8 @@ public class AggregateWindowFunction
             accumulator.addInput(end - start + 1);
         }
         else {
-            for (int position = start; position <= end; position++) {
-                for (int i = 0; i < function.getParameterTypes().size(); ++i) {
-                    accumulator.addInput(windowIndex, argumentChannels[i], position);
-                }
+            for (int i = 0; i < function.getParameterTypes().size(); ++i) {
+                accumulator.addInput(windowIndex, argumentChannels[i], start, end);
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/PagesWindowIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/PagesWindowIndex.java
@@ -87,6 +87,12 @@ public class PagesWindowIndex
     }
 
     @Override
+    public Block getObject(int channel, int position)
+    {
+        return pagesIndex.getObject(channel, position(position));
+    }
+
+    @Override
     public void appendTo(int channel, int position, BlockBuilder output)
     {
         pagesIndex.appendTo(channel, position(position), output);

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/PagesWindowIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/PagesWindowIndex.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.window;
 
 import com.facebook.presto.operator.PagesIndex;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.WindowIndex;
 import io.airlift.slice.Slice;
@@ -77,6 +78,12 @@ public class PagesWindowIndex
     public Slice getSlice(int channel, int position)
     {
         return pagesIndex.getSlice(channel, position(position));
+    }
+
+    @Override
+    public Block getSingleValueBlock(int channel, int position)
+    {
+        return pagesIndex.getSingleValueBlock(channel, position(position));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CompilerOperations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CompilerOperations.java
@@ -56,6 +56,11 @@ public final class CompilerOperations
         return left < right;
     }
 
+    public static boolean lessThanOrEqual(int left, int right)
+    {
+        return left <= right;
+    }
+
     public static boolean greaterThan(int left, int right)
     {
         return left > right;

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CompilerOperations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CompilerOperations.java
@@ -13,12 +13,14 @@
  */
 package com.facebook.presto.sql.gen;
 
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 
 import javax.annotation.Nullable;
 
 import java.util.Set;
 
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 
 // This methods are statically bound by the compiler
@@ -70,5 +72,10 @@ public final class CompilerOperations
             return BOOLEAN.getBoolean(masks, index);
         }
         return true;
+    }
+
+    public static void throwStandardPrestoException(String message)
+    {
+        throw new PrestoException(GENERIC_INTERNAL_ERROR, message);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/TestMapAggFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/TestMapAggFunction.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.window;
+
+import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.type.MapType;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+
+public class TestMapAggFunction
+        extends AbstractTestWindowFunction
+{
+    @Test
+    public void testMapAgg()
+    {
+        assertWindowQuery("map_agg(orderkey, orderstatus) OVER(PARTITION BY orderdate)",
+                resultBuilder(TEST_SESSION, BIGINT, VarcharType.createVarcharType(1), new MapType(BIGINT, VarcharType.createVarcharType(1)))
+                        .row(1, "O", ImmutableMap.of(1, "O"))
+                        .row(2, "O", ImmutableMap.of(2, "O"))
+                        .row(3, "F", ImmutableMap.of(3, "F"))
+                        .row(4, "O", ImmutableMap.of(4, "O"))
+                        .row(5, "F", ImmutableMap.of(5, "F"))
+                        .row(6, "F", ImmutableMap.of(6, "F"))
+                        .row(7, "O", ImmutableMap.of(7, "O"))
+                        .row(32, "O", ImmutableMap.of(32, "O"))
+                        .row(33, "F", ImmutableMap.of(33, "F"))
+                        .row(34, "O", ImmutableMap.of(34, "O"))
+                        .build());
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/WindowIndex.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/WindowIndex.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import io.airlift.slice.Slice;
 
@@ -70,6 +71,14 @@ public interface WindowIndex
      * @param position row within the partition, starting at zero
      */
     Slice getSlice(int channel, int position);
+
+    /**
+     * Gets a value stored as a {@link Block}.
+     * @param channel argument number
+     * @param position row within the partition, starting at zero
+     * @return
+     */
+    Block getSingleValueBlock(int channel, int position);
 
     /**
      * Outputs a value from the index. This is useful for "value"

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/WindowIndex.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/WindowIndex.java
@@ -81,6 +81,14 @@ public interface WindowIndex
     Block getSingleValueBlock(int channel, int position);
 
     /**
+     * Gets an object value.
+     * @param channel argument number
+     * @param position row within the partition, starting at zero
+     * @return
+     */
+    Block getObject(int channel, int position);
+
+    /**
      * Outputs a value from the index. This is useful for "value"
      * window functions such as {@code lag} that operate on arbitrary
      * types without caring about the specific contents.

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3779,6 +3779,36 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testWindowFunctionWithoutParameters()
+    {
+        MaterializedResult actual = computeActual("SELECT count() over(partition by custkey) from orders where custkey < 3 order by custkey");
+
+        MaterializedResult expected = resultBuilder(getSession(), BIGINT)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(9L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .build();
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
     public void testHaving()
     {
         assertQuery("SELECT orderstatus, sum(totalprice) FROM orders GROUP BY orderstatus HAVING orderstatus = 'O'");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -19,10 +19,12 @@ import com.facebook.presto.metadata.SqlFunction;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.TimeZoneKey;
+import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.testing.Arguments;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.type.MapType;
 import com.facebook.presto.type.SqlIntervalDayTime;
 import com.facebook.presto.type.SqlIntervalYearMonth;
 import com.facebook.presto.util.DateTimeZoneIndex;
@@ -4202,6 +4204,22 @@ public abstract class AbstractTestQueries
                 .row(32L, "O", 21L)
                 .row(33L, "F", 10L)
                 .row(34L, "O", 21L)
+                .build();
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testWindowMapAgg()
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT map_agg(orderkey, orderpriority) OVER(PARTITION BY orderstatus) FROM\n" +
+                "(SELECT * FROM orders ORDER BY orderkey LIMIT 5) t");
+        MaterializedResult expected = resultBuilder(getSession(), new MapType(BIGINT, VarcharType.createVarcharType(1)))
+                .row(ImmutableMap.of(1L, "5-LOW", 2L, "1-URGENT", 4L, "5-LOW"))
+                .row(ImmutableMap.of(1L, "5-LOW", 2L, "1-URGENT", 4L, "5-LOW"))
+                .row(ImmutableMap.of(1L, "5-LOW", 2L, "1-URGENT", 4L, "5-LOW"))
+                .row(ImmutableMap.of(3L, "5-LOW", 5L, "5-LOW"))
+                .row(ImmutableMap.of(3L, "5-LOW", 5L, "5-LOW"))
                 .build();
         assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.MapType;
 import com.facebook.presto.type.SqlIntervalDayTime;
 import com.facebook.presto.type.SqlIntervalYearMonth;
 import com.google.common.base.Function;
@@ -44,6 +45,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -226,6 +228,12 @@ public class TestingPrestoClient
             return ((List<Object>) value).stream()
                     .map(element -> convertToRowValue(((ArrayType) type).getElementType(), element, timeZoneKey))
                     .collect(toList());
+        }
+        else if (type instanceof MapType) {
+            return ((Map<Object, Object>) value).entrySet().stream()
+                    .collect(Collectors.toMap(
+                            e -> convertToRowValue(((MapType) type).getKeyType(), e.getKey(), timeZoneKey),
+                            e -> convertToRowValue(((MapType) type).getValueType(), e.getValue(), timeZoneKey)));
         }
         else if (type instanceof DecimalType) {
             return new BigDecimal((String) value);


### PR DESCRIPTION
Supersedes https://github.com/prestodb/presto/pull/6793

Previously mentioned benchmarks reran with similar results.
In addition to them, I also benchmarked a few corner case use cases (relevant to simplifications used in code):
```sql
select count(x) from (select map_agg(partkey, tax) over(partition by orderkey) x from sf100.lineitem) v;
```
is ~8x faster
```sql
select count(x) from (select count(orderkey) over() x from sf100.lineitem) v;
```
is ~70x faster

They are special cases because in both cases blocks are copied using `Block.getSingleValueBlock()`.

The way I use `getSingleValueBlock()` could be illustrated with below pseudo-code snippet:
```java
state = ...
block = ...

for (int i = startPosition; i < endPosition; ++i) {
function.input(state, block.getSingleValueBlock(i), 0);
}
```
which I claim is correctness-wise equal to (which is current implementation from `master`):

```java
state = ...
block = ...

for (int i = startPosition; i < endPosition; ++i) {
function.input(state, block, i);
}
```

---

This addresses https://github.com/prestodb/presto/pull/6793#issuecomment-268896263.

There's obviously a room for further improvement (to not copy blocks using `Block.getSingleValueBlock()` per position for `BLOCK_CHANNEL_INPUT`) but this patch improves a lot already, therefore I think it's worth to merge this patch now and leave further improvements (which may not be straight forward to implement) for later or when it's needed.

