### PR TITLE
Fix product tests debug environment

### DIFF
--- a/presto-product-tests/conf/presto/etc/config.properties
+++ b/presto-product-tests/conf/presto/etc/config.properties
@@ -32,6 +32,7 @@ plugin.bundles=\
   ../../../presto-teradata-functions/pom.xml,\
   ../../../presto-tpch/pom.xml,\
   ../../../presto-blackhole/pom.xml,\
+  ../../../presto-cassandra/pom.xml,\
   ../../../presto-mysql/pom.xml,\
   ../../../presto-postgresql/pom.xml
 


### PR DESCRIPTION
Local environment for product tests debugging doesn't start, because cassandra connector
is not registered, when it is used by cassandra catalog.