### PR TITLE
Make FloatingPointBitsConverterUtil public

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileAggregations.java
@@ -23,11 +23,11 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.stats.QuantileDigest;
 
-import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.doubleToSortableLong;
-import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.sortableLongToDouble;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.util.Failures.checkCondition;
+import static com.facebook.presto.util.FloatingPointBitsConverterUtil.doubleToSortableLong;
+import static com.facebook.presto.util.FloatingPointBitsConverterUtil.sortableLongToDouble;
 import static com.google.common.base.Preconditions.checkState;
 
 @AggregationFunction("approx_percentile")

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
@@ -26,9 +26,9 @@ import io.airlift.stats.QuantileDigest;
 
 import java.util.List;
 
-import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.doubleToSortableLong;
-import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.sortableLongToDouble;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.util.FloatingPointBitsConverterUtil.doubleToSortableLong;
+import static com.facebook.presto.util.FloatingPointBitsConverterUtil.sortableLongToDouble;
 
 @AggregationFunction("approx_percentile")
 public final class ApproximateDoublePercentileArrayAggregations

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileAggregations.java
@@ -23,11 +23,11 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.stats.QuantileDigest;
 
-import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.floatToSortableInt;
-import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.sortableIntToFloat;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.util.Failures.checkCondition;
+import static com.facebook.presto.util.FloatingPointBitsConverterUtil.floatToSortableInt;
+import static com.facebook.presto.util.FloatingPointBitsConverterUtil.sortableIntToFloat;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileArrayAggregations.java
@@ -26,9 +26,9 @@ import io.airlift.stats.QuantileDigest;
 
 import java.util.List;
 
-import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.floatToSortableInt;
-import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.sortableIntToFloat;
 import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.util.FloatingPointBitsConverterUtil.floatToSortableInt;
+import static com.facebook.presto.util.FloatingPointBitsConverterUtil.sortableIntToFloat;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 

--- a/presto-main/src/main/java/com/facebook/presto/util/FloatingPointBitsConverterUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/FloatingPointBitsConverterUtil.java
@@ -11,9 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.operator.aggregation;
+package com.facebook.presto.util;
 
-final class FloatingPointBitsConverterUtil
+public final class FloatingPointBitsConverterUtil
 {
     private FloatingPointBitsConverterUtil() {}
 


### PR DESCRIPTION
Make FloatingPointBitsConverterUtil public so that other modules (for example presto-facebook sharded mysql project) can reuse this utility. 