### PR TITLE
Update to airlift 0.142

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.6</dep.antlr.version>
-        <dep.airlift.version>0.141</dep.airlift.version>
+        <dep.airlift.version>0.142</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.28</dep.slice.version>
         <dep.aws-sdk.version>1.11.30</dep.aws-sdk.version>


### PR DESCRIPTION
Fixes a contention issue in Distribution's copy constructor
that can cause coordinator->worker requests to get "stuck"
computing various stats.