### PR TITLE
Introduce QueryOrderBy AST node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -77,6 +77,7 @@ import com.facebook.presto.sql.tree.JoinUsing;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.NaturalJoin;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
@@ -1251,7 +1252,9 @@ class StatementAnalyzer
             return legacyAnalyzeOrderBy(node, sourceScope, outputScope, outputExpressions);
         }
 
-        List<SortItem> items = node.getOrderBy();
+        List<SortItem> items = node.getOrderBy()
+                .map(OrderBy::getSortItems)
+                .orElse(emptyList());
 
         ImmutableList.Builder<Expression> orderByExpressionsBuilder = ImmutableList.builder();
 
@@ -1316,7 +1319,9 @@ class StatementAnalyzer
      */
     private List<Expression> legacyAnalyzeOrderBy(QuerySpecification node, Scope sourceScope, Scope outputScope, List<Expression> outputExpressions)
     {
-        List<SortItem> items = node.getOrderBy();
+        List<SortItem> items = node.getOrderBy()
+                .map(OrderBy::getSortItems)
+                .orElse(emptyList());
 
         ImmutableList.Builder<Expression> orderByExpressionsBuilder = ImmutableList.builder();
 
@@ -1708,8 +1713,8 @@ class StatementAnalyzer
                 .filter(SingleColumn.class::isInstance)
                 .forEach(extractor::process);
 
-        node.getOrderBy().stream()
-                .forEach(extractor::process);
+        node.getOrderBy().map(OrderBy::getSortItems).ifPresent(sortItems -> sortItems
+                .forEach(extractor::process));
 
         node.getHaving()
                 .ifPresent(extractor::process);
@@ -1862,7 +1867,9 @@ class StatementAnalyzer
 
     private void analyzeOrderBy(Query node, Scope scope)
     {
-        List<SortItem> items = node.getOrderBy();
+        List<SortItem> items = node.getOrderBy()
+                .map(OrderBy::getSortItems)
+                .orElse(emptyList());
 
         ImmutableList.Builder<Expression> orderByFieldsBuilder = ImmutableList.builder();
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
@@ -122,7 +122,7 @@ final class DescribeInputRewrite
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),
-                    ordering(ascending("Position")),
+                    Optional.of(ordering(ascending("Position"))),
                     limit
             );
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeOutputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeOutputRewrite.java
@@ -44,7 +44,6 @@ import static com.facebook.presto.sql.QueryUtil.row;
 import static com.facebook.presto.sql.QueryUtil.selectList;
 import static com.facebook.presto.sql.QueryUtil.simpleQuery;
 import static com.facebook.presto.sql.QueryUtil.values;
-import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 final class DescribeOutputRewrite
@@ -121,7 +120,7 @@ final class DescribeOutputRewrite
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),
-                    emptyList(),
+                    Optional.empty(),
                     limit);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -51,6 +51,7 @@ import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Relation;
@@ -207,7 +208,7 @@ final class ShowQueriesRewrite
                     selectList(aliasedName("schema_name", "Schema")),
                     from(node.getCatalog().orElseGet(() -> session.getCatalog().get()), TABLE_SCHEMATA),
                     predicate,
-                    ordering(ascending("schema_name")));
+                    Optional.of(ordering(ascending("schema_name"))));
         }
 
         @Override
@@ -227,7 +228,7 @@ final class ShowQueriesRewrite
                     selectList(new AllColumns()),
                     aliased(new Values(rows), "catalogs", ImmutableList.of("Catalog")),
                     predicate,
-                    ordering(ascending("Catalog")));
+                    Optional.of(ordering(ascending("Catalog"))));
         }
 
         @Override
@@ -344,7 +345,7 @@ final class ShowQueriesRewrite
                             equal(identifier("table_name"), new StringLiteral(table.getObjectName())))),
                     Optional.of(new GroupBy(false, ImmutableList.of(new SimpleGroupBy(ImmutableList.of(identifier("partition_number")))))),
                     Optional.empty(),
-                    ImmutableList.of(),
+                    Optional.empty(),
                     Optional.empty());
 
             return simpleQuery(
@@ -353,10 +354,10 @@ final class ShowQueriesRewrite
                     showPartitions.getWhere(),
                     Optional.empty(),
                     Optional.empty(),
-                    ImmutableList.<SortItem>builder()
+                    Optional.of(new OrderBy(ImmutableList.<SortItem>builder()
                             .addAll(showPartitions.getOrderBy())
                             .add(ascending("partition_number"))
-                            .build(),
+                            .build())),
                     showPartitions.getLimit());
         }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QueryBody;
@@ -140,9 +141,9 @@ public final class QueryUtil
         return new SingleColumn(new CoalesceExpression(identifier(column), new StringLiteral("")), alias);
     }
 
-    public static List<SortItem> ordering(SortItem... items)
+    public static OrderBy ordering(SortItem... items)
     {
-        return ImmutableList.copyOf(items);
+        return new OrderBy(ImmutableList.copyOf(items));
     }
 
     public static Query simpleQuery(Select select)
@@ -153,36 +154,36 @@ public final class QueryUtil
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                ImmutableList.of(),
+                Optional.empty(),
                 Optional.empty()));
     }
 
     public static Query simpleQuery(Select select, Relation from)
     {
-        return simpleQuery(select, from, Optional.empty(), ImmutableList.of());
+        return simpleQuery(select, from, Optional.empty(), Optional.empty());
     }
 
-    public static Query simpleQuery(Select select, Relation from, List<SortItem> ordering)
+    public static Query simpleQuery(Select select, Relation from, OrderBy orderBy)
     {
-        return simpleQuery(select, from, Optional.empty(), ordering);
+        return simpleQuery(select, from, Optional.empty(), Optional.of(orderBy));
     }
 
     public static Query simpleQuery(Select select, Relation from, Expression where)
     {
-        return simpleQuery(select, from, Optional.of(where), ImmutableList.of());
+        return simpleQuery(select, from, Optional.of(where), Optional.empty());
     }
 
-    public static Query simpleQuery(Select select, Relation from, Expression where, List<SortItem> ordering)
+    public static Query simpleQuery(Select select, Relation from, Expression where, OrderBy orderBy)
     {
-        return simpleQuery(select, from, Optional.of(where), ordering);
+        return simpleQuery(select, from, Optional.of(where), Optional.of(orderBy));
     }
 
-    public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, List<SortItem> ordering)
+    public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, Optional<OrderBy> orderBy)
     {
-        return simpleQuery(select, from, where, Optional.empty(), Optional.empty(), ordering, Optional.empty());
+        return simpleQuery(select, from, where, Optional.empty(), Optional.empty(), orderBy, Optional.empty());
     }
 
-    public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, Optional<GroupBy> groupBy, Optional<Expression> having, List<SortItem> ordering, Optional<String> limit)
+    public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, Optional<GroupBy> groupBy, Optional<Expression> having, Optional<OrderBy> orderBy, Optional<String> limit)
     {
         return query(new QuerySpecification(
                 select,
@@ -190,7 +191,7 @@ public final class QueryUtil
                 where,
                 groupBy,
                 having,
-                ordering,
+                orderBy,
                 limit));
     }
 
@@ -215,7 +216,7 @@ public final class QueryUtil
         return new Query(
                 Optional.empty(),
                 body,
-                ImmutableList.of(),
+                Optional.empty(),
                 Optional.empty());
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -50,6 +50,7 @@ import com.facebook.presto.sql.tree.JoinUsing;
 import com.facebook.presto.sql.tree.LikeClause;
 import com.facebook.presto.sql.tree.NaturalJoin;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
@@ -234,9 +235,8 @@ public final class SqlFormatter
 
             processRelation(node.getQueryBody(), indent);
 
-            if (!node.getOrderBy().isEmpty()) {
-                append(indent, "ORDER BY " + formatSortItems(node.getOrderBy(), parameters))
-                        .append('\n');
+            if (node.getOrderBy().isPresent()) {
+                process(node.getOrderBy().get(), indent);
             }
 
             if (node.getLimit().isPresent()) {
@@ -275,15 +275,22 @@ public final class SqlFormatter
                         .append('\n');
             }
 
-            if (!node.getOrderBy().isEmpty()) {
-                append(indent, "ORDER BY " + formatSortItems(node.getOrderBy(), parameters))
-                        .append('\n');
+            if (node.getOrderBy().isPresent()) {
+                process(node.getOrderBy().get(), indent);
             }
 
             if (node.getLimit().isPresent()) {
                 append(indent, "LIMIT " + node.getLimit().get())
                         .append('\n');
             }
+            return null;
+        }
+
+        @Override
+        protected Void visitOrderBy(OrderBy node, Integer indent)
+        {
+            append(indent, "ORDER BY " + formatSortItems(node.getSortItems(), parameters))
+                    .append('\n');
             return null;
         }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
@@ -33,6 +33,7 @@ import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
@@ -87,12 +88,9 @@ public class TreePrinter
 
                 print(indentLevel, "QueryBody");
                 process(node.getQueryBody(), indentLevel);
-
-                if (!node.getOrderBy().isEmpty()) {
+                if (node.getOrderBy().isPresent()) {
                     print(indentLevel, "OrderBy");
-                    for (SortItem sortItem : node.getOrderBy()) {
-                        process(sortItem, indentLevel + 1);
-                    }
+                    process(node.getOrderBy().get(), indentLevel + 1);
                 }
 
                 if (node.getLimit().isPresent()) {
@@ -164,15 +162,22 @@ public class TreePrinter
                     process(node.getHaving().get(), indentLevel + 1);
                 }
 
-                if (!node.getOrderBy().isEmpty()) {
+                if (node.getOrderBy().isPresent()) {
                     print(indentLevel, "OrderBy");
-                    for (SortItem sortItem : node.getOrderBy()) {
-                        process(sortItem, indentLevel + 1);
-                    }
+                    process(node.getOrderBy().get(), indentLevel + 1);
                 }
 
                 if (node.getLimit().isPresent()) {
                     print(indentLevel, "Limit: " + node.getLimit().get());
+                }
+
+                return null;
+            }
+
+            protected Void visitOrderBy(OrderBy node, Integer indentLevel)
+            {
+                for (SortItem sortItem : node.getSortItems()) {
+                    process(sortItem, indentLevel);
                 }
 
                 return null;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -92,6 +92,7 @@ import com.facebook.presto.sql.tree.NodeLocation;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullIfExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -437,6 +438,11 @@ class AstBuilder
     {
         QueryBody term = (QueryBody) visit(context.queryTerm());
 
+        Optional<OrderBy> orderBy = Optional.empty();
+        if (context.ORDER() != null) {
+            orderBy = Optional.of(new OrderBy(getLocation(context.ORDER()), visit(context.sortItem(), SortItem.class)));
+        }
+
         if (term instanceof QuerySpecification) {
             // When we have a simple query specification
             // followed by order by limit, fold the order by and limit
@@ -455,9 +461,9 @@ class AstBuilder
                             query.getWhere(),
                             query.getGroupBy(),
                             query.getHaving(),
-                            visit(context.sortItem(), SortItem.class),
+                            orderBy,
                             getTextIfPresent(context.limit)),
-                    ImmutableList.of(),
+                    Optional.empty(),
                     Optional.empty());
         }
 
@@ -465,7 +471,7 @@ class AstBuilder
                 getLocation(context),
                 Optional.empty(),
                 term,
-                visit(context.sortItem(), SortItem.class),
+                orderBy,
                 getTextIfPresent(context.limit));
     }
 
@@ -495,7 +501,7 @@ class AstBuilder
                 visitIfPresent(context.where, Expression.class),
                 visitIfPresent(context.groupBy(), GroupBy.class),
                 visitIfPresent(context.having, Expression.class),
-                ImmutableList.of(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -217,6 +217,11 @@ public abstract class AstVisitor<R, C>
         return visitRelation(node, context);
     }
 
+    protected R visitOrderBy(OrderBy node, C context)
+    {
+        return visitNode(node, context);
+    }
+
     protected R visitQuerySpecification(QuerySpecification node, C context)
     {
         return visitQueryBody(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -104,8 +104,8 @@ public abstract class DefaultTraversalVisitor<R, C>
             process(node.getWith().get(), context);
         }
         process(node.getQueryBody(), context);
-        for (SortItem sortItem : node.getOrderBy()) {
-            process(sortItem, context);
+        if (node.getOrderBy().isPresent()) {
+            process(node.getOrderBy().get(), context);
         }
 
         return null;
@@ -339,6 +339,15 @@ public abstract class DefaultTraversalVisitor<R, C>
     }
 
     @Override
+    protected R visitOrderBy(OrderBy node, C context)
+    {
+        for (SortItem sortItem : node.getSortItems()) {
+            process(sortItem, context);
+        }
+        return null;
+    }
+
+    @Override
     protected R visitSortItem(SortItem node, C context)
     {
         return process(node.getSortKey(), context);
@@ -360,8 +369,8 @@ public abstract class DefaultTraversalVisitor<R, C>
         if (node.getHaving().isPresent()) {
             process(node.getHaving().get(), context);
         }
-        for (SortItem sortItem : node.getOrderBy()) {
-            process(sortItem, context);
+        if (node.getOrderBy().isPresent()) {
+            process(node.getOrderBy().get(), context);
         }
         return null;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/OrderBy.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/OrderBy.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class OrderBy
+        extends Node
+{
+    private final List<SortItem> sortItems;
+
+    public OrderBy(List<SortItem> sortItems)
+    {
+        this(Optional.empty(), sortItems);
+    }
+
+    public OrderBy(NodeLocation location, List<SortItem> sortItems)
+    {
+        this(Optional.of(location), sortItems);
+    }
+
+    private OrderBy(Optional<NodeLocation> location, List<SortItem> sortItems)
+    {
+        super(location);
+        requireNonNull(sortItems, "sortItems is null");
+        checkArgument(!sortItems.isEmpty(), "sortItems should not be empty");
+        this.sortItems = ImmutableList.copyOf(sortItems);
+    }
+
+    public List<SortItem> getSortItems()
+    {
+        return sortItems;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitOrderBy(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return sortItems;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("sortItems", sortItems)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        OrderBy o = (OrderBy) obj;
+        return Objects.equals(sortItems, o.sortItems);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sortItems);
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Query.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Query.java
@@ -27,13 +27,13 @@ public class Query
 {
     private final Optional<With> with;
     private final QueryBody queryBody;
-    private final List<SortItem> orderBy;
+    private final Optional<OrderBy> orderBy;
     private final Optional<String> limit;
 
     public Query(
             Optional<With> with,
             QueryBody queryBody,
-            List<SortItem> orderBy,
+            Optional<OrderBy> orderBy,
             Optional<String> limit)
     {
         this(Optional.empty(), with, queryBody, orderBy, limit);
@@ -43,7 +43,7 @@ public class Query
             NodeLocation location,
             Optional<With> with,
             QueryBody queryBody,
-            List<SortItem> orderBy,
+            Optional<OrderBy> orderBy,
             Optional<String> limit)
     {
         this(Optional.of(location), with, queryBody, orderBy, limit);
@@ -53,7 +53,7 @@ public class Query
             Optional<NodeLocation> location,
             Optional<With> with,
             QueryBody queryBody,
-            List<SortItem> orderBy,
+            Optional<OrderBy> orderBy,
             Optional<String> limit)
     {
         super(location);
@@ -78,7 +78,7 @@ public class Query
         return queryBody;
     }
 
-    public List<SortItem> getOrderBy()
+    public Optional<OrderBy> getOrderBy()
     {
         return orderBy;
     }
@@ -99,9 +99,9 @@ public class Query
     {
         ImmutableList.Builder<Node> nodes = ImmutableList.builder();
         with.ifPresent(nodes::add);
-        return nodes.add(queryBody)
-                .addAll(orderBy)
-                .build();
+        nodes.add(queryBody);
+        orderBy.ifPresent(nodes::add);
+        return nodes.build();
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QuerySpecification.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QuerySpecification.java
@@ -30,7 +30,7 @@ public class QuerySpecification
     private final Optional<Expression> where;
     private final Optional<GroupBy> groupBy;
     private final Optional<Expression> having;
-    private final List<SortItem> orderBy;
+    private final Optional<OrderBy> orderBy;
     private final Optional<String> limit;
 
     public QuerySpecification(
@@ -39,7 +39,7 @@ public class QuerySpecification
             Optional<Expression> where,
             Optional<GroupBy> groupBy,
             Optional<Expression> having,
-            List<SortItem> orderBy,
+            Optional<OrderBy> orderBy,
             Optional<String> limit)
     {
         this(Optional.empty(), select, from, where, groupBy, having, orderBy, limit);
@@ -52,7 +52,7 @@ public class QuerySpecification
             Optional<Expression> where,
             Optional<GroupBy> groupBy,
             Optional<Expression> having,
-            List<SortItem> orderBy,
+            Optional<OrderBy> orderBy,
             Optional<String> limit)
     {
         this(Optional.of(location), select, from, where, groupBy, having, orderBy, limit);
@@ -65,7 +65,7 @@ public class QuerySpecification
             Optional<Expression> where,
             Optional<GroupBy> groupBy,
             Optional<Expression> having,
-            List<SortItem> orderBy,
+            Optional<OrderBy> orderBy,
             Optional<String> limit)
     {
         super(location);
@@ -111,7 +111,7 @@ public class QuerySpecification
         return having;
     }
 
-    public List<SortItem> getOrderBy()
+    public Optional<OrderBy> getOrderBy()
     {
         return orderBy;
     }
@@ -136,7 +136,7 @@ public class QuerySpecification
         where.ifPresent(nodes::add);
         groupBy.ifPresent(nodes::add);
         having.ifPresent(nodes::add);
-        nodes.addAll(orderBy);
+        orderBy.ifPresent(nodes::add);
         return nodes.build();
     }
 

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -74,6 +74,7 @@ import com.facebook.presto.sql.tree.NaturalJoin;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -410,7 +411,7 @@ public class TestSqlParser
                                 new Intersect(ImmutableList.of(createSelect123(), createSelect123()), true),
                                 createSelect123()
                         ), false),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -424,7 +425,7 @@ public class TestSqlParser
                                 new Union(ImmutableList.of(createSelect123(), createSelect123()), true),
                                 createSelect123()
                         ), false),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -436,7 +437,7 @@ public class TestSqlParser
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                ImmutableList.of(),
+                Optional.empty(),
                 Optional.empty()
         );
     }
@@ -462,7 +463,7 @@ public class TestSqlParser
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.of("ALL")));
     }
 
@@ -854,9 +855,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement(format("SELECT substring('%s' FROM 2 FOR 3)", givenString),
@@ -868,9 +869,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -887,9 +888,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement(format("SELECT substring('%s', 2, 3)", givenString),
@@ -901,9 +902,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -924,9 +925,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT col1.f1[0], col2, col3[2].f2.f3, col4[4] FROM table1",
@@ -943,9 +944,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT CAST(ROW(11, 12) AS ROW(COL0 INTEGER, COL1 INTEGER)).col0",
@@ -959,9 +960,28 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
+                        Optional.empty()));
+    }
+
+    @Test
+    public void testSelectWithOrderBy()
+            throws Exception
+    {
+        assertStatement("SELECT * FROM table1 ORDER BY a",
+                new Query(
+                        Optional.empty(),
+                        new QuerySpecification(
+                                selectList(new AllColumns()),
+                                Optional.of(new Table(QualifiedName.of("table1"))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(new OrderBy(ImmutableList.of(new SortItem(new Identifier("a"), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)))),
+                                Optional.empty()),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -978,9 +998,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.of(new GroupBy(false, ImmutableList.of(new SimpleGroupBy(ImmutableList.of(new Identifier("a")))))),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT * FROM table1 GROUP BY a, b",
@@ -994,9 +1014,9 @@ public class TestSqlParser
                                         new SimpleGroupBy(ImmutableList.of(new Identifier("a"))),
                                         new SimpleGroupBy(ImmutableList.of(new Identifier("b")))))),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT * FROM table1 GROUP BY ()",
@@ -1008,9 +1028,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.of(new GroupBy(false, ImmutableList.of(new SimpleGroupBy(ImmutableList.of())))),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT * FROM table1 GROUP BY GROUPING SETS (a)",
@@ -1022,9 +1042,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.of(new GroupBy(false, ImmutableList.of(new GroupingSets(ImmutableList.of(ImmutableList.of(QualifiedName.of("a"))))))),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT * FROM table1 GROUP BY ALL GROUPING SETS ((a, b), (a), ()), CUBE (c), ROLLUP (d)",
@@ -1042,9 +1062,9 @@ public class TestSqlParser
                                         new Cube(ImmutableList.of(QualifiedName.of("c"))),
                                         new Rollup(ImmutableList.of(QualifiedName.of("d")))))),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT * FROM table1 GROUP BY DISTINCT GROUPING SETS ((a, b), (a), ()), CUBE (c), ROLLUP (d)",
@@ -1062,9 +1082,9 @@ public class TestSqlParser
                                         new Cube(ImmutableList.of(QualifiedName.of("c"))),
                                         new Rollup(ImmutableList.of(QualifiedName.of("d")))))),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -1334,14 +1354,14 @@ public class TestSqlParser
                         new WithQuery("a", simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("x"))), Optional.of(ImmutableList.of("t", "u"))),
                         new WithQuery("b", simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("y"))), Optional.empty())))),
                         new Table(QualifiedName.of("z")),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("WITH RECURSIVE a AS (SELECT * FROM x) TABLE y",
                 new Query(Optional.of(new With(true, ImmutableList.of(
                         new WithQuery("a", simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("x"))), Optional.empty())))),
                         new Table(QualifiedName.of("y")),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -1515,9 +1535,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -1691,9 +1711,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryRewriter.java
@@ -163,10 +163,10 @@ public class QueryRewriter
                     querySpecification.getOrderBy(),
                     Optional.of("0"));
 
-            zeroRowsQuery = new com.facebook.presto.sql.tree.Query(createSelectClause.getWith(), innerQuery, ImmutableList.of(), Optional.empty());
+            zeroRowsQuery = new com.facebook.presto.sql.tree.Query(createSelectClause.getWith(), innerQuery, Optional.empty(), Optional.empty());
         }
         else {
-            zeroRowsQuery = new com.facebook.presto.sql.tree.Query(createSelectClause.getWith(), innerQuery, ImmutableList.of(), Optional.of("0"));
+            zeroRowsQuery = new com.facebook.presto.sql.tree.Query(createSelectClause.getWith(), innerQuery, Optional.empty(), Optional.of("0"));
         }
 
         ImmutableList.Builder<Column> columns = ImmutableList.builder();
@@ -199,7 +199,7 @@ public class QueryRewriter
         }
 
         Select select = new Select(false, selectItems.build());
-        return formatSql(new QuerySpecification(select, Optional.of(new Table(table)), Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of(), Optional.empty()), Optional.empty());
+        return formatSql(new QuerySpecification(select, Optional.of(new Table(table)), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()), Optional.empty());
     }
 
     private static String dropTableSql(QualifiedName table)
@@ -210,7 +210,7 @@ public class QueryRewriter
     public static class QueryRewriteException
             extends Exception
     {
-        public QueryRewriteException(String messageFormat, Object...args)
+        public QueryRewriteException(String messageFormat, Object... args)
         {
             super(format(messageFormat, args));
         }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/TestShadowing.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/TestShadowing.java
@@ -83,8 +83,8 @@ public class TestShadowing
         SingleColumn column1 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new Identifier("column1"))));
         SingleColumn column2 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new FunctionCall(QualifiedName.of("round"), ImmutableList.of(new Identifier("column2"), new LongLiteral("1"))))));
         Select select = new Select(false, ImmutableList.of(column1, column2));
-        QuerySpecification querySpecification = new QuerySpecification(select, Optional.of(table), Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of(), Optional.empty());
-        assertEquals(parser.createStatement(rewrittenQuery.getQuery()), new com.facebook.presto.sql.tree.Query(Optional.empty(), querySpecification, ImmutableList.of(), Optional.empty()));
+        QuerySpecification querySpecification = new QuerySpecification(select, Optional.of(table), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        assertEquals(parser.createStatement(rewrittenQuery.getQuery()), new com.facebook.presto.sql.tree.Query(Optional.empty(), querySpecification, Optional.empty(), Optional.empty()));
 
         assertEquals(parser.createStatement(rewrittenQuery.getPostQueries().get(0)), new DropTable(createTableAs.getName(), true));
     }


### PR DESCRIPTION
QueryOrderBy node enables specifying a separate
scope for sort expressions

FYI: @martint This PR shows the approach, next will follow