### PR TITLE
Prevent integer overflow calculating QueryQueue permits

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryQueue.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryQueue.java
@@ -38,7 +38,11 @@ public class QueryQueue
         checkArgument(maxQueuedQueries > 0, "maxQueuedQueries must be greater than zero");
         checkArgument(maxConcurrentQueries > 0, "maxConcurrentQueries must be greater than zero");
 
-        this.queuePermits = new AtomicInteger(maxQueuedQueries + maxConcurrentQueries);
+        int permits = maxQueuedQueries + maxConcurrentQueries;
+        // Check for overflow
+        checkArgument(permits > 0, "maxQueuedQueries + maxConcurrentQueries must be lower or equal %s", Integer.MAX_VALUE);
+
+        this.queuePermits = new AtomicInteger(permits);
         this.asyncSemaphore = new AsyncSemaphore<>(maxConcurrentQueries,
                 queryExecutor,
                 queueEntry -> {


### PR DESCRIPTION
Detect and report integer overflow when QueryQueue's permits cannot be
calculated. Not using Math.addExact() to be able to report problem
nicely.