### PR TITLE
Add product tests to verify owner's privileges

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -15,9 +15,11 @@
 package com.facebook.presto.tests.hive;
 
 import com.google.common.collect.ImmutableList;
+import com.teradata.tempto.AfterTestWithContext;
 import com.teradata.tempto.BeforeTestWithContext;
 import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.query.QueryExecutor;
+import io.airlift.log.Logger;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.tests.TestGroups.AUTHORIZATION;
@@ -62,6 +64,18 @@ public class TestGrantRevoke
         aliceExecutor.executeQuery(format("CREATE TABLE %s(month bigint, day bigint)", tableName));
 
         assertAccessDeniedOnAllOperationsOnTable(bobExecutor, tableName);
+    }
+
+    @AfterTestWithContext
+    public void cleanup()
+    {
+        try {
+            aliceExecutor.executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
+            aliceExecutor.executeQuery(format("DROP VIEW IF EXISTS %s", viewName));
+        }
+        catch (Exception e) {
+            Logger.get(getClass()).warn(e, "failed to drop table/view");
+        }
     }
 
     @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.tests.hive;
 
+import com.google.common.collect.ImmutableList;
 import com.teradata.tempto.BeforeTestWithContext;
 import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.query.QueryExecutor;
@@ -23,13 +24,19 @@ import static com.facebook.presto.tests.TestGroups.AUTHORIZATION;
 import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static com.facebook.presto.tests.utils.QueryExecutors.connectToPresto;
+import static com.teradata.tempto.assertions.QueryAssert.Row;
+import static com.teradata.tempto.assertions.QueryAssert.Row.row;
 import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static com.teradata.tempto.context.ContextDsl.executeWith;
+import static com.teradata.tempto.context.ThreadLocalTestContextHolder.testContext;
+import static com.teradata.tempto.sql.SqlContexts.createViewAs;
 import static java.lang.String.format;
 
 public class TestGrantRevoke
     extends ProductTest
 {
     private String tableName;
+    private String viewName;
     private QueryExecutor aliceExecutor;
     private QueryExecutor bobExecutor;
 
@@ -47,6 +54,7 @@ public class TestGrantRevoke
     public void setup()
     {
         tableName = "alice_owned_table";
+        viewName = "alice_view";
         aliceExecutor = connectToPresto("alice@presto");
         bobExecutor = connectToPresto("bob@presto");
 
@@ -100,6 +108,36 @@ public class TestGrantRevoke
         assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).
                 failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
         assertThat(aliceExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
+    }
+
+    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    public void testTableOwnerPrivileges()
+    {
+        onHive().executeQuery("set role admin;");
+        assertThat(onHive().executeQuery(format("SHOW GRANT USER alice ON TABLE %s", tableName)).
+                project(7, 8)). // Project only two relevant columns of SHOW GRANT: Privilege and Grant Option
+                containsOnly(ownerGrants());
+    }
+
+    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    public void testViewOwnerPrivileges()
+    {
+        onHive().executeQuery("set role admin;");
+        executeWith(createViewAs(viewName, format("SELECT * FROM %s", tableName), aliceExecutor), view -> {
+            assertThat(onHive().executeQuery(format("SHOW GRANT USER alice ON %s", viewName)).
+                    project(7, 8)). // Project only two relevant columns of SHOW GRANT: Privilege and Grant Option
+                    containsOnly(ownerGrants());
+        });
+    }
+
+    private ImmutableList<Row> ownerGrants()
+    {
+        return ImmutableList.of(row("SELECT", Boolean.TRUE), row("INSERT", Boolean.TRUE), row("UPDATE", Boolean.TRUE), row("DELETE", Boolean.TRUE));
+    }
+
+    public static QueryExecutor onHive()
+    {
+        return testContext().getDependency(QueryExecutor.class, "hive");
     }
 
     private static void assertAccessDeniedOnAllOperationsOnTable(QueryExecutor queryExecutor, String tableName)


### PR DESCRIPTION
Add product tests to verify that the owner of a table/view has the SELECT, INSERT, UPDATE and DELETE privileges.

These tests are to catch bugs like these:
prestodb@29319c5
prestodb@fc36eff

Privileges are being verified by running `SHOW GRANT` on Hive.

TD internal review: https://github.com/Teradata/presto/pull/458
