### PR TITLE
Fix FileHiveMetastore config

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/file/FileMetastoreModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/file/FileMetastoreModule.java
@@ -20,6 +20,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static java.util.Objects.requireNonNull;
 import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
@@ -37,7 +38,7 @@ public class FileMetastoreModule
     @Override
     public void configure(Binder binder)
     {
-        binder.bind(FileHiveMetastoreConfig.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(FileHiveMetastoreConfig.class);
         binder.bind(ExtendedHiveMetastore.class).annotatedWith(ForCachingHiveMetastore.class).to(FileHiveMetastore.class).in(Scopes.SINGLETON);
         binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ExtendedHiveMetastore.class)


### PR DESCRIPTION
This seems to be required to get the FileHiveMetastore working. The change was originally suggested in the original PR adding the FileHiveMetastore here: https://github.com/prestodb/presto/pull/6525#discussion_r87898105