### PR TITLE
Replace CompletableFuture with ListenableFuture

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.6</dep.antlr.version>
-        <dep.airlift.version>0.142</dep.airlift.version>
+        <dep.airlift.version>0.143-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.28</dep.slice.version>
         <dep.aws-sdk.version>1.11.30</dep.aws-sdk.version>

--- a/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
@@ -26,11 +26,11 @@ import com.facebook.presto.sql.tree.AddColumn;
 import com.facebook.presto.sql.tree.ColumnDefinition;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
@@ -38,8 +38,8 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.COLUMN_ALREADY_
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TYPE_MISMATCH;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.util.Locale.ENGLISH;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class AddColumnTask
         implements DataDefinitionTask<AddColumn>
@@ -51,7 +51,7 @@ public class AddColumnTask
     }
 
     @Override
-    public CompletableFuture<?> execute(AddColumn statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(AddColumn statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
@@ -75,6 +75,6 @@ public class AddColumnTask
 
         metadata.addColumn(session, tableHandle.get(), new ColumnMetadata(element.getName(), type));
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/CallTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CallTask.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.tree.CallArgument;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
@@ -41,7 +42,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
@@ -55,8 +55,8 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG
 import static com.facebook.presto.sql.planner.ExpressionInterpreter.evaluateConstantExpression;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.util.Arrays.asList;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class CallTask
         implements DataDefinitionTask<Call>
@@ -68,7 +68,7 @@ public class CallTask
     }
 
     @Override
-    public CompletableFuture<?> execute(Call call, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(Call call, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         if (!stateMachine.isAutoCommit()) {
             throw new PrestoException(NOT_SUPPORTED, "Procedures cannot be called within a transaction (use autocommit mode)");
@@ -168,7 +168,7 @@ public class CallTask
             throw new PrestoException(PROCEDURE_CALL_FAILED, t);
         }
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 
     private static Object toTypeObjectValue(Session session, Type type, Object value)

--- a/presto-main/src/main/java/com/facebook/presto/execution/CommitTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CommitTask.java
@@ -21,9 +21,9 @@ import com.facebook.presto.sql.tree.Commit;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.transaction.TransactionId;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_IN_TRANSACTION;
 
@@ -37,7 +37,7 @@ public class CommitTask
     }
 
     @Override
-    public CompletableFuture<?> execute(Commit statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(Commit statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         if (!session.getTransactionId().isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateSchemaTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateSchemaTask.java
@@ -23,16 +23,16 @@ import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.CreateSchema;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createCatalogSchemaName;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.SCHEMA_ALREADY_EXISTS;
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class CreateSchemaTask
         implements DataDefinitionTask<CreateSchema>
@@ -50,7 +50,7 @@ public class CreateSchemaTask
     }
 
     @Override
-    public CompletableFuture<?> execute(CreateSchema statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(CreateSchema statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         CatalogSchemaName schema = createCatalogSchemaName(session, statement, Optional.of(statement.getSchemaName()));
@@ -63,7 +63,7 @@ public class CreateSchemaTask
             if (!statement.isNotExists()) {
                 throw new SemanticException(SCHEMA_ALREADY_EXISTS, statement, "Schema '%s' already exists", schema);
             }
-            return completedFuture(null);
+            return immediateFuture(null);
         }
 
         ConnectorId connectorId = metadata.getCatalogHandle(session, schema.getCatalogName())
@@ -79,6 +79,6 @@ public class CreateSchemaTask
 
         metadata.createSchema(session, schema, properties);
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.tree.LikeClause;
 import com.facebook.presto.sql.tree.TableElement;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -39,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -52,7 +52,7 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TABLE_ALREADY_E
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TYPE_MISMATCH;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class CreateTableTask
         implements DataDefinitionTask<CreateTable>
@@ -70,7 +70,7 @@ public class CreateTableTask
     }
 
     @Override
-    public CompletableFuture<?> execute(CreateTable statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(CreateTable statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         checkArgument(!statement.getElements().isEmpty(), "no columns for table");
 
@@ -81,7 +81,7 @@ public class CreateTableTask
             if (!statement.isNotExists()) {
                 throw new SemanticException(TABLE_ALREADY_EXISTS, statement, "Table '%s' already exists", tableName);
             }
-            return completedFuture(null);
+            return immediateFuture(null);
         }
 
         List<ColumnMetadata> columns = new ArrayList<>();
@@ -147,7 +147,7 @@ public class CreateTableTask
 
         metadata.createTable(session, tableName.getCatalogName(), tableMetadata);
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 
     private static Map<String, Object> combineProperties(Set<String> specifiedPropertyKeys, Map<String, Object> defaultProperties, Map<String, Object> inheritedProperties)

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
@@ -26,20 +26,20 @@ import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.json.JsonCodec;
 
 import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.metadata.ViewDefinition.ViewColumn;
 import static com.facebook.presto.sql.SqlFormatterUtil.getFormattedSql;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class CreateViewTask
         implements DataDefinitionTask<CreateView>
@@ -71,7 +71,7 @@ public class CreateViewTask
     }
 
     @Override
-    public CompletableFuture<?> execute(CreateView statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(CreateView statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
@@ -91,7 +91,7 @@ public class CreateViewTask
 
         metadata.createView(session, name, data, statement.isReplace());
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 
     private Analysis analyzeStatement(Statement statement, Session session, Metadata metadata, AccessControl accessControl, List<Expression> parameters)

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionTask.java
@@ -20,16 +20,16 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 public interface DataDefinitionTask<T extends Statement>
 {
     String getName();
 
-    CompletableFuture<?> execute(T statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters);
+    ListenableFuture<?> execute(T statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters);
 
     default String explain(T statement, List<Expression> parameters)
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/DeallocateTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DeallocateTask.java
@@ -19,11 +19,11 @@ import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class DeallocateTask
         implements DataDefinitionTask<Deallocate>
@@ -35,10 +35,10 @@ public class DeallocateTask
     }
 
     @Override
-    public CompletableFuture<?> execute(Deallocate statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(Deallocate statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         String statementName = statement.getName();
         stateMachine.removePreparedStatement(statementName);
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/DropSchemaTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DropSchemaTask.java
@@ -22,15 +22,15 @@ import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.DropSchema;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createCatalogSchemaName;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_SCHEMA;
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class DropSchemaTask
         implements DataDefinitionTask<DropSchema>
@@ -48,7 +48,7 @@ public class DropSchemaTask
     }
 
     @Override
-    public CompletableFuture<?> execute(DropSchema statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(DropSchema statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         if (statement.isCascade()) {
             throw new PrestoException(NOT_SUPPORTED, "CASCADE is not yet supported for DROP SCHEMA");
@@ -61,13 +61,13 @@ public class DropSchemaTask
             if (!statement.isExists()) {
                 throw new SemanticException(MISSING_SCHEMA, statement, "Schema '%s' does not exist", schema);
             }
-            return completedFuture(null);
+            return immediateFuture(null);
         }
 
         accessControl.checkCanDropSchema(session.getRequiredTransactionId(), session.getIdentity(), schema);
 
         metadata.dropSchema(session, schema);
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/DropTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DropTableTask.java
@@ -22,14 +22,14 @@ import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class DropTableTask
         implements DataDefinitionTask<DropTable>
@@ -41,7 +41,7 @@ public class DropTableTask
     }
 
     @Override
-    public CompletableFuture<?> execute(DropTable statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(DropTable statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
@@ -51,13 +51,13 @@ public class DropTableTask
             if (!statement.isExists()) {
                 throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);
             }
-            return completedFuture(null);
+            return immediateFuture(null);
         }
 
         accessControl.checkCanDropTable(session.getRequiredTransactionId(), session.getIdentity(), tableName);
 
         metadata.dropTable(session, tableHandle.get());
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/DropViewTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DropViewTask.java
@@ -22,14 +22,14 @@ import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.DropView;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class DropViewTask
         implements DataDefinitionTask<DropView>
@@ -41,7 +41,7 @@ public class DropViewTask
     }
 
     @Override
-    public CompletableFuture<?> execute(DropView statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(DropView statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
@@ -51,13 +51,13 @@ public class DropViewTask
             if (!statement.isExists()) {
                 throw new SemanticException(MISSING_TABLE, statement, "View '%s' does not exist", name);
             }
-            return completedFuture(null);
+            return immediateFuture(null);
         }
 
         accessControl.checkCanDropView(session.getRequiredTransactionId(), session.getIdentity(), name);
 
         metadata.dropView(session, name);
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/GrantTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/GrantTask.java
@@ -23,18 +23,18 @@ import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Grant;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_PRIVILEGE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class GrantTask
         implements DataDefinitionTask<Grant>
@@ -46,7 +46,7 @@ public class GrantTask
     }
 
     @Override
-    public CompletableFuture<?> execute(Grant statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(Grant statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
@@ -72,7 +72,7 @@ public class GrantTask
         }
 
         metadata.grantTablePrivileges(session, tableName, privileges, statement.getGrantee(), statement.isWithGrantOption());
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 
     private static Privilege parsePrivilege(Grant statement, String privilegeString)

--- a/presto-main/src/main/java/com/facebook/presto/execution/PrepareTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/PrepareTask.java
@@ -24,18 +24,18 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.SqlFormatterUtil.getFormattedSql;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class PrepareTask
         implements DataDefinitionTask<Prepare>
@@ -61,7 +61,7 @@ public class PrepareTask
     }
 
     @Override
-    public CompletableFuture<?> execute(Prepare prepare, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(Prepare prepare, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Statement statement = prepare.getStatement();
         if ((statement instanceof Prepare) || (statement instanceof Execute) || (statement instanceof Deallocate)) {
@@ -71,6 +71,6 @@ public class PrepareTask
 
         String sql = getFormattedSql(statement, sqlParser, Optional.empty());
         stateMachine.addPreparedStatement(prepare.getName(), sql);
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
@@ -18,8 +18,7 @@ import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.Multimap;
-
-import java.util.concurrent.CompletableFuture;
+import com.google.common.util.concurrent.ListenableFuture;
 
 public interface RemoteTask
 {
@@ -41,7 +40,7 @@ public interface RemoteTask
 
     void addStateChangeListener(StateChangeListener<TaskStatus> stateChangeListener);
 
-    CompletableFuture<?> whenSplitQueueHasSpace(int threshold);
+    ListenableFuture<?> whenSplitQueueHasSpace(int threshold);
 
     void cancel();
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/RenameColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RenameColumnTask.java
@@ -23,18 +23,18 @@ import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.RenameColumn;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.COLUMN_ALREADY_EXISTS;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_COLUMN;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.util.Locale.ENGLISH;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class RenameColumnTask
         implements DataDefinitionTask<RenameColumn>
@@ -46,7 +46,7 @@ public class RenameColumnTask
     }
 
     @Override
-    public CompletableFuture<?> execute(RenameColumn statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(RenameColumn statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTable());
@@ -70,6 +70,6 @@ public class RenameColumnTask
         }
         metadata.renameColumn(session, tableHandle.get(), columnHandles.get(source), target);
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/RenameSchemaTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RenameSchemaTask.java
@@ -21,15 +21,15 @@ import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.RenameSchema;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createCatalogSchemaName;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_SCHEMA;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.SCHEMA_ALREADY_EXISTS;
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class RenameSchemaTask
         implements DataDefinitionTask<RenameSchema>
@@ -41,7 +41,7 @@ public class RenameSchemaTask
     }
 
     @Override
-    public CompletableFuture<?> execute(RenameSchema statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(RenameSchema statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         CatalogSchemaName source = createCatalogSchemaName(session, statement, Optional.of(statement.getSource()));
@@ -59,6 +59,6 @@ public class RenameSchemaTask
 
         metadata.renameSchema(session, source, statement.getTarget());
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/RenameTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RenameTableTask.java
@@ -22,17 +22,17 @@ import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.RenameTable;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TABLE_ALREADY_EXISTS;
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class RenameTableTask
         implements DataDefinitionTask<RenameTable>
@@ -44,7 +44,7 @@ public class RenameTableTask
     }
 
     @Override
-    public CompletableFuture<?> execute(RenameTable statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(RenameTable statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getSource());
@@ -67,6 +67,6 @@ public class RenameTableTask
 
         metadata.renameTable(session, tableHandle.get(), target);
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/ResetSessionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ResetSessionTask.java
@@ -20,13 +20,13 @@ import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ResetSession;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class ResetSessionTask
         implements DataDefinitionTask<ResetSession>
@@ -38,7 +38,7 @@ public class ResetSessionTask
     }
 
     @Override
-    public CompletableFuture<?> execute(ResetSession statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(ResetSession statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         List<String> parts = statement.getName().getParts();
         if (parts.size() > 2) {
@@ -59,6 +59,6 @@ public class ResetSessionTask
 
         stateMachine.addResetSessionProperties(statement.getName().toString());
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/RevokeTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RevokeTask.java
@@ -23,18 +23,18 @@ import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Revoke;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_PRIVILEGE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class RevokeTask
         implements DataDefinitionTask<Revoke>
@@ -46,7 +46,7 @@ public class RevokeTask
     }
 
     @Override
-    public CompletableFuture<?> execute(Revoke statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(Revoke statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
@@ -72,7 +72,7 @@ public class RevokeTask
         }
 
         metadata.revokeTablePrivileges(session, tableName, privileges, statement.getGrantee(), statement.isGrantOptionFor());
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 
     private static Privilege parsePrivilege(Revoke statement, String privilegeString)

--- a/presto-main/src/main/java/com/facebook/presto/execution/RollbackTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RollbackTask.java
@@ -21,12 +21,12 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Rollback;
 import com.facebook.presto.transaction.TransactionId;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_IN_TRANSACTION;
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class RollbackTask
         implements DataDefinitionTask<Rollback>
@@ -38,7 +38,7 @@ public class RollbackTask
     }
 
     @Override
-    public CompletableFuture<?> execute(Rollback statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(Rollback statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         if (!session.getTransactionId().isPresent()) {
@@ -48,7 +48,7 @@ public class RollbackTask
 
         stateMachine.clearTransactionId();
         transactionManager.asyncAbort(transactionId);
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/SetSessionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SetSessionTask.java
@@ -26,16 +26,16 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SetSession;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.metadata.SessionPropertyManager.evaluatePropertyValue;
 import static com.facebook.presto.metadata.SessionPropertyManager.serializeSessionProperty;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.lang.String.format;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class SetSessionTask
         implements DataDefinitionTask<SetSession>
@@ -47,7 +47,7 @@ public class SetSessionTask
     }
 
     @Override
-    public CompletableFuture<?> execute(SetSession statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(SetSession statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         QualifiedName propertyName = statement.getName();
@@ -87,6 +87,6 @@ public class SetSessionTask
         // verify the SQL value can be decoded by the property
         stateMachine.addSetSessionProperties(propertyName.toString(), value);
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -34,6 +34,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.concurrent.ThreadPoolExecutorMBean;
 import io.airlift.log.Logger;
 import io.airlift.node.NodeInfo;
@@ -52,7 +53,6 @@ import javax.inject.Inject;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -273,7 +273,7 @@ public class SqlTaskManager
     }
 
     @Override
-    public CompletableFuture<TaskInfo> getTaskInfo(TaskId taskId, TaskState currentState)
+    public ListenableFuture<TaskInfo> getTaskInfo(TaskId taskId, TaskState currentState)
     {
         requireNonNull(taskId, "taskId is null");
         requireNonNull(currentState, "currentState is null");
@@ -292,7 +292,7 @@ public class SqlTaskManager
     }
 
     @Override
-    public CompletableFuture<TaskStatus> getTaskStatus(TaskId taskId, TaskState currentState)
+    public ListenableFuture<TaskStatus> getTaskStatus(TaskId taskId, TaskState currentState)
     {
         requireNonNull(taskId, "taskId is null");
         requireNonNull(currentState, "currentState is null");
@@ -322,7 +322,7 @@ public class SqlTaskManager
     }
 
     @Override
-    public CompletableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize)
+    public ListenableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize)
     {
         requireNonNull(taskId, "taskId is null");
         requireNonNull(bufferId, "bufferId is null");

--- a/presto-main/src/main/java/com/facebook/presto/execution/StartTransactionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StartTransactionTask.java
@@ -26,13 +26,13 @@ import com.facebook.presto.sql.tree.StartTransaction;
 import com.facebook.presto.sql.tree.TransactionAccessMode;
 import com.facebook.presto.transaction.TransactionId;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_TRANSACTION_MODE;
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class StartTransactionTask
         implements DataDefinitionTask<StartTransaction>
@@ -44,7 +44,7 @@ public class StartTransactionTask
     }
 
     @Override
-    public CompletableFuture<?> execute(StartTransaction statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
+    public ListenableFuture<?> execute(StartTransaction statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
         if (!session.isClientTransactionSupport()) {
@@ -68,7 +68,7 @@ public class StartTransactionTask
         // when this statement completes.
         transactionManager.trySetInactive(transactionId);
 
-        return completedFuture(null);
+        return immediateFuture(null);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
@@ -21,11 +21,11 @@ import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
 import com.facebook.presto.sql.planner.PlanFragment;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 public interface TaskManager
 {
@@ -58,7 +58,7 @@ public interface TaskManager
      * NOTE: this design assumes that only tasks that will eventually exist are
      * queried.
      */
-    CompletableFuture<TaskInfo> getTaskInfo(TaskId taskId, TaskState currentState);
+    ListenableFuture<TaskInfo> getTaskInfo(TaskId taskId, TaskState currentState);
 
     /**
      * Gets the unique instance id of a task.  This can be used to detect a task
@@ -75,7 +75,7 @@ public interface TaskManager
      * NOTE: this design assumes that only tasks that will eventually exist are
      * queried.
      */
-    CompletableFuture<TaskStatus> getTaskStatus(TaskId taskId, TaskState currentState);
+    ListenableFuture<TaskStatus> getTaskStatus(TaskId taskId, TaskState currentState);
 
     void updateMemoryPoolAssignments(MemoryPoolAssignmentsRequest assignments);
 
@@ -105,7 +105,7 @@ public interface TaskManager
      * NOTE: this design assumes that only tasks and buffers that will
      * eventually exist are queried.
      */
-    CompletableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize);
+    ListenableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize);
 
     /**
      * Aborts a result buffer for a task.  If the task or buffer has not been

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskStateMachine.java
@@ -14,13 +14,14 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -69,15 +70,15 @@ public class TaskStateMachine
         return taskState.get();
     }
 
-    public CompletableFuture<TaskState> getStateChange(TaskState currentState)
+    public ListenableFuture<TaskState> getStateChange(TaskState currentState)
     {
         requireNonNull(currentState, "currentState is null");
         checkArgument(!currentState.isDone(), "Current state is already done");
 
-        CompletableFuture<TaskState> future = taskState.getStateChange(currentState);
+        ListenableFuture<TaskState> future = taskState.getStateChange(currentState);
         TaskState state = taskState.get();
         if (state.isDone()) {
-            return CompletableFuture.completedFuture(state);
+            return Futures.immediateFuture(state);
         }
         return future;
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
@@ -33,7 +33,6 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -233,7 +232,7 @@ public class ArbitraryOutputBuffer
     }
 
     @Override
-    public CompletableFuture<BufferResult> get(OutputBufferId bufferId, long startingSequenceId, DataSize maxSize)
+    public ListenableFuture<BufferResult> get(OutputBufferId bufferId, long startingSequenceId, DataSize maxSize)
     {
         requireNonNull(bufferId, "bufferId is null");
         checkArgument(maxSize.toBytes() > 0, "maxSize must be at least 1 byte");

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
@@ -230,7 +229,7 @@ public class BroadcastOutputBuffer
     }
 
     @Override
-    public CompletableFuture<BufferResult> get(OutputBufferId outputBufferId, long startingSequenceId, DataSize maxSize)
+    public ListenableFuture<BufferResult> get(OutputBufferId outputBufferId, long startingSequenceId, DataSize maxSize)
     {
         requireNonNull(outputBufferId, "outputBufferId is null");
         checkArgument(maxSize.toBytes() > 0, "maxSize must be at least 1 byte");

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBuffer.java
@@ -20,7 +20,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 public interface OutputBuffer
 {
@@ -58,7 +57,7 @@ public interface OutputBuffer
      * If the buffer result is marked as complete, the client must call abort to acknowledge
      * receipt of the final state.
      */
-    CompletableFuture<BufferResult> get(OutputBufferId bufferId, long token, DataSize maxSize);
+    ListenableFuture<BufferResult> get(OutputBufferId bufferId, long token, DataSize maxSize);
 
     /**
      * Closes the specified output buffer.

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/PartitionedOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/PartitionedOutputBuffer.java
@@ -23,7 +23,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -191,7 +190,7 @@ public class PartitionedOutputBuffer
     }
 
     @Override
-    public CompletableFuture<BufferResult> get(OutputBufferId outputBufferId, long startingSequenceId, DataSize maxSize)
+    public ListenableFuture<BufferResult> get(OutputBufferId outputBufferId, long startingSequenceId, DataSize maxSize)
     {
         requireNonNull(outputBufferId, "outputBufferId is null");
         checkArgument(maxSize.toBytes() > 0, "maxSize must be at least 1 byte");

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.planner.NodePartitionMap;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
 
 import java.util.ArrayDeque;
@@ -29,13 +30,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.util.Objects.requireNonNull;
 
 public class FixedSourcePartitionedScheduler
@@ -83,7 +84,7 @@ public class FixedSourcePartitionedScheduler
             scheduledTasks = true;
         }
 
-        CompletableFuture<?> blocked = CompletableFuture.completedFuture(null);
+        ListenableFuture<?> blocked = immediateFuture(null);
         ScheduleResult.BlockedReason blockedReason = null;
         int splitsScheduled = 0;
         while (!sourcePartitionedSchedulers.isEmpty()) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.stats.CounterStat;
 
 import javax.annotation.PreDestroy;
@@ -45,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType;
@@ -53,9 +53,9 @@ import static com.facebook.presto.spi.NodeState.ACTIVE;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.airlift.concurrent.MoreFutures.firstCompletedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static io.airlift.concurrent.MoreFutures.whenAnyComplete;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class NodeScheduler
 {
@@ -286,7 +286,7 @@ public class NodeScheduler
             }
         }
 
-        CompletableFuture<?> blocked = toWhenHasSplitQueueSpaceFuture(blockedNodes, existingTasks, calculateLowWatermark(maxPendingSplitsPerTask));
+        ListenableFuture<?> blocked = toWhenHasSplitQueueSpaceFuture(blockedNodes, existingTasks, calculateLowWatermark(maxPendingSplitsPerTask));
         return new SplitPlacementResult(blocked, ImmutableMultimap.copyOf(assignments));
     }
 
@@ -295,35 +295,35 @@ public class NodeScheduler
         return (int) Math.ceil(maxPendingSplitsPerTask / 2.0);
     }
 
-    public static CompletableFuture<?> toWhenHasSplitQueueSpaceFuture(Set<Node> blockedNodes, List<RemoteTask> existingTasks, int spaceThreshold)
+    public static ListenableFuture<?> toWhenHasSplitQueueSpaceFuture(Set<Node> blockedNodes, List<RemoteTask> existingTasks, int spaceThreshold)
     {
         if (blockedNodes.isEmpty()) {
-            return completedFuture(null);
+            return immediateFuture(null);
         }
         Map<String, RemoteTask> nodeToTaskMap = new HashMap<>();
         for (RemoteTask task : existingTasks) {
             nodeToTaskMap.put(task.getNodeId(), task);
         }
-        List<CompletableFuture<?>> blockedFutures = blockedNodes.stream()
+        List<ListenableFuture<?>> blockedFutures = blockedNodes.stream()
                 .map(Node::getNodeIdentifier)
                 .map(nodeToTaskMap::get)
                 .filter(Objects::nonNull)
                 .map(remoteTask -> remoteTask.whenSplitQueueHasSpace(spaceThreshold))
                 .collect(toImmutableList());
         if (blockedFutures.isEmpty()) {
-            return completedFuture(null);
+            return immediateFuture(null);
         }
-        return firstCompletedFuture(blockedFutures, true);
+        return whenAnyComplete(blockedFutures, true);
     }
 
-    public static CompletableFuture<?> toWhenHasSplitQueueSpaceFuture(List<RemoteTask> existingTasks, int spaceThreshold)
+    public static ListenableFuture<?> toWhenHasSplitQueueSpaceFuture(List<RemoteTask> existingTasks, int spaceThreshold)
     {
         if (existingTasks.isEmpty()) {
-            return completedFuture(null);
+            return immediateFuture(null);
         }
-        List<CompletableFuture<?>> stateChangeFutures = existingTasks.stream()
+        List<ListenableFuture<?>> stateChangeFutures = existingTasks.stream()
                 .map(remoteTask -> remoteTask.whenSplitQueueHasSpace(spaceThreshold))
                 .collect(toImmutableList());
-        return firstCompletedFuture(stateChangeFutures, true);
+        return whenAnyComplete(stateChangeFutures, true);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScheduleResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScheduleResult.java
@@ -15,14 +15,14 @@ package com.facebook.presto.execution.scheduler;
 
 import com.facebook.presto.execution.RemoteTask;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class ScheduleResult
 {
@@ -33,22 +33,22 @@ public class ScheduleResult
     }
 
     private final Set<RemoteTask> newTasks;
-    private final CompletableFuture<?> blocked;
+    private final ListenableFuture<?> blocked;
     private final Optional<BlockedReason> blockedReason;
     private final boolean finished;
     private final int splitsScheduled;
 
     public ScheduleResult(boolean finished, Iterable<? extends RemoteTask> newTasks, int splitsScheduled)
     {
-        this(finished, newTasks, completedFuture(null), Optional.empty(), splitsScheduled);
+        this(finished, newTasks, immediateFuture(null), Optional.empty(), splitsScheduled);
     }
 
-    public ScheduleResult(boolean finished, Iterable<? extends RemoteTask> newTasks, CompletableFuture<?> blocked, BlockedReason blockedReason, int splitsScheduled)
+    public ScheduleResult(boolean finished, Iterable<? extends RemoteTask> newTasks, ListenableFuture<?> blocked, BlockedReason blockedReason, int splitsScheduled)
     {
         this(finished, newTasks, blocked, Optional.of(requireNonNull(blockedReason, "blockedReason is null")), splitsScheduled);
     }
 
-    private ScheduleResult(boolean finished, Iterable<? extends RemoteTask> newTasks, CompletableFuture<?> blocked, Optional<BlockedReason> blockedReason, int splitsScheduled)
+    private ScheduleResult(boolean finished, Iterable<? extends RemoteTask> newTasks, ListenableFuture<?> blocked, Optional<BlockedReason> blockedReason, int splitsScheduled)
     {
         this.finished = finished;
         this.newTasks = ImmutableSet.copyOf(requireNonNull(newTasks, "newTasks is null"));
@@ -67,7 +67,7 @@ public class ScheduleResult
         return newTasks;
     }
 
-    public CompletableFuture<?> getBlocked()
+    public ListenableFuture<?> getBlocked()
     {
         return blocked;
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SimpleNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SimpleNodeSelector.java
@@ -25,12 +25,12 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.facebook.presto.execution.scheduler.NodeScheduler.calculateLowWatermark;
@@ -158,7 +158,7 @@ public class SimpleNodeSelector
             }
         }
 
-        CompletableFuture<?> blocked;
+        ListenableFuture<?> blocked;
         if (splitWaitingForAnyNode) {
             blocked = toWhenHasSplitQueueSpaceFuture(existingTasks, calculateLowWatermark(maxPendingSplitsPerTask));
         }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SplitPlacementResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SplitPlacementResult.java
@@ -16,23 +16,22 @@ package com.facebook.presto.execution.scheduler;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.Node;
 import com.google.common.collect.Multimap;
-
-import java.util.concurrent.CompletableFuture;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import static java.util.Objects.requireNonNull;
 
 public final class SplitPlacementResult
 {
-    private final CompletableFuture<?> blocked;
+    private final ListenableFuture<?> blocked;
     private final Multimap<Node, Split> assignments;
 
-    public SplitPlacementResult(CompletableFuture<?> blocked, Multimap<Node, Split> assignments)
+    public SplitPlacementResult(ListenableFuture<?> blocked, Multimap<Node, Split> assignments)
     {
         this.blocked = requireNonNull(blocked, "blocked is null");
         this.assignments = requireNonNull(assignments, "assignments is null");
     }
 
-    public CompletableFuture<?> getBlocked()
+    public ListenableFuture<?> getBlocked()
     {
         return blocked;
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/TopologyAwareNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/TopologyAwareNodeSelector.java
@@ -26,6 +26,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
 import io.airlift.stats.CounterStat;
 
@@ -35,7 +36,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.facebook.presto.execution.scheduler.NetworkLocation.ROOT_LOCATION;
@@ -191,7 +191,7 @@ public class TopologyAwareNodeSelector
             }
         }
 
-        CompletableFuture<?> blocked;
+        ListenableFuture<?> blocked;
         int maxPendingForWildcardNetworkAffinity = calculateMaxPendingSplits(0, networkLocationSegmentNames.size());
         if (splitWaitingForAnyNode) {
             blocked = toWhenHasSplitQueueSpaceFuture(existingTasks, calculateLowWatermark(maxPendingForWildcardNetworkAffinity));

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder.toTypes;
 import static com.google.common.base.Preconditions.checkState;
-import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
 
@@ -344,7 +343,7 @@ public class HashAggregationOperator
     public ListenableFuture<?> isBlocked()
     {
         if (aggregationBuilder != null) {
-            return toListenableFuture(aggregationBuilder.isBlocked());
+            return aggregationBuilder.isBlocked();
         }
         return NOT_BLOCKED;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -21,7 +21,6 @@ import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.util.ImmutableCollectors;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.airlift.concurrent.MoreFutures;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -222,7 +221,7 @@ public class HashBuilderOperator
         if (!finishing) {
             return NOT_BLOCKED;
         }
-        return MoreFutures.toListenableFuture(lookupSourceFactory.isDestroyed());
+        return lookupSourceFactory.isDestroyed();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -20,14 +20,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import io.airlift.concurrent.MoreFutures;
 
 import javax.annotation.concurrent.GuardedBy;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.operator.OuterLookupSource.createOuterLookupSourceSupplier;
@@ -45,7 +43,7 @@ public final class PartitionedLookupSourceFactory
     private final List<Type> hashChannelTypes;
     private final Supplier<LookupSource>[] partitions;
     private final boolean outer;
-    private final CompletableFuture<?> destroyed = new CompletableFuture<>();
+    private final SettableFuture<?> destroyed = SettableFuture.create();
 
     @GuardedBy("this")
     private int partitionsSet;
@@ -142,11 +140,11 @@ public final class PartitionedLookupSourceFactory
     @Override
     public void destroy()
     {
-        destroyed.complete(null);
+        destroyed.set(null);
     }
 
-    public CompletableFuture<?> isDestroyed()
+    public ListenableFuture<?> isDestroyed()
     {
-        return MoreFutures.unmodifiableFuture(destroyed);
+        return destroyed;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/HashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/HashAggregationBuilder.java
@@ -15,9 +15,9 @@ package com.facebook.presto.operator.aggregation.builder;
 
 import com.facebook.presto.operator.HashCollisionsCounter;
 import com.facebook.presto.spi.Page;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.Iterator;
-import java.util.concurrent.CompletableFuture;
 
 public interface HashAggregationBuilder
         extends AutoCloseable
@@ -28,7 +28,7 @@ public interface HashAggregationBuilder
 
     boolean isFull();
 
-    CompletableFuture<?> isBlocked();
+    ListenableFuture<?> isBlocked();
 
     void updateMemory();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -31,6 +31,7 @@ import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 import it.unimi.dsi.fastutil.ints.AbstractIntIterator;
 import it.unimi.dsi.fastutil.ints.IntIterator;
@@ -40,13 +41,12 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static com.facebook.presto.operator.GroupByHash.createGroupByHash;
+import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class InMemoryHashAggregationBuilder
         implements HashAggregationBuilder
@@ -171,9 +171,9 @@ public class InMemoryHashAggregationBuilder
     }
 
     @Override
-    public CompletableFuture<?> isBlocked()
+    public ListenableFuture<?> isBlocked()
     {
-        return completedFuture(null);
+        return NOT_BLOCKED;
     }
 
     public long getSizeInMemory()

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -27,15 +27,16 @@ import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static java.lang.Math.max;
 
@@ -55,7 +56,7 @@ public class SpillableHashAggregationBuilder
     private final long memoryLimitForMergeWithMemory;
     private Optional<Spiller> spiller = Optional.empty();
     private Optional<MergingHashAggregationBuilder> merger = Optional.empty();
-    private CompletableFuture<?> spillInProgress = CompletableFuture.completedFuture(null);
+    private ListenableFuture<?> spillInProgress = immediateFuture(null);
     private final LocalMemoryContext aggregationMemoryContext;
     private final LocalMemoryContext spillMemoryContext;
     private final JoinCompiler joinCompiler;
@@ -141,7 +142,7 @@ public class SpillableHashAggregationBuilder
     }
 
     @Override
-    public CompletableFuture<?> isBlocked()
+    public ListenableFuture<?> isBlocked()
     {
         return spillInProgress;
     }
@@ -203,7 +204,7 @@ public class SpillableHashAggregationBuilder
         }
     }
 
-    private CompletableFuture<?> spillToDisk()
+    private ListenableFuture<?> spillToDisk()
     {
         checkState(hasPreviousSpillCompletedSuccessfully(), "Previous spill hasn't yet finished");
         hashAggregationBuilder.setOutputPartial();

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/UpdateRequest.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/UpdateRequest.java
@@ -15,11 +15,10 @@ package com.facebook.presto.operator.index;
 
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
+import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.concurrent.MoreFutures;
 
 import javax.annotation.concurrent.ThreadSafe;
-
-import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -28,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 class UpdateRequest
 {
     private final Block[] blocks;
-    private final CompletableFuture<IndexSnapshot> indexSnapshotFuture = new CompletableFuture<>();
+    private final SettableFuture<IndexSnapshot> indexSnapshotFuture = SettableFuture.create();
     private final Page page;
 
     public UpdateRequest(Block... blocks)
@@ -51,12 +50,12 @@ class UpdateRequest
     public void finished(IndexSnapshot indexSnapshot)
     {
         requireNonNull(indexSnapshot, "indexSnapshot is null");
-        checkState(indexSnapshotFuture.complete(indexSnapshot), "Already finished!");
+        checkState(indexSnapshotFuture.set(indexSnapshot), "Already finished!");
     }
 
     public void failed(Throwable throwable)
     {
-        indexSnapshotFuture.completeExceptionally(throwable);
+        indexSnapshotFuture.setException(throwable);
     }
 
     public boolean isFinished()

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
@@ -30,7 +30,6 @@ import io.airlift.units.Duration;
 
 import javax.annotation.concurrent.GuardedBy;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -251,7 +250,7 @@ class ContinuousTaskStatusFetcher
         taskStatus.addStateChangeListener(stateChangeListener);
     }
 
-    public CompletableFuture<TaskStatus> getStateChange(TaskStatus taskStatus)
+    public ListenableFuture<TaskStatus> getStateChange(TaskStatus taskStatus)
     {
         return this.taskStatus.getStateChange(taskStatus);
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -63,7 +63,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -84,13 +83,13 @@ import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
 import static io.airlift.http.client.Request.Builder.prepareDelete;
 import static io.airlift.http.client.Request.Builder.preparePost;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
@@ -389,7 +388,7 @@ public final class HttpRemoteTask
     }
 
     @Override
-    public synchronized CompletableFuture<?> whenSplitQueueHasSpace(int threshold)
+    public synchronized ListenableFuture<?> whenSplitQueueHasSpace(int threshold)
     {
         if (whenSplitQueueHasSpaceThreshold.isPresent()) {
             checkArgument(threshold == whenSplitQueueHasSpaceThreshold.getAsInt(), "Multiple split queue space notification thresholds not supported");
@@ -399,7 +398,7 @@ public final class HttpRemoteTask
             updateSplitQueueSpace();
         }
         if (splitQueueHasSpace) {
-            return completedFuture(null);
+            return immediateFuture(null);
         }
         return whenSplitQueueHasSpace.createNewListener();
     }

--- a/presto-main/src/main/java/com/facebook/presto/spiller/Spiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/Spiller.java
@@ -14,11 +14,11 @@
 package com.facebook.presto.spiller;
 
 import com.facebook.presto.spi.Page;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.io.Closeable;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 public interface Spiller
         extends Closeable
@@ -26,7 +26,7 @@ public interface Spiller
     /**
      * Initiate spilling of pages stream. Returns completed future once spilling has finished.
      */
-    CompletableFuture<?> spill(Iterator<Page> pageIterator);
+    ListenableFuture<?> spill(Iterator<Page> pageIterator);
 
     /**
      * Returns list of previously spilled Pages streams.

--- a/presto-main/src/main/java/com/facebook/presto/split/ConnectorAwareSplitSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/ConnectorAwareSplitSource.java
@@ -15,13 +15,16 @@ package com.facebook.presto.split;
 
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.metadata.Split;
+import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
+import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static java.util.Objects.requireNonNull;
 
 public class ConnectorAwareSplitSource
@@ -45,10 +48,10 @@ public class ConnectorAwareSplitSource
     }
 
     @Override
-    public CompletableFuture<List<Split>> getNextBatch(int maxSize)
+    public ListenableFuture<List<Split>> getNextBatch(int maxSize)
     {
-        return source.getNextBatch(maxSize)
-                .thenApply(splits -> Lists.transform(splits, split -> new Split(connectorId, transactionHandle, split)));
+        ListenableFuture<List<ConnectorSplit>> nextBatch = toListenableFuture(source.getNextBatch(maxSize));
+        return Futures.transform(nextBatch, splits -> Lists.transform(splits, split -> new Split(connectorId, transactionHandle, split)));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/split/SplitSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/SplitSource.java
@@ -15,17 +15,17 @@ package com.facebook.presto.split;
 
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.metadata.Split;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.io.Closeable;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 public interface SplitSource
         extends Closeable
 {
     ConnectorId getConnectorId();
 
-    CompletableFuture<List<Split>> getNextBatch(int maxSize);
+    ListenableFuture<List<Split>> getNextBatch(int maxSize);
 
     @Override
     void close();

--- a/presto-main/src/main/java/com/facebook/presto/transaction/TransactionBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/TransactionBuilder.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static java.util.Objects.requireNonNull;
 
 public class TransactionBuilder
@@ -104,7 +105,7 @@ public class TransactionBuilder
         }
         finally {
             if (success) {
-                transactionManager.asyncCommit(transactionId).join();
+                getFutureValue(transactionManager.asyncCommit(transactionId));
             }
             else {
                 transactionManager.asyncAbort(transactionId);
@@ -153,7 +154,7 @@ public class TransactionBuilder
         finally {
             if (managedTransaction) {
                 if (success) {
-                    transactionManager.asyncCommit(transactionSession.getTransactionId().get()).join();
+                    getFutureValue(transactionManager.asyncCommit(transactionSession.getTransactionId().get()));
                 }
                 else {
                     transactionManager.asyncAbort(transactionSession.getTransactionId().get());

--- a/presto-main/src/main/java/com/facebook/presto/transaction/TransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/TransactionManager.java
@@ -22,10 +22,13 @@ import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.transaction.IsolationLevel;
-import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
 import io.airlift.concurrent.BoundedExecutor;
+import io.airlift.concurrent.ExecutorServiceAdapter;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import org.joda.time.DateTime;
@@ -37,8 +40,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -47,6 +50,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import static com.facebook.presto.spi.StandardErrorCode.AUTOCOMMIT_WRITE_CONFLICT;
 import static com.facebook.presto.spi.StandardErrorCode.MULTI_CATALOG_WRITE_CONFLICT;
@@ -58,14 +62,13 @@ import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static io.airlift.concurrent.MoreFutures.allAsList;
-import static io.airlift.concurrent.MoreFutures.failedFuture;
-import static io.airlift.concurrent.MoreFutures.unmodifiableFuture;
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static io.airlift.concurrent.MoreFutures.addExceptionCallback;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.concurrent.CompletableFuture.runAsync;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
 
@@ -131,9 +134,9 @@ public class TransactionManager
 
     private synchronized void cleanUpExpiredTransactions()
     {
-        Iterator<Map.Entry<TransactionId, TransactionMetadata>> iterator = transactions.entrySet().iterator();
+        Iterator<Entry<TransactionId, TransactionMetadata>> iterator = transactions.entrySet().iterator();
         while (iterator.hasNext()) {
-            Map.Entry<TransactionId, TransactionMetadata> entry = iterator.next();
+            Entry<TransactionId, TransactionMetadata> entry = iterator.next();
             if (entry.getValue().isExpired(idleTimeout)) {
                 iterator.remove();
                 log.info("Removing expired transaction: %s", entry.getKey());
@@ -244,13 +247,13 @@ public class TransactionManager
         return Optional.ofNullable(transactions.get(transactionId));
     }
 
-    private CompletableFuture<TransactionMetadata> removeTransactionMetadataAsFuture(TransactionId transactionId)
+    private ListenableFuture<TransactionMetadata> removeTransactionMetadataAsFuture(TransactionId transactionId)
     {
         TransactionMetadata transactionMetadata = transactions.remove(transactionId);
         if (transactionMetadata == null) {
-            return failedFuture(unknownTransactionError(transactionId));
+            return immediateFailedFuture(unknownTransactionError(transactionId));
         }
-        return completedFuture(transactionMetadata);
+        return immediateFuture(transactionMetadata);
     }
 
     private static PrestoException unknownTransactionError(TransactionId transactionId)
@@ -258,16 +261,14 @@ public class TransactionManager
         return new PrestoException(UNKNOWN_TRANSACTION, format("Unknown transaction ID: %s. Possibly expired? Commands ignored until end of transaction block", transactionId));
     }
 
-    public CompletableFuture<?> asyncCommit(TransactionId transactionId)
+    public ListenableFuture<?> asyncCommit(TransactionId transactionId)
     {
-        return unmodifiableFuture(removeTransactionMetadataAsFuture(transactionId)
-                .thenCompose(metadata -> metadata.asyncCommit()));
+        return Futures.transformAsync(removeTransactionMetadataAsFuture(transactionId), TransactionMetadata::asyncCommit);
     }
 
-    public CompletableFuture<?> asyncAbort(TransactionId transactionId)
+    public ListenableFuture<?> asyncAbort(TransactionId transactionId)
     {
-        return unmodifiableFuture(removeTransactionMetadataAsFuture(transactionId)
-                .thenCompose(metadata -> metadata.asyncAbort()));
+        return Futures.transformAsync(removeTransactionMetadataAsFuture(transactionId), TransactionMetadata::asyncAbort);
     }
 
     public void fail(TransactionId transactionId)
@@ -289,7 +290,7 @@ public class TransactionManager
         private final Map<ConnectorId, ConnectorTransactionMetadata> connectorIdToMetadata = new ConcurrentHashMap<>();
         @GuardedBy("this")
         private final AtomicReference<ConnectorId> writtenConnectorId = new AtomicReference<>();
-        private final Executor finishingExecutor;
+        private final ListeningExecutorService finishingExecutor;
         private final AtomicReference<Boolean> completedSuccessfully = new AtomicReference<>();
         private final AtomicReference<Long> idleStartTime = new AtomicReference<>();
 
@@ -313,7 +314,7 @@ public class TransactionManager
             this.readOnly = readOnly;
             this.autoCommitContext = autoCommitContext;
             this.catalogManager = requireNonNull(catalogManager, "catalogManager is null");
-            this.finishingExecutor = requireNonNull(finishingExecutor, "finishingExecutor is null");
+            this.finishingExecutor = listeningDecorator(ExecutorServiceAdapter.from(requireNonNull(finishingExecutor, "finishingExecutor is null")));
         }
 
         public void setActive()
@@ -441,72 +442,65 @@ public class TransactionManager
             }
         }
 
-        public synchronized CompletableFuture<?> asyncCommit()
+        public synchronized ListenableFuture<?> asyncCommit()
         {
             if (!completedSuccessfully.compareAndSet(null, true)) {
                 if (completedSuccessfully.get()) {
                     // Already done
-                    return completedFuture(null);
+                    return immediateFuture(null);
                 }
                 // Transaction already aborted
-                return failedFuture(new PrestoException(TRANSACTION_ALREADY_ABORTED, "Current transaction has already been aborted"));
+                return immediateFailedFuture(new PrestoException(TRANSACTION_ALREADY_ABORTED, "Current transaction has already been aborted"));
             }
 
             ConnectorId writeConnectorId = this.writtenConnectorId.get();
             if (writeConnectorId == null) {
-                List<CompletableFuture<?>> futures = connectorIdToMetadata.values().stream()
-                        .map(transactionMetadata -> runAsync(transactionMetadata::commit, finishingExecutor))
-                        .collect(toList());
-                return unmodifiableFuture(allAsList(futures)
-                        .whenComplete((value, throwable) -> {
-                            if (throwable != null) {
-                                abortInternal();
-                                log.error(throwable, "Read-only connector should not throw exception on commit");
-                            }
-                        }));
+                ListenableFuture<?> future = Futures.allAsList(connectorIdToMetadata.values().stream()
+                        .map(transactionMetadata -> finishingExecutor.submit(transactionMetadata::commit))
+                        .collect(toList()));
+                addExceptionCallback(future, throwable ->  {
+                    abortInternal();
+                    log.error(throwable, "Read-only connector should not throw exception on commit");
+                });
+                return future;
             }
 
-            Supplier<CompletableFuture<?>> commitReadOnlyConnectors = () -> allAsList(connectorIdToMetadata.entrySet().stream()
-                    .filter(entry -> !entry.getKey().equals(writeConnectorId))
-                    .map(Map.Entry::getValue)
-                    .map(transactionMetadata -> runAsync(transactionMetadata::commit, finishingExecutor))
-                    .collect(toList()))
-                    .whenComplete((value, throwable) -> {
-                        if (throwable != null) {
-                            log.error(throwable, "Read-only connector should not throw exception on commit");
-                        }
-                    });
+            Supplier<ListenableFuture<?>> commitReadOnlyConnectors = () -> {
+                ListenableFuture<? extends List<?>> future = Futures.allAsList(connectorIdToMetadata.entrySet().stream()
+                        .filter(entry -> !entry.getKey().equals(writeConnectorId))
+                        .map(Entry::getValue)
+                        .map(transactionMetadata -> finishingExecutor.submit(transactionMetadata::commit))
+                        .collect(toList()));
+                addExceptionCallback(future, throwable -> log.error(throwable, "Read-only connector should not throw exception on commit"));
+                return future;
+            };
 
             ConnectorTransactionMetadata writeConnector = connectorIdToMetadata.get(writeConnectorId);
-            return unmodifiableFuture(runAsync(writeConnector::commit, finishingExecutor)
-                    .thenCompose(aVoid -> commitReadOnlyConnectors.get())
-                    .whenComplete((value, throwable) -> {
-                        if (throwable != null) {
-                            abortInternal();
-                        }
-                    }));
+            ListenableFuture<?> commitFuture = finishingExecutor.submit(writeConnector::commit);
+            ListenableFuture<?> readOnlyCommitFuture = Futures.transformAsync(commitFuture, ignored -> commitReadOnlyConnectors.get());
+            addExceptionCallback(readOnlyCommitFuture, this::abortInternal);
+            return readOnlyCommitFuture;
         }
 
-        public synchronized CompletableFuture<?> asyncAbort()
+        public synchronized ListenableFuture<?> asyncAbort()
         {
             if (!completedSuccessfully.compareAndSet(null, false)) {
                 if (completedSuccessfully.get()) {
                     // Should not happen normally
-                    return failedFuture(new IllegalStateException("Current transaction already committed"));
+                    return immediateFailedFuture(new IllegalStateException("Current transaction already committed"));
                 }
                 // Already done
-                return completedFuture(null);
+                return immediateFuture(null);
             }
             return abortInternal();
         }
 
-        private synchronized CompletableFuture<?> abortInternal()
+        private synchronized ListenableFuture<?> abortInternal()
         {
             // the callbacks in statement performed on another thread so are safe
-            CompletableFuture<List<Void>> futures = allAsList(connectorIdToMetadata.values().stream()
-                    .map(connection -> runAsync(() -> safeAbort(connection), finishingExecutor))
+            return Futures.allAsList(connectorIdToMetadata.values().stream()
+                    .map(connection -> finishingExecutor.submit(() -> safeAbort(connection)))
                     .collect(toList()));
-            return unmodifiableFuture(futures);
         }
 
         private static void safeAbort(ConnectorTransactionMetadata connection)

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCommitTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCommitTask.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.spi.StandardErrorCode.UNKNOWN_TRANSACTION;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static com.facebook.presto.transaction.TransactionManager.createTestTransactionManager;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -72,7 +73,7 @@ public class TestCommitTask
         assertTrue(stateMachine.getSession().getTransactionId().isPresent());
         assertEquals(transactionManager.getAllTransactionInfos().size(), 1);
 
-        new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()).join();
+        getFutureValue(new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
         assertTrue(stateMachine.getQueryInfoWithoutDetails().isClearTransactionId());
         assertFalse(stateMachine.getQueryInfoWithoutDetails().getStartedTransactionId().isPresent());
 
@@ -92,7 +93,7 @@ public class TestCommitTask
 
         try {
             try {
-                new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()).join();
+                getFutureValue(new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
                 fail();
             }
             catch (CompletionException e) {
@@ -122,7 +123,7 @@ public class TestCommitTask
 
         try {
             try {
-                new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()).join();
+                getFutureValue(new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
                 fail();
             }
             catch (CompletionException e) {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestResetSessionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestResetSessionTask.java
@@ -42,6 +42,7 @@ import static com.facebook.presto.spi.session.PropertyMetadata.stringSessionProp
 import static com.facebook.presto.testing.TestingSession.createBogusTestingCatalog;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.transaction.TransactionManager.createTestTransactionManager;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -112,13 +113,13 @@ public class TestResetSessionTask
                 executor,
                 metadata);
 
-        new ResetSessionTask().execute(
+        getFutureValue(new ResetSessionTask().execute(
                 new ResetSession(QualifiedName.of(CATALOG_NAME, "baz")),
                 transactionManager,
                 metadata,
                 accessControl,
                 stateMachine,
-                emptyList()).join();
+                emptyList()));
 
         Set<String> sessionProperties = stateMachine.getResetSessionProperties();
         assertEquals(sessionProperties, ImmutableSet.of("catalog.baz"));

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestRollbackTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestRollbackTask.java
@@ -37,6 +37,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_IN_TRANSACTION;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static com.facebook.presto.transaction.TransactionManager.createTestTransactionManager;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -71,7 +72,7 @@ public class TestRollbackTask
         assertTrue(stateMachine.getSession().getTransactionId().isPresent());
         assertEquals(transactionManager.getAllTransactionInfos().size(), 1);
 
-        new RollbackTask().execute(new Rollback(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()).join();
+        getFutureValue(new RollbackTask().execute(new Rollback(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
         assertTrue(stateMachine.getQueryInfoWithoutDetails().isClearTransactionId());
         assertFalse(stateMachine.getQueryInfoWithoutDetails().getStartedTransactionId().isPresent());
 
@@ -91,7 +92,7 @@ public class TestRollbackTask
 
         try {
             try {
-                new RollbackTask().execute(new Rollback(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()).join();
+                getFutureValue(new RollbackTask().execute(new Rollback(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
                 fail();
             }
             catch (CompletionException e) {
@@ -119,7 +120,7 @@ public class TestRollbackTask
                 .build();
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "ROLLBACK", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor, metadata);
 
-        new RollbackTask().execute(new Rollback(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()).join();
+        getFutureValue(new RollbackTask().execute(new Rollback(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
         assertTrue(stateMachine.getQueryInfoWithoutDetails().isClearTransactionId()); // Still issue clear signal
         assertFalse(stateMachine.getQueryInfoWithoutDetails().getStartedTransactionId().isPresent());
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSetSessionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSetSessionTask.java
@@ -47,6 +47,7 @@ import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringSessionProperty;
 import static com.facebook.presto.testing.TestingSession.createBogusTestingCatalog;
 import static com.facebook.presto.transaction.TransactionManager.createTestTransactionManager;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -128,7 +129,7 @@ public class TestSetSessionTask
             throws Exception
     {
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "set foo.bar = 'baz'", TEST_SESSION, URI.create("fake://uri"), false, transactionManager, accessControl, executor, metadata);
-        new SetSessionTask().execute(new SetSession(QualifiedName.of(CATALOG_NAME, "bar"), expression), transactionManager, metadata, accessControl, stateMachine, parameters).join();
+        getFutureValue(new SetSessionTask().execute(new SetSession(QualifiedName.of(CATALOG_NAME, "bar"), expression), transactionManager, metadata, accessControl, stateMachine, parameters));
 
         Map<String, String> sessionProperties = stateMachine.getSetSessionProperties();
         assertEquals(sessionProperties, ImmutableMap.of("foo.bar", expectedValue));

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -30,6 +30,7 @@ import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.json.ObjectMapperProvider;
 import io.airlift.node.NodeInfo;
 import io.airlift.units.DataSize;
@@ -38,7 +39,6 @@ import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -224,7 +224,7 @@ public class TestSqlTask
         OutputBuffers outputBuffers = createInitialEmptyOutputBuffers(PARTITIONED).withBuffer(OUT, 0).withNoMoreBufferIds();
         updateTask(sqlTask, EMPTY_SOURCES, outputBuffers);
 
-        CompletableFuture<BufferResult> bufferResult = sqlTask.getTaskResults(OUT, 0, new DataSize(1, MEGABYTE));
+        ListenableFuture<BufferResult> bufferResult = sqlTask.getTaskResults(OUT, 0, new DataSize(1, MEGABYTE));
         assertFalse(bufferResult.isDone());
 
         // close the sources (no splits will ever be added)
@@ -250,7 +250,7 @@ public class TestSqlTask
 
         updateTask(sqlTask, EMPTY_SOURCES, createInitialEmptyOutputBuffers(PARTITIONED).withBuffer(OUT, 0).withNoMoreBufferIds());
 
-        CompletableFuture<BufferResult> bufferResult = sqlTask.getTaskResults(OUT, 0, new DataSize(1, MEGABYTE));
+        ListenableFuture<BufferResult> bufferResult = sqlTask.getTaskResults(OUT, 0, new DataSize(1, MEGABYTE));
         assertFalse(bufferResult.isDone());
 
         sqlTask.cancel();
@@ -272,7 +272,7 @@ public class TestSqlTask
 
         updateTask(sqlTask, EMPTY_SOURCES, createInitialEmptyOutputBuffers(PARTITIONED).withBuffer(OUT, 0).withNoMoreBufferIds());
 
-        CompletableFuture<BufferResult> bufferResult = sqlTask.getTaskResults(OUT, 0, new DataSize(1, MEGABYTE));
+        ListenableFuture<BufferResult> bufferResult = sqlTask.getTaskResults(OUT, 0, new DataSize(1, MEGABYTE));
         assertFalse(bufferResult.isDone());
 
         TaskState taskState = sqlTask.getTaskInfo().getTaskStatus().getState();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -296,31 +296,31 @@ public class TestSqlTaskManager
         @Override
         public URI createQueryLocation(QueryId queryId)
         {
-            return URI.create("fake://query/" + queryId);
+            return URI.create("http://fake.invalid/query/" + queryId);
         }
 
         @Override
         public URI createStageLocation(StageId stageId)
         {
-            return URI.create("fake://stage/" + stageId);
+            return URI.create("http://fake.invalid/stage/" + stageId);
         }
 
         @Override
         public URI createLocalTaskLocation(TaskId taskId)
         {
-            return URI.create("fake://task/" + taskId);
+            return URI.create("http://fake.invalid/task/" + taskId);
         }
 
         @Override
         public URI createTaskLocation(Node node, TaskId taskId)
         {
-            return URI.create("fake://task/" + node.getNodeIdentifier() + "/" + taskId);
+            return URI.create("http://fake.invalid/task/" + node.getNodeIdentifier() + "/" + taskId);
         }
 
         @Override
         public URI createMemoryInfoLocation(Node node)
         {
-            return URI.create("fake://" + node.getNodeIdentifier() + "/memory");
+            return URI.create("http://fake.invalid/" + node.getNodeIdentifier() + "/memory");
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStartTransactionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStartTransactionTask.java
@@ -49,6 +49,7 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_TRANSAC
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static com.facebook.presto.transaction.TransactionManager.createTestTransactionManager;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -84,7 +85,7 @@ public class TestStartTransactionTask
 
         try {
             try {
-                new StartTransactionTask().execute(new StartTransaction(ImmutableList.of()), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()).join();
+                getFutureValue(new StartTransactionTask().execute(new StartTransaction(ImmutableList.of()), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
                 fail();
             }
             catch (CompletionException e) {
@@ -115,7 +116,7 @@ public class TestStartTransactionTask
 
         try {
             try {
-                new StartTransactionTask().execute(new StartTransaction(ImmutableList.of()), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()).join();
+                getFutureValue(new StartTransactionTask().execute(new StartTransaction(ImmutableList.of()), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
                 fail();
             }
             catch (CompletionException e) {
@@ -143,7 +144,7 @@ public class TestStartTransactionTask
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor, metadata);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
-        new StartTransactionTask().execute(new StartTransaction(ImmutableList.of()), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()).join();
+        getFutureValue(new StartTransactionTask().execute(new StartTransaction(ImmutableList.of()), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
         assertFalse(stateMachine.getQueryInfoWithoutDetails().isClearTransactionId());
         assertTrue(stateMachine.getQueryInfoWithoutDetails().getStartedTransactionId().isPresent());
         assertEquals(transactionManager.getAllTransactionInfos().size(), 1);
@@ -164,13 +165,13 @@ public class TestStartTransactionTask
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor, metadata);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
-        new StartTransactionTask().execute(
+        getFutureValue(new StartTransactionTask().execute(
                 new StartTransaction(ImmutableList.of(new Isolation(Isolation.Level.SERIALIZABLE), new TransactionAccessMode(true))),
                 transactionManager,
                 metadata,
                 new AllowAllAccessControl(),
                 stateMachine,
-                emptyList()).join();
+                emptyList()));
         assertFalse(stateMachine.getQueryInfoWithoutDetails().isClearTransactionId());
         assertTrue(stateMachine.getQueryInfoWithoutDetails().getStartedTransactionId().isPresent());
         assertEquals(transactionManager.getAllTransactionInfos().size(), 1);
@@ -195,13 +196,13 @@ public class TestStartTransactionTask
 
         try {
             try {
-                new StartTransactionTask().execute(
+                getFutureValue(new StartTransactionTask().execute(
                         new StartTransaction(ImmutableList.of(new Isolation(Isolation.Level.READ_COMMITTED), new Isolation(Isolation.Level.READ_COMMITTED))),
                         transactionManager,
                         metadata,
                         new AllowAllAccessControl(),
                         stateMachine,
-                        emptyList()).join();
+                        emptyList()));
                 fail();
             }
             catch (CompletionException e) {
@@ -231,13 +232,13 @@ public class TestStartTransactionTask
 
         try {
             try {
-                new StartTransactionTask().execute(
+                getFutureValue(new StartTransactionTask().execute(
                         new StartTransaction(ImmutableList.of(new TransactionAccessMode(true), new TransactionAccessMode(true))),
                         transactionManager,
                         metadata,
                         new AllowAllAccessControl(),
                         stateMachine,
-                        emptyList()).join();
+                        emptyList()));
                 fail();
             }
             catch (CompletionException e) {
@@ -271,13 +272,13 @@ public class TestStartTransactionTask
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor, metadata);
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
-        new StartTransactionTask().execute(
+        getFutureValue(new StartTransactionTask().execute(
                 new StartTransaction(ImmutableList.of()),
                 transactionManager,
                 metadata,
                 new AllowAllAccessControl(),
                 stateMachine,
-                emptyList()).join();
+                emptyList()));
         assertFalse(stateMachine.getQueryInfoWithoutDetails().isClearTransactionId());
         assertTrue(stateMachine.getQueryInfoWithoutDetails().getStartedTransactionId().isPresent());
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStateMachine.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.Duration;
 import org.testng.annotations.AfterClass;
@@ -228,7 +229,7 @@ public class TestStateMachine
             throws Exception
     {
         State initialState = stateMachine.get();
-        Future<State> futureChange = stateMachine.getStateChange(initialState);
+        ListenableFuture<State> futureChange = stateMachine.getStateChange(initialState);
 
         SettableFuture<State> listenerChange = SettableFuture.create();
         stateMachine.addStateChangeListener(listenerChange::set);
@@ -266,7 +267,7 @@ public class TestStateMachine
             throws Exception
     {
         State initialState = stateMachine.get();
-        Future<State> futureChange = stateMachine.getStateChange(initialState);
+        ListenableFuture<State> futureChange = stateMachine.getStateChange(initialState);
 
         SettableFuture<State> listenerChange = SettableFuture.create();
         stateMachine.addStateChangeListener(listenerChange::set);

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
@@ -31,7 +31,6 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
@@ -383,7 +382,7 @@ public class TestArbitraryOutputBuffer
         assertFalse(buffer.isFinished());
 
         // get a page from a buffer that doesn't exist yet
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0L, sizeOfPages(1));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0L, sizeOfPages(1));
         assertFalse(future.isDone());
 
         // add a page and verify the future is complete
@@ -400,7 +399,7 @@ public class TestArbitraryOutputBuffer
         assertFalse(buffer.isFinished());
 
         // get a page from a buffer that doesn't exist yet
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, (long) 0, sizeOfPages(1));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, (long) 0, sizeOfPages(1));
         assertFalse(future.isDone());
 
         // abort that buffer, and verify the future is finishd
@@ -503,7 +502,7 @@ public class TestArbitraryOutputBuffer
         assertFalse(buffer.isFinished());
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -535,7 +534,7 @@ public class TestArbitraryOutputBuffer
         assertFalse(buffer.isFinished());
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -621,7 +620,7 @@ public class TestArbitraryOutputBuffer
         assertFalse(buffer.isFinished());
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -692,7 +691,7 @@ public class TestArbitraryOutputBuffer
         assertFalse(buffer.isFinished());
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -794,11 +793,11 @@ public class TestArbitraryOutputBuffer
 
     private static BufferResult getBufferResult(OutputBuffer buffer, OutputBufferId bufferId, long sequenceId, DataSize maxSize, Duration maxWait)
     {
-        CompletableFuture<BufferResult> future = buffer.get(bufferId, sequenceId, maxSize);
+        ListenableFuture<BufferResult> future = buffer.get(bufferId, sequenceId, maxSize);
         return getFuture(future, maxWait);
     }
 
-    private static BufferResult getFuture(CompletableFuture<BufferResult> future, Duration maxWait)
+    private static BufferResult getFuture(ListenableFuture<BufferResult> future, Duration maxWait)
     {
         return tryGetFutureValue(future, (int) maxWait.toMillis(), MILLISECONDS).get();
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
@@ -31,7 +31,6 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
@@ -395,7 +394,7 @@ public class TestBroadcastOutputBuffer
         assertFalse(buffer.isFinished());
 
         // get a page from a buffer that doesn't exist yet
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, (long) 0, sizeOfPages(1));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, (long) 0, sizeOfPages(1));
         assertFalse(future.isDone());
 
         // add a page and verify the future is complete
@@ -412,7 +411,7 @@ public class TestBroadcastOutputBuffer
         assertFalse(buffer.isFinished());
 
         // get a page from a buffer that doesn't exist yet
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, (long) 0, sizeOfPages(1));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, (long) 0, sizeOfPages(1));
         assertFalse(future.isDone());
 
         // add a page and set no more pages
@@ -439,7 +438,7 @@ public class TestBroadcastOutputBuffer
         assertFalse(buffer.isFinished());
 
         // get a page from a buffer that doesn't exist yet
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(1));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(1));
         assertFalse(future.isDone());
 
         // abort that buffer, and verify the future is complete and buffer is finished
@@ -569,7 +568,7 @@ public class TestBroadcastOutputBuffer
         assertFalse(buffer.isFinished());
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -608,7 +607,7 @@ public class TestBroadcastOutputBuffer
         assertFalse(buffer.isFinished());
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -690,7 +689,7 @@ public class TestBroadcastOutputBuffer
         assertFalse(buffer.isFinished());
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -762,7 +761,7 @@ public class TestBroadcastOutputBuffer
         assertFalse(buffer.isFinished());
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -865,11 +864,11 @@ public class TestBroadcastOutputBuffer
 
     public static BufferResult getBufferResult(BroadcastOutputBuffer buffer, OutputBufferId bufferId, long sequenceId, DataSize maxSize, Duration maxWait)
     {
-        CompletableFuture<BufferResult> future = buffer.get(bufferId, sequenceId, maxSize);
+        ListenableFuture<BufferResult> future = buffer.get(bufferId, sequenceId, maxSize);
         return getFuture(future, maxWait);
     }
 
-    public static BufferResult getFuture(CompletableFuture<BufferResult> future, Duration maxWait)
+    public static BufferResult getFuture(ListenableFuture<BufferResult> future, Duration maxWait)
     {
         return tryGetFutureValue(future, (int) maxWait.toMillis(), MILLISECONDS).get();
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestClientBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestClientBuffer.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
@@ -33,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -138,7 +138,7 @@ public class TestClientBuffer
         assertBufferInfo(buffer, 3, 0);
 
         // acknowledge first three pages in the buffer
-        CompletableFuture<BufferResult> pendingRead = buffer.getPages(3, sizeOfPages(1));
+        ListenableFuture<BufferResult> pendingRead = buffer.getPages(3, sizeOfPages(1));
         // pages now acknowledged
         assertEquals(supplier.getBufferedPages(), 0);
         assertBufferInfo(buffer, 0, 3);
@@ -266,7 +266,7 @@ public class TestClientBuffer
         ClientBuffer buffer = new ClientBuffer(TASK_INSTANCE_ID, BUFFER_ID);
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.getPages(0, sizeOfPages(10));
+        ListenableFuture<BufferResult> future = buffer.getPages(0, sizeOfPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -296,7 +296,7 @@ public class TestClientBuffer
         ClientBuffer buffer = new ClientBuffer(TASK_INSTANCE_ID, BUFFER_ID);
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.getPages(0, sizeOfPages(10));
+        ListenableFuture<BufferResult> future = buffer.getPages(0, sizeOfPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -387,17 +387,17 @@ public class TestClientBuffer
 
     private static BufferResult getBufferResult(ClientBuffer buffer, long sequenceId, DataSize maxSize, Duration maxWait)
     {
-        CompletableFuture<BufferResult> future = buffer.getPages(sequenceId, maxSize);
+        ListenableFuture<BufferResult> future = buffer.getPages(sequenceId, maxSize);
         return getFuture(future, maxWait);
     }
 
     private static BufferResult getBufferResult(ClientBuffer buffer, PagesSupplier supplier, long sequenceId, DataSize maxSize, Duration maxWait)
     {
-        CompletableFuture<BufferResult> future = buffer.getPages(sequenceId, maxSize, Optional.of(supplier));
+        ListenableFuture<BufferResult> future = buffer.getPages(sequenceId, maxSize, Optional.of(supplier));
         return getFuture(future, maxWait);
     }
 
-    private static BufferResult getFuture(CompletableFuture<BufferResult> future, Duration maxWait)
+    private static BufferResult getFuture(ListenableFuture<BufferResult> future, Duration maxWait)
     {
         return tryGetFutureValue(future, (int) maxWait.toMillis(), MILLISECONDS).get();
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPartitionedOutputBuffer.java
@@ -31,7 +31,6 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
@@ -451,7 +450,7 @@ public class TestPartitionedOutputBuffer
         assertFalse(buffer.isFinished());
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfBufferedPages(10));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfBufferedPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -490,7 +489,7 @@ public class TestPartitionedOutputBuffer
         assertFalse(buffer.isFinished());
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfBufferedPages(10));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfBufferedPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -572,7 +571,7 @@ public class TestPartitionedOutputBuffer
         assertFalse(buffer.isFinished());
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfBufferedPages(10));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfBufferedPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -644,7 +643,7 @@ public class TestPartitionedOutputBuffer
         assertFalse(buffer.isFinished());
 
         // attempt to get a page
-        CompletableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfBufferedPages(10));
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfBufferedPages(10));
 
         // verify we are waiting for a page
         assertFalse(future.isDone());
@@ -747,11 +746,11 @@ public class TestPartitionedOutputBuffer
 
     public static BufferResult getBufferResult(PartitionedOutputBuffer buffer, OutputBufferId bufferId, long sequenceId, DataSize maxSize, Duration maxWait)
     {
-        CompletableFuture<BufferResult> future = buffer.get(bufferId, sequenceId, maxSize);
+        ListenableFuture<BufferResult> future = buffer.get(bufferId, sequenceId, maxSize);
         return getFuture(future, maxWait);
     }
 
-    public static BufferResult getFuture(CompletableFuture<BufferResult> future, Duration maxWait)
+    public static BufferResult getFuture(ListenableFuture<BufferResult> future, Duration maxWait)
     {
         return tryGetFutureValue(future, (int) maxWait.toMillis(), MILLISECONDS).get();
     }

--- a/presto-main/src/test/java/com/facebook/presto/split/MockSplitSource.java
+++ b/presto-main/src/test/java/com/facebook/presto/split/MockSplitSource.java
@@ -19,10 +19,12 @@ import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class MockSplitSource
         implements SplitSource
@@ -53,7 +55,7 @@ public class MockSplitSource
     }
 
     @Override
-    public CompletableFuture<List<Split>> getNextBatch(int maxSize)
+    public ListenableFuture<List<Split>> getNextBatch(int maxSize)
     {
         nextBatchCalls++;
         if (nextBatchCalls > failAfter) {
@@ -61,7 +63,7 @@ public class MockSplitSource
         }
         int splits = Math.min(Math.min(batchSize, maxSize), remainingSplits);
         remainingSplits -= splits;
-        return CompletableFuture.completedFuture(Collections.nCopies(splits, SPLIT));
+        return immediateFuture(Collections.nCopies(splits, SPLIT));
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/transaction/TestTransactionManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/transaction/TestTransactionManager.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.connector.ConnectorId.createInformationSchemaConnectorId;
 import static com.facebook.presto.connector.ConnectorId.createSystemTablesConnectorId;
 import static com.facebook.presto.spi.StandardErrorCode.TRANSACTION_ALREADY_ABORTED;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -91,7 +92,7 @@ public class TestTransactionManager
             assertEquals(transactionInfo.getConnectorIds(), ImmutableList.of(CONNECTOR_ID, INFORMATION_SCHEMA_ID, SYSTEM_TABLES_ID));
             assertFalse(transactionInfo.getWrittenConnectorId().isPresent());
 
-            transactionManager.asyncCommit(transactionId).join();
+            getFutureValue(transactionManager.asyncCommit(transactionId));
 
             assertTrue(transactionManager.getAllTransactionInfos().isEmpty());
         }
@@ -122,7 +123,7 @@ public class TestTransactionManager
             assertEquals(transactionInfo.getConnectorIds(), ImmutableList.of(CONNECTOR_ID, INFORMATION_SCHEMA_ID, SYSTEM_TABLES_ID));
             assertFalse(transactionInfo.getWrittenConnectorId().isPresent());
 
-            transactionManager.asyncAbort(transactionId).join();
+            getFutureValue(transactionManager.asyncAbort(transactionId));
 
             assertTrue(transactionManager.getAllTransactionInfos().isEmpty());
         }
@@ -165,7 +166,7 @@ public class TestTransactionManager
             }
             assertEquals(transactionManager.getAllTransactionInfos().size(), 1);
 
-            transactionManager.asyncAbort(transactionId).join();
+            getFutureValue(transactionManager.asyncAbort(transactionId));
 
             assertTrue(transactionManager.getAllTransactionInfos().isEmpty());
         }


### PR DESCRIPTION
The CompletableFuture interface is difficult to use correctly, and it is
easy to introduce subtle bugs that result in lost notifications. For example
CompletableFuture does not propagate cancel from wrapped futures to the
core future. Additionally, it is easy to accidentally schedule tasks on a system
wide fork join pool.

ListenableFuture on the other hand is easy to understand and reasonable, and
the transformations in Guava handle cancelation properly.
