### PR TITLE
Optimize sort node whose input is already sorted.

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/Matcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/Matcher.java
@@ -25,7 +25,7 @@ public interface Matcher
      * should be limited to tests that validate the type of the node or
      * attributes of that type.
      * <p>
-     * Matchers that can be applied to nodes of any typeshould return true from
+     * Matchers that can be applied to nodes of any type should return true from
      * shapeMatches and do the rest of their work in detailMatches.
      *
      * @param node The node to apply the matching tests to

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.facebook.presto.sql.planner.plan.SortNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
@@ -176,6 +177,11 @@ public final class PlanMatchPattern
         assignments.entrySet().forEach(
                 assignment -> result.withAlias(assignment.getKey(), new WindowFunctionMatcher(assignment.getValue())));
         return result;
+    }
+
+    public static PlanMatchPattern sort(PlanMatchPattern source)
+    {
+        return node(SortNode.class, source);
     }
 
     public static PlanMatchPattern output(PlanMatchPattern source)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
+import com.facebook.presto.sql.planner.assertions.PlanAssert;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.specification;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.window;
+
+public class TestEliminateSorts
+        extends BasePlanTest
+{
+    private static final String QUANTITY_ALIAS = "QUANTITY";
+
+    private static final ExpectedValueProvider<WindowNode.Specification> windowSpec = specification(
+            ImmutableList.of(),
+            ImmutableList.of(QUANTITY_ALIAS),
+            ImmutableMap.of(QUANTITY_ALIAS, SortOrder.ASC_NULLS_LAST));
+
+    private static final PlanMatchPattern LINEITEM_TABLESCAN_Q = tableScan(
+            "lineitem",
+            ImmutableMap.of(QUANTITY_ALIAS, "quantity"));
+
+    @Test
+    public void testEliminateSorts()
+    {
+        @Language("SQL") String sql = "SELECT quantity, row_number() OVER (ORDER BY quantity) FROM lineitem ORDER BY quantity";
+
+        PlanMatchPattern pattern =
+                output(
+                        window(windowSpec,
+                                ImmutableList.of(functionCall("row_number", Optional.empty(), ImmutableList.of())),
+                                anyTree(LINEITEM_TABLESCAN_Q)));
+
+        assertUnitPlan(sql, pattern);
+    }
+
+    @Test
+    public void testNotEliminateSorts()
+    {
+        @Language("SQL") String sql = "SELECT quantity, row_number() OVER (ORDER BY quantity) FROM lineitem ORDER BY tax";
+
+        PlanMatchPattern pattern =
+                anyTree(
+                        sort(
+                                project(window(windowSpec,
+                                        ImmutableList.of(functionCall("row_number", Optional.empty(), ImmutableList.of())),
+                                        anyTree(LINEITEM_TABLESCAN_Q)))));
+
+        assertUnitPlan(sql, pattern);
+    }
+
+    public void assertUnitPlan(@Language("SQL") String sql, PlanMatchPattern pattern)
+    {
+        LocalQueryRunner queryRunner = getQueryRunner();
+        List<PlanOptimizer> optimizers = ImmutableList.of(
+                new UnaliasSymbolReferences(),
+                new AddExchanges(queryRunner.getMetadata(), new SqlParser()),
+                new PruneUnreferencedOutputs(),
+                new PruneIdentityProjections()
+        );
+
+        queryRunner.inTransaction(transactionSession -> {
+            Plan actualPlan = queryRunner.createPlan(transactionSession, sql, optimizers);
+            PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), actualPlan, pattern);
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
Work in progress, some thoughts:

1. Refactor/merge with some code that checks the sort ordering? (e.g. refactor into a method `meetsSortRequirements`?

2. Adding test cases.

Some initial tests:
- Sort is eliminated:
```
presto:tiny> explain SELECT linenumber, quantity, row_number() OVER (ORDER BY quantity) FROM lineitem ORDER BY quantity;
                                                         Query Plan
-------------------------------------------------------------------------------------------------
 - Output[linenumber, quantity, _col2] => [linenumber:integer, quantity:double, row_number_1:bigi
         _col2 := row_number_1
     - Window[order by (quantity ASC_NULLS_LAST)] => [linenumber:integer, quantity:double, row_nu
             row_number_1 := row_number()
         - LocalExchange[SINGLE] () => linenumber:integer, quantity:double
             - RemoteExchange[GATHER] => linenumber:integer, quantity:double
                 - TableScan[tpch:tpch:lineitem:sf0.01, originalConstraint = true] => [linenumber
                         linenumber := tpch:linenumber
                         quantity := tpch:quantity
```

- Sort is reserved: (sort by different column)
```
presto:tiny> explain SELECT linenumber, quantity, row_number() OVER (ORDER BY quantity) FROM lineitem order by tax;
                                                                   Query Plan
-------------------------------------------------------------------------------------------------
 - Output[linenumber, quantity, _col2] => [linenumber:integer, quantity:double, row_number_1:bigi
         _col2 := row_number_1
     - Project[] => [linenumber:integer, quantity:double, row_number_1:bigint]
         - Sort[tax ASC_NULLS_LAST] => [linenumber:integer, quantity:double, tax:double, row_numb
             - Window[order by (quantity ASC_NULLS_LAST)] => [linenumber:integer, quantity:double
                     row_number_1 := row_number()
                 - LocalExchange[SINGLE] () => linenumber:integer, quantity:double, tax:double
                     - RemoteExchange[GATHER] => linenumber:integer, quantity:double, tax:double
                         - TableScan[tpch:tpch:lineitem:sf0.01, originalConstraint = true] => [li
                                 linenumber := tpch:linenumber
                                 quantity := tpch:quantity
                                 tax := tpch:tax
```
