### PR TITLE
Selecting rows with empty blobs throws exception

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
@@ -46,6 +46,7 @@ import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharTyp
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.net.InetAddresses.toAddrString;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.Float.floatToRawIntBits;
@@ -202,7 +203,11 @@ public enum CassandraType
                     return NullableValue.of(nativeType, utf8Slice(row.getVarint(i).toString()));
                 case BLOB:
                 case CUSTOM:
-                    return NullableValue.of(nativeType, wrappedBuffer(row.getBytesUnsafe(i)));
+                    ByteBuffer value = row.getBytesUnsafe(i);
+                    if (value.capacity() == 0) {
+                        return NullableValue.of(nativeType, EMPTY_SLICE);
+                    }
+                    return NullableValue.of(nativeType, wrappedBuffer(value));
                 case SET:
                     checkTypeArguments(cassandraType, 1, typeArguments);
                     return NullableValue.of(nativeType, utf8Slice(buildSetValue(row, i, typeArguments.get(0))));

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraTestingUtils.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraTestingUtils.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.UUID;
 
+import static com.facebook.presto.cassandra.TestCassandraIntegrationSmokeTest.createTableWithEmptyBlobCell;
 import static org.testng.Assert.assertEquals;
 
 public class CassandraTestingUtils
@@ -39,6 +40,7 @@ public class CassandraTestingUtils
     public static final int PORT = 9142;
     public static final String TABLE_ALL_TYPES = "table_all_types";
     public static final String TABLE_ALL_TYPES_PARTITION_KEY = "table_all_types_partition_key";
+    public static final String TABLE_WITH_EMPTY_BLOB_CELL = "table_with_empty_blob_cell";
     private static final String CLUSTER_NAME = "TestCluster";
 
     private CassandraTestingUtils() {}
@@ -60,6 +62,7 @@ public class CassandraTestingUtils
             try (Session session = cluster.connect(keyspace)) {
                 createTableAllTypes(session, keyspace, TABLE_ALL_TYPES, date);
                 createTableAllTypesPartitionKey(session, keyspace, TABLE_ALL_TYPES_PARTITION_KEY, date);
+                createTableWithEmptyBlobCell(session, keyspace, TABLE_WITH_EMPTY_BLOB_CELL, date);
             }
         }
     }


### PR DESCRIPTION
FIX #6879 

Now querying a row with empty blobs will display nothing for the empty blob cell. Here are a visual compare of presto-cli and cqlsh

![image](https://cloud.githubusercontent.com/assets/5623867/22716149/60dbc494-ed49-11e6-8248-43ce312c8cea.png)

![image](https://cloud.githubusercontent.com/assets/5623867/22716152/66ae6cd2-ed49-11e6-98a1-ada6513680dd.png)
