### PR TITLE
Fix typo in ...benchmark/driver/Suite.java

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/Suite.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/Suite.java
@@ -114,7 +114,7 @@ public class Suite
             throws IOException
     {
         requireNonNull(file, "file is null");
-        checkArgument(file.canRead(), "Can not read file: %s" + file);
+        checkArgument(file.canRead(), String.format("Can not read file: %s", file));
         byte[] json = Files.readAllBytes(file.toPath());
         Map<String, OptionsJson> options = mapJsonCodec(String.class, OptionsJson.class).fromJson(json);
         ImmutableList.Builder<Suite> runOptions = ImmutableList.builder();


### PR DESCRIPTION
(My local fork was really dirty, so I initialized it and recreated #7197. Sorry...!)

I deleted unnecessary '+' and use string formatting.

Confirmed Result is following.
Exception in thread "main" java.lang.IllegalArgumentException: `Can not read file: suite.json` at com.google.common.base.Preconditions.checkArgument(Preconditions.java:12
... 

