### PR TITLE
Create the list of type-specific unnesters in UnnestOperator only once

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ArrayUnnester.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ArrayUnnester.java
@@ -27,11 +27,11 @@ public class ArrayUnnester
         implements Unnester
 {
     private final Type elementType;
-    private final Block arrayBlock;
+    private Block arrayBlock;
     private final int channelCount;
 
     private int position;
-    private final int positionCount;
+    private int positionCount;
 
     public ArrayUnnester(ArrayType arrayType, @Nullable Block arrayBlock)
     {
@@ -65,5 +65,13 @@ public class ArrayUnnester
     public final void appendNext(PageBuilder pageBuilder, int outputChannelOffset)
     {
         appendTo(pageBuilder, outputChannelOffset);
+    }
+
+    @Override
+    public void setBlock(@Nullable Block arrayBlock)
+    {
+        this.arrayBlock = arrayBlock;
+        this.position = 0;
+        this.positionCount = arrayBlock == null ? 0 : arrayBlock.getPositionCount();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/MapUnnester.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MapUnnester.java
@@ -28,11 +28,11 @@ public class MapUnnester
 {
     private final Type keyType;
     private final Type valueType;
-    private final Block block;
+    private Block block;
     private final int channelCount;
 
     private int position;
-    private final int positionCount;
+    private int positionCount;
 
     public MapUnnester(MapType mapType, @Nullable Block mapBlock)
     {
@@ -69,5 +69,13 @@ public class MapUnnester
     public final void appendNext(PageBuilder pageBuilder, int outputChannelOffset)
     {
         appendTo(pageBuilder, outputChannelOffset);
+    }
+
+    @Override
+    public void setBlock(@Nullable Block mapBlock)
+    {
+        this.block = mapBlock;
+        this.position = 0;
+        this.positionCount = mapBlock == null ? 0 : mapBlock.getPositionCount();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/Unnester.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Unnester.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
 
 public interface Unnester
 {
@@ -22,4 +23,6 @@ public interface Unnester
     void appendNext(PageBuilder pageBuilder, int outputChannelOffset);
 
     boolean hasNext();
+
+    void setBlock(Block block);
 }


### PR DESCRIPTION
Fixes #7323 

Add setBlock method to interface `Unnester` so that unnesters can be reused across different pages by calling `fillUnnesters` method which sets new blocks, unnesters are only initialized once for each `UnnestOperator`
