### PR TITLE
Optimize window frame computation for empty frames

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/window/WindowPartition.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/WindowPartition.java
@@ -104,8 +104,8 @@ public final class WindowPartition
                     pageBuilder.getBlockBuilder(channel),
                     peerGroupStart - partitionStart,
                     peerGroupEnd - partitionStart - 1,
-                    range.start,
-                    range.end);
+                    range.getStart(),
+                    range.getEnd());
             channel++;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/WindowPartition.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/WindowPartition.java
@@ -149,6 +149,11 @@ public final class WindowPartition
         int rowPosition = currentPosition - partitionStart;
         int endPosition = partitionEnd - partitionStart - 1;
 
+        // handle empty frame
+        if (emptyFrame(frameInfo, rowPosition, endPosition)) {
+            return new Range(-1, -1);
+        }
+
         int frameStart;
         int frameEnd;
 
@@ -184,12 +189,6 @@ public final class WindowPartition
         }
         else {
             frameEnd = rowPosition;
-        }
-
-        // handle empty frame
-        if (emptyFrame(frameInfo, rowPosition, endPosition)) {
-            frameStart = -1;
-            frameEnd = -1;
         }
 
         return new Range(frameStart, frameEnd);


### PR DESCRIPTION
We can check for an empty first and short-circuit the computation.