### PR TITLE
Fix generated class names

### DIFF
--- a/presto-bytecode/src/main/java/com/facebook/presto/bytecode/CompilerUtils.java
+++ b/presto-bytecode/src/main/java/com/facebook/presto/bytecode/CompilerUtils.java
@@ -55,9 +55,9 @@ public final class CompilerUtils
 
     public static ParameterizedType makeClassName(String baseName)
     {
-        String className = "com.facebook.presto.$gen." + baseName + "_" + CLASS_ID.incrementAndGet();
+        String className = baseName + "_" + CLASS_ID.incrementAndGet();
         String javaClassName = toJavaIdentifierString(className);
-        return ParameterizedType.typeFromJavaClassName(javaClassName);
+        return ParameterizedType.typeFromJavaClassName("com.facebook.presto.$gen." + javaClassName);
     }
 
     public static String toJavaIdentifierString(String className)


### PR DESCRIPTION
Right now the bytecode module generates classnames that look like `com_facebook_presto_$gen_PageProcessor_28` with no package name. It's annoying when you're trying to profile the code with VisualVM or the like and you want to filter on package name.

This PR fixes the use of `toJavaIndentifierString` so that generated classes are in the `com.facebook.presto.$gen` package. Instead of `com_facebook_presto_$gen_PageProcessor_28`, you get `com.facebook.presto.$gen.PageProcessor_28`