### PR TITLE
Optimize ArrayFilter by type-specialized method

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -54,6 +54,7 @@ import com.facebook.presto.operator.scalar.ArrayDistinctFunction;
 import com.facebook.presto.operator.scalar.ArrayElementAtFunction;
 import com.facebook.presto.operator.scalar.ArrayEqualOperator;
 import com.facebook.presto.operator.scalar.ArrayExceptFunction;
+import com.facebook.presto.operator.scalar.ArrayFilterFunction;
 import com.facebook.presto.operator.scalar.ArrayFunctions;
 import com.facebook.presto.operator.scalar.ArrayGreaterThanOperator;
 import com.facebook.presto.operator.scalar.ArrayGreaterThanOrEqualOperator;
@@ -201,7 +202,6 @@ import static com.facebook.presto.operator.aggregation.MinNAggregationFunction.M
 import static com.facebook.presto.operator.aggregation.MultimapAggregationFunction.MULTIMAP_AGG;
 import static com.facebook.presto.operator.scalar.ArrayConcatFunction.ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayConstructor.ARRAY_CONSTRUCTOR;
-import static com.facebook.presto.operator.scalar.ArrayFilterFunction.ARRAY_FILTER_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayFlattenFunction.ARRAY_FLATTEN_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayJoin.ARRAY_JOIN;
 import static com.facebook.presto.operator.scalar.ArrayJoin.ARRAY_JOIN_WITH_NULL_REPLACEMENT;
@@ -472,6 +472,7 @@ public class FunctionRegistry
                 .scalars(ArrayFunctions.class)
                 .scalar(ArrayCardinalityFunction.class)
                 .scalar(ArrayContains.class)
+                .scalar(ArrayFilterFunction.class)
                 .scalar(ArrayPositionFunction.class)
                 .scalars(CombineHashFunction.class)
                 .scalars(JsonOperators.class)
@@ -557,7 +558,7 @@ public class FunctionRegistry
                 .function(DECIMAL_AVERAGE_AGGREGATION)
                 .function(DECIMAL_SUM_AGGREGATION)
                 .function(DECIMAL_MOD_FUNCTION)
-                .functions(ARRAY_TRANSFORM_FUNCTION, ARRAY_FILTER_FUNCTION, ARRAY_REDUCE_FUNCTION)
+                .functions(ARRAY_TRANSFORM_FUNCTION, ARRAY_REDUCE_FUNCTION)
                 .functions(MAP_FILTER_FUNCTION, MAP_TRANSFORM_KEY_FUNCTION, MAP_TRANSFORM_VALUE_FUNCTION)
                 .function(TRY_CAST);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
@@ -14,90 +14,192 @@
 
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.metadata.BoundVariables;
-import com.facebook.presto.metadata.FunctionKind;
-import com.facebook.presto.metadata.FunctionRegistry;
-import com.facebook.presto.metadata.Signature;
-import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.function.TypeParameterSpecialization;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
 
-import static com.facebook.presto.metadata.Signature.typeVariable;
-import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
-import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.lang.Boolean.TRUE;
 
+@Description("return array containing elements that match the given predicate")
+@ScalarFunction(value = "filter", deterministic = false)
 public final class ArrayFilterFunction
-        extends SqlScalarFunction
 {
-    public static final ArrayFilterFunction ARRAY_FILTER_FUNCTION = new ArrayFilterFunction();
+    private ArrayFilterFunction() {}
 
-    private static final MethodHandle METHOD_HANDLE = methodHandle(ArrayFilterFunction.class, "filter", Type.class, Block.class, MethodHandle.class);
-
-    private ArrayFilterFunction()
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = long.class)
+    @SqlType("array(T)")
+    public static Block filterLong(@TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType("function(T, boolean)") MethodHandle function)
     {
-        super(new Signature(
-                "filter",
-                FunctionKind.SCALAR,
-                ImmutableList.of(typeVariable("T")),
-                ImmutableList.of(),
-                parseTypeSignature("array(T)"),
-                ImmutableList.of(parseTypeSignature("array(T)"), parseTypeSignature("function(T,boolean)")),
-                false));
-    }
-
-    @Override
-    public boolean isHidden()
-    {
-        return false;
-    }
-
-    @Override
-    public boolean isDeterministic()
-    {
-        return false;
-    }
-
-    @Override
-    public String getDescription()
-    {
-        return "return array containing elements that match the given predicate";
-    }
-
-    @Override
-    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
-    {
-        Type type = boundVariables.getTypeVariable("T");
-        return new ScalarFunctionImplementation(
-                false,
-                ImmutableList.of(false, false),
-                METHOD_HANDLE.bindTo(type),
-                isDeterministic());
-    }
-
-    public static Block filter(Type type, Block block, MethodHandle function)
-    {
-        int positionCount = block.getPositionCount();
-        BlockBuilder resultBuilder = type.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        int positionCount = arrayBlock.getPositionCount();
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
         for (int position = 0; position < positionCount; position++) {
-            Object input = readNativeValue(type, block, position);
+            Long input = null;
+            if (!arrayBlock.isNull(position)) {
+                input = elementType.getLong(arrayBlock, position);
+            }
+
             Boolean keep;
             try {
-                keep = (Boolean) function.invoke(input);
+                keep = (Boolean) function.invokeExact(input);
             }
             catch (Throwable throwable) {
                 throw Throwables.propagate(throwable);
             }
             if (TRUE.equals(keep)) {
-                type.appendTo(block, position, resultBuilder);
+                elementType.appendTo(arrayBlock, position, resultBuilder);
+            }
+        }
+        return resultBuilder.build();
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = double.class)
+    @SqlType("array(T)")
+    public static Block filterDouble(@TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType("function(T, boolean)") MethodHandle function)
+    {
+        int positionCount = arrayBlock.getPositionCount();
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        for (int position = 0; position < positionCount; position++) {
+            Double input = null;
+            if (!arrayBlock.isNull(position)) {
+                input = elementType.getDouble(arrayBlock, position);
+            }
+
+            Boolean keep;
+            try {
+                keep = (Boolean) function.invokeExact(input);
+            }
+            catch (Throwable throwable) {
+                throw Throwables.propagate(throwable);
+            }
+            if (TRUE.equals(keep)) {
+                elementType.appendTo(arrayBlock, position, resultBuilder);
+            }
+        }
+        return resultBuilder.build();
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = boolean.class)
+    @SqlType("array(T)")
+    public static Block filterBoolean(@TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType("function(T, boolean)") MethodHandle function)
+    {
+        int positionCount = arrayBlock.getPositionCount();
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        for (int position = 0; position < positionCount; position++) {
+            Boolean input = null;
+            if (!arrayBlock.isNull(position)) {
+                input = elementType.getBoolean(arrayBlock, position);
+            }
+
+            Boolean keep;
+            try {
+                keep = (Boolean) function.invokeExact(input);
+            }
+            catch (Throwable throwable) {
+                throw Throwables.propagate(throwable);
+            }
+            if (TRUE.equals(keep)) {
+                elementType.appendTo(arrayBlock, position, resultBuilder);
+            }
+        }
+        return resultBuilder.build();
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = Slice.class)
+    @SqlType("array(T)")
+    public static Block filterSlice(@TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType("function(T, boolean)") MethodHandle function)
+    {
+        int positionCount = arrayBlock.getPositionCount();
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        for (int position = 0; position < positionCount; position++) {
+            Slice input = null;
+            if (!arrayBlock.isNull(position)) {
+                input = elementType.getSlice(arrayBlock, position);
+            }
+
+            Boolean keep;
+            try {
+                keep = (Boolean) function.invokeExact(input);
+            }
+            catch (Throwable throwable) {
+                throw Throwables.propagate(throwable);
+            }
+            if (TRUE.equals(keep)) {
+                elementType.appendTo(arrayBlock, position, resultBuilder);
+            }
+        }
+        return resultBuilder.build();
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = Block.class)
+    @SqlType("array(T)")
+    public static Block filterBlock(@TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType("function(T, boolean)") MethodHandle function)
+    {
+        int positionCount = arrayBlock.getPositionCount();
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        for (int position = 0; position < positionCount; position++) {
+            Block input = null;
+            if (!arrayBlock.isNull(position)) {
+                input = (Block) elementType.getObject(arrayBlock, position);
+            }
+
+            Boolean keep;
+            try {
+                keep = (Boolean) function.invokeExact(input);
+            }
+            catch (Throwable throwable) {
+                throw Throwables.propagate(throwable);
+            }
+            if (TRUE.equals(keep)) {
+                elementType.appendTo(arrayBlock, position, resultBuilder);
+            }
+        }
+        return resultBuilder.build();
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = void.class)
+    @SqlType("array(T)")
+    public static Block filterVoid(@TypeParameter("T") Type elementType,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType("function(T, boolean)") MethodHandle function)
+    {
+        int positionCount = arrayBlock.getPositionCount();
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        for (int position = 0; position < positionCount; position++) {
+            Boolean keep;
+            try {
+                keep = (Boolean) function.invokeExact(null);
+            }
+            catch (Throwable throwable) {
+                throw Throwables.propagate(throwable);
+            }
+            if (TRUE.equals(keep)) {
+                resultBuilder.appendNull();
             }
         }
         return resultBuilder.build();

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFilterFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFilterFunction.java
@@ -58,6 +58,15 @@ public class TestArrayFilterFunction
         assertFunction("filter(ARRAY [CAST (NULL AS INTEGER)], x -> x IS NULL)", new ArrayType(INTEGER), singletonList(null));
         assertFunction("filter(ARRAY [NULL, NULL, NULL], x -> x IS NULL)", new ArrayType(UNKNOWN), asList(null, null, null));
         assertFunction("filter(ARRAY [NULL, NULL, NULL], x -> x IS NOT NULL)", new ArrayType(UNKNOWN), ImmutableList.of());
+
+        assertFunction("filter(ARRAY [25, 26, NULL], x -> x % 2 = 1 OR x IS NULL)", new ArrayType(INTEGER), asList(25, null));
+        assertFunction("filter(ARRAY [25.6, 37.3, NULL], x -> x < 30.0 OR x IS NULL)", new ArrayType(DOUBLE), asList(25.6, null));
+        assertFunction("filter(ARRAY [true, false, NULL], x -> not x OR x IS NULL)", new ArrayType(BOOLEAN), asList(false, null));
+        assertFunction("filter(ARRAY ['abc', 'def', NULL], x -> substr(x, 1, 1) = 'a' OR x IS NULL)", new ArrayType(createVarcharType(3)), asList("abc", null));
+        assertFunction(
+                "filter(ARRAY [ARRAY ['abc', null, '123'], NULL], x -> x[2] IS NULL OR x IS NULL)",
+                new ArrayType(new ArrayType(createVarcharType(3))),
+                asList(asList("abc", null, "123"), null));
     }
 
     @Test


### PR DESCRIPTION
This addresses https://github.com/prestodb/presto/issues/6779 and is based on annotation`TypeParameterSpecialization`

Benchmark before optimization:
```
Benchmark                             (name)  Mode  Cnt    Score   Error  Units
BenchmarkArrayFilter.benchmark        filter  avgt   20  134.575 ± 6.136  ns/op
BenchmarkArrayFilter.benchmark  exact_filter  avgt   20   83.188 ± 5.809  ns/op
```

After optimization
```
Benchmark                             (name)  Mode  Cnt   Score   Error  Units
BenchmarkArrayFilter.benchmark        filter  avgt   20  85.582 ± 4.233  ns/op
BenchmarkArrayFilter.benchmark  exact_filter  avgt   20  83.075 ± 3.952  ns/op
```