### PR TITLE
Allow inserts into tables above partition limit

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -33,7 +33,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.airlift.slice.Slice;
 import org.apache.hadoop.hive.common.FileUtils;
-import org.apache.hadoop.hive.metastore.ProtectMode;
 import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
@@ -49,14 +48,14 @@ import static com.facebook.presto.hive.HiveBucketing.getHiveBucketNumbers;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_EXCEEDED_PARTITION_LIMIT;
 import static com.facebook.presto.hive.HiveUtil.getPartitionKeyColumnHandles;
 import static com.facebook.presto.hive.HiveUtil.parsePartitionValue;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.getProtectMode;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.verifyOnline;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.not;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
-import static org.apache.hadoop.hive.metastore.ProtectMode.getProtectModeFromString;
 
 public class HivePartitionManager
 {
@@ -209,17 +208,7 @@ public class HivePartitionManager
             throw new TableNotFoundException(tableName);
         }
         Table table = target.get();
-
-        String protectMode = table.getParameters().get(ProtectMode.PARAMETER_NAME);
-        if (protectMode != null && getProtectModeFromString(protectMode).offline) {
-            throw new TableOfflineException(tableName, false, null);
-        }
-
-        String prestoOffline = table.getParameters().get(PRESTO_OFFLINE);
-        if (!isNullOrEmpty(prestoOffline)) {
-            throw new TableOfflineException(tableName, true, prestoOffline);
-        }
-
+        verifyOnline(tableName, Optional.empty(), getProtectMode(table), table.getParameters());
         return table;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -96,15 +96,14 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_DATABASE_LOCATION_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
-import static com.facebook.presto.hive.HiveSplitManager.PRESTO_OFFLINE;
 import static com.facebook.presto.hive.HiveUtil.checkCondition;
 import static com.facebook.presto.hive.HiveUtil.isArrayType;
 import static com.facebook.presto.hive.HiveUtil.isMapType;
 import static com.facebook.presto.hive.HiveUtil.isRowType;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getProtectMode;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.verifyOnline;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.Chars.isCharType;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.padEnd;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
@@ -367,20 +366,7 @@ public final class HiveWriteUtils
         }
 
         // verify online
-        if (protectMode.offline) {
-            if (partitionName.isPresent()) {
-                throw new PartitionOfflineException(tableName, partitionName.get(), false, null);
-            }
-            throw new TableOfflineException(tableName, false, null);
-        }
-
-        String prestoOffline = parameters.get(PRESTO_OFFLINE);
-        if (!isNullOrEmpty(prestoOffline)) {
-            if (partitionName.isPresent()) {
-                throw new PartitionOfflineException(tableName, partitionName.get(), true, prestoOffline);
-            }
-            throw new TableOfflineException(tableName, true, prestoOffline);
-        }
+        verifyOnline(tableName, partitionName, protectMode, parameters);
 
         // verify not read only
         if (protectMode.readOnly) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientLocal.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientLocal.java
@@ -80,4 +80,7 @@ public abstract class AbstractTestHiveClientLocal
 
     @Override
     public void testGetTableNames() {}
+
+    @Override
+    public void testGetTableSchemaOffline() {}
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -102,6 +102,7 @@ public final class HiveQueryRunner
                     .put("hive.metastore.uri", "thrift://localhost:8080")
                     .put("hive.time-zone", TIME_ZONE.getID())
                     .put("hive.security", security)
+                    .put("hive.max-partitions-per-scan", "1000")
                     .build();
             Map<String, String> hiveBucketedProperties = ImmutableMap.<String, String>builder()
                     .putAll(hiveProperties)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -1147,6 +1147,78 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testPartitionPerScanLimit()
+            throws Exception
+    {
+        TestingHiveStorageFormat storageFormat = new TestingHiveStorageFormat(getSession(), HiveStorageFormat.DWRF);
+        testPartitionPerScanLimit(storageFormat.getSession(), storageFormat.getFormat());
+    }
+
+    public void testPartitionPerScanLimit(Session session, HiveStorageFormat storageFormat)
+            throws Exception
+    {
+        String tableName = "test_partition_per_scan_limit";
+
+        @Language("SQL") String createTable = "" +
+                "CREATE TABLE " + tableName + " " +
+                "(" +
+                "  foo VARCHAR," +
+                "  part BIGINT" +
+                ") " +
+                "WITH (" +
+                "format = '" + storageFormat + "', " +
+                "partitioned_by = ARRAY[ 'part' ]" +
+                ") ";
+
+        assertUpdate(session, createTable);
+
+        TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
+        assertEquals(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY), storageFormat);
+        assertEquals(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY), ImmutableList.of("part"));
+
+        // insert 1200 partitions
+        for (int i = 0; i < 12; i++) {
+            int partStart = i * 100;
+            int partEnd = (i + 1) * 100 - 1;
+
+            @Language("SQL") String insertPartitions = "" +
+                    "INSERT INTO " + tableName + " " +
+                    "SELECT 'bar' foo, part " +
+                    "FROM UNNEST(SEQUENCE(" + partStart + ", " + partEnd + ")) AS TMP(part)";
+
+            assertUpdate(session, insertPartitions, 100);
+        }
+
+        // verify can query 1000 partitions
+        assertQuery(
+                session,
+                "SELECT count(foo) FROM " + tableName + " WHERE part < 1000",
+                "SELECT 1000");
+
+        // verify the rest 200 partitions are successfully inserted
+        assertQuery(
+                session,
+                "SELECT count(foo) FROM " + tableName + " WHERE part >= 1000 AND part < 1200",
+                "SELECT 200");
+
+        // verify cannot query more than 1000 partitions
+        assertQueryFails(
+                session,
+                "SELECT * from " + tableName + " WHERE part < 1001",
+                format("Query over table 'tpch.%s' can potentially read more than 1000 partitions", tableName));
+
+        // verify cannot query all partitions
+        assertQueryFails(
+                session,
+                "SELECT * from " + tableName,
+                format("Query over table 'tpch.%s' can potentially read more than 1000 partitions", tableName));
+
+        assertUpdate(session, "DROP TABLE " + tableName);
+
+        assertFalse(getQueryRunner().tableExists(session, tableName));
+    }
+
+    @Test
     public void testInsertUnpartitionedTable()
             throws Exception
     {


### PR DESCRIPTION
Introduced in [#5396](https://github.com/prestodb/presto/pull/5396/files#diff-13aa0bdc2b255255b85a1b0763c2cb6dL1332), `HiveMetadata` needs `BucketHandler` bucket writing and execution in Hive. Current implementation get the `BucketHandler` by first obtaining
`HivePartitionResult`. This is unnecessary and cause issues when the output table has over 100,000 partitions.