### PR TITLE
Remove Travis CI workaround for Codehaus repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,6 @@ cache:
 services:
   - docker
 
-before_install:
-  # This is needed until Travis #4629 is fixed (https://github.com/travis-ci/travis-ci/issues/4629)
-  - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
-
 install:
   - ./mvnw -v
   - |


### PR DESCRIPTION
This has been fixed on the Travis side.