### PR TITLE
Fix final query info not set for data definition queries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -193,7 +193,11 @@ public class DataDefinitionExecution<T extends Statement>
     @Override
     public QueryInfo getQueryInfo()
     {
-        return stateMachine.getQueryInfoWithoutDetails();
+        Optional<QueryInfo> finalQueryInfo = stateMachine.getFinalQueryInfo();
+        if (finalQueryInfo.isPresent()) {
+            return finalQueryInfo.get();
+        }
+        return stateMachine.updateQueryInfo(Optional.empty());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -44,7 +44,7 @@ public class FailedQueryExecution
         this.session = requireNonNull(session, "session is null");
         this.executor = requireNonNull(executor, "executor is null");
         QueryStateMachine queryStateMachine = QueryStateMachine.failed(queryId, query, session, self, transactionManager, executor, metadata, cause);
-        queryInfo = queryStateMachine.getQueryInfo(Optional.empty());
+        queryInfo = queryStateMachine.updateQueryInfo(Optional.empty());
         this.resourceGroup = requireNonNull(resourceGroup, "resourceGroup is null");
     }
 


### PR DESCRIPTION
This is built on top of @highker's work in #7337.