### PR TITLE
Improve the memory efficiency of TypedSet

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.operator.aggregation.TypedSet;
+import com.facebook.presto.operator.aggregation.TypedSet.ElementReference;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.Description;
@@ -32,6 +33,7 @@ import com.google.common.primitives.Doubles;
 import io.airlift.slice.Slice;
 
 import java.math.BigInteger;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
@@ -1203,11 +1205,10 @@ public final class MathFunctions
         double result = 0.0;
 
         for (int i = 0; i < leftMap.getPositionCount(); i += 2) {
-            int position = rightMapKeys.positionOf(leftMap, i);
-
-            if (position != -1) {
+            Optional<ElementReference> rightMapKeyReference = rightMapKeys.find(ElementReference.of(leftMap, VARCHAR, i));
+            if (rightMapKeyReference.isPresent()) {
                 result += DOUBLE.getDouble(leftMap, i + 1) *
-                        DOUBLE.getDouble(rightMap, 2 * position + 1);
+                        DOUBLE.getDouble(rightMap, rightMapKeyReference.get().getPosition() + 1);
             }
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedSet.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedSet.java
@@ -13,32 +13,56 @@
  */
 package com.facebook.presto.operator.aggregation;
 
+import com.facebook.presto.operator.aggregation.TypedSet.ElementReference;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.InterleavedBlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.RowType;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import static com.facebook.presto.block.BlockAssertions.createArrayBigintBlock;
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
 import static com.facebook.presto.block.BlockAssertions.createEmptyLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongDecimalsBlock;
 import static com.facebook.presto.block.BlockAssertions.createLongSequenceBlock;
 import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static com.facebook.presto.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.type.TypeJsonUtils.appendToBlockBuilder;
+import static com.facebook.presto.util.StructuralTestUtil.mapBlockOf;
 import static io.airlift.slice.Slices.utf8Slice;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestTypedSet
 {
     @Test
     public void testConstructor()
-            throws Exception
     {
         for (int i = -2; i <= -1; i++) {
             try {
@@ -46,8 +70,7 @@ public class TestTypedSet
                 new TypedSet(BIGINT, i);
                 fail("Should throw exception if expectedSize < 0");
             }
-            catch (IllegalArgumentException e) {
-                // ignored
+            catch (IllegalArgumentException ignored) {
             }
         }
 
@@ -56,58 +79,140 @@ public class TestTypedSet
             new TypedSet(null, 1);
             fail("Should throw exception if type is null");
         }
-        catch (NullPointerException | IllegalArgumentException e) {
-            // ignored
+        catch (NullPointerException | IllegalArgumentException ignored) {
         }
     }
 
     @Test
-    public void testGetElementPosition()
-            throws Exception
+    public void testNullElements()
     {
-        int elementCount = 100;
-        TypedSet typedSet = new TypedSet(BIGINT, elementCount);
-        BlockBuilder blockBuilder = BIGINT.createFixedSizeBlockBuilder(elementCount);
-        for (int i = 0; i < elementCount; i++) {
-            BIGINT.writeLong(blockBuilder, i);
-            typedSet.add(blockBuilder, i);
+        Stream<String> stringStream = Stream.<String>generate(() -> null).limit(1_000);
+        Block nullStringBlock = createStringsBlock(stringStream.toArray(String[]::new));
+        TypedSet typedSet = new TypedSet(VARCHAR, 1_000);
+
+        for (int i = 0; i < nullStringBlock.getPositionCount(); i++) {
+            typedSet.add(nullStringBlock, i);
         }
-        for (int j = 0; j < blockBuilder.getPositionCount(); j++) {
-            assertEquals(typedSet.positionOf(blockBuilder, j), j);
-        }
+
+        assertTrue(typedSet.size() == 1);
+        assertTrue(typedSet.contains(nullStringBlock, 0));
+
+        //add a non-null element & verify
+        Block nonNullStringBlock = createStringsBlock("test");
+        typedSet.add(nonNullStringBlock, 0);
+        assertTrue(typedSet.size() == 2);
+        assertTrue(typedSet.contains(nullStringBlock, 0));
+        assertTrue(typedSet.contains(nonNullStringBlock, 0));
     }
 
     @Test
-    public void testGetElementPositionRandom()
-            throws Exception
+    public void testBooleanTypedSet()
     {
-        BlockBuilder keys = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 5);
-        VARCHAR.writeSlice(keys, utf8Slice("hello"));
-        VARCHAR.writeSlice(keys, utf8Slice("bye"));
-        VARCHAR.writeSlice(keys, utf8Slice("abc"));
-
-        TypedSet set = new TypedSet(VARCHAR, keys.getPositionCount());
-        for (int i = 0; i < keys.getPositionCount(); i++) {
-            set.add(keys, i);
-        }
-
-        BlockBuilder values = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 5);
-        VARCHAR.writeSlice(values, utf8Slice("bye"));
-        VARCHAR.writeSlice(values, utf8Slice("abc"));
-        VARCHAR.writeSlice(values, utf8Slice("hello"));
-        VARCHAR.writeSlice(values, utf8Slice("bad"));
-
-        assertEquals(set.positionOf(values, 2), 0);
-        assertEquals(set.positionOf(values, 1), 2);
-        assertEquals(set.positionOf(values, 0), 1);
-        assertFalse(set.contains(values, 3));
+        BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), 5);
+        BOOLEAN.writeBoolean(blockBuilder, true);
+        BOOLEAN.writeBoolean(blockBuilder, false);
+        BOOLEAN.writeBoolean(blockBuilder, true);
+        BOOLEAN.writeBoolean(blockBuilder, false);
+        BOOLEAN.writeBoolean(blockBuilder, false);
+        testTypedSet(blockBuilder.build(), BOOLEAN, 2);
     }
 
     @Test
-    public void testBigintSimpleTypedSet()
-            throws Exception
+    public void testDecimalTypedSet()
     {
-        List<Integer> expectedSetSizes = ImmutableList.of(1, 10, 100, 1000);
+        Block decimalsBlock = createLongDecimalsBlock("11.11", "22.22", null, "11.11", "33.33");
+        testTypedSet(decimalsBlock, createDecimalType(18), 4);
+    }
+
+    @Test
+    public void testTimestampWithTimeZoneTypedSet()
+    {
+        BlockBuilder blockBuilder = TIMESTAMP_WITH_TIME_ZONE.createBlockBuilder(new BlockBuilderStatus(), 10);
+        TIMESTAMP_WITH_TIME_ZONE.writeLong(blockBuilder, packDateTimeWithZone(1111, getTimeZoneKeyForOffset(0)));
+        TIMESTAMP_WITH_TIME_ZONE.writeLong(blockBuilder, packDateTimeWithZone(1111, getTimeZoneKeyForOffset(1)));
+        TIMESTAMP_WITH_TIME_ZONE.writeLong(blockBuilder, packDateTimeWithZone(2222, getTimeZoneKeyForOffset(2)));
+        TIMESTAMP_WITH_TIME_ZONE.writeLong(blockBuilder, packDateTimeWithZone(2222, getTimeZoneKeyForOffset(3)));
+        TIMESTAMP_WITH_TIME_ZONE.writeLong(blockBuilder, packDateTimeWithZone(3333, getTimeZoneKeyForOffset(4)));
+        TIMESTAMP_WITH_TIME_ZONE.writeLong(blockBuilder, packDateTimeWithZone(4444, getTimeZoneKeyForOffset(5)));
+        testTypedSet(blockBuilder.build(), TIMESTAMP_WITH_TIME_ZONE, 4);
+    }
+
+    @Test
+    public void testTimestampTypedSet()
+    {
+        BlockBuilder blockBuilder = TIMESTAMP.createBlockBuilder(new BlockBuilderStatus(), 10);
+        TIMESTAMP.writeLong(blockBuilder, 1111);
+        TIMESTAMP.writeLong(blockBuilder, 1111);
+        TIMESTAMP.writeLong(blockBuilder, 2222);
+        TIMESTAMP.writeLong(blockBuilder, 3333);
+        TIMESTAMP.writeLong(blockBuilder, 3333);
+        TIMESTAMP.writeLong(blockBuilder, 4444);
+        testTypedSet(blockBuilder.build(), TIMESTAMP, 4);
+    }
+
+    @Test
+    public void testMapTypedSet()
+    {
+        MapType mapType = new MapType(VARCHAR, VARCHAR);
+        BlockBuilder builder = mapType.createBlockBuilder(new BlockBuilderStatus(), 5);
+        mapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("a", "b")));
+        mapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("c", "d")));
+        mapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("e", "f")));
+        mapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("e", "f")));
+        mapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("e", "f")));
+        testTypedSet(builder.build(), mapType, 3);
+    }
+
+    @Test
+    public void testRowTypedSet()
+    {
+        List<Type> fieldTypes = ImmutableList.of(DOUBLE, VARCHAR, TINYINT);
+        RowType rowType = new RowType(fieldTypes, Optional.empty());
+        BlockBuilder rowArrayBuilder = rowType.createBlockBuilder(new BlockBuilderStatus(), 5);
+        List<List<Object>> elements = ImmutableList.of(
+                ImmutableList.of(1.0, "a", 1), ImmutableList.of(2.0, "b", 2), ImmutableList.of(3.0, "c", 3), ImmutableList.of(1.0, "a", 1), ImmutableList.of(2.0, "b", 2));
+        for (List<Object> element : elements) {
+            BlockBuilder rowBuilder = new InterleavedBlockBuilder(fieldTypes, new BlockBuilderStatus(), fieldTypes.size());
+            for (int j = 0; j < fieldTypes.size(); j++) {
+                appendToBlockBuilder(fieldTypes.get(j), element.get(j), rowBuilder);
+            }
+            rowType.writeObject(rowArrayBuilder, rowBuilder.build());
+        }
+        testTypedSet(rowArrayBuilder.build(), rowType, 3);
+    }
+
+    @Test
+    public void testArrayTypedSet()
+    {
+        Block arrayBlock = createArrayBigintBlock(ImmutableList.of(ImmutableList.of(1L),
+                ImmutableList.of(1L, 2L), ImmutableList.of(1L, 2L), ImmutableList.of(3L)));
+        testTypedSet(arrayBlock, new ArrayType(BIGINT), 3);
+    }
+
+    @Test
+    public void testDoubleTypedSet()
+    {
+        Double[] values = IntStream.rangeClosed(0, 99).mapToDouble(integer -> (double) integer).boxed().toArray(Double[]::new);
+        Block doubleBlock = createDoublesBlock(values);
+        testTypedSet(doubleBlock, DOUBLE, 100);
+    }
+
+    @Test
+    public void testVarcharTypedSet()
+    {
+        BlockBuilder varcharBlockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 5);
+        VARCHAR.writeSlice(varcharBlockBuilder, utf8Slice("hello"));
+        VARCHAR.writeSlice(varcharBlockBuilder, utf8Slice("bye"));
+        VARCHAR.writeSlice(varcharBlockBuilder, utf8Slice("abc"));
+        VARCHAR.writeSlice(varcharBlockBuilder, utf8Slice("abc"));
+        VARCHAR.writeSlice(varcharBlockBuilder, utf8Slice("abc"));
+        testTypedSet(varcharBlockBuilder.build(), VARCHAR, 3);
+    }
+
+    @Test
+    public void testBigintTypedSet()
+    {
+        List<Integer> expectedSetSizes = ImmutableList.of(0, 1, 3, 3, 3, 1, 100, 200, 1, 1, 1);
         List<Block> longBlocks =
                 ImmutableList.of(
                         createEmptyLongsBlock(),
@@ -120,31 +225,76 @@ public class TestTypedSet
                         createLongSequenceBlock(-100, 100),
                         createLongsBlock(Collections.nCopies(1, null)),
                         createLongsBlock(Collections.nCopies(100, null)),
-                        createLongsBlock(Collections.nCopies(expectedSetSizes.get(expectedSetSizes.size() - 1) * 2, null)),
-                        createLongsBlock(Collections.nCopies(expectedSetSizes.get(expectedSetSizes.size() - 1) * 2, 0L))
+                        createLongsBlock(Collections.nCopies(100, 0L))
                 );
 
-        for (int expectedSetSize : expectedSetSizes) {
-            for (Block block : longBlocks) {
-                testBigint(block, expectedSetSize);
+        for (int i = 0; i < longBlocks.size(); i++) {
+            testTypedSet(longBlocks.get(i), BIGINT, expectedSetSizes.get(i));
+        }
+    }
+
+    @Test
+    public void testFind()
+    {
+        Block longBlock1 = createLongsBlock(1L);
+        Block longBlock2 = createLongsBlock(1L);
+        TypedSet typedSet = new TypedSet(BIGINT, 1);
+        typedSet.add(longBlock1, 0);
+        typedSet.add(longBlock2, 0);
+
+        Optional<ElementReference> existing = typedSet.find(ElementReference.of(longBlock2, BIGINT, 0));
+        assertTrue(existing.isPresent());
+        assertTrue(existing.get().getBlock() == longBlock1);
+    }
+
+    private void testTypedSet(Block block, Type elementType, int expectedSize)
+    {
+        Set<Object> set = new HashSet<>();
+        TypedSet typedSet = new TypedSet(elementType, 10);
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            typedSet.add(block, i);
+            set.add(getElement(block, elementType, i));
+        }
+
+        assertTrue(typedSet.size() == expectedSize);
+
+        if (elementType.getJavaType().isPrimitive()) {
+            assertTrue(typedSet.size() == set.size());
+        }
+
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            assertTrue(typedSet.contains(block, i));
+            if (elementType.getJavaType().isPrimitive()) {
+                assertTrue(set.contains(getElement(block, elementType, i)));
             }
         }
     }
 
-    private static void testBigint(Block longBlock, int expectedSetSize)
+    private Object getElement(Block block, Type type, int position)
     {
-        TypedSet typedSet = new TypedSet(BIGINT, expectedSetSize);
-        Set<Long> set = new HashSet<>();
-        for (int blockPosition = 0; blockPosition < longBlock.getPositionCount(); blockPosition++) {
-            long number = BIGINT.getLong(longBlock, blockPosition);
-            assertEquals(typedSet.contains(longBlock, blockPosition), set.contains(number));
-            assertEquals(typedSet.size(), set.size());
-
-            set.add(number);
-            typedSet.add(longBlock, blockPosition);
-
-            assertEquals(typedSet.contains(longBlock, blockPosition), set.contains(number));
-            assertEquals(typedSet.size(), set.size());
+        Class javaType = type.getJavaType();
+        if (javaType == boolean.class) {
+            return type.getBoolean(block, position);
+        }
+        else if (javaType == long.class) {
+            if (type == TIMESTAMP_WITH_TIME_ZONE) {
+                return unpackMillisUtc(type.getLong(block, position));
+            }
+            else {
+                return type.getLong(block, position);
+            }
+        }
+        else if (javaType == double.class) {
+            return type.getDouble(block, position);
+        }
+        else if (javaType == Slice.class) {
+            return type.getSlice(block, position);
+        }
+        else if (!type.getJavaType().isPrimitive()) {
+            return type.getObject(block, position);
+        }
+        else {
+            throw new UnsupportedOperationException("Type not handled: " + type.getJavaType());
         }
     }
 }


### PR DESCRIPTION
This PR improves the memory efficiency of `TypedSet`, which is mainly used for deduping map keys. The old version was copying the keys to an internal block and this was adding a lot of memory overhead to map union and aggregations (as reported in #7342). Instead of keeping separate copies this new version keeps references to individual keys (see `ElementReference` class below).

As shown in the screenshot below, for the test query in #7342 (on my laptop) the retained size on heap with the new implementation (named as `TypedKeySet` for testing) is ~40% less than the old implementation (named as `TypedSet` in this test). For ease of comparison, in the `KeyValuePairs` class I allocated instances of both the new set impl. (`TypedKeySet`) and the old impl. (`TypedSet`)  and populated them at the same time, that's why we have roughly the same number of instances on heap (the minor difference is probably due to GC while I was getting the memory snapshot). I expect more savings with complex type keys and variable length keys as their copies will be using more memory than only keeping references to the keys.

![screen shot 2017-02-21 at 9 52 59 am](https://cloud.githubusercontent.com/assets/1223839/23177778/f223d44a-f81c-11e6-8eb4-6c822a666ffa.png)

As another data point, the number of rows that can be processed subject to the same memory limit increases by ~25-30% with this new implementation (again for the same test query). 

Although I didn't run benchmarks, this PR should also improve the performance of the `array_distinct`, `array_union`, and `map_concat` functions, and may slightly reduce the performance of the `cosine_similarity` function (`*`) as these functions are also updated to use the new implementation.

`*`:  This new set implementation doesn't provide a `positionOf()` method, instead it provides a `find()` method that traverses the elements to find an existing `ElementReference` that `equals to` a given `ElementReference` (the caller can then get the referred `block` and `position` etc.).

This PR supersedes #7349.