### PR TITLE
[WIP] Dynamically adjust the number of worker threads

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/PidTaskExecutorController.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/PidTaskExecutorController.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class PidTaskExecutorController
+        implements TaskExectorController
+{
+    private final PidController controller;
+    private final double target;
+
+    public PidTaskExecutorController(double target, int minValue, int maxValue, double kp, double ki, double kd)
+    {
+        checkArgument(minValue > 0, "minValue must be greater than 0");
+        checkArgument(minValue <= maxValue, "minValue must be less than maxValue");
+        checkArgument(target >= 0 && target <= 1, "target must be in range of [0, 1]");
+
+        this.target = target;
+        this.controller = new PidController(minValue, maxValue, target, kp, ki, kd);
+    }
+
+    @Override
+    public int getNextRunnerThreads(TaskExecutor.TaskExectorStat stat)
+    {
+        if (stat != null && stat.getWallTime().getValue(TimeUnit.SECONDS) >= 0.05) {
+            double cpuUtilization = stat.getCpuUtilization();
+            if (stat.getTotalSplits() <= stat.getRunnerThreads()) {
+                cpuUtilization = Math.max(target, cpuUtilization);
+            }
+            controller.feedValue(cpuUtilization, stat.getWallTime().getValue(TimeUnit.SECONDS));
+        }
+        return (int) controller.getInput();
+    }
+
+    @VisibleForTesting
+    static class PidController
+    {
+        private final double minValue;
+        private final double maxValue;
+        private final double target;
+        private final double kp;
+        private final double ki;
+        private final double kd;
+
+        private double ratio;
+        private double integralValue;
+        private double lastError;
+
+        PidController(double minValue, double maxValue, double target, double kp, double ki, double kd)
+        {
+            this.lastError = 0;
+            this.target = target;
+            this.minValue = minValue;
+            this.maxValue = maxValue;
+
+            this.kp = kp;
+            this.ki = ki;
+            this.kd = kd;
+        }
+
+        public void feedValue(double value, double dt)
+        {
+            double error = target - value;
+
+            ratio = kp * error + ki * (integralValue + error * dt) + kd * (error - lastError) / dt;
+            System.out.println((minValue + (maxValue - minValue) * ratio) + ", error => " + error + ", target => " + target + ", current =>" + value + ", integration => " + integralValue);
+
+            // Do integration if and only if the generated value is within the allowed range
+            if (ratio <= 1 && ratio >= 0) {
+                integralValue += error * dt;
+            }
+            lastError = error;
+        }
+
+        public double getInput()
+        {
+            return Math.min(maxValue, Math.max(minValue, minValue + (maxValue - minValue) * ratio));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/StaticTaskExecutorController.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StaticTaskExecutorController.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class StaticTaskExecutorController
+        implements TaskExectorController
+{
+    private final int runnerThreads;
+
+    public StaticTaskExecutorController(int maxWorkerThreads)
+    {
+        checkArgument(maxWorkerThreads > 0, "maxWorkerThreads must be greater than 0");
+        this.runnerThreads = maxWorkerThreads;
+    }
+
+    @Override
+    public int getNextRunnerThreads(TaskExecutor.TaskExectorStat stat)
+    {
+        return runnerThreads;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskExectorController.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskExectorController.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+public interface TaskExectorController
+{
+    int getNextRunnerThreads(TaskExecutor.TaskExectorStat stat);
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -44,9 +44,12 @@ public class TaskManagerConfig
     private DataSize maxIndexMemoryUsage = new DataSize(64, Unit.MEGABYTE);
     private boolean shareIndexLoading;
     private int maxWorkerThreads = Runtime.getRuntime().availableProcessors() * 2;
+    private Integer minWorkerThreads;
     private Integer minDrivers;
     private Integer initialSplitsPerNode;
+    private Duration workerThreadsAdjustmentInterval = new Duration(1000, TimeUnit.MILLISECONDS);
     private Duration splitConcurrencyAdjustmentInterval = new Duration(100, TimeUnit.MILLISECONDS);
+    private double targetCpuUtilization = 0.8;
 
     private DataSize sinkMaxBufferSize = new DataSize(32, Unit.MEGABYTE);
     private DataSize maxPagePartitioningBufferSize = new DataSize(32, Unit.MEGABYTE);
@@ -169,6 +172,47 @@ public class TaskManagerConfig
     public TaskManagerConfig setMaxWorkerThreads(int maxWorkerThreads)
     {
         this.maxWorkerThreads = maxWorkerThreads;
+        return this;
+    }
+
+    @Min(1)
+    public int getMinWorkerThreads()
+    {
+        if (minWorkerThreads == null) {
+            return maxWorkerThreads;
+        }
+        return minWorkerThreads;
+    }
+
+    @Config("task.min-worker-threads")
+    public TaskManagerConfig setMinWorkerThreads(int minWorkerThreads)
+    {
+        this.minWorkerThreads = minWorkerThreads;
+        return this;
+    }
+
+    public double getTargetCpuUtilization()
+    {
+        return targetCpuUtilization;
+    }
+
+    @Config("task.target-cpu-utilization")
+    public TaskManagerConfig setTargetCpuUtilization(double targetCpuUtilization)
+    {
+        this.targetCpuUtilization = targetCpuUtilization;
+        return this;
+    }
+
+    @MinDuration("500ms")
+    public Duration getWorkerThreadsAdjustmentInterval()
+    {
+        return workerThreadsAdjustmentInterval;
+    }
+
+    @Config("task.worker-threads-adjustment-interval")
+    public TaskManagerConfig setWorkerThreadsAdjustmentInterval(Duration workerThreadsAdjustmentInterval)
+    {
+        this.workerThreadsAdjustmentInterval = workerThreadsAdjustmentInterval;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -177,7 +177,10 @@ public class TestingPrestoServer
                 .put("presto.version", "testversion")
                 .put("http-client.max-threads", "16")
                 .put("task.concurrency", "4")
-                .put("task.max-worker-threads", "4")
+                .put("task.max-worker-threads", "8")
+                .put("task.min-worker-threads", "2")
+                .put("task.min-drivers", "8")
+                .put("task.initial-splits-per-node", "4")
                 .put("exchange.client-threads", "4");
 
         if (!properties.containsKey("query.max-memory-per-node")) {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskExecutorSimulator.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskExecutorSimulator.java
@@ -70,7 +70,7 @@ public class TaskExecutorSimulator
     {
         executor = listeningDecorator(newCachedThreadPool(threadsNamed(getClass().getSimpleName() + "-%s")));
 
-        taskExecutor = new TaskExecutor(24, 48, new Ticker()
+        taskExecutor = new TaskExecutor(new StaticTaskExecutorController(24), new Duration(1, TimeUnit.SECONDS), 48, new Ticker()
         {
             private final long start = System.nanoTime();
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestPidTaskExecutorController.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestPidTaskExecutorController.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.execution.PidTaskExecutorController.PidController;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestPidTaskExecutorController
+{
+    @Test
+    public void testLinearFunction1()
+    {
+        double targetInput = 37.37;
+        Function<Double, Double> function = createLinearFunction(23.23, 123.0);
+        double targetOutput = function.apply(targetInput);
+
+        PidController controller = new PidController(-10, 100, targetOutput, 0.0001, 0.0001, 0.00005);
+        doTestFunction(controller, targetInput, function);
+    }
+
+    @Test
+    public void testLinearFunction2()
+    {
+        double targetInput = 99.99;
+        Function<Double, Double> function = createLinearFunction(3.81, -123.0);
+        double targetOutput = function.apply(targetInput);
+
+        PidController controller = new PidController(0, 120, targetOutput, 0.0005, 0.0005, 0.00005);
+        doTestFunction(controller, targetInput, function);
+    }
+
+    @Test
+    public void testLinearCombinedFunctions()
+    {
+        double targetInput = 99.99;
+        Function<Double, Double> function = createLinearFunction(3.81, -123.0);
+        double targetOutput = function.apply(targetInput);
+
+        PidController controller = new PidController(0, 100, targetOutput, 0.0002, 0.0002, 0.00000001);
+        doTestFunction(controller, targetInput, function);
+
+        // balance condition changed
+        function = createLinearFunction(23.23, 123.0);
+        targetInput = solveLinearFunction(23.23, 123.0, targetOutput);
+        doTestFunction(controller, targetInput, function);
+    }
+
+    @Test
+    public void testQuadraticFunction()
+    {
+        double targetInput = 9.5;
+        Function<Double, Double> function = createQuadraticFunction(-1, 20, 0);
+        double targetOutput = function.apply(targetInput);
+
+        PidController controller = new PidController(5, 30, targetOutput, 0.003, 0.003, 0.00003);
+        doTestFunction(controller, targetInput, function);
+    }
+
+    private void doTestFunction(PidController controller, double expected, Function<Double, Double> function)
+    {
+        Random random = new Random(0);
+        double input = controller.getInput();
+        for (int i = 0; i < 100; i++) {
+            double seconds = random.nextDouble() / 5 + 0.9;
+            //System.out.println(input);
+            controller.feedValue(function.apply(input), seconds);
+            input = controller.getInput();
+        }
+        assertEquals(input, expected, 0.1);
+    }
+
+    @Test
+    public void testPidTaskExectorController()
+    {
+        Random random = new Random(0);
+        PidTaskExecutorController controller = new PidTaskExecutorController(0.8, 10, 150, 0.1, 0.1, 0.1);
+        int input = controller.getNextRunnerThreads(null);
+        for (int i = 0; i < 100; i++) {
+            input = controller.getNextRunnerThreads(createTaskExectorStat(random, input, Integer.MAX_VALUE));
+        }
+        assertEquals(input, 59.02, 3);
+    }
+
+    private static TaskExecutor.TaskExectorStat createTaskExectorStat(Random random, int value, int splits)
+    {
+        // value < 50, output = 0.012 * value + 0.1, output will be below 0.7
+        // 50 <= value < 90, output = -0.00015625 * (90 - value)^2 + 0.95, output will be between 0.7 and 0.95
+        // value >= 90, output = 0.93 + random(0.04), output will be between 0.93 and 0.97
+        double output = 0.012 * value + 0.1;
+        if (50 <= value && value < 90) {
+            output = 0.95 - 0.00015625 * (90 - value) * (90 - value);
+        }
+        else if (value >= 90) {
+            output = 0.93 + random.nextDouble() / 25.0;
+        }
+        double randomSeconds = random.nextDouble() / 5 + 0.9;
+        return new TaskExecutor.TaskExectorStat(
+                new Duration(output * randomSeconds * Runtime.getRuntime().availableProcessors(), TimeUnit.SECONDS),
+                new Duration(randomSeconds, TimeUnit.SECONDS),
+                (int) value,
+                splits);
+    }
+
+    private static Function<Double, Double> createLinearFunction(double a, double b)
+    {
+        return x -> a * x + b;
+    }
+
+    private static double solveLinearFunction(double a, double b, double output)
+    {
+        return (output - b) / a;
+    }
+
+    private static Function<Double, Double> createQuadraticFunction(double a, double b, double c)
+    {
+        return x -> a * x * x + b * x + c;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.json.ObjectMapperProvider;
 import io.airlift.node.NodeInfo;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -77,7 +78,7 @@ public class TestSqlTask
 
     public TestSqlTask()
     {
-        taskExecutor = new TaskExecutor(8, 16);
+        taskExecutor = new TaskExecutor(new StaticTaskExecutorController(8), new Duration(1, SECONDS), 16);
         taskExecutor.start();
 
         taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -67,7 +67,7 @@ public class TestSqlTaskManager
     public TestSqlTaskManager()
     {
         localMemoryManager = new LocalMemoryManager(new NodeMemoryConfig(), new ReservedSystemMemoryConfig());
-        taskExecutor = new TaskExecutor(8, 16);
+        taskExecutor = new TaskExecutor(new StaticTaskExecutorController(8), new Duration(1, TimeUnit.SECONDS), 16);
         taskExecutor.start();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskExecutor.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskExecutor.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 
 public class TestTaskExecutor
@@ -36,7 +37,7 @@ public class TestTaskExecutor
             throws Exception
     {
         TestingTicker ticker = new TestingTicker();
-        TaskExecutor taskExecutor = new TaskExecutor(4, 8, ticker);
+        TaskExecutor taskExecutor = new TaskExecutor(new StaticTaskExecutorController(4), new Duration(1, SECONDS), 8, ticker);
         taskExecutor.start();
         ticker.increment(20, MILLISECONDS);
 
@@ -128,7 +129,7 @@ public class TestTaskExecutor
     public void testTaskHandle()
             throws Exception
     {
-        TaskExecutor taskExecutor = new TaskExecutor(4, 8);
+        TaskExecutor taskExecutor = new TaskExecutor(new StaticTaskExecutorController(4), new Duration(1, SECONDS), 8);
         taskExecutor.start();
 
         try {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -39,6 +39,7 @@ public class TestTaskManagerConfig
                 .setVerboseStats(false)
                 .setTaskCpuTimerEnabled(true)
                 .setMaxWorkerThreads(Runtime.getRuntime().availableProcessors() * 2)
+                .setMinWorkerThreads(Runtime.getRuntime().availableProcessors() * 2)
                 .setMinDrivers(Runtime.getRuntime().availableProcessors() * 2 * 2)
                 .setInfoMaxAge(new Duration(15, TimeUnit.MINUTES))
                 .setClientTimeout(new Duration(2, TimeUnit.MINUTES))
@@ -51,7 +52,9 @@ public class TestTaskManagerConfig
                 .setTaskConcurrency(16)
                 .setHttpResponseThreads(100)
                 .setHttpTimeoutThreads(3)
-                .setTaskNotificationThreads(5));
+                .setTaskNotificationThreads(5)
+                .setTargetCpuUtilization(0.8)
+                .setWorkerThreadsAdjustmentInterval(new Duration(1, TimeUnit.SECONDS)));
     }
 
     @Test
@@ -68,6 +71,7 @@ public class TestTaskManagerConfig
                 .put("task.share-index-loading", "true")
                 .put("task.max-partial-aggregation-memory", "32MB")
                 .put("task.max-worker-threads", "3")
+                .put("task.min-worker-threads", "1")
                 .put("task.min-drivers", "2")
                 .put("task.info.max-age", "22m")
                 .put("task.client.timeout", "10s")
@@ -78,6 +82,8 @@ public class TestTaskManagerConfig
                 .put("task.http-response-threads", "4")
                 .put("task.http-timeout-threads", "10")
                 .put("task.task-notification-threads", "13")
+                .put("task.target-cpu-utilization", "0.45")
+                .put("task.worker-threads-adjustment-interval", "2s")
                 .build();
 
         TaskManagerConfig expected = new TaskManagerConfig()
@@ -91,6 +97,7 @@ public class TestTaskManagerConfig
                 .setShareIndexLoading(true)
                 .setMaxPartialAggregationMemoryUsage(new DataSize(32, Unit.MEGABYTE))
                 .setMaxWorkerThreads(3)
+                .setMinWorkerThreads(1)
                 .setMinDrivers(2)
                 .setInfoMaxAge(new Duration(22, TimeUnit.MINUTES))
                 .setClientTimeout(new Duration(10, TimeUnit.SECONDS))
@@ -100,7 +107,9 @@ public class TestTaskManagerConfig
                 .setTaskConcurrency(8)
                 .setHttpResponseThreads(4)
                 .setHttpTimeoutThreads(10)
-                .setTaskNotificationThreads(13);
+                .setTaskNotificationThreads(13)
+                .setTargetCpuUtilization(0.45)
+                .setWorkerThreadsAdjustmentInterval(new Duration(2, TimeUnit.SECONDS));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Resolves #6005

Use PID controller to adjust the number of worker threads to align the target cpu utilization.

Two more configuration options:
```
task.min-worker-threads
task.target-cpu-utilization
```
`task.min-worker-threads` is default to `task.max-worker-threads`. When 
```task.min-worker-threads == task.max-worker-threads```,
 PID controller is disabled and the thread number will not change. Otherwise, PID controller is enabled and will adjust the number of worker threads between `task.min-worker-threads` and `task.max-worker-threads` according to the `task.target-cpu-utilization`.

As for the internal PID parameters, we don't make them configurable for users in this PR, but will consider exposing them in the future if needed.