### PR TITLE
Support CAST from JSON object to ROW type

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -216,6 +216,7 @@ import static com.facebook.presto.operator.scalar.Greatest.GREATEST;
 import static com.facebook.presto.operator.scalar.IdentityCast.IDENTITY_CAST;
 import static com.facebook.presto.operator.scalar.JsonToArrayCast.JSON_TO_ARRAY;
 import static com.facebook.presto.operator.scalar.JsonToMapCast.JSON_TO_MAP;
+import static com.facebook.presto.operator.scalar.JsonToRowCast.JSON_TO_ROW;
 import static com.facebook.presto.operator.scalar.Least.LEAST;
 import static com.facebook.presto.operator.scalar.MapConcatFunction.MAP_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.MapConstructor.MAP_CONSTRUCTOR;
@@ -539,7 +540,7 @@ public class FunctionRegistry
                 .functions(MAX_BY, MIN_BY, MAX_BY_N_AGGREGATION, MIN_BY_N_AGGREGATION)
                 .functions(MAX_AGGREGATION, MIN_AGGREGATION, MAX_N_AGGREGATION, MIN_N_AGGREGATION)
                 .function(COUNT_COLUMN)
-                .functions(ROW_HASH_CODE, ROW_TO_JSON, ROW_DISTINCT_FROM, ROW_EQUAL, ROW_NOT_EQUAL, ROW_TO_ROW_CAST)
+                .functions(ROW_HASH_CODE, ROW_TO_JSON, JSON_TO_ROW, ROW_DISTINCT_FROM, ROW_EQUAL, ROW_NOT_EQUAL, ROW_TO_ROW_CAST)
                 .function(CONCAT)
                 .function(DECIMAL_TO_DECIMAL_CAST)
                 .function(castVarcharToRe2JRegexp(featuresConfig.getRe2JDfaStatesLimit(), featuresConfig.getRe2JDfaRetries()))

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToRowCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToRowCast.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.annotation.UsedByGeneratedCode;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.SqlOperator;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.InterleavedBlockBuilder;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.metadata.Signature.withVariadicBound;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.type.TypeJsonUtils.appendToBlockBuilder;
+import static com.facebook.presto.type.TypeJsonUtils.canCastFromJson;
+import static com.facebook.presto.type.TypeJsonUtils.stackRepresentationToObject;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class JsonToRowCast
+        extends SqlOperator
+{
+    public static final JsonToRowCast JSON_TO_ROW = new JsonToRowCast();
+    private static final MethodHandle METHOD_HANDLE = methodHandle(JsonToRowCast.class, "toRow", Type.class, ConnectorSession.class, Slice.class);
+
+    private JsonToRowCast()
+    {
+        super(OperatorType.CAST,
+                ImmutableList.of(withVariadicBound("T", "row")),
+                ImmutableList.of(),
+                parseTypeSignature("T"),
+                ImmutableList.of(parseTypeSignature(StandardTypes.JSON)));
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        checkArgument(arity == 1, "Expected arity to be 1");
+        Type type = boundVariables.getTypeVariable("T");
+        MethodHandle methodHandle = METHOD_HANDLE.bindTo(type);
+        checkCondition(canCastFromJson(type), INVALID_CAST_ARGUMENT, "Cannot cast JSON to %s", type);
+        return new ScalarFunctionImplementation(false, ImmutableList.of(false), methodHandle, isDeterministic());
+    }
+
+    @UsedByGeneratedCode
+    public static Block toRow(Type rowType, ConnectorSession connectorSession, Slice json)
+    {
+        try {
+            List<?> row = (List<?>) stackRepresentationToObject(connectorSession, json, rowType);
+            if (row == null) {
+                return null;
+            }
+            BlockBuilder blockBuilder = new InterleavedBlockBuilder(rowType.getTypeParameters(), new BlockBuilderStatus(), row.size());
+            for (int field = 0; field < rowType.getTypeParameters().size(); field++) {
+                appendToBlockBuilder(rowType.getTypeParameters().get(field), row.get(field), blockBuilder);
+            }
+            return blockBuilder.build();
+        }
+        catch (RuntimeException e) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to " + rowType, e);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -78,6 +78,35 @@ public class TestRowOperators
     }
 
     @Test
+    public void testJsonToRow()
+    {
+        assertFunction("cast(JSON '{\"name\":\"b\",\"value\":9}' as ROW(name VARCHAR, value BIGINT)).name", VARCHAR, "b");
+        assertFunction("cast(JSON '{\"name\":\"b\",\"value\":9}' as ROW(name VARCHAR, value BIGINT)).value", BIGINT, 9L);
+        assertFunction("cast(JSON '{\"value\":9,\"name\":\"b\"}' as ROW(name VARCHAR, value BIGINT)).name", VARCHAR, "b");
+        assertFunction("cast(JSON '{\"value\":9,\"name\":\"b\"}' as ROW(name VARCHAR, value BIGINT)).value", BIGINT, 9L);
+        assertFunction("cast(JSON '[{\"name\":\"b\",\"value\":9}, {\"name\":\"c\",\"value\":10}]' as ARRAY(ROW(name VARCHAR, value BIGINT)))[2].name", VARCHAR, "c");
+        assertFunction("cast(JSON '[{\"name\":\"b\",\"value\":9}, {\"name\":\"c\",\"value\":10}]' as ARRAY(ROW(name VARCHAR, value BIGINT)))[2].value", BIGINT, 10L);
+
+        assertFunction("cast(JSON '{\"field0\":\"b\",\"field1\":9}' as ROW(VARCHAR, BIGINT)).field0", VARCHAR, "b");
+        assertFunction("cast(JSON '{\"field0\":\"b\",\"field1\":9}' as ROW(VARCHAR, BIGINT)).field1", BIGINT, 9L);
+        assertFunction("cast(JSON '{\"name\":\"b\",\"value\":[9,10]}' as ROW(name VARCHAR, value ARRAY(BIGINT))).value", new ArrayType(BIGINT), Arrays.asList(9L, 10L));
+
+        assertFunction("cast(JSON '{\"namex\":\"b\",\"value\":9}' as ROW(name VARCHAR, value BIGINT)).name", VARCHAR, null);
+        assertFunction("cast(JSON '{\"namex\":\"b\",\"value\":9}' as ROW(name VARCHAR, value BIGINT)).value", BIGINT, 9L);
+        assertFunction("cast(JSON '{\"name\":\"b\",\"value\":9}' as ROW(name VARCHAR, value VARCHAR)).value", VARCHAR, "9");
+        try {
+            assertFunction("cast(JSON '{\"name\":\"b\",\"value\":9}' as ROW(name BIGINT, value VARCHAR)).name", BIGINT, null);
+            fail("String value cannot be casted to numeric");
+        }
+        catch (RuntimeException e) {
+            // Expected
+        }
+        // case insensitive
+        assertFunction("cast(JSON '{\"NaMe\":\"b\",\"value\":9}' as ROW(name VARCHAR, value BIGINT)).name", VARCHAR, "b");
+        assertFunction("cast(JSON '{\"name\":\"b\",\"value\":{\"key\":\"x\",\"value\":\"y\"}}' as ROW(name VARCHAR, value ROW(key VARCHAR, value VARCHAR))).value.value", VARCHAR, "y");
+    }
+
+    @Test
     public void testFieldAccessor()
             throws Exception
     {


### PR DESCRIPTION
We've been facing the following patterns of JSON queries to fetch fields in JSON document.

```
SELECT
    json_extract_scalar(data, '$.k1'), 
    cast(json_extract_scalar(data, '$.k2') as bigint),
    cast(json_extract(data, '$.k3') as array(bigint))[1] 
FROM 
  (VALUES
          ( '{ "k1" : "abc", "k2" : 123, "k3" : [1, 2, 3] }'),
          ( '{ "k1" : "def", "k2" : 456, "k3" : [4, 5, 6] }')
  ) 
AS t(data);
```
For nested list of document
```
SELECT 
    json_extract_scalar(data, '$.k1'), 
    cast(json_extract_scalar(data, '$.k2') as bigint),
    cast(json_extract(data, '$.k3') as array(bigint))[1] 
FROM 
  (VALUES
     ('{"data" : [ { "k1" : "abc", "k2" : 123, "k3" : [1, 2, 3] }, { "k1" : "def", "k2" : 456, "k3" : [4, 5, 6] }]}'),
     ('{"data" : [ { "k1" : "ghi", "k2" : 789, "k3" : [7, 8, 9] }, { "k1" : "jki", "k2" : 987, "k3" : [9, 8, 7] }]}')
  ) 
AS t(json) CROSS JOIN UNNEST(
  cast(JSON_EXTRACT(t.json, '$.data') as array(json))) AS v(data)
``` 

But we could rewrite them as
```
SELECT 
  r.k1, r.k2, r.k3[1] 
FROM (
    SELECT cast(data as ROW(k1 VARCHAR, k2 BIGINT, k3 ARRAY(BIGINT))) as r 
    FROM 
       (VALUES 
           (JSON '{ "k1" : "abc", "k2" : 123, "k3" : [1, 2, 3] }'), 
           (JSON '{ "k1" : "def", "k2" : 456, "k3" : [4, 5, 6] }') 
       ) 
    AS t(data)
);
```

```
SELECT 
  r.k1, r.k2, r.k3[1] 
FROM 
  (VALUES 
      ('{"data" : [ { "k1" : "abc", "k2" : 123, "k3" : [1, 2, 3] }, { "k1" : "def", "k2" : 456, "k3" : [4, 5, 6] }]}'), 
      ('{"data" : [ { "k1" : "ghi", "k2" : 789, "k3" : [7, 8, 9] }, { "k1" : "jki", "k2" : 987, "k3" : [9, 8, 7] }]}') 
  ) AS t(json) CROSS JOIN UNNEST( 
       cast(JSON_EXTRACT(t.json, '$.data') as 
                  ARRAY(ROW(k1 VARCHAR, k2 BIGINT, k3 ARRAY(BIGINT))))) as v(r);
```

When many fields are involved, It could make query a bit shorter also faster.