### PR TITLE
Eliminate Immutable*.copyOf in requireNonNull method

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/Suite.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/Suite.java
@@ -136,8 +136,8 @@ public class Suite
                 @JsonProperty("session") Map<String, String> session,
                 @JsonProperty("query") List<String> query)
         {
-            this.schema = requireNonNull(schema, "schema is null");
-            this.session = requireNonNull(session, "session is null");
+            this.schema = ImmutableList.copyOf(requireNonNull(schema, "schema is null"));
+            this.session = ImmutableMap.copyOf(requireNonNull(session, "session is null"));
             this.query = requireNonNull(query, "query is null");
         }
 

--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/Suite.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/Suite.java
@@ -136,8 +136,8 @@ public class Suite
                 @JsonProperty("session") Map<String, String> session,
                 @JsonProperty("query") List<String> query)
         {
-            this.schema = requireNonNull(ImmutableList.copyOf(schema), "schema is null");
-            this.session = requireNonNull(ImmutableMap.copyOf(session), "session is null");
+            this.schema = requireNonNull(schema, "schema is null");
+            this.session = requireNonNull(session, "session is null");
             this.query = requireNonNull(query, "query is null");
         }
 


### PR DESCRIPTION
We shouldn’t Immutable*.copyOf in requireNonNull method because the result doesn’t show expected message.  

Tested suite.json
```
{
    "legacy_orc": {
        "query": ["sample.*"],
        "schema": [ "sf1" ]
    }
}
```

The error log before change doesn't have mising info about 'session'.
```
Exception in thread "main" java.lang.IllegalArgumentException: Invalid JSON bytes for [map type; class java.util.Map, [simple type, class java.lang.String] -> [simple type, class com.facebook.presto.benchmark.driver.Suite$OptionsJson]]
	at io.airlift.json.JsonCodec.fromJson(JsonCodec.java:201)
	at com.facebook.presto.benchmark.driver.Suite.readSuites(Suite.java:119)
	at com.facebook.presto.benchmark.driver.PrestoBenchmarkDriver.run(PrestoBenchmarkDriver.java:70)
	at com.facebook.presto.benchmark.driver.PrestoBenchmarkDriver.main(PrestoBenchmarkDriver.java:53)
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Can not construct instance of com.facebook.presto.benchmark.driver.Suite$OptionsJson, problem: null
 at [Source: [B@223f3642; line: 5, column: 5] (through reference chain: java.util.LinkedHashMap["legacy_orc"])
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:268)
	at com.fasterxml.jackson.databind.DeserializationContext.instantiationException(DeserializationContext.java:1405)
	at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.wrapAsJsonMappingException(StdValueInstantiator.java:468)
	at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.rewrapCtorProblem(StdValueInstantiator.java:487)
	at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.createFromObjectWith(StdValueInstantiator.java:276)
	at com.fasterxml.jackson.databind.deser.ValueInstantiator.createFromObjectWith(ValueInstantiator.java:224)
	at com.fasterxml.jackson.databind.deser.impl.PropertyBasedCreator.build(PropertyBasedCreator.java:135)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:471)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1194)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:314)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:148)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringKeyMap(MapDeserializer.java:507)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:352)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:27)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3789)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2950)
	at io.airlift.json.JsonCodec.fromJson(JsonCodec.java:198)
	... 3 more
Caused by: java.lang.NullPointerException
	at com.google.common.collect.ImmutableMap.copyOf(ImmutableMap.java:285)
	at com.facebook.presto.benchmark.driver.Suite$OptionsJson.<init>(Suite.java:140)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.fasterxml.jackson.databind.introspect.AnnotatedConstructor.call(AnnotatedConstructor.java:124)
	at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.createFromObjectWith(StdValueInstantiator.java:274)
	... 15 more
```

The error log after change has mising info about 'session' on 1st and 2nd 'Caused by' line.
```
Exception in thread "main" java.lang.IllegalArgumentException: Invalid JSON bytes for [map type; class java.util.Map, [simple type, class java.lang.String] -> [simple type, class com.facebook.presto.benchmark.driver.Suite$OptionsJson]]
	at io.airlift.json.JsonCodec.fromJson(JsonCodec.java:201)
	at com.facebook.presto.benchmark.driver.Suite.readSuites(Suite.java:119)
	at com.facebook.presto.benchmark.driver.PrestoBenchmarkDriver.run(PrestoBenchmarkDriver.java:70)
	at com.facebook.presto.benchmark.driver.PrestoBenchmarkDriver.main(PrestoBenchmarkDriver.java:53)
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Can not construct instance of com.facebook.presto.benchmark.driver.Suite$OptionsJson, problem: session is null
 at [Source: [B@223f3642; line: 5, column: 5] (through reference chain: java.util.LinkedHashMap["legacy_orc"])
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:268)
	at com.fasterxml.jackson.databind.DeserializationContext.instantiationException(DeserializationContext.java:1405)
	at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.wrapAsJsonMappingException(StdValueInstantiator.java:468)
	at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.rewrapCtorProblem(StdValueInstantiator.java:487)
	at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.createFromObjectWith(StdValueInstantiator.java:276)
	at com.fasterxml.jackson.databind.deser.ValueInstantiator.createFromObjectWith(ValueInstantiator.java:224)
	at com.fasterxml.jackson.databind.deser.impl.PropertyBasedCreator.build(PropertyBasedCreator.java:135)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:471)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1194)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:314)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:148)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringKeyMap(MapDeserializer.java:507)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:352)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:27)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3789)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2950)
	at io.airlift.json.JsonCodec.fromJson(JsonCodec.java:198)
	... 3 more
Caused by: java.lang.NullPointerException: session is null
	at java.util.Objects.requireNonNull(Objects.java:228)
	at com.facebook.presto.benchmark.driver.Suite$OptionsJson.<init>(Suite.java:140)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.fasterxml.jackson.databind.introspect.AnnotatedConstructor.call(AnnotatedConstructor.java:124)
	at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.createFromObjectWith(StdValueInstantiator.java:274)
```

