### PR TITLE
Check if second run of rule is not fired

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeFilters.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeFilters.java
@@ -32,6 +32,7 @@ public class TestMergeFilters
                         p.filter(expression("b > 44"),
                                 p.filter(expression("a < 42"),
                                         p.values(p.symbol("a", BIGINT), p.symbol("b", BIGINT)))))
+                .isFiredOnlyOnceAndThen()
                 .matches(filter("(a < 42) AND (b > 44)", values(ImmutableMap.of("a", 0, "b", 1))));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformExistsApplyToScalarApply.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformExistsApplyToScalarApply.java
@@ -92,6 +92,7 @@ public class TestTransformExistsApplyToScalarApply
                                 p.values(),
                                 p.values(p.symbol("a", BIGINT)))
                 )
+                .isFiredOnlyOnceAndThen()
                 .matches(apply(
                         ImmutableList.of(),
                         ImmutableMap.of("b", PlanMatchPattern.expression("\"b\"")),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestEvaluateZeroLimit.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestEvaluateZeroLimit.java
@@ -54,6 +54,7 @@ public class TestEvaluateZeroLimit
                                                 ImmutableList.of(
                                                         expressions("1", "10"),
                                                         expressions("2", "11"))))))
+                .isFiredOnlyOnceAndThen()
                 // TODO: verify contents
                 .matches(values(ImmutableMap.of()));
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestEvaluateZeroSample.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestEvaluateZeroSample.java
@@ -57,6 +57,7 @@ public class TestEvaluateZeroSample
                                                 ImmutableList.of(
                                                         expressions("1", "10"),
                                                         expressions("2", "11"))))))
+                .isFiredOnlyOnceAndThen()
                 // TODO: verify contents
                 .matches(values(ImmutableMap.of()));
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestRemoveFullSample.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestRemoveFullSample.java
@@ -58,6 +58,7 @@ public class TestRemoveFullSample
                                                 ImmutableList.of(
                                                         expressions("1", "10"),
                                                         expressions("2", "11"))))))
+                .isFiredOnlyOnceAndThen()
                 // TODO: verify contents
                 .matches(filter("b > 5", values(ImmutableMap.of("a", 0, "b", 1))));
     }


### PR DESCRIPTION
Check if second run of rule is not fired

It seems natural that optimizer Rule if run on output of the same Rule
should not fire again.
While we may think of rules that do only part of work on first run, and
some continuation of work on the second run, it does not seem like
necessary feature.
