### PR TITLE
Push partial aggregation through inner join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -72,6 +72,7 @@ public final class SystemSessionProperties
     public static final String EXCHANGE_COMPRESSION = "exchange_compression";
     public static final String ENABLE_INTERMEDIATE_AGGREGATIONS = "enable_intermediate_aggregations";
     public static final String PUSH_AGGREGATION_THROUGH_JOIN = "push_aggregation_through_join";
+    public static final String PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN = "push_partial_aggregation_through_join";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -312,6 +313,11 @@ public final class SystemSessionProperties
                         PUSH_AGGREGATION_THROUGH_JOIN,
                         "Allow pushing aggregations below joins",
                         featuresConfig.isPushAggregationThroughJoin(),
+                        false),
+                booleanSessionProperty(
+                        PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN,
+                        "Push partial aggregations below joins",
+                        false,
                         false));
     }
 
@@ -487,5 +493,10 @@ public final class SystemSessionProperties
     public static boolean shouldPushAggregationThroughJoin(Session session)
     {
         return session.getSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, Boolean.class);
+    }
+
+    public static boolean isPushAggregationThroughJoin(Session session)
+    {
+        return session.getSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, Boolean.class);
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -22,6 +22,7 @@ import com.facebook.presto.tpch.TpchConnectorFactory;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.SystemSessionProperties.PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
@@ -43,6 +44,7 @@ public class TestLocalQueries
         Session defaultSession = testSessionBuilder()
                 .setCatalog("local")
                 .setSchema(TINY_SCHEMA_NAME)
+                .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, "true")
                 .build();
 
         LocalQueryRunner localQueryRunner = new LocalQueryRunner(defaultSession);


### PR DESCRIPTION
Adding flag for pushing partial aggregation through join.

This is yet another PR that depends on jmh benchmarks defined in https://github.com/prestodb/presto/pull/5809. Results for simple query:
```
Benchmark                                                       (enabled)  Mode  Cnt    Score    Error  Units
BenchmarkPartialAggregationPushdown.pushdownPartialThroughJoin       true  avgt   10  210.992 ±  7.088  ms/op
BenchmarkPartialAggregationPushdown.pushdownPartialThroughJoin      false  avgt   10  494.724 ± 58.796  ms/op
```

With support for `filter function` (there is now `TODO` in the code for this) this change would significantly outperform SPARK 2.0 in [CERN use case](https://databricks.com/blog/2016/10/03/voice-from-cern-apache-spark-2-0-performance-improvements-investigated-with-flame-graphs.html)