### PR TITLE
Add comparison operators to row type

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -234,7 +234,11 @@ import static com.facebook.presto.operator.scalar.Re2JCastToRegexpFunction.castC
 import static com.facebook.presto.operator.scalar.Re2JCastToRegexpFunction.castVarcharToRe2JRegexp;
 import static com.facebook.presto.operator.scalar.RowDistinctFromOperator.ROW_DISTINCT_FROM;
 import static com.facebook.presto.operator.scalar.RowEqualOperator.ROW_EQUAL;
+import static com.facebook.presto.operator.scalar.RowGreaterThanOperator.ROW_GREATER_THAN;
+import static com.facebook.presto.operator.scalar.RowGreaterThanOrEqualOperator.ROW_GREATER_THAN_OR_EQUAL;
 import static com.facebook.presto.operator.scalar.RowHashCodeOperator.ROW_HASH_CODE;
+import static com.facebook.presto.operator.scalar.RowLessThanOperator.ROW_LESS_THAN;
+import static com.facebook.presto.operator.scalar.RowLessThanOrEqualOperator.ROW_LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.operator.scalar.RowNotEqualOperator.ROW_NOT_EQUAL;
 import static com.facebook.presto.operator.scalar.RowToJsonCast.ROW_TO_JSON;
 import static com.facebook.presto.operator.scalar.RowToRowCast.ROW_TO_ROW_CAST;
@@ -539,7 +543,7 @@ public class FunctionRegistry
                 .functions(MAX_BY, MIN_BY, MAX_BY_N_AGGREGATION, MIN_BY_N_AGGREGATION)
                 .functions(MAX_AGGREGATION, MIN_AGGREGATION, MAX_N_AGGREGATION, MIN_N_AGGREGATION)
                 .function(COUNT_COLUMN)
-                .functions(ROW_HASH_CODE, ROW_TO_JSON, ROW_DISTINCT_FROM, ROW_EQUAL, ROW_NOT_EQUAL, ROW_TO_ROW_CAST)
+                .functions(ROW_HASH_CODE, ROW_TO_JSON, ROW_DISTINCT_FROM, ROW_EQUAL, ROW_GREATER_THAN, ROW_GREATER_THAN_OR_EQUAL, ROW_LESS_THAN, ROW_LESS_THAN_OR_EQUAL, ROW_NOT_EQUAL, ROW_TO_ROW_CAST)
                 .function(CONCAT)
                 .function(DECIMAL_TO_DECIMAL_CAST)
                 .function(castVarcharToRe2JRegexp(featuresConfig.getRe2JDfaStatesLimit(), featuresConfig.getRe2JDfaRetries()))

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
@@ -215,6 +215,11 @@ public final class Signature
         return new TypeVariableConstraint(name, true, false, null);
     }
 
+    public static TypeVariableConstraint orderableWithVariadicBound(String name, String variadicBound)
+    {
+        return new TypeVariableConstraint(name, false, true, variadicBound);
+    }
+
     public static TypeVariableConstraint orderableTypeParameter(String name)
     {
         return new TypeVariableConstraint(name, false, true, null);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowComparisonOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowComparisonOperator.java
@@ -1,0 +1,88 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.metadata.SqlOperator;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.RowType;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.metadata.Signature.orderableWithVariadicBound;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
+import static com.facebook.presto.type.TypeUtils.checkElementNotNull;
+
+public abstract class RowComparisonOperator
+        extends SqlOperator
+{
+    protected RowComparisonOperator(OperatorType operatorType)
+    {
+        super(operatorType,
+                ImmutableList.of(orderableWithVariadicBound("T", StandardTypes.ROW)),
+                ImmutableList.of(),
+                parseTypeSignature(StandardTypes.BOOLEAN),
+                ImmutableList.of(parseTypeSignature("T"), parseTypeSignature("T")));
+    }
+
+    protected List<MethodHandle> getMethodHandles(RowType type, FunctionRegistry functionRegistry, OperatorType operatorType)
+    {
+        ImmutableList.Builder<MethodHandle> argumentMethods = ImmutableList.builder();
+        for (Type parameterType : type.getTypeParameters()) {
+            Signature signature = functionRegistry.resolveOperator(operatorType, ImmutableList.of(parameterType, parameterType));
+            argumentMethods.add(functionRegistry.getScalarFunctionImplementation(signature).getMethodHandle());
+        }
+        return argumentMethods.build();
+    }
+
+    protected static int compare(
+            RowType rowType,
+            List<MethodHandle> comparisonFunctions,
+            Block leftRow,
+            Block rightRow)
+    {
+        for (int i = 0; i < leftRow.getPositionCount(); i++) {
+            checkElementNotNull(leftRow.isNull(i), "null value at position " + i);
+            checkElementNotNull(rightRow.isNull(i), "null value at position " + i);
+            Type type = rowType.getTypeParameters().get(i);
+            Object leftElement = readNativeValue(type, leftRow, i);
+            Object rightElement = readNativeValue(type, rightRow, i);
+            try {
+                if ((boolean) comparisonFunctions.get(i).invoke(leftElement, rightElement)) {
+                    return 1;
+                }
+                if ((boolean) comparisonFunctions.get(i).invoke(rightElement, leftElement)) {
+                    return -1;
+                }
+            }
+            catch (Throwable t) {
+                Throwables.propagateIfInstanceOf(t, Error.class);
+                Throwables.propagateIfInstanceOf(t, PrestoException.class);
+
+                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            }
+        }
+        return 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowGreaterThanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowGreaterThanOperator.java
@@ -1,0 +1,60 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.RowType;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public final class RowGreaterThanOperator
+        extends RowComparisonOperator
+{
+    public static final RowGreaterThanOperator ROW_GREATER_THAN = new RowGreaterThanOperator();
+    private static final MethodHandle METHOD_HANDLE = methodHandle(RowGreaterThanOperator.class, "greater", RowType.class, List.class, Block.class, Block.class);
+
+    private RowGreaterThanOperator()
+    {
+        super(GREATER_THAN);
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type type = boundVariables.getTypeVariable("T");
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(false, false),
+                METHOD_HANDLE.bindTo(type).bindTo(getMethodHandles((RowType) type, functionRegistry, GREATER_THAN)),
+                isDeterministic());
+    }
+
+    public static boolean greater(
+            RowType rowType,
+            List<MethodHandle> lessThanFunctions,
+            Block leftRow, Block rightRow)
+    {
+        int compareResult = compare(rowType, lessThanFunctions, leftRow, rightRow);
+        return compareResult > 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowGreaterThanOrEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowGreaterThanOrEqualOperator.java
@@ -1,0 +1,61 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.RowType;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public final class RowGreaterThanOrEqualOperator
+        extends RowComparisonOperator
+{
+    public static final RowGreaterThanOrEqualOperator ROW_GREATER_THAN_OR_EQUAL = new RowGreaterThanOrEqualOperator();
+    private static final MethodHandle METHOD_HANDLE = methodHandle(RowGreaterThanOrEqualOperator.class, "greaterOrEqual", RowType.class, List.class, Block.class, Block.class);
+
+    private RowGreaterThanOrEqualOperator()
+    {
+        super(GREATER_THAN_OR_EQUAL);
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type type = boundVariables.getTypeVariable("T");
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(false, false),
+                METHOD_HANDLE.bindTo(type).bindTo(getMethodHandles((RowType) type, functionRegistry, GREATER_THAN)),
+                isDeterministic());
+    }
+
+    public static boolean greaterOrEqual(
+            RowType rowType,
+            List<MethodHandle> lessThanFunctions,
+            Block leftRow, Block rightRow)
+    {
+        int compareResult = compare(rowType, lessThanFunctions, leftRow, rightRow);
+        return compareResult >= 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowLessThanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowLessThanOperator.java
@@ -1,0 +1,60 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.RowType;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public final class RowLessThanOperator
+        extends RowComparisonOperator
+{
+    public static final RowLessThanOperator ROW_LESS_THAN = new RowLessThanOperator();
+    private static final MethodHandle METHOD_HANDLE = methodHandle(RowLessThanOperator.class, "less", RowType.class, List.class, Block.class, Block.class);
+
+    private RowLessThanOperator()
+    {
+        super(LESS_THAN);
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type type = boundVariables.getTypeVariable("T");
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(false, false),
+                METHOD_HANDLE.bindTo(type).bindTo(getMethodHandles((RowType) type, functionRegistry, LESS_THAN)),
+                isDeterministic());
+    }
+
+    public static boolean less(
+            RowType rowType,
+            List<MethodHandle> lessThanFunctions,
+            Block leftRow, Block rightRow)
+    {
+        int compareResult = compare(rowType, lessThanFunctions, leftRow, rightRow);
+        return compareResult > 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowLessThanOrEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowLessThanOrEqualOperator.java
@@ -1,0 +1,61 @@
+package com.facebook.presto.operator.scalar;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.RowType;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public final class RowLessThanOrEqualOperator
+        extends RowComparisonOperator
+{
+    public static final RowLessThanOrEqualOperator ROW_LESS_THAN_OR_EQUAL = new RowLessThanOrEqualOperator();
+    private static final MethodHandle METHOD_HANDLE = methodHandle(RowLessThanOrEqualOperator.class, "lessOrEqual", RowType.class, List.class, Block.class, Block.class);
+
+    private RowLessThanOrEqualOperator()
+    {
+        super(LESS_THAN_OR_EQUAL);
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type type = boundVariables.getTypeVariable("T");
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(false, false),
+                METHOD_HANDLE.bindTo(type).bindTo(getMethodHandles((RowType) type, functionRegistry, LESS_THAN)),
+                isDeterministic());
+    }
+
+    public static boolean lessOrEqual(
+            RowType rowType,
+            List<MethodHandle> lessThanFunctions,
+            Block leftRow, Block rightRow)
+    {
+        int compareResult = compare(rowType, lessThanFunctions, leftRow, rightRow);
+        return compareResult >= 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/RowType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RowType.java
@@ -181,6 +181,12 @@ public class RowType
     }
 
     @Override
+    public boolean isOrderable()
+    {
+        return fields.stream().allMatch(field -> field.getType().isOrderable());
+    }
+
+    @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
         Block leftRow = leftBlock.getObject(leftPosition, Block.class);
@@ -196,6 +202,28 @@ public class RowType
         }
 
         return true;
+    }
+
+    @Override
+    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        Block leftRow = leftBlock.getObject(leftPosition, Block.class);
+        Block rightRow = rightBlock.getObject(rightPosition, Block.class);
+
+        for (int i = 0; i < leftRow.getPositionCount(); i++) {
+            checkElementNotNull(leftRow.isNull(i));
+            checkElementNotNull(rightRow.isNull(i));
+            Type fieldType = fields.get(i).getType();
+            if (!fieldType.isOrderable()) {
+                throw new UnsupportedOperationException(fieldType.getTypeSignature() + " type is not orderable");
+            }
+            int compareResult = fieldType.compareTo(leftRow, i, rightRow, i);
+            if (compareResult != 0) {
+                return compareResult;
+            }
+        }
+
+        return 0;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -79,6 +79,17 @@ public abstract class AbstractTestFunctions
                 expectedResult);
     }
 
+    protected void assertInvalidFunction(String projection)
+    {
+        try {
+            evaluateInvalid(projection);
+            fail("Expected to fail");
+        }
+        catch (RuntimeException e) {
+            // Expected
+        }
+    }
+
     protected void assertInvalidFunction(String projection, String message)
     {
         try {
@@ -99,6 +110,18 @@ public abstract class AbstractTestFunctions
         }
         catch (SemanticException e) {
             assertEquals(e.getCode(), expectedErrorCode);
+        }
+    }
+
+    protected void assertInvalidFunction(String projection, SemanticErrorCode expectedErrorCode, String message)
+    {
+        try {
+            evaluateInvalid(projection);
+            fail(format("Expected to throw %s exception", expectedErrorCode));
+        }
+        catch (SemanticException e) {
+            assertEquals(e.getCode(), expectedErrorCode);
+            assertEquals(e.getMessage(), message);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -23,11 +23,14 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.SemanticErrorCode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
@@ -148,46 +151,41 @@ public class TestRowOperators
     }
 
     @Test
-    public void testRowEquality()
+    public void testRowComparison()
             throws Exception
     {
-        assertFunction("row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10') = " +
-                "row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10')", BOOLEAN, true);
-        assertFunction("row(1.0, row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10')) =" +
-                "row(1.0, row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10'))", BOOLEAN, true);
-        assertFunction("row(1.0, 'kittens') = row(1.0, 'kittens')", BOOLEAN, true);
-        assertFunction("row(1, 2.0) = row(1, 2.0)", BOOLEAN, true);
-        assertFunction("row(TRUE, FALSE, TRUE, FALSE) = row(TRUE, FALSE, TRUE, FALSE)", BOOLEAN, true);
-        assertFunction("row(TRUE, FALSE, TRUE, FALSE) = row(TRUE, TRUE, TRUE, FALSE)", BOOLEAN, false);
-        assertFunction("row(1, 2.0, TRUE, 'kittens', from_unixtime(1)) = row(1, 2.0, TRUE, 'kittens', from_unixtime(1))", BOOLEAN, true);
+        assertFunction("row(TIMESTAMP '2002-01-02 03:04:05.321 +08:10', TIMESTAMP '2002-01-02 03:04:05.321 +08:10') = " +
+                "row(TIMESTAMP '2002-01-02 02:04:05.321 +07:10', TIMESTAMP '2002-01-02 03:05:05.321 +08:11')", BOOLEAN, true);
+        assertFunction("row(1.0, row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10')) = " +
+                "row(1.0, row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:11'))", BOOLEAN, false);
 
-        assertFunction("row(1.0, row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10')) !=" +
-                "row(1.0, row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:11'))", BOOLEAN, true);
-        assertFunction("row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10') != " +
-                "row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:11')", BOOLEAN, true);
-        assertFunction("row(1.0, 'kittens') != row(1.0, 'kittens')", BOOLEAN, false);
-        assertFunction("row(1, 2.0) != row(1, 2.0)", BOOLEAN, false);
-        assertFunction("row(TRUE, FALSE, TRUE, FALSE) != row(TRUE, FALSE, TRUE, FALSE)", BOOLEAN, false);
-        assertFunction("row(TRUE, FALSE, TRUE, FALSE) != row(TRUE, TRUE, TRUE, FALSE)", BOOLEAN, true);
-        assertFunction("row(1, 2.0, TRUE, 'kittens', from_unixtime(1)) != row(1, 2.0, TRUE, 'puppies', from_unixtime(1))", BOOLEAN, true);
+        assertComparisonCombination("row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10')",
+                "row(TIMESTAMP '2002-01-02 03:04:05.321 +07:09', TIMESTAMP '2002-01-02 03:04:05.321 +07:09')");
+        assertComparisonCombination("row(1.0, row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10'))",
+                "row(2.0, row(TIMESTAMP '2001-01-02 03:04:05.321 +07:09', TIMESTAMP '2001-01-02 03:04:05.321 +07:10'))");
+
+        assertComparisonCombination("row(1.0, 'kittens')", "row(1.0, 'puppies')");
+        assertComparisonCombination("row(1, 2.0)", "row(5, 2.0)");
+        assertComparisonCombination("row(TRUE, FALSE, TRUE, FALSE)", "row(TRUE, TRUE, TRUE, FALSE)");
+        assertComparisonCombination("row(1, 2.0, TRUE, 'kittens', from_unixtime(1))", "row(1, 3.0, TRUE, 'kittens', from_unixtime(1))");
 
         assertInvalidFunction("cast(row(cast(cast ('' as varbinary) as hyperloglog)) as row(col0 hyperloglog)) = cast(row(cast(cast ('' as varbinary) as hyperloglog)) as row(col0 hyperloglog))",
                 SemanticErrorCode.TYPE_MISMATCH, "line 1:81: '=' cannot be applied to row(col0 HyperLogLog), row(col0 HyperLogLog)");
+        assertInvalidFunction("cast(row(cast(cast ('' as varbinary) as hyperloglog)) as row(col0 hyperloglog)) > cast(row(cast(cast ('' as varbinary) as hyperloglog)) as row(col0 hyperloglog))",
+                SemanticErrorCode.TYPE_MISMATCH, "line 1:81: '>' cannot be applied to row(col0 HyperLogLog), row(col0 HyperLogLog)");
 
         assertFunction("row(TRUE, ARRAY [1], MAP(ARRAY[1, 3], ARRAY[2.0, 4.0])) = row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0, 4.0]))", BOOLEAN, false);
         assertFunction("row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0, 4.0])) = row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0, 4.0]))", BOOLEAN, true);
+
         assertInvalidFunction("row(1, CAST(NULL AS INTEGER)) = row(1, 2)", StandardErrorCode.NOT_SUPPORTED);
+        assertInvalidFunction("row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0, 4.0])) > row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0, 4.0]))",
+                SemanticErrorCode.TYPE_MISMATCH, "line 1:60: '>' cannot be applied to row(field0 boolean,field1 array(integer),field2 map(integer,double)), row(field0 boolean,field1 array(integer),field2 map(integer,double))");
 
-        assertFunction("row(TRUE, ARRAY [1]) = row(TRUE, ARRAY [1])", BOOLEAN, true);
-        assertFunction("row(TRUE, ARRAY [1]) = row(TRUE, ARRAY [1,2])", BOOLEAN, false);
-        assertFunction("row(1.0, ARRAY [1,2,3], row(2,2.0)) = row(1.0, ARRAY [1,2,3], row(2,2.0))", BOOLEAN, true);
+        assertInvalidFunction("row(1, CAST(NULL AS INTEGER)) < row(1, 2)", StandardErrorCode.NOT_SUPPORTED);
 
-        assertFunction("row(TRUE, ARRAY [1]) != row(TRUE, ARRAY [1])", BOOLEAN, false);
-        assertFunction("row(TRUE, ARRAY [1]) != row(TRUE, ARRAY [1,2])", BOOLEAN, true);
-        assertFunction("row(1.0, ARRAY [1,2,3], row(2,2.0)) != row(1.0, ARRAY [1,2,3], row(1,2.0))", BOOLEAN, true);
-
-        assertFunction("ROW(1, 2) = ROW(1, 2)", BOOLEAN, true);
-        assertFunction("ROW(2, 1) != ROW(1, 2)", BOOLEAN, true);
+        assertComparisonCombination("row(1.0, ARRAY [1,2,3], row(2,2.0))", "row(1.0, ARRAY [1,3,3], row(2,2.0))");
+        assertComparisonCombination("row(TRUE, ARRAY [1])", "row(TRUE, ARRAY [1, 2])");
+        assertComparisonCombination("ROW(1, 2)", "ROW(2, 1)");
     }
 
     @Test
@@ -209,5 +207,17 @@ public class TestRowOperators
         rowType.writeObject(rowArrayBuilder, rowBuilder.build());
 
         assertOperator(HASH_CODE, inputString, BIGINT, rowType.hash(rowArrayBuilder.build(), 0));
+    }
+
+    private void assertComparisonCombination(String base, String greater)
+    {
+        Set<String> equalOperators = new HashSet<>(ImmutableSet.of("=", ">=", "<="));
+        Set<String> greaterOrInequalityOperators = new HashSet<>(ImmutableSet.of(">=", ">", "!="));
+        Set<String> lessOrInequalityOperators = new HashSet<>(ImmutableSet.of("<=", "<", "!="));
+        for (String operator : ImmutableList.of(">", "=", "<", ">=", "<=", "!=")) {
+            assertFunction(base + operator + base, BOOLEAN, equalOperators.contains(operator));
+            assertFunction(base + operator + greater, BOOLEAN, lessOrInequalityOperators.contains(operator));
+            assertFunction(greater + operator + base, BOOLEAN, greaterOrInequalityOperators.contains(operator));
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestSimpleRowType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestSimpleRowType.java
@@ -63,6 +63,15 @@ public class TestSimpleRowType
     @Override
     protected Object getGreaterValue(Object value)
     {
-        throw new UnsupportedOperationException();
+        ArrayBlockBuilder blockBuilder = (ArrayBlockBuilder) TYPE.createBlockBuilder(new BlockBuilderStatus(), 1);
+        ArrayElementBlockWriter arrayElementBlockWriter;
+
+        Block block = (Block) value;
+        arrayElementBlockWriter = blockBuilder.beginBlockEntry();
+        BIGINT.writeLong(arrayElementBlockWriter, block.getSingleValueBlock(0).getLong(0, 0) + 1);
+        VARCHAR.writeSlice(arrayElementBlockWriter, block.getSingleValueBlock(1).getSlice(0, 0, 1));
+        blockBuilder.closeEntry();
+
+        return TYPE.getObject(blockBuilder.build(), 0);
     }
 }


### PR DESCRIPTION
Row types now have the capability of comparing. This includes operstors '>', '>=', '<', and '<='.
The comparison starts with the first element of the row to the last one. All elements in a row
should be orderable in order to compare.