### PR TITLE
Enforce single-threaded run of TestMetadataManager

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
@@ -27,6 +27,7 @@ import static org.testng.Assert.assertEquals;
  * while registering catalog -> query Id mapping.
  * This mapping has to be manually cleaned when query finishes execution (Metadata#cleanupQuery method).
  */
+@Test(singleThreaded = true)
 public class TestMetadataManager
 {
     private final QueryRunner queryRunner;


### PR DESCRIPTION
`MetadataManager.getCatalogsByQueryId` is not synchronized,
therefore in some environments where tests are executed concurrently,
it may cause false negatives.

When `TestMetadataManager.testMetadataIsClearedAfterQueryFinished` is executed concurrently
with `TestMetadataManager.testMetadataIsClearedAfterQueryFailed`, it's possible that the first finishes a query
and clears the `MetadataManager.catalogsByQueryId` map as expected but before hitting `assertEquals` check,
the second test starts executing query (but has not gotten to the clean-up phase yet),
making first test see non-empty `catalogsByQueryId` map.

It's not worth to synchronize `MetadataManager.catalogsByQueryId` because it's used only in testing,
therefore it's better to enforce single-threaded execution of tests
instead of sacrificing performance of regular execution of `MetadataManager`.

TestNG 5.1 introduces class-level annotation `@Test(sequential = true)`,
enforcing execution of tests of such class by single thread.

---

This should fix #7379.