### PR TITLE
Support Subqueries in aggregation analyzer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -144,7 +144,10 @@ class AggregationAnalyzer
         // For a query like "SELECT * FROM T GROUP BY a", groupByExpressions will contain "a",
         // and the '*' will be expanded to Field references. Therefore we translate all simple name expressions
         // in the group by clause to fields they reference so that the expansion from '*' can be matched against them
-        for (Expression expression : Iterables.filter(expressions, analysis.getColumnReferences()::contains)) {
+        List<Expression> nonFieldReferenceGroupingExpressions = expressions.stream()
+                .filter(expression -> analysis.getColumnReferences().contains(expression) && !(expression instanceof FieldReference))
+                .collect(toImmutableList());
+        for (Expression expression : nonFieldReferenceGroupingExpressions) {
             QualifiedName name;
             if (expression instanceof Identifier) {
                 name = QualifiedName.of(((Identifier) expression).getName());

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import static com.facebook.presto.sql.NodeUtils.getSortItemsFromOrderBy;
 import static com.facebook.presto.sql.analyzer.LambdaReferenceExtractor.hasReferencesToLambdaArgument;
 import static com.facebook.presto.sql.analyzer.ScopeReferenceExtractor.getReferencesToScope;
+import static com.facebook.presto.sql.analyzer.ScopeReferenceExtractor.hasReferencesToScope;
 import static com.facebook.presto.sql.analyzer.ScopeReferenceExtractor.isFieldFromScope;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MUST_BE_AGGREGATE_OR_GROUP_BY;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MUST_BE_AGGREGATION_FUNCTION;
@@ -568,12 +569,12 @@ class AggregationAnalyzer
 
     private boolean hasOrderByReferencesToOutputColumns(Node node)
     {
-        return !getReferencesToScope(node, analysis, orderByScope.get()).isEmpty();
+        return hasReferencesToScope(node, analysis, orderByScope.get());
     }
 
     private void verifyNoOrderByReferencesToOutputColumns(Node node)
     {
-        getReferencesToScope(node, analysis, orderByScope.get()).stream()
+        getReferencesToScope(node, analysis, orderByScope.get())
                 .findFirst()
                 .ifPresent(expression -> {
                     throw new SemanticException(REFERENCE_TO_OUTPUT_ATTRIBUTE_WITHIN_ORDER_BY_AGGREGATION, expression, "Invalid reference to output projection attribute from ORDER BY aggregation");

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -47,7 +47,6 @@ import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullIfExpression;
 import com.facebook.presto.sql.tree.Parameter;
-import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Row;
 import com.facebook.presto.sql.tree.SearchedCaseExpression;
 import com.facebook.presto.sql.tree.SimpleCaseExpression;
@@ -59,12 +58,14 @@ import com.facebook.presto.sql.tree.WhenClause;
 import com.facebook.presto.sql.tree.Window;
 import com.facebook.presto.sql.tree.WindowFrame;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.sql.NodeUtils.getSortItemsFromOrderBy;
 import static com.facebook.presto.sql.analyzer.LambdaReferenceExtractor.hasReferencesToLambdaArgument;
@@ -78,6 +79,7 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.REFERENCE_TO_OU
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -86,8 +88,9 @@ import static java.util.Objects.requireNonNull;
 class AggregationAnalyzer
 {
     // fields and expressions in the group by clause
-    private final List<Integer> fieldIndexes;
+    private final Set<FieldId> groupingFields;
     private final List<Expression> expressions;
+    private final Map<Expression, FieldId> columnReferences;
 
     private final Metadata metadata;
     private final Analysis analysis;
@@ -133,38 +136,18 @@ class AggregationAnalyzer
         this.expressions = groupByExpressions.stream()
                 .map(e -> ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(analysis.getParameters()), e))
                 .collect(toImmutableList());
-        ImmutableList.Builder<Integer> fieldIndexes = ImmutableList.builder();
 
-        fieldIndexes.addAll(groupByExpressions.stream()
-                .filter(FieldReference.class::isInstance)
-                .map(FieldReference.class::cast)
-                .map(FieldReference::getFieldIndex)
-                .iterator());
+        this.columnReferences = analysis.getColumnReferenceFields();
 
-        // For a query like "SELECT * FROM T GROUP BY a", groupByExpressions will contain "a",
-        // and the '*' will be expanded to Field references. Therefore we translate all simple name expressions
-        // in the group by clause to fields they reference so that the expansion from '*' can be matched against them
-        List<Expression> nonFieldReferenceGroupingExpressions = expressions.stream()
-                .filter(expression -> analysis.getColumnReferences().contains(expression) && !(expression instanceof FieldReference))
-                .collect(toImmutableList());
-        for (Expression expression : nonFieldReferenceGroupingExpressions) {
-            QualifiedName name;
-            if (expression instanceof Identifier) {
-                name = QualifiedName.of(((Identifier) expression).getName());
-            }
-            else {
-                name = DereferenceExpression.getQualifiedName((DereferenceExpression) expression);
-            }
+        this.groupingFields = groupByExpressions.stream()
+                .filter(columnReferences::containsKey)
+                .map(columnReferences::get)
+                .collect(toImmutableSet());
 
-            List<Field> fields = sourceScope.getRelationType().resolveFields(name);
-            checkState(fields.size() <= 1, "Found more than one field for name '%s': %s", name, fields);
-
-            if (fields.size() == 1) {
-                Field field = Iterables.getOnlyElement(fields);
-                fieldIndexes.add(sourceScope.getRelationType().indexOf(field));
-            }
-        }
-        this.fieldIndexes = fieldIndexes.build();
+        this.groupingFields.forEach(fieldId -> {
+            checkState(isFieldFromScope(fieldId, sourceScope),
+                    "Grouping field %s should originate from %s", fieldId, sourceScope.getRelationType());
+        });
     }
 
     private void analyze(Expression expression)
@@ -428,30 +411,30 @@ class AggregationAnalyzer
             if (analysis.getLambdaArgumentReferences().containsKey(node)) {
                 return true;
             }
-            return isField(node, QualifiedName.of(node.getName()));
+            return isGroupingKey(node);
         }
 
         @Override
         protected Boolean visitDereferenceExpression(DereferenceExpression node, Void context)
         {
-            if (analysis.getColumnReferences().contains(node)) {
-                return isField(node, DereferenceExpression.getQualifiedName(node));
+            if (columnReferences.containsKey(node)) {
+                return isGroupingKey(node);
             }
 
             // Allow SELECT col1.f1 FROM table1 GROUP BY col1
             return process(node.getBase(), context);
         }
 
-        private boolean isField(Expression node, QualifiedName qualifiedName)
+        private boolean isGroupingKey(Expression node)
         {
-            Scope scope = orderByScope.orElse(sourceScope);
+            FieldId fieldId = columnReferences.get(node);
+            requireNonNull(fieldId, () -> "No FieldId for " + node);
 
-            ResolvedField resolvedField = scope.resolveField(node, qualifiedName);
-            if (orderByScope.isPresent() && resolvedField.getScope().equals(orderByScope.get())) {
+            if (orderByScope.isPresent() && isFieldFromScope(fieldId, orderByScope.get())) {
                 return true;
             }
 
-            return resolvedField.getScope().equals(sourceScope) && fieldIndexes.contains(resolvedField.getRelationFieldIndex());
+            return groupingFields.contains(fieldId);
         }
 
         @Override
@@ -461,7 +444,8 @@ class AggregationAnalyzer
                 return true;
             }
 
-            boolean inGroup = fieldIndexes.contains(node.getFieldIndex());
+            FieldId fieldId = requireNonNull(columnReferences.get(node), "No FieldId for FieldReference");
+            boolean inGroup = groupingFields.contains(fieldId);
             if (!inGroup) {
                 Field field = sourceScope.getRelationType().getFieldByIndex(node.getFieldIndex());
 
@@ -594,5 +578,10 @@ class AggregationAnalyzer
                 .ifPresent(expression -> {
                     throw new SemanticException(REFERENCE_TO_OUTPUT_ATTRIBUTE_WITHIN_ORDER_BY_AGGREGATION, expression, "Invalid reference to output projection attribute from ORDER BY aggregation");
                 });
+    }
+
+    public static boolean isFieldFromScope(FieldId fieldId, Scope scope)
+    {
+        return Objects.equals(fieldId.getRelationId(), scope.getRelationId());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -199,7 +199,8 @@ class AggregationAnalyzer
         @Override
         protected Boolean visitExists(ExistsPredicate node, Void context)
         {
-            return true;
+            checkState(node.getSubquery() instanceof SubqueryExpression);
+            return process(node.getSubquery(), context);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -63,13 +63,13 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.sql.NodeUtils.getSortItemsFromOrderBy;
 import static com.facebook.presto.sql.analyzer.LambdaReferenceExtractor.hasReferencesToLambdaArgument;
 import static com.facebook.presto.sql.analyzer.ScopeReferenceExtractor.getReferencesToScope;
+import static com.facebook.presto.sql.analyzer.ScopeReferenceExtractor.isFieldFromScope;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MUST_BE_AGGREGATE_OR_GROUP_BY;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MUST_BE_AGGREGATION_FUNCTION;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NESTED_AGGREGATION;
@@ -578,10 +578,5 @@ class AggregationAnalyzer
                 .ifPresent(expression -> {
                     throw new SemanticException(REFERENCE_TO_OUTPUT_ATTRIBUTE_WITHIN_ORDER_BY_AGGREGATION, expression, "Invalid reference to output projection attribute from ORDER BY aggregation");
                 });
-    }
-
-    public static boolean isFieldFromScope(FieldId fieldId, Scope scope)
-    {
-        return Objects.equals(fieldId.getRelationId(), scope.getRelationId());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -55,6 +55,7 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Collections.newSetFromMap;
+import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
 
@@ -419,6 +420,11 @@ public class Analysis
     public Set<Expression> getColumnReferences()
     {
         return unmodifiableSet(columnReferences.keySet());
+    }
+
+    public Map<Expression, FieldId> getColumnReferenceFields()
+    {
+        return unmodifiableMap(columnReferences);
     }
 
     public void addTypes(IdentityLinkedHashMap<Expression, Type> types)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -47,6 +47,7 @@ import javax.annotation.concurrent.Immutable;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -66,7 +67,7 @@ public class Analysis
     private final IdentityLinkedHashMap<Table, Query> namedQueries = new IdentityLinkedHashMap<>();
 
     private final IdentityLinkedHashMap<Node, Scope> scopes = new IdentityLinkedHashMap<>();
-    private final Set<Expression> columnReferences = newSetFromMap(new IdentityLinkedHashMap<>());
+    private final IdentityHashMap<Expression, FieldId> columnReferences = new IdentityHashMap<>();
 
     private final IdentityLinkedHashMap<QuerySpecification, List<FunctionCall>> aggregates = new IdentityLinkedHashMap<>();
     private final IdentityLinkedHashMap<OrderBy, List<Expression>> orderByAggregates = new IdentityLinkedHashMap<>();
@@ -351,9 +352,9 @@ public class Analysis
         return orderByWindowFunctions.get(query);
     }
 
-    public void addColumnReferences(Set<Expression> columnReferences)
+    public void addColumnReferences(IdentityLinkedHashMap<Expression, FieldId> columnReferences)
     {
-        this.columnReferences.addAll(columnReferences);
+        this.columnReferences.putAll(columnReferences);
     }
 
     public Scope getScope(Node node)
@@ -417,7 +418,7 @@ public class Analysis
 
     public Set<Expression> getColumnReferences()
     {
-        return unmodifiableSet(columnReferences);
+        return unmodifiableSet(columnReferences.keySet());
     }
 
     public void addTypes(IdentityLinkedHashMap<Expression, Type> types)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
@@ -88,9 +88,9 @@ public class ExpressionAnalysis
         return typeOnlyCoercions.contains(expression);
     }
 
-    public Set<Expression> getColumnReferences()
+    public boolean isColumnReference(Expression node)
     {
-        return columnReferences;
+        return columnReferences.contains(node);
     }
 
     public Set<InPredicate> getSubqueryInPredicates()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
@@ -25,7 +25,6 @@ import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 
 import java.util.Set;
 
-import static com.facebook.presto.util.MoreSets.newIdentityHashSet;
 import static java.util.Objects.requireNonNull;
 
 public class ExpressionAnalysis
@@ -33,7 +32,7 @@ public class ExpressionAnalysis
     private final IdentityLinkedHashMap<Expression, Type> expressionTypes;
     private final IdentityLinkedHashMap<Expression, Type> expressionCoercions;
     private final Set<Expression> typeOnlyCoercions;
-    private final Set<Expression> columnReferences;
+    private final IdentityLinkedHashMap<Expression, FieldId> columnReferences;
     private final Set<InPredicate> subqueryInPredicates;
     private final Set<SubqueryExpression> scalarSubqueries;
     private final Set<ExistsPredicate> existsSubqueries;
@@ -47,7 +46,7 @@ public class ExpressionAnalysis
             Set<InPredicate> subqueryInPredicates,
             Set<SubqueryExpression> scalarSubqueries,
             Set<ExistsPredicate> existsSubqueries,
-            Set<Expression> columnReferences,
+            IdentityLinkedHashMap<Expression, FieldId> columnReferences,
             Set<Expression> typeOnlyCoercions,
             Set<QuantifiedComparisonExpression> quantifiedComparisons,
             IdentityLinkedHashMap<Identifier, LambdaArgumentDeclaration> lambdaArgumentReferences)
@@ -55,7 +54,7 @@ public class ExpressionAnalysis
         this.expressionTypes = requireNonNull(expressionTypes, "expressionTypes is null");
         this.expressionCoercions = requireNonNull(expressionCoercions, "expressionCoercions is null");
         this.typeOnlyCoercions = requireNonNull(typeOnlyCoercions, "typeOnlyCoercions is null");
-        this.columnReferences = newIdentityHashSet(requireNonNull(columnReferences, "columnReferences is null"));
+        this.columnReferences = new IdentityLinkedHashMap<>(requireNonNull(columnReferences, "columnReferences is null"));
         this.subqueryInPredicates = requireNonNull(subqueryInPredicates, "subqueryInPredicates is null");
         this.scalarSubqueries = requireNonNull(scalarSubqueries, "subqueryInPredicates is null");
         this.existsSubqueries = requireNonNull(existsSubqueries, "existsSubqueries is null");
@@ -90,7 +89,7 @@ public class ExpressionAnalysis
 
     public boolean isColumnReference(Expression node)
     {
-        return columnReferences.contains(node);
+        return columnReferences.containsKey(node);
     }
 
     public Set<InPredicate> getSubqueryInPredicates()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -357,9 +357,14 @@ public class ExpressionAnalyzer
 
         private Type handleResolvedField(Expression node, ResolvedField resolvedField)
         {
-            FieldId previous = columnReferences.put(node, FieldId.from(resolvedField));
+            return handleResolvedField(node, FieldId.from(resolvedField), resolvedField.getType());
+        }
+
+        private Type handleResolvedField(Expression node, FieldId fieldId, Type resolvedType)
+        {
+            FieldId previous = columnReferences.put(node, fieldId);
             checkState(previous == null, "%s already known to refer to %s", node, previous);
-            return setExpressionType(node, resolvedField.getType());
+            return setExpressionType(node, resolvedType);
         }
 
         @Override
@@ -1039,7 +1044,7 @@ public class ExpressionAnalyzer
         public Type visitFieldReference(FieldReference node, StackableAstVisitorContext<Context> context)
         {
             Type type = scope.getRelationType().getFieldByIndex(node.getFieldIndex()).getType();
-            return setExpressionType(node, type);
+            return handleResolvedField(node, new FieldId(scope.getRelationId(), node.getFieldIndex()), type);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1389,7 +1389,7 @@ public class ExpressionAnalyzer
         Analysis analysis = new Analysis(null, parameters, isDescribe);
         ExpressionAnalyzer analyzer = create(analysis, session, metadata, sqlParser, new DenyAllAccessControl(), types);
         for (Expression expression : expressions) {
-            analyzer.analyze(expression, Scope.builder().withRelationType(tupleDescriptor).build());
+            analyzer.analyze(expression, Scope.builder().withRelationType(RelationId.anonymous(), tupleDescriptor).build());
         }
 
         return new ExpressionAnalysis(

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FieldId.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FieldId.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public final class FieldId
+{
+    public static FieldId from(ResolvedField field)
+    {
+        requireNonNull(field, "field is null");
+
+        Scope sourceScope = field.getScope();
+        RelationType relationType = sourceScope.getRelationType();
+        return new FieldId(sourceScope.getRelationId(), relationType.indexOf(field.getField()));
+    }
+
+    private final RelationId relationId;
+    private final int fieldIndex;
+
+    public FieldId(RelationId relationId, int fieldIndex)
+    {
+        this.relationId = requireNonNull(relationId, "relationId is null");
+
+        checkArgument(fieldIndex >= 0, "fieldIndex must be non-negative, got: %s", fieldIndex);
+        this.fieldIndex = fieldIndex;
+    }
+
+    public RelationId getRelationId()
+    {
+        return relationId;
+    }
+
+    /**
+     * Returns {@link RelationType#indexOf(Field) field index} of the field in the containing relation.
+     */
+    public int getFieldIndex()
+    {
+        return fieldIndex;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FieldId fieldId = (FieldId) o;
+        return fieldIndex == fieldId.fieldIndex &&
+                Objects.equals(relationId, fieldId.relationId);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(relationId, fieldIndex);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(relationId)
+                .addValue(fieldIndex)
+                .toString();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/RelationId.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/RelationId.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.sql.tree.Node;
+
+import javax.annotation.Nullable;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.lang.String.format;
+import static java.lang.System.identityHashCode;
+import static java.util.Objects.requireNonNull;
+
+public class RelationId
+{
+    /**
+     * Creates {@link RelationId} equal to any {@link RelationId} created from exactly the same source.
+     */
+    public static RelationId of(Node sourceNode)
+    {
+        return new RelationId(requireNonNull(sourceNode, "source cannot be null"));
+    }
+
+    /**
+     * Creates {@link RelationId} equal only to itself
+     */
+    public static RelationId anonymous()
+    {
+        return new RelationId(null);
+    }
+
+    @Nullable
+    private final Node sourceNode;
+
+    private RelationId(Node sourceNode)
+    {
+        this.sourceNode = sourceNode;
+    }
+
+    public boolean isAnonymous()
+    {
+        return sourceNode == null;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RelationId that = (RelationId) o;
+        return sourceNode != null && sourceNode == that.sourceNode;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return identityHashCode(sourceNode);
+    }
+
+    @Override
+    public String toString()
+    {
+        if (isAnonymous()) {
+            return toStringHelper(this)
+                    .addValue("anonymous")
+                    .addValue(format("x%08x", identityHashCode(this)))
+                    .toString();
+        }
+        else {
+            return toStringHelper(this)
+                    .addValue(sourceNode.getClass().getSimpleName())
+                    .addValue(format("x%08x", identityHashCode(sourceNode)))
+                    .toString();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.sql.analyzer.SemanticExceptions.ambiguousAttributeException;
 import static com.facebook.presto.sql.analyzer.SemanticExceptions.missingAttributeException;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Objects.requireNonNull;
@@ -38,6 +39,7 @@ public class Scope
 {
     private final Optional<Scope> parent;
     private final boolean queryBoundary;
+    private final RelationId relationId;
     private final RelationType relation;
     private final Map<String, WithQuery> namedQueries;
 
@@ -54,10 +56,12 @@ public class Scope
     private Scope(
             Optional<Scope> parent,
             boolean queryBoundary,
+            RelationId relationId,
             RelationType relation,
             Map<String, WithQuery> namedQueries)
     {
         this.parent = requireNonNull(parent, "parent is null");
+        this.relationId = requireNonNull(relationId, "relationId is null");
         this.queryBoundary = queryBoundary;
         this.relation = requireNonNull(relation, "relation is null");
         this.namedQueries = ImmutableMap.copyOf(requireNonNull(namedQueries, "namedQueries is null"));
@@ -83,6 +87,11 @@ public class Scope
         }
 
         return Optional.empty();
+    }
+
+    public RelationId getRelationId()
+    {
+        return relationId;
     }
 
     public RelationType getRelationType()
@@ -185,15 +194,25 @@ public class Scope
         return Optional.empty();
     }
 
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(relationId)
+                .toString();
+    }
+
     public static final class Builder
     {
+        private RelationId relationId = RelationId.anonymous();
         private RelationType relationType = new RelationType();
         private final Map<String, WithQuery> namedQueries = new HashMap<>();
         private Optional<Scope> parent = Optional.empty();
         private boolean queryBoundary;
 
-        public Builder withRelationType(RelationType relationType)
+        public Builder withRelationType(RelationId relationId, RelationType relationType)
         {
+            this.relationId = requireNonNull(relationId, "relationId is null");
             this.relationType = requireNonNull(relationType, "relationType is null");
             return this;
         }
@@ -227,7 +246,7 @@ public class Scope
 
         public Scope build()
         {
-            return new Scope(parent, queryBoundary, relationType, namedQueries);
+            return new Scope(parent, queryBoundary, relationId, relationType, namedQueries);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -610,7 +610,7 @@ class StatementAnalyzer
 
             Scope queryScope = Scope.builder()
                     .withParent(withScope)
-                    .withRelationType(queryBodyScope.getRelationType())
+                    .withRelationType(RelationId.of(node), queryBodyScope.getRelationType())
                     .build();
             analysis.setScope(node, queryScope);
             return queryScope;
@@ -1571,7 +1571,7 @@ class StatementAnalyzer
             // ORDER BY should "see" both output and FROM fields during initial analysis and non-aggregation query planning
             Scope orderByScope = Scope.builder()
                     .withParent(sourceScope)
-                    .withRelationType(outputScope.getRelationType())
+                    .withRelationType(outputScope.getRelationId(), outputScope.getRelationType())
                     .build();
             analysis.setScope(node, orderByScope);
             return orderByScope;
@@ -1604,12 +1604,12 @@ class StatementAnalyzer
                     .collect(toImmutableList());
 
             Scope orderByAggregationScope = Scope.builder()
-                    .withRelationType(new RelationType(orderByAggregationSourceFields))
+                    .withRelationType(RelationId.anonymous(), new RelationType(orderByAggregationSourceFields))
                     .build();
 
             Scope orderByScope = Scope.builder()
                     .withParent(orderByAggregationScope)
-                    .withRelationType(outputScope.getRelationType())
+                    .withRelationType(outputScope.getRelationId(), outputScope.getRelationType())
                     .build();
             analysis.setScope(node, orderByScope);
             analysis.setOrderByAggregates(node, orderByAggregationExpressions);
@@ -1983,7 +1983,7 @@ class StatementAnalyzer
         private Scope createAndAssignScope(Node node, Optional<Scope> parentScope, RelationType relationType)
         {
             Scope scope = scopeBuilder(parentScope)
-                    .withRelationType(relationType)
+                    .withRelationType(RelationId.of(node), relationType)
                     .build();
 
             analysis.setScope(node, scope);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -876,7 +876,7 @@ class StatementAnalyzer
             sourceExpressions.addAll(outputExpressions);
             node.getHaving().ifPresent(sourceExpressions::add);
 
-            List<FunctionCall> aggregations = analyzeAggregations(node, sourceScope, orderByScope, groupByExpressions, analysis.getColumnReferences(), sourceExpressions, orderByExpressions);
+            List<FunctionCall> aggregations = analyzeAggregations(node, sourceScope, orderByScope, groupByExpressions, sourceExpressions, orderByExpressions);
             analyzeWindowFunctions(node, outputExpressions, orderByExpressions);
 
             if (!groupByExpressions.isEmpty() && node.getOrderBy().isPresent()) {
@@ -920,7 +920,7 @@ class StatementAnalyzer
             expressions.addAll(orderByExpressions);
             node.getHaving().ifPresent(expressions::add);
 
-            analyzeAggregations(node, sourceScope, Optional.empty(), groupByExpressions, analysis.getColumnReferences(), expressions, emptyList());
+            analyzeAggregations(node, sourceScope, Optional.empty(), groupByExpressions, expressions, emptyList());
             analysis.setWindowFunctions(node, analyzeWindowFunctions(node, expressions));
 
             return outputScope;
@@ -1701,7 +1701,6 @@ class StatementAnalyzer
                 Scope sourceScope,
                 Optional<Scope> orderByScope,
                 List<List<Expression>> groupingSets,
-                Set<Expression> columnReferences,
                 List<Expression> outputExpressions,
                 List<Expression> orderByExpressions)
         {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -168,7 +168,7 @@ public class ExpressionInterpreter
     public static Object evaluateConstantExpression(Expression expression, Type expectedType, Metadata metadata, Session session, List<Expression> parameters)
     {
         ExpressionAnalyzer analyzer = createConstantAnalyzer(metadata, session, parameters);
-        analyzer.analyze(expression, Scope.builder().build());
+        analyzer.analyze(expression, Scope.create());
 
         Type actualType = analyzer.getExpressionTypes().get(expression);
         if (!metadata.getTypeManager().canCoerce(actualType, expectedType)) {
@@ -215,7 +215,7 @@ public class ExpressionInterpreter
 
         // redo the analysis since above expression rewriter might create new expressions which do not have entries in the type map
         ExpressionAnalyzer analyzer = createConstantAnalyzer(metadata, session, parameters);
-        analyzer.analyze(rewrite, Scope.builder().build());
+        analyzer.analyze(rewrite, Scope.create());
 
         // remove syntax sugar
         rewrite = ExpressionTreeRewriter.rewriteWith(new DesugaringRewriter(analyzer.getExpressionTypes()), rewrite);
@@ -227,7 +227,7 @@ public class ExpressionInterpreter
         // The optimization above may have rewritten the expression tree which breaks all the identity maps, so redo the analysis
         // to re-analyze coercions that might be necessary
         analyzer = createConstantAnalyzer(metadata, session, parameters);
-        analyzer.analyze(canonicalized, Scope.builder().build());
+        analyzer.analyze(canonicalized, Scope.create());
 
         // evaluate the expression
         Object result = expressionInterpreter(canonicalized, metadata, session, analyzer.getExpressionTypes()).evaluate(0);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Field;
+import com.facebook.presto.sql.analyzer.RelationId;
 import com.facebook.presto.sql.analyzer.RelationType;
 import com.facebook.presto.sql.analyzer.Scope;
 import com.facebook.presto.sql.parser.SqlParser;
@@ -245,7 +246,7 @@ public class LogicalPlanner
         List<Field> fields = visibleTableColumns.stream()
                 .map(column -> Field.newUnqualified(column.getName(), column.getType()))
                 .collect(toImmutableList());
-        Scope scope = Scope.builder().withRelationType(new RelationType(fields)).build();
+        Scope scope = Scope.builder().withRelationType(RelationId.anonymous(), new RelationType(fields)).build();
 
         plan = new RelationPlan(projectNode, scope, projectNode.getOutputSymbols());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Field;
+import com.facebook.presto.sql.analyzer.RelationId;
 import com.facebook.presto.sql.analyzer.RelationType;
 import com.facebook.presto.sql.analyzer.Scope;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
@@ -217,7 +218,7 @@ class QueryPlanner
 
         // create table scan
         PlanNode tableScan = new TableScanNode(idAllocator.getNextId(), handle, outputSymbols.build(), columns.build(), Optional.empty(), TupleDomain.all(), null);
-        Scope scope = Scope.builder().withRelationType(new RelationType(fields.build())).build();
+        Scope scope = Scope.builder().withRelationType(RelationId.anonymous(), new RelationType(fields.build())).build();
         RelationPlan relationPlan = new RelationPlan(tableScan, scope, outputSymbols.build());
 
         TranslationMap translations = new TranslationMap(relationPlan, analysis, lambdaDeclarationToSymbolMap);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.ExpressionUtils;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Field;
+import com.facebook.presto.sql.analyzer.RelationId;
 import com.facebook.presto.sql.analyzer.RelationType;
 import com.facebook.presto.sql.analyzer.Scope;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
@@ -561,7 +562,7 @@ class RelationPlanner
                     oldField.isAliased());
         }
         ProjectNode projectNode = new ProjectNode(idAllocator.getNextId(), plan.getRoot(), assignments.build());
-        return new RelationPlan(projectNode, Scope.builder().withRelationType(new RelationType(newFields)).build(), newSymbols.build());
+        return new RelationPlan(projectNode, Scope.builder().withRelationType(RelationId.anonymous(), new RelationType(newFields)).build(), newSymbols.build());
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -472,7 +472,7 @@ public final class FunctionAssertions
             @Override
             public Expression rewriteDereferenceExpression(DereferenceExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
             {
-                if (analysis.getColumnReferences().contains(node)) {
+                if (analysis.isColumnReference(node)) {
                     return rewriteExpression(node, context, treeRewriter);
                 }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -263,6 +263,39 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testGroupByWithExistsSelectExpression()
+            throws Exception
+    {
+        analyze("SELECT EXISTS(SELECT t1.a) FROM t1 GROUP BY a");
+        analyze("SELECT EXISTS(SELECT a) FROM t1 GROUP BY t1.a");
+
+        // u.a is not GROUP-ed BY and it is used in select Subquery expression
+        analyze("SELECT EXISTS(SELECT u.a FROM (values 1) u(a)) " +
+                "FROM t1 u GROUP BY b");
+
+        assertFails(
+                MUST_BE_AGGREGATE_OR_GROUP_BY,
+                "line 1:22: Subquery uses '\"u\".\"a\"' which must appear in GROUP BY clause",
+                "SELECT EXISTS(SELECT u.a from (values 1) x(a)) FROM t1 u GROUP BY b");
+
+        assertFails(
+                MUST_BE_AGGREGATE_OR_GROUP_BY,
+                "line 1:22: Subquery uses '\"a\"' which must appear in GROUP BY clause",
+                "SELECT EXISTS(SELECT a+2) FROM t1 GROUP BY a+1");
+
+        assertFails(
+                MUST_BE_AGGREGATE_OR_GROUP_BY,
+                "line 1:42: Subquery uses '\"u\".\"a\"' which must appear in GROUP BY clause",
+                "SELECT EXISTS(SELECT 1 FROM t1 WHERE a = u.a) FROM t1 u GROUP BY b");
+
+        // (t1.)a is not part of GROUP BY
+        assertFails(MUST_BE_AGGREGATE_OR_GROUP_BY, "SELECT EXISTS(SELECT a as a) FROM t1 GROUP BY b");
+
+        // u.a is not GROUP-ed BY but select Subquery expression is using a different (shadowing) u.a
+        analyze("SELECT EXISTS(SELECT 1 FROM t1 u WHERE a = u.a) FROM t1 u GROUP BY b");
+    }
+
+    @Test
     public void testGroupByWithSubquerySelectExpressionWithDereferenceExpression()
     {
         analyze("SELECT (SELECT t.a.someField) " +

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestScope.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestScope.java
@@ -34,11 +34,11 @@ public class TestScope
 
         Field outerColumn1 = Field.newQualified(QualifiedName.of("outer", "column1"), Optional.of("c1"), BIGINT, false, Optional.empty(), false);
         Field outerColumn2 = Field.newQualified(QualifiedName.of("outer", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), false);
-        Scope outer = Scope.builder().withParent(root).withRelationType(new RelationType(outerColumn1, outerColumn2)).build();
+        Scope outer = Scope.builder().withParent(root).withRelationType(RelationId.anonymous(), new RelationType(outerColumn1, outerColumn2)).build();
 
         Field innerColumn2 = Field.newQualified(QualifiedName.of("inner", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), false);
         Field innerColumn3 = Field.newQualified(QualifiedName.of("inner", "column3"), Optional.of("c3"), BIGINT, false, Optional.empty(), false);
-        Scope inner = Scope.builder().withOuterQueryParent(outer).withRelationType(new RelationType(innerColumn2, innerColumn3)).build();
+        Scope inner = Scope.builder().withOuterQueryParent(outer).withRelationType(RelationId.anonymous(), new RelationType(innerColumn2, innerColumn3)).build();
 
         Expression c1 = name("c1");
         Expression c2 = name("c2");

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestScope.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestScope.java
@@ -30,7 +30,7 @@ public class TestScope
     @Test
     public void test()
     {
-        Scope root = Scope.builder().build();
+        Scope root = Scope.create();
 
         Field outerColumn1 = Field.newQualified(QualifiedName.of("outer", "column1"), Optional.of("c1"), BIGINT, false, Optional.empty(), false);
         Field outerColumn2 = Field.newQualified(QualifiedName.of("outer", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), false);


### PR DESCRIPTION
This PR takes `Scope`-based field resolution to the next level. Scopes are hard to create correctly, as they need to follow SQL language rules. `StatementAnalyzer` creates them and `ExpressionAnalyzer` resolves column references. The PR introduces `FieldId` concept which allows `ExpressionAnalyzer` to _save_ resolved column references in `Analysis` and let `AggregationAnalyzer` use that. This unlocks ability to analyze subqueries in `AggregationAnalyzer`.

Fixes #7030. Based on @sopel39's #7315 