### PR TITLE
Reduce presto main tests memory usage

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -338,6 +338,16 @@
                      </ignorePackages>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- these tests take a very long time so only run them in the CI server -->
+                    <excludes>
+                        <exclude>**/TestLocalExecutionPlanner.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -367,6 +377,20 @@
                                 <argument>com.facebook.presto.benchmark.BenchmarkSuite</argument>
                             </arguments>
                             <classpathScope>test</classpathScope>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>ci</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.self="override"/>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -419,6 +419,11 @@ public class LocalQueryRunner
         return defaultSession;
     }
 
+    public ExpressionCompiler getExpressionCompiler()
+    {
+        return expressionCompiler;
+    }
+
     public void createCatalog(String catalogName, ConnectorFactory connectorFactory, Map<String, String> properties)
     {
         nodeManager.addCurrentNodeConnector(new ConnectorId(catalogName));

--- a/presto-main/src/test/java/com/facebook/presto/TestHiddenColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/TestHiddenColumns.java
@@ -18,6 +18,7 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tpch.TpchConnectorFactory;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
@@ -28,17 +29,20 @@ public class TestHiddenColumns
 {
     private LocalQueryRunner runner;
 
-    public TestHiddenColumns()
+    @BeforeClass
+    public void setUp()
+            throws Exception
     {
         runner = new LocalQueryRunner(TEST_SESSION);
         runner.createCatalog(TEST_SESSION.getCatalog().get(), new TpchConnectorFactory(1), ImmutableMap.of());
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void destroy()
     {
         if (runner != null) {
             runner.close();
+            runner = null;
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
@@ -95,6 +95,8 @@ public class TestMemoryPools
             // query should not block
             assertTrue(progress);
         } while (!drivers.stream().allMatch(Driver::isFinished));
+
+        localQueryRunner.close();
     }
 
     public static boolean isWaitingForMemory(List<Driver> drivers)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestRealAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestRealAverageAggregation.java
@@ -23,7 +23,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -40,7 +40,7 @@ public class TestRealAverageAggregation
 {
     private InternalAggregationFunction avgFunction;
 
-    @BeforeMethod
+    @BeforeClass
     public void setUp()
     {
         MetadataManager metadata = MetadataManager.createTestMetadataManager();

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
@@ -27,6 +27,8 @@ import com.facebook.presto.sql.analyzer.TypeSignatureProvider;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.Lists;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -36,8 +38,22 @@ import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypeSig
 
 public abstract class AbstractTestAggregationFunction
 {
-    protected final TypeRegistry typeRegistry = new TypeRegistry();
-    protected final FunctionRegistry functionRegistry = new FunctionRegistry(typeRegistry, new BlockEncodingManager(typeRegistry), new FeaturesConfig());
+    protected TypeRegistry typeRegistry;
+    protected FunctionRegistry functionRegistry;
+
+    @BeforeClass
+    public final void initTestAggregationFunction()
+    {
+        typeRegistry = new TypeRegistry();
+        functionRegistry = new FunctionRegistry(typeRegistry, new BlockEncodingManager(typeRegistry), new FeaturesConfig());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroyTestAggregationFunction()
+    {
+        functionRegistry = null;
+        typeRegistry = null;
+    }
 
     public abstract Block[] getSequenceBlocks(int start, int length);
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/index/TestFieldSetFilteringRecordSet.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/index/TestFieldSetFilteringRecordSet.java
@@ -34,15 +34,15 @@ import static org.testng.Assert.assertTrue;
 
 public class TestFieldSetFilteringRecordSet
 {
-    private static final TypeManager TYPE_MANAGER = new TypeRegistry();
-    private static final FunctionRegistry FUNCTION_REGISTRY = new FunctionRegistry(TYPE_MANAGER, new BlockEncodingManager(TYPE_MANAGER), new FeaturesConfig());
-
     @Test
     public void test()
     {
+        TypeManager typeManager = new TypeRegistry();
+        FunctionRegistry functionRegistry = new FunctionRegistry(typeManager, new BlockEncodingManager(typeManager), new FeaturesConfig());
+
         ArrayType arrayOfBigintType = new ArrayType(BIGINT);
         FieldSetFilteringRecordSet fieldSetFilteringRecordSet = new FieldSetFilteringRecordSet(
-                FUNCTION_REGISTRY,
+                functionRegistry,
                 new InMemoryRecordSet(
                         ImmutableList.of(BIGINT, BIGINT, TIMESTAMP_WITH_TIME_ZONE, TIMESTAMP_WITH_TIME_ZONE, arrayOfBigintType, arrayOfBigintType),
                         ImmutableList.of(

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -30,6 +30,8 @@ import com.facebook.presto.sql.analyzer.SemanticErrorCode;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -41,27 +43,50 @@ import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMEN
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 public abstract class AbstractTestFunctions
 {
-    protected final FunctionAssertions functionAssertions;
+    private final Session session;
+    private final FeaturesConfig config;
+    protected FunctionAssertions functionAssertions;
 
     protected AbstractTestFunctions()
     {
-        functionAssertions = new FunctionAssertions();
+        this(TEST_SESSION);
     }
 
     protected AbstractTestFunctions(Session session)
     {
-        functionAssertions = new FunctionAssertions(session);
+        this(session, new FeaturesConfig());
     }
 
-    protected AbstractTestFunctions(FeaturesConfig featuresConfig)
+    protected AbstractTestFunctions(FeaturesConfig config)
     {
-        functionAssertions = new FunctionAssertions(TEST_SESSION, featuresConfig);
+        this(TEST_SESSION, config);
+    }
+
+    protected AbstractTestFunctions(Session session, FeaturesConfig config)
+    {
+        this.session = requireNonNull(session, "session is null");
+        this.config = requireNonNull(config, "config is null");
+    }
+
+    @BeforeClass
+    public final void initTestFunctions()
+    {
+        functionAssertions = new FunctionAssertions(session, config);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroyTestFunctions()
+    {
+        closeAllRuntimeException(functionAssertions);
+        functionAssertions = null;
     }
 
     protected void assertFunction(String projection, Type expectedType, Object expected)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -197,7 +197,7 @@ public abstract class AbstractTestFunctions
         metadata.getFunctionRegistry().addFunctions(functions);
     }
 
-    protected SqlDecimal decimal(String decimalString)
+    protected static SqlDecimal decimal(String decimalString)
     {
         DecimalParseResult parseResult = Decimals.parseIncludeLeadingZerosInPrecision(decimalString);
         BigInteger unscaledValue;
@@ -210,7 +210,7 @@ public abstract class AbstractTestFunctions
         return new SqlDecimal(unscaledValue, parseResult.getType().getPrecision(), parseResult.getType().getScale());
     }
 
-    protected SqlDecimal maxPrecisionDecimal(long value)
+    protected static SqlDecimal maxPrecisionDecimal(long value)
     {
         final String maxPrecisionFormat = "%0" + (Decimals.MAX_PRECISION + (value < 0 ? 1 : 0)) + "d";
         return decimal(String.format(maxPrecisionFormat, value));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -202,7 +202,7 @@ public final class FunctionAssertions
         this.session = requireNonNull(session, "session is null");
         runner = new LocalQueryRunner(session, featuresConfig);
         metadata = runner.getMetadata();
-        compiler = new ExpressionCompiler(metadata);
+        compiler = runner.getExpressionCompiler();
     }
 
     public Metadata getMetadata()

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -75,6 +75,7 @@ import io.airlift.slice.Slices;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -120,6 +121,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public final class FunctionAssertions
+        implements Closeable
 {
     private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-%s"));
 
@@ -702,6 +704,12 @@ public final class FunctionAssertions
         assertTrue(types.size() == 1, "Expected one type, but got " + types);
         Type actualType = types.get(0);
         assertEquals(actualType, expectedType);
+    }
+
+    @Override
+    public void close()
+    {
+        runner.close();
     }
 
     private static class TestPageSourceProvider

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestCustomFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestCustomFunctions.java
@@ -13,11 +13,13 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestCustomFunctions
 {
@@ -27,6 +29,13 @@ public class TestCustomFunctions
     public void setupClass()
     {
         functionAssertions = new FunctionAssertions().addScalarFunctions(CustomFunctions.class);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(functionAssertions);
+        functionAssertions = null;
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestCustomFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestCustomFunctions.java
@@ -13,48 +13,38 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestCustomFunctions
+        extends AbstractTestFunctions
 {
-    private FunctionAssertions functionAssertions;
-
     @BeforeClass
     public void setupClass()
     {
-        functionAssertions = new FunctionAssertions().addScalarFunctions(CustomFunctions.class);
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(functionAssertions);
-        functionAssertions = null;
+        registerScalar(CustomFunctions.class);
     }
 
     @Test
     public void testCustomAdd()
     {
-        functionAssertions.assertFunction("custom_add(123, 456)", BIGINT, 579L);
+        assertFunction("custom_add(123, 456)", BIGINT, 579L);
     }
 
     @Test
     public void testSliceIsNull()
     {
-        functionAssertions.assertFunction("custom_is_null(CAST(NULL AS VARCHAR))", BOOLEAN, true);
-        functionAssertions.assertFunction("custom_is_null('not null')", BOOLEAN, false);
+        assertFunction("custom_is_null(CAST(NULL AS VARCHAR))", BOOLEAN, true);
+        assertFunction("custom_is_null('not null')", BOOLEAN, false);
     }
 
     @Test
     public void testLongIsNull()
     {
-        functionAssertions.assertFunction("custom_is_null(CAST(NULL AS BIGINT))", BOOLEAN, true);
-        functionAssertions.assertFunction("custom_is_null(0)", BOOLEAN, false);
+        assertFunction("custom_is_null(CAST(NULL AS BIGINT))", BOOLEAN, true);
+        assertFunction("custom_is_null(0)", BOOLEAN, false);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -872,6 +872,8 @@ public class TestDateTimeFunctions
         localeAssertions.assertFunction("parse_datetime('2013-05-17 12:35:10 午前', 'yyyy-MM-dd hh:mm:ss aaa')",
                 TIMESTAMP_WITH_TIME_ZONE,
                 toTimestampWithTimeZone(new DateTime(2013, 5, 17, 0, 35, 10, 0, DATE_TIME_ZONE)));
+
+        localeAssertions.close();
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestFailureFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestFailureFunction.java
@@ -38,6 +38,8 @@ public class TestFailureFunction
     {
         // The other test does not exercise this function during execution (i.e. inside a page processor).
         // It only verifies constant folding works.
-        new LocalQueryRunner(TEST_SESSION).execute("select if(x, 78, 0/0) from (values rand() >= 0, rand() < 0) t(x)");
+        try (LocalQueryRunner runner = new LocalQueryRunner(TEST_SESSION)) {
+            runner.execute("select if(x, 78, 0/0) from (values rand() >= 0, rand() < 0) t(x)");
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestIsNullAnnotation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestIsNullAnnotation.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.function.SqlNullable;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -31,7 +32,8 @@ import static io.airlift.slice.Slices.utf8Slice;
 public class TestIsNullAnnotation
         extends AbstractTestFunctions
 {
-    private TestIsNullAnnotation()
+    @BeforeClass
+    public void setUp()
     {
         registerScalar(getClass());
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestLambdaExpression.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestLambdaExpression.java
@@ -19,6 +19,7 @@ import com.facebook.presto.type.MapType;
 import com.facebook.presto.type.RowType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -47,6 +48,11 @@ public class TestLambdaExpression
     private TestLambdaExpression(Session session)
     {
         super(session);
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
         functionAssertions.getMetadata().addFunctions(ImmutableList.of(APPLY_FUNCTION, INVOKE_FUNCTION));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestRegexpFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestRegexpFunctions.java
@@ -21,6 +21,7 @@ import com.facebook.presto.type.ArrayType;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
@@ -44,14 +45,16 @@ public class TestRegexpFunctions
     private static final FeaturesConfig RE2J_FEATURES_CONFIG = new FeaturesConfig()
             .setRegexLibrary(RE2J);
 
-    {
-        registerScalar(TestRegexpFunctions.class);
-    }
-
     @Factory(dataProvider = "featuresConfig")
     public TestRegexpFunctions(FeaturesConfig featuresConfig)
     {
         super(featuresConfig);
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        registerScalar(TestRegexpFunctions.class);
     }
 
     @DataProvider(name = "featuresConfig")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -25,6 +25,7 @@ import com.facebook.presto.type.MapType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -42,7 +43,8 @@ import static java.lang.String.format;
 public class TestStringFunctions
         extends AbstractTestFunctions
 {
-    private TestStringFunctions()
+    @BeforeClass
+    public void setUp()
     {
         registerScalar(getClass());
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/AbstractTestWindowFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/AbstractTestWindowFunction.java
@@ -17,25 +17,29 @@ import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.testing.MaterializedResult;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 @Test
 public abstract class AbstractTestWindowFunction
 {
-    protected final LocalQueryRunner queryRunner;
+    protected LocalQueryRunner queryRunner;
 
-    protected AbstractTestWindowFunction()
+    @BeforeClass
+    public final void initTestWindowFunction()
     {
         queryRunner = new LocalQueryRunner(TEST_SESSION);
     }
 
-    @AfterClass
-    public void tearDown()
+    @AfterClass(alwaysRun = true)
+    public final void destroyTestWindowFunction()
     {
-        queryRunner.close();
+        closeAllRuntimeException(queryRunner);
+        queryRunner = null;
     }
 
     protected void assertWindowQuery(@Language("SQL") String sql, MaterializedResult expected)

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
@@ -32,12 +32,12 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 
 public class TestSqlToRowExpressionTranslator
 {
-    private static final TypeManager TYPE_MANAGER = new TypeRegistry();
-    private static final FunctionRegistry FUNCTION_REGISTRY = new FunctionRegistry(TYPE_MANAGER, new BlockEncodingManager(TYPE_MANAGER), new FeaturesConfig());
-
     @Test(timeOut = 10_000)
     public void testPossibleExponentialOptimizationTime()
     {
+        TypeManager typeManager = new TypeRegistry();
+        FunctionRegistry functionRegistry = new FunctionRegistry(typeManager, new BlockEncodingManager(typeManager), new FeaturesConfig());
+
         Expression expression = new LongLiteral("1");
         IdentityLinkedHashMap<Expression, Type> types = new IdentityLinkedHashMap<>();
         types.put(expression, BIGINT);
@@ -45,6 +45,6 @@ public class TestSqlToRowExpressionTranslator
             expression = new CoalesceExpression(expression);
             types.put(expression, BIGINT);
         }
-        SqlToRowExpressionTranslator.translate(expression, SCALAR, types, FUNCTION_REGISTRY, TYPE_MANAGER, TEST_SESSION, true);
+        SqlToRowExpressionTranslator.translate(expression, SCALAR, types, functionRegistry, typeManager, TEST_SESSION, true);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -84,6 +84,7 @@ import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static java.lang.Math.cos;
 import static java.lang.Runtime.getRuntime;
 import static java.lang.String.format;
@@ -167,6 +168,8 @@ public class TestExpressionCompiler
             executor.shutdownNow();
             executor = null;
         }
+        closeAllRuntimeException(functionAssertions);
+        functionAssertions = null;
     }
 
     @BeforeMethod

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestVarArgsToArrayAdapterGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestVarArgsToArrayAdapterGenerator.java
@@ -24,6 +24,7 @@ import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandle;
@@ -41,7 +42,8 @@ import static java.util.stream.Collectors.toSet;
 public class TestVarArgsToArrayAdapterGenerator
         extends AbstractTestFunctions
 {
-    public TestVarArgsToArrayAdapterGenerator()
+    @BeforeClass
+    public void setUp()
     {
         registerScalarFunction(VAR_ARGS_SUM);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
@@ -19,23 +19,31 @@ import com.facebook.presto.testing.LocalQueryRunner;
 import com.google.common.base.Joiner;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.StandardErrorCode.COMPILER_ERROR;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static java.util.Collections.nCopies;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 public class TestLocalExecutionPlanner
 {
-    @SuppressWarnings("resource")
-    private final LocalQueryRunner runner = new LocalQueryRunner(TEST_SESSION);
+    private LocalQueryRunner runner;
+
+    @BeforeClass
+    public void setUp()
+    {
+        runner = new LocalQueryRunner(TEST_SESSION);
+    }
 
     @AfterClass(alwaysRun = true)
     public void cleanup()
     {
-        runner.close();
+        closeAllRuntimeException(runner);
+        runner = null;
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeFilters.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeFilters.java
@@ -15,19 +15,37 @@ package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestMergeFilters
 {
+    private RuleTester tester;
+
+    @BeforeClass
+    public void setUp()
+    {
+        tester = new RuleTester();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(tester);
+        tester = null;
+    }
+
     @Test
     public void test()
     {
-        new RuleTester().assertThat(new MergeFilters())
+        tester.assertThat(new MergeFilters())
                 .on(p ->
                         p.filter(expression("b > 44"),
                                 p.filter(expression("a < 42"),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformExistsApplyToScalarApply.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformExistsApplyToScalarApply.java
@@ -23,6 +23,8 @@ import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -34,13 +36,28 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.limit;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestTransformExistsApplyToScalarApply
 {
-    private final RuleTester tester = new RuleTester();
     private final TypeRegistry typeManager = new TypeRegistry();
     private final FunctionRegistry registry = new FunctionRegistry(typeManager, new BlockEncodingManager(typeManager), new FeaturesConfig());
     private final Rule transformExistsApplyToScalarApply = new TransformExistsApplyToScalarApply(registry);
+
+    private RuleTester tester;
+
+    @BeforeClass
+    public void setUp()
+    {
+        tester = new RuleTester();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(tester);
+        tester = null;
+    }
 
     @Test
     public void testDoesNotFire()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformExistsApplyToScalarApply.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformExistsApplyToScalarApply.java
@@ -40,16 +40,16 @@ import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestTransformExistsApplyToScalarApply
 {
-    private final TypeRegistry typeManager = new TypeRegistry();
-    private final FunctionRegistry registry = new FunctionRegistry(typeManager, new BlockEncodingManager(typeManager), new FeaturesConfig());
-    private final Rule transformExistsApplyToScalarApply = new TransformExistsApplyToScalarApply(registry);
-
     private RuleTester tester;
+    private Rule transformExistsApplyToScalarApply;
 
     @BeforeClass
     public void setUp()
     {
         tester = new RuleTester();
+        TypeRegistry typeManager = new TypeRegistry();
+        FunctionRegistry registry = new FunctionRegistry(typeManager, new BlockEncodingManager(typeManager), new FeaturesConfig());
+        transformExistsApplyToScalarApply = new TransformExistsApplyToScalarApply(registry);
     }
 
     @AfterClass(alwaysRun = true)
@@ -57,6 +57,7 @@ public class TestTransformExistsApplyToScalarApply
     {
         closeAllRuntimeException(tester);
         tester = null;
+        transformExistsApplyToScalarApply = null;
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
@@ -20,9 +20,12 @@ import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.tpch.TpchConnectorFactory;
 import com.google.common.collect.ImmutableMap;
 
+import java.io.Closeable;
+
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 
 public class RuleTester
+        implements Closeable
 {
     private final Metadata metadata;
     private final Session session;
@@ -47,5 +50,11 @@ public class RuleTester
     public RuleAssert assertThat(Rule rule)
     {
         return new RuleAssert(metadata, session, rule);
+    }
+
+    @Override
+    public void close()
+    {
+        queryRunner.close();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestEvaluateZeroLimit.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestEvaluateZeroLimit.java
@@ -16,16 +16,32 @@ package com.facebook.presto.sql.planner.iterative.rule.test;
 import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroLimit;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expressions;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestEvaluateZeroLimit
 {
-    private final RuleTester tester = new RuleTester();
+    private RuleTester tester;
+
+    @BeforeClass
+    public void setUp()
+    {
+        tester = new RuleTester();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(tester);
+        tester = null;
+    }
 
     @Test
     public void testDoesNotFire()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestEvaluateZeroSample.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestEvaluateZeroSample.java
@@ -17,16 +17,32 @@ import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroSample;
 import com.facebook.presto.sql.planner.plan.SampleNode.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expressions;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestEvaluateZeroSample
 {
-    private final RuleTester tester = new RuleTester();
+    private RuleTester tester;
+
+    @BeforeClass
+    public void setUp()
+    {
+        tester = new RuleTester();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(tester);
+        tester = null;
+    }
 
     @Test
     public void testDoesNotFire()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestRemoveFullSample.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestRemoveFullSample.java
@@ -17,6 +17,8 @@ import com.facebook.presto.sql.planner.iterative.rule.RemoveFullSample;
 import com.facebook.presto.sql.planner.plan.SampleNode.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -24,10 +26,24 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expressions;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestRemoveFullSample
 {
-    private final RuleTester tester = new RuleTester();
+    private RuleTester tester;
+
+    @BeforeClass
+    public void setUp()
+    {
+        tester = new RuleTester();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(tester);
+        tester = null;
+    }
 
     @Test
     public void testDoesNotFire()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMixedDistinctAggregationOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMixedDistinctAggregationOptimizer.java
@@ -29,6 +29,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -45,12 +47,14 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableS
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestMixedDistinctAggregationOptimizer
 {
-    private final LocalQueryRunner queryRunner;
+    private LocalQueryRunner queryRunner;
 
-    public TestMixedDistinctAggregationOptimizer()
+    @BeforeClass
+    public void setUp()
     {
         Session defaultSession = testSessionBuilder()
                 .setCatalog("local")
@@ -58,10 +62,17 @@ public class TestMixedDistinctAggregationOptimizer
                 .setSystemProperty(SystemSessionProperties.OPTIMIZE_DISTINCT_AGGREGATIONS, "true")
                 .build();
 
-        this.queryRunner = new LocalQueryRunner(defaultSession);
+        queryRunner = new LocalQueryRunner(defaultSession);
         queryRunner.createCatalog(queryRunner.getDefaultSession().getCatalog().get(),
                 new TpchConnectorFactory(1),
                 ImmutableMap.of());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(queryRunner);
+        queryRunner = null;
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDate.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDate.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -35,6 +36,7 @@ import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_W
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.util.DateTimeZoneIndex.getDateTimeZone;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static org.joda.time.DateTimeZone.UTC;
 
 public class TestDate
@@ -51,6 +53,13 @@ public class TestDate
                 .setTimeZoneKey(TIME_ZONE_KEY)
                 .build();
         functionAssertions = new FunctionAssertions(session);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(functionAssertions);
+        functionAssertions = null;
     }
 
     private void assertFunction(String projection, Type expectedType, Object expected)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDateTimeOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDateTimeOperators.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -40,6 +41,7 @@ import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_W
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.util.DateTimeZoneIndex.getDateTimeZone;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.testng.Assert.fail;
@@ -60,6 +62,13 @@ public class TestDateTimeOperators
                 .setTimeZoneKey(TIME_ZONE_KEY)
                 .build();
         functionAssertions = new FunctionAssertions(session);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(functionAssertions);
+        functionAssertions = null;
     }
 
     private void assertFunction(String projection, Type expectedType, Object expected)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestInstanceFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestInstanceFunction.java
@@ -17,6 +17,7 @@ import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -24,7 +25,8 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 public class TestInstanceFunction
         extends AbstractTestFunctions
 {
-    public TestInstanceFunction()
+    @BeforeClass
+    public void setUp()
     {
         registerScalar(PrecomputedFunction.class);
     }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
@@ -66,7 +67,8 @@ import static org.testng.Assert.assertEquals;
 public class TestMapOperators
         extends AbstractTestFunctions
 {
-    private TestMapOperators()
+    @BeforeClass
+    public void setUp()
     {
         registerScalar(getClass());
     }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTime.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTime.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -35,6 +36,7 @@ import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_W
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.util.DateTimeZoneIndex.getDateTimeZone;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestTime
 {
@@ -50,6 +52,13 @@ public class TestTime
                 .setTimeZoneKey(TIME_ZONE_KEY)
                 .build();
         functionAssertions = new FunctionAssertions(session);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(functionAssertions);
+        functionAssertions = null;
     }
 
     private void assertFunction(String projection, Type expectedType, Object expected)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimeWithTimeZone.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimeWithTimeZone.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -35,6 +36,7 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestTimeWithTimeZone
 {
@@ -52,6 +54,13 @@ public class TestTimeWithTimeZone
                 .build();
 
         functionAssertions = new FunctionAssertions(session);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(functionAssertions);
+        functionAssertions = null;
     }
 
     private void assertFunction(String projection, Type expectedType, Object expected)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestamp.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestamp.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -40,6 +41,7 @@ import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_W
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.util.DateTimeZoneIndex.getDateTimeZone;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static org.joda.time.DateTimeZone.UTC;
 
 public class TestTimestamp
@@ -60,6 +62,13 @@ public class TestTimestamp
                 .setTimeZoneKey(TIME_ZONE_KEY)
                 .build();
         functionAssertions = new FunctionAssertions(session);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(functionAssertions);
+        functionAssertions = null;
     }
 
     private void assertFunction(String projection, Type expectedType, Object expected)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZone.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZone.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -40,6 +41,7 @@ import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_W
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.util.DateTimeZoneIndex.getDateTimeZone;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static org.joda.time.DateTimeZone.UTC;
 
 public class TestTimestampWithTimeZone
@@ -61,6 +63,13 @@ public class TestTimestampWithTimeZone
                 .setTimeZoneKey(TIME_ZONE_KEY)
                 .build();
         functionAssertions = new FunctionAssertions(session);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(functionAssertions);
+        functionAssertions = null;
     }
 
     private void assertFunction(String projection, Type expectedType, Object expected)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestUnknownOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestUnknownOperators.java
@@ -17,6 +17,7 @@ import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlNullable;
 import com.facebook.presto.spi.function.SqlType;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -28,7 +29,8 @@ import static com.facebook.presto.type.UnknownType.UNKNOWN;
 public class TestUnknownOperators
         extends AbstractTestFunctions
 {
-    private TestUnknownOperators()
+    @BeforeClass
+    public void setUp()
     {
         registerScalar(getClass());
     }

--- a/presto-teradata-functions/src/test/java/com/facebook/presto/teradata/functions/TestTeradataDateFunctions.java
+++ b/presto-teradata-functions/src/test/java/com/facebook/presto/teradata/functions/TestTeradataDateFunctions.java
@@ -51,7 +51,6 @@ public class TestTeradataDateFunctions
 
     @BeforeClass
     public void setUp()
-            throws Exception
     {
         functionAssertions.addFunctions(extractFunctions(new TeradataFunctionsPlugin().getFunctions()));
     }


### PR DESCRIPTION
We are experiencing intermittent OOM errors on Teradata Presto fork. Presto master is not affected yet, because of the smaller amount of tests.