### PR TITLE
Remove isFinished check for updating quanta stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskExecutor.java
@@ -59,6 +59,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.function.DoubleSupplier;
 
+import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -594,16 +595,13 @@ public class TaskExecutor
                 priorityLevel.set(calculatePriorityLevel(threadUsageNanos));
 
                 long durationMicros = elapsed.getWall().roundTo(MICROSECONDS);
+                overallQuantaWallTime.add(durationMicros, MICROSECONDS);
 
-                if (!split.isFinished()) {
-                    overallQuantaWallTime.add(durationMicros, MICROSECONDS);
-
-                    if (blocked.isDone()) {
-                        blockedQuantaWallTime.add(durationMicros, MICROSECONDS);
-                    }
-                    else {
-                        unblockedQuantaWallTime.add(durationMicros, MICROSECONDS);
-                    }
+                if (blocked == NOT_BLOCKED) {
+                    unblockedQuantaWallTime.add(durationMicros, MICROSECONDS);
+                }
+                else {
+                    blockedQuantaWallTime.add(durationMicros, MICROSECONDS);
                 }
 
                 // record last run for prioritization within a level


### PR DESCRIPTION
The check does not appear to have any material effect on the reported
results, and has unintended side effects (including test failures).