### PR TITLE
Rename read-timeout to idle-timeout in QueryRunners

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -164,7 +164,7 @@ public class DistributedQueryRunner
         long start = System.nanoTime();
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.<String, String>builder()
                 .put("query.client.timeout", "10m")
-                .put("exchange.http-client.read-timeout", "1h")
+                .put("exchange.http-client.idle-timeout", "1h")
                 .put("compiler.interpreter-enabled", "false")
                 .put("task.max-index-memory", "16kB") // causes index joins to fault load
                 .put("datasources", "system")

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -229,7 +229,7 @@ public final class StandaloneQueryRunner
     {
         ImmutableMap.Builder<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("query.client.timeout", "10m")
-                .put("exchange.http-client.read-timeout", "1h")
+                .put("exchange.http-client.idle-timeout", "1h")
                 .put("compiler.interpreter-enabled", "false")
                 .put("node-scheduler.min-candidates", "1")
                 .put("datasources", "system");


### PR DESCRIPTION
This is to get rid of:

`2017-02-18 07:45:50 WARNING Warning: Configuration property 'exchange.http-client.read-timeout' has been replaced. Use 'exchange.http-client.idle-timeout' instead.`