### PR TITLE
Fix invalid "No more buffers already set" in Broadcast buffer

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
@@ -392,6 +392,21 @@ public class TestArbitraryOutputBuffer
         assertBufferResultEquals(TYPES, getFuture(future, NO_WAIT), bufferResult(0, createPage(33)));
     }
 
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "No more buffers already set")
+    public void testUseUndeclaredBufferAfterFinalBuffersSet()
+            throws Exception
+    {
+        ArbitraryOutputBuffer buffer = createArbitraryBuffer(
+                createInitialEmptyOutputBuffers(ARBITRARY)
+                        .withBuffer(FIRST, BROADCAST_PARTITION_ID)
+                        .withNoMoreBufferIds(),
+                sizeOfPages(10));
+        assertFalse(buffer.isFinished());
+
+        // get a page from a buffer that was not declared, which will fail
+        buffer.get(SECOND, (long) 0, sizeOfPages(1));
+    }
+
     @Test
     public void testAbortBeforeCreate()
             throws Exception

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
@@ -405,7 +405,7 @@ public class TestBroadcastOutputBuffer
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*does not contain.*\\[0\\]")
-    public void testFinishWithoutDeclaringBuffer()
+    public void testSetFinalBuffersWihtoutDeclaringUsedBuffer()
             throws Exception
     {
         BroadcastOutputBuffer buffer = createBroadcastBuffer(createInitialEmptyOutputBuffers(BROADCAST), sizeOfPages(10));
@@ -427,8 +427,23 @@ public class TestBroadcastOutputBuffer
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 1, sizeOfPages(10), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 1, true));
         buffer.abort(FIRST);
 
-        // destroy without declaring the buffer, which will fail
-        buffer.destroy();
+        // set final buffers to a set that does not contain the buffer, which will fail
+        buffer.setOutputBuffers(createInitialEmptyOutputBuffers(BROADCAST).withNoMoreBufferIds());
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "No more buffers already set")
+    public void testUseUndeclaredBufferAfterFinalBuffersSet()
+            throws Exception
+    {
+        BroadcastOutputBuffer buffer = createBroadcastBuffer(
+                createInitialEmptyOutputBuffers(BROADCAST)
+                        .withBuffer(FIRST, BROADCAST_PARTITION_ID)
+                        .withNoMoreBufferIds(),
+                sizeOfPages(10));
+        assertFalse(buffer.isFinished());
+
+        // get a page from a buffer that was not declared, which will fail
+        buffer.get(SECOND, (long) 0, sizeOfPages(1));
     }
 
     @Test


### PR DESCRIPTION
When the broadcast buffer is closed early the buffer may not have received
the final buffer declaration, so buffer creation must be allowed in this case.

This causes queries to fail with the following stack:
```
java.lang.IllegalStateException: No more buffers already set
    at com.google.common.base.Preconditions.checkState(Preconditions.java:173)
    at com.facebook.presto.execution.buffer.BroadcastOutputBuffer.getBuffer(BroadcastOutputBuffer.java:301)
    at com.facebook.presto.execution.buffer.BroadcastOutputBuffer.get(BroadcastOutputBuffer.java:246)
    at com.facebook.presto.execution.buffer.LazyOutputBuffer.get(LazyOutputBuffer.java:177)
    at com.facebook.presto.execution.SqlTask.getTaskResults(SqlTask.java:341)
    at com.facebook.presto.execution.SqlTaskManager.getTaskResults(SqlTaskManager.java:335)
    at com.facebook.presto.server.TaskResource.getResults(TaskResource.java:242)
```