### PR TITLE
Add mongodb.ssl.enabled

### DIFF
--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -46,6 +46,7 @@ Property Name                         Description
 ``mongodb.connection-timeout``        The socket connect timeout
 ``mongodb.socket-timeout``            The socket timeout
 ``mongodb.socket-keep-alive``         Whether keep-alive is enabled on each socket
+``mongodb.ssl.enabled``               Use TLS/SSL for connections to mongod/mongos
 ``mongodb.read-preference``           The read preference
 ``mongodb.write-concern``             The write concern
 ``mongodb.required-replica-set``      The required replica set name
@@ -115,6 +116,13 @@ This property is optional; the default is ``0`` and means no timeout.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This flag controls the socket keep alive feature that keeps a connection alive through firewalls.
+
+This property is optional; the default is ``false``.
+
+``mongodb.ssl.enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+This flag enables SSL connections to MongoDB servers.
 
 This property is optional; the default is ``false``.
 

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoClientConfig.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoClientConfig.java
@@ -46,6 +46,7 @@ public class MongoClientConfig
     private int connectionTimeout = 10_000;
     private int socketTimeout = 0;
     private boolean socketKeepAlive = false;
+    private boolean sslEnabled = false;
 
     // query configurations
     private int cursorBatchSize = 0; // use driver default
@@ -274,6 +275,18 @@ public class MongoClientConfig
     public MongoClientConfig setImplicitRowFieldPrefix(String implicitRowFieldPrefix)
     {
         this.implicitRowFieldPrefix = implicitRowFieldPrefix;
+        return this;
+    }
+
+    public boolean getSslEnabled()
+    {
+        return this.sslEnabled;
+    }
+
+    @Config("mongodb.ssl.enabled")
+    public MongoClientConfig setSslEnabled(boolean sslEnabled)
+    {
+        this.sslEnabled = sslEnabled;
         return this;
     }
 }

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoClientModule.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoClientModule.java
@@ -52,6 +52,7 @@ public class MongoClientModule
                 .connectTimeout(config.getConnectionTimeout())
                 .socketTimeout(config.getSocketTimeout())
                 .socketKeepAlive(config.getSocketKeepAlive())
+                .sslEnabled(config.getSslEnabled())
                 .maxWaitTime(config.getMaxWaitTime())
                 .minConnectionsPerHost(config.getMinConnectionsPerHost())
                 .readPreference(config.getReadPreference().getReadPreference())


### PR DESCRIPTION
MongoDB Atlas forces all the deployments to use SSL/TLS. This option is necessary for Atlas users

https://docs.atlas.mongodb.com/setup-cluster-security/
https://docs.atlas.mongodb.com/faq/#can-i-disable-ssl-tls-on-my-deployment

EDIT: I saw there is a newly created Github issue and applied the changes accordingly: https://github.com/prestodb/presto/issues/7447