### PR TITLE
Dynamically adjust the number of runner threads

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskExecutor.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.execution.controller.TaskExectorController;
+import com.facebook.presto.execution.controller.TaskExecutorStatistics;
+import com.facebook.presto.execution.controller.TaskExecutorStatisticsFactory;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ticker;
@@ -54,6 +56,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -70,7 +73,9 @@ import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 @ThreadSafe
@@ -89,8 +94,9 @@ public class TaskExecutor
 
     private final ExecutorService executor;
     private final ThreadPoolExecutorMBean executorMBean;
+    private final ScheduledExecutorService runnerThreadsAdjustmentExecutor = newSingleThreadScheduledExecutor(threadsNamed("runner-threads-adjustment-%s"));
+    private final TaskExecutorStatisticsFactory taskExecutorStatisticsFactory = new TaskExecutorStatisticsFactory();
 
-    private final int runnerThreads;
     private final int minimumNumberOfDrivers;
 
     private final Ticker ticker;
@@ -148,28 +154,44 @@ public class TaskExecutor
     private final TimeDistribution normalSplitScheduledTime = new TimeDistribution(MICROSECONDS);
     private final TimeDistribution forcedSplitScheduledTime = new TimeDistribution(MICROSECONDS);
 
+    private final TaskExectorController taskExectorController;
+    private final Duration runnerThreadsAdjustmentInterval;
+
+    @GuardedBy("this")
+    private int targetRunnerThreads;
+    @GuardedBy("this")
+    private int runnerThreads;
+
     private volatile boolean closed;
 
     @Inject
     public TaskExecutor(TaskManagerConfig config)
     {
-        this(createTaskExecutorController(requireNonNull(config, "config is null")), config.getMinDrivers());
+        this(
+                createTaskExecutorController(requireNonNull(config, "config is null")),
+                config.getWorkerThreadsAdjustmentInterval(),
+                config.getMinDrivers());
     }
 
-    public TaskExecutor(TaskExectorController controller, int minDrivers)
+    public TaskExecutor(TaskExectorController controller, Duration workerThreadsAdjustmentInterval, int minDrivers)
     {
-        this(controller, minDrivers, Ticker.systemTicker());
+        this(controller, workerThreadsAdjustmentInterval, minDrivers, Ticker.systemTicker());
     }
 
     @VisibleForTesting
-    public TaskExecutor(TaskExectorController controller, int minDrivers, Ticker ticker)
+    public TaskExecutor(TaskExectorController controller, Duration workerThreadsAdjustmentInterval, int minDrivers, Ticker ticker)
     {
         requireNonNull(controller, "controller is null");
+        requireNonNull(workerThreadsAdjustmentInterval, "workerThreadsAdjustmentInterval is null");
 
         // we manages thread pool size directly, so create an unlimited pool
         this.executor = newCachedThreadPool(threadsNamed("task-processor-%s"));
         this.executorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) executor);
-        this.runnerThreads = controller.getNextRunnerThreads(Optional.empty());
+
+        this.taskExectorController = controller;
+        this.targetRunnerThreads = 0;
+        this.runnerThreads = 0;
+        this.runnerThreadsAdjustmentInterval = workerThreadsAdjustmentInterval;
 
         this.ticker = requireNonNull(ticker, "ticker is null");
 
@@ -182,9 +204,7 @@ public class TaskExecutor
     public synchronized void start()
     {
         checkState(!closed, "TaskExecutor is closed");
-        for (int i = 0; i < runnerThreads; i++) {
-            addRunnerThread();
-        }
+        startRunnerThreadsAdjustment();
     }
 
     @PreDestroy
@@ -192,6 +212,7 @@ public class TaskExecutor
     {
         closed = true;
         executor.shutdownNow();
+        runnerThreadsAdjustmentExecutor.shutdownNow();
     }
 
     @Override
@@ -207,13 +228,40 @@ public class TaskExecutor
                 .toString();
     }
 
-    private synchronized void addRunnerThread()
+    private synchronized void addRunnerThreadsIfNeeded(int targetRunnerThreadsCount)
+    {
+        targetRunnerThreads = targetRunnerThreadsCount;
+
+        for (int i = 0; i < targetRunnerThreadsCount - runnerThreads; i++) {
+            addRunnerThreadInternal();
+            runnerThreads++;
+        }
+    }
+
+    private synchronized boolean tryStopRunner()
+    {
+        if (runnerThreads > targetRunnerThreads) {
+            runnerThreads--;
+            return true;
+        }
+        return false;
+    }
+
+    private synchronized void addRunnerThreadInternal()
     {
         try {
             executor.execute(new Runner());
         }
         catch (RejectedExecutionException ignored) {
         }
+    }
+
+    private synchronized void startRunnerThreadsAdjustment()
+    {
+        runnerThreadsAdjustmentExecutor.scheduleWithFixedDelay(() -> {
+            Optional<TaskExecutorStatistics> stat = taskExecutorStatisticsFactory.createTaskExectorStatistics(runnerThreads, allSplits.size());
+            addRunnerThreadsIfNeeded(taskExectorController.getNextRunnerThreads(stat));
+        }, 0, runnerThreadsAdjustmentInterval.toMillis(), MILLISECONDS);
     }
 
     public synchronized TaskHandle addTask(TaskId taskId, DoubleSupplier utilizationSupplier, int initialSplitConcurrency, Duration splitConcurrencyAdjustFrequency)
@@ -750,8 +798,15 @@ public class TaskExecutor
         @Override
         public void run()
         {
+            boolean stopped = false;
             try (SetThreadName runnerName = new SetThreadName("SplitRunner-%s", runnerId)) {
-                while (!closed && !Thread.currentThread().isInterrupted()) {
+                while (true) {
+                    // check if the current thread need to be stopped
+                    stopped = tryStopRunner();
+                    if (closed || stopped || Thread.currentThread().isInterrupted()) {
+                        break;
+                    }
+
                     // select next worker
                     final PrioritizedSplitRunner split;
                     try {
@@ -822,8 +877,8 @@ public class TaskExecutor
             }
             finally {
                 // unless we have been closed, we need to replace this thread
-                if (!closed) {
-                    addRunnerThread();
+                if (!closed && !stopped) {
+                    addRunnerThreadInternal();
                 }
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskExecutor.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.presto.execution.controller.TaskExectorController;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ticker;
@@ -43,6 +44,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.SortedSet;
@@ -60,9 +62,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.function.DoubleSupplier;
 
+import static com.facebook.presto.execution.controller.TaskExectorControllerFactory.createTaskExecutorController;
 import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static io.airlift.concurrent.Threads.threadsNamed;
@@ -151,23 +153,23 @@ public class TaskExecutor
     @Inject
     public TaskExecutor(TaskManagerConfig config)
     {
-        this(requireNonNull(config, "config is null").getMaxWorkerThreads(), config.getMinDrivers());
+        this(createTaskExecutorController(requireNonNull(config, "config is null")), config.getMinDrivers());
     }
 
-    public TaskExecutor(int runnerThreads, int minDrivers)
+    public TaskExecutor(TaskExectorController controller, int minDrivers)
     {
-        this(runnerThreads, minDrivers, Ticker.systemTicker());
+        this(controller, minDrivers, Ticker.systemTicker());
     }
 
     @VisibleForTesting
-    public TaskExecutor(int runnerThreads, int minDrivers, Ticker ticker)
+    public TaskExecutor(TaskExectorController controller, int minDrivers, Ticker ticker)
     {
-        checkArgument(runnerThreads > 0, "runnerThreads must be at least 1");
+        requireNonNull(controller, "controller is null");
 
         // we manages thread pool size directly, so create an unlimited pool
         this.executor = newCachedThreadPool(threadsNamed("task-processor-%s"));
         this.executorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) executor);
-        this.runnerThreads = runnerThreads;
+        this.runnerThreads = controller.getNextRunnerThreads(Optional.empty());
 
         this.ticker = requireNonNull(ticker, "ticker is null");
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -44,10 +44,12 @@ public class TaskManagerConfig
     private DataSize maxIndexMemoryUsage = new DataSize(64, Unit.MEGABYTE);
     private boolean shareIndexLoading;
     private int maxWorkerThreads = Runtime.getRuntime().availableProcessors() * 2;
+    private Integer minWorkerThreads;
     private Integer minDrivers;
     private Integer initialSplitsPerNode;
     private Duration workerThreadsAdjustmentInterval = new Duration(1000, TimeUnit.MILLISECONDS);
     private Duration splitConcurrencyAdjustmentInterval = new Duration(100, TimeUnit.MILLISECONDS);
+    private double targetCpuUtilization = 0.8;
 
     private DataSize sinkMaxBufferSize = new DataSize(32, Unit.MEGABYTE);
     private DataSize maxPagePartitioningBufferSize = new DataSize(32, Unit.MEGABYTE);
@@ -170,6 +172,34 @@ public class TaskManagerConfig
     public TaskManagerConfig setMaxWorkerThreads(int maxWorkerThreads)
     {
         this.maxWorkerThreads = maxWorkerThreads;
+        return this;
+    }
+
+    @Min(1)
+    public int getMinWorkerThreads()
+    {
+        if (minWorkerThreads == null) {
+            return maxWorkerThreads;
+        }
+        return minWorkerThreads;
+    }
+
+    @Config("task.min-worker-threads")
+    public TaskManagerConfig setMinWorkerThreads(int minWorkerThreads)
+    {
+        this.minWorkerThreads = minWorkerThreads;
+        return this;
+    }
+
+    public double getTargetCpuUtilization()
+    {
+        return targetCpuUtilization;
+    }
+
+    @Config("task.target-cpu-utilization")
+    public TaskManagerConfig setTargetCpuUtilization(double targetCpuUtilization)
+    {
+        this.targetCpuUtilization = targetCpuUtilization;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -46,6 +46,7 @@ public class TaskManagerConfig
     private int maxWorkerThreads = Runtime.getRuntime().availableProcessors() * 2;
     private Integer minDrivers;
     private Integer initialSplitsPerNode;
+    private Duration workerThreadsAdjustmentInterval = new Duration(1000, TimeUnit.MILLISECONDS);
     private Duration splitConcurrencyAdjustmentInterval = new Duration(100, TimeUnit.MILLISECONDS);
 
     private DataSize sinkMaxBufferSize = new DataSize(32, Unit.MEGABYTE);
@@ -169,6 +170,19 @@ public class TaskManagerConfig
     public TaskManagerConfig setMaxWorkerThreads(int maxWorkerThreads)
     {
         this.maxWorkerThreads = maxWorkerThreads;
+        return this;
+    }
+
+    @MinDuration("500ms")
+    public Duration getWorkerThreadsAdjustmentInterval()
+    {
+        return workerThreadsAdjustmentInterval;
+    }
+
+    @Config("task.worker-threads-adjustment-interval")
+    public TaskManagerConfig setWorkerThreadsAdjustmentInterval(Duration workerThreadsAdjustmentInterval)
+    {
+        this.workerThreadsAdjustmentInterval = workerThreadsAdjustmentInterval;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/controller/PidTaskExecutorController.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/controller/PidTaskExecutorController.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.controller;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class PidTaskExecutorController
+        implements TaskExectorController
+{
+    private final PidController controller;
+    private final double target;
+
+    public PidTaskExecutorController(double target, int minValue, int maxValue, double kp, double ki, double kd)
+    {
+        checkArgument(minValue > 0, "minValue must be greater than 0");
+        checkArgument(minValue <= maxValue, "minValue must be less than maxValue");
+        checkArgument(target >= 0 && target <= 1, "target must be in range of [0, 1]");
+
+        this.target = target;
+        this.controller = new PidController(minValue, maxValue, target, kp, ki, kd);
+    }
+
+    @Override
+    public int getNextRunnerThreads(Optional<TaskExecutorStatistics> statistics)
+    {
+        requireNonNull(statistics, "statistics is null");
+
+        if (statistics.isPresent() && statistics.get().getWallTime().getValue(TimeUnit.SECONDS) >= 0.05) {
+            double cpuUtilization = statistics.get().getCpuUtilization();
+            if (statistics.get().getTotalSplits() <= statistics.get().getRunnerThreads()) {
+                cpuUtilization = Math.max(target, cpuUtilization);
+            }
+            controller.feedValue(cpuUtilization, statistics.get().getWallTime().getValue(TimeUnit.SECONDS));
+        }
+        return (int) controller.getInput();
+    }
+
+    @VisibleForTesting
+    static class PidController
+    {
+        private final double minValue;
+        private final double maxValue;
+        private final double target;
+        private final double kp;
+        private final double ki;
+        private final double kd;
+
+        private double ratio;
+        private double integralValue;
+        private double lastError;
+
+        PidController(double minValue, double maxValue, double target, double kp, double ki, double kd)
+        {
+            this.lastError = 0;
+            this.target = target;
+            this.minValue = minValue;
+            this.maxValue = maxValue;
+
+            this.kp = kp;
+            this.ki = ki;
+            this.kd = kd;
+        }
+
+        public void feedValue(double value, double dt)
+        {
+            double error = target - value;
+
+            ratio = kp * error + ki * (integralValue + error * dt) + kd * (error - lastError) / dt;
+
+            // Do integration if and only if the generated value is within the allowed range
+            if (ratio <= 1 && ratio >= 0) {
+                integralValue += error * dt;
+            }
+            lastError = error;
+        }
+
+        public double getInput()
+        {
+            return Math.min(maxValue, Math.max(minValue, minValue + (maxValue - minValue) * ratio));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/controller/StaticTaskExecutorController.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/controller/StaticTaskExecutorController.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.controller;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class StaticTaskExecutorController
+        implements TaskExectorController
+{
+    private final int runnerThreads;
+
+    public StaticTaskExecutorController(int maxWorkerThreads)
+    {
+        checkArgument(maxWorkerThreads > 0, "maxWorkerThreads must be greater than 0");
+        this.runnerThreads = maxWorkerThreads;
+    }
+
+    @Override
+    public int getNextRunnerThreads(Optional<TaskExecutorStatistics> stat)
+    {
+        return runnerThreads;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/controller/TaskExectorController.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/controller/TaskExectorController.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.controller;
+
+import java.util.Optional;
+
+public interface TaskExectorController
+{
+    int getNextRunnerThreads(Optional<TaskExecutorStatistics> stat);
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/controller/TaskExectorControllerFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/controller/TaskExectorControllerFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.controller;
+
+import com.facebook.presto.execution.TaskManagerConfig;
+
+import static java.util.Objects.requireNonNull;
+
+public final class TaskExectorControllerFactory
+{
+    private TaskExectorControllerFactory() {}
+
+    public static TaskExectorController createTaskExecutorController(TaskManagerConfig config)
+    {
+        requireNonNull(config, "config is null");
+        return new StaticTaskExecutorController(config.getMaxWorkerThreads());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/controller/TaskExecutorStatistics.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/controller/TaskExecutorStatistics.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.controller;
+
+import io.airlift.units.Duration;
+
+import java.util.concurrent.TimeUnit;
+
+public class TaskExecutorStatistics
+{
+    private final Duration cpuTime;
+    private final Duration wallTime;
+    private final int runnerThreads;
+    private final int totalSplits;
+
+    public TaskExecutorStatistics(Duration cpuTime, Duration wallTime, int runnerThreads, int totalSplits)
+    {
+        this.cpuTime = cpuTime;
+        this.wallTime = wallTime;
+        this.runnerThreads = runnerThreads;
+        this.totalSplits = totalSplits;
+    }
+
+    public Duration getCpuTime()
+    {
+        return cpuTime;
+    }
+
+    public Duration getWallTime()
+    {
+        return wallTime;
+    }
+
+    public int getRunnerThreads()
+    {
+        return runnerThreads;
+    }
+
+    public int getTotalSplits()
+    {
+        return totalSplits;
+    }
+
+    public double getCpuUtilization()
+    {
+        return cpuTime.getValue(TimeUnit.SECONDS) / (Runtime.getRuntime().availableProcessors() * wallTime.getValue(TimeUnit.SECONDS));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/controller/TaskExecutorStatisticsFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/controller/TaskExecutorStatisticsFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.controller;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.StandardErrorCode;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+import java.lang.management.ManagementFactory;
+import java.util.Optional;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class TaskExecutorStatisticsFactory
+{
+    private static final String OPERATING_SYSTEM_OBJECT = "java.lang:type=OperatingSystem";
+    private static final String PROCESS_CPU_TIME_ATTRIBUTE = "ProcessCpuTime";
+    private static final Logger logger = Logger.get(TaskExecutorStatisticsFactory.class);
+
+    private final MBeanServer mBeanServer;
+    private final ObjectName operatingSystemObjectName;
+
+    private long lastWallNanos;
+    private long lastCpuNanos;
+
+    public TaskExecutorStatisticsFactory()
+    {
+        mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        try {
+            operatingSystemObjectName = new ObjectName(OPERATING_SYSTEM_OBJECT);
+        }
+        catch (MalformedObjectNameException e) {
+            throw new PrestoException(StandardErrorCode.GENERIC_INTERNAL_ERROR, "Cannot create ObjectName for " + OPERATING_SYSTEM_OBJECT);
+        }
+        Long cpuTime = getProcessCpuTime();
+        if (cpuTime != null) {
+            lastCpuNanos = cpuTime.longValue();
+            lastWallNanos = System.nanoTime();
+        }
+    }
+
+    public Optional<TaskExecutorStatistics> createTaskExectorStatistics(int runnerThreads, int allSplitCount)
+    {
+        Long cpuTime = getProcessCpuTime();
+        if (cpuTime == null) {
+            return Optional.empty();
+        }
+        long currentCpuNanos = cpuTime.longValue();
+        long currentWallNanos = System.nanoTime();
+        TaskExecutorStatistics state = new TaskExecutorStatistics(
+                new Duration(currentCpuNanos - lastCpuNanos, NANOSECONDS),
+                new Duration(currentWallNanos - lastWallNanos, NANOSECONDS),
+                runnerThreads,
+                allSplitCount);
+        lastCpuNanos = currentCpuNanos;
+        lastWallNanos = currentWallNanos;
+        return Optional.of(state);
+    }
+
+    private Long getProcessCpuTime()
+    {
+        try {
+            return (Long) mBeanServer.getAttribute(operatingSystemObjectName, PROCESS_CPU_TIME_ATTRIBUTE);
+        }
+        catch (MBeanException | AttributeNotFoundException | InstanceNotFoundException | ReflectionException e) {
+            logger.error(
+                    "Cannot get %s attribute from %s object when creating TaskExecutorStatistics due to: %s",
+                    PROCESS_CPU_TIME_ATTRIBUTE,
+                    OPERATING_SYSTEM_OBJECT,
+                    e);
+        }
+        return null;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -177,7 +177,10 @@ public class TestingPrestoServer
                 .put("presto.version", "testversion")
                 .put("http-client.max-threads", "16")
                 .put("task.concurrency", "4")
-                .put("task.max-worker-threads", "4")
+                .put("task.max-worker-threads", String.valueOf(Runtime.getRuntime().availableProcessors() * 2))
+                .put("task.min-worker-threads", "4")
+                .put("task.min-drivers", "8")
+                .put("task.initial-splits-per-node", "4")
                 .put("exchange.client-threads", "4");
 
         if (!properties.containsKey("query.max-memory-per-node")) {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskExecutorSimulator.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskExecutorSimulator.java
@@ -49,6 +49,7 @@ import static io.airlift.concurrent.Threads.threadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TaskExecutorSimulator
         implements Closeable
@@ -71,7 +72,7 @@ public class TaskExecutorSimulator
     {
         executor = listeningDecorator(newCachedThreadPool(threadsNamed(getClass().getSimpleName() + "-%s")));
 
-        taskExecutor = new TaskExecutor(new StaticTaskExecutorController(24), 48, new Ticker()
+        taskExecutor = new TaskExecutor(new StaticTaskExecutorController(24), new Duration(1, SECONDS), 48, new Ticker()
         {
             private final long start = System.nanoTime();
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskExecutorSimulator.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskExecutorSimulator.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.execution.TaskExecutor.TaskHandle;
+import com.facebook.presto.execution.controller.StaticTaskExecutorController;
 import com.google.common.base.Throwables;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ArrayListMultimap;
@@ -70,7 +71,7 @@ public class TaskExecutorSimulator
     {
         executor = listeningDecorator(newCachedThreadPool(threadsNamed(getClass().getSimpleName() + "-%s")));
 
-        taskExecutor = new TaskExecutor(24, 48, new Ticker()
+        taskExecutor = new TaskExecutor(new StaticTaskExecutorController(24), 48, new Ticker()
         {
             private final long start = System.nanoTime();
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -22,6 +22,7 @@ import com.facebook.presto.event.query.QueryMonitorConfig;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.BufferState;
+import com.facebook.presto.execution.controller.StaticTaskExecutorController;
 import com.facebook.presto.memory.MemoryPool;
 import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.spi.QueryId;
@@ -77,7 +78,7 @@ public class TestSqlTask
 
     public TestSqlTask()
     {
-        taskExecutor = new TaskExecutor(8, 16);
+        taskExecutor = new TaskExecutor(new StaticTaskExecutorController(8), 16);
         taskExecutor.start();
 
         taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -35,6 +35,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.json.ObjectMapperProvider;
 import io.airlift.node.NodeInfo;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -78,7 +79,7 @@ public class TestSqlTask
 
     public TestSqlTask()
     {
-        taskExecutor = new TaskExecutor(new StaticTaskExecutorController(8), 16);
+        taskExecutor = new TaskExecutor(new StaticTaskExecutorController(8), new Duration(1, SECONDS), 16);
         taskExecutor.start();
 
         taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -51,6 +51,7 @@ import static com.facebook.presto.execution.TaskTestUtils.SPLIT;
 import static com.facebook.presto.execution.TaskTestUtils.TABLE_SCAN_NODE_ID;
 import static com.facebook.presto.execution.TaskTestUtils.createTestingPlanner;
 import static io.airlift.json.JsonCodec.jsonCodec;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
@@ -68,7 +69,7 @@ public class TestSqlTaskManager
     public TestSqlTaskManager()
     {
         localMemoryManager = new LocalMemoryManager(new NodeMemoryConfig(), new ReservedSystemMemoryConfig());
-        taskExecutor = new TaskExecutor(new StaticTaskExecutorController(8), 16);
+        taskExecutor = new TaskExecutor(new StaticTaskExecutorController(8), new Duration(1, SECONDS), 16);
         taskExecutor.start();
     }
 
@@ -142,7 +143,7 @@ public class TestSqlTaskManager
             TaskInfo info = sqlTaskManager.abortTaskResults(taskId, OUT);
             assertEquals(info.getOutputBuffers().getState(), BufferState.FINISHED);
 
-            taskInfo = sqlTaskManager.getTaskInfo(taskId, taskInfo.getTaskStatus().getState()).get(1, TimeUnit.SECONDS);
+            taskInfo = sqlTaskManager.getTaskInfo(taskId, taskInfo.getTaskStatus().getState()).get(1, SECONDS);
             assertEquals(taskInfo.getTaskStatus().getState(), TaskState.FINISHED);
             taskInfo = sqlTaskManager.getTaskInfo(taskId);
             assertEquals(taskInfo.getTaskStatus().getState(), TaskState.FINISHED);
@@ -229,7 +230,7 @@ public class TestSqlTaskManager
 
             sqlTaskManager.abortTaskResults(taskId, OUT);
 
-            taskInfo = sqlTaskManager.getTaskInfo(taskId, taskInfo.getTaskStatus().getState()).get(1, TimeUnit.SECONDS);
+            taskInfo = sqlTaskManager.getTaskInfo(taskId, taskInfo.getTaskStatus().getState()).get(1, SECONDS);
             assertEquals(taskInfo.getTaskStatus().getState(), TaskState.FINISHED);
 
             taskInfo = sqlTaskManager.getTaskInfo(taskId);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -21,6 +21,7 @@ import com.facebook.presto.event.query.QueryMonitorConfig;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.BufferState;
+import com.facebook.presto.execution.controller.StaticTaskExecutorController;
 import com.facebook.presto.memory.LocalMemoryManager;
 import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.memory.ReservedSystemMemoryConfig;
@@ -67,7 +68,7 @@ public class TestSqlTaskManager
     public TestSqlTaskManager()
     {
         localMemoryManager = new LocalMemoryManager(new NodeMemoryConfig(), new ReservedSystemMemoryConfig());
-        taskExecutor = new TaskExecutor(8, 16);
+        taskExecutor = new TaskExecutor(new StaticTaskExecutorController(8), 16);
         taskExecutor.start();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskExecutor.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskExecutor.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.execution.TaskExecutor.TaskHandle;
+import com.facebook.presto.execution.controller.StaticTaskExecutorController;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -36,7 +37,7 @@ public class TestTaskExecutor
             throws Exception
     {
         TestingTicker ticker = new TestingTicker();
-        TaskExecutor taskExecutor = new TaskExecutor(4, 8, ticker);
+        TaskExecutor taskExecutor = new TaskExecutor(new StaticTaskExecutorController(4), 8, ticker);
         taskExecutor.start();
         ticker.increment(20, MILLISECONDS);
 
@@ -128,7 +129,7 @@ public class TestTaskExecutor
     public void testTaskHandle()
             throws Exception
     {
-        TaskExecutor taskExecutor = new TaskExecutor(4, 8);
+        TaskExecutor taskExecutor = new TaskExecutor(new StaticTaskExecutorController(4), 8);
         taskExecutor.start();
 
         try {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskExecutor.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskExecutor.java
@@ -23,11 +23,11 @@ import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.Phaser;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 
 public class TestTaskExecutor
@@ -37,7 +37,7 @@ public class TestTaskExecutor
             throws Exception
     {
         TestingTicker ticker = new TestingTicker();
-        TaskExecutor taskExecutor = new TaskExecutor(new StaticTaskExecutorController(4), 8, ticker);
+        TaskExecutor taskExecutor = new TaskExecutor(new StaticTaskExecutorController(4), new Duration(1, SECONDS), 8, ticker);
         taskExecutor.start();
         ticker.increment(20, MILLISECONDS);
 
@@ -94,8 +94,8 @@ public class TestTaskExecutor
             assertEquals(driver1.getCompletedPhases(), 10);
             assertEquals(driver2.getCompletedPhases(), 10);
             assertEquals(driver3.getCompletedPhases(), 8);
-            future1.get(1, TimeUnit.SECONDS);
-            future2.get(1, TimeUnit.SECONDS);
+            future1.get(1, SECONDS);
+            future2.get(1, SECONDS);
             verificationComplete.arriveAndAwaitAdvance();
 
             // advance two more times and verify
@@ -105,7 +105,7 @@ public class TestTaskExecutor
             assertEquals(driver1.getCompletedPhases(), 10);
             assertEquals(driver2.getCompletedPhases(), 10);
             assertEquals(driver3.getCompletedPhases(), 10);
-            future3.get(1, TimeUnit.SECONDS);
+            future3.get(1, SECONDS);
             verificationComplete.arriveAndAwaitAdvance();
 
             assertEquals(driver1.getFirstPhase(), 0);
@@ -129,7 +129,7 @@ public class TestTaskExecutor
     public void testTaskHandle()
             throws Exception
     {
-        TaskExecutor taskExecutor = new TaskExecutor(new StaticTaskExecutorController(4), 8);
+        TaskExecutor taskExecutor = new TaskExecutor(new StaticTaskExecutorController(4), new Duration(1, SECONDS), 8);
         taskExecutor.start();
 
         try {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -51,7 +51,8 @@ public class TestTaskManagerConfig
                 .setTaskConcurrency(16)
                 .setHttpResponseThreads(100)
                 .setHttpTimeoutThreads(3)
-                .setTaskNotificationThreads(5));
+                .setTaskNotificationThreads(5)
+                .setWorkerThreadsAdjustmentInterval(new Duration(1, TimeUnit.SECONDS)));
     }
 
     @Test
@@ -78,6 +79,7 @@ public class TestTaskManagerConfig
                 .put("task.http-response-threads", "4")
                 .put("task.http-timeout-threads", "10")
                 .put("task.task-notification-threads", "13")
+                .put("task.worker-threads-adjustment-interval", "2s")
                 .build();
 
         TaskManagerConfig expected = new TaskManagerConfig()
@@ -100,7 +102,8 @@ public class TestTaskManagerConfig
                 .setTaskConcurrency(8)
                 .setHttpResponseThreads(4)
                 .setHttpTimeoutThreads(10)
-                .setTaskNotificationThreads(13);
+                .setTaskNotificationThreads(13)
+                .setWorkerThreadsAdjustmentInterval(new Duration(2, TimeUnit.SECONDS));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -39,6 +39,7 @@ public class TestTaskManagerConfig
                 .setVerboseStats(false)
                 .setTaskCpuTimerEnabled(true)
                 .setMaxWorkerThreads(Runtime.getRuntime().availableProcessors() * 2)
+                .setMinWorkerThreads(Runtime.getRuntime().availableProcessors() * 2)
                 .setMinDrivers(Runtime.getRuntime().availableProcessors() * 2 * 2)
                 .setInfoMaxAge(new Duration(15, TimeUnit.MINUTES))
                 .setClientTimeout(new Duration(2, TimeUnit.MINUTES))
@@ -52,6 +53,7 @@ public class TestTaskManagerConfig
                 .setHttpResponseThreads(100)
                 .setHttpTimeoutThreads(3)
                 .setTaskNotificationThreads(5)
+                .setTargetCpuUtilization(0.8)
                 .setWorkerThreadsAdjustmentInterval(new Duration(1, TimeUnit.SECONDS)));
     }
 
@@ -69,6 +71,7 @@ public class TestTaskManagerConfig
                 .put("task.share-index-loading", "true")
                 .put("task.max-partial-aggregation-memory", "32MB")
                 .put("task.max-worker-threads", "3")
+                .put("task.min-worker-threads", "1")
                 .put("task.min-drivers", "2")
                 .put("task.info.max-age", "22m")
                 .put("task.client.timeout", "10s")
@@ -80,6 +83,7 @@ public class TestTaskManagerConfig
                 .put("task.http-timeout-threads", "10")
                 .put("task.task-notification-threads", "13")
                 .put("task.worker-threads-adjustment-interval", "2s")
+                .put("task.target-cpu-utilization", "0.45")
                 .build();
 
         TaskManagerConfig expected = new TaskManagerConfig()
@@ -93,6 +97,7 @@ public class TestTaskManagerConfig
                 .setShareIndexLoading(true)
                 .setMaxPartialAggregationMemoryUsage(new DataSize(32, Unit.MEGABYTE))
                 .setMaxWorkerThreads(3)
+                .setMinWorkerThreads(1)
                 .setMinDrivers(2)
                 .setInfoMaxAge(new Duration(22, TimeUnit.MINUTES))
                 .setClientTimeout(new Duration(10, TimeUnit.SECONDS))
@@ -103,6 +108,7 @@ public class TestTaskManagerConfig
                 .setHttpResponseThreads(4)
                 .setHttpTimeoutThreads(10)
                 .setTaskNotificationThreads(13)
+                .setTargetCpuUtilization(0.45)
                 .setWorkerThreadsAdjustmentInterval(new Duration(2, TimeUnit.SECONDS));
 
         assertFullMapping(properties, expected);

--- a/presto-main/src/test/java/com/facebook/presto/execution/controller/TestPidTaskExecutorController.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/controller/TestPidTaskExecutorController.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.controller;
+
+import com.facebook.presto.execution.controller.PidTaskExecutorController.PidController;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestPidTaskExecutorController
+{
+    @Test
+    public void testLinearFunctions()
+    {
+        double targetInput = 37.37;
+        Function<Double, Double> function = createLinearFunction(23.23, 123.0);
+        double targetOutput = function.apply(targetInput);
+
+        PidController controller = new PidController(-10, 100, targetOutput, 0.0001, 0.0001, 0.00005);
+        doTestFunction(controller, targetInput, function);
+
+        // test different linear function
+        targetInput = 99.99;
+        function = createLinearFunction(3.81, -123.0);
+        targetOutput = function.apply(targetInput);
+
+        controller = new PidController(0, 120, targetOutput, 0.0005, 0.0005, 0.00005);
+        doTestFunction(controller, targetInput, function);
+    }
+
+    @Test
+    public void testLinearCombinedFunctions()
+    {
+        double targetInput = 99.99;
+        Function<Double, Double> function = createLinearFunction(3.81, -123.0);
+        double targetOutput = function.apply(targetInput);
+
+        PidController controller = new PidController(0, 100, targetOutput, 0.0002, 0.0002, 0.00000001);
+        doTestFunction(controller, targetInput, function);
+
+        // balance condition changed
+        function = createLinearFunction(23.23, 123.0);
+        targetInput = solveLinearFunction(23.23, 123.0, targetOutput);
+        doTestFunction(controller, targetInput, function);
+    }
+
+    @Test
+    public void testQuadraticFunction()
+    {
+        double targetInput = 9.5;
+        Function<Double, Double> function = createQuadraticFunction(-1, 20, 0);
+        double targetOutput = function.apply(targetInput);
+
+        PidController controller = new PidController(5, 30, targetOutput, 0.003, 0.003, 0.00003);
+        doTestFunction(controller, targetInput, function);
+    }
+
+    private void doTestFunction(PidController controller, double expected, Function<Double, Double> function)
+    {
+        Random random = new Random(0);
+        double input = controller.getInput();
+        for (int i = 0; i < 100; i++) {
+            double seconds = random.nextDouble() / 5 + 0.9;
+            controller.feedValue(function.apply(input), seconds);
+            input = controller.getInput();
+        }
+        assertEquals(input, expected, 0.1);
+    }
+
+    @Test
+    public void testPidTaskExectorController()
+    {
+        Random random = new Random(0);
+        PidTaskExecutorController controller = new PidTaskExecutorController(0.8, 10, 150, 0.1, 0.1, 0.1);
+        int input = controller.getNextRunnerThreads(Optional.empty());
+        for (int i = 0; i < 100; i++) {
+            input = controller.getNextRunnerThreads(Optional.of(createTaskExectorStat(random, input, Integer.MAX_VALUE)));
+        }
+        assertEquals(input, 59.02, 3);
+    }
+
+    private static TaskExecutorStatistics createTaskExectorStat(Random random, int value, int splits)
+    {
+        // value < 50, output = 0.012 * value + 0.1, output will be below 0.7
+        // 50 <= value < 90, output = -0.00015625 * (90 - value)^2 + 0.95, output will be between 0.7 and 0.95
+        // value >= 90, output = 0.93 + random(0.04), output will be between 0.93 and 0.97
+        double output = 0.012 * value + 0.1;
+        if (50 <= value && value < 90) {
+            output = 0.95 - 0.00015625 * (90 - value) * (90 - value);
+        }
+        else if (value >= 90) {
+            output = 0.93 + random.nextDouble() / 25.0;
+        }
+        double randomSeconds = random.nextDouble() / 5 + 0.9;
+        return new TaskExecutorStatistics(
+                new Duration(output * randomSeconds * Runtime.getRuntime().availableProcessors(), TimeUnit.SECONDS),
+                new Duration(randomSeconds, TimeUnit.SECONDS),
+                (int) value,
+                splits);
+    }
+
+    private static Function<Double, Double> createLinearFunction(double a, double b)
+    {
+        return x -> a * x + b;
+    }
+
+    private static double solveLinearFunction(double a, double b, double output)
+    {
+        return (output - b) / a;
+    }
+
+    private static Function<Double, Double> createQuadraticFunction(double a, double b, double c)
+    {
+        return x -> a * x * x + b * x + c;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/controller/TestStaticTaskExecutorController.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/controller/TestStaticTaskExecutorController.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.controller;
+
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+
+public class TestStaticTaskExecutorController
+{
+    @Test
+    public void testStaticTaskExecutorController()
+    {
+        TaskExectorController controller = new StaticTaskExecutorController(37);
+        for (int i = 0; i < 10; i++) {
+            TaskExecutorStatistics statistics = null;
+            if (i % 2 == 1) {
+                statistics = new TaskExecutorStatistics(
+                        new Duration(2 * i + 1, SECONDS),
+                        new Duration(i, SECONDS),
+                        i + 23,
+                        3 * 100);
+            }
+            assertEquals(37, controller.getNextRunnerThreads(Optional.ofNullable(statistics)));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/controller/TestTaskExecutorStatistics.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/controller/TestTaskExecutorStatistics.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.controller;
+
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+
+public class TestTaskExecutorStatistics
+{
+    @Test
+    public void testTaskExecutorStatistics()
+    {
+        int cpus = Runtime.getRuntime().availableProcessors();
+        double expectedCpuUtilization = 0.67;
+        int expectedWallTimeSeconds = 123;
+        TaskExecutorStatistics statistics = new TaskExecutorStatistics(
+                new Duration(expectedWallTimeSeconds * cpus * expectedCpuUtilization, SECONDS),
+                new Duration(expectedWallTimeSeconds, SECONDS),
+                123,
+                456);
+        assertEquals(statistics.getCpuTime().getValue(SECONDS), expectedWallTimeSeconds * cpus * expectedCpuUtilization);
+        assertEquals(statistics.getWallTime().getValue(SECONDS), (double) expectedWallTimeSeconds);
+        assertEquals(statistics.getCpuUtilization(), expectedCpuUtilization);
+        assertEquals(statistics.getRunnerThreads(), 123);
+        assertEquals(statistics.getTotalSplits(), 456);
+    }
+}


### PR DESCRIPTION
This closes #6005.

This change makes Presto worker able to automatically adjust the number
of runner threads between the specified range according to the given
taget CPU utilization, which can:

- help user find a good number for runner threads
- help workers make full use of CPU

In this change, proportional–integral–derivative (PID) controller is
used to control the adjustment process, and conservative parameters for
PID have been chosen to make the adjustment more reasonable.