### PR TITLE
CLI: when last line had multiple statements

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -218,6 +218,7 @@ public class Console
                 // execute any complete statements
                 String sql = buffer.toString();
                 StatementSplitter splitter = new StatementSplitter(sql, ImmutableSet.of(";", "\\G"));
+                StringBuilder statements = new StringBuilder();
                 for (Statement split : splitter.getCompleteStatements()) {
                     Optional<Object> statement = getParsedStatement(split.statement());
                     if (statement.isPresent() && isSessionParameterChange(statement.get())) {
@@ -235,7 +236,15 @@ public class Console
 
                         process(queryRunner, split.statement(), outputFormat, true);
                     }
-                    reader.getHistory().add(squeezeStatement(split.statement()) + split.terminator());
+                    if (statements.length() == 0) {
+                        statements.append(squeezeStatement(split.statement())).append(split.terminator());
+                    }
+                    else {
+                        statements.append(" ").append(squeezeStatement(split.statement())).append(split.terminator());
+                    }
+                }
+                if (statements.length() != 0) {
+                    reader.getHistory().add(statements);
                 }
 
                 // replace buffer with trailing partial statement


### PR DESCRIPTION
Fixes #7098 

run "select 1; select 2;" on one line,  press arrow up will restore "select 1; select 2;"
run "select \n 1; select 2;" on two lines, arrow up will still restore "select 1; select 2;"
run "select 1; select"  arrow up only restores "select 1;", then run "2;", arrow up restores "select 2;"