### PR TITLE
Add config to support rollbacking client auth to simple

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfigurationUpdater.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfigurationUpdater.java
@@ -75,6 +75,7 @@ public class HdfsConfigurationUpdater
     private final File s3StagingDirectory;
     private final boolean pinS3ClientToCurrentRegion;
     private final String s3UserAgentPrefix;
+    private final boolean clientFallbackSimpleAuthAllowed;
 
     @Inject
     public HdfsConfigurationUpdater(HiveClientConfig hiveClientConfig, HiveS3Config s3Config)
@@ -115,6 +116,7 @@ public class HdfsConfigurationUpdater
         this.s3StagingDirectory = s3Config.getS3StagingDirectory();
         this.pinS3ClientToCurrentRegion = s3Config.isPinS3ClientToCurrentRegion();
         this.s3UserAgentPrefix = s3Config.getS3UserAgentPrefix();
+        this.clientFallbackSimpleAuthAllowed = hiveClientConfig.isClientFallbackSimpleAuthAllowed();
     }
 
     private static Configuration readConfiguration(List<String> resourcePaths)
@@ -158,6 +160,9 @@ public class HdfsConfigurationUpdater
         config.setInt("ipc.ping.interval", toIntExact(ipcPingInterval.toMillis()));
         config.setInt("ipc.client.connect.timeout", toIntExact(dfsConnectTimeout.toMillis()));
         config.setInt("ipc.client.connect.max.retries", dfsConnectMaxRetries);
+
+        // set whether ipc client can fallback to simple auth
+        config.setBoolean("ipc.client.fallback-to-simple-auth-allowed", clientFallbackSimpleAuthAllowed);
 
         // re-map filesystem schemes to match Amazon Elastic MapReduce
         config.set("fs.s3.impl", PrestoS3FileSystem.class.getName());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -74,6 +74,7 @@ public class HiveClientConfig
     private Duration dfsConnectTimeout = new Duration(500, TimeUnit.MILLISECONDS);
     private int dfsConnectMaxRetries = 5;
     private boolean verifyChecksum = true;
+    private boolean fallbackSimpleAuthAllowed = false;
     private String domainSocketPath;
 
     private HiveStorageFormat hiveStorageFormat = HiveStorageFormat.RCBINARY;
@@ -572,6 +573,18 @@ public class HiveClientConfig
     {
         this.verifyChecksum = verifyChecksum;
         return this;
+    }
+
+    @Config("hive.ipc.client.fallback-to-simple-auth-allowed")
+    public HiveClientConfig setClientFallbackSimpleAuthAllowed(boolean fallbackAllowed)
+    {
+        this.fallbackSimpleAuthAllowed = fallbackAllowed;
+        return this;
+    }
+
+    public boolean isClientFallbackSimpleAuthAllowed()
+    {
+        return this.fallbackSimpleAuthAllowed;
     }
 
     @Deprecated

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -90,7 +90,8 @@ public class TestHiveClientConfig
                 .setSkipDeletionForAlter(false)
                 .setBucketExecutionEnabled(true)
                 .setBucketWritingEnabled(true)
-                .setFileSystemMaxCacheSize(1000));
+                .setFileSystemMaxCacheSize(1000)
+                .setClientFallbackSimpleAuthAllowed(false));
     }
 
     @Test
@@ -154,6 +155,7 @@ public class TestHiveClientConfig
                 .put("hive.bucket-execution", "false")
                 .put("hive.bucket-writing", "false")
                 .put("hive.fs.cache.max-size", "1010")
+                .put("hive.ipc.client.fallback-to-simple-auth-allowed", "false")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -213,7 +215,8 @@ public class TestHiveClientConfig
                 .setSkipDeletionForAlter(true)
                 .setBucketExecutionEnabled(false)
                 .setBucketWritingEnabled(false)
-                .setFileSystemMaxCacheSize(1010);
+                .setFileSystemMaxCacheSize(1010)
+                .setClientFallbackSimpleAuthAllowed(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Add a new config to hive connector "hive.ipc.client.fallback-to-simple-auth-allowed" representing the one "ipc.client.fallback-to-simple-auth-allowed" used in HDFS client. When this config is enabled, it allows the Kerberos Presto talk to non-kerberized HDFS.