### PR TITLE
Replace QualifiedNameReference with Identifier

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
@@ -20,11 +20,11 @@ import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IsNullPredicate;
 import com.facebook.presto.sql.tree.LambdaExpression;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.NotExpression;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -311,9 +311,9 @@ public final class ExpressionUtils
     {
         return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>() {
             @Override
-            public Expression rewriteQualifiedNameReference(QualifiedNameReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            public Expression rewriteIdentifier(Identifier node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
             {
-                return new SymbolReference(node.getName().toString());
+                return new SymbolReference(node.getName());
             }
 
             @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.Extract;
 import com.facebook.presto.sql.tree.FieldReference;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IfExpression;
 import com.facebook.presto.sql.tree.InListExpression;
 import com.facebook.presto.sql.tree.InPredicate;
@@ -46,7 +47,6 @@ import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullIfExpression;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.Row;
 import com.facebook.presto.sql.tree.SearchedCaseExpression;
 import com.facebook.presto.sql.tree.SimpleCaseExpression;
@@ -123,8 +123,8 @@ class AggregationAnalyzer
         // in the group by clause to fields they reference so that the expansion from '*' can be matched against them
         for (Expression expression : Iterables.filter(expressions, columnReferences::contains)) {
             QualifiedName name;
-            if (expression instanceof QualifiedNameReference) {
-                name = ((QualifiedNameReference) expression).getName();
+            if (expression instanceof Identifier) {
+                name = QualifiedName.of(((Identifier) expression).getName());
             }
             else {
                 name = DereferenceExpression.getQualifiedName(checkType(expression, DereferenceExpression.class, "expression"));
@@ -383,9 +383,9 @@ class AggregationAnalyzer
         }
 
         @Override
-        protected Boolean visitQualifiedNameReference(QualifiedNameReference node, Void context)
+        protected Boolean visitIdentifier(Identifier node, Void context)
         {
-            return isField(node.getName());
+            return isField(QualifiedName.of(node.getName()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -22,11 +22,11 @@ import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.ExistsPredicate;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.Join;
 import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
 import com.facebook.presto.sql.tree.Node;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
@@ -89,7 +89,7 @@ public class Analysis
     private final Set<Expression> typeOnlyCoercions = newIdentityHashSet();
     private final IdentityHashMap<Relation, Type[]> relationCoercions = new IdentityHashMap<>();
     private final IdentityHashMap<FunctionCall, Signature> functionSignature = new IdentityHashMap<>();
-    private final IdentityHashMap<QualifiedNameReference, LambdaArgumentDeclaration> lambdaArgumentReferences = new IdentityHashMap<>();
+    private final IdentityHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences = new IdentityHashMap<>();
 
     private final IdentityHashMap<Field, ColumnHandle> columns = new IdentityHashMap<>();
 
@@ -203,17 +203,17 @@ public class Analysis
         return coercions.get(expression);
     }
 
-    public void addLambdaArgumentReferences(IdentityHashMap<QualifiedNameReference, LambdaArgumentDeclaration> lambdaArgumentReferences)
+    public void addLambdaArgumentReferences(IdentityHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences)
     {
         this.lambdaArgumentReferences.putAll(lambdaArgumentReferences);
     }
 
-    public LambdaArgumentDeclaration getLambdaArgumentReference(QualifiedNameReference qualifiedNameReference)
+    public LambdaArgumentDeclaration getLambdaArgumentReference(Identifier identifier)
     {
-        return lambdaArgumentReferences.get(qualifiedNameReference);
+        return lambdaArgumentReferences.get(identifier);
     }
 
-    public Map<QualifiedNameReference, LambdaArgumentDeclaration> getLambdaArgumentReferences()
+    public Map<Identifier, LambdaArgumentDeclaration> getLambdaArgumentReferences()
     {
         return lambdaArgumentReferences;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
@@ -16,9 +16,9 @@ package com.facebook.presto.sql.analyzer;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.tree.ExistsPredicate;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.facebook.presto.sql.tree.SubqueryExpression;
 import com.google.common.collect.ImmutableSet;
@@ -39,7 +39,7 @@ public class ExpressionAnalysis
     private final Set<ExistsPredicate> existsSubqueries;
     private final Set<QuantifiedComparisonExpression> quantifiedComparisons;
     // For lambda argument references, maps each QualifiedNameReference to the referenced LambdaArgumentDeclaration
-    private final IdentityHashMap<QualifiedNameReference, LambdaArgumentDeclaration> lambdaArgumentReferences;
+    private final IdentityHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences;
 
     public ExpressionAnalysis(
             IdentityHashMap<Expression, Type> expressionTypes,
@@ -50,7 +50,7 @@ public class ExpressionAnalysis
             Set<Expression> columnReferences,
             Set<Expression> typeOnlyCoercions,
             Set<QuantifiedComparisonExpression> quantifiedComparisons,
-            IdentityHashMap<QualifiedNameReference, LambdaArgumentDeclaration> lambdaArgumentReferences)
+            IdentityHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences)
     {
         this.expressionTypes = requireNonNull(expressionTypes, "expressionTypes is null");
         this.expressionCoercions = requireNonNull(expressionCoercions, "expressionCoercions is null");
@@ -78,7 +78,7 @@ public class ExpressionAnalysis
         return expressionCoercions.get(expression);
     }
 
-    public LambdaArgumentDeclaration getLambdaArgumentReference(QualifiedNameReference qualifiedNameReference)
+    public LambdaArgumentDeclaration getLambdaArgumentReference(Identifier qualifiedNameReference)
     {
         return lambdaArgumentReferences.get(qualifiedNameReference);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
@@ -15,8 +15,8 @@ package com.facebook.presto.sql.analyzer;
 
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.WithQuery;
 import com.google.common.collect.ImmutableMap;
 
@@ -82,8 +82,8 @@ public class Scope
     private static QualifiedName asQualifiedName(Expression expression)
     {
         QualifiedName name = null;
-        if (expression instanceof QualifiedNameReference) {
-            name = ((QualifiedNameReference) expression).getName();
+        if (expression instanceof Identifier) {
+            name = QualifiedName.of(((Identifier) expression).getName());
         }
         else if (expression instanceof DereferenceExpression) {
             name = DereferenceExpression.getQualifiedName((DereferenceExpression) expression);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DependencyExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DependencyExtractor.java
@@ -18,8 +18,8 @@ import com.facebook.presto.sql.tree.DefaultExpressionTraversalVisitor;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -105,9 +105,9 @@ public final class DependencyExtractor
         }
 
         @Override
-        protected Void visitQualifiedNameReference(QualifiedNameReference node, ImmutableSet.Builder<QualifiedName> builder)
+        protected Void visitIdentifier(Identifier node, ImmutableSet.Builder<QualifiedName> builder)
         {
-            builder.add(node.getName());
+            builder.add(QualifiedName.of(node.getName()));
             return null;
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -54,6 +54,7 @@ import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FieldReference;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IfExpression;
 import com.facebook.presto.sql.tree.InListExpression;
 import com.facebook.presto.sql.tree.InPredicate;
@@ -70,7 +71,6 @@ import com.facebook.presto.sql.tree.NullIfExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.facebook.presto.sql.tree.Row;
 import com.facebook.presto.sql.tree.SearchedCaseExpression;
@@ -295,7 +295,7 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Void visitQualifiedNameReference(QualifiedNameReference node, Void context)
+        protected Void visitIdentifier(Identifier node, Void context)
         {
             throw new SemanticException(EXPRESSION_NOT_CONSTANT, expression, "Constant expression cannot contain column references");
         }
@@ -430,7 +430,7 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitQualifiedNameReference(QualifiedNameReference node, Object context)
+        protected Object visitIdentifier(Identifier node, Object context)
         {
             return node;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -32,11 +32,11 @@ import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.ExistsPredicate;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NotExpression;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression.Quantifier;
 import com.facebook.presto.sql.tree.SubqueryExpression;
@@ -529,7 +529,7 @@ class SubqueryPlanner
         }
 
         @Override
-        protected Void visitQualifiedNameReference(QualifiedNameReference node, ImmutableSet.Builder<Expression> builder)
+        protected Void visitIdentifier(Identifier node, ImmutableSet.Builder<Expression> builder)
         {
             builder.add(node);
             return null;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolAllocator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolAllocator.java
@@ -18,7 +18,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.Field;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.primitives.Ints;
 
@@ -85,8 +85,8 @@ public class SymbolAllocator
     public Symbol newSymbol(Expression expression, Type type, String suffix)
     {
         String nameHint = "expr";
-        if (expression instanceof QualifiedNameReference) {
-            nameHint = ((QualifiedNameReference) expression).getName().getSuffix();
+        if (expression instanceof Identifier) {
+            nameHint = ((Identifier) expression).getName();
         }
         else if (expression instanceof FunctionCall) {
             nameHint = ((FunctionCall) expression).getName().getSuffix();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslationMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslationMap.java
@@ -22,9 +22,9 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FieldReference;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
 import com.facebook.presto.sql.tree.LambdaExpression;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.google.common.collect.ImmutableList;
 
 import java.util.HashMap;
@@ -236,7 +236,7 @@ class TranslationMap
             }
 
             @Override
-            public Expression rewriteQualifiedNameReference(QualifiedNameReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            public Expression rewriteIdentifier(Identifier node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
             {
                 LambdaArgumentDeclaration referencedLambdaArgumentDeclaration = analysis.getLambdaArgumentReference(node);
                 if (referencedLambdaArgumentDeclaration != null) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 import static com.facebook.presto.execution.ParameterExtractor.getParameters;
 import static com.facebook.presto.sql.QueryUtil.aliased;
 import static com.facebook.presto.sql.QueryUtil.ascending;
-import static com.facebook.presto.sql.QueryUtil.nameReference;
+import static com.facebook.presto.sql.QueryUtil.identifier;
 import static com.facebook.presto.sql.QueryUtil.ordering;
 import static com.facebook.presto.sql.QueryUtil.row;
 import static com.facebook.presto.sql.QueryUtil.selectList;
@@ -114,7 +114,7 @@ final class DescribeInputRewrite
             }
 
             return simpleQuery(
-                    selectList(nameReference("Position"), nameReference("Type")),
+                    selectList(identifier("Position"), identifier("Type")),
                     aliased(
                             values(rows),
                             "Parameter Input",

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeOutputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeOutputRewrite.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.sql.QueryUtil.aliased;
-import static com.facebook.presto.sql.QueryUtil.nameReference;
+import static com.facebook.presto.sql.QueryUtil.identifier;
 import static com.facebook.presto.sql.QueryUtil.row;
 import static com.facebook.presto.sql.QueryUtil.selectList;
 import static com.facebook.presto.sql.QueryUtil.simpleQuery;
@@ -107,13 +107,13 @@ final class DescribeOutputRewrite
             }
             return simpleQuery(
                     selectList(
-                            nameReference("Column Name"),
-                            nameReference("Catalog"),
-                            nameReference("Schema"),
-                            nameReference("Table"),
-                            nameReference("Type"),
-                            nameReference("Type Size"),
-                            nameReference("Aliased")),
+                            identifier("Column Name"),
+                            identifier("Catalog"),
+                            identifier("Schema"),
+                            identifier("Table"),
+                            identifier("Type"),
+                            identifier("Type Size"),
+                            identifier("Aliased")),
                     aliased(
                             values(rows),
                             "Statement Output",

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionUtils.java
@@ -15,13 +15,12 @@ package com.facebook.presto.sql;
 
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IsNullPredicate;
 import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.NotExpression;
-import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.StringLiteral;
 import org.testng.annotations.Test;
 
@@ -79,9 +78,9 @@ public class TestExpressionUtils
         assertEquals(normalize(expression), normalized);
     }
 
-    private static QualifiedNameReference name(String name)
+    private static Identifier name(String name)
     {
-        return new QualifiedNameReference(QualifiedName.of(name));
+        return new Identifier(name);
     }
 
     private LogicalBinaryExpression and(Expression left, Expression right)

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestScope.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestScope.java
@@ -13,8 +13,9 @@
  */
 package com.facebook.presto.sql.analyzer;
 
+import com.facebook.presto.sql.tree.DereferenceExpression;
+import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -39,10 +40,10 @@ public class TestScope
         Field innerColumn3 = Field.newQualified(QualifiedName.of("inner", "column3"), Optional.of("c3"), BIGINT, false, Optional.empty(), false);
         Scope inner = Scope.builder().withParent(outer).withRelationType(new RelationType(innerColumn2, innerColumn3)).build();
 
-        QualifiedNameReference c1 = name("c1");
-        QualifiedNameReference c2 = name("c2");
-        QualifiedNameReference c3 = name("c3");
-        QualifiedNameReference c4 = name("c4");
+        Expression c1 = name("c1");
+        Expression c2 = name("c2");
+        Expression c3 = name("c3");
+        Expression c4 = name("c4");
 
         assertFalse(root.tryResolveField(c1).isPresent());
 
@@ -67,8 +68,8 @@ public class TestScope
         assertFalse(inner.tryResolveField(c4).isPresent());
     }
 
-    private static QualifiedNameReference name(String first, String... parts)
+    private static Expression name(String first, String... parts)
     {
-        return new QualifiedNameReference(QualifiedName.of(first, parts));
+        return DereferenceExpression.from(QualifiedName.of(first, parts));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDeterminismEvaluator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDeterminismEvaluator.java
@@ -15,8 +15,8 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -43,8 +43,8 @@ public class TestDeterminismEvaluator
         return new FunctionCall(QualifiedName.of(name), Arrays.asList(inputs));
     }
 
-    private static QualifiedNameReference input(String symbol)
+    private static Identifier input(String symbol)
     {
-        return new QualifiedNameReference(QualifiedName.of(symbol));
+        return new Identifier(symbol);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCountConstantOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCountConstantOptimizer.java
@@ -25,9 +25,9 @@ import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -79,7 +79,7 @@ public class TestCountConstantOptimizer
                         new ProjectNode(
                                 planNodeIdAllocator.getNextId(),
                                 valuesNode,
-                                Assignments.of(new Symbol("expr"), new FunctionCall(QualifiedName.of("function"), ImmutableList.of(new QualifiedNameReference(QualifiedName.of("x")))))),
+                                Assignments.of(new Symbol("expr"), new FunctionCall(QualifiedName.of("function"), ImmutableList.of(new Identifier("x"))))),
                         aggregations,
                         functions,
                         ImmutableMap.of(),

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -40,6 +40,7 @@ import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GenericLiteral;
 import com.facebook.presto.sql.tree.GroupingElement;
 import com.facebook.presto.sql.tree.GroupingSets;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IfExpression;
 import com.facebook.presto.sql.tree.InListExpression;
 import com.facebook.presto.sql.tree.InPredicate;
@@ -57,7 +58,6 @@ import com.facebook.presto.sql.tree.NullIfExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.facebook.presto.sql.tree.Rollup;
 import com.facebook.presto.sql.tree.Row;
@@ -287,9 +287,9 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitQualifiedNameReference(QualifiedNameReference node, Boolean unmangleNames)
+        protected String visitIdentifier(Identifier node, Boolean unmangleNames)
         {
-            return formatQualifiedName(node.getName());
+            return formatIdentifier(node.getName());
         }
 
         @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
@@ -21,9 +21,9 @@ import com.facebook.presto.sql.tree.ComparisonExpressionType;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupBy;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QueryBody;
 import com.facebook.presto.sql.tree.QuerySpecification;
@@ -51,19 +51,19 @@ public final class QueryUtil
 {
     private QueryUtil() {}
 
-    public static Expression nameReference(String name)
+    public static Expression identifier(String name)
     {
-        return new QualifiedNameReference(QualifiedName.of(name));
+        return new Identifier(name);
     }
 
     public static SelectItem unaliasedName(String name)
     {
-        return new SingleColumn(nameReference(name));
+        return new SingleColumn(identifier(name));
     }
 
     public static SelectItem aliasedName(String name, String alias)
     {
-        return new SingleColumn(nameReference(name), alias);
+        return new SingleColumn(identifier(name), alias);
     }
 
     public static Select selectList(Expression... expressions)
@@ -97,7 +97,7 @@ public final class QueryUtil
 
     public static SortItem ascending(String name)
     {
-        return new SortItem(nameReference(name), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED);
+        return new SortItem(identifier(name), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED);
     }
 
     public static Expression logicalAnd(Expression left, Expression right)
@@ -137,7 +137,7 @@ public final class QueryUtil
 
     public static SelectItem aliasedNullToEmpty(String column, String alias)
     {
-        return new SingleColumn(new CoalesceExpression(nameReference(column), new StringLiteral("")), alias);
+        return new SingleColumn(new CoalesceExpression(identifier(column), new StringLiteral("")), alias);
     }
 
     public static List<SortItem> ordering(SortItem... items)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
@@ -27,13 +27,13 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupingElement;
 import com.facebook.presto.sql.tree.GroupingSets;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.Rollup;
@@ -286,14 +286,14 @@ public class TreePrinter
             }
 
             @Override
-            protected Void visitQualifiedNameReference(QualifiedNameReference node, Integer indentLevel)
+            protected Void visitIdentifier(Identifier node, Integer indentLevel)
             {
                 QualifiedName resolved = resolvedNameReferences.get(node);
                 String resolvedName = "";
                 if (resolved != null) {
                     resolvedName = "=>" + resolved.toString();
                 }
-                print(indentLevel, "QualifiedName[" + node.getName() + resolvedName + "]");
+                print(indentLevel, "Identifier[" + node.getName() + resolvedName + "]");
                 return null;
             }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -66,6 +66,7 @@ import com.facebook.presto.sql.tree.Grant;
 import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.GroupingElement;
 import com.facebook.presto.sql.tree.GroupingSets;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IfExpression;
 import com.facebook.presto.sql.tree.InListExpression;
 import com.facebook.presto.sql.tree.InPredicate;
@@ -94,7 +95,6 @@ import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QueryBody;
@@ -1153,7 +1153,7 @@ class AstBuilder
     @Override
     public Node visitColumnReference(SqlBaseParser.ColumnReferenceContext context)
     {
-        return new QualifiedNameReference(getLocation(context), QualifiedName.of(context.getText()));
+        return new Identifier(getLocation(context), context.getText());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -302,7 +302,7 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
-    protected R visitQualifiedNameReference(QualifiedNameReference node, C context)
+    protected R visitIdentifier(Identifier node, C context)
     {
         return visitExpression(node, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
@@ -55,7 +55,7 @@ public final class Cube
     public List<Set<Expression>> enumerateGroupingSets()
     {
         return ImmutableList.copyOf(Sets.powerSet(columns.stream()
-                .map(QualifiedNameReference::new)
+                .map(DereferenceExpression::from)
                 .collect(toSet())));
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DereferenceExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DereferenceExpression.java
@@ -79,12 +79,26 @@ public class DereferenceExpression
         return parts == null ? null : QualifiedName.of(parts);
     }
 
+    public static Expression from(QualifiedName name)
+    {
+        Expression result = null;
+
+        for (String part : name.getParts()) {
+            if (result == null) {
+                result = new Identifier(part);
+            }
+            else {
+                result = new DereferenceExpression(result, part);
+            }
+        }
+
+        return result;
+    }
+
     private static List<String> tryParseParts(Expression base, String fieldName)
     {
-        if (base instanceof QualifiedNameReference) {
-            List<String> newList = new ArrayList<>(((QualifiedNameReference) base).getName().getParts());
-            newList.add(fieldName);
-            return newList;
+        if (base instanceof Identifier) {
+            return ImmutableList.of(((Identifier) base).getName(), fieldName);
         }
         else if (base instanceof DereferenceExpression) {
             QualifiedName baseQualifiedName = getQualifiedName((DereferenceExpression) base);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionRewriter.java
@@ -145,7 +145,7 @@ public class ExpressionRewriter<C>
         return rewriteExpression(node, context, treeRewriter);
     }
 
-    public Expression rewriteQualifiedNameReference(QualifiedNameReference node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    public Expression rewriteIdentifier(Identifier node, C context, ExpressionTreeRewriter<C> treeRewriter)
     {
         return rewriteExpression(node, context, treeRewriter);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -694,10 +694,10 @@ public final class ExpressionTreeRewriter<C>
         }
 
         @Override
-        public Expression visitQualifiedNameReference(QualifiedNameReference node, Context<C> context)
+        public Expression visitIdentifier(Identifier node, Context<C> context)
         {
             if (!context.isDefaultRewrite()) {
-                Expression result = rewriter.rewriteQualifiedNameReference(node, context.get(), ExpressionTreeRewriter.this);
+                Expression result = rewriter.rewriteIdentifier(node, context.get(), ExpressionTreeRewriter.this);
                 if (result != null) {
                     return result;
                 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
@@ -60,7 +60,7 @@ public final class GroupingSets
     {
         return sets.stream()
                 .map(groupingSet -> groupingSet.stream()
-                        .map(QualifiedNameReference::new)
+                        .map(DereferenceExpression::from)
                         .collect(Collectors.<Expression>toSet()))
                 .collect(collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Identifier.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Identifier.java
@@ -19,41 +19,36 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-public class QualifiedNameReference
+public class Identifier
         extends Expression
 {
-    private final QualifiedName name;
+    private final String name;
 
-    public QualifiedNameReference(QualifiedName name)
+    public Identifier(String name)
     {
         this(Optional.empty(), name);
     }
 
-    public QualifiedNameReference(NodeLocation location, QualifiedName name)
+    public Identifier(NodeLocation location, String name)
     {
         this(Optional.of(location), name);
     }
 
-    private QualifiedNameReference(Optional<NodeLocation> location, QualifiedName name)
+    private Identifier(Optional<NodeLocation> location, String name)
     {
         super(location);
         this.name = name;
     }
 
-    public QualifiedName getName()
+    public String getName()
     {
         return name;
-    }
-
-    public QualifiedName getSuffix()
-    {
-        return QualifiedName.of(name.getSuffix());
     }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context)
     {
-        return visitor.visitQualifiedNameReference(this, context);
+        return visitor.visitIdentifier(this, context);
     }
 
     @Override
@@ -72,7 +67,7 @@ public class QualifiedNameReference
             return false;
         }
 
-        QualifiedNameReference that = (QualifiedNameReference) o;
+        Identifier that = (Identifier) o;
         return Objects.equals(name, that.name);
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
@@ -61,7 +61,7 @@ public final class Rollup
                 .addAll(IntStream.range(0, numColumns)
                         .mapToObj(i -> columns.subList(0, numColumns - i)
                                 .stream()
-                                .map(QualifiedNameReference::new)
+                                .map(DereferenceExpression::from)
                                 .map(Expression.class::cast)
                                 .collect(toSet()))
                         .collect(toList()))

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -56,6 +56,7 @@ import com.facebook.presto.sql.tree.GenericLiteral;
 import com.facebook.presto.sql.tree.Grant;
 import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.GroupingSets;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.Insert;
 import com.facebook.presto.sql.tree.Intersect;
 import com.facebook.presto.sql.tree.IntervalLiteral;
@@ -76,7 +77,6 @@ import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
@@ -118,7 +118,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static com.facebook.presto.sql.QueryUtil.nameReference;
+import static com.facebook.presto.sql.QueryUtil.identifier;
 import static com.facebook.presto.sql.QueryUtil.query;
 import static com.facebook.presto.sql.QueryUtil.row;
 import static com.facebook.presto.sql.QueryUtil.selectList;
@@ -815,29 +815,29 @@ public class TestSqlParser
         assertStatement("SHOW PARTITIONS FROM t WHERE x = 1",
                 new ShowPartitions(
                         QualifiedName.of("t"),
-                        Optional.of(new ComparisonExpression(ComparisonExpressionType.EQUAL, new QualifiedNameReference(QualifiedName.of("x")), new LongLiteral("1"))),
+                        Optional.of(new ComparisonExpression(ComparisonExpressionType.EQUAL, new Identifier("x"), new LongLiteral("1"))),
                         ImmutableList.of(),
                         Optional.empty()));
 
         assertStatement("SHOW PARTITIONS FROM t WHERE x = 1 ORDER BY y",
                 new ShowPartitions(
                         QualifiedName.of("t"),
-                        Optional.of(new ComparisonExpression(ComparisonExpressionType.EQUAL, new QualifiedNameReference(QualifiedName.of("x")), new LongLiteral("1"))),
-                        ImmutableList.of(new SortItem(new QualifiedNameReference(QualifiedName.of("y")), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
+                        Optional.of(new ComparisonExpression(ComparisonExpressionType.EQUAL, new Identifier("x"), new LongLiteral("1"))),
+                        ImmutableList.of(new SortItem(new Identifier("y"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
                         Optional.empty()));
 
         assertStatement("SHOW PARTITIONS FROM t WHERE x = 1 ORDER BY y LIMIT 10",
                 new ShowPartitions(
                         QualifiedName.of("t"),
-                        Optional.of(new ComparisonExpression(ComparisonExpressionType.EQUAL, new QualifiedNameReference(QualifiedName.of("x")), new LongLiteral("1"))),
-                        ImmutableList.of(new SortItem(new QualifiedNameReference(QualifiedName.of("y")), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
+                        Optional.of(new ComparisonExpression(ComparisonExpressionType.EQUAL, new Identifier("x"), new LongLiteral("1"))),
+                        ImmutableList.of(new SortItem(new Identifier("y"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
                         Optional.of("10")));
 
         assertStatement("SHOW PARTITIONS FROM t WHERE x = 1 ORDER BY y LIMIT ALL",
                 new ShowPartitions(
                         QualifiedName.of("t"),
-                        Optional.of(new ComparisonExpression(ComparisonExpressionType.EQUAL, new QualifiedNameReference(QualifiedName.of("x")), new LongLiteral("1"))),
-                        ImmutableList.of(new SortItem(new QualifiedNameReference(QualifiedName.of("y")), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
+                        Optional.of(new ComparisonExpression(ComparisonExpressionType.EQUAL, new Identifier("x"), new LongLiteral("1"))),
+                        ImmutableList.of(new SortItem(new Identifier("y"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
                         Optional.of("ALL")));
     }
 
@@ -916,10 +916,10 @@ public class TestSqlParser
                         Optional.empty(),
                         new QuerySpecification(
                                 selectList(
-                                        new DereferenceExpression(new QualifiedNameReference(QualifiedName.of("col1")), "f1"),
-                                        new QualifiedNameReference(QualifiedName.of("col2")),
+                                        new DereferenceExpression(new Identifier("col1"), "f1"),
+                                        new Identifier("col2"),
                                         new DereferenceExpression(
-                                                new DereferenceExpression(new DereferenceExpression(new QualifiedNameReference(QualifiedName.of("col3")), "f1"), "f2"), "f3")),
+                                                new DereferenceExpression(new DereferenceExpression(new Identifier("col3"), "f1"), "f2"), "f3")),
                                 Optional.of(new Table(QualifiedName.of("table1"))),
                                 Optional.empty(),
                                 Optional.empty(),
@@ -934,10 +934,10 @@ public class TestSqlParser
                         Optional.empty(),
                         new QuerySpecification(
                                 selectList(
-                                        new SubscriptExpression(new DereferenceExpression(new QualifiedNameReference(QualifiedName.of("col1")), "f1"), new LongLiteral("0")),
-                                        new QualifiedNameReference(QualifiedName.of("col2")),
-                                        new DereferenceExpression(new DereferenceExpression(new SubscriptExpression(new QualifiedNameReference(QualifiedName.of("col3")), new LongLiteral("2")), "f2"), "f3"),
-                                        new SubscriptExpression(new QualifiedNameReference(QualifiedName.of("col4")), new LongLiteral("4"))
+                                        new SubscriptExpression(new DereferenceExpression(new Identifier("col1"), "f1"), new LongLiteral("0")),
+                                        new Identifier("col2"),
+                                        new DereferenceExpression(new DereferenceExpression(new SubscriptExpression(new Identifier("col3"), new LongLiteral("2")), "f2"), "f3"),
+                                        new SubscriptExpression(new Identifier("col4"), new LongLiteral("4"))
                                 ),
                                 Optional.of(new Table(QualifiedName.of("table1"))),
                                 Optional.empty(),
@@ -976,7 +976,7 @@ public class TestSqlParser
                                 selectList(new AllColumns()),
                                 Optional.of(new Table(QualifiedName.of("table1"))),
                                 Optional.empty(),
-                                Optional.of(new GroupBy(false, ImmutableList.of(new SimpleGroupBy(ImmutableList.of(new QualifiedNameReference(QualifiedName.of("a"))))))),
+                                Optional.of(new GroupBy(false, ImmutableList.of(new SimpleGroupBy(ImmutableList.of(new Identifier("a")))))),
                                 Optional.empty(),
                                 ImmutableList.of(),
                                 Optional.empty()),
@@ -991,8 +991,8 @@ public class TestSqlParser
                                 Optional.of(new Table(QualifiedName.of("table1"))),
                                 Optional.empty(),
                                 Optional.of(new GroupBy(false, ImmutableList.of(
-                                        new SimpleGroupBy(ImmutableList.of(new QualifiedNameReference(QualifiedName.of("a")))),
-                                        new SimpleGroupBy(ImmutableList.of(new QualifiedNameReference(QualifiedName.of("b"))))))),
+                                        new SimpleGroupBy(ImmutableList.of(new Identifier("a"))),
+                                        new SimpleGroupBy(ImmutableList.of(new Identifier("b")))))),
                                 Optional.empty(),
                                 ImmutableList.of(),
                                 Optional.empty()),
@@ -1257,8 +1257,8 @@ public class TestSqlParser
 
         assertStatement("DELETE FROM t WHERE a = b", new Delete(table(QualifiedName.of("t")), Optional.of(
                 new ComparisonExpression(ComparisonExpressionType.EQUAL,
-                        new QualifiedNameReference(QualifiedName.of("a")),
-                        new QualifiedNameReference(QualifiedName.of("b"))))));
+                        new Identifier("a"),
+                        new Identifier("b")))));
     }
 
     @Test
@@ -1435,7 +1435,7 @@ public class TestSqlParser
                         new Join(
                                 Join.Type.CROSS,
                                 new Table(QualifiedName.of("t")),
-                                new Unnest(ImmutableList.of(new QualifiedNameReference(QualifiedName.of("a"))), false),
+                                new Unnest(ImmutableList.of(new Identifier("a")), false),
                                 Optional.empty())));
         assertStatement("SELECT * FROM t CROSS JOIN UNNEST(a) WITH ORDINALITY",
                 simpleQuery(
@@ -1443,7 +1443,7 @@ public class TestSqlParser
                         new Join(
                                 Join.Type.CROSS,
                                 new Table(QualifiedName.of("t")),
-                                new Unnest(ImmutableList.of(new QualifiedNameReference(QualifiedName.of("a"))), true),
+                                new Unnest(ImmutableList.of(new Identifier("a")), true),
                                 Optional.empty())));
     }
 
@@ -1528,14 +1528,14 @@ public class TestSqlParser
         assertExpression("x -> sin(x)",
                 new LambdaExpression(
                         ImmutableList.of(new LambdaArgumentDeclaration("x")),
-                        new FunctionCall(QualifiedName.of("sin"), ImmutableList.of(new QualifiedNameReference(QualifiedName.of("x"))))
+                        new FunctionCall(QualifiedName.of("sin"), ImmutableList.of(new Identifier("x")))
                 ));
         assertExpression("(x, y) -> mod(x, y)",
                 new LambdaExpression(
                         ImmutableList.of(new LambdaArgumentDeclaration("x"), new LambdaArgumentDeclaration("y")),
                         new FunctionCall(
                                 QualifiedName.of("mod"),
-                                ImmutableList.of(new QualifiedNameReference(QualifiedName.of("x")), new QualifiedNameReference(QualifiedName.of("y"))))
+                                ImmutableList.of(new Identifier("x"), new Identifier("y")))
                 ));
     }
 
@@ -1545,21 +1545,21 @@ public class TestSqlParser
     {
         assertStatement("SELECT zone FROM t",
                 simpleQuery(
-                        selectList(new QualifiedNameReference(QualifiedName.of("zone"))),
+                        selectList(new Identifier("zone")),
                         table(QualifiedName.of("t"))));
         assertStatement("SELECT INCLUDING, EXCLUDING, PROPERTIES FROM t",
                 simpleQuery(
                         selectList(
-                                new QualifiedNameReference(QualifiedName.of("INCLUDING")),
-                                new QualifiedNameReference(QualifiedName.of("EXCLUDING")),
-                                new QualifiedNameReference(QualifiedName.of("PROPERTIES"))),
+                                new Identifier("INCLUDING"),
+                                new Identifier("EXCLUDING"),
+                                new Identifier("PROPERTIES")),
                         table(QualifiedName.of("t"))));
         assertStatement("SELECT ALL, SOME, ANY FROM t",
                 simpleQuery(
                         selectList(
-                                new QualifiedNameReference(QualifiedName.of("ALL")),
-                                new QualifiedNameReference(QualifiedName.of("SOME")),
-                                new QualifiedNameReference(QualifiedName.of("ANY"))),
+                                new Identifier("ALL"),
+                                new Identifier("SOME"),
+                                new Identifier("ANY")),
                         table(QualifiedName.of("t"))));
     }
 
@@ -1683,10 +1683,10 @@ public class TestSqlParser
                                                 Optional.empty(),
                                                 Optional.of(new ComparisonExpression(
                                                         ComparisonExpressionType.GREATER_THAN,
-                                                        new QualifiedNameReference(QualifiedName.of("x")),
+                                                        new Identifier("x"),
                                                         new LongLiteral("4"))),
                                                 false,
-                                                ImmutableList.of(new QualifiedNameReference(QualifiedName.of("x"))))),
+                                                ImmutableList.of(new Identifier("x")))),
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
@@ -1704,21 +1704,21 @@ public class TestSqlParser
                 new QuantifiedComparisonExpression(
                         ComparisonExpressionType.LESS_THAN,
                         QuantifiedComparisonExpression.Quantifier.ANY,
-                        nameReference("col1"),
-                        new SubqueryExpression(simpleQuery(selectList(new SingleColumn(nameReference("col2"))), table(QualifiedName.of("table1"))))
+                        identifier("col1"),
+                        new SubqueryExpression(simpleQuery(selectList(new SingleColumn(identifier("col2"))), table(QualifiedName.of("table1"))))
                 ));
         assertExpression("col1 = ALL (VALUES ROW(1), ROW(2))",
                 new QuantifiedComparisonExpression(
                         ComparisonExpressionType.EQUAL,
                         QuantifiedComparisonExpression.Quantifier.ALL,
-                        nameReference("col1"),
+                        identifier("col1"),
                         new SubqueryExpression(query(values(row(new LongLiteral("1")), row(new LongLiteral("2")))))
                 ));
         assertExpression("col1 >= SOME (SELECT 10)",
                 new QuantifiedComparisonExpression(
                         ComparisonExpressionType.GREATER_THAN_OR_EQUAL,
                         QuantifiedComparisonExpression.Quantifier.SOME,
-                        nameReference("col1"),
+                        identifier("col1"),
                         new SubqueryExpression(simpleQuery(selectList(new LongLiteral("10"))))
                 ));
     }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryRewriter.java
@@ -18,9 +18,9 @@ import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.QueryBody;
 import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.Select;
@@ -191,7 +191,7 @@ public class QueryRewriter
     {
         ImmutableList.Builder<SelectItem> selectItems = ImmutableList.builder();
         for (Column column : columns) {
-            Expression expression = new QualifiedNameReference(QualifiedName.of(column.getName()));
+            Expression expression = new Identifier(column.getName());
             if (column.isApproximateType()) {
                 expression = new FunctionCall(QualifiedName.of("round"), ImmutableList.of(expression, new LongLiteral(Integer.toString(doublePrecision))));
             }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/TestShadowing.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/TestShadowing.java
@@ -17,9 +17,9 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.Select;
 import com.facebook.presto.sql.tree.SingleColumn;
@@ -80,8 +80,8 @@ public class TestShadowing
         assertEquals(PrestoVerifier.statementToQueryType(parser, rewrittenQuery.getQuery()), READ);
 
         Table table = new Table(createTableAs.getName());
-        SingleColumn column1 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new QualifiedNameReference(QualifiedName.of("column1")))));
-        SingleColumn column2 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new FunctionCall(QualifiedName.of("round"), ImmutableList.of(new QualifiedNameReference(QualifiedName.of("column2")), new LongLiteral("1"))))));
+        SingleColumn column1 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new Identifier("column1"))));
+        SingleColumn column2 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new FunctionCall(QualifiedName.of("round"), ImmutableList.of(new Identifier("column2"), new LongLiteral("1"))))));
         Select select = new Select(false, ImmutableList.of(column1, column2));
         QuerySpecification querySpecification = new QuerySpecification(select, Optional.of(table), Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of(), Optional.empty());
         assertEquals(parser.createStatement(rewrittenQuery.getQuery()), new com.facebook.presto.sql.tree.Query(Optional.empty(), querySpecification, ImmutableList.of(), Optional.empty()));


### PR DESCRIPTION
This change introduces a new AST node, Identifier, designed to
represent an identifier atom. Qualified name references are now
encoded as DereferenceExpression across the board.

It does away with the special distinction between QualifiedNameReference
and DereferenceExpression. This is the first step in being able
to support quoted identifiers and other simplifications to the
analyzer.