### PR TITLE
Fix JSON serialization bug about SchemaTableName

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
@@ -50,7 +50,7 @@ public class TestHiveMetadata
             ColumnDomain<HiveColumnHandle> columnDomain = new ColumnDomain<>(TEST_COLUMN_HANDLE, Domain.singleValue(VarcharType.VARCHAR, Slices.utf8Slice(Integer.toString(i))));
             TupleDomain<HiveColumnHandle> tupleDomain = TupleDomain.fromColumnDomains(Optional.of(ImmutableList.of(columnDomain)));
             partitions.add(new HivePartition(
-                    SchemaTableName.valueOf("test.test"),
+                    new SchemaTableName("test", "test"),
                     tupleDomain,
                     Integer.toString(i),
                     ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.of(VarcharType.VARCHAR, Slices.utf8Slice(Integer.toString(i)))), ImmutableList.of()));
@@ -68,7 +68,7 @@ public class TestHiveMetadata
             ColumnDomain<HiveColumnHandle> columnDomain = new ColumnDomain<>(TEST_COLUMN_HANDLE, Domain.onlyNull(VarcharType.VARCHAR));
             TupleDomain<HiveColumnHandle> tupleDomain = TupleDomain.fromColumnDomains(Optional.of(ImmutableList.of(columnDomain)));
             partitions.add(new HivePartition(
-                    SchemaTableName.valueOf("test.test"),
+                    new SchemaTableName("test", "test"),
                     tupleDomain,
                     Integer.toString(i),
                     ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.asNull(VarcharType.VARCHAR)), ImmutableList.of()));
@@ -86,7 +86,7 @@ public class TestHiveMetadata
             ColumnDomain<HiveColumnHandle> columnDomain = new ColumnDomain<>(TEST_COLUMN_HANDLE, Domain.singleValue(VarcharType.VARCHAR, Slices.utf8Slice(Integer.toString(i))));
             TupleDomain<HiveColumnHandle> tupleDomain = TupleDomain.fromColumnDomains(Optional.of(ImmutableList.of(columnDomain)));
             partitions.add(new HivePartition(
-                    SchemaTableName.valueOf("test.test"),
+                    new SchemaTableName("test", "test"),
                     tupleDomain,
                     Integer.toString(i),
                     ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.of(VarcharType.VARCHAR, Slices.utf8Slice(Integer.toString(i)))), ImmutableList.of()));
@@ -95,7 +95,7 @@ public class TestHiveMetadata
         ColumnDomain<HiveColumnHandle> columnDomain = new ColumnDomain<>(TEST_COLUMN_HANDLE, Domain.onlyNull(VarcharType.VARCHAR));
         TupleDomain<HiveColumnHandle> tupleDomain = TupleDomain.fromColumnDomains(Optional.of(ImmutableList.of(columnDomain)));
         partitions.add(new HivePartition(
-                SchemaTableName.valueOf("test.test"),
+                new SchemaTableName("test", "test"),
                 tupleDomain,
                 "null",
                 ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.asNull(VarcharType.VARCHAR)), ImmutableList.of()));

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaTableDescriptionSupplier.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaTableDescriptionSupplier.java
@@ -15,6 +15,7 @@ package com.facebook.presto.kafka;
 
 import com.facebook.presto.decoder.dummy.DummyRowDecoder;
 import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -32,6 +33,8 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.nio.file.Files.readAllBytes;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
@@ -83,7 +86,7 @@ public class KafkaTableDescriptionSupplier
             for (String definedTable : tableNames) {
                 SchemaTableName tableName;
                 try {
-                    tableName = SchemaTableName.valueOf(definedTable);
+                    tableName = parseTableName(definedTable);
                 }
                 catch (IllegalArgumentException iae) {
                     tableName = new SchemaTableName(defaultSchema, definedTable);
@@ -123,5 +126,13 @@ public class KafkaTableDescriptionSupplier
             }
         }
         return ImmutableList.of();
+    }
+
+    private static SchemaTableName parseTableName(String schemaTableName)
+    {
+        checkArgument(!isNullOrEmpty(schemaTableName), "schemaTableName is null or is empty");
+        List<String> parts = Splitter.on('.').splitToList(schemaTableName);
+        checkArgument(parts.size() == 2, "Invalid schemaTableName: %s", schemaTableName);
+        return new SchemaTableName(parts.get(0), parts.get(1));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestRemoveEmptyDelete.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestRemoveEmptyDelete.java
@@ -31,7 +31,7 @@ public class TestRemoveEmptyDelete
     {
         tester.assertThat(new RemoveEmptyDelete())
                 .on(p -> p.tableDelete(
-                        SchemaTableName.valueOf("sch.tab"),
+                        new SchemaTableName("sch", "tab"),
                         p.tableScan(ImmutableList.of(), ImmutableMap.of()),
                         p.symbol("a", BigintType.BIGINT))
                 )
@@ -43,7 +43,7 @@ public class TestRemoveEmptyDelete
     {
         tester.assertThat(new RemoveEmptyDelete())
                 .on(p -> p.tableDelete(
-                        SchemaTableName.valueOf("sch.tab"),
+                        new SchemaTableName("sch", "tab"),
                         p.values(),
                         p.symbol("a", BigintType.BIGINT)
                         )

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -152,6 +152,15 @@ public class TestMongoIntegrationSmokeTest
         assertOneNotNullResult("SELECT col[TIMESTAMP '2001-08-22 03:04:05.321'] FROM tmp_map7");
     }
 
+    @Test
+    public void testCollectionNameContainsDots()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE \"tmp.dot1\" AS SELECT 'foo' _varchar", 1);
+        assertQuery("SELECT _varchar FROM \"tmp.dot1\"", "SELECT 'foo'");
+        assertUpdate("DROP TABLE \"tmp.dot1\"");
+    }
+
     private void assertOneNotNullResult(String query)
     {
         MaterializedResult results = getQueryRunner().execute(getSession(), query).toJdbcTypes();

--- a/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestFileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestFileBasedAccessControl.java
@@ -35,17 +35,17 @@ public class TestFileBasedAccessControl
             throws IOException
     {
         ConnectorAccessControl accessControl = createAccessControl("schema.json");
-        accessControl.checkCanCreateTable(TRANSACTION_HANDLE, user("admin"), SchemaTableName.valueOf("test.test"));
-        accessControl.checkCanCreateTable(TRANSACTION_HANDLE, user("bob"), SchemaTableName.valueOf("bob.test"));
+        accessControl.checkCanCreateTable(TRANSACTION_HANDLE, user("admin"), new SchemaTableName("test", "test"));
+        accessControl.checkCanCreateTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bob", "test"));
         try {
-            accessControl.checkCanCreateTable(TRANSACTION_HANDLE, user("bob"), SchemaTableName.valueOf("test.test"));
+            accessControl.checkCanCreateTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("test", "test"));
             fail();
         }
         catch (AccessDeniedException e) {
             // expected
         }
         try {
-            accessControl.checkCanCreateTable(TRANSACTION_HANDLE, user("admin"), SchemaTableName.valueOf("secret.test"));
+            accessControl.checkCanCreateTable(TRANSACTION_HANDLE, user("admin"), new SchemaTableName("secret", "test"));
             fail();
         }
         catch (AccessDeniedException e) {
@@ -58,36 +58,36 @@ public class TestFileBasedAccessControl
             throws IOException
     {
         ConnectorAccessControl accessControl = createAccessControl("table.json");
-        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("alice"), SchemaTableName.valueOf("test.test"));
-        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("alice"), SchemaTableName.valueOf("bobschema.bobtable"));
-        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("bob"), SchemaTableName.valueOf("bobschema.bobtable"));
-        accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, user("bob"), SchemaTableName.valueOf("bobschema.bobtable"));
-        accessControl.checkCanDeleteFromTable(TRANSACTION_HANDLE, user("bob"), SchemaTableName.valueOf("bobschema.bobtable"));
-        accessControl.checkCanCreateViewWithSelectFromTable(TRANSACTION_HANDLE, user("bob"), SchemaTableName.valueOf("bobschema.bobtable"));
-        accessControl.checkCanDropTable(TRANSACTION_HANDLE, user("admin"), SchemaTableName.valueOf("bobschema.bobtable"));
+        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("alice"), new SchemaTableName("test", "test"));
+        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("alice"), new SchemaTableName("bobschema", "bobtable"));
+        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable"));
+        accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable"));
+        accessControl.checkCanDeleteFromTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable"));
+        accessControl.checkCanCreateViewWithSelectFromTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable"));
+        accessControl.checkCanDropTable(TRANSACTION_HANDLE, user("admin"), new SchemaTableName("bobschema", "bobtable"));
         try {
-            accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, user("alice"), SchemaTableName.valueOf("bobschema.bobtable"));
+            accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, user("alice"), new SchemaTableName("bobschema", "bobtable"));
             fail();
         }
         catch (AccessDeniedException e) {
             // expected
         }
         try {
-            accessControl.checkCanDropTable(TRANSACTION_HANDLE, user("bob"), SchemaTableName.valueOf("bobschema.bobtable"));
+            accessControl.checkCanDropTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable"));
             fail();
         }
         catch (AccessDeniedException e) {
             // expected
         }
         try {
-            accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, user("bob"), SchemaTableName.valueOf("test.test"));
+            accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("test", "test"));
             fail();
         }
         catch (AccessDeniedException e) {
             // expected
         }
         try {
-            accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("admin"), SchemaTableName.valueOf("secret.secret"));
+            accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("admin"), new SchemaTableName("secret", "secret"));
             fail();
         }
         catch (AccessDeniedException e) {

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisTableDescriptionSupplier.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisTableDescriptionSupplier.java
@@ -15,6 +15,7 @@ package com.facebook.presto.redis;
 
 import com.facebook.presto.decoder.dummy.DummyRowDecoder;
 import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -30,6 +31,8 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.nio.file.Files.readAllBytes;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
@@ -72,7 +75,7 @@ public class RedisTableDescriptionSupplier
             for (String definedTable : redisConnectorConfig.getTableNames()) {
                 SchemaTableName tableName;
                 try {
-                    tableName = SchemaTableName.valueOf(definedTable);
+                    tableName = parseTableName(definedTable);
                 }
                 catch (IllegalArgumentException iae) {
                     tableName = new SchemaTableName(redisConnectorConfig.getDefaultSchema(), definedTable);
@@ -111,5 +114,13 @@ public class RedisTableDescriptionSupplier
             }
         }
         return ImmutableList.of();
+    }
+
+    private static SchemaTableName parseTableName(String schemaTableName)
+    {
+        checkArgument(!isNullOrEmpty(schemaTableName), "schemaTableName is null or is empty");
+        List<String> parts = Splitter.on('.').splitToList(schemaTableName);
+        checkArgument(parts.size() == 2, "Invalid schemaTableName: %s", schemaTableName);
+        return new SchemaTableName(parts.get(0), parts.get(1));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SchemaTableName.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SchemaTableName.java
@@ -13,8 +13,7 @@
  */
 package com.facebook.presto.spi;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
@@ -26,28 +25,19 @@ public class SchemaTableName
     private final String schemaName;
     private final String tableName;
 
-    @JsonCreator
-    public static SchemaTableName valueOf(String schemaTableName)
-    {
-        checkNotEmpty(schemaTableName, "schemaTableName");
-        String[] parts = schemaTableName.split("\\.");
-        if (parts.length != 2) {
-            throw new IllegalArgumentException("Invalid schemaTableName " + schemaTableName);
-        }
-        return new SchemaTableName(parts[0], parts[1]);
-    }
-
-    public SchemaTableName(String schemaName, String tableName)
+    public SchemaTableName(@JsonProperty("schema") String schemaName, @JsonProperty("table") String tableName)
     {
         this.schemaName = checkNotEmpty(schemaName, "schemaName").toLowerCase(ENGLISH);
         this.tableName = checkNotEmpty(tableName, "tableName").toLowerCase(ENGLISH);
     }
 
+    @JsonProperty("schema")
     public String getSchemaName()
     {
         return schemaName;
     }
 
+    @JsonProperty("table")
     public String getTableName()
     {
         return tableName;
@@ -73,7 +63,6 @@ public class SchemaTableName
                 Objects.equals(this.tableName, other.tableName);
     }
 
-    @JsonValue
     @Override
     public String toString()
     {


### PR DESCRIPTION
If the query uses mongodb and the collection name contains period(.), it throws exception.
This change is wrapping word in double quotes if the word contains period.