### PR TITLE
Remove unnecessary locking in assertQueryFails method

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -162,16 +162,12 @@ public abstract class AbstractTestQueryFramework
 
     protected void assertQueryFails(Session session, @Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
     {
-        queryRunner.getExclusiveLock().lock();
         try {
             queryRunner.execute(session, sql);
             fail(format("Expected query to fail: %s", sql));
         }
         catch (RuntimeException ex) {
             assertExceptionMessage(sql, ex, expectedMessageRegExp);
-        }
-        finally {
-            queryRunner.getExclusiveLock().unlock();
         }
     }
 


### PR DESCRIPTION
Locking is not needed since no QueryRunner state is changed.