### PR TITLE
Fix hive.config.resources property behaviour

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfigurationUpdater.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfigurationUpdater.java
@@ -30,6 +30,7 @@ import javax.net.SocketFactory;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 import static com.facebook.hive.orc.OrcConf.ConfVars.HIVE_ORC_COMPRESSION;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -116,7 +117,7 @@ public class HdfsConfigurationUpdater
     {
         if (resourcePaths != null) {
             for (String resourcePath : resourcePaths) {
-                config.addResource(new Path(resourcePath));
+                addResource(config, new Path(resourcePath));
             }
         }
 
@@ -233,6 +234,15 @@ public class HdfsConfigurationUpdater
         public void reloadCachedMappings()
         {
             // no-op
+        }
+    }
+
+    private static void addResource(Configuration config, Path resource)
+    {
+        Configuration resourceProperties = new Configuration(false);
+        resourceProperties.addResource(resource);
+        for (Map.Entry<String, String> entry : resourceProperties) {
+            config.set(entry.getKey(), entry.getValue());
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
@@ -18,8 +18,8 @@ import org.apache.hadoop.conf.Configuration;
 import javax.inject.Inject;
 
 import java.net.URI;
-import java.util.Map;
 
+import static com.facebook.presto.hive.util.ConfigurationUtils.copy;
 import static java.util.Objects.requireNonNull;
 
 public class HiveHdfsConfiguration
@@ -35,9 +35,7 @@ public class HiveHdfsConfiguration
         // all the required default resources must be declared above
         INITIAL_CONFIGURATION = new Configuration(false);
         Configuration defaultConfiguration = new Configuration();
-        for (Map.Entry<String, String> entry : defaultConfiguration) {
-            INITIAL_CONFIGURATION.set(entry.getKey(), entry.getValue());
-        }
+        copy(defaultConfiguration, INITIAL_CONFIGURATION);
     }
 
     @SuppressWarnings("ThreadLocalNotStaticFinal")
@@ -47,9 +45,7 @@ public class HiveHdfsConfiguration
         protected Configuration initialValue()
         {
             Configuration config = new Configuration(false);
-            for (Map.Entry<String, String> entry : INITIAL_CONFIGURATION) {
-                config.set(entry.getKey(), entry.getValue());
-            }
+            copy(INITIAL_CONFIGURATION, config);
             updater.updateConfiguration(config);
             return config;
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/ConfigurationUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/ConfigurationUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.util;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.Map;
+
+public final class ConfigurationUtils
+{
+    private ConfigurationUtils() {}
+
+    public static void copy(Configuration from, Configuration to)
+    {
+        for (Map.Entry<String, String> entry : from) {
+            to.set(entry.getKey(), entry.getValue());
+        }
+    }
+}


### PR DESCRIPTION
`hive.config.resources` property allows to set additional resources
that must override the default properties for HDFS.

`Configuration#addResource` method loads the resource, and handles the
properties from that resource kind of like a defaults. So if before
some property has been set explicitly via `set*` method, that property
won't be overwritten with the value loaded from the resource.

The way how defaults are being populated to the configuration uses
`set` method. So, further properties loaded from the specified resources
can't override the defaults.

This commits loads the resource into temporary clean configuration. And
then copies all the properties to the destination using the `set` method,
so that way the defaults are being actually overwritten.