### PR TITLE
Move TransformCorrelatedScalarAggregationToJoin to the iterative optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DependencyExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DependencyExtractor.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.tree.DefaultExpressionTraversalVisitor;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
@@ -38,6 +39,14 @@ public final class DependencyExtractor
     {
         ImmutableSet.Builder<Symbol> uniqueSymbols = ImmutableSet.builder();
         extractExpressions(node).forEach(expression -> uniqueSymbols.addAll(extractUnique(expression)));
+
+        return uniqueSymbols.build();
+    }
+
+    public static Set<Symbol> extractUnique(PlanNode node, Lookup lookup)
+    {
+        ImmutableSet.Builder<Symbol> uniqueSymbols = ImmutableSet.builder();
+        extractExpressions(node, lookup).forEach(expression -> uniqueSymbols.addAll(extractUnique(expression)));
 
         return uniqueSymbols.build();
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.sql.planner.iterative.GroupReference;
+import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
@@ -25,6 +27,10 @@ import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 
 public class ExpressionExtractor
 {
@@ -32,6 +38,13 @@ public class ExpressionExtractor
     {
         ImmutableList.Builder<Expression> expressionsBuilder = ImmutableList.builder();
         plan.accept(new Visitor(true), expressionsBuilder);
+        return expressionsBuilder.build();
+    }
+
+    public static List<Expression> extractExpressions(PlanNode plan, Lookup lookup)
+    {
+        ImmutableList.Builder<Expression> expressionsBuilder = ImmutableList.builder();
+        plan.accept(new Visitor(true, lookup), expressionsBuilder);
         return expressionsBuilder.build();
     }
 
@@ -50,15 +63,32 @@ public class ExpressionExtractor
             extends SimplePlanVisitor<ImmutableList.Builder<Expression>>
     {
         private final boolean recursive;
+        private final Optional<Lookup> lookup;
 
         public Visitor(boolean recursive)
         {
+            this(recursive, Optional.empty());
+        }
+
+        public Visitor(boolean recursive, Lookup lookup)
+        {
+            this(recursive, Optional.of(lookup));
+        }
+
+        private Visitor(boolean recursive, Optional<Lookup> lookup)
+        {
             this.recursive = recursive;
+            this.lookup = requireNonNull(lookup, "lookup is null");
         }
 
         @Override
         protected Void visitPlan(PlanNode node, ImmutableList.Builder<Expression> context)
         {
+            if (node instanceof GroupReference) {
+                checkState(lookup.isPresent(), "Cannot extract expressions in iterative optimizer without providing a Lookup method");
+                return lookup.get().resolve(node).accept(this, context);
+            }
+
             if (recursive) {
                 return super.visitPlan(node, context);
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -182,7 +182,7 @@ public class PlanOptimizers
                 new RemoveUnreferencedScalarInputApplyNodes(),
                 new TransformUncorrelatedInPredicateSubqueryToSemiJoin(),
                 new TransformUncorrelatedScalarToJoin(),
-                new TransformCorrelatedScalarAggregationToJoin(metadata),
+                new TransformCorrelatedScalarAggregationToJoin(metadata.getFunctionRegistry()),
                 new PredicatePushDown(metadata, sqlParser),
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -182,7 +182,10 @@ public class PlanOptimizers
                 new RemoveUnreferencedScalarInputApplyNodes(),
                 new TransformUncorrelatedInPredicateSubqueryToSemiJoin(),
                 new TransformUncorrelatedScalarToJoin(),
-                new TransformCorrelatedScalarAggregationToJoin(metadata.getFunctionRegistry()),
+                new IterativeOptimizer(
+                        stats,
+                        ImmutableList.of(new TransformCorrelatedScalarAggregationToJoin(metadata.getFunctionRegistry())),
+                        ImmutableSet.of(new com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedScalarAggregationToJoin(metadata.getFunctionRegistry()))),
                 new PredicatePushDown(metadata, sqlParser),
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedScalarAggregationToJoin.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.optimizations.ScalarAggregationToJoinRewriter;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static com.facebook.presto.sql.planner.optimizations.Predicates.isInstanceOfAny;
+import static com.facebook.presto.sql.planner.optimizations.ScalarQueryUtil.isScalar;
+import static java.util.Objects.requireNonNull;
+
+public class TransformCorrelatedScalarAggregationToJoin
+        implements Rule
+{
+    private final FunctionRegistry functionRegistry;
+
+    public TransformCorrelatedScalarAggregationToJoin(FunctionRegistry functionRegistry)
+    {
+        this.functionRegistry = requireNonNull(functionRegistry, "functionRegistry is null");
+    }
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        if (!(node instanceof ApplyNode)) {
+            return Optional.empty();
+        }
+
+        ApplyNode applyNode = (ApplyNode) node;
+        PlanNode subquery = lookup.resolve(applyNode.getSubquery());
+
+        if (applyNode.getCorrelation().isEmpty() || !(isScalar(subquery, lookup) && applyNode.isSubqueryResolved())) {
+            return Optional.empty();
+        }
+
+        Optional<AggregationNode> aggregation = findAggregation(subquery, lookup);
+        if (!(aggregation.isPresent() && aggregation.get().getGroupingKeys().isEmpty())) {
+            return Optional.empty();
+        }
+
+        ScalarAggregationToJoinRewriter rewriter = new ScalarAggregationToJoinRewriter(functionRegistry, symbolAllocator, idAllocator, lookup);
+
+        PlanNode rewrittenNode = rewriter.rewriteScalarAggregation(applyNode, aggregation.get());
+
+        if (rewrittenNode instanceof ApplyNode) {
+            return Optional.empty();
+        }
+
+        return Optional.of(rewrittenNode);
+    }
+
+    private static Optional<AggregationNode> findAggregation(PlanNode rootNode, Lookup lookup)
+    {
+        return searchFrom(rootNode, lookup)
+                .where(AggregationNode.class::isInstance)
+                .skipOnlyWhen(isInstanceOfAny(ProjectNode.class, EnforceSingleRowNode.class))
+                .findFirst();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -43,6 +43,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -153,9 +154,11 @@ public class ScalarAggregationToJoinRewriter
                 .skipOnlyWhen(EnforceSingleRowNode.class::isInstance)
                 .findFirst();
 
+        List<Symbol> aggregationOutputSymbols = getTruncatedAggregationSymbols(applyNode, aggregationNode.get());
+
         if (subqueryProjection.isPresent()) {
             Assignments assignments = Assignments.builder()
-                    .putAll(Assignments.identity(aggregationNode.get().getOutputSymbols()))
+                    .putAll(Assignments.identity(aggregationOutputSymbols))
                     .putAll(subqueryProjection.get().getAssignments())
                     .build();
 
@@ -165,8 +168,23 @@ public class ScalarAggregationToJoinRewriter
                     assignments);
         }
         else {
-            return aggregationNode.get();
+            Assignments assignments = Assignments.builder()
+                    .putAll(Assignments.identity(aggregationOutputSymbols))
+                    .build();
+
+            return new ProjectNode(
+                    idAllocator.getNextId(),
+                    aggregationNode.get(),
+                    assignments);
         }
+    }
+
+    private static List<Symbol> getTruncatedAggregationSymbols(ApplyNode applyNode, AggregationNode aggregationNode)
+    {
+        Set<Symbol> applySymbols = new HashSet<>(applyNode.getOutputSymbols());
+        return aggregationNode.getOutputSymbols().stream()
+                .filter(symbol -> applySymbols.contains(symbol))
+                .collect(toImmutableList());
     }
 
     private Optional<AggregationNode> createAggregationNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -1,0 +1,348 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.sql.ExpressionUtils;
+import com.facebook.presto.sql.planner.DependencyExtractor;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.AssignUniqueId;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.LogicalBinaryExpression;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static com.facebook.presto.sql.planner.optimizations.Predicates.isInstanceOfAny;
+import static com.facebook.presto.sql.planner.plan.SimplePlanRewriter.rewriteWith;
+import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class ScalarAggregationToJoinRewriter
+{
+    private final Metadata metadata;
+    private final SymbolAllocator symbolAllocator;
+    private final PlanNodeIdAllocator idAllocator;
+
+    public ScalarAggregationToJoinRewriter(Metadata metadata, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
+        this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+    }
+
+    public PlanNode rewriteScalarAggregation(ApplyNode apply, AggregationNode aggregation)
+    {
+        List<Symbol> correlation = apply.getCorrelation();
+        Optional<DecorrelatedNode> source = decorrelateFilters(aggregation.getSource(), correlation);
+        if (!source.isPresent()) {
+            return apply;
+        }
+
+        Symbol nonNull = symbolAllocator.newSymbol("non_null", BooleanType.BOOLEAN);
+        Assignments scalarAggregationSourceAssignments = Assignments.builder()
+                .putAll(Assignments.identity(source.get().getNode().getOutputSymbols()))
+                .put(nonNull, TRUE_LITERAL)
+                .build();
+        ProjectNode scalarAggregationSourceWithNonNullableSymbol = new ProjectNode(
+                idAllocator.getNextId(),
+                source.get().getNode(),
+                scalarAggregationSourceAssignments);
+
+        return rewriteScalarAggregation(
+                apply,
+                aggregation,
+                scalarAggregationSourceWithNonNullableSymbol,
+                source.get().getCorrelatedPredicates(),
+                nonNull);
+    }
+
+    private PlanNode rewriteScalarAggregation(
+            ApplyNode applyNode,
+            AggregationNode scalarAggregation,
+            PlanNode scalarAggregationSource,
+            Optional<Expression> joinExpression,
+            Symbol nonNull)
+    {
+        AssignUniqueId inputWithUniqueColumns = new AssignUniqueId(
+                idAllocator.getNextId(),
+                applyNode.getInput(),
+                symbolAllocator.newSymbol("unique", BigintType.BIGINT));
+
+        JoinNode leftOuterJoin = new JoinNode(
+                idAllocator.getNextId(),
+                JoinNode.Type.LEFT,
+                inputWithUniqueColumns,
+                scalarAggregationSource,
+                ImmutableList.of(),
+                ImmutableList.<Symbol>builder()
+                        .addAll(inputWithUniqueColumns.getOutputSymbols())
+                        .addAll(scalarAggregationSource.getOutputSymbols())
+                        .build(),
+                joinExpression,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+
+        Optional<AggregationNode> aggregationNode = createAggregationNode(
+                scalarAggregation,
+                leftOuterJoin,
+                nonNull);
+
+        if (!aggregationNode.isPresent()) {
+            return applyNode;
+        }
+
+        Optional<ProjectNode> subqueryProjection = searchFrom(applyNode.getSubquery())
+                .where(ProjectNode.class::isInstance)
+                .skipOnlyWhen(EnforceSingleRowNode.class::isInstance)
+                .findFirst();
+
+        if (subqueryProjection.isPresent()) {
+            Assignments assignments = Assignments.builder()
+                    .putAll(Assignments.identity(aggregationNode.get().getOutputSymbols()))
+                    .putAll(subqueryProjection.get().getAssignments())
+                    .build();
+
+            return new ProjectNode(
+                    idAllocator.getNextId(),
+                    aggregationNode.get(),
+                    assignments);
+        }
+        else {
+            return aggregationNode.get();
+        }
+    }
+
+    private Optional<AggregationNode> createAggregationNode(
+            AggregationNode scalarAggregation,
+            JoinNode leftOuterJoin,
+            Symbol nonNullableAggregationSourceSymbol)
+    {
+        ImmutableMap.Builder<Symbol, FunctionCall> aggregations = ImmutableMap.builder();
+        ImmutableMap.Builder<Symbol, Signature> functions = ImmutableMap.builder();
+        FunctionRegistry functionRegistry = metadata.getFunctionRegistry();
+        for (Map.Entry<Symbol, FunctionCall> entry : scalarAggregation.getAggregations().entrySet()) {
+            FunctionCall call = entry.getValue();
+            QualifiedName count = QualifiedName.of("count");
+            Symbol symbol = entry.getKey();
+            if (call.getName().equals(count)) {
+                aggregations.put(symbol, new FunctionCall(
+                        count,
+                        ImmutableList.of(nonNullableAggregationSourceSymbol.toSymbolReference())));
+                List<TypeSignature> scalarAggregationSourceTypeSignatures = ImmutableList.of(
+                        symbolAllocator.getTypes().get(nonNullableAggregationSourceSymbol).getTypeSignature());
+                functions.put(symbol, functionRegistry.resolveFunction(
+                        count,
+                        fromTypeSignatures(scalarAggregationSourceTypeSignatures)));
+            }
+            else {
+                aggregations.put(symbol, entry.getValue());
+                functions.put(symbol, scalarAggregation.getFunctions().get(symbol));
+            }
+        }
+
+        List<Symbol> groupBySymbols = leftOuterJoin.getLeft().getOutputSymbols();
+        return Optional.of(new AggregationNode(
+                idAllocator.getNextId(),
+                leftOuterJoin,
+                aggregations.build(),
+                functions.build(),
+                scalarAggregation.getMasks(),
+                ImmutableList.of(groupBySymbols),
+                scalarAggregation.getStep(),
+                scalarAggregation.getHashSymbol(),
+                Optional.empty()));
+    }
+
+    private Optional<DecorrelatedNode> decorrelateFilters(PlanNode node, List<Symbol> correlation)
+    {
+        PlanNodeSearcher filterNodeSearcher = searchFrom(node)
+                .where(FilterNode.class::isInstance)
+                .skipOnlyWhen(isInstanceOfAny(ProjectNode.class));
+        List<FilterNode> filterNodes = filterNodeSearcher.findAll();
+
+        if (filterNodes.isEmpty()) {
+            return decorrelatedNode(ImmutableList.of(), node, correlation);
+        }
+
+        if (filterNodes.size() > 1) {
+            return Optional.empty();
+        }
+
+        FilterNode filterNode = filterNodes.get(0);
+        Expression predicate = filterNode.getPredicate();
+
+        if (!isSupportedPredicate(predicate)) {
+            return Optional.empty();
+        }
+
+        if (!DependencyExtractor.extractUnique(predicate).containsAll(correlation)) {
+            return Optional.empty();
+        }
+
+        Map<Boolean, List<Expression>> predicates = ExpressionUtils.extractConjuncts(predicate).stream()
+                .collect(Collectors.partitioningBy(isUsingPredicate(correlation)));
+        List<Expression> correlatedPredicates = ImmutableList.copyOf(predicates.get(true));
+        List<Expression> uncorrelatedPredicates = ImmutableList.copyOf(predicates.get(false));
+
+        node = updateFilterNode(filterNodeSearcher, uncorrelatedPredicates);
+        node = ensureJoinSymbolsAreReturned(node, correlatedPredicates);
+
+        return decorrelatedNode(correlatedPredicates, node, correlation);
+    }
+
+    private static Optional<DecorrelatedNode> decorrelatedNode(
+            List<Expression> correlatedPredicates,
+            PlanNode node,
+            List<Symbol> correlation)
+    {
+        if (DependencyExtractor.extractUnique(node).stream().anyMatch(correlation::contains)) {
+            // node is still correlated ; /
+            return Optional.empty();
+        }
+        return Optional.of(new DecorrelatedNode(correlatedPredicates, node));
+    }
+
+    private static Predicate<Expression> isUsingPredicate(List<Symbol> symbols)
+    {
+        return expression -> symbols.stream().anyMatch(DependencyExtractor.extractUnique(expression)::contains);
+    }
+
+    private PlanNode updateFilterNode(PlanNodeSearcher filterNodeSearcher, List<Expression> newPredicates)
+    {
+        if (newPredicates.isEmpty()) {
+            return filterNodeSearcher.removeAll();
+        }
+        FilterNode oldFilterNode = Iterables.getOnlyElement(filterNodeSearcher.findAll());
+        FilterNode newFilterNode = new FilterNode(
+                idAllocator.getNextId(),
+                oldFilterNode.getSource(),
+                ExpressionUtils.combineConjuncts(newPredicates));
+        return filterNodeSearcher.replaceAll(newFilterNode);
+    }
+
+    private PlanNode ensureJoinSymbolsAreReturned(PlanNode scalarAggregationSource, List<Expression> joinPredicate)
+    {
+        Set<Symbol> joinExpressionSymbols = DependencyExtractor.extractUnique(joinPredicate);
+        ExtendProjectionRewriter extendProjectionRewriter = new ExtendProjectionRewriter(
+                idAllocator,
+                joinExpressionSymbols);
+        return rewriteWith(extendProjectionRewriter, scalarAggregationSource);
+    }
+
+    private static boolean isSupportedPredicate(Expression predicate)
+    {
+        AtomicBoolean isSupported = new AtomicBoolean(true);
+        new DefaultTraversalVisitor<Void, AtomicBoolean>()
+        {
+            @Override
+            protected Void visitLogicalBinaryExpression(LogicalBinaryExpression node, AtomicBoolean context)
+            {
+                if (node.getType() != LogicalBinaryExpression.Type.AND) {
+                    context.set(false);
+                }
+                return null;
+            }
+        }.process(predicate, isSupported);
+        return isSupported.get();
+    }
+
+    private static class DecorrelatedNode
+    {
+        private final List<Expression> correlatedPredicates;
+        private final PlanNode node;
+
+        public DecorrelatedNode(List<Expression> correlatedPredicates, PlanNode node)
+        {
+            requireNonNull(correlatedPredicates, "correlatedPredicates is null");
+            this.correlatedPredicates = ImmutableList.copyOf(correlatedPredicates);
+            this.node = requireNonNull(node, "node is null");
+        }
+
+        public Optional<Expression> getCorrelatedPredicates()
+        {
+            if (correlatedPredicates.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(ExpressionUtils.and(correlatedPredicates));
+        }
+
+        public PlanNode getNode()
+        {
+            return node;
+        }
+    }
+
+    private static class ExtendProjectionRewriter
+            extends SimplePlanRewriter<PlanNode>
+    {
+        private final PlanNodeIdAllocator idAllocator;
+        private final Set<Symbol> symbols;
+
+        ExtendProjectionRewriter(PlanNodeIdAllocator idAllocator, Set<Symbol> symbols)
+        {
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+            this.symbols = requireNonNull(symbols, "symbols is null");
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode node, RewriteContext<PlanNode> context)
+        {
+            ProjectNode rewrittenNode = (ProjectNode) context.defaultRewrite(node, context.get());
+
+            List<Symbol> symbolsToAdd = symbols.stream()
+                    .filter(rewrittenNode.getSource().getOutputSymbols()::contains)
+                    .filter(symbol -> !rewrittenNode.getOutputSymbols().contains(symbol))
+                    .collect(toImmutableList());
+
+            Assignments assignments = Assignments.builder()
+                    .putAll(rewrittenNode.getAssignments())
+                    .putAll(Assignments.identity(symbolsToAdd))
+                    .build();
+
+            return new ProjectNode(idAllocator.getNextId(), rewrittenNode.getSource(), assignments);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.planner.DependencyExtractor;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.AssignUniqueId;
@@ -51,7 +52,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
-import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.planner.optimizations.Predicates.isInstanceOfAny;
 import static com.facebook.presto.sql.planner.plan.SimplePlanRewriter.rewriteWith;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
@@ -65,18 +65,31 @@ public class ScalarAggregationToJoinRewriter
     private final FunctionRegistry functionRegistry;
     private final SymbolAllocator symbolAllocator;
     private final PlanNodeIdAllocator idAllocator;
+    private final Optional<Lookup> lookup;
 
+    @Deprecated
     public ScalarAggregationToJoinRewriter(FunctionRegistry functionRegistry, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        this(functionRegistry, symbolAllocator, idAllocator, Optional.empty());
+    }
+
+    public ScalarAggregationToJoinRewriter(FunctionRegistry functionRegistry, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, Lookup lookup)
+    {
+        this(functionRegistry, symbolAllocator, idAllocator, Optional.of(lookup));
+    }
+
+    private ScalarAggregationToJoinRewriter(FunctionRegistry functionRegistry, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, Optional<Lookup> lookup)
     {
         this.functionRegistry = requireNonNull(functionRegistry, "metadata is null");
         this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
         this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+        this.lookup = requireNonNull(lookup, "lookup is null");
     }
 
     public PlanNode rewriteScalarAggregation(ApplyNode apply, AggregationNode aggregation)
     {
         List<Symbol> correlation = apply.getCorrelation();
-        Optional<DecorrelatedNode> source = decorrelateFilters(aggregation.getSource(), correlation);
+        Optional<DecorrelatedNode> source = decorrelateFilters(resolve(aggregation.getSource()), correlation);
         if (!source.isPresent()) {
             return apply;
         }
@@ -232,12 +245,20 @@ public class ScalarAggregationToJoinRewriter
         return decorrelatedNode(correlatedPredicates, node, correlation);
     }
 
-    private static Optional<DecorrelatedNode> decorrelatedNode(
+    private Optional<DecorrelatedNode> decorrelatedNode(
             List<Expression> correlatedPredicates,
             PlanNode node,
             List<Symbol> correlation)
     {
-        if (DependencyExtractor.extractUnique(node).stream().anyMatch(correlation::contains)) {
+        Set<Symbol> uniqueSymbols;
+        // TODO: lookup will become mandatory part once we get rid of the old optimizer
+        if (lookup.isPresent()) {
+            uniqueSymbols = DependencyExtractor.extractUnique(node, lookup.get());
+        }
+        else {
+            uniqueSymbols = DependencyExtractor.extractUnique(node);
+        }
+        if (uniqueSymbols.stream().anyMatch(correlation::contains)) {
             // node is still correlated ; /
             return Optional.empty();
         }
@@ -286,6 +307,22 @@ public class ScalarAggregationToJoinRewriter
             }
         }.process(predicate, isSupported);
         return isSupported.get();
+    }
+
+    // Helper method until we get rid of old optimizer and can hold onto new with Lookup
+    private PlanNodeSearcher searchFrom(PlanNode node)
+    {
+        return lookup
+                .map(lookup -> PlanNodeSearcher.searchFrom(node, lookup))
+                .orElseGet(() -> PlanNodeSearcher.searchFrom(node));
+    }
+
+    // Helper method until we get rid of old optimizer and can hold onto new with Lookup
+    private PlanNode resolve(PlanNode node)
+    {
+        return lookup
+                .map(lookup -> lookup.resolve(node))
+                .orElse(node);
     }
 
     private static class DecorrelatedNode

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -59,6 +59,7 @@ import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
+// TODO: move this class to TransformCorrelatedScalarAggregationToJoin when old optimizer is gone
 public class ScalarAggregationToJoinRewriter
 {
     private static final QualifiedName COUNT = QualifiedName.of("count");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarQueryUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarQueryUtil.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.sql.planner.optimizations;
 
+import com.facebook.presto.sql.planner.iterative.GroupReference;
+import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
@@ -23,23 +25,44 @@ import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.google.common.collect.ImmutableList;
 
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Objects.requireNonNull;
 
 public final class ScalarQueryUtil
 {
     private ScalarQueryUtil() {}
 
+    public static boolean isScalar(PlanNode node, Lookup lookup)
+    {
+        return node.accept(new IsScalarPlanVisitor(Optional.ofNullable(lookup)), null);
+    }
+
     public static boolean isScalar(PlanNode node)
     {
-        return node.accept(new IsScalarPlanVisitor(), null);
+        return isScalar(node, null);
     }
 
     private static final class IsScalarPlanVisitor
             extends PlanVisitor<Void, Boolean>
     {
+        private final Optional<Lookup> lookup;
+
+        public IsScalarPlanVisitor(Optional<Lookup> lookup)
+        {
+            this.lookup = requireNonNull(lookup, "lookup is null");
+        }
+
         @Override
         protected Boolean visitPlan(PlanNode node, Void context)
         {
+            if (node instanceof GroupReference) {
+                checkState(lookup.isPresent(), "Lookup has to be provided to test plans with GroupReference nodes");
+                return lookup.get().resolve(node).accept(this, null);
+            }
+
             return false;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
@@ -62,6 +62,7 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * Note only conjunction predicates in FilterNode are supported
  */
+@Deprecated
 public class TransformCorrelatedScalarAggregationToJoin
         implements PlanOptimizer
 {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
@@ -14,51 +14,24 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.metadata.Signature;
-import com.facebook.presto.spi.type.BigintType;
-import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.TypeSignature;
-import com.facebook.presto.sql.ExpressionUtils;
-import com.facebook.presto.sql.planner.DependencyExtractor;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
-import com.facebook.presto.sql.planner.plan.AssignUniqueId;
-import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
-import com.facebook.presto.sql.planner.plan.FilterNode;
-import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
-import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
-import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.FunctionCall;
-import com.facebook.presto.sql.tree.LogicalBinaryExpression;
-import com.facebook.presto.sql.tree.QualifiedName;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
-import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.planner.optimizations.Predicates.isInstanceOfAny;
 import static com.facebook.presto.sql.planner.plan.SimplePlanRewriter.rewriteWith;
-import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -134,284 +107,11 @@ public class TransformCorrelatedScalarAggregationToJoin
                         .skipOnlyWhen(isInstanceOfAny(ProjectNode.class, EnforceSingleRowNode.class))
                         .findFirst();
                 if (aggregation.isPresent() && aggregation.get().getGroupingKeys().isEmpty()) {
-                    return rewriteScalarAggregation(rewrittenNode, aggregation.get());
+                    ScalarAggregationToJoinRewriter scalarAggregationToJoinRewriter = new ScalarAggregationToJoinRewriter(metadata, symbolAllocator, idAllocator);
+                    return scalarAggregationToJoinRewriter.rewriteScalarAggregation(rewrittenNode, aggregation.get());
                 }
             }
             return rewrittenNode;
-        }
-
-        private PlanNode rewriteScalarAggregation(ApplyNode apply, AggregationNode aggregation)
-        {
-            List<Symbol> correlation = apply.getCorrelation();
-            Optional<DecorrelatedNode> source = decorrelateFilters(aggregation.getSource(), correlation);
-            if (!source.isPresent()) {
-                return apply;
-            }
-
-            Symbol nonNull = symbolAllocator.newSymbol("non_null", BooleanType.BOOLEAN);
-            Assignments scalarAggregationSourceAssignments = Assignments.builder()
-                    .putAll(Assignments.identity(source.get().getNode().getOutputSymbols()))
-                    .put(nonNull, TRUE_LITERAL)
-                    .build();
-            ProjectNode scalarAggregationSourceWithNonNullableSymbol = new ProjectNode(
-                    idAllocator.getNextId(),
-                    source.get().getNode(),
-                    scalarAggregationSourceAssignments);
-
-            return rewriteScalarAggregation(
-                    apply,
-                    aggregation,
-                    scalarAggregationSourceWithNonNullableSymbol,
-                    source.get().getCorrelatedPredicates(),
-                    nonNull);
-        }
-
-        private PlanNode rewriteScalarAggregation(
-                ApplyNode applyNode,
-                AggregationNode scalarAggregation,
-                PlanNode scalarAggregationSource,
-                Optional<Expression> joinExpression,
-                Symbol nonNull)
-        {
-            AssignUniqueId inputWithUniqueColumns = new AssignUniqueId(
-                    idAllocator.getNextId(),
-                    applyNode.getInput(),
-                    symbolAllocator.newSymbol("unique", BigintType.BIGINT));
-
-            JoinNode leftOuterJoin = new JoinNode(
-                    idAllocator.getNextId(),
-                    JoinNode.Type.LEFT,
-                    inputWithUniqueColumns,
-                    scalarAggregationSource,
-                    ImmutableList.of(),
-                    ImmutableList.<Symbol>builder()
-                            .addAll(inputWithUniqueColumns.getOutputSymbols())
-                            .addAll(scalarAggregationSource.getOutputSymbols())
-                            .build(),
-                    joinExpression,
-                    Optional.empty(),
-                    Optional.empty(),
-                    Optional.empty());
-
-            Optional<AggregationNode> aggregationNode = createAggregationNode(
-                    scalarAggregation,
-                    leftOuterJoin,
-                    nonNull);
-
-            if (!aggregationNode.isPresent()) {
-                return applyNode;
-            }
-
-            Optional<ProjectNode> subqueryProjection = searchFrom(applyNode.getSubquery())
-                    .where(ProjectNode.class::isInstance)
-                    .skipOnlyWhen(EnforceSingleRowNode.class::isInstance)
-                    .findFirst();
-
-            if (subqueryProjection.isPresent()) {
-                Assignments assignments = Assignments.builder()
-                        .putAll(Assignments.identity(aggregationNode.get().getOutputSymbols()))
-                        .putAll(subqueryProjection.get().getAssignments())
-                        .build();
-
-                return new ProjectNode(
-                        idAllocator.getNextId(),
-                        aggregationNode.get(),
-                        assignments);
-            }
-            else {
-                return aggregationNode.get();
-            }
-        }
-
-        private Optional<AggregationNode> createAggregationNode(
-                AggregationNode scalarAggregation,
-                JoinNode leftOuterJoin,
-                Symbol nonNullableAggregationSourceSymbol)
-        {
-            ImmutableMap.Builder<Symbol, FunctionCall> aggregations = ImmutableMap.builder();
-            ImmutableMap.Builder<Symbol, Signature> functions = ImmutableMap.builder();
-            FunctionRegistry functionRegistry = metadata.getFunctionRegistry();
-            for (Map.Entry<Symbol, FunctionCall> entry : scalarAggregation.getAggregations().entrySet()) {
-                FunctionCall call = entry.getValue();
-                QualifiedName count = QualifiedName.of("count");
-                Symbol symbol = entry.getKey();
-                if (call.getName().equals(count)) {
-                    aggregations.put(symbol, new FunctionCall(
-                            count,
-                            ImmutableList.of(nonNullableAggregationSourceSymbol.toSymbolReference())));
-                    List<TypeSignature> scalarAggregationSourceTypeSignatures = ImmutableList.of(
-                            symbolAllocator.getTypes().get(nonNullableAggregationSourceSymbol).getTypeSignature());
-                    functions.put(symbol, functionRegistry.resolveFunction(
-                            count,
-                            fromTypeSignatures(scalarAggregationSourceTypeSignatures)));
-                }
-                else {
-                    aggregations.put(symbol, entry.getValue());
-                    functions.put(symbol, scalarAggregation.getFunctions().get(symbol));
-                }
-            }
-
-            List<Symbol> groupBySymbols = leftOuterJoin.getLeft().getOutputSymbols();
-            return Optional.of(new AggregationNode(
-                    idAllocator.getNextId(),
-                    leftOuterJoin,
-                    aggregations.build(),
-                    functions.build(),
-                    scalarAggregation.getMasks(),
-                    ImmutableList.of(groupBySymbols),
-                    scalarAggregation.getStep(),
-                    scalarAggregation.getHashSymbol(),
-                    Optional.empty()));
-        }
-
-        private Optional<DecorrelatedNode> decorrelateFilters(PlanNode node, List<Symbol> correlation)
-        {
-            PlanNodeSearcher filterNodeSearcher = searchFrom(node)
-                    .where(FilterNode.class::isInstance)
-                    .skipOnlyWhen(isInstanceOfAny(ProjectNode.class));
-            List<FilterNode> filterNodes = filterNodeSearcher.findAll();
-
-            if (filterNodes.isEmpty()) {
-                return decorrelatedNode(ImmutableList.of(), node, correlation);
-            }
-
-            if (filterNodes.size() > 1) {
-                return Optional.empty();
-            }
-
-            FilterNode filterNode = filterNodes.get(0);
-            Expression predicate = filterNode.getPredicate();
-
-            if (!isSupportedPredicate(predicate)) {
-                return Optional.empty();
-            }
-
-            if (!DependencyExtractor.extractUnique(predicate).containsAll(correlation)) {
-                return Optional.empty();
-            }
-
-            Map<Boolean, List<Expression>> predicates = ExpressionUtils.extractConjuncts(predicate).stream()
-                    .collect(Collectors.partitioningBy(isUsingPredicate(correlation)));
-            List<Expression> correlatedPredicates = ImmutableList.copyOf(predicates.get(true));
-            List<Expression> uncorrelatedPredicates = ImmutableList.copyOf(predicates.get(false));
-
-            node = updateFilterNode(filterNodeSearcher, uncorrelatedPredicates);
-            node = ensureJoinSymbolsAreReturned(node, correlatedPredicates);
-
-            return decorrelatedNode(correlatedPredicates, node, correlation);
-        }
-
-        private static Optional<DecorrelatedNode> decorrelatedNode(
-                List<Expression> correlatedPredicates,
-                PlanNode node,
-                List<Symbol> correlation)
-        {
-            if (DependencyExtractor.extractUnique(node).stream().anyMatch(correlation::contains)) {
-                // node is still correlated ; /
-                return Optional.empty();
-            }
-            return Optional.of(new DecorrelatedNode(correlatedPredicates, node));
-        }
-
-        private static Predicate<Expression> isUsingPredicate(List<Symbol> symbols)
-        {
-            return expression -> symbols.stream().anyMatch(DependencyExtractor.extractUnique(expression)::contains);
-        }
-
-        private PlanNode updateFilterNode(PlanNodeSearcher filterNodeSearcher, List<Expression> newPredicates)
-        {
-            if (newPredicates.isEmpty()) {
-                return filterNodeSearcher.removeAll();
-            }
-            FilterNode oldFilterNode = Iterables.getOnlyElement(filterNodeSearcher.findAll());
-            FilterNode newFilterNode = new FilterNode(
-                    idAllocator.getNextId(),
-                    oldFilterNode.getSource(),
-                    ExpressionUtils.combineConjuncts(newPredicates));
-            return filterNodeSearcher.replaceAll(newFilterNode);
-        }
-
-        private PlanNode ensureJoinSymbolsAreReturned(PlanNode scalarAggregationSource, List<Expression> joinPredicate)
-        {
-            Set<Symbol> joinExpressionSymbols = DependencyExtractor.extractUnique(joinPredicate);
-            ExtendProjectionRewriter extendProjectionRewriter = new ExtendProjectionRewriter(
-                    idAllocator,
-                    joinExpressionSymbols);
-            return rewriteWith(extendProjectionRewriter, scalarAggregationSource);
-        }
-
-        private static boolean isSupportedPredicate(Expression predicate)
-        {
-            AtomicBoolean isSupported = new AtomicBoolean(true);
-            new DefaultTraversalVisitor<Void, AtomicBoolean>()
-            {
-                @Override
-                protected Void visitLogicalBinaryExpression(LogicalBinaryExpression node, AtomicBoolean context)
-                {
-                    if (node.getType() != LogicalBinaryExpression.Type.AND) {
-                        context.set(false);
-                    }
-                    return null;
-                }
-            }.process(predicate, isSupported);
-            return isSupported.get();
-        }
-    }
-
-    private static class DecorrelatedNode
-    {
-        private final List<Expression> correlatedPredicates;
-        private final PlanNode node;
-
-        public DecorrelatedNode(List<Expression> correlatedPredicates, PlanNode node)
-        {
-            requireNonNull(correlatedPredicates, "correlatedPredicates is null");
-            this.correlatedPredicates = ImmutableList.copyOf(correlatedPredicates);
-            this.node = requireNonNull(node, "node is null");
-        }
-
-        Optional<Expression> getCorrelatedPredicates()
-        {
-            if (correlatedPredicates.isEmpty()) {
-                return Optional.empty();
-            }
-            return Optional.of(ExpressionUtils.and(correlatedPredicates));
-        }
-
-        public PlanNode getNode()
-        {
-            return node;
-        }
-    }
-
-    private static class ExtendProjectionRewriter
-            extends SimplePlanRewriter<PlanNode>
-    {
-        private final PlanNodeIdAllocator idAllocator;
-        private final Set<Symbol> symbols;
-
-        ExtendProjectionRewriter(PlanNodeIdAllocator idAllocator, Set<Symbol> symbols)
-        {
-            this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
-            this.symbols = requireNonNull(symbols, "symbols is null");
-        }
-
-        @Override
-        public PlanNode visitProject(ProjectNode node, RewriteContext<PlanNode> context)
-        {
-            ProjectNode rewrittenNode = (ProjectNode) context.defaultRewrite(node, context.get());
-
-            List<Symbol> symbolsToAdd = symbols.stream()
-                    .filter(rewrittenNode.getSource().getOutputSymbols()::contains)
-                    .filter(symbol -> !rewrittenNode.getOutputSymbols().contains(symbol))
-                    .collect(toImmutableList());
-
-            Assignments assignments = Assignments.builder()
-                    .putAll(rewrittenNode.getAssignments())
-                    .putAll(Assignments.identity(symbolsToAdd))
-                    .build();
-
-            return new ProjectNode(idAllocator.getNextId(), rewrittenNode.getSource(), assignments);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
@@ -65,11 +65,11 @@ import static java.util.Objects.requireNonNull;
 public class TransformCorrelatedScalarAggregationToJoin
         implements PlanOptimizer
 {
-    private final Metadata metadata;
+    private final FunctionRegistry functionRegistry;
 
-    public TransformCorrelatedScalarAggregationToJoin(Metadata metadata)
+    public TransformCorrelatedScalarAggregationToJoin(FunctionRegistry functionRegistry)
     {
-        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.functionRegistry = requireNonNull(functionRegistry, "functionRegistry is null");
     }
 
     @Override
@@ -80,7 +80,7 @@ public class TransformCorrelatedScalarAggregationToJoin
             SymbolAllocator symbolAllocator,
             PlanNodeIdAllocator idAllocator)
     {
-        return rewriteWith(new Rewriter(idAllocator, symbolAllocator, metadata), plan, null);
+        return rewriteWith(new Rewriter(idAllocator, symbolAllocator, functionRegistry), plan, null);
     }
 
     private static class Rewriter
@@ -88,13 +88,13 @@ public class TransformCorrelatedScalarAggregationToJoin
     {
         private final PlanNodeIdAllocator idAllocator;
         private final SymbolAllocator symbolAllocator;
-        private final Metadata metadata;
+        private final FunctionRegistry functionRegistry;
 
-        public Rewriter(PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Metadata metadata)
+        public Rewriter(PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, FunctionRegistry functionRegistry)
         {
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
-            this.metadata = requireNonNull(metadata, "metadata is null");
+            this.functionRegistry = requireNonNull(functionRegistry, "functionRegistry is null");
         }
 
         @Override
@@ -107,7 +107,7 @@ public class TransformCorrelatedScalarAggregationToJoin
                         .skipOnlyWhen(isInstanceOfAny(ProjectNode.class, EnforceSingleRowNode.class))
                         .findFirst();
                 if (aggregation.isPresent() && aggregation.get().getGroupingKeys().isEmpty()) {
-                    ScalarAggregationToJoinRewriter scalarAggregationToJoinRewriter = new ScalarAggregationToJoinRewriter(metadata, symbolAllocator, idAllocator);
+                    ScalarAggregationToJoinRewriter scalarAggregationToJoinRewriter = new ScalarAggregationToJoinRewriter(functionRegistry, symbolAllocator, idAllocator);
                     return scalarAggregationToJoinRewriter.rewriteScalarAggregation(rewrittenNode, aggregation.get());
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ApplyNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ApplyNode.java
@@ -85,12 +85,17 @@ public class ApplyNode
         this.correlation = ImmutableList.copyOf(correlation);
     }
 
-    /**
-     * @return true when subquery is scalar and it's output symbols are directly mapped to ApplyNode output symbols
-     */
     public boolean isResolvedScalarSubquery()
     {
-        return isScalar(subquery) && subqueryAssignments.getExpressions().stream()
+        return isScalar(subquery) && isSubqueryResolved();
+    }
+
+    /**
+     * @return true if output symbols of subquery are directly mapped to ApplyNode output symbols
+     */
+    public boolean isSubqueryResolved()
+    {
+        return subqueryAssignments.getExpressions().stream()
                 .allMatch(expression -> expression instanceof SymbolReference);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AssignUniqueIdMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AssignUniqueIdMatcher.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.AssignUniqueId;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.Optional;
+
+public class AssignUniqueIdMatcher
+        implements RvalueMatcher
+{
+    @Override
+    public Optional<Symbol> getAssignedSymbol(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        if (!(node instanceof AssignUniqueId)) {
+            return Optional.empty();
+        }
+
+        AssignUniqueId assignUniqueIdNode = (AssignUniqueId) node;
+
+        return Optional.of(assignUniqueIdNode.getIdColumn());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.AssignUniqueId;
 import com.facebook.presto.sql.planner.plan.ExceptNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
@@ -260,6 +261,12 @@ public final class PlanMatchPattern
     public static PlanMatchPattern union(PlanMatchPattern... sources)
     {
         return node(UnionNode.class, sources);
+    }
+
+    public static PlanMatchPattern assignUniqueId(String uniqueSymbolAlias, PlanMatchPattern source)
+    {
+        return node(AssignUniqueId.class, source)
+                .withAlias(uniqueSymbolAlias, new AssignUniqueIdMatcher());
     }
 
     public static PlanMatchPattern intersect(PlanMatchPattern... sources)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedScalarAggregationToJoin.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.type.TypeRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.assignUniqueId;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestTransformCorrelatedScalarAggregationToJoin
+{
+    private static final QualifiedName SUM = QualifiedName.of("sum");
+
+    private RuleTester tester;
+    private FunctionRegistry functionRegistry;
+    private Rule rule;
+
+    @BeforeClass
+    public void setUp()
+    {
+        tester = new RuleTester();
+        TypeRegistry typeRegistry = new TypeRegistry();
+        functionRegistry = new FunctionRegistry(typeRegistry, new BlockEncodingManager(typeRegistry), new FeaturesConfig());
+        rule = new TransformCorrelatedScalarAggregationToJoin(functionRegistry);
+    }
+
+    @Test
+    public void doesNotFireOnPlanWithoutApplyNode()
+    {
+        tester.assertThat(rule)
+                .on(p -> p.values(p.symbol("a", BIGINT)))
+                .doesNotFire();
+    }
+
+    @Test
+    public void doesNotFireOnCorrelatedWithoutAggregation()
+    {
+        tester.assertThat(rule)
+                .on(p -> p.apply(Assignments.identity(p.symbol("a", BIGINT)),
+                        ImmutableList.of(p.symbol("corr", BIGINT)),
+                        p.values(p.symbol("corr", BIGINT)),
+                        p.values(p.symbol("a", BIGINT))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void doesNotFireOnUncorrelated()
+    {
+        tester.assertThat(rule)
+                .on(p -> p.apply(Assignments.identity(p.symbol("a", BIGINT)),
+                        ImmutableList.of(),
+                        p.values(p.symbol("a", BIGINT)),
+                        p.values(p.symbol("b", BIGINT))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void doesNotFireOnCorrelatedWithNonScalarAggregation()
+    {
+        tester.assertThat(rule)
+                .on(p -> p.apply(Assignments.identity(p.symbol("a", BIGINT)),
+                        ImmutableList.of(p.symbol("corr", BIGINT)),
+                        p.values(p.symbol("corr", BIGINT)),
+                        createSumAggregation(p, p.symbol("a", BIGINT), ImmutableList.of(ImmutableList.of(p.symbol("b", BIGINT))),
+                                p.values(p.symbol("a", BIGINT), p.symbol("b", BIGINT)))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void rewritesOnSubqueryWithoutProjection()
+    {
+        tester.assertThat(rule)
+                .on(p -> p.apply(Assignments.identity(p.symbol("sum", BIGINT)),
+                        ImmutableList.of(p.symbol("corr", BIGINT)),
+                        p.values(p.symbol("corr", BIGINT)),
+                        createSumAggregation(p, p.symbol("a", BIGINT), ImmutableList.of(ImmutableList.of()),
+                                p.values(p.symbol("a", BIGINT), p.symbol("b", BIGINT)))))
+                .matches(project(ImmutableMap.of("sum_1", expression("sum_1"), "corr", expression("corr")),
+                        aggregation(ImmutableMap.of("sum_1", functionCall("sum", ImmutableList.of("a"))),
+                                join(JoinNode.Type.LEFT,
+                                        ImmutableList.of(),
+                                        assignUniqueId("unique",
+                                                values(ImmutableMap.of("corr", 0))),
+                                        project(ImmutableMap.of("non_null", expression("true")),
+                                                values(ImmutableMap.of("a", 0, "b", 1)))))));
+    }
+
+    @Test
+    public void rewritesOnSubqueryWithProjection()
+    {
+        tester.assertThat(rule)
+                .on(p -> p.apply(Assignments.identity(p.symbol("sum", BIGINT), p.symbol("expr", BIGINT)),
+                        ImmutableList.of(p.symbol("corr", BIGINT)),
+                        p.values(p.symbol("corr", BIGINT)),
+                        p.project(Assignments.of(p.symbol("expr", BIGINT), new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Type.ADD, p.symbol("sum", BIGINT).toSymbolReference(), new LongLiteral("1"))),
+                                createSumAggregation(p, p.symbol("a", BIGINT), ImmutableList.of(ImmutableList.of()),
+                                        p.values(p.symbol("a", BIGINT), p.symbol("b", BIGINT))))))
+                .matches(project(ImmutableMap.of("sum_1", expression("sum_1"), "corr", expression("corr"), "expr", expression("(\"sum_1\" + 1)")),
+                        aggregation(ImmutableMap.of("sum_1", functionCall("sum", ImmutableList.of("a"))),
+                                join(JoinNode.Type.LEFT,
+                                        ImmutableList.of(),
+                                        assignUniqueId("unique",
+                                                values(ImmutableMap.of("corr", 0))),
+                                        project(ImmutableMap.of("non_null", expression("true")),
+                                                values(ImmutableMap.of("a", 0, "b", 1)))))));
+    }
+
+    private AggregationNode createSumAggregation(PlanBuilder p, Symbol symbol, List<List<Symbol>> groupingSets, PlanNode source)
+    {
+        FunctionCall functionCall = new FunctionCall(SUM, ImmutableList.of(p.symbol("a", BIGINT).toSymbolReference()));
+        TypeSignature typeSignature = p.getSymbols().get(symbol).getTypeSignature();
+        Signature signature = functionRegistry.resolveFunction(SUM, fromTypeSignatures(ImmutableList.of(typeSignature)));
+
+        AggregationNode.Aggregation aggregation = new AggregationNode.Aggregation(functionCall, signature, Optional.empty());
+
+        return p.aggregation(source, ImmutableMap.of(p.symbol("sum", BIGINT), aggregation), groupingSets, AggregationNode.Step.SINGLE, Optional.empty(), Optional.empty());
+    }
+}


### PR DESCRIPTION
Fix from https://github.com/maciejgrzybek/presto/commit/77deae9ff0384b9c0c7f9fb76a7e5b73e8df5f84 is nothing specific to the new optimizer. Previous optimizer (in the old framework) was also not preserving the invariant of output symbols but we didn't have a check for that so we never noticed.