### PR TITLE
Feature refactor cleanup analyzer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -18,7 +18,6 @@ import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.ExistsPredicate;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
@@ -42,7 +41,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.ArrayDeque;
@@ -349,57 +347,12 @@ public class Analysis
             return Optional.of(scopes.get(node));
         }
 
-        if (root == null) {
-            return Optional.empty();
-        }
-
-        GetScopeVisitor visitor = new GetScopeVisitor(scopes, node);
-        visitor.process(root, null);
-        return visitor.getResult();
+        return Optional.empty();
     }
 
     public Scope getRootScope()
     {
         return getScope(root);
-    }
-
-    private static class GetScopeVisitor
-            extends DefaultTraversalVisitor<Void, Scope>
-    {
-        private final IdentityHashMap<Node, Scope> scopes;
-        private final Node node;
-        private Scope result;
-
-        public GetScopeVisitor(IdentityHashMap<Node, Scope> scopes, Node node)
-        {
-            this.scopes = requireNonNull(scopes, "scopes is null");
-            this.node = requireNonNull(node, "node is null");
-        }
-
-        @Override
-        public Void process(Node current, @Nullable Scope candidate)
-        {
-            if (result != null) {
-                return null;
-            }
-
-            if (scopes.containsKey(current)) {
-                candidate = scopes.get(current);
-            }
-            if (node == current) {
-                result = candidate;
-            }
-            else {
-                super.process(current, candidate);
-            }
-
-            return null;
-        }
-
-        public Optional<Scope> getResult()
-        {
-            return Optional.ofNullable(result);
-        }
     }
 
     public void setScope(Node node, Scope scope)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -65,7 +65,7 @@ public class Analyzer
         Statement rewrittenStatement = StatementRewrite.rewrite(session, metadata, sqlParser, queryExplainer, statement, parameters, accessControl);
         Analysis analysis = new Analysis(rewrittenStatement, parameters, isDescribe);
         StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, accessControl, session);
-        analyzer.analyze(rewrittenStatement, Scope.create());
+        analyzer.analyze(rewrittenStatement, Optional.empty());
         return analysis;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -65,7 +65,7 @@ public class Analyzer
         Statement rewrittenStatement = StatementRewrite.rewrite(session, metadata, sqlParser, queryExplainer, statement, parameters, accessControl);
         Analysis analysis = new Analysis(rewrittenStatement, parameters, isDescribe);
         StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, accessControl, session);
-        analyzer.process(rewrittenStatement, Scope.create());
+        analyzer.analyze(rewrittenStatement, Scope.create());
         return analysis;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1015,7 +1015,6 @@ public class ExpressionAnalyzer
             Scope subqueryScope = Scope.builder()
                     .withParent(scope)
                     .build();
-            analyzer.getAnalysis().setScope(node, subqueryScope);
             Scope queryScope = analyzer.process(node.getQuery(), subqueryScope);
 
             // Subquery should only produce one column

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1015,7 +1015,7 @@ public class ExpressionAnalyzer
             Scope subqueryScope = Scope.builder()
                     .withParent(scope)
                     .build();
-            Scope queryScope = analyzer.process(node.getQuery(), subqueryScope);
+            Scope queryScope = analyzer.analyze(node.getQuery(), subqueryScope);
 
             // Subquery should only produce one column
             if (queryScope.getRelationType().getVisibleFieldCount() != 1) {
@@ -1046,7 +1046,7 @@ public class ExpressionAnalyzer
         {
             StatementAnalyzer analyzer = statementAnalyzerFactory.apply(node);
             Scope subqueryScope = Scope.builder().withParent(scope).build();
-            analyzer.process(node.getSubquery(), subqueryScope);
+            analyzer.analyze(node.getSubquery(), subqueryScope);
 
             existsSubqueries.add(node);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1046,7 +1046,6 @@ public class ExpressionAnalyzer
         {
             StatementAnalyzer analyzer = statementAnalyzerFactory.apply(node);
             Scope subqueryScope = Scope.builder().withParent(scope).build();
-            analyzer.getAnalysis().setScope(node, subqueryScope);
             analyzer.process(node.getSubquery(), subqueryScope);
 
             existsSubqueries.add(node);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
@@ -162,7 +162,6 @@ public class Scope
     public static final class Builder
     {
         private RelationType relationType = new RelationType();
-        private Optional<Boolean> approximate = Optional.empty();
         private final Map<String, WithQuery> namedQueries = new HashMap<>();
         private Optional<Scope> parent = Optional.empty();
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
@@ -82,6 +82,15 @@ public class Scope
         return Optional.empty();
     }
 
+    public Optional<Scope> getLocalParent()
+    {
+        if (!queryBoundary) {
+            return parent;
+        }
+
+        return Optional.empty();
+    }
+
     public RelationType getRelationType()
     {
         return relation;
@@ -115,32 +124,32 @@ public class Scope
 
     public Optional<ResolvedField> tryResolveField(Expression node, QualifiedName name)
     {
-        return resolveField(node, name, true);
+        return resolveField(node, name, 0, true);
     }
 
-    private Optional<ResolvedField> resolveField(Expression node, QualifiedName name, boolean local)
+    private Optional<ResolvedField> resolveField(Expression node, QualifiedName name, int fieldIndexOffset, boolean local)
     {
         List<Field> matches = relation.resolveFields(name);
         if (matches.size() > 1) {
             throw ambiguousAttributeException(node, name);
         }
         else if (matches.size() == 1) {
-            return Optional.of(asResolvedField(getOnlyElement(matches), local));
+            return Optional.of(asResolvedField(getOnlyElement(matches), fieldIndexOffset, local));
         }
         else {
             if (isColumnReference(name, relation)) {
                 return Optional.empty();
             }
             if (parent.isPresent()) {
-                return parent.get().resolveField(node, name, false);
+                return parent.get().resolveField(node, name, fieldIndexOffset + relation.getAllFieldCount(), local && !queryBoundary);
             }
             return Optional.empty();
         }
     }
 
-    private ResolvedField asResolvedField(Field field, boolean local)
+    private ResolvedField asResolvedField(Field field, int fieldIndexOffset, boolean local)
     {
-        int fieldIndex = relation.indexOf(field);
+        int fieldIndex = relation.indexOf(field) + fieldIndexOffset;
         return new ResolvedField(this, field, fieldIndex, local);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
@@ -69,6 +69,19 @@ public class Scope
         }
     }
 
+    public Optional<Scope> getOuterParent()
+    {
+        Scope scope = this;
+        while (scope.parent.isPresent()) {
+            if (scope.queryBoundary) {
+                return scope.parent;
+            }
+            scope = scope.parent.get();
+        }
+
+        return Optional.empty();
+    }
+
     public RelationType getRelationType()
     {
         return relation;

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -277,7 +277,7 @@ class StatementAnalyzer
                     "Query: [" + Joiner.on(", ").join(queryTypes) + "]");
         }
 
-        return createScope(insert, scope, Field.newUnqualified("rows", BIGINT));
+        return createAndAssignScope(insert, scope, Field.newUnqualified("rows", BIGINT));
     }
 
     private boolean typesMatchForInsert(Iterable<Type> tableTypes, Iterable<Type> queryTypes)
@@ -325,7 +325,7 @@ class StatementAnalyzer
 
         accessControl.checkCanDeleteFromTable(session.getRequiredTransactionId(), session.getIdentity(), tableName);
 
-        return createScope(node, scope, Field.newUnqualified("rows", BIGINT));
+        return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
     }
 
     @Override
@@ -341,7 +341,7 @@ class StatementAnalyzer
         if (targetTableHandle.isPresent()) {
             if (node.isNotExists()) {
                 analysis.setCreateTableAsSelectNoOp(true);
-                return createScope(node, scope, Field.newUnqualified("rows", BIGINT));
+                return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
             }
             throw new SemanticException(TABLE_ALREADY_EXISTS, node, "Destination table '%s' already exists", targetTable);
         }
@@ -362,7 +362,7 @@ class StatementAnalyzer
 
         validateColumns(node, queryScope.getRelationType());
 
-        return createScope(node, scope, Field.newUnqualified("rows", BIGINT));
+        return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
     }
 
     @Override
@@ -386,127 +386,127 @@ class StatementAnalyzer
 
         validateColumns(node, queryScope.getRelationType());
 
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitSetSession(SetSession node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitResetSession(ResetSession node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitAddColumn(AddColumn node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitCreateSchema(CreateSchema node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitDropSchema(DropSchema node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitRenameSchema(RenameSchema node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitCreateTable(CreateTable node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitDropTable(DropTable node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitRenameTable(RenameTable node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitRenameColumn(RenameColumn node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitDropView(DropView node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitStartTransaction(StartTransaction node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitCommit(Commit node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitRollback(Rollback node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitPrepare(Prepare node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitDeallocate(Deallocate node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitExecute(Execute node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitGrant(Grant node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitRevoke(Revoke node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     @Override
     protected Scope visitCall(Call node, Scope scope)
     {
-        return createScope(node, scope, emptyList());
+        return createAndAssignScope(node, scope, emptyList());
     }
 
     private static void validateColumns(Statement node, RelationType descriptor)
@@ -538,7 +538,7 @@ class StatementAnalyzer
         }
         process(node.getStatement(), scope);
         analysis.setUpdateType(null);
-        return createScope(node, scope, Field.newUnqualified("Query Plan", VARCHAR));
+        return createAndAssignScope(node, scope, Field.newUnqualified("Query Plan", VARCHAR));
     }
 
     @Override
@@ -583,7 +583,7 @@ class StatementAnalyzer
         if (node.isWithOrdinality()) {
             outputFields.add(Field.newUnqualified(Optional.empty(), BIGINT));
         }
-        return createScope(node, scope, outputFields.build());
+        return createAndAssignScope(node, scope, outputFields.build());
     }
 
     @Override
@@ -635,7 +635,7 @@ class StatementAnalyzer
                             .collect(toImmutableList());
                 }
 
-                return createScope(table, scope, fields);
+                return createAndAssignScope(table, scope, fields);
             }
         }
 
@@ -685,7 +685,7 @@ class StatementAnalyzer
 
             analysis.addRelationCoercion(table, outputFields.stream().map(Field::getType).toArray(Type[]::new));
 
-            return createScope(table, scope, outputFields);
+            return createAndAssignScope(table, scope, outputFields);
         }
 
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, name);
@@ -720,7 +720,7 @@ class StatementAnalyzer
 
         analysis.registerTable(table, tableHandle.get());
 
-        return createScope(table, scope, fields.build());
+        return createAndAssignScope(table, scope, fields.build());
     }
 
     @Override
@@ -738,7 +738,7 @@ class StatementAnalyzer
         }
 
         RelationType descriptor = relationType.withAlias(relation.getAlias(), relation.getColumnNames());
-        return createScope(relation, scope, descriptor);
+        return createAndAssignScope(relation, scope, descriptor);
     }
 
     @Override
@@ -777,7 +777,7 @@ class StatementAnalyzer
 
         analysis.setSampleRatio(relation, samplePercentageValue / 100);
         Scope relationScope = process(relation.getRelation(), scope);
-        return createScope(relation, scope, relationScope.getRelationType());
+        return createAndAssignScope(relation, scope, relationScope.getRelationType());
     }
 
     @Override
@@ -785,7 +785,7 @@ class StatementAnalyzer
     {
         StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, accessControl, session);
         Scope queryScope = analyzer.process(node.getQuery(), scope);
-        return createScope(node, scope, queryScope.getRelationType());
+        return createAndAssignScope(node, scope, queryScope.getRelationType());
     }
 
     @Override
@@ -825,7 +825,7 @@ class StatementAnalyzer
         List<Scope> relationScopes = node.getRelations().stream()
                 .map(relation -> {
                     Scope relationScope = process(relation, scope);
-                    return createScope(relation, scope, relationScope.getRelationType().withOnlyVisibleFields());
+                    return createAndAssignScope(relation, scope, relationScope.getRelationType().withOnlyVisibleFields());
                 })
                 .collect(toImmutableList());
 
@@ -882,7 +882,7 @@ class StatementAnalyzer
                 }
             }
         }
-        return createScope(node, scope, outputDescriptorFields);
+        return createAndAssignScope(node, scope, outputDescriptorFields);
     }
 
     @Override
@@ -916,7 +916,7 @@ class StatementAnalyzer
         Scope left = process(node.getLeft(), scope);
         Scope right = process(node.getRight(), isUnnestRelation(node.getRight()) ? left : scope);
 
-        Scope output = createScope(node, scope, left.getRelationType().joinWith(right.getRelationType()));
+        Scope output = createAndAssignScope(node, scope, left.getRelationType().joinWith(right.getRelationType()));
 
         if (node.getType() == Join.Type.CROSS || node.getType() == Join.Type.IMPLICIT) {
             return output;
@@ -1137,7 +1137,7 @@ class StatementAnalyzer
                 .map(valueType -> Field.newUnqualified(Optional.empty(), valueType))
                 .collect(toImmutableList());
 
-        return createScope(node, scope, fields);
+        return createAndAssignScope(node, scope, fields);
     }
 
     private void analyzeWindowFunctions(QuerySpecification node, List<Expression> outputExpressions, List<Expression> orderByExpressions)
@@ -1590,7 +1590,7 @@ class StatementAnalyzer
             }
         }
 
-        return createScope(node, scope, outputFields.build());
+        return createAndAssignScope(node, scope, outputFields.build());
     }
 
     private List<Expression> analyzeSelect(QuerySpecification node, Scope scope)
@@ -1902,17 +1902,17 @@ class StatementAnalyzer
         analysis.setOrderByExpressions(node, orderByFieldsBuilder.build());
     }
 
-    public Scope createScope(Node node, Scope parent, Field... fields)
+    private Scope createAndAssignScope(Node node, Scope parent, Field... fields)
     {
-        return createScope(node, parent, new RelationType(fields));
+        return createAndAssignScope(node, parent, new RelationType(fields));
     }
 
-    public Scope createScope(Node node, Scope parent, List<Field> fields)
+    private Scope createAndAssignScope(Node node, Scope parent, List<Field> fields)
     {
-        return createScope(node, parent, new RelationType(fields));
+        return createAndAssignScope(node, parent, new RelationType(fields));
     }
 
-    public Scope createScope(Node node, Scope parent, RelationType relationType)
+    private Scope createAndAssignScope(Node node, Scope parent, RelationType relationType)
     {
         Scope scope = Scope.builder()
                 .withParent(parent)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1921,9 +1921,4 @@ class StatementAnalyzer
         analysis.setScope(node, scope);
         return scope;
     }
-
-    public Analysis getAnalysis()
-    {
-        return analysis;
-    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -187,7 +187,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 class StatementAnalyzer
-        extends DefaultTraversalVisitor<Scope, Scope>
 {
     private final Analysis analysis;
     private final Metadata metadata;
@@ -208,1717 +207,1731 @@ class StatementAnalyzer
         this.session = requireNonNull(session, "session is null");
     }
 
-    @Override
-    protected Scope visitUse(Use node, Scope scope)
+    public Scope analyze(Node node, Scope scope)
     {
-        throw new SemanticException(NOT_SUPPORTED, node, "USE statement is not supported");
+        return new Visitor().process(node, scope);
     }
 
-    @Override
-    protected Scope visitInsert(Insert insert, Scope scope)
+    private void analyzeWhere(Node node, Scope scope, Expression predicate)
     {
-        QualifiedObjectName targetTable = createQualifiedObjectName(session, insert, insert.getTarget());
-        if (metadata.getView(session, targetTable).isPresent()) {
-            throw new SemanticException(NOT_SUPPORTED, insert, "Inserting into views is not supported");
+        Visitor visitor = new Visitor();
+        visitor.analyzeWhere(node, scope, predicate);
+    }
+
+    private class Visitor
+            extends DefaultTraversalVisitor<Scope, Scope>
+    {
+        @Override
+        protected Scope visitUse(Use node, Scope scope)
+        {
+            throw new SemanticException(NOT_SUPPORTED, node, "USE statement is not supported");
         }
 
-        // analyze the query that creates the data
-        Scope queryScope = process(insert.getQuery(), scope);
+        @Override
+        protected Scope visitInsert(Insert insert, Scope scope)
+        {
+            QualifiedObjectName targetTable = createQualifiedObjectName(session, insert, insert.getTarget());
+            if (metadata.getView(session, targetTable).isPresent()) {
+                throw new SemanticException(NOT_SUPPORTED, insert, "Inserting into views is not supported");
+            }
 
-        analysis.setUpdateType("INSERT");
+            // analyze the query that creates the data
+            Scope queryScope = process(insert.getQuery(), scope);
 
-        // verify the insert destination columns match the query
-        Optional<TableHandle> targetTableHandle = metadata.getTableHandle(session, targetTable);
-        if (!targetTableHandle.isPresent()) {
-            throw new SemanticException(MISSING_TABLE, insert, "Table '%s' does not exist", targetTable);
-        }
-        accessControl.checkCanInsertIntoTable(session.getRequiredTransactionId(), session.getIdentity(), targetTable);
+            analysis.setUpdateType("INSERT");
 
-        TableMetadata tableMetadata = metadata.getTableMetadata(session, targetTableHandle.get());
-        List<String> tableColumns = tableMetadata.getColumns().stream()
-                .filter(column -> !column.isHidden())
-                .map(ColumnMetadata::getName)
-                .collect(toImmutableList());
+            // verify the insert destination columns match the query
+            Optional<TableHandle> targetTableHandle = metadata.getTableHandle(session, targetTable);
+            if (!targetTableHandle.isPresent()) {
+                throw new SemanticException(MISSING_TABLE, insert, "Table '%s' does not exist", targetTable);
+            }
+            accessControl.checkCanInsertIntoTable(session.getRequiredTransactionId(), session.getIdentity(), targetTable);
 
-        List<String> insertColumns;
-        if (insert.getColumns().isPresent()) {
-            insertColumns = insert.getColumns().get().stream()
-                    .map(String::toLowerCase)
+            TableMetadata tableMetadata = metadata.getTableMetadata(session, targetTableHandle.get());
+            List<String> tableColumns = tableMetadata.getColumns().stream()
+                    .filter(column -> !column.isHidden())
+                    .map(ColumnMetadata::getName)
                     .collect(toImmutableList());
 
-            Set<String> columnNames = new HashSet<>();
-            for (String insertColumn : insertColumns) {
-                if (!tableColumns.contains(insertColumn)) {
-                    throw new SemanticException(MISSING_COLUMN, insert, "Insert column name does not exist in target table: %s", insertColumn);
+            List<String> insertColumns;
+            if (insert.getColumns().isPresent()) {
+                insertColumns = insert.getColumns().get().stream()
+                        .map(String::toLowerCase)
+                        .collect(toImmutableList());
+
+                Set<String> columnNames = new HashSet<>();
+                for (String insertColumn : insertColumns) {
+                    if (!tableColumns.contains(insertColumn)) {
+                        throw new SemanticException(MISSING_COLUMN, insert, "Insert column name does not exist in target table: %s", insertColumn);
+                    }
+                    if (!columnNames.add(insertColumn)) {
+                        throw new SemanticException(DUPLICATE_COLUMN_NAME, insert, "Insert column name is specified more than once: %s", insertColumn);
+                    }
                 }
-                if (!columnNames.add(insertColumn)) {
-                    throw new SemanticException(DUPLICATE_COLUMN_NAME, insert, "Insert column name is specified more than once: %s", insertColumn);
-                }
-            }
-        }
-        else {
-            insertColumns = tableColumns;
-        }
-
-        Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, targetTableHandle.get());
-        analysis.setInsert(new Analysis.Insert(
-                targetTableHandle.get(),
-                insertColumns.stream().map(columnHandles::get).collect(toImmutableList())));
-
-        Iterable<Type> tableTypes = insertColumns.stream()
-                .map(insertColumn -> tableMetadata.getColumn(insertColumn).getType())
-                .collect(toImmutableList());
-
-        Iterable<Type> queryTypes = transform(queryScope.getRelationType().getVisibleFields(), Field::getType);
-
-        if (!typesMatchForInsert(tableTypes, queryTypes)) {
-            throw new SemanticException(MISMATCHED_SET_COLUMN_TYPES, insert, "Insert query has mismatched column types: " +
-                    "Table: [" + Joiner.on(", ").join(tableTypes) + "], " +
-                    "Query: [" + Joiner.on(", ").join(queryTypes) + "]");
-        }
-
-        return createAndAssignScope(insert, scope, Field.newUnqualified("rows", BIGINT));
-    }
-
-    private boolean typesMatchForInsert(Iterable<Type> tableTypes, Iterable<Type> queryTypes)
-    {
-        if (Iterables.size(tableTypes) != Iterables.size(queryTypes)) {
-            return false;
-        }
-
-        Iterator<Type> tableTypesIterator = tableTypes.iterator();
-        Iterator<Type> queryTypesIterator = queryTypes.iterator();
-        while (tableTypesIterator.hasNext()) {
-            Type tableType = tableTypesIterator.next();
-            Type queryType = queryTypesIterator.next();
-
-            if (!metadata.getTypeManager().canCoerce(queryType, tableType)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    @Override
-    protected Scope visitDelete(Delete node, Scope scope)
-    {
-        Table table = node.getTable();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, table, table.getName());
-        if (metadata.getView(session, tableName).isPresent()) {
-            throw new SemanticException(NOT_SUPPORTED, node, "Deleting from views is not supported");
-        }
-
-        // Analyzer checks for select permissions but DELETE has a separate permission, so disable access checks
-        // TODO: we shouldn't need to create a new analyzer. The access control should be carried in the context object
-        StatementAnalyzer analyzer = new StatementAnalyzer(
-                analysis,
-                metadata,
-                sqlParser,
-                new AllowAllAccessControl(),
-                session);
-
-        Scope tableScope = analyzer.process(table, scope);
-        node.getWhere().ifPresent(where -> analyzer.analyzeWhere(node, tableScope, where));
-
-        analysis.setUpdateType("DELETE");
-
-        accessControl.checkCanDeleteFromTable(session.getRequiredTransactionId(), session.getIdentity(), tableName);
-
-        return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
-    }
-
-    @Override
-    protected Scope visitCreateTableAsSelect(CreateTableAsSelect node, Scope scope)
-    {
-        analysis.setUpdateType("CREATE TABLE");
-
-        // turn this into a query that has a new table writer node on top.
-        QualifiedObjectName targetTable = createQualifiedObjectName(session, node, node.getName());
-        analysis.setCreateTableDestination(targetTable);
-
-        Optional<TableHandle> targetTableHandle = metadata.getTableHandle(session, targetTable);
-        if (targetTableHandle.isPresent()) {
-            if (node.isNotExists()) {
-                analysis.setCreateTableAsSelectNoOp(true);
-                return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
-            }
-            throw new SemanticException(TABLE_ALREADY_EXISTS, node, "Destination table '%s' already exists", targetTable);
-        }
-
-        for (Expression expression : node.getProperties().values()) {
-            // analyze table property value expressions which must be constant
-            createConstantAnalyzer(metadata, session, analysis.getParameters(), analysis.isDescribe())
-                    .analyze(expression, scope);
-        }
-        analysis.setCreateTableProperties(node.getProperties());
-
-        accessControl.checkCanCreateTable(session.getRequiredTransactionId(), session.getIdentity(), targetTable);
-
-        analysis.setCreateTableAsSelectWithData(node.isWithData());
-
-        // analyze the query that creates the table
-        Scope queryScope = process(node.getQuery(), scope);
-
-        validateColumns(node, queryScope.getRelationType());
-
-        return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
-    }
-
-    @Override
-    protected Scope visitCreateView(CreateView node, Scope scope)
-    {
-        analysis.setUpdateType("CREATE VIEW");
-
-        QualifiedObjectName viewName = createQualifiedObjectName(session, node, node.getName());
-
-        // analyze the query that creates the view
-        StatementAnalyzer analyzer = new StatementAnalyzer(
-                analysis,
-                metadata,
-                sqlParser,
-                new ViewAccessControl(accessControl),
-                session);
-
-        Scope queryScope = analyzer.process(node.getQuery(), scope);
-
-        accessControl.checkCanCreateView(session.getRequiredTransactionId(), session.getIdentity(), viewName);
-
-        validateColumns(node, queryScope.getRelationType());
-
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitSetSession(SetSession node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitResetSession(ResetSession node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitAddColumn(AddColumn node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitCreateSchema(CreateSchema node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitDropSchema(DropSchema node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitRenameSchema(RenameSchema node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitCreateTable(CreateTable node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitDropTable(DropTable node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitRenameTable(RenameTable node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitRenameColumn(RenameColumn node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitDropView(DropView node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitStartTransaction(StartTransaction node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitCommit(Commit node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitRollback(Rollback node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitPrepare(Prepare node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitDeallocate(Deallocate node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitExecute(Execute node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitGrant(Grant node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitRevoke(Revoke node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    @Override
-    protected Scope visitCall(Call node, Scope scope)
-    {
-        return createAndAssignScope(node, scope, emptyList());
-    }
-
-    private static void validateColumns(Statement node, RelationType descriptor)
-    {
-        // verify that all column names are specified and unique
-        // TODO: collect errors and return them all at once
-        Set<String> names = new HashSet<>();
-        for (Field field : descriptor.getVisibleFields()) {
-            Optional<String> fieldName = field.getName();
-            if (!fieldName.isPresent()) {
-                throw new SemanticException(COLUMN_NAME_NOT_SPECIFIED, node, "Column name not specified at position %s", descriptor.indexOf(field) + 1);
-            }
-            if (!names.add(fieldName.get())) {
-                throw new SemanticException(DUPLICATE_COLUMN_NAME, node, "Column name '%s' specified more than once", fieldName.get());
-            }
-            if (field.getType().equals(UNKNOWN)) {
-                throw new SemanticException(COLUMN_TYPE_UNKNOWN, node, "Column type is unknown: %s", fieldName.get());
-            }
-        }
-    }
-
-    @Override
-    protected Scope visitExplain(Explain node, Scope scope)
-            throws SemanticException
-    {
-        checkState(node.isAnalyze(), "Non analyze explain should be rewritten to Query");
-        if (node.getOptions().stream().anyMatch(option -> !option.equals(new ExplainType(DISTRIBUTED)))) {
-            throw new SemanticException(NOT_SUPPORTED, node, "EXPLAIN ANALYZE only supports TYPE DISTRIBUTED option");
-        }
-        process(node.getStatement(), scope);
-        analysis.setUpdateType(null);
-        return createAndAssignScope(node, scope, Field.newUnqualified("Query Plan", VARCHAR));
-    }
-
-    @Override
-    protected Scope visitQuery(Query node, Scope scope)
-    {
-        Scope withScope = analyzeWith(node, scope);
-        Scope queryScope = Scope.builder()
-                .withParent(withScope)
-                .build();
-        Scope queryBodyScope = process(node.getQueryBody(), queryScope);
-        analyzeOrderBy(node, queryBodyScope);
-
-        // Input fields == Output fields
-        analysis.setOutputExpressions(node, descriptorToFields(queryBodyScope));
-
-        queryScope = Scope.builder()
-                .withParent(withScope)
-                .withRelationType(queryBodyScope.getRelationType())
-                .build();
-        analysis.setScope(node, queryScope);
-        return queryScope;
-    }
-
-    @Override
-    protected Scope visitUnnest(Unnest node, Scope scope)
-    {
-        ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
-        for (Expression expression : node.getExpressions()) {
-            ExpressionAnalysis expressionAnalysis = analyzeExpression(expression, scope);
-            Type expressionType = expressionAnalysis.getType(expression);
-            if (expressionType instanceof ArrayType) {
-                outputFields.add(Field.newUnqualified(Optional.empty(), ((ArrayType) expressionType).getElementType()));
-            }
-            else if (expressionType instanceof MapType) {
-                outputFields.add(Field.newUnqualified(Optional.empty(), ((MapType) expressionType).getKeyType()));
-                outputFields.add(Field.newUnqualified(Optional.empty(), ((MapType) expressionType).getValueType()));
             }
             else {
-                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Cannot unnest type: " + expressionType);
-            }
-        }
-        if (node.isWithOrdinality()) {
-            outputFields.add(Field.newUnqualified(Optional.empty(), BIGINT));
-        }
-        return createAndAssignScope(node, scope, outputFields.build());
-    }
-
-    @Override
-    protected Scope visitTable(Table table, Scope scope)
-    {
-        if (!table.getName().getPrefix().isPresent()) {
-            // is this a reference to a WITH query?
-            String name = table.getName().getSuffix();
-
-            Optional<WithQuery> withQuery = scope.getNamedQuery(name);
-            if (withQuery.isPresent()) {
-                Query query = withQuery.get().getQuery();
-                analysis.registerNamedQuery(table, query);
-
-                // re-alias the fields with the name assigned to the query in the WITH declaration
-                RelationType queryDescriptor = analysis.getOutputDescriptor(query);
-
-                List<Field> fields;
-                Optional<List<String>> columnNames = withQuery.get().getColumnNames();
-                if (columnNames.isPresent()) {
-                    // if columns are explicitly aliased -> WITH cte(alias1, alias2 ...)
-                    ImmutableList.Builder<Field> fieldBuilder = ImmutableList.builder();
-
-                    int field = 0;
-                    for (String columnName : columnNames.get()) {
-                        Field inputField = queryDescriptor.getFieldByIndex(field);
-                        fieldBuilder.add(Field.newQualified(
-                                QualifiedName.of(name),
-                                Optional.of(columnName),
-                                inputField.getType(),
-                                false,
-                                inputField.getOriginTable(),
-                                inputField.isAliased()));
-
-                        field++;
-                    }
-
-                    fields = fieldBuilder.build();
-                }
-                else {
-                    fields = queryDescriptor.getAllFields().stream()
-                            .map(field -> Field.newQualified(
-                                    QualifiedName.of(name),
-                                    field.getName(),
-                                    field.getType(),
-                                    field.isHidden(),
-                                    field.getOriginTable(),
-                                    field.isAliased()))
-                            .collect(toImmutableList());
-                }
-
-                return createAndAssignScope(table, scope, fields);
-            }
-        }
-
-        QualifiedObjectName name = createQualifiedObjectName(session, table, table.getName());
-
-        Optional<ViewDefinition> optionalView = metadata.getView(session, name);
-        if (optionalView.isPresent()) {
-            Statement statement = analysis.getStatement();
-            if (statement instanceof CreateView) {
-                CreateView viewStatement = (CreateView) statement;
-                QualifiedObjectName viewNameFromStatement = createQualifiedObjectName(session, viewStatement, viewStatement.getName());
-                if (viewStatement.isReplace() && viewNameFromStatement.equals(name)) {
-                    throw new SemanticException(VIEW_IS_RECURSIVE, table, "Statement would create a recursive view");
-                }
-            }
-            if (analysis.hasTableInView(table)) {
-                throw new SemanticException(VIEW_IS_RECURSIVE, table, "View is recursive");
-            }
-            ViewDefinition view = optionalView.get();
-
-            Query query = parseView(view.getOriginalSql(), name, table);
-
-            analysis.registerNamedQuery(table, query);
-
-            accessControl.checkCanSelectFromView(session.getRequiredTransactionId(), session.getIdentity(), name);
-
-            analysis.registerTableForView(table);
-            RelationType descriptor = analyzeView(query, name, view.getCatalog(), view.getSchema(), view.getOwner(), table);
-            analysis.unregisterTableForView();
-
-            if (isViewStale(view.getColumns(), descriptor.getVisibleFields())) {
-                throw new SemanticException(VIEW_IS_STALE, table, "View '%s' is stale; it must be re-created", name);
+                insertColumns = tableColumns;
             }
 
-            // Derive the type of the view from the stored definition, not from the analysis of the underlying query.
-            // This is needed in case the underlying table(s) changed and the query in the view now produces types that
-            // are implicitly coercible to the declared view types.
-            List<Field> outputFields = view.getColumns().stream()
-                    .map(column -> Field.newQualified(
-                            QualifiedName.of(name.getObjectName()),
-                            Optional.of(column.getName()),
-                            column.getType(),
-                            false,
-                            Optional.of(name),
-                            false))
+            Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, targetTableHandle.get());
+            analysis.setInsert(new Analysis.Insert(
+                    targetTableHandle.get(),
+                    insertColumns.stream().map(columnHandles::get).collect(toImmutableList())));
+
+            Iterable<Type> tableTypes = insertColumns.stream()
+                    .map(insertColumn -> tableMetadata.getColumn(insertColumn).getType())
                     .collect(toImmutableList());
 
-            analysis.addRelationCoercion(table, outputFields.stream().map(Field::getType).toArray(Type[]::new));
+            Iterable<Type> queryTypes = transform(queryScope.getRelationType().getVisibleFields(), Field::getType);
 
-            return createAndAssignScope(table, scope, outputFields);
-        }
-
-        Optional<TableHandle> tableHandle = metadata.getTableHandle(session, name);
-        if (!tableHandle.isPresent()) {
-            if (!metadata.getCatalogHandle(session, name.getCatalogName()).isPresent()) {
-                throw new SemanticException(MISSING_CATALOG, table, "Catalog %s does not exist", name.getCatalogName());
+            if (!typesMatchForInsert(tableTypes, queryTypes)) {
+                throw new SemanticException(MISMATCHED_SET_COLUMN_TYPES, insert, "Insert query has mismatched column types: " +
+                        "Table: [" + Joiner.on(", ").join(tableTypes) + "], " +
+                        "Query: [" + Joiner.on(", ").join(queryTypes) + "]");
             }
-            if (!metadata.schemaExists(session, new CatalogSchemaName(name.getCatalogName(), name.getSchemaName()))) {
-                throw new SemanticException(MISSING_SCHEMA, table, "Schema %s does not exist", name.getSchemaName());
+
+            return createAndAssignScope(insert, scope, Field.newUnqualified("rows", BIGINT));
+        }
+
+        private boolean typesMatchForInsert(Iterable<Type> tableTypes, Iterable<Type> queryTypes)
+        {
+            if (Iterables.size(tableTypes) != Iterables.size(queryTypes)) {
+                return false;
             }
-            throw new SemanticException(MISSING_TABLE, table, "Table %s does not exist", name);
-        }
-        accessControl.checkCanSelectFromTable(session.getRequiredTransactionId(), session.getIdentity(), name);
-        TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle.get());
-        Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle.get());
 
-        // TODO: discover columns lazily based on where they are needed (to support connectors that can't enumerate all tables)
-        ImmutableList.Builder<Field> fields = ImmutableList.builder();
-        for (ColumnMetadata column : tableMetadata.getColumns()) {
-            Field field = Field.newQualified(
-                    table.getName(),
-                    Optional.of(column.getName()),
-                    column.getType(),
-                    column.isHidden(),
-                    Optional.of(name),
-                    false);
-            fields.add(field);
-            ColumnHandle columnHandle = columnHandles.get(column.getName());
-            checkArgument(columnHandle != null, "Unknown field %s", field);
-            analysis.setColumn(field, columnHandle);
-        }
+            Iterator<Type> tableTypesIterator = tableTypes.iterator();
+            Iterator<Type> queryTypesIterator = queryTypes.iterator();
+            while (tableTypesIterator.hasNext()) {
+                Type tableType = tableTypesIterator.next();
+                Type queryType = queryTypesIterator.next();
 
-        analysis.registerTable(table, tableHandle.get());
-
-        return createAndAssignScope(table, scope, fields.build());
-    }
-
-    @Override
-    protected Scope visitAliasedRelation(AliasedRelation relation, Scope scope)
-    {
-        Scope relationScope = process(relation.getRelation(), scope);
-
-        // todo this check should be inside of TupleDescriptor.withAlias, but the exception needs the node object
-        RelationType relationType = relationScope.getRelationType();
-        if (relation.getColumnNames() != null) {
-            int totalColumns = relationType.getVisibleFieldCount();
-            if (totalColumns != relation.getColumnNames().size()) {
-                throw new SemanticException(MISMATCHED_COLUMN_ALIASES, relation, "Column alias list has %s entries but '%s' has %s columns available", relation.getColumnNames().size(), relation.getAlias(), totalColumns);
-            }
-        }
-
-        RelationType descriptor = relationType.withAlias(relation.getAlias(), relation.getColumnNames());
-        return createAndAssignScope(relation, scope, descriptor);
-    }
-
-    @Override
-    protected Scope visitSampledRelation(SampledRelation relation, Scope scope)
-    {
-        if (!DependencyExtractor.extractNames(relation.getSamplePercentage(), analysis.getColumnReferences()).isEmpty()) {
-            throw new SemanticException(NON_NUMERIC_SAMPLE_PERCENTAGE, relation.getSamplePercentage(), "Sample percentage cannot contain column references");
-        }
-
-        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(
-                session,
-                metadata,
-                sqlParser,
-                ImmutableMap.of(),
-                relation.getSamplePercentage(),
-                analysis.getParameters(),
-                analysis.isDescribe());
-        ExpressionInterpreter samplePercentageEval = expressionOptimizer(relation.getSamplePercentage(), metadata, session, expressionTypes);
-
-        Object samplePercentageObject = samplePercentageEval.optimize(symbol -> {
-            throw new SemanticException(NON_NUMERIC_SAMPLE_PERCENTAGE, relation.getSamplePercentage(), "Sample percentage cannot contain column references");
-        });
-
-        if (!(samplePercentageObject instanceof Number)) {
-            throw new SemanticException(NON_NUMERIC_SAMPLE_PERCENTAGE, relation.getSamplePercentage(), "Sample percentage should evaluate to a numeric expression");
-        }
-
-        double samplePercentageValue = ((Number) samplePercentageObject).doubleValue();
-
-        if (samplePercentageValue < 0.0) {
-            throw new SemanticException(SemanticErrorCode.SAMPLE_PERCENTAGE_OUT_OF_RANGE, relation.getSamplePercentage(), "Sample percentage must be greater than or equal to 0");
-        }
-        if ((samplePercentageValue > 100.0)) {
-            throw new SemanticException(SemanticErrorCode.SAMPLE_PERCENTAGE_OUT_OF_RANGE, relation.getSamplePercentage(), "Sample percentage must be less than or equal to 100");
-        }
-
-        analysis.setSampleRatio(relation, samplePercentageValue / 100);
-        Scope relationScope = process(relation.getRelation(), scope);
-        return createAndAssignScope(relation, scope, relationScope.getRelationType());
-    }
-
-    @Override
-    protected Scope visitTableSubquery(TableSubquery node, Scope scope)
-    {
-        StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, accessControl, session);
-        Scope queryScope = analyzer.process(node.getQuery(), scope);
-        return createAndAssignScope(node, scope, queryScope.getRelationType());
-    }
-
-    @Override
-    protected Scope visitQuerySpecification(QuerySpecification node, Scope scope)
-    {
-        // TODO: extract candidate names from SELECT, WHERE, HAVING, GROUP BY and ORDER BY expressions
-        // to pass down to analyzeFrom
-
-        Scope sourceScope = analyzeFrom(node, scope);
-
-        node.getWhere().ifPresent(where -> analyzeWhere(node, sourceScope, where));
-
-        List<Expression> outputExpressions = analyzeSelect(node, sourceScope);
-        List<List<Expression>> groupByExpressions = analyzeGroupBy(node, sourceScope, outputExpressions);
-
-        Scope outputScope = computeOutputScope(node, sourceScope);
-
-        List<Expression> orderByExpressions = analyzeOrderBy(node, sourceScope, outputScope, outputExpressions);
-        analyzeHaving(node, sourceScope);
-
-        List<Expression> expressions = new ArrayList<>();
-        expressions.addAll(outputExpressions);
-        expressions.addAll(orderByExpressions);
-        node.getHaving().ifPresent(expressions::add);
-
-        analyzeAggregations(node, sourceScope, groupByExpressions, analysis.getColumnReferences(), expressions);
-        analyzeWindowFunctions(node, outputExpressions, orderByExpressions);
-
-        return outputScope;
-    }
-
-    @Override
-    protected Scope visitSetOperation(SetOperation node, Scope scope)
-    {
-        checkState(node.getRelations().size() >= 2);
-
-        List<Scope> relationScopes = node.getRelations().stream()
-                .map(relation -> {
-                    Scope relationScope = process(relation, scope);
-                    return createAndAssignScope(relation, scope, relationScope.getRelationType().withOnlyVisibleFields());
-                })
-                .collect(toImmutableList());
-
-        Type[] outputFieldTypes = relationScopes.get(0).getRelationType().getVisibleFields().stream()
-                .map(Field::getType)
-                .toArray(Type[]::new);
-        for (Scope relationScope : relationScopes) {
-            int outputFieldSize = outputFieldTypes.length;
-            RelationType relationType = relationScope.getRelationType();
-            int descFieldSize = relationType.getVisibleFields().size();
-            String setOperationName = node.getClass().getSimpleName();
-            if (outputFieldSize != descFieldSize) {
-                throw new SemanticException(MISMATCHED_SET_COLUMN_TYPES,
-                        node,
-                        "%s query has different number of fields: %d, %d",
-                        setOperationName, outputFieldSize, descFieldSize);
-            }
-            for (int i = 0; i < descFieldSize; i++) {
-                Type descFieldType = relationType.getFieldByIndex(i).getType();
-                Optional<Type> commonSuperType = metadata.getTypeManager().getCommonSuperType(outputFieldTypes[i], descFieldType);
-                if (!commonSuperType.isPresent()) {
-                    throw new SemanticException(TYPE_MISMATCH,
-                            node,
-                            "column %d in %s query has incompatible types: %s, %s",
-                            i, outputFieldTypes[i].getDisplayName(), setOperationName, descFieldType.getDisplayName());
-                }
-                outputFieldTypes[i] = commonSuperType.get();
-            }
-        }
-
-        Field[] outputDescriptorFields = new Field[outputFieldTypes.length];
-        RelationType firstDescriptor = relationScopes.get(0).getRelationType().withOnlyVisibleFields();
-        for (int i = 0; i < outputFieldTypes.length; i++) {
-            Field oldField = firstDescriptor.getFieldByIndex(i);
-            outputDescriptorFields[i] = new Field(
-                    oldField.getRelationAlias(),
-                    oldField.getName(),
-                    outputFieldTypes[i],
-                    oldField.isHidden(),
-                    oldField.getOriginTable(),
-                    oldField.isAliased());
-        }
-
-        for (int i = 0; i < node.getRelations().size(); i++) {
-            Relation relation = node.getRelations().get(i);
-            Scope relationScope = relationScopes.get(i);
-            RelationType relationType = relationScope.getRelationType();
-            for (int j = 0; j < relationType.getVisibleFields().size(); j++) {
-                Type outputFieldType = outputFieldTypes[j];
-                Type descFieldType = relationType.getFieldByIndex(j).getType();
-                if (!outputFieldType.equals(descFieldType)) {
-                    analysis.addRelationCoercion(relation, outputFieldTypes);
-                    break;
+                if (!metadata.getTypeManager().canCoerce(queryType, tableType)) {
+                    return false;
                 }
             }
-        }
-        return createAndAssignScope(node, scope, outputDescriptorFields);
-    }
 
-    @Override
-    protected Scope visitIntersect(Intersect node, Scope scope)
-    {
-        if (!node.isDistinct()) {
-            throw new SemanticException(NOT_SUPPORTED, node, "INTERSECT ALL not yet implemented");
+            return true;
         }
 
-        return visitSetOperation(node, scope);
-    }
-
-    @Override
-    protected Scope visitExcept(Except node, Scope scope)
-    {
-        if (!node.isDistinct()) {
-            throw new SemanticException(NOT_SUPPORTED, node, "EXCEPT ALL not yet implemented");
-        }
-
-        return visitSetOperation(node, scope);
-    }
-
-    @Override
-    protected Scope visitJoin(Join node, Scope scope)
-    {
-        JoinCriteria criteria = node.getCriteria().orElse(null);
-        if (criteria instanceof NaturalJoin) {
-            throw new SemanticException(NOT_SUPPORTED, node, "Natural join not supported");
-        }
-
-        Scope left = process(node.getLeft(), scope);
-        Scope right = process(node.getRight(), isUnnestRelation(node.getRight()) ? left : scope);
-
-        Scope output = createAndAssignScope(node, scope, left.getRelationType().joinWith(right.getRelationType()));
-
-        if (node.getType() == Join.Type.CROSS || node.getType() == Join.Type.IMPLICIT) {
-            return output;
-        }
-
-        if (criteria instanceof JoinUsing) {
-            // TODO: implement proper "using" semantics with respect to output columns
-            List<String> columns = ((JoinUsing) criteria).getColumns();
-
-            List<Expression> expressions = new ArrayList<>();
-            for (String column : columns) {
-                Expression leftExpression = new Identifier(column);
-                Expression rightExpression = new Identifier(column);
-
-                ExpressionAnalysis leftExpressionAnalysis = analyzeExpression(leftExpression, left);
-                ExpressionAnalysis rightExpressionAnalysis = analyzeExpression(rightExpression, right);
-                checkState(leftExpressionAnalysis.getSubqueryInPredicates().isEmpty(), "INVARIANT");
-                checkState(rightExpressionAnalysis.getSubqueryInPredicates().isEmpty(), "INVARIANT");
-                checkState(leftExpressionAnalysis.getScalarSubqueries().isEmpty(), "INVARIANT");
-                checkState(rightExpressionAnalysis.getScalarSubqueries().isEmpty(), "INVARIANT");
-
-                addCoercionForJoinCriteria(node, leftExpression, rightExpression);
-                expressions.add(new ComparisonExpression(EQUAL, leftExpression, rightExpression));
+        @Override
+        protected Scope visitDelete(Delete node, Scope scope)
+        {
+            Table table = node.getTable();
+            QualifiedObjectName tableName = createQualifiedObjectName(session, table, table.getName());
+            if (metadata.getView(session, tableName).isPresent()) {
+                throw new SemanticException(NOT_SUPPORTED, node, "Deleting from views is not supported");
             }
 
-            analysis.setJoinCriteria(node, ExpressionUtils.and(expressions));
+            // Analyzer checks for select permissions but DELETE has a separate permission, so disable access checks
+            // TODO: we shouldn't need to create a new analyzer. The access control should be carried in the context object
+            StatementAnalyzer analyzer = new StatementAnalyzer(
+                    analysis,
+                    metadata,
+                    sqlParser,
+                    new AllowAllAccessControl(),
+                    session);
+
+            Scope tableScope = analyzer.analyze(table, scope);
+            node.getWhere().ifPresent(where -> analyzer.analyzeWhere(node, tableScope, where));
+
+            analysis.setUpdateType("DELETE");
+
+            accessControl.checkCanDeleteFromTable(session.getRequiredTransactionId(), session.getIdentity(), tableName);
+
+            return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
         }
-        else if (criteria instanceof JoinOn) {
-            Expression expression = ((JoinOn) criteria).getExpression();
 
-            // ensure all names can be resolved, types match, etc (we don't need to record resolved names, subexpression types, etc. because
-            // we do it further down when after we determine which subexpressions apply to left vs right tuple)
-            ExpressionAnalyzer analyzer = ExpressionAnalyzer.create(analysis, session, metadata, sqlParser, accessControl);
+        @Override
+        protected Scope visitCreateTableAsSelect(CreateTableAsSelect node, Scope scope)
+        {
+            analysis.setUpdateType("CREATE TABLE");
 
-            Type clauseType = analyzer.analyze(expression, output);
-            if (!clauseType.equals(BOOLEAN)) {
-                if (!clauseType.equals(UNKNOWN)) {
-                    throw new SemanticException(TYPE_MISMATCH, expression, "JOIN ON clause must evaluate to a boolean: actual type %s", clauseType);
+            // turn this into a query that has a new table writer node on top.
+            QualifiedObjectName targetTable = createQualifiedObjectName(session, node, node.getName());
+            analysis.setCreateTableDestination(targetTable);
+
+            Optional<TableHandle> targetTableHandle = metadata.getTableHandle(session, targetTable);
+            if (targetTableHandle.isPresent()) {
+                if (node.isNotExists()) {
+                    analysis.setCreateTableAsSelectNoOp(true);
+                    return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
                 }
-                // coerce null to boolean
-                analysis.addCoercion(expression, BOOLEAN, false);
+                throw new SemanticException(TABLE_ALREADY_EXISTS, node, "Destination table '%s' already exists", targetTable);
             }
 
-            Analyzer.verifyNoAggregatesOrWindowFunctions(metadata.getFunctionRegistry(), expression, "JOIN clause");
+            for (Expression expression : node.getProperties().values()) {
+                // analyze table property value expressions which must be constant
+                createConstantAnalyzer(metadata, session, analysis.getParameters(), analysis.isDescribe())
+                        .analyze(expression, scope);
+            }
+            analysis.setCreateTableProperties(node.getProperties());
 
-            // expressionInterpreter/optimizer only understands a subset of expression types
-            // TODO: remove this when the new expression tree is implemented
-            Expression canonicalized = CanonicalizeExpressions.canonicalizeExpression(expression);
-            analyzer.analyze(canonicalized, output);
+            accessControl.checkCanCreateTable(session.getRequiredTransactionId(), session.getIdentity(), targetTable);
 
-            Object optimizedExpression = expressionOptimizer(canonicalized, metadata, session, analyzer.getExpressionTypes()).optimize(NoOpSymbolResolver.INSTANCE);
+            analysis.setCreateTableAsSelectWithData(node.isWithData());
 
-            if (!(optimizedExpression instanceof Expression) && (optimizedExpression instanceof Boolean || optimizedExpression == null)) {
-                // If the JoinOn clause evaluates to a boolean expression, simulate a cross join by adding the relevant redundant expression
-                // optimizedExpression can be TRUE, FALSE or NULL here
-                if (optimizedExpression != null && optimizedExpression.equals(Boolean.TRUE)) {
-                    optimizedExpression = new ComparisonExpression(EQUAL, new LongLiteral("0"), new LongLiteral("0"));
+            // analyze the query that creates the table
+            Scope queryScope = process(node.getQuery(), scope);
+
+            validateColumns(node, queryScope.getRelationType());
+
+            return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
+        }
+
+        @Override
+        protected Scope visitCreateView(CreateView node, Scope scope)
+        {
+            analysis.setUpdateType("CREATE VIEW");
+
+            QualifiedObjectName viewName = createQualifiedObjectName(session, node, node.getName());
+
+            // analyze the query that creates the view
+            StatementAnalyzer analyzer = new StatementAnalyzer(
+                    analysis,
+                    metadata,
+                    sqlParser,
+                    new ViewAccessControl(accessControl),
+                    session);
+
+            Scope queryScope = analyzer.analyze(node.getQuery(), scope);
+
+            accessControl.checkCanCreateView(session.getRequiredTransactionId(), session.getIdentity(), viewName);
+
+            validateColumns(node, queryScope.getRelationType());
+
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitSetSession(SetSession node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitResetSession(ResetSession node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitAddColumn(AddColumn node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitCreateSchema(CreateSchema node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitDropSchema(DropSchema node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitRenameSchema(RenameSchema node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitCreateTable(CreateTable node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitDropTable(DropTable node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitRenameTable(RenameTable node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitRenameColumn(RenameColumn node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitDropView(DropView node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitStartTransaction(StartTransaction node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitCommit(Commit node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitRollback(Rollback node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitPrepare(Prepare node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitDeallocate(Deallocate node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitExecute(Execute node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitGrant(Grant node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitRevoke(Revoke node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        @Override
+        protected Scope visitCall(Call node, Scope scope)
+        {
+            return createAndAssignScope(node, scope, emptyList());
+        }
+
+        private void validateColumns(Statement node, RelationType descriptor)
+        {
+            // verify that all column names are specified and unique
+            // TODO: collect errors and return them all at once
+            Set<String> names = new HashSet<>();
+            for (Field field : descriptor.getVisibleFields()) {
+                Optional<String> fieldName = field.getName();
+                if (!fieldName.isPresent()) {
+                    throw new SemanticException(COLUMN_NAME_NOT_SPECIFIED, node, "Column name not specified at position %s", descriptor.indexOf(field) + 1);
+                }
+                if (!names.add(fieldName.get())) {
+                    throw new SemanticException(DUPLICATE_COLUMN_NAME, node, "Column name '%s' specified more than once", fieldName.get());
+                }
+                if (field.getType().equals(UNKNOWN)) {
+                    throw new SemanticException(COLUMN_TYPE_UNKNOWN, node, "Column type is unknown: %s", fieldName.get());
+                }
+            }
+        }
+
+        @Override
+        protected Scope visitExplain(Explain node, Scope scope)
+                throws SemanticException
+        {
+            checkState(node.isAnalyze(), "Non analyze explain should be rewritten to Query");
+            if (node.getOptions().stream().anyMatch(option -> !option.equals(new ExplainType(DISTRIBUTED)))) {
+                throw new SemanticException(NOT_SUPPORTED, node, "EXPLAIN ANALYZE only supports TYPE DISTRIBUTED option");
+            }
+            process(node.getStatement(), scope);
+            analysis.setUpdateType(null);
+            return createAndAssignScope(node, scope, Field.newUnqualified("Query Plan", VARCHAR));
+        }
+
+        @Override
+        protected Scope visitQuery(Query node, Scope scope)
+        {
+            Scope withScope = analyzeWith(node, scope);
+            Scope queryScope = Scope.builder()
+                    .withParent(withScope)
+                    .build();
+            Scope queryBodyScope = process(node.getQueryBody(), queryScope);
+            analyzeOrderBy(node, queryBodyScope);
+
+            // Input fields == Output fields
+            analysis.setOutputExpressions(node, descriptorToFields(queryBodyScope));
+
+            queryScope = Scope.builder()
+                    .withParent(withScope)
+                    .withRelationType(queryBodyScope.getRelationType())
+                    .build();
+            analysis.setScope(node, queryScope);
+            return queryScope;
+        }
+
+        @Override
+        protected Scope visitUnnest(Unnest node, Scope scope)
+        {
+            ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
+            for (Expression expression : node.getExpressions()) {
+                ExpressionAnalysis expressionAnalysis = analyzeExpression(expression, scope);
+                Type expressionType = expressionAnalysis.getType(expression);
+                if (expressionType instanceof ArrayType) {
+                    outputFields.add(Field.newUnqualified(Optional.empty(), ((ArrayType) expressionType).getElementType()));
+                }
+                else if (expressionType instanceof MapType) {
+                    outputFields.add(Field.newUnqualified(Optional.empty(), ((MapType) expressionType).getKeyType()));
+                    outputFields.add(Field.newUnqualified(Optional.empty(), ((MapType) expressionType).getValueType()));
                 }
                 else {
-                    optimizedExpression = new ComparisonExpression(EQUAL, new LongLiteral("0"), new LongLiteral("1"));
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Cannot unnest type: " + expressionType);
+                }
+            }
+            if (node.isWithOrdinality()) {
+                outputFields.add(Field.newUnqualified(Optional.empty(), BIGINT));
+            }
+            return createAndAssignScope(node, scope, outputFields.build());
+        }
+
+        @Override
+        protected Scope visitTable(Table table, Scope scope)
+        {
+            if (!table.getName().getPrefix().isPresent()) {
+                // is this a reference to a WITH query?
+                String name = table.getName().getSuffix();
+
+                Optional<WithQuery> withQuery = scope.getNamedQuery(name);
+                if (withQuery.isPresent()) {
+                    Query query = withQuery.get().getQuery();
+                    analysis.registerNamedQuery(table, query);
+
+                    // re-alias the fields with the name assigned to the query in the WITH declaration
+                    RelationType queryDescriptor = analysis.getOutputDescriptor(query);
+
+                    List<Field> fields;
+                    Optional<List<String>> columnNames = withQuery.get().getColumnNames();
+                    if (columnNames.isPresent()) {
+                        // if columns are explicitly aliased -> WITH cte(alias1, alias2 ...)
+                        ImmutableList.Builder<Field> fieldBuilder = ImmutableList.builder();
+
+                        int field = 0;
+                        for (String columnName : columnNames.get()) {
+                            Field inputField = queryDescriptor.getFieldByIndex(field);
+                            fieldBuilder.add(Field.newQualified(
+                                    QualifiedName.of(name),
+                                    Optional.of(columnName),
+                                    inputField.getType(),
+                                    false,
+                                    inputField.getOriginTable(),
+                                    inputField.isAliased()));
+
+                            field++;
+                        }
+
+                        fields = fieldBuilder.build();
+                    }
+                    else {
+                        fields = queryDescriptor.getAllFields().stream()
+                                .map(field -> Field.newQualified(
+                                        QualifiedName.of(name),
+                                        field.getName(),
+                                        field.getType(),
+                                        field.isHidden(),
+                                        field.getOriginTable(),
+                                        field.isAliased()))
+                                .collect(toImmutableList());
+                    }
+
+                    return createAndAssignScope(table, scope, fields);
                 }
             }
 
-            if (!(optimizedExpression instanceof Expression)) {
-                throw new SemanticException(TYPE_MISMATCH, node, "Join clause must be a boolean expression");
+            QualifiedObjectName name = createQualifiedObjectName(session, table, table.getName());
+
+            Optional<ViewDefinition> optionalView = metadata.getView(session, name);
+            if (optionalView.isPresent()) {
+                Statement statement = analysis.getStatement();
+                if (statement instanceof CreateView) {
+                    CreateView viewStatement = (CreateView) statement;
+                    QualifiedObjectName viewNameFromStatement = createQualifiedObjectName(session, viewStatement, viewStatement.getName());
+                    if (viewStatement.isReplace() && viewNameFromStatement.equals(name)) {
+                        throw new SemanticException(VIEW_IS_RECURSIVE, table, "Statement would create a recursive view");
+                    }
+                }
+                if (analysis.hasTableInView(table)) {
+                    throw new SemanticException(VIEW_IS_RECURSIVE, table, "View is recursive");
+                }
+                ViewDefinition view = optionalView.get();
+
+                Query query = parseView(view.getOriginalSql(), name, table);
+
+                analysis.registerNamedQuery(table, query);
+
+                accessControl.checkCanSelectFromView(session.getRequiredTransactionId(), session.getIdentity(), name);
+
+                analysis.registerTableForView(table);
+                RelationType descriptor = analyzeView(query, name, view.getCatalog(), view.getSchema(), view.getOwner(), table);
+                analysis.unregisterTableForView();
+
+                if (isViewStale(view.getColumns(), descriptor.getVisibleFields())) {
+                    throw new SemanticException(VIEW_IS_STALE, table, "View '%s' is stale; it must be re-created", name);
+                }
+
+                // Derive the type of the view from the stored definition, not from the analysis of the underlying query.
+                // This is needed in case the underlying table(s) changed and the query in the view now produces types that
+                // are implicitly coercible to the declared view types.
+                List<Field> outputFields = view.getColumns().stream()
+                        .map(column -> Field.newQualified(
+                                QualifiedName.of(name.getObjectName()),
+                                Optional.of(column.getName()),
+                                column.getType(),
+                                false,
+                                Optional.of(name),
+                                false))
+                        .collect(toImmutableList());
+
+                analysis.addRelationCoercion(table, outputFields.stream().map(Field::getType).toArray(Type[]::new));
+
+                return createAndAssignScope(table, scope, outputFields);
             }
-            // The optimization above may have rewritten the expression tree which breaks all the identity maps, so redo the analysis
-            // to re-analyze coercions that might be necessary
-            analyzer = ExpressionAnalyzer.create(analysis, session, metadata, sqlParser, accessControl);
-            analyzer.analyze((Expression) optimizedExpression, output);
-            analysis.addCoercions(analyzer.getExpressionCoercions(), analyzer.getTypeOnlyCoercions());
 
-            Set<Expression> postJoinConjuncts = new HashSet<>();
+            Optional<TableHandle> tableHandle = metadata.getTableHandle(session, name);
+            if (!tableHandle.isPresent()) {
+                if (!metadata.getCatalogHandle(session, name.getCatalogName()).isPresent()) {
+                    throw new SemanticException(MISSING_CATALOG, table, "Catalog %s does not exist", name.getCatalogName());
+                }
+                if (!metadata.schemaExists(session, new CatalogSchemaName(name.getCatalogName(), name.getSchemaName()))) {
+                    throw new SemanticException(MISSING_SCHEMA, table, "Schema %s does not exist", name.getSchemaName());
+                }
+                throw new SemanticException(MISSING_TABLE, table, "Table %s does not exist", name);
+            }
+            accessControl.checkCanSelectFromTable(session.getRequiredTransactionId(), session.getIdentity(), name);
+            TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle.get());
+            Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle.get());
 
-            for (Expression conjunct : ExpressionUtils.extractConjuncts((Expression) optimizedExpression)) {
-                conjunct = ExpressionUtils.normalize(conjunct);
+            // TODO: discover columns lazily based on where they are needed (to support connectors that can't enumerate all tables)
+            ImmutableList.Builder<Field> fields = ImmutableList.builder();
+            for (ColumnMetadata column : tableMetadata.getColumns()) {
+                Field field = Field.newQualified(
+                        table.getName(),
+                        Optional.of(column.getName()),
+                        column.getType(),
+                        column.isHidden(),
+                        Optional.of(name),
+                        false);
+                fields.add(field);
+                ColumnHandle columnHandle = columnHandles.get(column.getName());
+                checkArgument(columnHandle != null, "Unknown field %s", field);
+                analysis.setColumn(field, columnHandle);
+            }
 
-                if (conjunct instanceof ComparisonExpression
-                        && (((ComparisonExpression) conjunct).getType() == EQUAL || node.getType() == Join.Type.INNER)) {
-                    Expression conjunctFirst = ((ComparisonExpression) conjunct).getLeft();
-                    Expression conjunctSecond = ((ComparisonExpression) conjunct).getRight();
-                    Set<QualifiedName> firstDependencies = DependencyExtractor.extractNames(conjunctFirst, analyzer.getColumnReferences());
-                    Set<QualifiedName> secondDependencies = DependencyExtractor.extractNames(conjunctSecond, analyzer.getColumnReferences());
+            analysis.registerTable(table, tableHandle.get());
 
-                    Expression leftExpression = null;
-                    Expression rightExpression = null;
-                    if (firstDependencies.stream().allMatch(left.getRelationType()::canResolve) && secondDependencies.stream().allMatch(right.getRelationType()::canResolve)) {
-                        leftExpression = conjunctFirst;
-                        rightExpression = conjunctSecond;
+            return createAndAssignScope(table, scope, fields.build());
+        }
+
+        @Override
+        protected Scope visitAliasedRelation(AliasedRelation relation, Scope scope)
+        {
+            Scope relationScope = process(relation.getRelation(), scope);
+
+            // todo this check should be inside of TupleDescriptor.withAlias, but the exception needs the node object
+            RelationType relationType = relationScope.getRelationType();
+            if (relation.getColumnNames() != null) {
+                int totalColumns = relationType.getVisibleFieldCount();
+                if (totalColumns != relation.getColumnNames().size()) {
+                    throw new SemanticException(MISMATCHED_COLUMN_ALIASES, relation, "Column alias list has %s entries but '%s' has %s columns available", relation.getColumnNames().size(), relation.getAlias(), totalColumns);
+                }
+            }
+
+            RelationType descriptor = relationType.withAlias(relation.getAlias(), relation.getColumnNames());
+            return createAndAssignScope(relation, scope, descriptor);
+        }
+
+        @Override
+        protected Scope visitSampledRelation(SampledRelation relation, Scope scope)
+        {
+            if (!DependencyExtractor.extractNames(relation.getSamplePercentage(), analysis.getColumnReferences()).isEmpty()) {
+                throw new SemanticException(NON_NUMERIC_SAMPLE_PERCENTAGE, relation.getSamplePercentage(), "Sample percentage cannot contain column references");
+            }
+
+            IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(
+                    session,
+                    metadata,
+                    sqlParser,
+                    ImmutableMap.of(),
+                    relation.getSamplePercentage(),
+                    analysis.getParameters(),
+                    analysis.isDescribe());
+            ExpressionInterpreter samplePercentageEval = expressionOptimizer(relation.getSamplePercentage(), metadata, session, expressionTypes);
+
+            Object samplePercentageObject = samplePercentageEval.optimize(symbol -> {
+                throw new SemanticException(NON_NUMERIC_SAMPLE_PERCENTAGE, relation.getSamplePercentage(), "Sample percentage cannot contain column references");
+            });
+
+            if (!(samplePercentageObject instanceof Number)) {
+                throw new SemanticException(NON_NUMERIC_SAMPLE_PERCENTAGE, relation.getSamplePercentage(), "Sample percentage should evaluate to a numeric expression");
+            }
+
+            double samplePercentageValue = ((Number) samplePercentageObject).doubleValue();
+
+            if (samplePercentageValue < 0.0) {
+                throw new SemanticException(SemanticErrorCode.SAMPLE_PERCENTAGE_OUT_OF_RANGE, relation.getSamplePercentage(), "Sample percentage must be greater than or equal to 0");
+            }
+            if ((samplePercentageValue > 100.0)) {
+                throw new SemanticException(SemanticErrorCode.SAMPLE_PERCENTAGE_OUT_OF_RANGE, relation.getSamplePercentage(), "Sample percentage must be less than or equal to 100");
+            }
+
+            analysis.setSampleRatio(relation, samplePercentageValue / 100);
+            Scope relationScope = process(relation.getRelation(), scope);
+            return createAndAssignScope(relation, scope, relationScope.getRelationType());
+        }
+
+        @Override
+        protected Scope visitTableSubquery(TableSubquery node, Scope scope)
+        {
+            StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, accessControl, session);
+            Scope queryScope = analyzer.analyze(node.getQuery(), scope);
+            return createAndAssignScope(node, scope, queryScope.getRelationType());
+        }
+
+        @Override
+        protected Scope visitQuerySpecification(QuerySpecification node, Scope scope)
+        {
+            // TODO: extract candidate names from SELECT, WHERE, HAVING, GROUP BY and ORDER BY expressions
+            // to pass down to analyzeFrom
+
+            Scope sourceScope = analyzeFrom(node, scope);
+
+            node.getWhere().ifPresent(where -> analyzeWhere(node, sourceScope, where));
+
+            List<Expression> outputExpressions = analyzeSelect(node, sourceScope);
+            List<List<Expression>> groupByExpressions = analyzeGroupBy(node, sourceScope, outputExpressions);
+
+            Scope outputScope = computeOutputScope(node, sourceScope);
+
+            List<Expression> orderByExpressions = analyzeOrderBy(node, sourceScope, outputScope, outputExpressions);
+            analyzeHaving(node, sourceScope);
+
+            List<Expression> expressions = new ArrayList<>();
+            expressions.addAll(outputExpressions);
+            expressions.addAll(orderByExpressions);
+            node.getHaving().ifPresent(expressions::add);
+
+            analyzeAggregations(node, sourceScope, groupByExpressions, analysis.getColumnReferences(), expressions);
+            analyzeWindowFunctions(node, outputExpressions, orderByExpressions);
+
+            return outputScope;
+        }
+
+        @Override
+        protected Scope visitSetOperation(SetOperation node, Scope scope)
+        {
+            checkState(node.getRelations().size() >= 2);
+
+            List<Scope> relationScopes = node.getRelations().stream()
+                    .map(relation -> {
+                        Scope relationScope = process(relation, scope);
+                        return createAndAssignScope(relation, scope, relationScope.getRelationType().withOnlyVisibleFields());
+                    })
+                    .collect(toImmutableList());
+
+            Type[] outputFieldTypes = relationScopes.get(0).getRelationType().getVisibleFields().stream()
+                    .map(Field::getType)
+                    .toArray(Type[]::new);
+            for (Scope relationScope : relationScopes) {
+                int outputFieldSize = outputFieldTypes.length;
+                RelationType relationType = relationScope.getRelationType();
+                int descFieldSize = relationType.getVisibleFields().size();
+                String setOperationName = node.getClass().getSimpleName();
+                if (outputFieldSize != descFieldSize) {
+                    throw new SemanticException(MISMATCHED_SET_COLUMN_TYPES,
+                            node,
+                            "%s query has different number of fields: %d, %d",
+                            setOperationName, outputFieldSize, descFieldSize);
+                }
+                for (int i = 0; i < descFieldSize; i++) {
+                    Type descFieldType = relationType.getFieldByIndex(i).getType();
+                    Optional<Type> commonSuperType = metadata.getTypeManager().getCommonSuperType(outputFieldTypes[i], descFieldType);
+                    if (!commonSuperType.isPresent()) {
+                        throw new SemanticException(TYPE_MISMATCH,
+                                node,
+                                "column %d in %s query has incompatible types: %s, %s",
+                                i, outputFieldTypes[i].getDisplayName(), setOperationName, descFieldType.getDisplayName());
                     }
-                    else if (firstDependencies.stream().allMatch(right.getRelationType()::canResolve) && secondDependencies.stream().allMatch(left.getRelationType()::canResolve)) {
-                        leftExpression = conjunctSecond;
-                        rightExpression = conjunctFirst;
-                    }
+                    outputFieldTypes[i] = commonSuperType.get();
+                }
+            }
 
-                    // expression on each side of comparison operator references only symbols from one side of join.
-                    // analyze the clauses to record the types of all subexpressions and resolve names against the left/right underlying tuples
-                    if (rightExpression != null) {
-                        ExpressionAnalysis leftExpressionAnalysis = analyzeExpression(leftExpression, left);
-                        ExpressionAnalysis rightExpressionAnalysis = analyzeExpression(rightExpression, right);
-                        analysis.recordSubqueries(node, leftExpressionAnalysis);
-                        analysis.recordSubqueries(node, rightExpressionAnalysis);
-                        addCoercionForJoinCriteria(node, leftExpression, rightExpression);
+            Field[] outputDescriptorFields = new Field[outputFieldTypes.length];
+            RelationType firstDescriptor = relationScopes.get(0).getRelationType().withOnlyVisibleFields();
+            for (int i = 0; i < outputFieldTypes.length; i++) {
+                Field oldField = firstDescriptor.getFieldByIndex(i);
+                outputDescriptorFields[i] = new Field(
+                        oldField.getRelationAlias(),
+                        oldField.getName(),
+                        outputFieldTypes[i],
+                        oldField.isHidden(),
+                        oldField.getOriginTable(),
+                        oldField.isAliased());
+            }
+
+            for (int i = 0; i < node.getRelations().size(); i++) {
+                Relation relation = node.getRelations().get(i);
+                Scope relationScope = relationScopes.get(i);
+                RelationType relationType = relationScope.getRelationType();
+                for (int j = 0; j < relationType.getVisibleFields().size(); j++) {
+                    Type outputFieldType = outputFieldTypes[j];
+                    Type descFieldType = relationType.getFieldByIndex(j).getType();
+                    if (!outputFieldType.equals(descFieldType)) {
+                        analysis.addRelationCoercion(relation, outputFieldTypes);
+                        break;
+                    }
+                }
+            }
+            return createAndAssignScope(node, scope, outputDescriptorFields);
+        }
+
+        @Override
+        protected Scope visitIntersect(Intersect node, Scope scope)
+        {
+            if (!node.isDistinct()) {
+                throw new SemanticException(NOT_SUPPORTED, node, "INTERSECT ALL not yet implemented");
+            }
+
+            return visitSetOperation(node, scope);
+        }
+
+        @Override
+        protected Scope visitExcept(Except node, Scope scope)
+        {
+            if (!node.isDistinct()) {
+                throw new SemanticException(NOT_SUPPORTED, node, "EXCEPT ALL not yet implemented");
+            }
+
+            return visitSetOperation(node, scope);
+        }
+
+        @Override
+        protected Scope visitJoin(Join node, Scope scope)
+        {
+            JoinCriteria criteria = node.getCriteria().orElse(null);
+            if (criteria instanceof NaturalJoin) {
+                throw new SemanticException(NOT_SUPPORTED, node, "Natural join not supported");
+            }
+
+            Scope left = process(node.getLeft(), scope);
+            Scope right = process(node.getRight(), isUnnestRelation(node.getRight()) ? left : scope);
+
+            Scope output = createAndAssignScope(node, scope, left.getRelationType().joinWith(right.getRelationType()));
+
+            if (node.getType() == Join.Type.CROSS || node.getType() == Join.Type.IMPLICIT) {
+                return output;
+            }
+
+            if (criteria instanceof JoinUsing) {
+                // TODO: implement proper "using" semantics with respect to output columns
+                List<String> columns = ((JoinUsing) criteria).getColumns();
+
+                List<Expression> expressions = new ArrayList<>();
+                for (String column : columns) {
+                    Expression leftExpression = new Identifier(column);
+                    Expression rightExpression = new Identifier(column);
+
+                    ExpressionAnalysis leftExpressionAnalysis = analyzeExpression(leftExpression, left);
+                    ExpressionAnalysis rightExpressionAnalysis = analyzeExpression(rightExpression, right);
+                    checkState(leftExpressionAnalysis.getSubqueryInPredicates().isEmpty(), "INVARIANT");
+                    checkState(rightExpressionAnalysis.getSubqueryInPredicates().isEmpty(), "INVARIANT");
+                    checkState(leftExpressionAnalysis.getScalarSubqueries().isEmpty(), "INVARIANT");
+                    checkState(rightExpressionAnalysis.getScalarSubqueries().isEmpty(), "INVARIANT");
+
+                    addCoercionForJoinCriteria(node, leftExpression, rightExpression);
+                    expressions.add(new ComparisonExpression(EQUAL, leftExpression, rightExpression));
+                }
+
+                analysis.setJoinCriteria(node, ExpressionUtils.and(expressions));
+            }
+            else if (criteria instanceof JoinOn) {
+                Expression expression = ((JoinOn) criteria).getExpression();
+
+                // ensure all names can be resolved, types match, etc (we don't need to record resolved names, subexpression types, etc. because
+                // we do it further down when after we determine which subexpressions apply to left vs right tuple)
+                ExpressionAnalyzer analyzer = ExpressionAnalyzer.create(analysis, session, metadata, sqlParser, accessControl);
+
+                Type clauseType = analyzer.analyze(expression, output);
+                if (!clauseType.equals(BOOLEAN)) {
+                    if (!clauseType.equals(UNKNOWN)) {
+                        throw new SemanticException(TYPE_MISMATCH, expression, "JOIN ON clause must evaluate to a boolean: actual type %s", clauseType);
+                    }
+                    // coerce null to boolean
+                    analysis.addCoercion(expression, BOOLEAN, false);
+                }
+
+                Analyzer.verifyNoAggregatesOrWindowFunctions(metadata.getFunctionRegistry(), expression, "JOIN clause");
+
+                // expressionInterpreter/optimizer only understands a subset of expression types
+                // TODO: remove this when the new expression tree is implemented
+                Expression canonicalized = CanonicalizeExpressions.canonicalizeExpression(expression);
+                analyzer.analyze(canonicalized, output);
+
+                Object optimizedExpression = expressionOptimizer(canonicalized, metadata, session, analyzer.getExpressionTypes()).optimize(NoOpSymbolResolver.INSTANCE);
+
+                if (!(optimizedExpression instanceof Expression) && (optimizedExpression instanceof Boolean || optimizedExpression == null)) {
+                    // If the JoinOn clause evaluates to a boolean expression, simulate a cross join by adding the relevant redundant expression
+                    // optimizedExpression can be TRUE, FALSE or NULL here
+                    if (optimizedExpression != null && optimizedExpression.equals(Boolean.TRUE)) {
+                        optimizedExpression = new ComparisonExpression(EQUAL, new LongLiteral("0"), new LongLiteral("0"));
                     }
                     else {
-                        // mixed references to both left and right join relation on one side of comparison operator.
+                        optimizedExpression = new ComparisonExpression(EQUAL, new LongLiteral("0"), new LongLiteral("1"));
+                    }
+                }
+
+                if (!(optimizedExpression instanceof Expression)) {
+                    throw new SemanticException(TYPE_MISMATCH, node, "Join clause must be a boolean expression");
+                }
+                // The optimization above may have rewritten the expression tree which breaks all the identity maps, so redo the analysis
+                // to re-analyze coercions that might be necessary
+                analyzer = ExpressionAnalyzer.create(analysis, session, metadata, sqlParser, accessControl);
+                analyzer.analyze((Expression) optimizedExpression, output);
+                analysis.addCoercions(analyzer.getExpressionCoercions(), analyzer.getTypeOnlyCoercions());
+
+                Set<Expression> postJoinConjuncts = new HashSet<>();
+
+                for (Expression conjunct : ExpressionUtils.extractConjuncts((Expression) optimizedExpression)) {
+                    conjunct = ExpressionUtils.normalize(conjunct);
+
+                    if (conjunct instanceof ComparisonExpression
+                            && (((ComparisonExpression) conjunct).getType() == EQUAL || node.getType() == Join.Type.INNER)) {
+                        Expression conjunctFirst = ((ComparisonExpression) conjunct).getLeft();
+                        Expression conjunctSecond = ((ComparisonExpression) conjunct).getRight();
+                        Set<QualifiedName> firstDependencies = DependencyExtractor.extractNames(conjunctFirst, analyzer.getColumnReferences());
+                        Set<QualifiedName> secondDependencies = DependencyExtractor.extractNames(conjunctSecond, analyzer.getColumnReferences());
+
+                        Expression leftExpression = null;
+                        Expression rightExpression = null;
+                        if (firstDependencies.stream().allMatch(left.getRelationType()::canResolve) && secondDependencies.stream().allMatch(right.getRelationType()::canResolve)) {
+                            leftExpression = conjunctFirst;
+                            rightExpression = conjunctSecond;
+                        }
+                        else if (firstDependencies.stream().allMatch(right.getRelationType()::canResolve) && secondDependencies.stream().allMatch(left.getRelationType()::canResolve)) {
+                            leftExpression = conjunctSecond;
+                            rightExpression = conjunctFirst;
+                        }
+
+                        // expression on each side of comparison operator references only symbols from one side of join.
+                        // analyze the clauses to record the types of all subexpressions and resolve names against the left/right underlying tuples
+                        if (rightExpression != null) {
+                            ExpressionAnalysis leftExpressionAnalysis = analyzeExpression(leftExpression, left);
+                            ExpressionAnalysis rightExpressionAnalysis = analyzeExpression(rightExpression, right);
+                            analysis.recordSubqueries(node, leftExpressionAnalysis);
+                            analysis.recordSubqueries(node, rightExpressionAnalysis);
+                            addCoercionForJoinCriteria(node, leftExpression, rightExpression);
+                        }
+                        else {
+                            // mixed references to both left and right join relation on one side of comparison operator.
+                            // expression will be put in post-join condition; analyze in context of output table.
+                            postJoinConjuncts.add(conjunct);
+                        }
+                    }
+                    else {
+                        // non-comparison expression.
                         // expression will be put in post-join condition; analyze in context of output table.
                         postJoinConjuncts.add(conjunct);
                     }
                 }
-                else {
-                    // non-comparison expression.
-                    // expression will be put in post-join condition; analyze in context of output table.
-                    postJoinConjuncts.add(conjunct);
-                }
+                Expression postJoinPredicate = ExpressionUtils.combineConjuncts(postJoinConjuncts);
+                analysis.recordSubqueries(node, analyzeExpression(postJoinPredicate, output));
+                analysis.setJoinCriteria(node, (Expression) optimizedExpression);
             }
-            Expression postJoinPredicate = ExpressionUtils.combineConjuncts(postJoinConjuncts);
-            analysis.recordSubqueries(node, analyzeExpression(postJoinPredicate, output));
-            analysis.setJoinCriteria(node, (Expression) optimizedExpression);
-        }
-        else {
-            throw new UnsupportedOperationException("unsupported join criteria: " + criteria.getClass().getName());
-        }
-
-        return output;
-    }
-
-    private static boolean isUnnestRelation(Relation node)
-    {
-        if (node instanceof AliasedRelation) {
-            return isUnnestRelation(((AliasedRelation) node).getRelation());
-        }
-        return node instanceof Unnest;
-    }
-
-    private void addCoercionForJoinCriteria(Join node, Expression leftExpression, Expression rightExpression)
-    {
-        Type leftType = analysis.getTypeWithCoercions(leftExpression);
-        Type rightType = analysis.getTypeWithCoercions(rightExpression);
-        Optional<Type> superType = metadata.getTypeManager().getCommonSuperType(leftType, rightType);
-        if (!superType.isPresent()) {
-            throw new SemanticException(TYPE_MISMATCH, node, "Join criteria has incompatible types: %s, %s", leftType.getDisplayName(), rightType.getDisplayName());
-        }
-        if (!leftType.equals(superType.get())) {
-            analysis.addCoercion(leftExpression, superType.get(), metadata.getTypeManager().isTypeOnlyCoercion(leftType, rightType));
-        }
-        if (!rightType.equals(superType.get())) {
-            analysis.addCoercion(rightExpression, superType.get(), metadata.getTypeManager().isTypeOnlyCoercion(rightType, leftType));
-        }
-    }
-
-    @Override
-    protected Scope visitValues(Values node, Scope scope)
-    {
-        checkState(node.getRows().size() >= 1);
-
-        List<List<Type>> rowTypes = node.getRows().stream()
-                .map(row -> analyzeExpression(row, scope).getType(row))
-                .map(type -> {
-                    if (type instanceof RowType) {
-                        return type.getTypeParameters();
-                    }
-                    return ImmutableList.of(type);
-                })
-                .collect(toImmutableList());
-
-        // determine common super type of the rows
-        List<Type> fieldTypes = new ArrayList<>(rowTypes.iterator().next());
-        for (List<Type> rowType : rowTypes) {
-            // check field count consistency for rows
-            if (rowType.size() != fieldTypes.size()) {
-                throw new SemanticException(MISMATCHED_SET_COLUMN_TYPES,
-                        node,
-                        "Values rows have mismatched types: %s vs %s",
-                        rowTypes.get(0),
-                        rowType);
+            else {
+                throw new UnsupportedOperationException("unsupported join criteria: " + criteria.getClass().getName());
             }
 
-            for (int i = 0; i < rowType.size(); i++) {
-                Type fieldType = rowType.get(i);
-                Type superType = fieldTypes.get(i);
+            return output;
+        }
 
-                Optional<Type> commonSuperType = metadata.getTypeManager().getCommonSuperType(fieldType, superType);
-                if (!commonSuperType.isPresent()) {
+        private boolean isUnnestRelation(Relation node)
+        {
+            if (node instanceof AliasedRelation) {
+                return isUnnestRelation(((AliasedRelation) node).getRelation());
+            }
+            return node instanceof Unnest;
+        }
+
+        private void addCoercionForJoinCriteria(Join node, Expression leftExpression, Expression rightExpression)
+        {
+            Type leftType = analysis.getTypeWithCoercions(leftExpression);
+            Type rightType = analysis.getTypeWithCoercions(rightExpression);
+            Optional<Type> superType = metadata.getTypeManager().getCommonSuperType(leftType, rightType);
+            if (!superType.isPresent()) {
+                throw new SemanticException(TYPE_MISMATCH, node, "Join criteria has incompatible types: %s, %s", leftType.getDisplayName(), rightType.getDisplayName());
+            }
+            if (!leftType.equals(superType.get())) {
+                analysis.addCoercion(leftExpression, superType.get(), metadata.getTypeManager().isTypeOnlyCoercion(leftType, rightType));
+            }
+            if (!rightType.equals(superType.get())) {
+                analysis.addCoercion(rightExpression, superType.get(), metadata.getTypeManager().isTypeOnlyCoercion(rightType, leftType));
+            }
+        }
+
+        @Override
+        protected Scope visitValues(Values node, Scope scope)
+        {
+            checkState(node.getRows().size() >= 1);
+
+            List<List<Type>> rowTypes = node.getRows().stream()
+                    .map(row -> analyzeExpression(row, scope).getType(row))
+                    .map(type -> {
+                        if (type instanceof RowType) {
+                            return type.getTypeParameters();
+                        }
+                        return ImmutableList.of(type);
+                    })
+                    .collect(toImmutableList());
+
+            // determine common super type of the rows
+            List<Type> fieldTypes = new ArrayList<>(rowTypes.iterator().next());
+            for (List<Type> rowType : rowTypes) {
+                // check field count consistency for rows
+                if (rowType.size() != fieldTypes.size()) {
                     throw new SemanticException(MISMATCHED_SET_COLUMN_TYPES,
                             node,
                             "Values rows have mismatched types: %s vs %s",
                             rowTypes.get(0),
                             rowType);
                 }
-                fieldTypes.set(i, commonSuperType.get());
-            }
-        }
 
-        // add coercions for the rows
-        for (Expression row : node.getRows()) {
-            if (row instanceof Row) {
-                List<Expression> items = ((Row) row).getItems();
-                for (int i = 0; i < items.size(); i++) {
-                    Type expectedType = fieldTypes.get(i);
-                    Expression item = items.get(i);
-                    Type actualType = analysis.getType(item);
+                for (int i = 0; i < rowType.size(); i++) {
+                    Type fieldType = rowType.get(i);
+                    Type superType = fieldTypes.get(i);
+
+                    Optional<Type> commonSuperType = metadata.getTypeManager().getCommonSuperType(fieldType, superType);
+                    if (!commonSuperType.isPresent()) {
+                        throw new SemanticException(MISMATCHED_SET_COLUMN_TYPES,
+                                node,
+                                "Values rows have mismatched types: %s vs %s",
+                                rowTypes.get(0),
+                                rowType);
+                    }
+                    fieldTypes.set(i, commonSuperType.get());
+                }
+            }
+
+            // add coercions for the rows
+            for (Expression row : node.getRows()) {
+                if (row instanceof Row) {
+                    List<Expression> items = ((Row) row).getItems();
+                    for (int i = 0; i < items.size(); i++) {
+                        Type expectedType = fieldTypes.get(i);
+                        Expression item = items.get(i);
+                        Type actualType = analysis.getType(item);
+                        if (!actualType.equals(expectedType)) {
+                            analysis.addCoercion(item, expectedType, metadata.getTypeManager().isTypeOnlyCoercion(actualType, expectedType));
+                        }
+                    }
+                }
+                else {
+                    Type actualType = analysis.getType(row);
+                    Type expectedType = fieldTypes.get(0);
                     if (!actualType.equals(expectedType)) {
-                        analysis.addCoercion(item, expectedType, metadata.getTypeManager().isTypeOnlyCoercion(actualType, expectedType));
+                        analysis.addCoercion(row, expectedType, metadata.getTypeManager().isTypeOnlyCoercion(actualType, expectedType));
                     }
                 }
             }
-            else {
-                Type actualType = analysis.getType(row);
-                Type expectedType = fieldTypes.get(0);
-                if (!actualType.equals(expectedType)) {
-                    analysis.addCoercion(row, expectedType, metadata.getTypeManager().isTypeOnlyCoercion(actualType, expectedType));
+
+            List<Field> fields = fieldTypes.stream()
+                    .map(valueType -> Field.newUnqualified(Optional.empty(), valueType))
+                    .collect(toImmutableList());
+
+            return createAndAssignScope(node, scope, fields);
+        }
+
+        private void analyzeWindowFunctions(QuerySpecification node, List<Expression> outputExpressions, List<Expression> orderByExpressions)
+        {
+            WindowFunctionExtractor extractor = new WindowFunctionExtractor();
+
+            for (Expression expression : Iterables.concat(outputExpressions, orderByExpressions)) {
+                extractor.process(expression, null);
+                new WindowFunctionValidator().process(expression, analysis);
+            }
+
+            List<FunctionCall> windowFunctions = extractor.getWindowFunctions();
+
+            for (FunctionCall windowFunction : windowFunctions) {
+                // filter with window function is not supported yet
+                if (windowFunction.getFilter().isPresent()) {
+                    throw new SemanticException(NOT_SUPPORTED, node, "FILTER is not yet supported for window functions");
+                }
+
+                Window window = windowFunction.getWindow().get();
+
+                WindowFunctionExtractor nestedExtractor = new WindowFunctionExtractor();
+                for (Expression argument : windowFunction.getArguments()) {
+                    nestedExtractor.process(argument, null);
+                }
+
+                for (Expression expression : window.getPartitionBy()) {
+                    nestedExtractor.process(expression, null);
+                }
+
+                for (SortItem sortItem : window.getOrderBy()) {
+                    nestedExtractor.process(sortItem.getSortKey(), null);
+                }
+
+                if (window.getFrame().isPresent()) {
+                    nestedExtractor.process(window.getFrame().get(), null);
+                }
+
+                if (!nestedExtractor.getWindowFunctions().isEmpty()) {
+                    throw new SemanticException(NESTED_WINDOW, node, "Cannot nest window functions inside window function '%s': %s",
+                            windowFunction,
+                            extractor.getWindowFunctions());
+                }
+
+                if (windowFunction.isDistinct()) {
+                    throw new SemanticException(NOT_SUPPORTED, node, "DISTINCT in window function parameters not yet supported: %s", windowFunction);
+                }
+
+                if (window.getFrame().isPresent()) {
+                    analyzeWindowFrame(window.getFrame().get());
+                }
+
+                List<TypeSignature> argumentTypes = Lists.transform(windowFunction.getArguments(), expression -> analysis.getType(expression).getTypeSignature());
+
+                FunctionKind kind = metadata.getFunctionRegistry().resolveFunction(windowFunction.getName(), fromTypeSignatures(argumentTypes)).getKind();
+                if (kind != AGGREGATE && kind != WINDOW) {
+                    throw new SemanticException(MUST_BE_WINDOW_FUNCTION, node, "Not a window function: %s", windowFunction.getName());
                 }
             }
+
+            analysis.setWindowFunctions(node, windowFunctions);
         }
 
-        List<Field> fields = fieldTypes.stream()
-                .map(valueType -> Field.newUnqualified(Optional.empty(), valueType))
-                .collect(toImmutableList());
+        private void analyzeWindowFrame(WindowFrame frame)
+        {
+            FrameBound.Type startType = frame.getStart().getType();
+            FrameBound.Type endType = frame.getEnd().orElse(new FrameBound(CURRENT_ROW)).getType();
 
-        return createAndAssignScope(node, scope, fields);
-    }
-
-    private void analyzeWindowFunctions(QuerySpecification node, List<Expression> outputExpressions, List<Expression> orderByExpressions)
-    {
-        WindowFunctionExtractor extractor = new WindowFunctionExtractor();
-
-        for (Expression expression : Iterables.concat(outputExpressions, orderByExpressions)) {
-            extractor.process(expression, null);
-            new WindowFunctionValidator().process(expression, analysis);
-        }
-
-        List<FunctionCall> windowFunctions = extractor.getWindowFunctions();
-
-        for (FunctionCall windowFunction : windowFunctions) {
-            // filter with window function is not supported yet
-            if (windowFunction.getFilter().isPresent()) {
-                throw new SemanticException(NOT_SUPPORTED, node, "FILTER is not yet supported for window functions");
+            if (startType == UNBOUNDED_FOLLOWING) {
+                throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame start cannot be UNBOUNDED FOLLOWING");
             }
-
-            Window window = windowFunction.getWindow().get();
-
-            WindowFunctionExtractor nestedExtractor = new WindowFunctionExtractor();
-            for (Expression argument : windowFunction.getArguments()) {
-                nestedExtractor.process(argument, null);
+            if (endType == UNBOUNDED_PRECEDING) {
+                throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame end cannot be UNBOUNDED PRECEDING");
             }
-
-            for (Expression expression : window.getPartitionBy()) {
-                nestedExtractor.process(expression, null);
+            if ((startType == CURRENT_ROW) && (endType == PRECEDING)) {
+                throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame starting from CURRENT ROW cannot end with PRECEDING");
             }
-
-            for (SortItem sortItem : window.getOrderBy()) {
-                nestedExtractor.process(sortItem.getSortKey(), null);
+            if ((startType == FOLLOWING) && (endType == PRECEDING)) {
+                throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame starting from FOLLOWING cannot end with PRECEDING");
             }
-
-            if (window.getFrame().isPresent()) {
-                nestedExtractor.process(window.getFrame().get(), null);
+            if ((startType == FOLLOWING) && (endType == CURRENT_ROW)) {
+                throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame starting from FOLLOWING cannot end with CURRENT ROW");
             }
-
-            if (!nestedExtractor.getWindowFunctions().isEmpty()) {
-                throw new SemanticException(NESTED_WINDOW, node, "Cannot nest window functions inside window function '%s': %s",
-                        windowFunction,
-                        extractor.getWindowFunctions());
+            if ((frame.getType() == RANGE) && ((startType == PRECEDING) || (endType == PRECEDING))) {
+                throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame RANGE PRECEDING is only supported with UNBOUNDED");
             }
-
-            if (windowFunction.isDistinct()) {
-                throw new SemanticException(NOT_SUPPORTED, node, "DISTINCT in window function parameters not yet supported: %s", windowFunction);
-            }
-
-            if (window.getFrame().isPresent()) {
-                analyzeWindowFrame(window.getFrame().get());
-            }
-
-            List<TypeSignature> argumentTypes = Lists.transform(windowFunction.getArguments(), expression -> analysis.getType(expression).getTypeSignature());
-
-            FunctionKind kind = metadata.getFunctionRegistry().resolveFunction(windowFunction.getName(), fromTypeSignatures(argumentTypes)).getKind();
-            if (kind != AGGREGATE && kind != WINDOW) {
-                throw new SemanticException(MUST_BE_WINDOW_FUNCTION, node, "Not a window function: %s", windowFunction.getName());
+            if ((frame.getType() == RANGE) && ((startType == FOLLOWING) || (endType == FOLLOWING))) {
+                throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame RANGE FOLLOWING is only supported with UNBOUNDED");
             }
         }
 
-        analysis.setWindowFunctions(node, windowFunctions);
-    }
+        private void analyzeHaving(QuerySpecification node, Scope scope)
+        {
+            if (node.getHaving().isPresent()) {
+                Expression predicate = node.getHaving().get();
 
-    private static void analyzeWindowFrame(WindowFrame frame)
-    {
-        FrameBound.Type startType = frame.getStart().getType();
-        FrameBound.Type endType = frame.getEnd().orElse(new FrameBound(CURRENT_ROW)).getType();
+                ExpressionAnalysis expressionAnalysis = analyzeExpression(predicate, scope);
+                analysis.recordSubqueries(node, expressionAnalysis);
 
-        if (startType == UNBOUNDED_FOLLOWING) {
-            throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame start cannot be UNBOUNDED FOLLOWING");
-        }
-        if (endType == UNBOUNDED_PRECEDING) {
-            throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame end cannot be UNBOUNDED PRECEDING");
-        }
-        if ((startType == CURRENT_ROW) && (endType == PRECEDING)) {
-            throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame starting from CURRENT ROW cannot end with PRECEDING");
-        }
-        if ((startType == FOLLOWING) && (endType == PRECEDING)) {
-            throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame starting from FOLLOWING cannot end with PRECEDING");
-        }
-        if ((startType == FOLLOWING) && (endType == CURRENT_ROW)) {
-            throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame starting from FOLLOWING cannot end with CURRENT ROW");
-        }
-        if ((frame.getType() == RANGE) && ((startType == PRECEDING) || (endType == PRECEDING))) {
-            throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame RANGE PRECEDING is only supported with UNBOUNDED");
-        }
-        if ((frame.getType() == RANGE) && ((startType == FOLLOWING) || (endType == FOLLOWING))) {
-            throw new SemanticException(INVALID_WINDOW_FRAME, frame, "Window frame RANGE FOLLOWING is only supported with UNBOUNDED");
-        }
-    }
+                Type predicateType = expressionAnalysis.getType(predicate);
+                if (!predicateType.equals(BOOLEAN) && !predicateType.equals(UNKNOWN)) {
+                    throw new SemanticException(TYPE_MISMATCH, predicate, "HAVING clause must evaluate to a boolean: actual type %s", predicateType);
+                }
 
-    private void analyzeHaving(QuerySpecification node, Scope scope)
-    {
-        if (node.getHaving().isPresent()) {
-            Expression predicate = node.getHaving().get();
+                analysis.setHaving(node, predicate);
+            }
+        }
+
+        private List<Expression> analyzeOrderBy(QuerySpecification node, Scope sourceScope, Scope outputScope, List<Expression> outputExpressions)
+        {
+            if (SystemSessionProperties.isLegacyOrderByEnabled(session)) {
+                return legacyAnalyzeOrderBy(node, sourceScope, outputScope, outputExpressions);
+            }
+
+            List<SortItem> items = node.getOrderBy()
+                    .map(OrderBy::getSortItems)
+                    .orElse(emptyList());
+
+            ImmutableList.Builder<Expression> orderByExpressionsBuilder = ImmutableList.builder();
+
+            if (!items.isEmpty()) {
+                for (SortItem item : items) {
+                    Expression expression = item.getSortKey();
+
+                    Expression orderByExpression;
+                    if (expression instanceof LongLiteral) {
+                        // this is an ordinal in the output tuple
+
+                        long ordinal = ((LongLiteral) expression).getValue();
+                        if (ordinal < 1 || ordinal > outputExpressions.size()) {
+                            throw new SemanticException(INVALID_ORDINAL, expression, "ORDER BY position %s is not in select list", ordinal);
+                        }
+
+                        int field = toIntExact(ordinal - 1);
+                        Type type = outputScope.getRelationType().getFieldByIndex(field).getType();
+                        if (!type.isOrderable()) {
+                            throw new SemanticException(TYPE_MISMATCH, node, "The type of expression in position %s is not orderable (actual: %s), and therefore cannot be used in ORDER BY", ordinal, type);
+                        }
+
+                        orderByExpression = outputExpressions.get(field);
+                    }
+                    else {
+                        // Analyze the original expression using a synthetic scope (which delegates to the source scope for any missing name)
+                        // to catch any semantic errors (due to type mismatch, etc)
+                        Scope synthetic = Scope.builder()
+                                .withParent(sourceScope)
+                                .withRelationType(outputScope.getRelationType())
+                                .build();
+
+                        analyzeExpression(expression, synthetic);
+
+                        orderByExpression = ExpressionTreeRewriter.rewriteWith(new OrderByExpressionRewriter(extractNamedOutputExpressions(node)), expression);
+
+                        ExpressionAnalysis expressionAnalysis = analyzeExpression(orderByExpression, sourceScope);
+                        analysis.recordSubqueries(node, expressionAnalysis);
+                    }
+
+                    Type type = analysis.getType(orderByExpression);
+                    if (!type.isOrderable()) {
+                        throw new SemanticException(TYPE_MISMATCH, node, "Type %s is not orderable, and therefore cannot be used in ORDER BY: %s", type, expression);
+                    }
+
+                    orderByExpressionsBuilder.add(orderByExpression);
+                }
+            }
+
+            List<Expression> orderByExpressions = orderByExpressionsBuilder.build();
+            analysis.setOrderByExpressions(node, orderByExpressions);
+
+            if (node.getSelect().isDistinct() && !outputExpressions.containsAll(orderByExpressions)) {
+                throw new SemanticException(ORDER_BY_MUST_BE_IN_SELECT, node.getSelect(), "For SELECT DISTINCT, ORDER BY expressions must appear in select list");
+            }
+            return orderByExpressions;
+        }
+
+        /**
+         * Preserve the old column resolution behavior for ORDER BY while we transition workloads to new semantics
+         * TODO: remove this
+         */
+        private List<Expression> legacyAnalyzeOrderBy(QuerySpecification node, Scope sourceScope, Scope outputScope, List<Expression> outputExpressions)
+        {
+            List<SortItem> items = node.getOrderBy()
+                    .map(OrderBy::getSortItems)
+                    .orElse(emptyList());
+
+            ImmutableList.Builder<Expression> orderByExpressionsBuilder = ImmutableList.builder();
+
+            if (!items.isEmpty()) {
+                // Compute aliased output terms so we can resolve order by expressions against them first
+                ImmutableMultimap.Builder<QualifiedName, Expression> byAliasBuilder = ImmutableMultimap.builder();
+                for (SelectItem item : node.getSelect().getSelectItems()) {
+                    if (item instanceof SingleColumn) {
+                        Optional<String> alias = ((SingleColumn) item).getAlias();
+                        if (alias.isPresent()) {
+                            byAliasBuilder.put(QualifiedName.of(alias.get()), ((SingleColumn) item).getExpression()); // TODO: need to know if alias was quoted
+                        }
+                    }
+                }
+                Multimap<QualifiedName, Expression> byAlias = byAliasBuilder.build();
+
+                for (SortItem item : items) {
+                    Expression expression = item.getSortKey();
+
+                    Expression orderByExpression = null;
+                    if (expression instanceof Identifier) {
+                        // if this is a simple name reference, try to resolve against output columns
+
+                        QualifiedName name = QualifiedName.of(((Identifier) expression).getName());
+                        Collection<Expression> expressions = byAlias.get(name);
+                        if (expressions.size() > 1) {
+                            throw new SemanticException(AMBIGUOUS_ATTRIBUTE, expression, "'%s' in ORDER BY is ambiguous", name.getSuffix());
+                        }
+                        if (expressions.size() == 1) {
+                            orderByExpression = Iterables.getOnlyElement(expressions);
+                        }
+
+                        // otherwise, couldn't resolve name against output aliases, so fall through...
+                    }
+                    else if (expression instanceof LongLiteral) {
+                        // this is an ordinal in the output tuple
+
+                        long ordinal = ((LongLiteral) expression).getValue();
+                        if (ordinal < 1 || ordinal > outputExpressions.size()) {
+                            throw new SemanticException(INVALID_ORDINAL, expression, "ORDER BY position %s is not in select list", ordinal);
+                        }
+
+                        int field = toIntExact(ordinal - 1);
+                        Type type = outputScope.getRelationType().getFieldByIndex(field).getType();
+                        if (!type.isOrderable()) {
+                            throw new SemanticException(TYPE_MISMATCH, node, "The type of expression in position %s is not orderable (actual: %s), and therefore cannot be used in ORDER BY", ordinal, type);
+                        }
+
+                        orderByExpression = outputExpressions.get(field);
+                    }
+
+                    // otherwise, just use the expression as is
+                    if (orderByExpression == null) {
+                        orderByExpression = expression;
+                    }
+
+                    ExpressionAnalysis expressionAnalysis = analyzeExpression(orderByExpression, sourceScope);
+                    analysis.recordSubqueries(node, expressionAnalysis);
+
+                    Type type = expressionAnalysis.getType(orderByExpression);
+                    if (!type.isOrderable()) {
+                        throw new SemanticException(TYPE_MISMATCH, node, "Type %s is not orderable, and therefore cannot be used in ORDER BY: %s", type, expression);
+                    }
+
+                    orderByExpressionsBuilder.add(orderByExpression);
+                }
+            }
+
+            List<Expression> orderByExpressions = orderByExpressionsBuilder.build();
+            analysis.setOrderByExpressions(node, orderByExpressions);
+
+            if (node.getSelect().isDistinct() && !outputExpressions.containsAll(orderByExpressions)) {
+                throw new SemanticException(ORDER_BY_MUST_BE_IN_SELECT, node.getSelect(), "For SELECT DISTINCT, ORDER BY expressions must appear in select list");
+            }
+            return orderByExpressions;
+        }
+
+        private Multimap<QualifiedName, Expression> extractNamedOutputExpressions(QuerySpecification node)
+        {
+            // Compute aliased output terms so we can resolve order by expressions against them first
+            ImmutableMultimap.Builder<QualifiedName, Expression> assignments = ImmutableMultimap.builder();
+            for (SelectItem item : node.getSelect().getSelectItems()) {
+                if (item instanceof SingleColumn) {
+                    SingleColumn column = (SingleColumn) item;
+                    Optional<String> alias = column.getAlias();
+                    if (alias.isPresent()) {
+                        assignments.put(QualifiedName.of(alias.get()), column.getExpression()); // TODO: need to know if alias was quoted
+                    }
+                    else if (column.getExpression() instanceof Identifier) {
+                        assignments.put(QualifiedName.of(((Identifier) column.getExpression()).getName()), column.getExpression());
+                    }
+                }
+            }
+
+            return assignments.build();
+        }
+
+        private class OrderByExpressionRewriter
+                extends ExpressionRewriter<Void>
+        {
+            private final Multimap<QualifiedName, Expression> assignments;
+
+            public OrderByExpressionRewriter(Multimap<QualifiedName, Expression> assignments)
+            {
+                this.assignments = assignments;
+            }
+
+            @Override
+            public Expression rewriteIdentifier(Identifier reference, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                // if this is a simple name reference, try to resolve against output columns
+                QualifiedName name = QualifiedName.of(reference.getName());
+                Set<Expression> expressions = assignments.get(name)
+                        .stream()
+                        .collect(Collectors.toSet());
+
+                if (expressions.size() > 1) {
+                    throw new SemanticException(AMBIGUOUS_ATTRIBUTE, reference, "'%s' in ORDER BY is ambiguous", name);
+                }
+
+                if (expressions.size() == 1) {
+                    return Iterables.getOnlyElement(expressions);
+                }
+
+                // otherwise, couldn't resolve name against output aliases, so fall through...
+                return reference;
+            }
+        }
+
+        private List<List<Expression>> analyzeGroupBy(QuerySpecification node, Scope scope, List<Expression> outputExpressions)
+        {
+            List<Set<Expression>> computedGroupingSets = ImmutableList.of(); // empty list = no aggregations
+
+            if (node.getGroupBy().isPresent()) {
+                List<List<Set<Expression>>> enumeratedGroupingSets = node.getGroupBy().get().getGroupingElements().stream()
+                        .map(GroupingElement::enumerateGroupingSets)
+                        .collect(toImmutableList());
+
+                // compute cross product of enumerated grouping sets, if there are any
+                computedGroupingSets = computeGroupingSetsCrossProduct(enumeratedGroupingSets, node.getGroupBy().get().isDistinct());
+                checkState(!computedGroupingSets.isEmpty(), "computed grouping sets cannot be empty");
+            }
+            else if (hasAggregates(node)) {
+                // if there are aggregates, but no group by, create a grand total grouping set (global aggregation)
+                computedGroupingSets = ImmutableList.of(ImmutableSet.of());
+            }
+
+            List<List<Expression>> analyzedGroupingSets = computedGroupingSets.stream()
+                    .map(groupingSet -> analyzeGroupingColumns(groupingSet, node, scope, outputExpressions))
+                    .collect(toImmutableList());
+
+            analysis.setGroupingSets(node, analyzedGroupingSets);
+            return analyzedGroupingSets;
+        }
+
+        private List<Set<Expression>> computeGroupingSetsCrossProduct(List<List<Set<Expression>>> enumeratedGroupingSets, boolean isDistinct)
+        {
+            checkState(!enumeratedGroupingSets.isEmpty(), "enumeratedGroupingSets cannot be empty");
+
+            List<Set<Expression>> groupingSetsCrossProduct = new ArrayList<>();
+            enumeratedGroupingSets.get(0)
+                    .stream()
+                    .map(ImmutableSet::copyOf)
+                    .forEach(groupingSetsCrossProduct::add);
+
+            for (int i = 1; i < enumeratedGroupingSets.size(); i++) {
+                List<Set<Expression>> groupingSets = enumeratedGroupingSets.get(i);
+                List<Set<Expression>> oldGroupingSetsCrossProduct = ImmutableList.copyOf(groupingSetsCrossProduct);
+                groupingSetsCrossProduct.clear();
+                for (Set<Expression> existingSet : oldGroupingSetsCrossProduct) {
+                    for (Set<Expression> groupingSet : groupingSets) {
+                        Set<Expression> concatenatedSet = ImmutableSet.<Expression>builder()
+                                .addAll(existingSet)
+                                .addAll(groupingSet)
+                                .build();
+                        groupingSetsCrossProduct.add(concatenatedSet);
+                    }
+                }
+            }
+
+            if (isDistinct) {
+                return ImmutableList.copyOf(ImmutableSet.copyOf(groupingSetsCrossProduct));
+            }
+
+            return groupingSetsCrossProduct;
+        }
+
+        private List<Expression> analyzeGroupingColumns(Set<Expression> groupingColumns, QuerySpecification node, Scope scope, List<Expression> outputExpressions)
+        {
+            ImmutableList.Builder<Expression> groupingColumnsBuilder = ImmutableList.builder();
+            for (Expression groupingColumn : groupingColumns) {
+                // first, see if this is an ordinal
+                Expression groupByExpression;
+
+                if (groupingColumn instanceof LongLiteral) {
+                    long ordinal = ((LongLiteral) groupingColumn).getValue();
+                    if (ordinal < 1 || ordinal > outputExpressions.size()) {
+                        throw new SemanticException(INVALID_ORDINAL, groupingColumn, "GROUP BY position %s is not in select list", ordinal);
+                    }
+
+                    groupByExpression = outputExpressions.get(toIntExact(ordinal - 1));
+                }
+                else {
+                    ExpressionAnalysis expressionAnalysis = analyzeExpression(groupingColumn, scope);
+                    analysis.recordSubqueries(node, expressionAnalysis);
+                    groupByExpression = groupingColumn;
+                }
+
+                Analyzer.verifyNoAggregatesOrWindowFunctions(metadata.getFunctionRegistry(), groupByExpression, "GROUP BY clause");
+                Type type = analysis.getType(groupByExpression);
+                if (!type.isComparable()) {
+                    throw new SemanticException(TYPE_MISMATCH, node, "%s is not comparable, and therefore cannot be used in GROUP BY", type);
+                }
+
+                groupingColumnsBuilder.add(groupByExpression);
+            }
+            return groupingColumnsBuilder.build();
+        }
+
+        private Scope computeOutputScope(QuerySpecification node, Scope scope)
+        {
+            ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
+
+            for (SelectItem item : node.getSelect().getSelectItems()) {
+                if (item instanceof AllColumns) {
+                    // expand * and T.*
+                    Optional<QualifiedName> starPrefix = ((AllColumns) item).getPrefix();
+
+                    for (Field field : scope.getRelationType().resolveFieldsWithPrefix(starPrefix)) {
+                        outputFields.add(Field.newUnqualified(field.getName(), field.getType(), field.getOriginTable(), false));
+                    }
+                }
+                else if (item instanceof SingleColumn) {
+                    SingleColumn column = (SingleColumn) item;
+
+                    Expression expression = column.getExpression();
+                    Optional<String> fieldName = column.getAlias();
+
+                    Optional<QualifiedObjectName> originTable = Optional.empty();
+                    QualifiedName name = null;
+
+                    if (expression instanceof Identifier) {
+                        name = QualifiedName.of(((Identifier) expression).getName());
+                    }
+                    else if (expression instanceof DereferenceExpression) {
+                        name = DereferenceExpression.getQualifiedName((DereferenceExpression) expression);
+                    }
+
+                    if (name != null) {
+                        List<Field> matchingFields = scope.getRelationType().resolveFields(name);
+                        if (!matchingFields.isEmpty()) {
+                            originTable = matchingFields.get(0).getOriginTable();
+                        }
+                    }
+
+                    if (!fieldName.isPresent()) {
+                        if (name != null) {
+                            fieldName = Optional.of(getLast(name.getOriginalParts()));
+                        }
+                    }
+
+                    outputFields.add(Field.newUnqualified(fieldName, analysis.getType(expression), originTable, column.getAlias().isPresent())); // TODO don't use analysis as a side-channel. Use outputExpressions to look up the type
+                }
+                else {
+                    throw new IllegalArgumentException("Unsupported SelectItem type: " + item.getClass().getName());
+                }
+            }
+
+            return createAndAssignScope(node, scope, outputFields.build());
+        }
+
+        private List<Expression> analyzeSelect(QuerySpecification node, Scope scope)
+        {
+            ImmutableList.Builder<Expression> outputExpressionBuilder = ImmutableList.builder();
+
+            for (SelectItem item : node.getSelect().getSelectItems()) {
+                if (item instanceof AllColumns) {
+                    // expand * and T.*
+                    Optional<QualifiedName> starPrefix = ((AllColumns) item).getPrefix();
+
+                    RelationType relationType = scope.getRelationType();
+                    List<Field> fields = relationType.resolveFieldsWithPrefix(starPrefix);
+                    if (fields.isEmpty()) {
+                        if (starPrefix.isPresent()) {
+                            throw new SemanticException(MISSING_TABLE, item, "Table '%s' not found", starPrefix.get());
+                        }
+                        throw new SemanticException(WILDCARD_WITHOUT_FROM, item, "SELECT * not allowed in queries without FROM clause");
+                    }
+
+                    for (Field field : fields) {
+                        int fieldIndex = relationType.indexOf(field);
+                        FieldReference expression = new FieldReference(fieldIndex);
+                        outputExpressionBuilder.add(expression);
+                        ExpressionAnalysis expressionAnalysis = analyzeExpression(expression, scope);
+
+                        Type type = expressionAnalysis.getType(expression);
+                        if (node.getSelect().isDistinct() && !type.isComparable()) {
+                            throw new SemanticException(TYPE_MISMATCH, node.getSelect(), "DISTINCT can only be applied to comparable types (actual: %s)", type);
+                        }
+                    }
+                }
+                else if (item instanceof SingleColumn) {
+                    SingleColumn column = (SingleColumn) item;
+                    ExpressionAnalysis expressionAnalysis = analyzeExpression(column.getExpression(), scope);
+                    analysis.recordSubqueries(node, expressionAnalysis);
+                    outputExpressionBuilder.add(column.getExpression());
+
+                    Type type = expressionAnalysis.getType(column.getExpression());
+                    if (node.getSelect().isDistinct() && !type.isComparable()) {
+                        throw new SemanticException(TYPE_MISMATCH, node.getSelect(), "DISTINCT can only be applied to comparable types (actual: %s): %s", type, column.getExpression());
+                    }
+                }
+                else {
+                    throw new IllegalArgumentException("Unsupported SelectItem type: " + item.getClass().getName());
+                }
+            }
+
+            ImmutableList<Expression> result = outputExpressionBuilder.build();
+            analysis.setOutputExpressions(node, result);
+
+            return result;
+        }
+
+        public void analyzeWhere(Node node, Scope scope, Expression predicate)
+        {
+            Analyzer.verifyNoAggregatesOrWindowFunctions(metadata.getFunctionRegistry(), predicate, "WHERE clause");
 
             ExpressionAnalysis expressionAnalysis = analyzeExpression(predicate, scope);
             analysis.recordSubqueries(node, expressionAnalysis);
 
             Type predicateType = expressionAnalysis.getType(predicate);
-            if (!predicateType.equals(BOOLEAN) && !predicateType.equals(UNKNOWN)) {
-                throw new SemanticException(TYPE_MISMATCH, predicate, "HAVING clause must evaluate to a boolean: actual type %s", predicateType);
+            if (!predicateType.equals(BOOLEAN)) {
+                if (!predicateType.equals(UNKNOWN)) {
+                    throw new SemanticException(TYPE_MISMATCH, predicate, "WHERE clause must evaluate to a boolean: actual type %s", predicateType);
+                }
+                // coerce null to boolean
+                analysis.addCoercion(predicate, BOOLEAN, false);
             }
 
-            analysis.setHaving(node, predicate);
-        }
-    }
-
-    private List<Expression> analyzeOrderBy(QuerySpecification node, Scope sourceScope, Scope outputScope, List<Expression> outputExpressions)
-    {
-        if (SystemSessionProperties.isLegacyOrderByEnabled(session)) {
-            return legacyAnalyzeOrderBy(node, sourceScope, outputScope, outputExpressions);
+            analysis.setWhere(node, predicate);
         }
 
-        List<SortItem> items = node.getOrderBy()
-                .map(OrderBy::getSortItems)
-                .orElse(emptyList());
+        private Scope analyzeFrom(QuerySpecification node, Scope scope)
+        {
+            if (node.getFrom().isPresent()) {
+                return process(node.getFrom().get(), scope);
+            }
 
-        ImmutableList.Builder<Expression> orderByExpressionsBuilder = ImmutableList.builder();
+            return scope;
+        }
 
-        if (!items.isEmpty()) {
+        private void analyzeAggregations(
+                QuerySpecification node,
+                Scope scope,
+                List<List<Expression>> groupingSets,
+                Set<Expression> columnReferences,
+                List<Expression> expressions)
+        {
+            AggregateExtractor extractor = new AggregateExtractor(metadata.getFunctionRegistry());
+            for (Expression expression : expressions) {
+                extractor.process(expression);
+            }
+            analysis.setAggregates(node, extractor.getAggregates());
+
+            // is this an aggregation query?
+            if (!groupingSets.isEmpty()) {
+                // ensure SELECT, ORDER BY and HAVING are constant with respect to group
+                // e.g, these are all valid expressions:
+                //     SELECT f(a) GROUP BY a
+                //     SELECT f(a + 1) GROUP BY a + 1
+                //     SELECT a + sum(b) GROUP BY a
+                ImmutableList<Expression> distinctGroupingColumns = groupingSets.stream()
+                        .flatMap(Collection::stream)
+                        .distinct()
+                        .collect(toImmutableList());
+
+                for (Expression expression : expressions) {
+                    verifyAggregations(distinctGroupingColumns, scope, expression, columnReferences);
+                }
+            }
+        }
+
+        private boolean hasAggregates(QuerySpecification node)
+        {
+            AggregateExtractor extractor = new AggregateExtractor(metadata.getFunctionRegistry());
+
+            node.getSelect()
+                    .getSelectItems().stream()
+                    .filter(SingleColumn.class::isInstance)
+                    .forEach(extractor::process);
+
+            node.getOrderBy().map(OrderBy::getSortItems).ifPresent(
+                    sortItems -> sortItems
+                            .forEach(extractor::process));
+
+            node.getHaving()
+                    .ifPresent(extractor::process);
+
+            return !extractor.getAggregates().isEmpty();
+        }
+
+        private void verifyAggregations(
+                List<Expression> groupByExpressions,
+                Scope scope,
+                Expression expression,
+                Set<Expression> columnReferences)
+        {
+            AggregationAnalyzer analyzer = new AggregationAnalyzer(groupByExpressions, metadata, scope, columnReferences, analysis.getParameters(), analysis.isDescribe());
+            analyzer.analyze(expression);
+        }
+
+        private RelationType analyzeView(Query query, QualifiedObjectName name, Optional<String> catalog, Optional<String> schema, Optional<String> owner, Table node)
+        {
+            try {
+                // run view as view owner if set; otherwise, run as session user
+                Identity identity;
+                AccessControl viewAccessControl;
+                if (owner.isPresent()) {
+                    identity = new Identity(owner.get(), Optional.empty());
+                    viewAccessControl = new ViewAccessControl(accessControl);
+                }
+                else {
+                    identity = session.getIdentity();
+                    viewAccessControl = accessControl;
+                }
+
+                Session viewSession = Session.builder(metadata.getSessionPropertyManager())
+                        .setQueryId(session.getQueryId())
+                        .setTransactionId(session.getTransactionId().orElse(null))
+                        .setIdentity(identity)
+                        .setSource(session.getSource().orElse(null))
+                        .setCatalog(catalog.orElse(null))
+                        .setSchema(schema.orElse(null))
+                        .setTimeZoneKey(session.getTimeZoneKey())
+                        .setLocale(session.getLocale())
+                        .setRemoteUserAddress(session.getRemoteUserAddress().orElse(null))
+                        .setUserAgent(session.getUserAgent().orElse(null))
+                        .setClientInfo(session.getClientInfo().orElse(null))
+                        .setStartTime(session.getStartTime())
+                        .setSystemProperty(LEGACY_ORDER_BY, session.getSystemProperty(LEGACY_ORDER_BY, Boolean.class).toString())
+                        .build();
+
+                StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, viewAccessControl, viewSession);
+                Scope queryScope = analyzer.analyze(query, Scope.create());
+                return queryScope.getRelationType().withAlias(name.getObjectName(), null);
+            }
+            catch (RuntimeException e) {
+                throw new SemanticException(VIEW_ANALYSIS_ERROR, node, "Failed analyzing stored view '%s': %s", name, e.getMessage());
+            }
+        }
+
+        private Query parseView(String view, QualifiedObjectName name, Node node)
+        {
+            try {
+                Statement statement = sqlParser.createStatement(view);
+                return checkType(statement, Query.class, "parsed view");
+            }
+            catch (ParsingException e) {
+                throw new SemanticException(VIEW_PARSE_ERROR, node, "Failed parsing stored view '%s': %s", name, e.getMessage());
+            }
+        }
+
+        private boolean isViewStale(List<ViewDefinition.ViewColumn> columns, Collection<Field> fields)
+        {
+            if (columns.size() != fields.size()) {
+                return true;
+            }
+
+            List<Field> fieldList = ImmutableList.copyOf(fields);
+            for (int i = 0; i < columns.size(); i++) {
+                ViewDefinition.ViewColumn column = columns.get(i);
+                Field field = fieldList.get(i);
+                if (!column.getName().equalsIgnoreCase(field.getName().orElse(null)) ||
+                        !metadata.getTypeManager().canCoerce(field.getType(), column.getType())) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private ExpressionAnalysis analyzeExpression(Expression expression, Scope scope)
+        {
+            return ExpressionAnalyzer.analyzeExpression(
+                    session,
+                    metadata,
+                    accessControl,
+                    sqlParser,
+                    scope,
+                    analysis,
+                    expression);
+        }
+
+        private List<Expression> descriptorToFields(Scope scope)
+        {
+            ImmutableList.Builder<Expression> builder = ImmutableList.builder();
+            for (int fieldIndex = 0; fieldIndex < scope.getRelationType().getAllFieldCount(); fieldIndex++) {
+                FieldReference expression = new FieldReference(fieldIndex);
+                builder.add(expression);
+                analyzeExpression(expression, scope);
+            }
+            return builder.build();
+        }
+
+        private Scope analyzeWith(Query node, Scope scope)
+        {
+            // analyze WITH clause
+            if (!node.getWith().isPresent()) {
+                return scope;
+            }
+            With with = node.getWith().get();
+            if (with.isRecursive()) {
+                throw new SemanticException(NOT_SUPPORTED, with, "Recursive WITH queries are not supported");
+            }
+
+            Scope.Builder withScopeBuilder = Scope.builder()
+                    .withParent(scope);
+            for (WithQuery withQuery : with.getQueries()) {
+                Query query = withQuery.getQuery();
+                process(query, withScopeBuilder.build());
+
+                String name = withQuery.getName();
+                if (withScopeBuilder.containsNamedQuery(name)) {
+                    throw new SemanticException(DUPLICATE_RELATION, withQuery, "WITH query name '%s' specified more than once", name);
+                }
+
+                // check if all or none of the columns are explicitly alias
+                if (withQuery.getColumnNames().isPresent()) {
+                    List<String> columnNames = withQuery.getColumnNames().get();
+                    RelationType queryDescriptor = analysis.getOutputDescriptor(query);
+                    if (columnNames.size() != queryDescriptor.getVisibleFieldCount()) {
+                        throw new SemanticException(MISMATCHED_COLUMN_ALIASES, withQuery, "WITH column alias list has %s entries but WITH query(%s) has %s columns", columnNames.size(), name, queryDescriptor.getVisibleFieldCount());
+                    }
+                }
+
+                withScopeBuilder.withNamedQuery(name, withQuery);
+            }
+
+            Scope withScope = withScopeBuilder.build();
+            analysis.setScope(with, withScope);
+            return withScope;
+        }
+
+        private void analyzeOrderBy(Query node, Scope scope)
+        {
+            List<SortItem> items = node.getOrderBy()
+                    .map(OrderBy::getSortItems)
+                    .orElse(emptyList());
+
+            ImmutableList.Builder<Expression> orderByFieldsBuilder = ImmutableList.builder();
+
             for (SortItem item : items) {
                 Expression expression = item.getSortKey();
 
-                Expression orderByExpression;
                 if (expression instanceof LongLiteral) {
                     // this is an ordinal in the output tuple
 
                     long ordinal = ((LongLiteral) expression).getValue();
-                    if (ordinal < 1 || ordinal > outputExpressions.size()) {
+                    if (ordinal < 1 || ordinal > scope.getRelationType().getVisibleFieldCount()) {
                         throw new SemanticException(INVALID_ORDINAL, expression, "ORDER BY position %s is not in select list", ordinal);
                     }
 
-                    int field = toIntExact(ordinal - 1);
-                    Type type = outputScope.getRelationType().getFieldByIndex(field).getType();
-                    if (!type.isOrderable()) {
-                        throw new SemanticException(TYPE_MISMATCH, node, "The type of expression in position %s is not orderable (actual: %s), and therefore cannot be used in ORDER BY", ordinal, type);
-                    }
-
-                    orderByExpression = outputExpressions.get(field);
-                }
-                else {
-                    // Analyze the original expression using a synthetic scope (which delegates to the source scope for any missing name)
-                    // to catch any semantic errors (due to type mismatch, etc)
-                    Scope synthetic = Scope.builder()
-                            .withParent(sourceScope)
-                            .withRelationType(outputScope.getRelationType())
-                            .build();
-
-                    analyzeExpression(expression, synthetic);
-
-                    orderByExpression = ExpressionTreeRewriter.rewriteWith(new OrderByExpressionRewriter(extractNamedOutputExpressions(node)), expression);
-
-                    ExpressionAnalysis expressionAnalysis = analyzeExpression(orderByExpression, sourceScope);
-                    analysis.recordSubqueries(node, expressionAnalysis);
+                    expression = new FieldReference(toIntExact(ordinal - 1));
                 }
 
-                Type type = analysis.getType(orderByExpression);
-                if (!type.isOrderable()) {
-                    throw new SemanticException(TYPE_MISMATCH, node, "Type %s is not orderable, and therefore cannot be used in ORDER BY: %s", type, expression);
-                }
-
-                orderByExpressionsBuilder.add(orderByExpression);
-            }
-        }
-
-        List<Expression> orderByExpressions = orderByExpressionsBuilder.build();
-        analysis.setOrderByExpressions(node, orderByExpressions);
-
-        if (node.getSelect().isDistinct() && !outputExpressions.containsAll(orderByExpressions)) {
-            throw new SemanticException(ORDER_BY_MUST_BE_IN_SELECT, node.getSelect(), "For SELECT DISTINCT, ORDER BY expressions must appear in select list");
-        }
-        return orderByExpressions;
-    }
-
-    /**
-     * Preserve the old column resolution behavior for ORDER BY while we transition workloads to new semantics
-     * TODO: remove this
-     */
-    private List<Expression> legacyAnalyzeOrderBy(QuerySpecification node, Scope sourceScope, Scope outputScope, List<Expression> outputExpressions)
-    {
-        List<SortItem> items = node.getOrderBy()
-                .map(OrderBy::getSortItems)
-                .orElse(emptyList());
-
-        ImmutableList.Builder<Expression> orderByExpressionsBuilder = ImmutableList.builder();
-
-        if (!items.isEmpty()) {
-            // Compute aliased output terms so we can resolve order by expressions against them first
-            ImmutableMultimap.Builder<QualifiedName, Expression> byAliasBuilder = ImmutableMultimap.builder();
-            for (SelectItem item : node.getSelect().getSelectItems()) {
-                if (item instanceof SingleColumn) {
-                    Optional<String> alias = ((SingleColumn) item).getAlias();
-                    if (alias.isPresent()) {
-                        byAliasBuilder.put(QualifiedName.of(alias.get()), ((SingleColumn) item).getExpression()); // TODO: need to know if alias was quoted
-                    }
-                }
-            }
-            Multimap<QualifiedName, Expression> byAlias = byAliasBuilder.build();
-
-            for (SortItem item : items) {
-                Expression expression = item.getSortKey();
-
-                Expression orderByExpression = null;
-                if (expression instanceof Identifier) {
-                    // if this is a simple name reference, try to resolve against output columns
-
-                    QualifiedName name = QualifiedName.of(((Identifier) expression).getName());
-                    Collection<Expression> expressions = byAlias.get(name);
-                    if (expressions.size() > 1) {
-                        throw new SemanticException(AMBIGUOUS_ATTRIBUTE, expression, "'%s' in ORDER BY is ambiguous", name.getSuffix());
-                    }
-                    if (expressions.size() == 1) {
-                        orderByExpression = Iterables.getOnlyElement(expressions);
-                    }
-
-                    // otherwise, couldn't resolve name against output aliases, so fall through...
-                }
-                else if (expression instanceof LongLiteral) {
-                    // this is an ordinal in the output tuple
-
-                    long ordinal = ((LongLiteral) expression).getValue();
-                    if (ordinal < 1 || ordinal > outputExpressions.size()) {
-                        throw new SemanticException(INVALID_ORDINAL, expression, "ORDER BY position %s is not in select list", ordinal);
-                    }
-
-                    int field = toIntExact(ordinal - 1);
-                    Type type = outputScope.getRelationType().getFieldByIndex(field).getType();
-                    if (!type.isOrderable()) {
-                        throw new SemanticException(TYPE_MISMATCH, node, "The type of expression in position %s is not orderable (actual: %s), and therefore cannot be used in ORDER BY", ordinal, type);
-                    }
-
-                    orderByExpression = outputExpressions.get(field);
-                }
-
-                // otherwise, just use the expression as is
-                if (orderByExpression == null) {
-                    orderByExpression = expression;
-                }
-
-                ExpressionAnalysis expressionAnalysis = analyzeExpression(orderByExpression, sourceScope);
+                ExpressionAnalysis expressionAnalysis = ExpressionAnalyzer.analyzeExpression(session,
+                        metadata,
+                        accessControl, sqlParser,
+                        scope,
+                        analysis,
+                        expression);
                 analysis.recordSubqueries(node, expressionAnalysis);
 
-                Type type = expressionAnalysis.getType(orderByExpression);
-                if (!type.isOrderable()) {
-                    throw new SemanticException(TYPE_MISMATCH, node, "Type %s is not orderable, and therefore cannot be used in ORDER BY: %s", type, expression);
-                }
-
-                orderByExpressionsBuilder.add(orderByExpression);
+                orderByFieldsBuilder.add(expression);
             }
+
+            analysis.setOrderByExpressions(node, orderByFieldsBuilder.build());
         }
 
-        List<Expression> orderByExpressions = orderByExpressionsBuilder.build();
-        analysis.setOrderByExpressions(node, orderByExpressions);
-
-        if (node.getSelect().isDistinct() && !outputExpressions.containsAll(orderByExpressions)) {
-            throw new SemanticException(ORDER_BY_MUST_BE_IN_SELECT, node.getSelect(), "For SELECT DISTINCT, ORDER BY expressions must appear in select list");
-        }
-        return orderByExpressions;
-    }
-
-    private static Multimap<QualifiedName, Expression> extractNamedOutputExpressions(QuerySpecification node)
-    {
-        // Compute aliased output terms so we can resolve order by expressions against them first
-        ImmutableMultimap.Builder<QualifiedName, Expression> assignments = ImmutableMultimap.builder();
-        for (SelectItem item : node.getSelect().getSelectItems()) {
-            if (item instanceof SingleColumn) {
-                SingleColumn column = (SingleColumn) item;
-                Optional<String> alias = column.getAlias();
-                if (alias.isPresent()) {
-                    assignments.put(QualifiedName.of(alias.get()), column.getExpression()); // TODO: need to know if alias was quoted
-                }
-                else if (column.getExpression() instanceof Identifier) {
-                    assignments.put(QualifiedName.of(((Identifier) column.getExpression()).getName()), column.getExpression());
-                }
-            }
-        }
-
-        return assignments.build();
-    }
-
-    private static class OrderByExpressionRewriter
-            extends ExpressionRewriter<Void>
-    {
-        private final Multimap<QualifiedName, Expression> assignments;
-
-        public OrderByExpressionRewriter(Multimap<QualifiedName, Expression> assignments)
+        private Scope createAndAssignScope(Node node, Scope parent, Field... fields)
         {
-            this.assignments = assignments;
+            return createAndAssignScope(node, parent, new RelationType(fields));
         }
 
-        @Override
-        public Expression rewriteIdentifier(Identifier reference, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        private Scope createAndAssignScope(Node node, Scope parent, List<Field> fields)
         {
-            // if this is a simple name reference, try to resolve against output columns
-            QualifiedName name = QualifiedName.of(reference.getName());
-            Set<Expression> expressions = assignments.get(name)
-                    .stream()
-                    .collect(Collectors.toSet());
-
-            if (expressions.size() > 1) {
-                throw new SemanticException(AMBIGUOUS_ATTRIBUTE, reference, "'%s' in ORDER BY is ambiguous", name);
-            }
-
-            if (expressions.size() == 1) {
-                return Iterables.getOnlyElement(expressions);
-            }
-
-            // otherwise, couldn't resolve name against output aliases, so fall through...
-            return reference;
-        }
-    }
-
-    private List<List<Expression>> analyzeGroupBy(QuerySpecification node, Scope scope, List<Expression> outputExpressions)
-    {
-        List<Set<Expression>> computedGroupingSets = ImmutableList.of(); // empty list = no aggregations
-
-        if (node.getGroupBy().isPresent()) {
-            List<List<Set<Expression>>> enumeratedGroupingSets = node.getGroupBy().get().getGroupingElements().stream()
-                    .map(GroupingElement::enumerateGroupingSets)
-                    .collect(toImmutableList());
-
-            // compute cross product of enumerated grouping sets, if there are any
-            computedGroupingSets = computeGroupingSetsCrossProduct(enumeratedGroupingSets, node.getGroupBy().get().isDistinct());
-            checkState(!computedGroupingSets.isEmpty(), "computed grouping sets cannot be empty");
-        }
-        else if (hasAggregates(node)) {
-            // if there are aggregates, but no group by, create a grand total grouping set (global aggregation)
-            computedGroupingSets = ImmutableList.of(ImmutableSet.of());
+            return createAndAssignScope(node, parent, new RelationType(fields));
         }
 
-        List<List<Expression>> analyzedGroupingSets = computedGroupingSets.stream()
-                .map(groupingSet -> analyzeGroupingColumns(groupingSet, node, scope, outputExpressions))
-                .collect(toImmutableList());
-
-        analysis.setGroupingSets(node, analyzedGroupingSets);
-        return analyzedGroupingSets;
-    }
-
-    private static List<Set<Expression>> computeGroupingSetsCrossProduct(List<List<Set<Expression>>> enumeratedGroupingSets, boolean isDistinct)
-    {
-        checkState(!enumeratedGroupingSets.isEmpty(), "enumeratedGroupingSets cannot be empty");
-
-        List<Set<Expression>> groupingSetsCrossProduct = new ArrayList<>();
-        enumeratedGroupingSets.get(0)
-                .stream()
-                .map(ImmutableSet::copyOf)
-                .forEach(groupingSetsCrossProduct::add);
-
-        for (int i = 1; i < enumeratedGroupingSets.size(); i++) {
-            List<Set<Expression>> groupingSets = enumeratedGroupingSets.get(i);
-            List<Set<Expression>> oldGroupingSetsCrossProduct = ImmutableList.copyOf(groupingSetsCrossProduct);
-            groupingSetsCrossProduct.clear();
-            for (Set<Expression> existingSet : oldGroupingSetsCrossProduct) {
-                for (Set<Expression> groupingSet : groupingSets) {
-                    Set<Expression> concatenatedSet = ImmutableSet.<Expression>builder()
-                            .addAll(existingSet)
-                            .addAll(groupingSet)
-                            .build();
-                    groupingSetsCrossProduct.add(concatenatedSet);
-                }
-            }
-        }
-
-        if (isDistinct) {
-            return ImmutableList.copyOf(ImmutableSet.copyOf(groupingSetsCrossProduct));
-        }
-
-        return groupingSetsCrossProduct;
-    }
-
-    private List<Expression> analyzeGroupingColumns(Set<Expression> groupingColumns, QuerySpecification node, Scope scope, List<Expression> outputExpressions)
-    {
-        ImmutableList.Builder<Expression> groupingColumnsBuilder = ImmutableList.builder();
-        for (Expression groupingColumn : groupingColumns) {
-            // first, see if this is an ordinal
-            Expression groupByExpression;
-
-            if (groupingColumn instanceof LongLiteral) {
-                long ordinal = ((LongLiteral) groupingColumn).getValue();
-                if (ordinal < 1 || ordinal > outputExpressions.size()) {
-                    throw new SemanticException(INVALID_ORDINAL, groupingColumn, "GROUP BY position %s is not in select list", ordinal);
-                }
-
-                groupByExpression = outputExpressions.get(toIntExact(ordinal - 1));
-            }
-            else {
-                ExpressionAnalysis expressionAnalysis = analyzeExpression(groupingColumn, scope);
-                analysis.recordSubqueries(node, expressionAnalysis);
-                groupByExpression = groupingColumn;
-            }
-
-            Analyzer.verifyNoAggregatesOrWindowFunctions(metadata.getFunctionRegistry(), groupByExpression, "GROUP BY clause");
-            Type type = analysis.getType(groupByExpression);
-            if (!type.isComparable()) {
-                throw new SemanticException(TYPE_MISMATCH, node, "%s is not comparable, and therefore cannot be used in GROUP BY", type);
-            }
-
-            groupingColumnsBuilder.add(groupByExpression);
-        }
-        return groupingColumnsBuilder.build();
-    }
-
-    private Scope computeOutputScope(QuerySpecification node, Scope scope)
-    {
-        ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
-
-        for (SelectItem item : node.getSelect().getSelectItems()) {
-            if (item instanceof AllColumns) {
-                // expand * and T.*
-                Optional<QualifiedName> starPrefix = ((AllColumns) item).getPrefix();
-
-                for (Field field : scope.getRelationType().resolveFieldsWithPrefix(starPrefix)) {
-                    outputFields.add(Field.newUnqualified(field.getName(), field.getType(), field.getOriginTable(), false));
-                }
-            }
-            else if (item instanceof SingleColumn) {
-                SingleColumn column = (SingleColumn) item;
-
-                Expression expression = column.getExpression();
-                Optional<String> fieldName = column.getAlias();
-
-                Optional<QualifiedObjectName> originTable = Optional.empty();
-                QualifiedName name = null;
-
-                if (expression instanceof Identifier) {
-                    name = QualifiedName.of(((Identifier) expression).getName());
-                }
-                else if (expression instanceof DereferenceExpression) {
-                    name = DereferenceExpression.getQualifiedName((DereferenceExpression) expression);
-                }
-
-                if (name != null) {
-                    List<Field> matchingFields = scope.getRelationType().resolveFields(name);
-                    if (!matchingFields.isEmpty()) {
-                        originTable = matchingFields.get(0).getOriginTable();
-                    }
-                }
-
-                if (!fieldName.isPresent()) {
-                    if (name != null) {
-                        fieldName = Optional.of(getLast(name.getOriginalParts()));
-                    }
-                }
-
-                outputFields.add(Field.newUnqualified(fieldName, analysis.getType(expression), originTable, column.getAlias().isPresent())); // TODO don't use analysis as a side-channel. Use outputExpressions to look up the type
-            }
-            else {
-                throw new IllegalArgumentException("Unsupported SelectItem type: " + item.getClass().getName());
-            }
-        }
-
-        return createAndAssignScope(node, scope, outputFields.build());
-    }
-
-    private List<Expression> analyzeSelect(QuerySpecification node, Scope scope)
-    {
-        ImmutableList.Builder<Expression> outputExpressionBuilder = ImmutableList.builder();
-
-        for (SelectItem item : node.getSelect().getSelectItems()) {
-            if (item instanceof AllColumns) {
-                // expand * and T.*
-                Optional<QualifiedName> starPrefix = ((AllColumns) item).getPrefix();
-
-                RelationType relationType = scope.getRelationType();
-                List<Field> fields = relationType.resolveFieldsWithPrefix(starPrefix);
-                if (fields.isEmpty()) {
-                    if (starPrefix.isPresent()) {
-                        throw new SemanticException(MISSING_TABLE, item, "Table '%s' not found", starPrefix.get());
-                    }
-                    throw new SemanticException(WILDCARD_WITHOUT_FROM, item, "SELECT * not allowed in queries without FROM clause");
-                }
-
-                for (Field field : fields) {
-                    int fieldIndex = relationType.indexOf(field);
-                    FieldReference expression = new FieldReference(fieldIndex);
-                    outputExpressionBuilder.add(expression);
-                    ExpressionAnalysis expressionAnalysis = analyzeExpression(expression, scope);
-
-                    Type type = expressionAnalysis.getType(expression);
-                    if (node.getSelect().isDistinct() && !type.isComparable()) {
-                        throw new SemanticException(TYPE_MISMATCH, node.getSelect(), "DISTINCT can only be applied to comparable types (actual: %s)", type);
-                    }
-                }
-            }
-            else if (item instanceof SingleColumn) {
-                SingleColumn column = (SingleColumn) item;
-                ExpressionAnalysis expressionAnalysis = analyzeExpression(column.getExpression(), scope);
-                analysis.recordSubqueries(node, expressionAnalysis);
-                outputExpressionBuilder.add(column.getExpression());
-
-                Type type = expressionAnalysis.getType(column.getExpression());
-                if (node.getSelect().isDistinct() && !type.isComparable()) {
-                    throw new SemanticException(TYPE_MISMATCH, node.getSelect(), "DISTINCT can only be applied to comparable types (actual: %s): %s", type, column.getExpression());
-                }
-            }
-            else {
-                throw new IllegalArgumentException("Unsupported SelectItem type: " + item.getClass().getName());
-            }
-        }
-
-        ImmutableList<Expression> result = outputExpressionBuilder.build();
-        analysis.setOutputExpressions(node, result);
-
-        return result;
-    }
-
-    public void analyzeWhere(Node node, Scope scope, Expression predicate)
-    {
-        Analyzer.verifyNoAggregatesOrWindowFunctions(metadata.getFunctionRegistry(), predicate, "WHERE clause");
-
-        ExpressionAnalysis expressionAnalysis = analyzeExpression(predicate, scope);
-        analysis.recordSubqueries(node, expressionAnalysis);
-
-        Type predicateType = expressionAnalysis.getType(predicate);
-        if (!predicateType.equals(BOOLEAN)) {
-            if (!predicateType.equals(UNKNOWN)) {
-                throw new SemanticException(TYPE_MISMATCH, predicate, "WHERE clause must evaluate to a boolean: actual type %s", predicateType);
-            }
-            // coerce null to boolean
-            analysis.addCoercion(predicate, BOOLEAN, false);
-        }
-
-        analysis.setWhere(node, predicate);
-    }
-
-    private Scope analyzeFrom(QuerySpecification node, Scope scope)
-    {
-        if (node.getFrom().isPresent()) {
-            return process(node.getFrom().get(), scope);
-        }
-
-        return scope;
-    }
-
-    private void analyzeAggregations(
-            QuerySpecification node,
-            Scope scope,
-            List<List<Expression>> groupingSets,
-            Set<Expression> columnReferences,
-            List<Expression> expressions)
-    {
-        AggregateExtractor extractor = new AggregateExtractor(metadata.getFunctionRegistry());
-        for (Expression expression : expressions) {
-            extractor.process(expression);
-        }
-        analysis.setAggregates(node, extractor.getAggregates());
-
-        // is this an aggregation query?
-        if (!groupingSets.isEmpty()) {
-            // ensure SELECT, ORDER BY and HAVING are constant with respect to group
-            // e.g, these are all valid expressions:
-            //     SELECT f(a) GROUP BY a
-            //     SELECT f(a + 1) GROUP BY a + 1
-            //     SELECT a + sum(b) GROUP BY a
-            ImmutableList<Expression> distinctGroupingColumns = groupingSets.stream()
-                    .flatMap(Collection::stream)
-                    .distinct()
-                    .collect(toImmutableList());
-
-            for (Expression expression : expressions) {
-                verifyAggregations(distinctGroupingColumns, scope, expression, columnReferences);
-            }
-        }
-    }
-
-    private boolean hasAggregates(QuerySpecification node)
-    {
-        AggregateExtractor extractor = new AggregateExtractor(metadata.getFunctionRegistry());
-
-        node.getSelect()
-                .getSelectItems().stream()
-                .filter(SingleColumn.class::isInstance)
-                .forEach(extractor::process);
-
-        node.getOrderBy().map(OrderBy::getSortItems).ifPresent(
-                sortItems -> sortItems
-                        .forEach(extractor::process));
-
-        node.getHaving()
-                .ifPresent(extractor::process);
-
-        return !extractor.getAggregates().isEmpty();
-    }
-
-    private void verifyAggregations(
-            List<Expression> groupByExpressions,
-            Scope scope,
-            Expression expression,
-            Set<Expression> columnReferences)
-    {
-        AggregationAnalyzer analyzer = new AggregationAnalyzer(groupByExpressions, metadata, scope, columnReferences, analysis.getParameters(), analysis.isDescribe());
-        analyzer.analyze(expression);
-    }
-
-    private RelationType analyzeView(Query query, QualifiedObjectName name, Optional<String> catalog, Optional<String> schema, Optional<String> owner, Table node)
-    {
-        try {
-            // run view as view owner if set; otherwise, run as session user
-            Identity identity;
-            AccessControl viewAccessControl;
-            if (owner.isPresent()) {
-                identity = new Identity(owner.get(), Optional.empty());
-                viewAccessControl = new ViewAccessControl(accessControl);
-            }
-            else {
-                identity = session.getIdentity();
-                viewAccessControl = accessControl;
-            }
-
-            Session viewSession = Session.builder(metadata.getSessionPropertyManager())
-                    .setQueryId(session.getQueryId())
-                    .setTransactionId(session.getTransactionId().orElse(null))
-                    .setIdentity(identity)
-                    .setSource(session.getSource().orElse(null))
-                    .setCatalog(catalog.orElse(null))
-                    .setSchema(schema.orElse(null))
-                    .setTimeZoneKey(session.getTimeZoneKey())
-                    .setLocale(session.getLocale())
-                    .setRemoteUserAddress(session.getRemoteUserAddress().orElse(null))
-                    .setUserAgent(session.getUserAgent().orElse(null))
-                    .setClientInfo(session.getClientInfo().orElse(null))
-                    .setStartTime(session.getStartTime())
-                    .setSystemProperty(LEGACY_ORDER_BY, session.getSystemProperty(LEGACY_ORDER_BY, Boolean.class).toString())
+        private Scope createAndAssignScope(Node node, Scope parent, RelationType relationType)
+        {
+            Scope scope = Scope.builder()
+                    .withParent(parent)
+                    .withRelationType(relationType)
                     .build();
-
-            StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, viewAccessControl, viewSession);
-            Scope queryScope = analyzer.process(query, Scope.create());
-            return queryScope.getRelationType().withAlias(name.getObjectName(), null);
-        }
-        catch (RuntimeException e) {
-            throw new SemanticException(VIEW_ANALYSIS_ERROR, node, "Failed analyzing stored view '%s': %s", name, e.getMessage());
-        }
-    }
-
-    private Query parseView(String view, QualifiedObjectName name, Node node)
-    {
-        try {
-            Statement statement = sqlParser.createStatement(view);
-            return checkType(statement, Query.class, "parsed view");
-        }
-        catch (ParsingException e) {
-            throw new SemanticException(VIEW_PARSE_ERROR, node, "Failed parsing stored view '%s': %s", name, e.getMessage());
-        }
-    }
-
-    private boolean isViewStale(List<ViewDefinition.ViewColumn> columns, Collection<Field> fields)
-    {
-        if (columns.size() != fields.size()) {
-            return true;
-        }
-
-        List<Field> fieldList = ImmutableList.copyOf(fields);
-        for (int i = 0; i < columns.size(); i++) {
-            ViewDefinition.ViewColumn column = columns.get(i);
-            Field field = fieldList.get(i);
-            if (!column.getName().equalsIgnoreCase(field.getName().orElse(null)) ||
-                    !metadata.getTypeManager().canCoerce(field.getType(), column.getType())) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private ExpressionAnalysis analyzeExpression(Expression expression, Scope scope)
-    {
-        return ExpressionAnalyzer.analyzeExpression(
-                session,
-                metadata,
-                accessControl,
-                sqlParser,
-                scope,
-                analysis,
-                expression);
-    }
-
-    private List<Expression> descriptorToFields(Scope scope)
-    {
-        ImmutableList.Builder<Expression> builder = ImmutableList.builder();
-        for (int fieldIndex = 0; fieldIndex < scope.getRelationType().getAllFieldCount(); fieldIndex++) {
-            FieldReference expression = new FieldReference(fieldIndex);
-            builder.add(expression);
-            analyzeExpression(expression, scope);
-        }
-        return builder.build();
-    }
-
-    private Scope analyzeWith(Query node, Scope scope)
-    {
-        // analyze WITH clause
-        if (!node.getWith().isPresent()) {
+            analysis.setScope(node, scope);
             return scope;
         }
-
-        With with = node.getWith().get();
-        if (with.isRecursive()) {
-            throw new SemanticException(NOT_SUPPORTED, with, "Recursive WITH queries are not supported");
-        }
-
-        Scope.Builder withScopeBuilder = Scope.builder()
-                .withParent(scope);
-        for (WithQuery withQuery : with.getQueries()) {
-            Query query = withQuery.getQuery();
-            process(query, withScopeBuilder.build());
-
-            String name = withQuery.getName();
-            if (withScopeBuilder.containsNamedQuery(name)) {
-                throw new SemanticException(DUPLICATE_RELATION, withQuery, "WITH query name '%s' specified more than once", name);
-            }
-
-            // check if all or none of the columns are explicitly alias
-            if (withQuery.getColumnNames().isPresent()) {
-                List<String> columnNames = withQuery.getColumnNames().get();
-                RelationType queryDescriptor = analysis.getOutputDescriptor(query);
-                if (columnNames.size() != queryDescriptor.getVisibleFieldCount()) {
-                    throw new SemanticException(MISMATCHED_COLUMN_ALIASES, withQuery, "WITH column alias list has %s entries but WITH query(%s) has %s columns", columnNames.size(), name, queryDescriptor.getVisibleFieldCount());
-                }
-            }
-
-            withScopeBuilder.withNamedQuery(name, withQuery);
-        }
-
-        Scope withScope = withScopeBuilder.build();
-        analysis.setScope(with, withScope);
-        return withScope;
-    }
-
-    private void analyzeOrderBy(Query node, Scope scope)
-    {
-        List<SortItem> items = node.getOrderBy()
-                .map(OrderBy::getSortItems)
-                .orElse(emptyList());
-
-        ImmutableList.Builder<Expression> orderByFieldsBuilder = ImmutableList.builder();
-
-        for (SortItem item : items) {
-            Expression expression = item.getSortKey();
-
-            if (expression instanceof LongLiteral) {
-                // this is an ordinal in the output tuple
-
-                long ordinal = ((LongLiteral) expression).getValue();
-                if (ordinal < 1 || ordinal > scope.getRelationType().getVisibleFieldCount()) {
-                    throw new SemanticException(INVALID_ORDINAL, expression, "ORDER BY position %s is not in select list", ordinal);
-                }
-
-                expression = new FieldReference(toIntExact(ordinal - 1));
-            }
-
-            ExpressionAnalysis expressionAnalysis = ExpressionAnalyzer.analyzeExpression(session,
-                    metadata,
-                    accessControl, sqlParser,
-                    scope,
-                    analysis,
-                    expression);
-            analysis.recordSubqueries(node, expressionAnalysis);
-
-            orderByFieldsBuilder.add(expression);
-        }
-
-        analysis.setOrderByExpressions(node, orderByFieldsBuilder.build());
-    }
-
-    private Scope createAndAssignScope(Node node, Scope parent, Field... fields)
-    {
-        return createAndAssignScope(node, parent, new RelationType(fields));
-    }
-
-    private Scope createAndAssignScope(Node node, Scope parent, List<Field> fields)
-    {
-        return createAndAssignScope(node, parent, new RelationType(fields));
-    }
-
-    private Scope createAndAssignScope(Node node, Scope parent, RelationType relationType)
-    {
-        Scope scope = Scope.builder()
-                .withParent(parent)
-                .withRelationType(relationType)
-                .build();
-        analysis.setScope(node, scope);
-        return scope;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -198,7 +198,8 @@ class StatementAnalyzer
             Analysis analysis,
             Metadata metadata,
             SqlParser sqlParser,
-            AccessControl accessControl, Session session)
+            AccessControl accessControl,
+            Session session)
     {
         this.analysis = requireNonNull(analysis, "analysis is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
@@ -207,28 +208,45 @@ class StatementAnalyzer
         this.session = requireNonNull(session, "session is null");
     }
 
-    public Scope analyze(Node node, Scope scope)
+    public Scope analyze(Node node, Scope outerQueryScope)
     {
-        return new Visitor().process(node, scope);
+        return analyze(node, Optional.of(outerQueryScope));
     }
 
-    private void analyzeWhere(Node node, Scope scope, Expression predicate)
+    public Scope analyze(Node node, Optional<Scope> outerQueryScope)
     {
-        Visitor visitor = new Visitor();
-        visitor.analyzeWhere(node, scope, predicate);
+        return new Visitor(outerQueryScope).process(node, Optional.empty());
+    }
+
+    private void analyzeWhere(Node node, Scope outerQueryScope, Expression predicate)
+    {
+        Visitor visitor = new Visitor(Optional.of(outerQueryScope));
+        visitor.analyzeWhere(node, outerQueryScope, predicate);
     }
 
     private class Visitor
-            extends DefaultTraversalVisitor<Scope, Scope>
+            extends DefaultTraversalVisitor<Scope, Optional<Scope>>
     {
+        private final Optional<Scope> outerQueryScope;
+
+        private Visitor(Optional<Scope> outerQueryScope)
+        {
+            this.outerQueryScope = requireNonNull(outerQueryScope, "outerQueryScope is null");
+        }
+
+        private Scope process(Node node, Scope scope)
+        {
+            return process(node, Optional.of(scope));
+        }
+
         @Override
-        protected Scope visitUse(Use node, Scope scope)
+        protected Scope visitUse(Use node, Optional<Scope> scope)
         {
             throw new SemanticException(NOT_SUPPORTED, node, "USE statement is not supported");
         }
 
         @Override
-        protected Scope visitInsert(Insert insert, Scope scope)
+        protected Scope visitInsert(Insert insert, Optional<Scope> scope)
         {
             QualifiedObjectName targetTable = createQualifiedObjectName(session, insert, insert.getTarget());
             if (metadata.getView(session, targetTable).isPresent()) {
@@ -314,7 +332,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitDelete(Delete node, Scope scope)
+        protected Scope visitDelete(Delete node, Optional<Scope> scope)
         {
             Table table = node.getTable();
             QualifiedObjectName tableName = createQualifiedObjectName(session, table, table.getName());
@@ -342,7 +360,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitCreateTableAsSelect(CreateTableAsSelect node, Scope scope)
+        protected Scope visitCreateTableAsSelect(CreateTableAsSelect node, Optional<Scope> scope)
         {
             analysis.setUpdateType("CREATE TABLE");
 
@@ -362,7 +380,7 @@ class StatementAnalyzer
             for (Expression expression : node.getProperties().values()) {
                 // analyze table property value expressions which must be constant
                 createConstantAnalyzer(metadata, session, analysis.getParameters(), analysis.isDescribe())
-                        .analyze(expression, scope);
+                        .analyze(expression, createScope(scope));
             }
             analysis.setCreateTableProperties(node.getProperties());
 
@@ -379,7 +397,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitCreateView(CreateView node, Scope scope)
+        protected Scope visitCreateView(CreateView node, Optional<Scope> scope)
         {
             analysis.setUpdateType("CREATE VIEW");
 
@@ -399,127 +417,127 @@ class StatementAnalyzer
 
             validateColumns(node, queryScope.getRelationType());
 
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitSetSession(SetSession node, Scope scope)
+        protected Scope visitSetSession(SetSession node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitResetSession(ResetSession node, Scope scope)
+        protected Scope visitResetSession(ResetSession node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitAddColumn(AddColumn node, Scope scope)
+        protected Scope visitAddColumn(AddColumn node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitCreateSchema(CreateSchema node, Scope scope)
+        protected Scope visitCreateSchema(CreateSchema node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitDropSchema(DropSchema node, Scope scope)
+        protected Scope visitDropSchema(DropSchema node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitRenameSchema(RenameSchema node, Scope scope)
+        protected Scope visitRenameSchema(RenameSchema node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitCreateTable(CreateTable node, Scope scope)
+        protected Scope visitCreateTable(CreateTable node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitDropTable(DropTable node, Scope scope)
+        protected Scope visitDropTable(DropTable node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitRenameTable(RenameTable node, Scope scope)
+        protected Scope visitRenameTable(RenameTable node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitRenameColumn(RenameColumn node, Scope scope)
+        protected Scope visitRenameColumn(RenameColumn node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitDropView(DropView node, Scope scope)
+        protected Scope visitDropView(DropView node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitStartTransaction(StartTransaction node, Scope scope)
+        protected Scope visitStartTransaction(StartTransaction node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitCommit(Commit node, Scope scope)
+        protected Scope visitCommit(Commit node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitRollback(Rollback node, Scope scope)
+        protected Scope visitRollback(Rollback node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitPrepare(Prepare node, Scope scope)
+        protected Scope visitPrepare(Prepare node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitDeallocate(Deallocate node, Scope scope)
+        protected Scope visitDeallocate(Deallocate node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitExecute(Execute node, Scope scope)
+        protected Scope visitExecute(Execute node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitGrant(Grant node, Scope scope)
+        protected Scope visitGrant(Grant node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitRevoke(Revoke node, Scope scope)
+        protected Scope visitRevoke(Revoke node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         @Override
-        protected Scope visitCall(Call node, Scope scope)
+        protected Scope visitCall(Call node, Optional<Scope> scope)
         {
-            return createAndAssignScope(node, scope, emptyList());
+            return createAndAssignScope(node, scope);
         }
 
         private void validateColumns(Statement node, RelationType descriptor)
@@ -542,7 +560,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitExplain(Explain node, Scope scope)
+        protected Scope visitExplain(Explain node, Optional<Scope> scope)
                 throws SemanticException
         {
             checkState(node.isAnalyze(), "Non analyze explain should be rewritten to Query");
@@ -555,7 +573,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitQuery(Query node, Scope scope)
+        protected Scope visitQuery(Query node, Optional<Scope> scope)
         {
             Scope withScope = analyzeWith(node, scope);
             Scope queryScope = Scope.builder()
@@ -576,11 +594,11 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitUnnest(Unnest node, Scope scope)
+        protected Scope visitUnnest(Unnest node, Optional<Scope> scope)
         {
             ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
             for (Expression expression : node.getExpressions()) {
-                ExpressionAnalysis expressionAnalysis = analyzeExpression(expression, scope);
+                ExpressionAnalysis expressionAnalysis = analyzeExpression(expression, createScope(scope));
                 Type expressionType = expressionAnalysis.getType(expression);
                 if (expressionType instanceof ArrayType) {
                     outputFields.add(Field.newUnqualified(Optional.empty(), ((ArrayType) expressionType).getElementType()));
@@ -600,13 +618,13 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitTable(Table table, Scope scope)
+        protected Scope visitTable(Table table, Optional<Scope> scope)
         {
             if (!table.getName().getPrefix().isPresent()) {
                 // is this a reference to a WITH query?
                 String name = table.getName().getSuffix();
 
-                Optional<WithQuery> withQuery = scope.getNamedQuery(name);
+                Optional<WithQuery> withQuery = createScope(scope).getNamedQuery(name);
                 if (withQuery.isPresent()) {
                     Query query = withQuery.get().getQuery();
                     analysis.registerNamedQuery(table, query);
@@ -737,7 +755,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitAliasedRelation(AliasedRelation relation, Scope scope)
+        protected Scope visitAliasedRelation(AliasedRelation relation, Optional<Scope> scope)
         {
             Scope relationScope = process(relation.getRelation(), scope);
 
@@ -755,7 +773,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitSampledRelation(SampledRelation relation, Scope scope)
+        protected Scope visitSampledRelation(SampledRelation relation, Optional<Scope> scope)
         {
             if (!DependencyExtractor.extractNames(relation.getSamplePercentage(), analysis.getColumnReferences()).isEmpty()) {
                 throw new SemanticException(NON_NUMERIC_SAMPLE_PERCENTAGE, relation.getSamplePercentage(), "Sample percentage cannot contain column references");
@@ -794,7 +812,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitTableSubquery(TableSubquery node, Scope scope)
+        protected Scope visitTableSubquery(TableSubquery node, Optional<Scope> scope)
         {
             StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, accessControl, session);
             Scope queryScope = analyzer.analyze(node.getQuery(), scope);
@@ -802,7 +820,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitQuerySpecification(QuerySpecification node, Scope scope)
+        protected Scope visitQuerySpecification(QuerySpecification node, Optional<Scope> scope)
         {
             // TODO: extract candidate names from SELECT, WHERE, HAVING, GROUP BY and ORDER BY expressions
             // to pass down to analyzeFrom
@@ -831,7 +849,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitSetOperation(SetOperation node, Scope scope)
+        protected Scope visitSetOperation(SetOperation node, Optional<Scope> scope)
         {
             checkState(node.getRelations().size() >= 2);
 
@@ -899,7 +917,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitIntersect(Intersect node, Scope scope)
+        protected Scope visitIntersect(Intersect node, Optional<Scope> scope)
         {
             if (!node.isDistinct()) {
                 throw new SemanticException(NOT_SUPPORTED, node, "INTERSECT ALL not yet implemented");
@@ -909,7 +927,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitExcept(Except node, Scope scope)
+        protected Scope visitExcept(Except node, Optional<Scope> scope)
         {
             if (!node.isDistinct()) {
                 throw new SemanticException(NOT_SUPPORTED, node, "EXCEPT ALL not yet implemented");
@@ -919,7 +937,7 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitJoin(Join node, Scope scope)
+        protected Scope visitJoin(Join node, Optional<Scope> scope)
         {
             JoinCriteria criteria = node.getCriteria().orElse(null);
             if (criteria instanceof NaturalJoin) {
@@ -927,7 +945,7 @@ class StatementAnalyzer
             }
 
             Scope left = process(node.getLeft(), scope);
-            Scope right = process(node.getRight(), isUnnestRelation(node.getRight()) ? left : scope);
+            Scope right = process(node.getRight(), isUnnestRelation(node.getRight()) ? Optional.of(left) : scope);
 
             Scope output = createAndAssignScope(node, scope, left.getRelationType().joinWith(right.getRelationType()));
 
@@ -1082,12 +1100,12 @@ class StatementAnalyzer
         }
 
         @Override
-        protected Scope visitValues(Values node, Scope scope)
+        protected Scope visitValues(Values node, Optional<Scope> scope)
         {
             checkState(node.getRows().size() >= 1);
 
             List<List<Type>> rowTypes = node.getRows().stream()
-                    .map(row -> analyzeExpression(row, scope).getType(row))
+                    .map(row -> analyzeExpression(row, createScope(scope)).getType(row))
                     .map(type -> {
                         if (type instanceof RowType) {
                             return type.getTypeParameters();
@@ -1603,7 +1621,7 @@ class StatementAnalyzer
                 }
             }
 
-            return createAndAssignScope(node, scope, outputFields.build());
+            return createAndAssignScope(node, Optional.of(scope), outputFields.build());
         }
 
         private List<Expression> analyzeSelect(QuerySpecification node, Scope scope)
@@ -1677,13 +1695,13 @@ class StatementAnalyzer
             analysis.setWhere(node, predicate);
         }
 
-        private Scope analyzeFrom(QuerySpecification node, Scope scope)
+        private Scope analyzeFrom(QuerySpecification node, Optional<Scope> scope)
         {
             if (node.getFrom().isPresent()) {
                 return process(node.getFrom().get(), scope);
             }
 
-            return scope;
+            return createScope(scope);
         }
 
         private void analyzeAggregations(
@@ -1839,19 +1857,18 @@ class StatementAnalyzer
             return builder.build();
         }
 
-        private Scope analyzeWith(Query node, Scope scope)
+        private Scope analyzeWith(Query node, Optional<Scope> scope)
         {
             // analyze WITH clause
             if (!node.getWith().isPresent()) {
-                return scope;
+                return createScope(scope);
             }
             With with = node.getWith().get();
             if (with.isRecursive()) {
                 throw new SemanticException(NOT_SUPPORTED, with, "Recursive WITH queries are not supported");
             }
 
-            Scope.Builder withScopeBuilder = Scope.builder()
-                    .withParent(scope);
+            Scope.Builder withScopeBuilder = scopeBuilder(scope);
             for (WithQuery withQuery : with.getQueries()) {
                 Query query = withQuery.getQuery();
                 process(query, withScopeBuilder.build());
@@ -1914,24 +1931,49 @@ class StatementAnalyzer
             analysis.setOrderByExpressions(node, orderByFieldsBuilder.build());
         }
 
-        private Scope createAndAssignScope(Node node, Scope parent, Field... fields)
+        private Scope createAndAssignScope(Node node, Optional<Scope> parentScope)
         {
-            return createAndAssignScope(node, parent, new RelationType(fields));
+            return createAndAssignScope(node, parentScope, emptyList());
         }
 
-        private Scope createAndAssignScope(Node node, Scope parent, List<Field> fields)
+        private Scope createAndAssignScope(Node node, Optional<Scope> parentScope, Field... fields)
         {
-            return createAndAssignScope(node, parent, new RelationType(fields));
+            return createAndAssignScope(node, parentScope, new RelationType(fields));
         }
 
-        private Scope createAndAssignScope(Node node, Scope parent, RelationType relationType)
+        private Scope createAndAssignScope(Node node, Optional<Scope> parentScope, List<Field> fields)
         {
-            Scope scope = Scope.builder()
-                    .withParent(parent)
-                    .withRelationType(relationType)
-                    .build();
+            return createAndAssignScope(node, parentScope, new RelationType(fields));
+        }
+
+        private Scope createAndAssignScope(Node node, Optional<Scope> parentScope, RelationType relationType)
+        {
+            Scope.Builder scopeBuilder = scopeBuilder(parentScope);
+            scopeBuilder.withRelationType(relationType);
+
+            Scope scope = scopeBuilder.build();
             analysis.setScope(node, scope);
             return scope;
+        }
+
+        private Scope createScope(Optional<Scope> parentScope)
+        {
+            return scopeBuilder(parentScope).build();
+        }
+
+        private Scope.Builder scopeBuilder(Optional<Scope> parentScope)
+        {
+            Scope.Builder scopeBuilder = Scope.builder();
+
+            if (parentScope.isPresent()) {
+                scopeBuilder.withParent(parentScope.get());
+            }
+            else if (outerQueryScope.isPresent()) {
+                scopeBuilder.withOuterQueryParent(outerQueryScope.get())
+                        .withParentNamedQueries(outerQueryScope.get());
+            }
+
+            return scopeBuilder;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1628,7 +1628,11 @@ class StatementAnalyzer
                 }
             }
 
-            return createAndAssignScope(node, Optional.of(scope), outputFields.build());
+            Scope.Builder scopeBuilder = scopeBuilderWithParentNamedQueries(scope);
+            scopeBuilder.withRelationType(new RelationType(outputFields.build()));
+            Scope outputScope = scopeBuilder.build();
+            analysis.setScope(node, outputScope);
+            return outputScope;
         }
 
         private List<Expression> analyzeSelect(QuerySpecification node, Scope scope)
@@ -1981,6 +1985,16 @@ class StatementAnalyzer
                 scopeBuilder.withOuterQueryParent(outerQueryScope.get())
                         .withParentNamedQueries(outerQueryScope.get());
             }
+
+            return scopeBuilder;
+        }
+
+        private Scope.Builder scopeBuilderWithParentNamedQueries(Scope namedQueriesParent)
+        {
+            Scope.Builder scopeBuilder = Scope.builder()
+                    .withParentNamedQueries(namedQueriesParent);
+
+            outerQueryScope.ifPresent(scopeBuilder::withOuterQueryParent);
 
             return scopeBuilder;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -77,6 +77,7 @@ import com.facebook.presto.sql.tree.JoinUsing;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.NaturalJoin;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
@@ -1251,7 +1252,9 @@ class StatementAnalyzer
             return legacyAnalyzeOrderBy(node, sourceScope, outputScope, outputExpressions);
         }
 
-        List<SortItem> items = node.getOrderBy();
+        List<SortItem> items = node.getOrderBy()
+                .map(OrderBy::getSortItems)
+                .orElse(emptyList());
 
         ImmutableList.Builder<Expression> orderByExpressionsBuilder = ImmutableList.builder();
 
@@ -1316,7 +1319,9 @@ class StatementAnalyzer
      */
     private List<Expression> legacyAnalyzeOrderBy(QuerySpecification node, Scope sourceScope, Scope outputScope, List<Expression> outputExpressions)
     {
-        List<SortItem> items = node.getOrderBy();
+        List<SortItem> items = node.getOrderBy()
+                .map(OrderBy::getSortItems)
+                .orElse(emptyList());
 
         ImmutableList.Builder<Expression> orderByExpressionsBuilder = ImmutableList.builder();
 
@@ -1708,8 +1713,9 @@ class StatementAnalyzer
                 .filter(SingleColumn.class::isInstance)
                 .forEach(extractor::process);
 
-        node.getOrderBy().stream()
-                .forEach(extractor::process);
+        node.getOrderBy().map(OrderBy::getSortItems).ifPresent(
+                sortItems -> sortItems
+                        .forEach(extractor::process));
 
         node.getHaving()
                 .ifPresent(extractor::process);
@@ -1862,7 +1868,9 @@ class StatementAnalyzer
 
     private void analyzeOrderBy(Query node, Scope scope)
     {
-        List<SortItem> items = node.getOrderBy();
+        List<SortItem> items = node.getOrderBy()
+                .map(OrderBy::getSortItems)
+                .orElse(emptyList());
 
         ImmutableList.Builder<Expression> orderByFieldsBuilder = ImmutableList.builder();
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -583,16 +583,13 @@ class StatementAnalyzer
         protected Scope visitQuery(Query node, Optional<Scope> scope)
         {
             Scope withScope = analyzeWith(node, scope);
-            Scope queryScope = Scope.builder()
-                    .withParent(withScope)
-                    .build();
-            Scope queryBodyScope = process(node.getQueryBody(), queryScope);
+            Scope queryBodyScope = process(node.getQueryBody(), withScope);
             analyzeOrderBy(node, queryBodyScope);
 
             // Input fields == Output fields
             analysis.setOutputExpressions(node, descriptorToFields(queryBodyScope));
 
-            queryScope = Scope.builder()
+            Scope queryScope = Scope.builder()
                     .withParent(withScope)
                     .withRelationType(queryBodyScope.getRelationType())
                     .build();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -260,7 +260,9 @@ class QueryPlanner
     private RelationPlan planImplicitTable(QuerySpecification node)
     {
         List<Expression> emptyRow = ImmutableList.of();
-        Scope scope = Scope.builder().withParent(analysis.getScope(node)).build();
+        Scope scope = Scope.builder()
+                .withParent(analysis.getScope(node))
+                .build();
         return new RelationPlan(
                 new ValuesNode(idAllocator.getNextId(), ImmutableList.of(), ImmutableList.of(emptyRow)),
                 scope,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -245,7 +245,7 @@ class QueryPlanner
                     .process(node.getFrom().get(), null);
         }
         else {
-            relationPlan = planImplicitTable(node);
+            relationPlan = planImplicitTable();
         }
 
         TranslationMap translations = new TranslationMap(relationPlan, analysis, lambdaDeclarationToSymbolMap);
@@ -257,12 +257,10 @@ class QueryPlanner
         return new PlanBuilder(translations, relationPlan.getRoot(), analysis.getParameters());
     }
 
-    private RelationPlan planImplicitTable(QuerySpecification node)
+    private RelationPlan planImplicitTable()
     {
         List<Expression> emptyRow = ImmutableList.of();
-        Scope scope = Scope.builder()
-                .withParent(analysis.getScope(node))
-                .build();
+        Scope scope = Scope.builder().build();
         return new RelationPlan(
                 new ValuesNode(idAllocator.getNextId(), ImmutableList.of(), ImmutableList.of(emptyRow)),
                 scope,

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
@@ -122,7 +122,7 @@ final class DescribeInputRewrite
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),
-                    ordering(ascending("Position")),
+                    Optional.of(ordering(ascending("Position"))),
                     limit
             );
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeOutputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeOutputRewrite.java
@@ -44,7 +44,6 @@ import static com.facebook.presto.sql.QueryUtil.row;
 import static com.facebook.presto.sql.QueryUtil.selectList;
 import static com.facebook.presto.sql.QueryUtil.simpleQuery;
 import static com.facebook.presto.sql.QueryUtil.values;
-import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 final class DescribeOutputRewrite
@@ -121,7 +120,7 @@ final class DescribeOutputRewrite
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),
-                    emptyList(),
+                    Optional.empty(),
                     limit);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -51,6 +51,7 @@ import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Relation;
@@ -207,7 +208,7 @@ final class ShowQueriesRewrite
                     selectList(aliasedName("schema_name", "Schema")),
                     from(node.getCatalog().orElseGet(() -> session.getCatalog().get()), TABLE_SCHEMATA),
                     predicate,
-                    ordering(ascending("schema_name")));
+                    Optional.of(ordering(ascending("schema_name"))));
         }
 
         @Override
@@ -227,7 +228,7 @@ final class ShowQueriesRewrite
                     selectList(new AllColumns()),
                     aliased(new Values(rows), "catalogs", ImmutableList.of("Catalog")),
                     predicate,
-                    ordering(ascending("Catalog")));
+                    Optional.of(ordering(ascending("Catalog"))));
         }
 
         @Override
@@ -344,7 +345,7 @@ final class ShowQueriesRewrite
                             equal(identifier("table_name"), new StringLiteral(table.getObjectName())))),
                     Optional.of(new GroupBy(false, ImmutableList.of(new SimpleGroupBy(ImmutableList.of(identifier("partition_number")))))),
                     Optional.empty(),
-                    ImmutableList.of(),
+                    Optional.empty(),
                     Optional.empty());
 
             return simpleQuery(
@@ -353,10 +354,10 @@ final class ShowQueriesRewrite
                     showPartitions.getWhere(),
                     Optional.empty(),
                     Optional.empty(),
-                    ImmutableList.<SortItem>builder()
+                    Optional.of(new OrderBy(ImmutableList.<SortItem>builder()
                             .addAll(showPartitions.getOrderBy())
                             .add(ascending("partition_number"))
-                            .build(),
+                            .build())),
                     showPartitions.getLimit());
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestScope.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestScope.java
@@ -38,7 +38,7 @@ public class TestScope
 
         Field innerColumn2 = Field.newQualified(QualifiedName.of("inner", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), false);
         Field innerColumn3 = Field.newQualified(QualifiedName.of("inner", "column3"), Optional.of("c3"), BIGINT, false, Optional.empty(), false);
-        Scope inner = Scope.builder().withParent(outer).withRelationType(new RelationType(innerColumn2, innerColumn3)).build();
+        Scope inner = Scope.builder().withOuterQueryParent(outer).withParentNamedQueries(outer).withRelationType(new RelationType(innerColumn2, innerColumn3)).build();
 
         Expression c1 = name("c1");
         Expression c2 = name("c2");
@@ -50,21 +50,26 @@ public class TestScope
         assertTrue(outer.tryResolveField(c1).isPresent());
         assertEquals(outer.tryResolveField(c1).get().getField(), outerColumn1);
         assertEquals(outer.tryResolveField(c1).get().isLocal(), true);
+        assertEquals(outer.tryResolveField(c1).get().getFieldIndex(), 0);
         assertTrue(outer.tryResolveField(c2).isPresent());
         assertEquals(outer.tryResolveField(c2).get().getField(), outerColumn2);
         assertEquals(outer.tryResolveField(c2).get().isLocal(), true);
+        assertEquals(outer.tryResolveField(c2).get().getFieldIndex(), 1);
         assertFalse(outer.tryResolveField(c3).isPresent());
         assertFalse(outer.tryResolveField(c4).isPresent());
 
         assertTrue(inner.tryResolveField(c1).isPresent());
         assertEquals(inner.tryResolveField(c1).get().getField(), outerColumn1);
         assertEquals(inner.tryResolveField(c1).get().isLocal(), false);
+        assertEquals(inner.tryResolveField(c1).get().getFieldIndex(), 2);
         assertTrue(inner.tryResolveField(c2).isPresent());
         assertEquals(inner.tryResolveField(c2).get().getField(), innerColumn2);
         assertEquals(inner.tryResolveField(c2).get().isLocal(), true);
+        assertEquals(inner.tryResolveField(c2).get().getFieldIndex(), 0);
         assertTrue(inner.tryResolveField(c2).isPresent());
         assertEquals(inner.tryResolveField(c3).get().getField(), innerColumn3);
         assertEquals(inner.tryResolveField(c3).get().isLocal(), true);
+        assertEquals(inner.tryResolveField(c3).get().getFieldIndex(), 1);
         assertFalse(inner.tryResolveField(c4).isPresent());
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QueryBody;
@@ -140,9 +141,9 @@ public final class QueryUtil
         return new SingleColumn(new CoalesceExpression(identifier(column), new StringLiteral("")), alias);
     }
 
-    public static List<SortItem> ordering(SortItem... items)
+    public static OrderBy ordering(SortItem... items)
     {
-        return ImmutableList.copyOf(items);
+        return new OrderBy(ImmutableList.copyOf(items));
     }
 
     public static Query simpleQuery(Select select)
@@ -153,36 +154,36 @@ public final class QueryUtil
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                ImmutableList.of(),
+                Optional.empty(),
                 Optional.empty()));
     }
 
     public static Query simpleQuery(Select select, Relation from)
     {
-        return simpleQuery(select, from, Optional.empty(), ImmutableList.of());
+        return simpleQuery(select, from, Optional.empty(), Optional.empty());
     }
 
-    public static Query simpleQuery(Select select, Relation from, List<SortItem> ordering)
+    public static Query simpleQuery(Select select, Relation from, OrderBy orderBy)
     {
-        return simpleQuery(select, from, Optional.empty(), ordering);
+        return simpleQuery(select, from, Optional.empty(), Optional.of(orderBy));
     }
 
     public static Query simpleQuery(Select select, Relation from, Expression where)
     {
-        return simpleQuery(select, from, Optional.of(where), ImmutableList.of());
+        return simpleQuery(select, from, Optional.of(where), Optional.empty());
     }
 
-    public static Query simpleQuery(Select select, Relation from, Expression where, List<SortItem> ordering)
+    public static Query simpleQuery(Select select, Relation from, Expression where, OrderBy orderBy)
     {
-        return simpleQuery(select, from, Optional.of(where), ordering);
+        return simpleQuery(select, from, Optional.of(where), Optional.of(orderBy));
     }
 
-    public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, List<SortItem> ordering)
+    public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, Optional<OrderBy> orderBy)
     {
-        return simpleQuery(select, from, where, Optional.empty(), Optional.empty(), ordering, Optional.empty());
+        return simpleQuery(select, from, where, Optional.empty(), Optional.empty(), orderBy, Optional.empty());
     }
 
-    public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, Optional<GroupBy> groupBy, Optional<Expression> having, List<SortItem> ordering, Optional<String> limit)
+    public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, Optional<GroupBy> groupBy, Optional<Expression> having, Optional<OrderBy> orderBy, Optional<String> limit)
     {
         return query(new QuerySpecification(
                 select,
@@ -190,7 +191,7 @@ public final class QueryUtil
                 where,
                 groupBy,
                 having,
-                ordering,
+                orderBy,
                 limit));
     }
 
@@ -215,7 +216,7 @@ public final class QueryUtil
         return new Query(
                 Optional.empty(),
                 body,
-                ImmutableList.of(),
+                Optional.empty(),
                 Optional.empty());
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -50,6 +50,7 @@ import com.facebook.presto.sql.tree.JoinUsing;
 import com.facebook.presto.sql.tree.LikeClause;
 import com.facebook.presto.sql.tree.NaturalJoin;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
@@ -234,9 +235,8 @@ public final class SqlFormatter
 
             processRelation(node.getQueryBody(), indent);
 
-            if (!node.getOrderBy().isEmpty()) {
-                append(indent, "ORDER BY " + formatSortItems(node.getOrderBy(), parameters))
-                        .append('\n');
+            if (node.getOrderBy().isPresent()) {
+                process(node.getOrderBy().get(), indent);
             }
 
             if (node.getLimit().isPresent()) {
@@ -275,15 +275,22 @@ public final class SqlFormatter
                         .append('\n');
             }
 
-            if (!node.getOrderBy().isEmpty()) {
-                append(indent, "ORDER BY " + formatSortItems(node.getOrderBy(), parameters))
-                        .append('\n');
+            if (node.getOrderBy().isPresent()) {
+                process(node.getOrderBy().get(), indent);
             }
 
             if (node.getLimit().isPresent()) {
                 append(indent, "LIMIT " + node.getLimit().get())
                         .append('\n');
             }
+            return null;
+        }
+
+        @Override
+        protected Void visitOrderBy(OrderBy node, Integer indent)
+        {
+            append(indent, "ORDER BY " + formatSortItems(node.getSortItems(), parameters))
+                    .append('\n');
             return null;
         }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
@@ -33,6 +33,7 @@ import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
@@ -87,12 +88,9 @@ public class TreePrinter
 
                 print(indentLevel, "QueryBody");
                 process(node.getQueryBody(), indentLevel);
-
-                if (!node.getOrderBy().isEmpty()) {
+                if (node.getOrderBy().isPresent()) {
                     print(indentLevel, "OrderBy");
-                    for (SortItem sortItem : node.getOrderBy()) {
-                        process(sortItem, indentLevel + 1);
-                    }
+                    process(node.getOrderBy().get(), indentLevel + 1);
                 }
 
                 if (node.getLimit().isPresent()) {
@@ -164,15 +162,22 @@ public class TreePrinter
                     process(node.getHaving().get(), indentLevel + 1);
                 }
 
-                if (!node.getOrderBy().isEmpty()) {
+                if (node.getOrderBy().isPresent()) {
                     print(indentLevel, "OrderBy");
-                    for (SortItem sortItem : node.getOrderBy()) {
-                        process(sortItem, indentLevel + 1);
-                    }
+                    process(node.getOrderBy().get(), indentLevel + 1);
                 }
 
                 if (node.getLimit().isPresent()) {
                     print(indentLevel, "Limit: " + node.getLimit().get());
+                }
+
+                return null;
+            }
+
+            protected Void visitOrderBy(OrderBy node, Integer indentLevel)
+            {
+                for (SortItem sortItem : node.getSortItems()) {
+                    process(sortItem, indentLevel);
                 }
 
                 return null;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -92,6 +92,7 @@ import com.facebook.presto.sql.tree.NodeLocation;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullIfExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -437,6 +438,11 @@ class AstBuilder
     {
         QueryBody term = (QueryBody) visit(context.queryTerm());
 
+        Optional<OrderBy> orderBy = Optional.empty();
+        if (context.ORDER() != null) {
+            orderBy = Optional.of(new OrderBy(getLocation(context.ORDER()), visit(context.sortItem(), SortItem.class)));
+        }
+
         if (term instanceof QuerySpecification) {
             // When we have a simple query specification
             // followed by order by limit, fold the order by and limit
@@ -455,9 +461,9 @@ class AstBuilder
                             query.getWhere(),
                             query.getGroupBy(),
                             query.getHaving(),
-                            visit(context.sortItem(), SortItem.class),
+                            orderBy,
                             getTextIfPresent(context.limit)),
-                    ImmutableList.of(),
+                    Optional.empty(),
                     Optional.empty());
         }
 
@@ -465,7 +471,7 @@ class AstBuilder
                 getLocation(context),
                 Optional.empty(),
                 term,
-                visit(context.sortItem(), SortItem.class),
+                orderBy,
                 getTextIfPresent(context.limit));
     }
 
@@ -495,7 +501,7 @@ class AstBuilder
                 visitIfPresent(context.where, Expression.class),
                 visitIfPresent(context.groupBy(), GroupBy.class),
                 visitIfPresent(context.having, Expression.class),
-                ImmutableList.of(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -217,6 +217,11 @@ public abstract class AstVisitor<R, C>
         return visitRelation(node, context);
     }
 
+    protected R visitOrderBy(OrderBy node, C context)
+    {
+        return visitNode(node, context);
+    }
+
     protected R visitQuerySpecification(QuerySpecification node, C context)
     {
         return visitQueryBody(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -104,8 +104,8 @@ public abstract class DefaultTraversalVisitor<R, C>
             process(node.getWith().get(), context);
         }
         process(node.getQueryBody(), context);
-        for (SortItem sortItem : node.getOrderBy()) {
-            process(sortItem, context);
+        if (node.getOrderBy().isPresent()) {
+            process(node.getOrderBy().get(), context);
         }
 
         return null;
@@ -339,6 +339,15 @@ public abstract class DefaultTraversalVisitor<R, C>
     }
 
     @Override
+    protected R visitOrderBy(OrderBy node, C context)
+    {
+        for (SortItem sortItem : node.getSortItems()) {
+            process(sortItem, context);
+        }
+        return null;
+    }
+
+    @Override
     protected R visitSortItem(SortItem node, C context)
     {
         return process(node.getSortKey(), context);
@@ -360,8 +369,8 @@ public abstract class DefaultTraversalVisitor<R, C>
         if (node.getHaving().isPresent()) {
             process(node.getHaving().get(), context);
         }
-        for (SortItem sortItem : node.getOrderBy()) {
-            process(sortItem, context);
+        if (node.getOrderBy().isPresent()) {
+            process(node.getOrderBy().get(), context);
         }
         return null;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/OrderBy.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/OrderBy.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class OrderBy
+        extends Node
+{
+    private final List<SortItem> sortItems;
+
+    public OrderBy(List<SortItem> sortItems)
+    {
+        this(Optional.empty(), sortItems);
+    }
+
+    public OrderBy(NodeLocation location, List<SortItem> sortItems)
+    {
+        this(Optional.of(location), sortItems);
+    }
+
+    private OrderBy(Optional<NodeLocation> location, List<SortItem> sortItems)
+    {
+        super(location);
+        requireNonNull(sortItems, "sortItems is null");
+        checkArgument(!sortItems.isEmpty(), "sortItems should not be empty");
+        this.sortItems = ImmutableList.copyOf(sortItems);
+    }
+
+    public List<SortItem> getSortItems()
+    {
+        return sortItems;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitOrderBy(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return sortItems;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("sortItems", sortItems)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        OrderBy o = (OrderBy) obj;
+        return Objects.equals(sortItems, o.sortItems);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sortItems);
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Query.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Query.java
@@ -27,13 +27,13 @@ public class Query
 {
     private final Optional<With> with;
     private final QueryBody queryBody;
-    private final List<SortItem> orderBy;
+    private final Optional<OrderBy> orderBy;
     private final Optional<String> limit;
 
     public Query(
             Optional<With> with,
             QueryBody queryBody,
-            List<SortItem> orderBy,
+            Optional<OrderBy> orderBy,
             Optional<String> limit)
     {
         this(Optional.empty(), with, queryBody, orderBy, limit);
@@ -43,7 +43,7 @@ public class Query
             NodeLocation location,
             Optional<With> with,
             QueryBody queryBody,
-            List<SortItem> orderBy,
+            Optional<OrderBy> orderBy,
             Optional<String> limit)
     {
         this(Optional.of(location), with, queryBody, orderBy, limit);
@@ -53,7 +53,7 @@ public class Query
             Optional<NodeLocation> location,
             Optional<With> with,
             QueryBody queryBody,
-            List<SortItem> orderBy,
+            Optional<OrderBy> orderBy,
             Optional<String> limit)
     {
         super(location);
@@ -78,7 +78,7 @@ public class Query
         return queryBody;
     }
 
-    public List<SortItem> getOrderBy()
+    public Optional<OrderBy> getOrderBy()
     {
         return orderBy;
     }
@@ -99,9 +99,9 @@ public class Query
     {
         ImmutableList.Builder<Node> nodes = ImmutableList.builder();
         with.ifPresent(nodes::add);
-        return nodes.add(queryBody)
-                .addAll(orderBy)
-                .build();
+        nodes.add(queryBody);
+        orderBy.ifPresent(nodes::add);
+        return nodes.build();
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QuerySpecification.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QuerySpecification.java
@@ -30,7 +30,7 @@ public class QuerySpecification
     private final Optional<Expression> where;
     private final Optional<GroupBy> groupBy;
     private final Optional<Expression> having;
-    private final List<SortItem> orderBy;
+    private final Optional<OrderBy> orderBy;
     private final Optional<String> limit;
 
     public QuerySpecification(
@@ -39,7 +39,7 @@ public class QuerySpecification
             Optional<Expression> where,
             Optional<GroupBy> groupBy,
             Optional<Expression> having,
-            List<SortItem> orderBy,
+            Optional<OrderBy> orderBy,
             Optional<String> limit)
     {
         this(Optional.empty(), select, from, where, groupBy, having, orderBy, limit);
@@ -52,7 +52,7 @@ public class QuerySpecification
             Optional<Expression> where,
             Optional<GroupBy> groupBy,
             Optional<Expression> having,
-            List<SortItem> orderBy,
+            Optional<OrderBy> orderBy,
             Optional<String> limit)
     {
         this(Optional.of(location), select, from, where, groupBy, having, orderBy, limit);
@@ -65,7 +65,7 @@ public class QuerySpecification
             Optional<Expression> where,
             Optional<GroupBy> groupBy,
             Optional<Expression> having,
-            List<SortItem> orderBy,
+            Optional<OrderBy> orderBy,
             Optional<String> limit)
     {
         super(location);
@@ -111,7 +111,7 @@ public class QuerySpecification
         return having;
     }
 
-    public List<SortItem> getOrderBy()
+    public Optional<OrderBy> getOrderBy()
     {
         return orderBy;
     }
@@ -136,7 +136,7 @@ public class QuerySpecification
         where.ifPresent(nodes::add);
         groupBy.ifPresent(nodes::add);
         having.ifPresent(nodes::add);
-        nodes.addAll(orderBy);
+        orderBy.ifPresent(nodes::add);
         return nodes.build();
     }
 

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -74,6 +74,7 @@ import com.facebook.presto.sql.tree.NaturalJoin;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -410,7 +411,7 @@ public class TestSqlParser
                                 new Intersect(ImmutableList.of(createSelect123(), createSelect123()), true),
                                 createSelect123()
                         ), false),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -424,7 +425,7 @@ public class TestSqlParser
                                 new Union(ImmutableList.of(createSelect123(), createSelect123()), true),
                                 createSelect123()
                         ), false),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -436,7 +437,7 @@ public class TestSqlParser
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                ImmutableList.of(),
+                Optional.empty(),
                 Optional.empty()
         );
     }
@@ -462,7 +463,7 @@ public class TestSqlParser
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.of("ALL")));
     }
 
@@ -854,9 +855,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement(format("SELECT substring('%s' FROM 2 FOR 3)", givenString),
@@ -868,9 +869,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -887,9 +888,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement(format("SELECT substring('%s', 2, 3)", givenString),
@@ -901,9 +902,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -924,9 +925,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT col1.f1[0], col2, col3[2].f2.f3, col4[4] FROM table1",
@@ -943,9 +944,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT CAST(ROW(11, 12) AS ROW(COL0 INTEGER, COL1 INTEGER)).col0",
@@ -959,9 +960,31 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
+                        Optional.empty()));
+    }
+
+    @Test
+    public void testSelectWithOrderBy()
+            throws Exception
+    {
+        assertStatement("SELECT * FROM table1 ORDER BY a",
+                new Query(
+                        Optional.empty(),
+                        new QuerySpecification(
+                                selectList(new AllColumns()),
+                                Optional.of(new Table(QualifiedName.of("table1"))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(new OrderBy(ImmutableList.of(new SortItem(
+                                        new Identifier("a"),
+                                        SortItem.Ordering.ASCENDING,
+                                        SortItem.NullOrdering.UNDEFINED)))),
+                                Optional.empty()),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -978,9 +1001,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.of(new GroupBy(false, ImmutableList.of(new SimpleGroupBy(ImmutableList.of(new Identifier("a")))))),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT * FROM table1 GROUP BY a, b",
@@ -994,9 +1017,9 @@ public class TestSqlParser
                                         new SimpleGroupBy(ImmutableList.of(new Identifier("a"))),
                                         new SimpleGroupBy(ImmutableList.of(new Identifier("b")))))),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT * FROM table1 GROUP BY ()",
@@ -1008,9 +1031,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.of(new GroupBy(false, ImmutableList.of(new SimpleGroupBy(ImmutableList.of())))),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT * FROM table1 GROUP BY GROUPING SETS (a)",
@@ -1022,9 +1045,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.of(new GroupBy(false, ImmutableList.of(new GroupingSets(ImmutableList.of(ImmutableList.of(QualifiedName.of("a"))))))),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT * FROM table1 GROUP BY ALL GROUPING SETS ((a, b), (a), ()), CUBE (c), ROLLUP (d)",
@@ -1042,9 +1065,9 @@ public class TestSqlParser
                                         new Cube(ImmutableList.of(QualifiedName.of("c"))),
                                         new Rollup(ImmutableList.of(QualifiedName.of("d")))))),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("SELECT * FROM table1 GROUP BY DISTINCT GROUPING SETS ((a, b), (a), ()), CUBE (c), ROLLUP (d)",
@@ -1062,9 +1085,9 @@ public class TestSqlParser
                                         new Cube(ImmutableList.of(QualifiedName.of("c"))),
                                         new Rollup(ImmutableList.of(QualifiedName.of("d")))))),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -1334,14 +1357,14 @@ public class TestSqlParser
                         new WithQuery("a", simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("x"))), Optional.of(ImmutableList.of("t", "u"))),
                         new WithQuery("b", simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("y"))), Optional.empty())))),
                         new Table(QualifiedName.of("z")),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertStatement("WITH RECURSIVE a AS (SELECT * FROM x) TABLE y",
                 new Query(Optional.of(new With(true, ImmutableList.of(
                         new WithQuery("a", simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("x"))), Optional.empty())))),
                         new Table(QualifiedName.of("y")),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -1515,9 +1538,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 
@@ -1691,9 +1714,9 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of(),
+                                Optional.empty(),
                                 Optional.empty()),
-                        ImmutableList.of(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryRewriter.java
@@ -163,10 +163,10 @@ public class QueryRewriter
                     querySpecification.getOrderBy(),
                     Optional.of("0"));
 
-            zeroRowsQuery = new com.facebook.presto.sql.tree.Query(createSelectClause.getWith(), innerQuery, ImmutableList.of(), Optional.empty());
+            zeroRowsQuery = new com.facebook.presto.sql.tree.Query(createSelectClause.getWith(), innerQuery, Optional.empty(), Optional.empty());
         }
         else {
-            zeroRowsQuery = new com.facebook.presto.sql.tree.Query(createSelectClause.getWith(), innerQuery, ImmutableList.of(), Optional.of("0"));
+            zeroRowsQuery = new com.facebook.presto.sql.tree.Query(createSelectClause.getWith(), innerQuery, Optional.empty(), Optional.of("0"));
         }
 
         ImmutableList.Builder<Column> columns = ImmutableList.builder();
@@ -199,7 +199,7 @@ public class QueryRewriter
         }
 
         Select select = new Select(false, selectItems.build());
-        return formatSql(new QuerySpecification(select, Optional.of(new Table(table)), Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of(), Optional.empty()), Optional.empty());
+        return formatSql(new QuerySpecification(select, Optional.of(new Table(table)), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()), Optional.empty());
     }
 
     private static String dropTableSql(QualifiedName table)
@@ -210,7 +210,7 @@ public class QueryRewriter
     public static class QueryRewriteException
             extends Exception
     {
-        public QueryRewriteException(String messageFormat, Object...args)
+        public QueryRewriteException(String messageFormat, Object... args)
         {
             super(format(messageFormat, args));
         }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/TestShadowing.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/TestShadowing.java
@@ -83,8 +83,8 @@ public class TestShadowing
         SingleColumn column1 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new Identifier("column1"))));
         SingleColumn column2 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new FunctionCall(QualifiedName.of("round"), ImmutableList.of(new Identifier("column2"), new LongLiteral("1"))))));
         Select select = new Select(false, ImmutableList.of(column1, column2));
-        QuerySpecification querySpecification = new QuerySpecification(select, Optional.of(table), Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of(), Optional.empty());
-        assertEquals(parser.createStatement(rewrittenQuery.getQuery()), new com.facebook.presto.sql.tree.Query(Optional.empty(), querySpecification, ImmutableList.of(), Optional.empty()));
+        QuerySpecification querySpecification = new QuerySpecification(select, Optional.of(table), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        assertEquals(parser.createStatement(rewrittenQuery.getQuery()), new com.facebook.presto.sql.tree.Query(Optional.empty(), querySpecification, Optional.empty(), Optional.empty()));
 
         assertEquals(parser.createStatement(rewrittenQuery.getPostQueries().get(0)), new DropTable(createTableAs.getName(), true));
     }


### PR DESCRIPTION
This PR cleans up and formalizes analyzer and planner in relation to scopes. The main goal is to be able to use hierarchal scopes during planning (currently only top scope is used for field resolution) and to hide (when required) parent scope fields. This is required to cleanly fix: https://github.com/prestodb/presto/issues/7142

Various cleanups/improvments:
- added `OrderBy` AST node
- removed unnecessary/dead code
- hide `StatementAnalyzer` visitor methods (previously external classes were directly calling on them. However, only `StatementAnalyzer` should decide what visitors context is)
- always build entire `WithQueries` map in child scope. This allows to decouple `Scope.parent` from `WithQuery` resolution (those are not the same)
- reintroduce concept of query boundary. Now `ResolvedField.local=false` means resolved field is from outer query scope
- refactor `StatementAnalyzer` so that context scope is always query local to the node, while there is also `outerQueryScope`, e.g: provided by subquery parent
- add support for hierarchical scopes during planning (redefine how fields are resolved in `TranslationMap`, make `QuerySpecification` scope not to link to it's local query parent (hide parent scope fields))