### PR TITLE
Do not require all TPC-H tables if they are not used

### DIFF
--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runAggrWithoutGroupBy.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runAggrWithoutGroupBy.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: nation; groups: group-by;
 select count(*), count(n_regionkey), min(n_regionkey), max(n_regionkey), sum(n_regionkey) from nation

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runAggregatesGroupByOridnalAndHaving.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runAggregatesGroupByOridnalAndHaving.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: nation; groups: group-by;
 select n_regionkey, count(*) from nation group by 1 having sum(n_regionkey) > 5 and sum(n_regionkey) < 20

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runAggregatesWithGroupByOrdinal.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runAggregatesWithGroupByOrdinal.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: nation; groups: group-by;
 select n_regionkey, count(*), sum(n_nationkey) from nation group by 1

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runAggregatesWithGroupByWithFalseWherePredicate.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runAggregatesWithGroupByWithFalseWherePredicate.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: nation; groups: group-by;
 select count(*), sum(n_nationkey) from nation where 1=2 group by n_regionkey

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runAggregatesWithWherePredicatesAndGroupByOrdinal.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runAggregatesWithWherePredicatesAndGroupByOrdinal.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: nation; groups: group-by;
 select n_regionkey, count(*), sum(n_regionkey) from nation where n_regionkey > 2 group by 1

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runAggregatesWithoutGroupByButWithPredicates.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runAggregatesWithoutGroupByButWithPredicates.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: nation; groups: group-by;
 select count(*), sum(n_nationkey) from nation where 1=2

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runConstantGroupBy.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runConstantGroupBy.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: nation; groups: group-by;
 select 2 from nation group by 1

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runCountNull.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runCountNull.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: nation; groups: group-by;
 SELECT n_regionkey, COUNT(null) FROM nation WHERE n_nationkey > 5 GROUP BY n_regionkey

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingOnEmptyResult.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingOnEmptyResult.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: nation; groups: group-by;
 SELECT COUNT(n_regionkey) FROM nation WHERE 1=2 HAVING SUM(n_regionkey) IS NULL

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingOutsideSubq.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingOutsideSubq.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: nation; groups: group-by;
 SELECT n_regionkey FROM (SELECT n_regionkey, COUNT(*) cnt FROM nation GROUP BY n_regionkey) t GROUP BY n_regionkey HAVING n_regionkey < 3 AND COUNT(cnt) > 0

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithAggExpr.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithAggExpr.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: workers; groups: group-by;
 SELECT COUNT(*) FROM workers HAVING SUM(salary * 2)/COUNT(*) > 0

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithExpr.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithExpr.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: workers; groups: group-by;
 SELECT COUNT(*) FROM workers GROUP BY id_department * 2 HAVING SUM(log(10, salary + 1)) > 0

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithGrpExpr.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithGrpExpr.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: workers; groups: group-by;
 SELECT COUNT(*) FROM workers GROUP BY salary * id_department HAVING salary * id_department IS NOT NULL

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithMultipleAggs.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithMultipleAggs.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: part; groups: group-by;
 SELECT p_type, COUNT(*) FROM part GROUP BY p_type HAVING COUNT(*) > 20 and AVG(p_retailprice) > 1000

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithNullCheck.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithNullCheck.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: workers; groups: group-by;
 SELECT first_name, COUNT(*) FROM workers GROUP BY first_name HAVING first_name IS NULL

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithOrderBy.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithOrderBy.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: workers; groups: group-by;
 SELECT id_department, COUNT(*) FROM workers GROUP BY id_department HAVING COUNT(*) > 1 ORDER BY id_department desc

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithoutGroupBy.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runHavingWithoutGroupBy.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: nation; groups: group-by;
 SELECT COUNT(*) FROM nation HAVING COUNT(*) > 20

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runMultipleGroupBy.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/group-by/runMultipleGroupBy.sql
@@ -1,2 +1,2 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: workers; groups: group-by;
+-- database: presto; tables: nation; groups: group-by;
 SELECT COUNT(*), n_regionkey, n_nationkey FROM nation WHERE n_regionkey < 2 GROUP BY n_nationkey, n_regionkey ORDER BY n_regionkey, n_nationkey DESC

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/set_operation/except.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/set_operation/except.sql
@@ -1,4 +1,4 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: nation, workers; groups: set_operation;
+-- database: presto; tables: nation, workers; groups: set_operation;
 -- delimiter: |; ignoreOrder: true;
 --! name: except_union_intersect
 SELECT n_name FROM nation WHERE n_nationkey = 17

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/set_operation/intersect.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/set_operation/intersect.sql
@@ -1,4 +1,4 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: nation, workers; groups: set_operation;
+-- database: presto; tables: nation, workers; groups: set_operation;
 -- delimiter: |; ignoreOrder: true;
 --! name: intersect_and_union
 SELECT n_name FROM nation WHERE n_nationkey = 17 

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/union/unionAllSameTable.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/union/unionAllSameTable.sql
@@ -1,4 +1,4 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: nation; groups: union;
+-- database: presto; tables: nation; groups: union;
 SELECT *
 FROM nation
 UNION ALL

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/union/unionDistinctSameTable.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/union/unionDistinctSameTable.sql
@@ -1,4 +1,4 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: nation; groups: union;
+-- database: presto; tables: nation; groups: union;
 SELECT *
 FROM nation
 UNION DISTINCT

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/union/unionMoreThanTwoTables.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/union/unionMoreThanTwoTables.sql
@@ -1,4 +1,4 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: nation; groups: union;
+-- database: presto; tables: nation; groups: union;
 SELECT count(*)
 FROM nation
 UNION ALL

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/union/unionOrderBy.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/union/unionOrderBy.sql
@@ -1,4 +1,4 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: nation; groups: union;
+-- database: presto; tables: nation; groups: union;
 SELECT count(*)
 FROM nation
 UNION ALL

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/union/unionWithAggregation.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/union/unionWithAggregation.sql
@@ -1,4 +1,4 @@
--- database: presto; requires: com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements; tables: nation; groups: union;
+-- database: presto; tables: nation; groups: union;
 SELECT count(*)
 FROM nation
 UNION ALL


### PR DESCRIPTION
Do not require all TPC-H tables if they are not used
