### PR TITLE
Do not gather partitioned sources of union by default (Version 2)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/FragmentTableScanCounter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/FragmentTableScanCounter.java
@@ -18,6 +18,8 @@ import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 
+import java.util.List;
+
 /**
  * Visitor to count number of tables scanned in the current fragment
  * (fragments separated by ExchangeNodes).
@@ -27,6 +29,15 @@ import com.facebook.presto.sql.planner.plan.TableScanNode;
 public final class FragmentTableScanCounter
 {
     private FragmentTableScanCounter() {}
+
+    public static boolean hasMultipleSources(List<PlanNode> nodes)
+    {
+        int count = 0;
+        for (PlanNode node : nodes) {
+            count += node.accept(new Visitor(), null);
+        }
+        return count > 1;
+    }
 
     public static boolean hasMultipleSources(PlanNode... nodes)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -112,6 +112,7 @@ import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Glo
 import static com.facebook.presto.sql.planner.optimizations.LocalProperties.grouped;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.gatheringExchange;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.partitionedExchange;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.replicatedExchange;
@@ -1090,9 +1091,11 @@ public class AddExchanges
             List<PlanNode> partitionedChildren = new ArrayList<>();
             List<List<Symbol>> partitionedOutputLayouts = new ArrayList<>();
 
-            List<PlanNode> sources = node.getSources();
-            for (int i = 0; i < sources.size(); i++) {
-                PlanWithProperties child = sources.get(i).accept(this, context.withPreferredProperties(PreferredProperties.any()));
+            List<PlanWithProperties> plannedChildren = new ArrayList<>();
+
+            for (int i = 0; i < node.getSources().size(); i++) {
+                PlanWithProperties child = node.getSources().get(i).accept(this, context.withPreferredProperties(PreferredProperties.any()));
+                plannedChildren.add(child);
                 if (child.getProperties().isSingleNode()) {
                     unpartitionedChildren.add(child.getNode());
                     unpartitionedOutputLayouts.add(node.sourceOutputLayout(i));
@@ -1106,6 +1109,13 @@ public class AddExchanges
 
             PlanNode result;
             if (!partitionedChildren.isEmpty() && unpartitionedChildren.isEmpty()) {
+                // parent does not have preference or prefers some partitioning without any explicit partitioning - just use
+                // children partitioning and don't GATHER partitioned inputs
+                // TODO: add FIXED_ARBITRARY_DISTRIBUTION support on non empty unpartitionedChildren
+                if (!parentGlobal.isPresent() || parentGlobal.get().isDistributed()) {
+                    return arbitraryDistributeUnion(node, plannedChildren, partitionedChildren, partitionedOutputLayouts);
+                }
+
                 // add a gathering exchange above partitioned inputs
                 result = new ExchangeNode(
                         idAllocator.getNextId(),
@@ -1157,6 +1167,31 @@ public class AddExchanges
                             .build());
         }
 
+        private PlanWithProperties arbitraryDistributeUnion(
+                UnionNode node,
+                List<PlanWithProperties> plannedChildren,
+                List<PlanNode> partitionedChildren,
+                List<List<Symbol>> partitionedOutputLayouts)
+        {
+            if (!hasMultipleSources(partitionedChildren)) {
+                // At most one source distributed child, we can use insert LOCAL exchange
+                // TODO: if all children have the same partitioning, pass this partitioning to the parent instead of "arbitraryPartition".
+                return new PlanWithProperties(replaceChildren(node, plannedChildren));
+            }
+            else {
+                // Presto currently can not execute stage that has multiple table scans, so in that case we have to insert REMOTE exchange
+                // with FIXED_ARBITRARY_DISTRIBUTION instead of local exchange
+                return new PlanWithProperties(
+                        new ExchangeNode(
+                                idAllocator.getNextId(),
+                                REPARTITION,
+                                REMOTE,
+                                new PartitioningScheme(Partitioning.create(FIXED_ARBITRARY_DISTRIBUTION, ImmutableList.of()), node.getOutputSymbols()),
+                                partitionedChildren,
+                                partitionedOutputLayouts));
+            }
+        }
+
         @Override
         public PlanWithProperties visitApply(ApplyNode node, Context context)
         {
@@ -1186,7 +1221,7 @@ public class AddExchanges
 
         private PlanWithProperties rebaseAndDeriveProperties(PlanNode node, List<PlanWithProperties> children)
         {
-            PlanNode result = ChildReplacer.replaceChildren(node, children.stream().map(PlanWithProperties::getNode).collect(toList()));
+            PlanNode result = replaceChildren(node, children);
             return new PlanWithProperties(result, deriveProperties(result, children.stream().map(PlanWithProperties::getProperties).collect(toList())));
         }
 
@@ -1203,6 +1238,11 @@ public class AddExchanges
         private ActualProperties deriveProperties(PlanNode result, List<ActualProperties> inputProperties)
         {
             return PropertyDerivations.deriveProperties(result, inputProperties, metadata, session, types, parser);
+        }
+
+        private PlanNode replaceChildren(PlanNode node, List<PlanWithProperties> children)
+        {
+            return ChildReplacer.replaceChildren(node, children.stream().map(PlanWithProperties::getNode).collect(toList()));
         }
     }
 
@@ -1297,6 +1337,11 @@ public class AddExchanges
     {
         private final PlanNode node;
         private final ActualProperties properties;
+
+        public PlanWithProperties(PlanNode node)
+        {
+            this(node, ActualProperties.builder().build());
+        }
 
         public PlanWithProperties(PlanNode node, ActualProperties properties)
         {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnion.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnion.java
@@ -18,19 +18,34 @@ import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
 import static java.util.stream.Collectors.toList;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestUnion
         extends BasePlanTest
 {
+    public TestUnion()
+    {
+        super();
+    }
+
+    public TestUnion(Map<String, String> sessionProperties)
+    {
+        super(sessionProperties);
+    }
+
     @Test
     public void testPartialAggregationsWithUnion()
     {
@@ -51,6 +66,36 @@ public class TestUnion
         assertAtMostOneAggregationBetweenRemoteExchanges(plan);
     }
 
+    @Test
+    public void testUnionOnProbeSide()
+    {
+        Plan plan = plan(
+                "SELECT * FROM (SELECT * FROM nation UNION ALL SELECT * from nation) n, region r WHERE n.regionkey=r.regionkey",
+                LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED,
+                false);
+
+        assertPlanIsFullyDistributed(plan);
+    }
+
+    private void assertPlanIsFullyDistributed(Plan plan)
+    {
+        assertTrue(
+                searchFrom(plan.getRoot())
+                        .skipOnlyWhen(TestUnion::isNotRemoteGatheringExchange)
+                        .findAll()
+                        .stream()
+                        .noneMatch(planNode -> planNode instanceof AggregationNode || planNode instanceof JoinNode),
+                "There is an Aggregation or Join between output and first REMOTE GATHER ExchangeNode");
+
+        List<PlanNode> gathers = searchFrom(plan.getRoot())
+                .where(TestUnion::isRemoteGatheringExchange)
+                .findAll()
+                .stream()
+                .collect(toList());
+
+        assertEquals(gathers.size(), 1, "Only a single REMOTE GATHER was expected");
+    }
+
     private static void assertAtMostOneAggregationBetweenRemoteExchanges(Plan plan)
     {
         List<PlanNode> fragments = searchFrom(plan.getRoot())
@@ -68,6 +113,16 @@ public class TestUnion
 
             assertFalse(aggregations.size() > 1, "More than a single AggregationNode between remote exchanges");
         }
+    }
+
+    private static boolean isNotRemoteGatheringExchange(PlanNode planNode)
+    {
+        return !isRemoteGatheringExchange(planNode);
+    }
+
+    private static boolean isRemoteGatheringExchange(PlanNode planNode)
+    {
+        return isRemoteExchange(planNode) && ((ExchangeNode) planNode).getType().equals(GATHER);
     }
 
     private static boolean isNotRemoteExchange(PlanNode planNode)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnionWithReplicatedJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnionWithReplicatedJoin.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.SystemSessionProperties;
+import com.google.common.collect.ImmutableMap;
+
+public class TestUnionWithReplicatedJoin
+        extends TestUnion
+{
+    public TestUnionWithReplicatedJoin()
+    {
+        super(ImmutableMap.of(SystemSessionProperties.DISTRIBUTED_JOIN, "false"));
+    }
+}


### PR DESCRIPTION
For example broadcast join does not prefer any partitionig from probe side. Because of that Before this change GATHER exchange was inserted in place of UNION on probe side, which forced Join to be performed on a single node.

Example query:

```
set session distributed_join=false;
explain (type distributed) select * from (select * from nation union all select * from nation) n, region r where n.regionkey=r.regionkey;
```

Please compare where is `InnerJoin` node AFTER change:
```
 Fragment 0 [SINGLE]                                                                                                                                                                                         
     Output layout: [expr_20, expr_21, expr_22, expr_23, expr_22, name_33, comment_34]                                                                                                                       
     Output partitioning: SINGLE []                                                                                                                                                                          
     - Output[nationkey, name, regionkey, comment, regionkey, name, comment] => [expr_20:bigint, expr_21:varchar(25), expr_22:bigint, expr_23:varchar(152), expr_22:bigint, name_33:varchar(25), comment_34:v
             nationkey := expr_20                                                                                                                                                                            
             name := expr_21                                                                                                                                                                                 
             regionkey := expr_22                                                                                                                                                                            
             comment := expr_23                                                                                                                                                                              
             regionkey := expr_22                                                                                                                                                                            
             name := name_33                                                                                                                                                                                 
             comment := comment_34                                                                                                                                                                           
         - RemoteSource[1] => [expr_20:bigint, expr_21:varchar(25), expr_22:bigint, expr_23:varchar(152), name_33:varchar(25), comment_34:varchar(152)]                                                      
                                                                                                                                                                                                             
 Fragment 1 [ROUND_ROBIN]                                                                                                                                                                                    
     Output layout: [expr_20, expr_21, expr_22, expr_23, name_33, comment_34]                                                                                                                                
     Output partitioning: SINGLE []                                                                                                                                                                          
     - Project[] => [expr_20:bigint, expr_21:varchar(25), expr_22:bigint, expr_23:varchar(152), name_33:varchar(25), comment_34:varchar(152)]                                                                
         - InnerJoin[("expr_22" = "regionkey_32")][$hashvalue, $hashvalue_74] => [expr_22:bigint, expr_23:varchar(152), expr_20:bigint, expr_21:varchar(25), comment_34:varchar(152), name_33:varchar(25)]   
             - RemoteSource[2,3] => [expr_22:bigint, expr_23:varchar(152), expr_20:bigint, expr_21:varchar(25), $hashvalue:bigint]                                                                           
             - LocalExchange[HASH][$hashvalue_74] ("regionkey_32") => regionkey_32:bigint, comment_34:varchar(152), name_33:varchar(25), $hashvalue_74:bigint                                                
                 - RemoteSource[4] => [regionkey_32:bigint, comment_34:varchar(152), name_33:varchar(25), $hashvalue_75:bigint]                                                                              
                                                                                                                                                                                                             
 Fragment 2 [SOURCE]                                                                                                                                                                                         
     Output layout: [regionkey, comment, nationkey, name, $hashvalue_72]                                                                                                                                     
     Output partitioning: ROUND_ROBIN []                                                                                                                                                                     
     - ScanProject[table = tpch:tpch:nation:sf0.01, originalConstraint = true] => [regionkey:bigint, comment:varchar(152), nationkey:bigint, name:varchar(25), $hashvalue_72:bigint]                         
             $hashvalue_72 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("regionkey"), 0))                                                                                                    
             nationkey := tpch:nationkey                                                                                                                                                                     
             name := tpch:name                                                                                                                                                                               
             regionkey := tpch:regionkey                                                                                                                                                                     
             comment := tpch:comment                                                                                                                                                                         
                                                                                                                                                                                                             
 Fragment 3 [SOURCE]                                                                                                                                                                                         
     Output layout: [regionkey_9, comment_10, nationkey_7, name_8, $hashvalue_73]                                                                                                                            
     Output partitioning: ROUND_ROBIN []                                                                                                                                                                     
     - ScanProject[table = tpch:tpch:nation:sf0.01, originalConstraint = true] => [regionkey_9:bigint, comment_10:varchar(152), nationkey_7:bigint, name_8:varchar(25), $hashvalue_73:bigint]                
             $hashvalue_73 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("regionkey_9"), 0))                                                                                                  
             nationkey_7 := tpch:nationkey                                                                                                                                                                   
             name_8 := tpch:name                                                                                                                                                                             
             regionkey_9 := tpch:regionkey                                                                                                                                                                   
             comment_10 := tpch:comment                                                                                                                                                                      
                                                                                                                                                                                                             
 Fragment 4 [SOURCE]                                                                                                                                                                                         
     Output layout: [regionkey_32, comment_34, name_33, $hashvalue_76]                                                                                                                                       
     Output partitioning: BROADCAST []                                                                                                                                                                       
     - ScanProject[table = tpch:tpch:region:sf0.01, originalConstraint = true] => [regionkey_32:bigint, comment_34:varchar(152), name_33:varchar(25), $hashvalue_76:bigint]                                  
             $hashvalue_76 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("regionkey_32"), 0))                                                                                                 
             regionkey_32 := tpch:regionkey                                                                                                                                                                  
             name_33 := tpch:name                                                                                                                                                                            
             comment_34 := tpch:comment      
```
and BEFORE change:
```
 Fragment 0 [SINGLE]                                                                                                                                                                                         
     Output layout: [expr_20, expr_21, expr_22, expr_23, expr_22, name_33, comment_34]                                                                                                                       
     Output partitioning: SINGLE []                                                                                                                                                                          
     - Output[nationkey, name, regionkey, comment, regionkey, name, comment] => [expr_20:bigint, expr_21:varchar(25), expr_22:bigint, expr_23:varchar(152), expr_22:bigint, name_33:varchar(25), comment_34:v
             nationkey := expr_20                                                                                                                                                                            
             name := expr_21                                                                                                                                                                                 
             regionkey := expr_22                                                                                                                                                                            
             comment := expr_23                                                                                                                                                                              
             regionkey := expr_22                                                                                                                                                                            
             name := name_33                                                                                                                                                                                 
             comment := comment_34                                                                                                                                                                           
         - Project[] => [expr_20:bigint, expr_21:varchar(25), expr_22:bigint, expr_23:varchar(152), name_33:varchar(25), comment_34:varchar(152)]                                                            
             - InnerJoin[("expr_22" = "regionkey_32")][$hashvalue, $hashvalue_74] => [expr_22:bigint, expr_23:varchar(152), expr_20:bigint, expr_21:varchar(25), comment_34:varchar(152), name_33:varchar(25)
                 - RemoteSource[1,2] => [expr_22:bigint, expr_23:varchar(152), expr_20:bigint, expr_21:varchar(25), $hashvalue:bigint]                                                                       
                 - LocalExchange[HASH][$hashvalue_74] ("regionkey_32") => regionkey_32:bigint, comment_34:varchar(152), name_33:varchar(25), $hashvalue_74:bigint                                            
                     - RemoteSource[3] => [regionkey_32:bigint, comment_34:varchar(152), name_33:varchar(25), $hashvalue_75:bigint]                                                                          
                                                                                                                                                                                                             
 Fragment 1 [SOURCE]                                                                                                                                                                                         
     Output layout: [regionkey, comment, nationkey, name, $hashvalue_72]                                                                                                                                     
     Output partitioning: SINGLE []                                                                                                                                                                          
     - ScanProject[table = tpch:tpch:nation:sf0.01, originalConstraint = true] => [regionkey:bigint, comment:varchar(152), nationkey:bigint, name:varchar(25), $hashvalue_72:bigint]                         
             $hashvalue_72 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("regionkey"), 0))                                                                                                    
             nationkey := tpch:nationkey                                                                                                                                                                     
             name := tpch:name                                                                                                                                                                               
             regionkey := tpch:regionkey                                                                                                                                                                     
             comment := tpch:comment                                                                                                                                                                         
                                                                                                                                                                                                             
 Fragment 2 [SOURCE]                                                                                                                                                                                         
     Output layout: [regionkey_9, comment_10, nationkey_7, name_8, $hashvalue_73]                                                                                                                            
     Output partitioning: SINGLE []                                                                                                                                                                          
     - ScanProject[table = tpch:tpch:nation:sf0.01, originalConstraint = true] => [regionkey_9:bigint, comment_10:varchar(152), nationkey_7:bigint, name_8:varchar(25), $hashvalue_73:bigint]                
             $hashvalue_73 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("regionkey_9"), 0))                                                                                                  
             nationkey_7 := tpch:nationkey                                                                                                                                                                   
             name_8 := tpch:name                                                                                                                                                                             
             regionkey_9 := tpch:regionkey                                                                                                                                                                   
             comment_10 := tpch:comment                                                                                                                                                                      
                                                                                                                                                                                                             
 Fragment 3 [SOURCE]                                                                                                                                                                                         
     Output layout: [regionkey_32, comment_34, name_33, $hashvalue_76]                                                                                                                                       
     Output partitioning: SINGLE []                                                                                                                                                                          
     - ScanProject[table = tpch:tpch:region:sf0.01, originalConstraint = true] => [regionkey_32:bigint, comment_34:varchar(152), name_33:varchar(25), $hashvalue_76:bigint]                                  
             $hashvalue_76 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("regionkey_32"), 0))                                                                                                 
             regionkey_32 := tpch:regionkey                                                                                                                                                                  
             name_33 := tpch:name                                                                                                                                                                            
             comment_34 := tpch:comment                                                                                                                                                                                                               
```