### PR TITLE
Improve handling of missing Fields in RelationType.indexOf

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/RelationType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/RelationType.java
@@ -63,11 +63,16 @@ public class RelationType
     }
 
     /**
-     * Gets the index of the specified field or -1 if not found.
+     * Gets the index of the specified field.
+     *
+     * @throws IllegalArgumentException when field is not found
      */
     public int indexOf(Field field)
     {
-        return requireNonNull(fieldIndexes.get(field));
+        requireNonNull(field, "field cannot be null");
+        Integer index = fieldIndexes.get(field);
+        checkArgument(index != null, "Field %s not found", field);
+        return index;
     }
 
     /**


### PR DESCRIPTION
Previously, the method would throw NullPointerException without a
message when passed field was null or not found, although documentation
stated differently.

Now exception is always with a message, and documentation is aligned
with the code.