### PR TITLE
Fix attempted double free of reserved memory

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -483,6 +483,14 @@ public class Driver
                             driverContext.getTaskId());
                 }
             }
+            if (driverContext.getMemoryUsage() > 0) {
+                log.error("Driver still has memory reserved after freeing all operator memory. Freeing it.");
+            }
+            if (driverContext.getSystemMemoryUsage() > 0) {
+                log.error("Driver still has system memory reserved after freeing all operator memory. Freeing it.");
+            }
+            driverContext.freeMemory(driverContext.getMemoryUsage());
+            driverContext.freeSystemMemory(driverContext.getSystemMemoryUsage());
             driverContext.finished();
         }
         catch (Throwable t) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -166,8 +165,6 @@ public class DriverContext
         executionEndTime.set(DateTime.now());
         endNanos.set(System.nanoTime());
 
-        freeMemory(memoryReservation.get());
-
         pipelineContext.driverFinished(this);
     }
 
@@ -175,8 +172,6 @@ public class DriverContext
     {
         pipelineContext.failed(cause);
         finished.set(true);
-
-        freeMemory(memoryReservation.get());
     }
 
     public boolean isDone()
@@ -236,10 +231,14 @@ public class DriverContext
         systemMemoryReservation.getAndAdd(-bytes);
     }
 
-    @VisibleForTesting
     public long getSystemMemoryUsage()
     {
         return systemMemoryReservation.get();
+    }
+
+    public long getMemoryUsage()
+    {
+        return memoryReservation.get();
     }
 
     public void moreMemoryAvailable()


### PR DESCRIPTION
When a driver fails, memory that was reserved would be freed twice,
resulting in an error message, but otherwise harmless.