### PR TITLE
Expose failure stats for optimizer rules

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/StatsRecorder.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/StatsRecorder.java
@@ -39,6 +39,11 @@ public class StatsRecorder
         stats.get(rule.getClass()).record(nanos, match);
     }
 
+    public void recordFailure(Rule rule)
+    {
+        stats.get(rule.getClass()).recordFailure();
+    }
+
     void export(MBeanExporter exporter)
     {
         for (Map.Entry<Class<?>, RuleStats> entry : stats.entrySet()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -109,10 +109,17 @@ public class IterativeOptimizer
         while (!done) {
             done = true;
             for (Rule rule : rules) {
-                long start = System.nanoTime();
-                Optional<PlanNode> transformed = rule.apply(node, context.getLookup(), context.getIdAllocator(), context.getSymbolAllocator());
-                long duration = System.nanoTime() - start;
-
+                Optional<PlanNode> transformed;
+                long duration;
+                try {
+                    long start = System.nanoTime();
+                    transformed = rule.apply(node, context.getLookup(), context.getIdAllocator(), context.getSymbolAllocator());
+                    duration = System.nanoTime() - start;
+                }
+                catch (RuntimeException e) {
+                    stats.recordFailure(rule);
+                    throw e;
+                }
                 stats.record(rule, duration, transformed.isPresent());
 
                 if (transformed.isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/RuleStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/RuleStats.java
@@ -24,6 +24,7 @@ public class RuleStats
 {
     private final AtomicLong hits = new AtomicLong();
     private final TimeDistribution time = new TimeDistribution(TimeUnit.MICROSECONDS);
+    private final AtomicLong failures = new AtomicLong();
 
     public void record(long nanos, boolean match)
     {
@@ -32,6 +33,11 @@ public class RuleStats
         }
 
         time.add(nanos);
+    }
+
+    public void recordFailure()
+    {
+        failures.incrementAndGet();
     }
 
     @Managed
@@ -45,5 +51,11 @@ public class RuleStats
     public TimeDistribution getTime()
     {
         return time;
+    }
+
+    @Managed
+    public long getFailures()
+    {
+        return failures.get();
     }
 }


### PR DESCRIPTION
This can help understand which rules are causing queries to fail due to exceptions.