### PR TITLE
Successful metadata queries not logged

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -142,7 +142,7 @@ public class DataDefinitionExecution<T extends Statement>
     @Override
     public void addFinalQueryInfoListener(StateChangeListener<QueryInfo> stateChangeListener)
     {
-        stateMachine.addQueryInfoStateChangeListener(stateChangeListener);
+        stateMachine.addDefinitionQueryInfoStateChangeListener(stateChangeListener);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -653,7 +653,19 @@ public class QueryStateMachine
         queryState.addStateChangeListener(stateChangeListener);
     }
 
-    public void addQueryInfoStateChangeListener(StateChangeListener<QueryInfo> stateChangeListener)
+    public void addDefinitionQueryInfoStateChangeListener(StateChangeListener<QueryInfo> stateChangeListener)
+    {
+        AtomicBoolean done = new AtomicBoolean();
+        StateChangeListener<QueryState> fireOnceStateChangeListener = queryState -> {
+            if (queryState.isDone() && done.compareAndSet(false, true)) {
+                stateChangeListener.stateChanged(getQueryInfo(Optional.empty()));
+            }
+        };
+        queryState.addStateChangeListener(fireOnceStateChangeListener);
+        fireOnceStateChangeListener.stateChanged(queryState.get());
+    }
+
+    public void addSqlQueryInfoStateChangeListener(StateChangeListener<QueryInfo> stateChangeListener)
     {
         AtomicBoolean done = new AtomicBoolean();
         StateChangeListener<Optional<QueryInfo>> fireOnceStateChangeListener = finalQueryInfo -> {

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -267,7 +267,7 @@ public final class SqlQueryExecution
     @Override
     public void addFinalQueryInfoListener(StateChangeListener<QueryInfo> stateChangeListener)
     {
-        stateMachine.addQueryInfoStateChangeListener(stateChangeListener);
+        stateMachine.addSqlQueryInfoStateChangeListener(stateChangeListener);
     }
 
     private PlanRoot analyzeQuery()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.tests;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
@@ -707,6 +708,25 @@ public abstract class AbstractTestDistributedQueries
         assertEquals(getOnlyElement(actual.getOnlyColumnAsSet()), expectedSql);
 
         assertUpdate("DROP VIEW meta_test_view");
+    }
+
+    @Test
+    public void testQueryLoggingCount()
+            throws Exception
+    {
+        assertTrue(queryRunner instanceof DistributedQueryRunner);
+        QueryManager queryManager = ((DistributedQueryRunner) queryRunner).getCoordinator().getQueryManager();
+        Runnable queryCountChecker = () -> {
+            long beforeQueryCount = queryManager.getStats().getCompletedQueries().getTotalCount();
+            assertUpdate("CREATE TABLE test_query_logging_count AS SELECT 1 foo_1, 2 foo_2_4", 1);
+            assertQuery("SELECT foo_1, foo_2_4 FROM test_query_logging_count", "SELECT 1, 2");
+            assertUpdate("DROP TABLE test_query_logging_count");
+            assertQueryFails("SELECT * FROM test_query_logging_count", ".*Table .* does not exist");
+
+            long queryCount = queryManager.getStats().getCompletedQueries().getTotalCount() - beforeQueryCount;
+            assertEquals(queryCount, 4, format("expected [%s] but found [%s]", 4, queryCount));
+        };
+        executeInLock(queryCountChecker);
     }
 
     @Test


### PR DESCRIPTION
Two state machines are used in class QueryStateMachine: queryState and finalQueryInfo. The query log callback function was previously hooked only with finalQueryInfo, which does not have information with the query state (RUNNING, FINISHING, etc). The state of finalQueryInfo will be updated only when the output result is handled. This is not true for metadata queries, which do not have outputs. This patch hooks the metadata query callback function with queryState. The callback is invoked when the query finishes.