### PR TITLE
fixup! Close drivers and operators in LocalQueryRunner

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -504,7 +504,7 @@ public class LocalQueryRunner
             TaskContext taskContext = createTaskContext(executor, session);
 
             List<Driver> drivers = createDrivers(session, sql, outputFactory, taskContext);
-            drivers.stream().map(closer::register);
+            drivers.forEach(closer::register);
 
             boolean done = false;
             while (!done) {


### PR DESCRIPTION
Stream was not being collected, so actually no drivers were registered to the closer.

This should fix: https://github.com/prestodb/presto/issues/6735