### PR TITLE
Remove running split info before a split is set to finished

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskExecutor.java
@@ -693,18 +693,16 @@ public class TaskExecutor
                         runningSplitInfos.add(splitInfo);
                         runningSplits.add(split);
 
-                        boolean finished;
                         ListenableFuture<?> blocked;
                         try {
                             blocked = split.process();
-                            finished = split.isFinished();
                         }
                         finally {
                             runningSplitInfos.remove(splitInfo);
                             runningSplits.remove(split);
                         }
 
-                        if (finished) {
+                        if (split.isFinished()) {
                             log.debug("%s is finished", split.getInfo());
                             splitFinished(split);
                         }


### PR DESCRIPTION
ListenableFuture::get is listening on the finish of split. If a running
split info is removed after it has been set to finished, There may still
have remaining running split info alive. This can fail the unit test due
to race.