### PR TITLE
Move tempto cassandra configuration

### DIFF
--- a/presto-product-tests/conf/presto/etc/config.properties
+++ b/presto-product-tests/conf/presto/etc/config.properties
@@ -34,6 +34,7 @@ plugin.bundles=\
   ../../../presto-blackhole/pom.xml,\
   ../../../presto-cassandra/pom.xml,\
   ../../../presto-mysql/pom.xml,\
+  ../../../presto-cassandra/pom.xml,\
   ../../../presto-postgresql/pom.xml
 
 presto.version=testversion

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-default.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-default.yaml
@@ -4,9 +4,3 @@ databases:
   presto:
     host: presto-master
     configured_hdfs_user: hive
-  cassandra:
-    host: cassandra
-    port: 9042
-    default_schema: test
-    skip_create_schema: false
-    table_manager_type: cassandra

--- a/presto-product-tests/src/main/resources/tempto-configuration.yaml
+++ b/presto-product-tests/src/main/resources/tempto-configuration.yaml
@@ -71,6 +71,13 @@ databases:
     jdbc_pooling: true
     table_manager_type: jdbc
 
+  cassandra:
+    host: cassandra
+    port: 9042
+    default_schema: test
+    skip_create_schema: false
+    table_manager_type: cassandra
+
 tests:
   hdfs:
     path: /product-test


### PR DESCRIPTION
Move tempto cassandra configuration

Move cassandra configuration to default tempto-configuration.yaml in
resources file. Previously it was only configured for running tempto in
docker, now it is possible to run tempto natively (without using
additional configuration from conf/tempto).
