### PR TITLE
Fix invalid plan when converting to index join

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIndexedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIndexedQueries.java
@@ -666,4 +666,11 @@ public abstract class AbstractTestIndexedQueries
         assertQuery("SELECT COUNT(*) FROM lineitem LEFT OUTER JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5 WHERE orders.orderkey IS NULL");
         assertQuery("SELECT COUNT(*) FROM orders RIGHT OUTER JOIN lineitem ON lineitem.orderkey = orders.orderkey AND lineitem.quantity > 5 WHERE orders.orderkey IS NULL");
     }
+
+    @Test
+    public void testNonEquiJoin()
+            throws Exception
+    {
+        assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND lineitem.quantity + length(orders.comment) > 7");
+    }
 }


### PR DESCRIPTION
The projection needed to preserve the outputs of the original
join node needs to be added after the filter, which may need
to reference the outputs of the join.