### PR TITLE
Add additional statistics for WindowOperator in Explain Analyze

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorInfo.java
@@ -15,6 +15,7 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.operator.PartitionedOutputOperator.PartitionedOutputInfo;
+import com.facebook.presto.operator.WindowOperator.WindowInfo;
 import com.facebook.presto.operator.exchange.LocalExchangeBufferInfo;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -29,7 +30,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = TableFinishInfo.class, name = "tableFinish"),
         @JsonSubTypes.Type(value = SplitOperatorInfo.class, name = "splitOperator"),
         @JsonSubTypes.Type(value = HashCollisionsInfo.class, name = "hashCollisionsInfo"),
-        @JsonSubTypes.Type(value = PartitionedOutputInfo.class, name = "partitionedOutput")
+        @JsonSubTypes.Type(value = PartitionedOutputInfo.class, name = "partitionedOutput"),
+        @JsonSubTypes.Type(value = WindowInfo.class, name = "windowInfo")
 })
 public interface OperatorInfo
 {

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
@@ -634,5 +634,10 @@ public class WindowOperator
         {
             return partitions;
         }
+
+        public long getTotalRowCountInPartitions()
+        {
+            return partitions.stream().mapToInt(Integer::intValue).sum();
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/WindowPartition.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/WindowPartition.java
@@ -71,6 +71,11 @@ public final class WindowPartition
         updatePeerGroup();
     }
 
+    public int getPartitionStart()
+    {
+        return partitionStart;
+    }
+
     public int getPartitionEnd()
     {
         return partitionEnd;


### PR DESCRIPTION
In order to determine the cause of slow execution of queries extensively using window functions, we need additional statistics.
I.e. we want to know what was the size of the index, how many times it had to be rebuilt, how many partitions were processed and by what drivers (was there any skew etc.?).