### PR TITLE
Allow Simultaneous LDAP and Kerberos Authentication

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
@@ -28,7 +28,8 @@ public class SecurityConfig
     {
         NONE,
         KERBEROS,
-        LDAP
+        LDAP,
+        MIXED
     }
 
     @NotNull

--- a/presto-main/src/main/java/com/facebook/presto/server/security/ServerSecurityModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/ServerSecurityModule.java
@@ -26,6 +26,7 @@ import java.util.function.Predicate;
 
 import static com.facebook.presto.server.security.SecurityConfig.AuthenticationType.KERBEROS;
 import static com.facebook.presto.server.security.SecurityConfig.AuthenticationType.LDAP;
+import static com.facebook.presto.server.security.SecurityConfig.AuthenticationType.MIXED;
 import static io.airlift.configuration.ConditionalModule.installModuleIf;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
@@ -53,6 +54,15 @@ public class ServerSecurityModule
                                     .addBinding()
                                     .to(LdapFilter.class)
                                     .in(Scopes.SINGLETON);
+                });
+        bindSecurityConfig(
+                securityConfig -> securityConfig.getAuthenticationType() == MIXED,
+                binder -> {
+                    configBinder(binder).bindConfig(LdapConfig.class);
+                    configBinder(binder).bindConfig(KerberosConfig.class);
+                    Multibinder<Filter> multibinder =  Multibinder.newSetBinder(binder, Filter.class, TheServlet.class);
+                    multibinder.addBinding().to(SpnegoFilter.class).in(Scopes.SINGLETON);
+                    multibinder.addBinding().to(LdapFilter.class).in(Scopes.SINGLETON);
                 });
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/security/SpnegoFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/SpnegoFilter.java
@@ -67,17 +67,20 @@ public class SpnegoFilter
 {
     private static final Logger LOG = Logger.get(SpnegoFilter.class);
 
+    private static final String BASIC_AUTHENTICATION_PREFIX = "Basic ";
     private static final String NEGOTIATE_SCHEME = "Negotiate";
     private static final String INCLUDE_REALM_HEADER = "X-Airlift-Realm-In-Challenge";
 
     private final GSSManager gssManager = GSSManager.getInstance();
     private final LoginContext loginContext;
     private final GSSCredential serverCredential;
+    private final SecurityConfig securityConfig;
 
     @Inject
-    public SpnegoFilter(KerberosConfig config)
+    public SpnegoFilter(KerberosConfig config, SecurityConfig securityConfig)
     {
         System.setProperty("java.security.krb5.conf", config.getKerberosConfig().getAbsolutePath());
+        this.securityConfig = securityConfig;
 
         try {
             String hostname = InetAddress.getLocalHost().getCanonicalHostName().toLowerCase(Locale.US);
@@ -174,6 +177,11 @@ public class SpnegoFilter
                 catch (GSSException | RuntimeException e) {
                     throw new RuntimeException("Authentication error for token: " + parts[1], e);
                 }
+            }
+            else if (header.startsWith(BASIC_AUTHENTICATION_PREFIX)
+                            && securityConfig.getAuthenticationType() == SecurityConfig.AuthenticationType.MIXED) { // Pass to ldap
+                    nextFilter.doFilter(servletRequest, servletResponse);
+                    return;
             }
         }
 


### PR DESCRIPTION
This allows both LDAP and Kerberos based requests to be authenticated by the Presto coordinator, by allowing http-server.authentication.type to be set to a new value MIXED.