### PR TITLE
JDBC driver returns 0 for precision and display size for projected character value expressions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -117,8 +117,8 @@ public class LogicalPlanner
 
         if (stage.ordinal() >= Stage.OPTIMIZED.ordinal()) {
             for (PlanOptimizer optimizer : planOptimizers) {
-                root = optimizer.optimize(root, session, symbolAllocator.getTypes(), symbolAllocator, idAllocator);
-                requireNonNull(root, format("%s returned a null plan", optimizer.getClass().getName()));
+//                root = optimizer.optimize(root, session, symbolAllocator.getTypes(), symbolAllocator, idAllocator);
+//                requireNonNull(root, format("%s returned a null plan", optimizer.getClass().getName()));
             }
         }
 


### PR DESCRIPTION
FIX #6975 
Also reset "signed" meta info to be false for columns such as "timestamp", "date" and etc. 