### PR TITLE
Delete file on rollback in HiveRecordWriter

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriter.java
@@ -79,6 +79,7 @@ public class HiveWriter
     {
         return toStringHelper(this)
                 .add("fileWriter", fileWriter)
+                .add("filePath", writePath + "/" + fileName)
                 .toString();
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RcFileFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RcFileFileWriter.java
@@ -34,6 +34,7 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
@@ -46,12 +47,14 @@ public class RcFileFileWriter
         implements HiveFileWriter
 {
     private final RcFileWriter rcFileWriter;
+    private final Callable<Void> outputFileDeleteRoutine;
     private final int[] fileInputColumnIndexes;
     private final List<Block> nullBlocks;
     private final Optional<Supplier<RcFileDataSource>> validationInputFactory;
 
     public RcFileFileWriter(
             OutputStream outputStream,
+            Callable<Void> outputFileDeleteRoutine,
             RcFileEncoding rcFileEncoding,
             List<Type> fileColumnTypes,
             Optional<String> codecName,
@@ -68,6 +71,7 @@ public class RcFileFileWriter
                 new AircompressorCodecFactory(new HadoopCodecFactory(getClass().getClassLoader())),
                 metadata,
                 validationInputFactory.isPresent());
+        this.outputFileDeleteRoutine = outputFileDeleteRoutine;
 
         this.fileInputColumnIndexes = requireNonNull(fileInputColumnIndexes, "outputColumnInputIndexes is null");
 
@@ -116,7 +120,12 @@ public class RcFileFileWriter
             rcFileWriter.close();
         }
         catch (IOException e) {
-            // todo delete file
+            try {
+                outputFileDeleteRoutine.call();
+            }
+            catch (Exception e2) {
+                // ignore
+            }
             throw new PrestoException(HIVE_WRITER_CLOSE_ERROR, "Error committing write to Hive", e);
         }
 
@@ -136,10 +145,14 @@ public class RcFileFileWriter
     public void rollback()
     {
         try {
-            rcFileWriter.close();
-            // todo delete file
+            try {
+                rcFileWriter.close();
+            }
+            finally {
+                outputFileDeleteRoutine.call();
+            }
         }
-        catch (IOException e) {
+        catch (Exception e) {
             throw new PrestoException(HIVE_WRITER_CLOSE_ERROR, "Error rolling back write to Hive", e);
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RcFileFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RcFileFileWriterFactory.java
@@ -40,6 +40,7 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.hive.HiveType.toHiveTypes;
@@ -139,8 +140,14 @@ public class RcFileFileWriterFactory
                 });
             }
 
+            Callable<Void> outputFileDeleteRoutine = () -> {
+                fileSystem.delete(path, false);
+                return null;
+            };
+
             return Optional.of(new RcFileFileWriter(
                     outputStream,
+                    outputFileDeleteRoutine,
                     rcFileEncoding,
                     fileColumnTypes,
                     codecName,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RcFileFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RcFileFileWriterFactory.java
@@ -140,14 +140,14 @@ public class RcFileFileWriterFactory
                 });
             }
 
-            Callable<Void> outputFileDeleteRoutine = () -> {
+            Callable<Void> rollbackAction = () -> {
                 fileSystem.delete(path, false);
                 return null;
             };
 
             return Optional.of(new RcFileFileWriter(
                     outputStream,
-                    outputFileDeleteRoutine,
+                    rollbackAction,
                     rcFileEncoding,
                     fileColumnTypes,
                     codecName,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RecordFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RecordFileWriter.java
@@ -57,6 +57,7 @@ public class RecordFileWriter
         implements HiveFileWriter
 {
     private final Path path;
+    private final JobConf conf;
     private final int fieldCount;
     @SuppressWarnings("deprecation")
     private final Serializer serializer;
@@ -77,6 +78,7 @@ public class RecordFileWriter
             TypeManager typeManager)
     {
         this.path = requireNonNull(path, "path is null");
+        this.conf = requireNonNull(conf, "conf is null");
 
         // existing tables may have columns in a different order
         List<String> fileColumnNames = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(schema.getProperty(META_TABLE_COLUMNS, ""));
@@ -160,7 +162,13 @@ public class RecordFileWriter
     public void rollback()
     {
         try {
-            recordWriter.close(true);
+            try {
+                recordWriter.close(true);
+            }
+            finally {
+                // perform explicit delete of written file here as recordWriter.close() ignores the abort flag.
+                path.getFileSystem(conf).delete(path, false);
+            }
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_WRITER_CLOSE_ERROR, "Error rolling back write to Hive", e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RecordFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RecordFileWriter.java
@@ -166,7 +166,7 @@ public class RecordFileWriter
                 recordWriter.close(true);
             }
             finally {
-                // perform explicit delete of written file here as recordWriter.close() ignores the abort flag.
+                // perform explicit deletion here as implementations of RecordWriter.close() often ignore the abort flag.
                 path.getFileSystem(conf).delete(path, false);
             }
         }


### PR DESCRIPTION
Currently if table write operation was interrupted by user
the files which were already partly written to table directory were not
deleted.
In RecordFileWriter.rollback() the RecordWriter.close() was called with
abort parameter set to true. But implementations of RecordWriters ignore
that parameter.
That resulted with garbage files for CTAS/INSERT flows which did not use
temporary directory (when S3 FS was in use).

By explicitly deleting file in RecordFileWriter.rollback() we make this
proble less probable to surface.