### PR TITLE
Use in-memory H2 database for Raptor development

### DIFF
--- a/presto-main/etc/catalog/raptor.properties
+++ b/presto-main/etc/catalog/raptor.properties
@@ -7,7 +7,7 @@
 
 connector.name=raptor
 metadata.db.type=h2
-metadata.db.filename=./var/data/db/MetaStore
+metadata.db.filename=mem:raptor;DB_CLOSE_DELAY=-1
 #metadata.db.type=mysql
 #metadata.db.connections.max=500
 storage.data-directory=var/data


### PR DESCRIPTION
The server won't start after schema changes, and persisting data across
restarts is not that useful for development, so make it ephemeral.