### PR TITLE
Added ability to connect to cassandra over ssl using configurable key…

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
@@ -73,6 +73,71 @@ public class CassandraClientConfig
     private int noHostAvailableRetryCount = 1;
     private int speculativeExecutionLimit = 1;
     private Duration speculativeExecutionDelay = new Duration(500, MILLISECONDS);
+    private boolean isUseTls;
+    private String sslTrustStore;
+    private String sslTrustStorePassword;
+    private String sslKeyStore;
+    private String sslKeyStorePassword;
+
+    public boolean getUseTls()
+    {
+        return isUseTls;
+    }
+
+    @Config("cassandra.ssl.enabled")
+    public CassandraClientConfig setUseTls(boolean useTls)
+    {
+        this.isUseTls = useTls;
+        return this;
+    }
+
+    public String getSslTrustStore()
+    {
+        return sslTrustStore;
+    }
+
+    @Config("cassandra.ssl.trust-store")
+    public CassandraClientConfig setSslTrustStore(String sslTrustStore)
+    {
+        this.sslTrustStore = sslTrustStore;
+        return this;
+    }
+
+    public String getSslTrustStorePassword()
+    {
+        return sslTrustStorePassword;
+    }
+
+    @Config("cassandra.ssl.trust-store-password")
+    public CassandraClientConfig setSslTrustStorePassword(String sslTrustStorePassword)
+    {
+        this.sslTrustStorePassword = sslTrustStorePassword;
+        return this;
+    }
+
+    public String getSslKeyStore()
+    {
+        return sslKeyStore;
+    }
+
+    @Config("cassandra.ssl.key-store")
+    public CassandraClientConfig setSslKeyStore(String sslKeyStore)
+    {
+        this.sslKeyStore = sslKeyStore;
+        return this;
+    }
+
+    public String getSslKeyStorePassword()
+    {
+        return sslKeyStorePassword;
+    }
+
+    @Config("cassandra.ssl.key-store-password")
+    public CassandraClientConfig setSslKeyStorePassword(String sslKeyStorePassword)
+    {
+        this.sslKeyStorePassword = sslKeyStorePassword;
+        return this;
+    }
 
     @Min(0)
     public int getLimitForPartitionKeySelect()

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/util/SslContextProvider.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/util/SslContextProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cassandra.util;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import java.io.FileInputStream;
+
+import java.security.KeyStore;
+import java.security.SecureRandom;
+
+public class SslContextProvider
+{
+    public SSLContext getSSLContext(String truststorePath,
+                                    String truststorePassword,
+                                    String keystorePath,
+                                    String keystorePassword)
+            throws Exception
+    {
+        FileInputStream tsf = new FileInputStream(truststorePath);
+        FileInputStream ksf = new FileInputStream(keystorePath);
+        SSLContext ctx = SSLContext.getInstance("SSL");
+
+        KeyStore ts = KeyStore.getInstance("JKS");
+        ts.load(tsf, truststorePassword.toCharArray());
+        TrustManagerFactory tmf =
+                TrustManagerFactory.getInstance(
+                        TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(ts);
+
+        KeyStore ks = KeyStore.getInstance("JKS");
+        ks.load(ksf, keystorePassword.toCharArray());
+        KeyManagerFactory kmf =
+                KeyManagerFactory.getInstance(
+                        KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, keystorePassword.toCharArray());
+
+        ctx.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
+        return ctx;
+    }
+}

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraClientConfig.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraClientConfig.java
@@ -64,7 +64,12 @@ public class TestCassandraClientConfig
                 .setWhiteListAddresses("")
                 .setNoHostAvailableRetryCount(1)
                 .setSpeculativeExecutionLimit(1)
-                .setSpeculativeExecutionDelay(new Duration(500, MILLISECONDS)));
+                .setSpeculativeExecutionDelay(new Duration(500, MILLISECONDS))
+                .setSslKeyStore(null)
+                .setSslKeyStorePassword(null)
+                .setSslTrustStore(null)
+                .setSslTrustStorePassword(null)
+                .setUseTls(false));
     }
 
     @Test
@@ -104,6 +109,11 @@ public class TestCassandraClientConfig
                 .put("cassandra.no-host-available-retry-count", "10")
                 .put("cassandra.speculative-execution.limit", "10")
                 .put("cassandra.speculative-execution.delay", "101s")
+                .put("cassandra.ssl.enabled", "true")
+                .put("cassandra.ssl.trust-store", "truststore")
+                .put("cassandra.ssl.trust-store-password", "truststorepassword")
+                .put("cassandra.ssl.key-store-password", "keystorepassword")
+                .put("cassandra.ssl.key-store", "keystore")
                 .build();
 
         CassandraClientConfig expected = new CassandraClientConfig()
@@ -139,7 +149,12 @@ public class TestCassandraClientConfig
                 .setWhiteListAddresses("host1")
                 .setNoHostAvailableRetryCount(10)
                 .setSpeculativeExecutionLimit(10)
-                .setSpeculativeExecutionDelay(new Duration(101, SECONDS));
+                .setSpeculativeExecutionDelay(new Duration(101, SECONDS))
+                .setUseTls(true)
+                .setSslKeyStore("keystore")
+                .setSslKeyStorePassword("keystorepassword")
+                .setSslTrustStore("truststore")
+                .setSslTrustStorePassword("truststorepassword");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -158,6 +158,17 @@ Property Name                                                 Description
 ``cassandra.speculative-execution.limit``                     The number of speculative executions (defaults to ``1``).
 
 ``cassandra.speculative-execution.delay``                     The delay between each speculative execution (defaults to ``500ms``).
+
+``cassandra.ssl.enabled``                                     Set to ``true`` to use enable ssl (defaults to ``false``).
+
+``cassandra.ssl.trust-store``                                 The name of the trust store location to use.
+
+``cassandra.ssl.trust-store-password``                        The trust store password.
+
+``cassandra.ssl.key-store``                                   The name of the key store location.
+
+``cassandra.ssl.key-store-password``                          Key store location password.
+
 ============================================================= ======================================================================
 
 Querying Cassandra Tables
@@ -196,3 +207,8 @@ This table can be described in Presto::
 This table can then be queried in Presto::
 
     SELECT * FROM cassandra.mykeyspace.users;
+
+When using SSL, use both the cassandra.ssl properties outlined above, as well as the followinf thrift port config:
+
+cassandra.thrift-connection-factory-class=org.apache.cassandra.thrift.SSLTransportFactory
+cassandra.transport-factory-options=enc.keystore=/etc/cassandra/conf/keystore,enc.truststore=/etc/cassandra/conf/truststore,enc.truststore.password=somepassword,enc.keystore.password=somepassword

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -208,7 +208,7 @@ This table can then be queried in Presto::
 
     SELECT * FROM cassandra.mykeyspace.users;
 
-When using SSL, use both the cassandra.ssl properties outlined above, as well as the followinf thrift port config:
+When using SSL, use both the cassandra.ssl properties outlined above, as well as the following thrift port config:
 
 cassandra.thrift-connection-factory-class=org.apache.cassandra.thrift.SSLTransportFactory
 cassandra.transport-factory-options=enc.keystore=/etc/cassandra/conf/keystore,enc.truststore=/etc/cassandra/conf/truststore,enc.truststore.password=somepassword,enc.keystore.password=somepassword


### PR DESCRIPTION
… and trust store locations.

Sample config:

cassandra.ssl.enabled=true
cassandra.ssl.trust-store=/etc/cassandra/conf/truststore
cassandra.ssl.trust-store-password=somepassword
cassandra.ssl.key-store=/etc/cassandra/conf/keystore
cassandra.ssl.key-store-password=somepassword
cassandra.thrift-connection-factory-class=org.apache.cassandra.thrift.SSLTransportFactory
cassandra.transport-factory-options=enc.keystore=/etc/cassandra/conf/keystore,enc.truststore=/etc/cassandra/conf/truststore,enc.truststore.password=somepassword,enc.keystore.password=somepassword