### PR TITLE
Fix decimal parsing of Hive data

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursor.java
@@ -42,6 +42,7 @@ import java.util.Properties;
 import static com.facebook.presto.hive.HiveBooleanParser.isFalse;
 import static com.facebook.presto.hive.HiveBooleanParser.isTrue;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.HiveDecimalParser.parseHiveDecimal;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
 import static com.facebook.presto.hive.HiveUtil.base64Decode;
 import static com.facebook.presto.hive.HiveUtil.closeWithSuppression;
@@ -59,7 +60,6 @@ import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
-import static com.facebook.presto.spi.type.Decimals.rescale;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -76,7 +76,6 @@ import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.String.format;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 class ColumnarTextHiveRecordCursor<K>
@@ -504,7 +503,7 @@ class ColumnarTextHiveRecordCursor<K>
         }
         else {
             DecimalType columnType = (DecimalType) types[column];
-            BigDecimal decimal = rescale(new BigDecimal(new String(bytes, start, length, UTF_8)), columnType);
+            BigDecimal decimal = parseHiveDecimal(bytes, start, length, columnType);
 
             if (columnType.isShort()) {
                 longs[column] = decimal.unscaledValue().longValue();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveDecimalParser.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveDecimalParser.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.type.DecimalType;
 import java.math.BigDecimal;
 
 import static com.facebook.presto.spi.type.Decimals.rescale;
+import static java.math.RoundingMode.HALF_UP;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class HiveDecimalParser
@@ -26,6 +27,11 @@ public final class HiveDecimalParser
 
     public static BigDecimal parseHiveDecimal(byte[] bytes, int start, int length, DecimalType columnType)
     {
-        return rescale(new BigDecimal(new String(bytes, start, length, UTF_8)), columnType);
+        BigDecimal parsed = new BigDecimal(new String(bytes, start, length, UTF_8));
+        if (parsed.scale() > columnType.getScale()) {
+            // Hive rounds HALF_UP too
+            parsed = parsed.setScale(columnType.getScale(), HALF_UP);
+        }
+        return rescale(parsed, columnType);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveDecimalParser.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveDecimalParser.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.type.DecimalType;
+
+import java.math.BigDecimal;
+
+import static com.facebook.presto.spi.type.Decimals.rescale;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public final class HiveDecimalParser
+{
+    private HiveDecimalParser() {}
+
+    public static BigDecimal parseHiveDecimal(byte[] bytes, int start, int length, DecimalType columnType)
+    {
+        return rescale(new BigDecimal(new String(bytes, start, length, UTF_8)), columnType);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDecimalParser.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDecimalParser.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.type.DecimalType;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.testng.Assert.assertEquals;
+
+public class TestHiveDecimalParser
+{
+    @Test
+    public void testParseDecimal()
+    {
+        checkParseDecimal("3", 2, 1, new BigDecimal("3.0"));
+        checkParseDecimal("3.1", 2, 1, new BigDecimal("3.1"));
+
+        // rounding
+        checkParseDecimal("3.11", 2, 1, new BigDecimal("3.1"));
+        checkParseDecimal("3.16", 2, 1, new BigDecimal("3.2"));
+
+        // rouding of half (odd and even)
+        checkParseDecimal("3.15", 2, 1, new BigDecimal("3.2"));
+        checkParseDecimal("3.25", 2, 1, new BigDecimal("3.3"));
+
+        // negative
+        checkParseDecimal("-3", 2, 1, new BigDecimal("-3.0"));
+        checkParseDecimal("-3.1", 2, 1, new BigDecimal("-3.1"));
+
+        // negative rounding
+        checkParseDecimal("-3.11", 2, 1, new BigDecimal("-3.1"));
+        checkParseDecimal("-3.16", 2, 1, new BigDecimal("-3.2"));
+
+        // negative rounding of half (odd and even)
+        checkParseDecimal("-3.15", 2, 1, new BigDecimal("-3.2"));
+        checkParseDecimal("-3.25", 2, 1, new BigDecimal("-3.3"));
+    }
+
+    private void checkParseDecimal(String input, int precision, int scale, BigDecimal expected)
+    {
+        byte[] bytes = input.getBytes(US_ASCII);
+        BigDecimal parsed = HiveDecimalParser.parseHiveDecimal(bytes, 0, bytes.length, DecimalType.createDecimalType(precision, scale));
+        assertEquals(parsed, expected);
+    }
+}


### PR DESCRIPTION
Fixes #7250, _assuming_ the expected behavior is "do like Hive does (round)" rather than "throw a more meaningful exception".