### PR TITLE
Simple PlanNode matching in IterativeOptimizer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+[*]
+charset=utf-8
+end_of_line=lf
+insert_final_newline=false
+indent_style=space
+indent_size=4
+
+[*.json]
+indent_style=space
+indent_size=2
+
+[{*.yml,*.yaml}]
+indent_style=space
+indent_size=2
+

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Pattern.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Pattern.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative;
+
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public abstract class Pattern
+{
+    private static final Pattern ANY_NODE = new MatchNodeClass(PlanNode.class);
+
+    private Pattern() {}
+
+    public abstract boolean matches(PlanNode node);
+
+    public static Pattern any()
+    {
+        return ANY_NODE;
+    }
+
+    public static <T extends PlanNode> Pattern node(Class<T> nodeClass)
+    {
+        return new MatchNodeClass(nodeClass);
+    }
+
+    static class MatchNodeClass<T extends PlanNode>
+            extends Pattern
+    {
+        private final Class<T> nodeClass;
+
+        MatchNodeClass(Class<T> nodeClass)
+        {
+            this.nodeClass = requireNonNull(nodeClass, "nodeClass is null");
+        }
+
+        Class<T> getNodeClass()
+        {
+            return nodeClass;
+        }
+
+        @Override
+        public boolean matches(PlanNode node)
+        {
+            return nodeClass.isInstance(node);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("nodeClass", nodeClass)
+                    .toString();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Rule.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Rule.java
@@ -22,5 +22,15 @@ import java.util.Optional;
 
 public interface Rule
 {
+    /**
+     * Returns a pattern to which plan nodes this rule applies.
+     * Notice that rule may be still invoked for plan nodes which given pattern does not apply,
+     * then rule should return Optional.empty() in such case
+     */
+    default Pattern getPattern()
+    {
+        return Pattern.any();
+    }
+
     Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session);
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/RuleStore.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/RuleStore.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative;
+
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Streams;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class RuleStore
+{
+    private final ListMultimap<Class<? extends PlanNode>, Rule> rulesByClass;
+
+    private RuleStore(ListMultimap<Class<? extends PlanNode>, Rule> rulesByClass)
+    {
+        this.rulesByClass = ImmutableListMultimap.copyOf(rulesByClass);
+    }
+
+    public Stream<Rule> getCandidates(PlanNode planNode)
+    {
+        return Streams.stream(ancestors(planNode.getClass()))
+                .flatMap(clazz -> rulesByClass.get(clazz).stream());
+    }
+
+    private static Iterator<Class<? extends PlanNode>> ancestors(Class<? extends PlanNode> planNodeClass)
+    {
+        return new AbstractIterator<Class<? extends PlanNode>>() {
+            private Class<?> current = planNodeClass;
+
+            @Override
+            protected Class<? extends PlanNode> computeNext()
+            {
+                if (!PlanNode.class.isAssignableFrom(current)) {
+                    return endOfData();
+                }
+
+                Class<? extends PlanNode> result = (Class<? extends PlanNode>) current;
+                current = current.getSuperclass();
+
+                return result;
+            }
+        };
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static class Builder
+    {
+        private final ImmutableListMultimap.Builder<Class<? extends PlanNode>, Rule> rulesByClass = ImmutableListMultimap.builder();
+
+        public Builder register(Set<Rule> newRules)
+        {
+            newRules.forEach(this::register);
+            return this;
+        }
+
+        public Builder register(Rule newRule)
+        {
+            Pattern pattern = newRule.getPattern();
+            if (pattern instanceof Pattern.MatchNodeClass) {
+                rulesByClass.put(((Pattern.MatchNodeClass) pattern).getNodeClass(), newRule);
+            }
+            else {
+                throw new IllegalArgumentException("Unexpected Pattern: " + pattern);
+            }
+            return this;
+        }
+
+        public RuleStore build()
+        {
+            return new RuleStore(rulesByClass.build());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddIntermediateAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddIntermediateAggregations.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
@@ -66,6 +67,14 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 public class AddIntermediateAggregations
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(AggregationNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CreatePartialTopN.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CreatePartialTopN.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.TopNNode;
@@ -30,6 +31,14 @@ import static com.facebook.presto.sql.planner.plan.TopNNode.Step.SINGLE;
 public class CreatePartialTopN
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(TopNNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.optimizations.joins.JoinGraph;
 import com.facebook.presto.sql.planner.plan.Assignments;
@@ -47,6 +48,14 @@ import static java.util.Objects.requireNonNull;
 public class EliminateCrossJoins
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(JoinNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EvaluateZeroLimit.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EvaluateZeroLimit.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -28,13 +29,17 @@ import java.util.Optional;
 public class EvaluateZeroLimit
     implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(LimitNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof LimitNode)) {
-            return Optional.empty();
-        }
-
         LimitNode limit = (LimitNode) node;
 
         if (limit.getCount() != 0) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EvaluateZeroSample.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EvaluateZeroSample.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
@@ -31,13 +32,17 @@ import java.util.Optional;
 public class EvaluateZeroSample
     implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(SampleNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof SampleNode)) {
-            return Optional.empty();
-        }
-
         SampleNode sample = (SampleNode) node;
 
         if (sample.getSampleRatio() != 0) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementBernoulliSampleAsFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementBernoulliSampleAsFilter.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -49,13 +50,17 @@ import java.util.Optional;
 public class ImplementBernoulliSampleAsFilter
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(SampleNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof SampleNode)) {
-            return Optional.empty();
-        }
-
         SampleNode sample = (SampleNode) node;
 
         if (sample.getSampleType() != SampleNode.Type.BERNOULLI) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/InlineProjections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/InlineProjections.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -47,13 +48,17 @@ import static java.util.stream.Collectors.toSet;
 public class InlineProjections
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(ProjectNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof ProjectNode)) {
-            return Optional.empty();
-        }
-
         ProjectNode parent = (ProjectNode) node;
 
         PlanNode source = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeAdjacentWindows.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeAdjacentWindows.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
@@ -30,6 +31,14 @@ import static com.facebook.presto.sql.planner.optimizations.WindowNodeUtil.depen
 public class MergeAdjacentWindows
     implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(WindowNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeFilters.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeFilters.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -28,13 +29,17 @@ import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 public class MergeFilters
     implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(FilterNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof FilterNode)) {
-            return Optional.empty();
-        }
-
         FilterNode parent = (FilterNode) node;
 
         PlanNode source = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithDistinct.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.DistinctLimitNode;
@@ -28,13 +29,17 @@ import java.util.Optional;
 public class MergeLimitWithDistinct
     implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(LimitNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof LimitNode)) {
-            return Optional.empty();
-        }
-
         LimitNode parent = (LimitNode) node;
 
         PlanNode input = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithSort.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithSort.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -28,13 +29,17 @@ import java.util.Optional;
 public class MergeLimitWithSort
     implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(LimitNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof LimitNode)) {
-            return Optional.empty();
-        }
-
         LimitNode parent = (LimitNode) node;
 
         PlanNode source = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithTopN.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithTopN.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -27,13 +28,17 @@ import java.util.Optional;
 public class MergeLimitWithTopN
     implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(LimitNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof LimitNode)) {
-            return Optional.empty();
-        }
-
         LimitNode parent = (LimitNode) node;
 
         PlanNode source = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimits.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimits.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -26,13 +27,17 @@ import java.util.Optional;
 public class MergeLimits
     implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(LimitNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof LimitNode)) {
-            return Optional.empty();
-        }
-
         LimitNode parent = (LimitNode) node;
 
         PlanNode source = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTableScanColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTableScanColumns.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
@@ -33,13 +34,17 @@ import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
 public class PruneTableScanColumns
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(ProjectNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof ProjectNode)) {
-            return Optional.empty();
-        }
-
         ProjectNode parent = (ProjectNode) node;
 
         PlanNode source = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneValuesColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneValuesColumns.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
@@ -35,13 +36,17 @@ import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
 public class PruneValuesColumns
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(ProjectNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof ProjectNode)) {
-            return Optional.empty();
-        }
-
         ProjectNode parent = (ProjectNode) node;
 
         PlanNode child = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.Assignments;
@@ -85,6 +86,14 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 public class PushAggregationThroughOuterJoin
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(AggregationNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitThroughMarkDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitThroughMarkDistinct.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
@@ -29,13 +30,17 @@ import static com.facebook.presto.sql.planner.iterative.rule.Util.transpose;
 public class PushLimitThroughMarkDistinct
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(LimitNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof LimitNode)) {
-            return Optional.empty();
-        }
-
         LimitNode parent = (LimitNode) node;
 
         PlanNode child = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitThroughProject.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitThroughProject.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -29,13 +30,17 @@ import static com.facebook.presto.sql.planner.iterative.rule.Util.transpose;
 public class PushLimitThroughProject
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(LimitNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof LimitNode)) {
-            return Optional.empty();
-        }
-
         LimitNode parent = (LimitNode) node;
 
         PlanNode child = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitThroughSemiJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitThroughSemiJoin.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -29,13 +30,17 @@ import static com.facebook.presto.sql.planner.iterative.rule.Util.transpose;
 public class PushLimitThroughSemiJoin
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(LimitNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof LimitNode)) {
-            return Optional.empty();
-        }
-
         LimitNode parent = (LimitNode) node;
 
         PlanNode child = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushProjectionThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushProjectionThroughExchange.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
@@ -69,6 +70,14 @@ import static com.facebook.presto.sql.planner.plan.Assignments.identity;
 public class PushProjectionThroughExchange
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(ProjectNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushProjectionThroughUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushProjectionThroughUnion.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -38,6 +39,14 @@ import java.util.Optional;
 public class PushProjectionThroughUnion
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(ProjectNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushTopNThroughUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushTopNThroughUnion.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.optimizations.SymbolMapper;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -36,6 +37,14 @@ import static com.google.common.collect.Sets.intersection;
 public class PushTopNThroughUnion
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(TopNNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveEmptyDelete.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveEmptyDelete.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.DeleteNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
@@ -51,14 +52,19 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 public class RemoveEmptyDelete
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(TableFinishNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
         // TODO split into multiple rules (https://github.com/prestodb/presto/issues/7292)
 
-        if (!(node instanceof TableFinishNode)) {
-            return Optional.empty();
-        }
         TableFinishNode finish = (TableFinishNode) node;
 
         PlanNode finishSource = lookup.resolve(finish.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveFullSample.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveFullSample.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
@@ -29,13 +30,17 @@ import java.util.Optional;
 public class RemoveFullSample
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(SampleNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof SampleNode)) {
-            return Optional.empty();
-        }
-
         SampleNode sample = (SampleNode) node;
 
         //noinspection FloatingPointEquality

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantIdentityProjections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantIdentityProjections.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
@@ -30,13 +31,17 @@ import java.util.Optional;
 public class RemoveRedundantIdentityProjections
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(ProjectNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof ProjectNode)) {
-            return Optional.empty();
-        }
-
         ProjectNode project = (ProjectNode) node;
 
         if (!project.isIdentity()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.Assignments;
@@ -44,13 +45,17 @@ import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 public class SimplifyCountOverConstant
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(AggregationNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof AggregationNode)) {
-            return Optional.empty();
-        }
-
         AggregationNode parent = (AggregationNode) node;
 
         PlanNode input = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SingleMarkDistinctToGroupBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SingleMarkDistinctToGroupBy.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
@@ -52,13 +53,17 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 public class SingleMarkDistinctToGroupBy
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(AggregationNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof AggregationNode)) {
-            return Optional.empty();
-        }
-
         AggregationNode parent = (AggregationNode) node;
 
         PlanNode source = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SwapAdjacentWindowsBySpecifications.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SwapAdjacentWindowsBySpecifications.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
@@ -31,13 +32,17 @@ import static com.facebook.presto.sql.planner.optimizations.WindowNodeUtil.depen
 public class SwapAdjacentWindowsBySpecifications
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(WindowNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof WindowNode)) {
-            return Optional.empty();
-        }
-
         WindowNode parent = (WindowNode) node;
 
         PlanNode child = lookup.resolve(parent.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.optimizations.TransformCorrelatedScalarAggregationToJoin;
 import com.facebook.presto.sql.planner.optimizations.TransformUncorrelatedInPredicateSubqueryToSemiJoin;
@@ -94,6 +95,14 @@ import static java.util.Objects.requireNonNull;
 public class TransformCorrelatedInPredicateToJoin
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(ApplyNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedScalarAggregationToJoin.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.optimizations.ScalarAggregationToJoinRewriter;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
@@ -36,6 +37,14 @@ import static java.util.Objects.requireNonNull;
 public class TransformCorrelatedScalarAggregationToJoin
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(LateralJoinNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
     private final FunctionRegistry functionRegistry;
 
     public TransformCorrelatedScalarAggregationToJoin(FunctionRegistry functionRegistry)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
@@ -58,6 +59,7 @@ import static java.util.Objects.requireNonNull;
 public class TransformExistsApplyToLateralNode
         implements Rule
 {
+    private static final Pattern PATTERN = Pattern.node(ApplyNode.class);
     private static final QualifiedName COUNT = QualifiedName.of("count");
     private static final FunctionCall COUNT_CALL = new FunctionCall(COUNT, ImmutableList.of());
     private final Signature countSignature;
@@ -69,12 +71,14 @@ public class TransformExistsApplyToLateralNode
     }
 
     @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
     public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
     {
-        if (!(node instanceof ApplyNode)) {
-            return Optional.empty();
-        }
-
         ApplyNode parent = (ApplyNode) node;
 
         if (parent.getSubqueryAssignments().size() != 1) {

--- a/presto-main/src/test/java/com/facebook/presto/metadata/DummyMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/DummyMetadata.java
@@ -1,0 +1,414 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.spi.CatalogSchemaName;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnIdentity;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.TableIdentity;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.security.GrantInfo;
+import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.sql.tree.QualifiedName;
+import io.airlift.slice.Slice;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+
+public class DummyMetadata implements Metadata
+{
+    @Override
+    public void verifyComparableOrderableContract()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Type getType(TypeSignature signature)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAggregationFunction(QualifiedName name)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<SqlFunction> listFunctions()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addFunctions(List<? extends SqlFunction> functions)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean schemaExists(Session session, CatalogSchemaName schema)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> listSchemaNames(Session session, String catalogName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<TableLayoutResult> getLayouts(
+        Session session,
+        TableHandle tableHandle,
+        Constraint<ColumnHandle> constraint,
+        Optional<Set<ColumnHandle>> desiredColumns)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TableLayout getLayout(Session session, TableLayoutHandle handle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Object> getInfo(Session session, TableLayoutHandle handle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TableMetadata getTableMetadata(Session session, TableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TableStatistics getTableStatistics(Session session, TableHandle tableHandle, Constraint<ColumnHandle> constraint)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(Session session, TableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<QualifiedObjectName, List<ColumnMetadata>> listTableColumns(Session session, QualifiedTablePrefix prefix)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createSchema(Session session, CatalogSchemaName schema, Map<String, Object> properties)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dropSchema(Session session, CatalogSchemaName schema)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void renameSchema(Session session, CatalogSchemaName source, String target)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void renameTable(Session session, TableHandle tableHandle, QualifiedObjectName newTableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void renameColumn(Session session, TableHandle tableHandle, ColumnHandle source, String target)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dropTable(Session session, TableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TableIdentity getTableIdentity(Session session, TableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TableIdentity deserializeTableIdentity(Session session, String catalogName, byte[] bytes)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ColumnIdentity getColumnIdentity(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ColumnIdentity deserializeColumnIdentity(Session session, String catalogName, byte[] bytes)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<NewTableLayout> getNewTableLayout(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OutputTableHandle beginCreateTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, Optional<NewTableLayout> layout)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateTable(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<NewTableLayout> getInsertLayout(Session session, TableHandle target)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void beginQuery(Session session, Set<ConnectorId> connectors)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void cleanupQuery(Session session)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ColumnHandle getUpdateRowIdColumnHandle(Session session, TableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean supportsMetadataDelete(Session session, TableHandle tableHandle, TableLayoutHandle tableLayoutHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OptionalLong metadataDelete(Session session, TableHandle tableHandle, TableLayoutHandle tableLayoutHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TableHandle beginDelete(Session session, TableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void finishDelete(Session session, TableHandle tableHandle, Collection<Slice> fragments)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<ConnectorId> getCatalogHandle(Session session, String catalogName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, ConnectorId> getCatalogNames(Session session)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<QualifiedObjectName> listViews(Session session, QualifiedTablePrefix prefix)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<QualifiedObjectName, ViewDefinition> getViews(Session session, QualifiedTablePrefix prefix)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<ViewDefinition> getView(Session session, QualifiedObjectName viewName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createView(Session session, QualifiedObjectName viewName, String viewData, boolean replace)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dropView(Session session, QualifiedObjectName viewName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<ResolvedIndex> resolveIndex(
+        Session session,
+        TableHandle tableHandle,
+        Set<ColumnHandle> indexableColumns,
+        Set<ColumnHandle> outputColumns,
+        TupleDomain<ColumnHandle> tupleDomain)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void grantTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, String grantee, boolean grantOption)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void revokeTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, String grantee, boolean grantOption)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionRegistry getFunctionRegistry()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ProcedureRegistry getProcedureRegistry()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TypeManager getTypeManager()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BlockEncodingSerde getBlockEncodingSerde()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SessionPropertyManager getSessionPropertyManager()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SchemaPropertyManager getSchemaPropertyManager()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TablePropertyManager getTablePropertyManager()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestRuleStore.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestRuleStore.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.DummyMetadata;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.tree.BooleanLiteral;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.stream.Collectors.toList;
+import static org.testng.Assert.assertEquals;
+
+public class TestRuleStore
+{
+    private final PlanBuilder planBuilder = new PlanBuilder(new PlanNodeIdAllocator(), new DummyMetadata());
+
+    @Test
+    public void test()
+    {
+        Rule projectRule1 = new NoOpRule(Pattern.node(ProjectNode.class));
+        Rule projectRule2 = new NoOpRule(Pattern.node(ProjectNode.class));
+        Rule filterRule = new NoOpRule(Pattern.node(FilterNode.class));
+        Rule anyRule = new NoOpRule(Pattern.any());
+
+        RuleStore ruleStore = RuleStore.builder()
+                .register(projectRule1)
+                .register(projectRule2)
+                .register(filterRule)
+                .register(anyRule)
+                .build();
+
+        ProjectNode projectNode = planBuilder.project(Assignments.of(), planBuilder.values());
+        FilterNode filterNode = planBuilder.filter(BooleanLiteral.TRUE_LITERAL, planBuilder.values());
+        ValuesNode valuesNode = planBuilder.values();
+
+        assertEquals(
+                ruleStore.getCandidates(projectNode).collect(toList()),
+                ImmutableList.of(projectRule1, projectRule2, anyRule));
+        assertEquals(
+                ruleStore.getCandidates(filterNode).collect(toList()),
+                ImmutableList.of(filterRule, anyRule));
+        assertEquals(
+                ruleStore.getCandidates(valuesNode).collect(toList()),
+                ImmutableList.of(anyRule));
+    }
+
+    private static class NoOpRule
+            implements Rule
+    {
+        private final Pattern pattern;
+
+        private NoOpRule(Pattern pattern)
+        {
+            this.pattern = pattern;
+        }
+
+        @Override
+        public Pattern getPattern()
+        {
+            return pattern;
+        }
+
+        @Override
+        public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+        {
+            return Optional.empty();
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("pattern", pattern)
+                    .toString();
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -104,75 +104,80 @@ public class RuleAssert
 
     public void matches(PlanMatchPattern pattern)
     {
-        RuleApplication ruleApplication = applyRule();
-        Map<Symbol, Type> types = ruleApplication.types;
+      RuleApplication ruleApplication = applyRule();
+      Map<Symbol, Type> types = ruleApplication.types;
 
-        if (!ruleApplication.wasRuleApplied()) {
-            fail(String.format(
-                    "%s did not fire for:\n%s",
-                    rule.getClass().getName(),
-                    formatPlan(plan, types)));
-        }
+      if (!ruleApplication.wasRuleApplied()) {
+          fail(String.format(
+                  "%s did not fire for:\n%s",
+                  rule.getClass().getName(),
+                  formatPlan(plan, types)));
+      }
 
-        PlanNode actual = ruleApplication.getResult();
+      PlanNode actual = ruleApplication.getResult();
 
-        if (actual == plan) { // plans are not comparable, so we can only ensure they are not the same instance
-            fail(String.format(
-                    "%s: rule fired but return the original plan:\n%s",
-                    rule.getClass().getName(),
-                    formatPlan(plan, types)));
-        }
+      if (actual == plan) { // plans are not comparable, so we can only ensure they are not the same instance
+          fail(String.format(
+                  "%s: rule fired but return the original plan:\n%s",
+                  rule.getClass().getName(),
+                  formatPlan(plan, types)));
+      }
 
-        if (!ImmutableSet.copyOf(plan.getOutputSymbols()).equals(ImmutableSet.copyOf(actual.getOutputSymbols()))) {
-            fail(String.format(
-                    "%s: output schema of transformed and original plans are not equivalent\n" +
-                            "\texpected: %s\n" +
-                            "\tactual:   %s",
-                    rule.getClass().getName(),
-                    plan.getOutputSymbols(),
-                    actual.getOutputSymbols()));
-        }
+      if (!ImmutableSet.copyOf(plan.getOutputSymbols()).equals(ImmutableSet.copyOf(actual.getOutputSymbols()))) {
+          fail(String.format(
+                  "%s: output schema of transformed and original plans are not equivalent\n" +
+                          "\texpected: %s\n" +
+                          "\tactual:   %s",
+                  rule.getClass().getName(),
+                  plan.getOutputSymbols(),
+                  actual.getOutputSymbols()));
+      }
 
-        inTransaction(session -> {
-            Map<PlanNodeId, PlanNodeCost> planNodeCosts = costCalculator.calculateCostForPlan(session, types, actual);
-            assertPlan(session, metadata, costCalculator, new Plan(actual, types, planNodeCosts), ruleApplication.lookup, pattern);
-            return null;
-        });
-    }
+      inTransaction(session -> {
+          Map<PlanNodeId, PlanNodeCost> planNodeCosts = costCalculator.calculateCostForPlan(session, types, actual);
+          assertPlan(session, metadata, costCalculator, new Plan(actual, types, planNodeCosts), ruleApplication.lookup, pattern);
+          return null;
+      });
+  }
 
-    private RuleApplication applyRule()
-    {
-        SymbolAllocator symbolAllocator = new SymbolAllocator(symbols);
-        Memo memo = new Memo(idAllocator, plan);
-        Lookup lookup = Lookup.from(memo::resolve);
-        Optional<PlanNode> result = inTransaction(session -> rule.apply(memo.getNode(memo.getRootGroup()), lookup, idAllocator, symbolAllocator, session));
+  private RuleApplication applyRule()
+  {
+      SymbolAllocator symbolAllocator = new SymbolAllocator(symbols);
+      Memo memo = new Memo(idAllocator, plan);
+      Lookup lookup = Lookup.from(memo::resolve);
 
-        return new RuleApplication(lookup, symbolAllocator.getTypes(), result);
-    }
+      if (!rule.getPattern().matches(plan)) {
+          return new RuleApplication(lookup, symbolAllocator.getTypes(), Optional.empty());
+      }
 
-    private String formatPlan(PlanNode plan, Map<Symbol, Type> types)
-    {
-        return inTransaction(session -> PlanPrinter.textLogicalPlan(plan, types, metadata, costCalculator, session, 2));
-    }
+      Optional<PlanNode> result = inTransaction(session -> rule.apply(memo.getNode(memo.getRootGroup()), lookup, idAllocator, symbolAllocator, session));
 
-    private <T> T inTransaction(Function<Session, T> transactionSessionConsumer)
-    {
-        return transaction(transactionManager, accessControl)
-                .singleStatement()
-                .execute(session, session -> {
-                    // metadata.getCatalogHandle() registers the catalog for the transaction
-                    session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
-                    return transactionSessionConsumer.apply(session);
-                });
-    }
+      return new RuleApplication(lookup, symbolAllocator.getTypes(), result);
+  }
 
-    private static class RuleApplication
-    {
-        private final Lookup lookup;
-        private final Map<Symbol, Type> types;
-        private final Optional<PlanNode> result;
+  private String formatPlan(PlanNode plan, Map<Symbol, Type> types)
+  {
+      return inTransaction(session -> PlanPrinter.textLogicalPlan(plan, types, metadata, costCalculator, session, 2));
+  }
 
-        public RuleApplication(Lookup lookup, Map<Symbol, Type> types, Optional<PlanNode> result)
+  private <T> T inTransaction(Function<Session, T> transactionSessionConsumer)
+  {
+      return transaction(transactionManager, accessControl)
+              .singleStatement()
+              .execute(session, session -> {
+                  // metadata.getCatalogHandle() registers the catalog for the transaction
+                  session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
+                  return transactionSessionConsumer.apply(session);
+              });
+  }
+
+  private static class RuleApplication
+  {
+      private final Lookup lookup;
+      private final Map<Symbol, Type> types;
+      private final Optional<PlanNode> result;
+
+      public RuleApplication(Lookup lookup, Map<Symbol, Type> types, Optional<PlanNode> result)
         {
             this.lookup = requireNonNull(lookup, "lookup is null");
             this.types = requireNonNull(types, "types is null");


### PR DESCRIPTION
Simple PlanNode matching in IterativeOptimizer

This simple PlanNode class based pattern matching.
This might be a trow-away code once the more sophisticated pattern
matching get in.

Even though it is very simple it has a value as it filter outs many
rules which have no chance to to match given plan node.
