### PR TITLE
Add example of a comment in a create table statement

### DIFF
--- a/presto-docs/src/main/sphinx/sql/create-table.rst
+++ b/presto-docs/src/main/sphinx/sql/create-table.rst
@@ -54,12 +54,12 @@ Create a new table ``orders``::
     )
     WITH (format = 'ORC')
 
-Create the table ``orders`` if it does not already exist::
+Create the table ``orders`` if it does not already exist, adding a comment::
 
     CREATE TABLE IF NOT EXISTS orders (
       orderkey bigint,
       orderstatus varchar,
-      totalprice double,
+      totalprice double COMMENT 'Price in cents.',
       orderdate date
     )
 


### PR DESCRIPTION
We define how to do this in the synopsis but that syntax is a bit hard to parse
for people not familiar with it. Be explicit on how to add comments. I tested
this by running the command locally.