### PR TITLE
Remove expression from typeOnlyCoercions when the type and the supertype is not TypeOnlyCoercion

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1157,10 +1157,7 @@ public class ExpressionAnalyzer
                 if (!typeManager.canCoerce(actualType, expectedType)) {
                     throw new SemanticException(TYPE_MISMATCH, expression, message + " must evaluate to a %s (actual: %s)", expectedType, actualType);
                 }
-                expressionCoercions.put(expression, expectedType);
-                if (typeManager.isTypeOnlyCoercion(actualType, expectedType)) {
-                    typeOnlyCoercions.add(expression);
-                }
+                addOrReplaceExpressionCoercion(expression, actualType, expectedType);
             }
         }
 
@@ -1188,16 +1185,10 @@ public class ExpressionAnalyzer
                     && typeManager.canCoerce(secondType, superTypeOptional.get())) {
                 Type superType = superTypeOptional.get();
                 if (!firstType.equals(superType)) {
-                    expressionCoercions.put(first, superType);
-                    if (typeManager.isTypeOnlyCoercion(firstType, superType)) {
-                        typeOnlyCoercions.add(first);
-                    }
+                    addOrReplaceExpressionCoercion(first, firstType, superType);
                 }
                 if (!secondType.equals(superType)) {
-                    expressionCoercions.put(second, superType);
-                    if (typeManager.isTypeOnlyCoercion(secondType, superType)) {
-                        typeOnlyCoercions.add(second);
-                    }
+                    addOrReplaceExpressionCoercion(second, secondType, superType);
                 }
                 return superType;
             }
@@ -1224,14 +1215,22 @@ public class ExpressionAnalyzer
                     if (!typeManager.canCoerce(type, superType)) {
                         throw new SemanticException(TYPE_MISMATCH, expression, message, superType);
                     }
-                    expressionCoercions.put(expression, superType);
-                    if (typeManager.isTypeOnlyCoercion(type, superType)) {
-                        typeOnlyCoercions.add(expression);
-                    }
+                    addOrReplaceExpressionCoercion(expression, type, superType);
                 }
             }
 
             return superType;
+        }
+
+        private void addOrReplaceExpressionCoercion(Expression expression, Type type, Type superType)
+        {
+            expressionCoercions.put(expression, superType);
+            if (typeManager.isTypeOnlyCoercion(type, superType)) {
+                typeOnlyCoercions.add(expression);
+            }
+            else if (typeOnlyCoercions.contains(expression)) {
+                typeOnlyCoercions.remove(expression);
+            }
         }
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4819,6 +4819,7 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT x FROM (values DATE '1970-01-01', DATE '1970-01-03') t(x) WHERE x IN (DATE '1970-01-01')", "values DATE '1970-01-01'");
         assertQuery("SELECT x FROM (values TIMESTAMP '1970-01-01 00:01:00+00:00', TIMESTAMP '1970-01-01 08:01:00+08:00', TIMESTAMP '1970-01-01 00:01:00+08:00') t(x) WHERE x IN (TIMESTAMP '1970-01-01 00:01:00+00:00')", "values TIMESTAMP '1970-01-01 00:01:00+00:00', TIMESTAMP '1970-01-01 08:01:00+08:00'");
         assertQuery("SELECT COUNT(*) FROM (values 1) t(x) WHERE x IN (null, 0)", "SELECT 0");
+        assertQuery("SELECT d IN (DECIMAL '2.0', DECIMAL '30.0') FROM (VALUES (DOUBLE '2.0')) t(d)", "SELECT true"); // coercion with type only coercion inside IN list
     }
 
     @Test


### PR DESCRIPTION
#6984 

I think that the expression whose type is not typeonly with the supertype should be removed from typeOnlyCoercions list.  

In this case, decimal(2,1)'s supertype become decimal(3,1) at first. It is OK because the difference is only the precision.
Next, decimal(2,1)'s supertype become double. It is not OK because typeOnlyCoercions still contains the expression and the node {decimal(2,1) vaulue(2.0)} keeps typeonly true.

