### PR TITLE
Update docker configs for Hive integration tests

### DIFF
--- a/presto-hive-hadoop2/bin/run_on_docker.sh
+++ b/presto-hive-hadoop2/bin/run_on_docker.sh
@@ -112,11 +112,11 @@ set +e
   -Dhive.hadoop2.timeZone=UTC \
   -DHADOOP_USER_NAME=hive \
   -Dhive.hadoop2.metastoreHost=hadoop-master \
-  -Dhive.metastore.thrift.client.socks-proxy=$PROXY:1080 \
+  -Dhive.metastore.thrift.client.socks-proxy=$PROXY:1180 \
   -Dsun.net.spi.nameservice.provider.1=default \
   -Dsun.net.spi.nameservice.provider.2=dns,dnsjava \
   -Ddns.server=$PROXY \
-  -Ddns.port=5353 \
+  -Ddns.port=55353 \
   -Ddns.search=. &
 PRODUCT_TESTS_PROCESS_ID=$!
 

--- a/presto-hive-hadoop2/conf/docker-compose.yml
+++ b/presto-hive-hadoop2/conf/docker-compose.yml
@@ -2,9 +2,9 @@ version: '2'
 services:
   hadoop-master:
     hostname: hadoop-master
-    image: 'teradatalabs/cdh5-hive:2.6.0-cdh5.6.0-sshd-4e54a19'
+    image: 'teradatalabs/cdh5-hive:14'
     ports:
-      - '1080:1080'
+      - '1180:1180'
       - '8020:8020'
       - '8088:8088'
       - '9083:9083'
@@ -20,4 +20,4 @@ services:
     cap_add:
       - NET_ADMIN
     ports:
-      - '5353:53/udp'
+      - '55353:53/udp'


### PR DESCRIPTION
- Update the DNS port number to something in the IANA dynamic port range.
  The current 5353 conflicts with a system service on Ubuntu.
- Update the version of the CDH docker image used along with the
  Metastore Thrift proxy port.