### PR TITLE
Include original exception when it has wrong message

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -232,7 +232,7 @@ public abstract class AbstractTestQueryFramework
     private static void assertExceptionMessage(String sql, Exception exception, @Language("RegExp") String regex)
     {
         if (!exception.getMessage().matches(regex)) {
-            fail(format("Expected exception message '%s' to match '%s' for query: %s", exception.getMessage(), regex, sql));
+            fail(format("Expected exception message '%s' to match '%s' for query: %s", exception.getMessage(), regex, sql), exception);
         }
     }
 


### PR DESCRIPTION
Trivial, yet helpful, when a test fails during development.