### PR TITLE
Fix cumulative memory counter to track query memory

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -334,12 +334,12 @@ public class TaskContext
 
         synchronized (cumulativeMemoryLock) {
             double sinceLastPeriodMillis = (System.nanoTime() - lastTaskStatCallNanos) / 1_000_000.0;
-            long currentSystemMemory = systemMemoryReservation.get();
-            long averageMemoryForLastPeriod = (currentSystemMemory + lastMemoryReservation) / 2;
+            long currentMemory = memoryReservation.get();
+            long averageMemoryForLastPeriod = (currentMemory + lastMemoryReservation) / 2;
             cumulativeMemory.addAndGet(averageMemoryForLastPeriod * sinceLastPeriodMillis);
 
             lastTaskStatCallNanos = System.nanoTime();
-            lastMemoryReservation = currentSystemMemory;
+            lastMemoryReservation = currentMemory;
         }
 
         boolean fullyBlocked = pipelineStats.stream()


### PR DESCRIPTION
Previously, this counter tracked system memory, which is incorrect.

Fixes #6442.