### PR TITLE
Refactor AbstractTestQueryFramework

### DIFF
--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloDistributedQueries.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloDistributedQueries.java
@@ -56,16 +56,16 @@ public class TestAccumuloDistributedQueries
         // Some test cases from the base class are removed
 
         assertUpdate("CREATE TABLE test_create_table_as_if_not_exists (a bigint, b double)");
-        assertTrue(queryRunner.tableExists(getSession(), "test_create_table_as_if_not_exists"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_create_table_as_if_not_exists"));
         assertTableColumnNames("test_create_table_as_if_not_exists", "a", "b");
 
         MaterializedResult materializedRows = computeActual("CREATE TABLE IF NOT EXISTS test_create_table_as_if_not_exists AS SELECT UUID() AS uuid, orderkey, discount FROM lineitem");
         assertEquals(materializedRows.getRowCount(), 0);
-        assertTrue(queryRunner.tableExists(getSession(), "test_create_table_as_if_not_exists"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_create_table_as_if_not_exists"));
         assertTableColumnNames("test_create_table_as_if_not_exists", "a", "b");
 
         assertUpdate("DROP TABLE test_create_table_as_if_not_exists");
-        assertFalse(queryRunner.tableExists(getSession(), "test_create_table_as_if_not_exists"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_create_table_as_if_not_exists"));
 
         this.assertCreateTableAsSelect(
                 "test_group",

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloDistributedQueries.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloDistributedQueries.java
@@ -40,7 +40,7 @@ public class TestAccumuloDistributedQueries
     public TestAccumuloDistributedQueries()
             throws Exception
     {
-        super(createAccumuloQueryRunner(ImmutableMap.of()));
+        super(() -> createAccumuloQueryRunner(ImmutableMap.of()));
     }
 
     @Override

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloIntegrationSmokeTest.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloIntegrationSmokeTest.java
@@ -25,7 +25,7 @@ public class TestAccumuloIntegrationSmokeTest
     public TestAccumuloIntegrationSmokeTest()
             throws Exception
     {
-        super(AccumuloQueryRunner.createAccumuloQueryRunner(ImmutableMap.of()));
+        super(() -> AccumuloQueryRunner.createAccumuloQueryRunner(ImmutableMap.of()));
     }
 
     @Override

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcDistributedQueries.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcDistributedQueries.java
@@ -24,7 +24,7 @@ public class TestJdbcDistributedQueries
     public TestJdbcDistributedQueries()
             throws Exception
     {
-        super(createJdbcQueryRunner(TpchTable.getTables()));
+        super(() -> createJdbcQueryRunner(TpchTable.getTables()));
     }
 
     @Override

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
@@ -24,6 +24,6 @@ public class TestJdbcIntegrationSmokeTest
     public TestJdbcIntegrationSmokeTest()
             throws Exception
     {
-        super(createJdbcQueryRunner(ORDERS));
+        super(() -> createJdbcQueryRunner(ORDERS));
     }
 }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -17,7 +17,6 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.cassandra.CassandraQueryRunner.createCassandraQueryRunner;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static org.testng.Assert.assertEquals;
@@ -31,7 +30,7 @@ public class TestCassandraDistributed
     public TestCassandraDistributed()
             throws Exception
     {
-        super(createCassandraQueryRunner());
+        super(CassandraQueryRunner::createCassandraQueryRunner);
     }
 
     @Override

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -30,7 +30,6 @@ import java.util.Date;
 import java.util.List;
 
 import static com.datastax.driver.core.utils.Bytes.toRawHexString;
-import static com.facebook.presto.cassandra.CassandraQueryRunner.createCassandraQueryRunner;
 import static com.facebook.presto.cassandra.CassandraQueryRunner.createCassandraSession;
 import static com.facebook.presto.cassandra.CassandraTestingUtils.TABLE_ALL_TYPES;
 import static com.facebook.presto.cassandra.CassandraTestingUtils.TABLE_ALL_TYPES_PARTITION_KEY;
@@ -67,7 +66,7 @@ public class TestCassandraIntegrationSmokeTest
     public TestCassandraIntegrationSmokeTest()
             throws Exception
     {
-        super(createCassandraQueryRunner());
+        super(CassandraQueryRunner::createCassandraQueryRunner);
     }
 
     @BeforeClass

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -276,6 +276,6 @@ public class TestCassandraIntegrationSmokeTest
 
     private MaterializedResult execute(String sql)
     {
-        return queryRunner.execute(SESSION, sql);
+        return getQueryRunner().execute(SESSION, sql);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
@@ -29,7 +29,7 @@ public class TestHiveDistributedQueries
     public TestHiveDistributedQueries()
             throws Exception
     {
-        super(createQueryRunner(getTables()));
+        super(() -> createQueryRunner(getTables()));
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -179,7 +179,7 @@ public class TestHiveIntegrationSmokeTest
 
         assertUpdate(query, 1);
 
-        MaterializedResult results = queryRunner.execute(getSession(), "SELECT * FROM test_types_table").toJdbcTypes();
+        MaterializedResult results = getQueryRunner().execute(getSession(), "SELECT * FROM test_types_table").toJdbcTypes();
         assertEquals(results.getRowCount(), 1);
         MaterializedRow row = results.getMaterializedRows().get(0);
         assertEquals(row.getField(0), "foo");
@@ -195,7 +195,7 @@ public class TestHiveIntegrationSmokeTest
         assertEquals(row.getField(10), "bar       ");
         assertUpdate("DROP TABLE test_types_table");
 
-        assertFalse(queryRunner.tableExists(getSession(), "test_types_table"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_types_table"));
     }
 
     @Test
@@ -301,7 +301,7 @@ public class TestHiveIntegrationSmokeTest
 
         assertUpdate(session, "DROP TABLE test_partitioned_table");
 
-        assertFalse(queryRunner.tableExists(session, "test_partitioned_table"));
+        assertFalse(getQueryRunner().tableExists(session, "test_partitioned_table"));
     }
 
     @Test
@@ -466,7 +466,7 @@ public class TestHiveIntegrationSmokeTest
 
         assertUpdate(session, "DROP TABLE test_format_table");
 
-        assertFalse(queryRunner.tableExists(session, "test_format_table"));
+        assertFalse(getQueryRunner().tableExists(session, "test_format_table"));
     }
 
     @Test
@@ -504,7 +504,7 @@ public class TestHiveIntegrationSmokeTest
 
         assertUpdate(session, "DROP TABLE test_create_partitioned_table_as");
 
-        assertFalse(queryRunner.tableExists(session, "test_create_partitioned_table_as"));
+        assertFalse(getQueryRunner().tableExists(session, "test_create_partitioned_table_as"));
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Partition keys must be the last columns in the table and in the same order as the table properties.*")
@@ -601,7 +601,7 @@ public class TestHiveIntegrationSmokeTest
         }
 
         assertUpdate(session, "DROP TABLE " + tableName);
-        assertFalse(queryRunner.tableExists(session, tableName));
+        assertFalse(getQueryRunner().tableExists(session, tableName));
     }
 
     @Test
@@ -637,7 +637,7 @@ public class TestHiveIntegrationSmokeTest
         verifyPartitionedBucketedTable(storageFormat, tableName);
 
         assertUpdate("DROP TABLE " + tableName);
-        assertFalse(queryRunner.tableExists(getSession(), tableName));
+        assertFalse(getQueryRunner().tableExists(getSession(), tableName));
     }
 
     @Test
@@ -678,7 +678,7 @@ public class TestHiveIntegrationSmokeTest
         verifyPartitionedBucketedTable(storageFormat, tableName);
 
         assertUpdate("DROP TABLE " + tableName);
-        assertFalse(queryRunner.tableExists(getSession(), tableName));
+        assertFalse(getQueryRunner().tableExists(getSession(), tableName));
     }
 
     private void verifyPartitionedBucketedTable(HiveStorageFormat storageFormat, String tableName)
@@ -759,7 +759,7 @@ public class TestHiveIntegrationSmokeTest
             assertEquals(e.getMessage(), "INSERT must write all distribution columns: [custkey, custkey3]");
         }
 
-        assertFalse(queryRunner.tableExists(getSession(), tableName));
+        assertFalse(getQueryRunner().tableExists(getSession(), tableName));
     }
 
     @Test
@@ -809,7 +809,7 @@ public class TestHiveIntegrationSmokeTest
         }
 
         assertUpdate(session, "DROP TABLE test_insert_partitioned_bucketed_table_few_rows");
-        assertFalse(queryRunner.tableExists(session, tableName));
+        assertFalse(getQueryRunner().tableExists(session, tableName));
     }
 
     private void verifyPartitionedBucketedTableAsFewRows(HiveStorageFormat storageFormat, String tableName)
@@ -875,7 +875,7 @@ public class TestHiveIntegrationSmokeTest
         verifyPartitionedBucketedTable(storageFormat, tableName);
 
         assertUpdate("DROP TABLE " + tableName);
-        assertFalse(queryRunner.tableExists(getSession(), tableName));
+        assertFalse(getQueryRunner().tableExists(getSession(), tableName));
     }
 
     @Test
@@ -924,7 +924,7 @@ public class TestHiveIntegrationSmokeTest
         verifyPartitionedBucketedTable(storageFormat, tableName);
 
         assertUpdate("DROP TABLE " + tableName);
-        assertFalse(queryRunner.tableExists(getSession(), tableName));
+        assertFalse(getQueryRunner().tableExists(getSession(), tableName));
     }
 
     @Test
@@ -1012,7 +1012,7 @@ public class TestHiveIntegrationSmokeTest
 
         assertUpdate(session, "DROP TABLE test_insert_format_table");
 
-        assertFalse(queryRunner.tableExists(session, "test_insert_format_table"));
+        assertFalse(getQueryRunner().tableExists(session, "test_insert_format_table"));
     }
 
     @Test
@@ -1082,7 +1082,7 @@ public class TestHiveIntegrationSmokeTest
 
         assertUpdate(session, "DROP TABLE test_insert_partitioned_table");
 
-        assertFalse(queryRunner.tableExists(session, "test_insert_partitioned_table"));
+        assertFalse(getQueryRunner().tableExists(session, "test_insert_partitioned_table"));
     }
 
     @Test
@@ -1140,7 +1140,7 @@ public class TestHiveIntegrationSmokeTest
 
         assertUpdate(session, "DROP TABLE " + tableName);
 
-        assertFalse(queryRunner.tableExists(session, tableName));
+        assertFalse(getQueryRunner().tableExists(session, tableName));
     }
 
     @Test
@@ -1192,7 +1192,7 @@ public class TestHiveIntegrationSmokeTest
 
         assertUpdate(session, "DROP TABLE " + tableName);
 
-        assertFalse(queryRunner.tableExists(session, tableName));
+        assertFalse(getQueryRunner().tableExists(session, tableName));
     }
 
     @Test
@@ -1208,7 +1208,7 @@ public class TestHiveIntegrationSmokeTest
 
         assertUpdate("DROP TABLE test_delete_unpartitioned");
 
-        assertFalse(queryRunner.tableExists(getSession(), "test_delete_unpartitioned"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_delete_unpartitioned"));
     }
 
     @Test
@@ -1245,7 +1245,7 @@ public class TestHiveIntegrationSmokeTest
         assertQuery("SELECT * from test_metadata_delete", "SELECT orderkey, linenumber, linestatus FROM lineitem WHERE linestatus<>'O' and linenumber<>3");
 
         try {
-            queryRunner.execute("DELETE FROM test_metadata_delete WHERE ORDER_KEY=1");
+            getQueryRunner().execute("DELETE FROM test_metadata_delete WHERE ORDER_KEY=1");
             fail("expected exception");
         }
         catch (RuntimeException e) {
@@ -1256,15 +1256,15 @@ public class TestHiveIntegrationSmokeTest
 
         assertUpdate("DROP TABLE test_metadata_delete");
 
-        assertFalse(queryRunner.tableExists(getSession(), "test_metadata_delete"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_metadata_delete"));
     }
 
     private TableMetadata getTableMetadata(String catalog, String schema, String tableName)
     {
         Session session = getSession();
-        Metadata metadata = ((DistributedQueryRunner) queryRunner).getCoordinator().getMetadata();
+        Metadata metadata = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getMetadata();
 
-        return transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
+        return transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
                 .readOnly()
                 .execute(session, transactionSession -> {
                     Optional<TableHandle> tableHandle = metadata.getTableHandle(transactionSession, new QualifiedObjectName(catalog, schema, tableName));
@@ -1276,9 +1276,9 @@ public class TestHiveIntegrationSmokeTest
     private Object getHiveTableProperty(String tableName, Function<HiveTableLayoutHandle, Object> propertyGetter)
     {
         Session session = getSession();
-        Metadata metadata = ((DistributedQueryRunner) queryRunner).getCoordinator().getMetadata();
+        Metadata metadata = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getMetadata();
 
-        return transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
+        return transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
                 .readOnly()
                 .execute(session, transactionSession -> {
                     Optional<TableHandle> tableHandle = metadata.getTableHandle(transactionSession, new QualifiedObjectName(catalog, TPCH_SCHEMA, tableName));
@@ -1569,7 +1569,7 @@ public class TestHiveIntegrationSmokeTest
                 "(2, 2), (5, 2) " +
                 " ) t(col0, col1) ";
         assertUpdate(session, createTable, 8);
-        assertTrue(queryRunner.tableExists(getSession(), "test_path"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_path"));
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, "test_path");
         assertEquals(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY), storageFormat);
@@ -1609,7 +1609,7 @@ public class TestHiveIntegrationSmokeTest
         assertEquals(partitionPathMap.size(), 3);
 
         assertUpdate(session, "DROP TABLE test_path");
-        assertFalse(queryRunner.tableExists(session, "test_path"));
+        assertFalse(getQueryRunner().tableExists(session, "test_path"));
     }
 
     @Test
@@ -1627,7 +1627,7 @@ public class TestHiveIntegrationSmokeTest
                 "(6, 17), (7, 18), (8, 19)" +
                 " ) t (col0, col1) ";
         assertUpdate(createTable, 9);
-        assertTrue(queryRunner.tableExists(getSession(), "test_bucket_hidden_column"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_bucket_hidden_column"));
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, "test_bucket_hidden_column");
         assertEquals(tableMetadata.getMetadata().getProperties().get(BUCKETED_BY_PROPERTY), ImmutableList.of("col0"));
@@ -1663,7 +1663,7 @@ public class TestHiveIntegrationSmokeTest
         assertEquals(results.getRowCount(), 4);
 
         assertUpdate("DROP TABLE test_bucket_hidden_column");
-        assertFalse(queryRunner.tableExists(getSession(), "test_bucket_hidden_column"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_bucket_hidden_column"));
     }
 
     @Test
@@ -1702,7 +1702,7 @@ public class TestHiveIntegrationSmokeTest
                 .getMaterializedRows();
 
         try {
-            transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
+            transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
                     .execute(session, transactionSession -> {
                         assertUpdate(transactionSession, "DELETE FROM tmp_delete_insert WHERE z >= 2");
                         assertUpdate(transactionSession, "INSERT INTO tmp_delete_insert VALUES (203, 2), (204, 2), (205, 2), (301, 2), (302, 3)", 5);
@@ -1720,7 +1720,7 @@ public class TestHiveIntegrationSmokeTest
         MaterializedResult actualAfterRollback = computeActual(session, "SELECT * FROM tmp_delete_insert");
         assertEqualsIgnoreOrder(actualAfterRollback, expectedBefore);
 
-        transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
+        transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
                 .execute(session, transactionSession -> {
                     assertUpdate(transactionSession, "DELETE FROM tmp_delete_insert WHERE z >= 2");
                     assertUpdate(transactionSession, "INSERT INTO tmp_delete_insert VALUES (203, 2), (204, 2), (205, 2), (301, 2), (302, 3)", 5);
@@ -1748,7 +1748,7 @@ public class TestHiveIntegrationSmokeTest
                 .build()
                 .getMaterializedRows();
 
-        transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
+        transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
                 .execute(session, transactionSession -> {
                     assertUpdate(
                             transactionSession,
@@ -1803,7 +1803,7 @@ public class TestHiveIntegrationSmokeTest
 
     private void assertOneNotNullResult(@Language("SQL") String query)
     {
-        MaterializedResult results = queryRunner.execute(getSession(), query).toJdbcTypes();
+        MaterializedResult results = getQueryRunner().execute(getSession(), query).toJdbcTypes();
         assertEquals(results.getRowCount(), 1);
         assertEquals(results.getMaterializedRows().get(0).getFieldCount(), 1);
         assertNotNull(results.getMaterializedRows().get(0).getField(0));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -27,7 +27,6 @@ import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
-import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.facebook.presto.type.TypeRegistry;
@@ -96,19 +95,12 @@ public class TestHiveIntegrationSmokeTest
     private final TypeManager typeManager;
     private final TypeTranslator typeTranslator;
 
-    @SuppressWarnings("unused")
     public TestHiveIntegrationSmokeTest()
-            throws Exception
     {
-        this(createQueryRunner(ORDERS, CUSTOMER), createBucketedSession(), HIVE_CATALOG, new HiveTypeTranslator());
-    }
-
-    protected TestHiveIntegrationSmokeTest(QueryRunner queryRunner, Session bucketedSession, String catalog, TypeTranslator typeTranslator)
-    {
-        super(queryRunner);
-        this.catalog = requireNonNull(catalog, "catalog is null");
-        this.bucketedSession = requireNonNull(bucketedSession, "bucketSession is null");
-        this.typeTranslator = requireNonNull(typeTranslator, "typeTranslator is null");
+        super(() -> createQueryRunner(ORDERS, CUSTOMER));
+        this.catalog = HIVE_CATALOG;
+        this.bucketedSession = createBucketedSession();
+        this.typeTranslator = new HiveTypeTranslator();
 
         this.typeManager = new TypeRegistry();
     }

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxQueries.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxQueries.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.INFORMATION_SCHEMA;
 import static com.facebook.presto.connector.jmx.JmxMetadata.HISTORY_SCHEMA_NAME;
 import static com.facebook.presto.connector.jmx.JmxMetadata.JMX_SCHEMA_NAME;
-import static com.facebook.presto.connector.jmx.JmxQueryRunner.createJmxQueryRunner;
 import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static java.lang.String.format;
@@ -45,7 +44,7 @@ public class TestJmxQueries
     public TestJmxQueries()
             throws Exception
     {
-        super(createJmxQueryRunner());
+        super(JmxQueryRunner::createJmxQueryRunner);
     }
 
     @Test

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaDistributed.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaDistributed.java
@@ -48,6 +48,6 @@ public class TestKafkaDistributed
     public void destroy()
             throws IOException
     {
-        closeAllRuntimeException(queryRunner, embeddedKafka);
+        closeAllRuntimeException(getQueryRunner(), embeddedKafka);
     }
 }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaDistributed.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaDistributed.java
@@ -40,7 +40,7 @@ public class TestKafkaDistributed
     public TestKafkaDistributed(EmbeddedKafka embeddedKafka)
             throws Exception
     {
-        super(createKafkaQueryRunner(embeddedKafka, TpchTable.getTables()));
+        super(() -> createKafkaQueryRunner(embeddedKafka, TpchTable.getTables()));
         this.embeddedKafka = embeddedKafka;
     }
 

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
@@ -48,6 +48,6 @@ public class TestKafkaIntegrationSmokeTest
     public void destroy()
             throws IOException
     {
-        closeAllRuntimeException(queryRunner, embeddedKafka);
+        closeAllRuntimeException(getQueryRunner(), embeddedKafka);
     }
 }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
@@ -40,7 +40,7 @@ public class TestKafkaIntegrationSmokeTest
     public TestKafkaIntegrationSmokeTest(EmbeddedKafka embeddedKafka)
             throws Exception
     {
-        super(createKafkaQueryRunner(embeddedKafka, ORDERS));
+        super(() -> createKafkaQueryRunner(embeddedKafka, ORDERS));
         this.embeddedKafka = embeddedKafka;
     }
 

--- a/presto-ml/src/test/java/com/facebook/presto/ml/TestMLQueries.java
+++ b/presto-ml/src/test/java/com/facebook/presto/ml/TestMLQueries.java
@@ -31,7 +31,7 @@ public class TestMLQueries
 {
     public TestMLQueries()
     {
-        super(createLocalQueryRunner());
+        super(TestMLQueries::createLocalQueryRunner);
     }
 
     @Test

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoDistributedQueries.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoDistributedQueries.java
@@ -16,31 +16,34 @@ package com.facebook.presto.mongodb;
 import com.facebook.presto.tests.AbstractTestQueries;
 import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.mongodb.MongoQueryRunner.createMongoQueryRunner;
+import static java.util.Objects.requireNonNull;
 
 @Test
 public class TestMongoDistributedQueries
         extends AbstractTestQueries
 {
-    private final MongoQueryRunner runner;
+    private MongoQueryRunner mongoQueryRunner;
 
     public TestMongoDistributedQueries()
-            throws Exception
     {
-        this(createMongoQueryRunner(TpchTable.getTables()));
+        super(() -> createMongoQueryRunner(TpchTable.getTables()));
     }
 
-    private TestMongoDistributedQueries(MongoQueryRunner runner)
+    @BeforeClass
+    public void setUp()
+            throws Exception
     {
-        super(runner);
-        this.runner = runner;
+        mongoQueryRunner = (MongoQueryRunner) requireNonNull(queryRunner, "queryRunner is null");
     }
 
     @AfterClass(alwaysRun = true)
     public final void destroy()
     {
-        runner.shutdown();
+        mongoQueryRunner.shutdown();
+        mongoQueryRunner = null;
     }
 }

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoDistributedQueries.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoDistributedQueries.java
@@ -37,7 +37,7 @@ public class TestMongoDistributedQueries
     public void setUp()
             throws Exception
     {
-        mongoQueryRunner = (MongoQueryRunner) requireNonNull(queryRunner, "queryRunner is null");
+        mongoQueryRunner = (MongoQueryRunner) requireNonNull(getQueryRunner(), "queryRunner is null");
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -18,6 +18,7 @@ import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
 import org.joda.time.DateTime;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.sql.Timestamp;
@@ -26,6 +27,7 @@ import java.util.Date;
 import static com.facebook.presto.mongodb.MongoQueryRunner.createMongoQueryRunner;
 import static io.airlift.tpch.TpchTable.ORDERS;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -35,18 +37,25 @@ import static org.testng.Assert.assertNotNull;
 public class TestMongoIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
 {
-    private final MongoQueryRunner runner;
+    private MongoQueryRunner mongoQueryRunner;
 
     public TestMongoIntegrationSmokeTest()
-            throws Exception
     {
-        this(createMongoQueryRunner(ORDERS));
+        super(() -> createMongoQueryRunner(ORDERS));
     }
 
-    public TestMongoIntegrationSmokeTest(MongoQueryRunner runner)
+    @BeforeClass
+    public void setUp()
+            throws Exception
     {
-        super(runner);
-        this.runner = runner;
+        mongoQueryRunner = (MongoQueryRunner) requireNonNull(queryRunner, "queryRunner is null");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+    {
+        mongoQueryRunner.shutdown();
+        mongoQueryRunner = null;
     }
 
     @Test
@@ -150,11 +159,5 @@ public class TestMongoIntegrationSmokeTest
         assertEquals(results.getRowCount(), 1);
         assertEquals(results.getMaterializedRows().get(0).getFieldCount(), 1);
         assertNotNull(results.getMaterializedRows().get(0).getField(0));
-    }
-
-    @AfterClass(alwaysRun = true)
-    public final void destroy()
-    {
-        runner.shutdown();
     }
 }

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -48,7 +48,7 @@ public class TestMongoIntegrationSmokeTest
     public void setUp()
             throws Exception
     {
-        mongoQueryRunner = (MongoQueryRunner) requireNonNull(queryRunner, "queryRunner is null");
+        mongoQueryRunner = (MongoQueryRunner) requireNonNull(getQueryRunner(), "queryRunner is null");
     }
 
     @AfterClass(alwaysRun = true)
@@ -75,7 +75,7 @@ public class TestMongoIntegrationSmokeTest
 
         assertUpdate(query, 1);
 
-        MaterializedResult results = queryRunner.execute(getSession(), "SELECT * FROM test_types_table").toJdbcTypes();
+        MaterializedResult results = getQueryRunner().execute(getSession(), "SELECT * FROM test_types_table").toJdbcTypes();
         assertEquals(results.getRowCount(), 1);
         MaterializedRow row = results.getMaterializedRows().get(0);
         assertEquals(row.getField(0), "foo");
@@ -87,7 +87,7 @@ public class TestMongoIntegrationSmokeTest
         assertEquals(row.getField(6), new Timestamp(new DateTime(1980, 5, 7, 11, 22, 33, 456, UTC).getMillis()));
         assertUpdate("DROP TABLE test_types_table");
 
-        assertFalse(queryRunner.tableExists(getSession(), "test_types_table"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_types_table"));
     }
 
     @Test
@@ -155,7 +155,7 @@ public class TestMongoIntegrationSmokeTest
 
     private void assertOneNotNullResult(String query)
     {
-        MaterializedResult results = queryRunner.execute(getSession(), query).toJdbcTypes();
+        MaterializedResult results = getQueryRunner().execute(getSession(), query).toJdbcTypes();
         assertEquals(results.getRowCount(), 1);
         assertEquals(results.getMaterializedRows().get(0).getFieldCount(), 1);
         assertNotNull(results.getMaterializedRows().get(0).getField(0));

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
@@ -77,10 +77,10 @@ public class TestMySqlDistributedQueries
     public void testDropTable()
     {
         assertUpdate("CREATE TABLE test_drop AS SELECT 123 x", 1);
-        assertTrue(queryRunner.tableExists(getSession(), "test_drop"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_drop"));
 
         assertUpdate("DROP TABLE test_drop");
-        assertFalse(queryRunner.tableExists(getSession(), "test_drop"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_drop"));
     }
 
     @Test
@@ -107,7 +107,7 @@ public class TestMySqlDistributedQueries
                 .addRoundTrip(stringDataType("varchar(16777216)", createUnboundedVarcharType()), "text_g")
                 .addRoundTrip(stringDataType("varchar(" + VarcharType.MAX_LENGTH + ")", createUnboundedVarcharType()), "text_h")
                 .addRoundTrip(stringDataType("varchar", createUnboundedVarcharType()), "unbounded")
-                .execute(queryRunner, prestoCreateAsSelect("presto_test_parameterized_varchar"));
+                .execute(getQueryRunner(), prestoCreateAsSelect("presto_test_parameterized_varchar"));
     }
 
     @Test
@@ -120,7 +120,7 @@ public class TestMySqlDistributedQueries
                 .addRoundTrip(stringDataType("longtext", createUnboundedVarcharType()), "d")
                 .addRoundTrip(varcharDataType(32), "e")
                 .addRoundTrip(varcharDataType(20000), "f")
-                .execute(queryRunner, mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar"));
+                .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar"));
     }
 
     @Test
@@ -135,19 +135,19 @@ public class TestMySqlDistributedQueries
                 .addRoundTrip(varcharDataType(sampleUnicodeText.length(), CHARACTER_SET_UTF8), sampleUnicodeText)
                 .addRoundTrip(varcharDataType(32, CHARACTER_SET_UTF8), sampleUnicodeText)
                 .addRoundTrip(varcharDataType(20000, CHARACTER_SET_UTF8), sampleUnicodeText)
-                .execute(queryRunner, mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar_unicode"));
+                .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar_unicode"));
     }
 
     @Test
     public void testPrestoCreatedParameterizedChar()
     {
-        mysqlCharTypeTest().execute(queryRunner, prestoCreateAsSelect("mysql_test_parameterized_char"));
+        mysqlCharTypeTest().execute(getQueryRunner(), prestoCreateAsSelect("mysql_test_parameterized_char"));
     }
 
     @Test
     public void testMySqlCreatedParameterizedChar()
     {
-        mysqlCharTypeTest().execute(queryRunner, mysqlCreateAndInsert("tpch.mysql_test_parameterized_char"));
+        mysqlCharTypeTest().execute(getQueryRunner(), mysqlCreateAndInsert("tpch.mysql_test_parameterized_char"));
     }
 
     private DataTypeTest mysqlCharTypeTest()
@@ -169,12 +169,12 @@ public class TestMySqlDistributedQueries
                 .addRoundTrip(charDataType(1, CHARACTER_SET_UTF8), "\u653b")
                 .addRoundTrip(charDataType(5, CHARACTER_SET_UTF8), "\u653b\u6bbb")
                 .addRoundTrip(charDataType(5, CHARACTER_SET_UTF8), "\u653b\u6bbb\u6a5f\u52d5\u968a")
-                .execute(queryRunner, mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar"));
+                .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar"));
     }
 
     private DataSetup prestoCreateAsSelect(String tableNamePrefix)
     {
-        return new CreateAsSelectDataSetup(new PrestoSqlExecutor(queryRunner), tableNamePrefix);
+        return new CreateAsSelectDataSetup(new PrestoSqlExecutor(getQueryRunner()), tableNamePrefix);
     }
 
     private DataSetup mysqlCreateAndInsert(String tableNamePrefix)

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
@@ -63,7 +63,7 @@ public class TestMySqlDistributedQueries
     public TestMySqlDistributedQueries(TestingMySqlServer mysqlServer)
             throws Exception
     {
-        super(createMySqlQueryRunner(mysqlServer, TpchTable.getTables()));
+        super(() -> createMySqlQueryRunner(mysqlServer, TpchTable.getTables()));
         this.mysqlServer = mysqlServer;
     }
 

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -63,7 +63,7 @@ public class TestMySqlIntegrationSmokeTest
         MaterializedResult actualColumns = computeActual("DESC ORDERS").toJdbcTypes();
 
         // some connectors don't support dates, and some do not support parametrized varchars, so we check multiple options
-        MaterializedResult expectedColumns = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+        MaterializedResult expectedColumns = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                 .row("orderkey", "bigint", "", "")
                 .row("custkey", "bigint", "", "")
                 .row("orderstatus", "varchar(255)", "", "")
@@ -102,15 +102,15 @@ public class TestMySqlIntegrationSmokeTest
                 .setSchema("test_database")
                 .build();
 
-        assertFalse(queryRunner.tableExists(session, "test_table"));
+        assertFalse(getQueryRunner().tableExists(session, "test_table"));
 
         assertUpdate(session, "CREATE TABLE test_table AS SELECT 123 x", 1);
-        assertTrue(queryRunner.tableExists(session, "test_table"));
+        assertTrue(getQueryRunner().tableExists(session, "test_table"));
 
         assertQuery(session, "SELECT * FROM test_table", "SELECT 123");
 
         assertUpdate(session, "DROP TABLE test_table");
-        assertFalse(queryRunner.tableExists(session, "test_table"));
+        assertFalse(getQueryRunner().tableExists(session, "test_table"));
     }
 
     @Test

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -51,7 +51,7 @@ public class TestMySqlIntegrationSmokeTest
     public TestMySqlIntegrationSmokeTest(TestingMySqlServer mysqlServer)
             throws Exception
     {
-        super(createMySqlQueryRunner(mysqlServer, ORDERS));
+        super(() -> createMySqlQueryRunner(mysqlServer, ORDERS));
         this.mysqlServer = mysqlServer;
     }
 

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -77,10 +77,10 @@ public class TestPostgreSqlDistributedQueries
     public void testDropTable()
     {
         assertUpdate("CREATE TABLE test_drop AS SELECT 123 x", 1);
-        assertTrue(queryRunner.tableExists(getSession(), "test_drop"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_drop"));
 
         assertUpdate("DROP TABLE test_drop");
-        assertFalse(queryRunner.tableExists(getSession(), "test_drop"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_drop"));
     }
 
     @Test
@@ -97,13 +97,13 @@ public class TestPostgreSqlDistributedQueries
     @Test
     public void testPrestoCreatedParameterizedVarchar()
     {
-        varcharDataTypeTest().execute(queryRunner, prestoCreateAsSelect("presto_test_parameterized_varchar"));
+        varcharDataTypeTest().execute(getQueryRunner(), prestoCreateAsSelect("presto_test_parameterized_varchar"));
     }
 
     @Test
     public void testPostgreSqlCreatedParameterizedVarchar()
     {
-        varcharDataTypeTest().execute(queryRunner, postgresCreateAndInsert("tpch.postgresql_test_parameterized_varchar"));
+        varcharDataTypeTest().execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_parameterized_varchar"));
     }
 
     private DataTypeTest varcharDataTypeTest()
@@ -119,25 +119,25 @@ public class TestPostgreSqlDistributedQueries
     @Test
     public void testPrestoCreatedParameterizedVarcharUnicode()
     {
-        unicodeVarcharDateTypeTest().execute(queryRunner, prestoCreateAsSelect("postgresql_test_parameterized_varchar_unicode"));
+        unicodeVarcharDateTypeTest().execute(getQueryRunner(), prestoCreateAsSelect("postgresql_test_parameterized_varchar_unicode"));
     }
 
     @Test
     public void testPostgreSqlCreatedParameterizedVarcharUnicode()
     {
-        unicodeVarcharDateTypeTest().execute(queryRunner, postgresCreateAndInsert("tpch.postgresql_test_parameterized_varchar_unicode"));
+        unicodeVarcharDateTypeTest().execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_parameterized_varchar_unicode"));
     }
 
     @Test
     public void testPrestoCreatedParameterizedCharUnicode()
     {
-        unicodeDataTypeTest(DataType::charDataType).execute(queryRunner, prestoCreateAsSelect("postgresql_test_parameterized_char_unicode"));
+        unicodeDataTypeTest(DataType::charDataType).execute(getQueryRunner(), prestoCreateAsSelect("postgresql_test_parameterized_char_unicode"));
     }
 
     @Test
     public void testPostgreSqlCreatedParameterizedCharUnicode()
     {
-        unicodeDataTypeTest(DataType::charDataType).execute(queryRunner, postgresCreateAndInsert("tpch.postgresql_test_parameterized_char_unicode"));
+        unicodeDataTypeTest(DataType::charDataType).execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_parameterized_char_unicode"));
     }
 
     private DataTypeTest unicodeVarcharDateTypeTest()
@@ -159,7 +159,7 @@ public class TestPostgreSqlDistributedQueries
 
     private DataSetup prestoCreateAsSelect(String tableNamePrefix)
     {
-        return new CreateAsSelectDataSetup(new PrestoSqlExecutor(queryRunner), tableNamePrefix);
+        return new CreateAsSelectDataSetup(new PrestoSqlExecutor(getQueryRunner()), tableNamePrefix);
     }
 
     private DataSetup postgresCreateAndInsert(String tableNamePrefix)

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -54,7 +54,7 @@ public class TestPostgreSqlDistributedQueries
     public TestPostgreSqlDistributedQueries(TestingPostgreSqlServer postgreSqlServer)
             throws Exception
     {
-        super(createPostgreSqlQueryRunner(postgreSqlServer, TpchTable.getTables()));
+        super(() -> createPostgreSqlQueryRunner(postgreSqlServer, TpchTable.getTables()));
         this.postgreSqlServer = postgreSqlServer;
     }
 

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -43,7 +43,7 @@ public class TestPostgreSqlIntegrationSmokeTest
     public TestPostgreSqlIntegrationSmokeTest(TestingPostgreSqlServer postgreSqlServer)
             throws Exception
     {
-        super(PostgreSqlQueryRunner.createPostgreSqlQueryRunner(postgreSqlServer, ORDERS));
+        super(() -> PostgreSqlQueryRunner.createPostgreSqlQueryRunner(postgreSqlServer, ORDERS));
         this.postgreSqlServer = postgreSqlServer;
     }
 

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -69,7 +69,7 @@ public class TestPostgreSqlIntegrationSmokeTest
             throws Exception
     {
         execute("CREATE MATERIALIZED VIEW tpch.test_mv as SELECT * FROM tpch.orders");
-        assertTrue(queryRunner.tableExists(getSession(), "test_mv"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_mv"));
         assertQuery("SELECT orderkey FROM test_mv", "SELECT orderkey FROM orders");
         execute("DROP MATERIALIZED VIEW tpch.test_mv");
     }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorDistributedQueries.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorDistributedQueries.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.raptor;
 
-import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
 import com.google.common.collect.ImmutableMap;
 
@@ -26,11 +25,11 @@ public class TestRaptorDistributedQueries
     public TestRaptorDistributedQueries()
             throws Exception
     {
-        this(createRaptorQueryRunner(ImmutableMap.of(), true, false));
+        this(() -> createRaptorQueryRunner(ImmutableMap.of(), true, false));
     }
 
-    protected TestRaptorDistributedQueries(QueryRunner queryRunner)
+    protected TestRaptorDistributedQueries(QueryRunnerSupplier supplier)
     {
-        super(queryRunner);
+        super(supplier);
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorDistributedQueriesBucketed.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorDistributedQueriesBucketed.java
@@ -23,6 +23,6 @@ public class TestRaptorDistributedQueriesBucketed
     public TestRaptorDistributedQueriesBucketed()
             throws Exception
     {
-        super(createRaptorQueryRunner(ImmutableMap.of(), true, true));
+        super(() -> createRaptorQueryRunner(ImmutableMap.of(), true, true));
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTest.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTest.java
@@ -15,7 +15,6 @@ package com.facebook.presto.raptor;
 
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
-import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
 import com.facebook.presto.type.ArrayType;
 import com.facebook.presto.util.ImmutableCollectors;
@@ -61,12 +60,12 @@ public class TestRaptorIntegrationSmokeTest
     public TestRaptorIntegrationSmokeTest()
             throws Exception
     {
-        this(createRaptorQueryRunner(ImmutableMap.of(), true, false));
+        this(() -> createRaptorQueryRunner(ImmutableMap.of(), true, false));
     }
 
-    protected TestRaptorIntegrationSmokeTest(QueryRunner queryRunner)
+    protected TestRaptorIntegrationSmokeTest(QueryRunnerSupplier supplier)
     {
-        super(queryRunner);
+        super(supplier);
     }
 
     @Test

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTestBucketed.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTestBucketed.java
@@ -24,7 +24,7 @@ public class TestRaptorIntegrationSmokeTestBucketed
     public TestRaptorIntegrationSmokeTestBucketed()
             throws Exception
     {
-        super(createRaptorQueryRunner(ImmutableMap.of(), true, true));
+        super(() -> createRaptorQueryRunner(ImmutableMap.of(), true, true));
     }
 
     @Test

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTestMySql.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTestMySql.java
@@ -44,7 +44,7 @@ public class TestRaptorIntegrationSmokeTestMySql
     public TestRaptorIntegrationSmokeTestMySql(TestingMySqlServer mysqlServer)
             throws Exception
     {
-        super(createRaptorMySqlQueryRunner(mysqlServer));
+        super(() -> createRaptorMySqlQueryRunner(mysqlServer));
         this.mysqlServer = mysqlServer;
     }
 

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributed.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributed.java
@@ -39,7 +39,7 @@ public class TestRedisDistributed
     public TestRedisDistributed(EmbeddedRedis embeddedRedis)
             throws Exception
     {
-        super(RedisQueryRunner.createRedisQueryRunner(embeddedRedis, "string", TpchTable.getTables()));
+        super(() -> RedisQueryRunner.createRedisQueryRunner(embeddedRedis, "string", TpchTable.getTables()));
         this.embeddedRedis = embeddedRedis;
     }
 

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributed.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributed.java
@@ -47,6 +47,6 @@ public class TestRedisDistributed
     public void destroy()
             throws IOException
     {
-        closeAllRuntimeException(queryRunner, embeddedRedis);
+        closeAllRuntimeException(getQueryRunner(), embeddedRedis);
     }
 }

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributedHash.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributedHash.java
@@ -39,7 +39,7 @@ public class TestRedisDistributedHash
     public TestRedisDistributedHash(EmbeddedRedis embeddedRedis)
             throws Exception
     {
-        super(RedisQueryRunner.createRedisQueryRunner(embeddedRedis, "hash", TpchTable.getTables()));
+        super(() -> RedisQueryRunner.createRedisQueryRunner(embeddedRedis, "hash", TpchTable.getTables()));
         this.embeddedRedis = embeddedRedis;
     }
 

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributedHash.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributedHash.java
@@ -47,6 +47,6 @@ public class TestRedisDistributedHash
     public void destroy()
             throws IOException
     {
-        closeAllRuntimeException(queryRunner, embeddedRedis);
+        closeAllRuntimeException(getQueryRunner(), embeddedRedis);
     }
 }

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationSmokeTest.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationSmokeTest.java
@@ -40,7 +40,7 @@ public class TestRedisIntegrationSmokeTest
     public TestRedisIntegrationSmokeTest(EmbeddedRedis embeddedRedis)
             throws Exception
     {
-        super(createRedisQueryRunner(embeddedRedis, "string", ORDERS));
+        super(() -> createRedisQueryRunner(embeddedRedis, "string", ORDERS));
         this.embeddedRedis = embeddedRedis;
     }
 

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationSmokeTest.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationSmokeTest.java
@@ -48,6 +48,6 @@ public class TestRedisIntegrationSmokeTest
     public void destroy()
             throws IOException
     {
-        closeAllRuntimeException(queryRunner, embeddedRedis);
+        closeAllRuntimeException(getQueryRunner(), embeddedRedis);
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -17,7 +17,6 @@ import com.facebook.presto.Session;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
-import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.TestingSession;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
@@ -57,9 +56,9 @@ import static org.testng.Assert.assertTrue;
 public abstract class AbstractTestDistributedQueries
         extends AbstractTestQueries
 {
-    protected AbstractTestDistributedQueries(QueryRunner queryRunner)
+    protected AbstractTestDistributedQueries(QueryRunnerSupplier supplier)
     {
-        super(queryRunner);
+        super(supplier);
     }
 
     protected boolean supportsViews()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -118,53 +118,53 @@ public abstract class AbstractTestDistributedQueries
     public void testCreateTable()
     {
         assertUpdate("CREATE TABLE test_create (a bigint, b double, c varchar)");
-        assertTrue(queryRunner.tableExists(getSession(), "test_create"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_create"));
         assertTableColumnNames("test_create", "a", "b", "c");
 
         assertUpdate("DROP TABLE test_create");
-        assertFalse(queryRunner.tableExists(getSession(), "test_create"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_create"));
 
         assertUpdate("CREATE TABLE test_create_table_if_not_exists (a bigint, b varchar, c double)");
-        assertTrue(queryRunner.tableExists(getSession(), "test_create_table_if_not_exists"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_create_table_if_not_exists"));
         assertTableColumnNames("test_create_table_if_not_exists", "a", "b", "c");
 
         assertUpdate("CREATE TABLE IF NOT EXISTS test_create_table_if_not_exists (d bigint, e varchar)");
-        assertTrue(queryRunner.tableExists(getSession(), "test_create_table_if_not_exists"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_create_table_if_not_exists"));
         assertTableColumnNames("test_create_table_if_not_exists", "a", "b", "c");
 
         assertUpdate("DROP TABLE test_create_table_if_not_exists");
-        assertFalse(queryRunner.tableExists(getSession(), "test_create_table_if_not_exists"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_create_table_if_not_exists"));
 
         // Test CREATE TABLE LIKE
         assertUpdate("CREATE TABLE test_create_original (a bigint, b double, c varchar)");
-        assertTrue(queryRunner.tableExists(getSession(), "test_create_original"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_create_original"));
         assertTableColumnNames("test_create_original", "a", "b", "c");
 
         assertUpdate("CREATE TABLE test_create_like (LIKE test_create_original, d boolean, e varchar)");
-        assertTrue(queryRunner.tableExists(getSession(), "test_create_like"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_create_like"));
         assertTableColumnNames("test_create_like", "a", "b", "c", "d", "e");
 
         assertUpdate("DROP TABLE test_create_original");
-        assertFalse(queryRunner.tableExists(getSession(), "test_create_original"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_create_original"));
 
         assertUpdate("DROP TABLE test_create_like");
-        assertFalse(queryRunner.tableExists(getSession(), "test_create_like"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_create_like"));
     }
 
     @Test
     public void testCreateTableAsSelect()
     {
         assertUpdate("CREATE TABLE test_create_table_as_if_not_exists (a bigint, b double)");
-        assertTrue(queryRunner.tableExists(getSession(), "test_create_table_as_if_not_exists"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_create_table_as_if_not_exists"));
         assertTableColumnNames("test_create_table_as_if_not_exists", "a", "b");
 
         MaterializedResult materializedRows = computeActual("CREATE TABLE IF NOT EXISTS test_create_table_as_if_not_exists AS SELECT orderkey, discount FROM lineitem");
         assertEquals(materializedRows.getRowCount(), 0);
-        assertTrue(queryRunner.tableExists(getSession(), "test_create_table_as_if_not_exists"));
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_create_table_as_if_not_exists"));
         assertTableColumnNames("test_create_table_as_if_not_exists", "a", "b");
 
         assertUpdate("DROP TABLE test_create_table_as_if_not_exists");
-        assertFalse(queryRunner.tableExists(getSession(), "test_create_table_as_if_not_exists"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_create_table_as_if_not_exists"));
 
         assertCreateTableAsSelect(
                 "test_select",
@@ -304,7 +304,7 @@ public abstract class AbstractTestDistributedQueries
         assertQuery(session, "SELECT * FROM " + table, expectedQuery);
         assertUpdate(session, "DROP TABLE " + table);
 
-        assertFalse(queryRunner.tableExists(session, table));
+        assertFalse(getQueryRunner().tableExists(session, table));
     }
 
     @Test
@@ -323,8 +323,8 @@ public abstract class AbstractTestDistributedQueries
 
         assertUpdate("DROP TABLE test_rename");
 
-        assertFalse(queryRunner.tableExists(getSession(), "test_rename"));
-        assertFalse(queryRunner.tableExists(getSession(), "test_rename_new"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_rename"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_rename_new"));
     }
 
     @Test
@@ -341,7 +341,7 @@ public abstract class AbstractTestDistributedQueries
         assertEquals(getOnlyElement(materializedRows.getMaterializedRows()).getField(0), 123);
 
         assertUpdate("DROP TABLE test_rename_column");
-        assertFalse(queryRunner.tableExists(getSession(), "test_rename_column"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_rename_column"));
     }
 
     @Test
@@ -378,9 +378,9 @@ public abstract class AbstractTestDistributedQueries
         assertUpdate("DROP TABLE test_add_column");
         assertUpdate("DROP TABLE test_add_column_a");
         assertUpdate("DROP TABLE test_add_column_ab");
-        assertFalse(queryRunner.tableExists(getSession(), "test_add_column"));
-        assertFalse(queryRunner.tableExists(getSession(), "test_add_column_a"));
-        assertFalse(queryRunner.tableExists(getSession(), "test_add_column_ab"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_add_column"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_add_column_a"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_add_column_ab"));
     }
 
     @Test
@@ -554,9 +554,9 @@ public abstract class AbstractTestDistributedQueries
     @Test
     public void testDropTableIfExists()
     {
-        assertFalse(queryRunner.tableExists(getSession(), "test_drop_if_exists"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_drop_if_exists"));
         assertUpdate("DROP TABLE IF EXISTS test_drop_if_exists");
-        assertFalse(queryRunner.tableExists(getSession(), "test_drop_if_exists"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_drop_if_exists"));
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIndexedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIndexedQueries.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.tests;
 
 import com.facebook.presto.testing.MaterializedResult;
-import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.tpch.TpchIndexSpec;
 import com.facebook.presto.tests.tpch.TpchIndexSpec.Builder;
 import com.facebook.presto.tpch.TpchMetadata;
@@ -35,9 +34,9 @@ public abstract class AbstractTestIndexedQueries
             .addIndex("orders", TpchMetadata.TINY_SCALE_FACTOR, ImmutableSet.of("orderstatus", "shippriority"))
             .build();
 
-    protected AbstractTestIndexedQueries(QueryRunner queryRunner)
+    protected AbstractTestIndexedQueries(QueryRunnerSupplier supplier)
     {
-        super(queryRunner);
+        super(supplier);
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -102,7 +102,7 @@ public abstract class AbstractTestIntegrationSmokeTest
     {
         MaterializedResult actualSchemas = computeActual("SHOW SCHEMAS").toJdbcTypes();
 
-        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR)
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR)
                 .row("tpch");
 
         assertContains(actualSchemas, resultBuilder.build());
@@ -113,7 +113,7 @@ public abstract class AbstractTestIntegrationSmokeTest
             throws Exception
     {
         MaterializedResult actualTables = computeActual("SHOW TABLES").toJdbcTypes();
-        MaterializedResult expectedTables = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR)
+        MaterializedResult expectedTables = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR)
                 .row("orders")
                 .build();
         assertContains(actualTables, expectedTables);
@@ -145,7 +145,7 @@ public abstract class AbstractTestIntegrationSmokeTest
             orderDateType = "varchar";
         }
         if (parametrizedVarchar) {
-            return MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+            return MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                     .row("orderkey", "bigint", "", "")
                     .row("custkey", "bigint", "", "")
                     .row("orderstatus", "varchar", "", "")
@@ -158,7 +158,7 @@ public abstract class AbstractTestIntegrationSmokeTest
                     .build();
         }
         else {
-            return MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+            return MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                     .row("orderkey", "bigint", "", "")
                     .row("custkey", "bigint", "", "")
                     .row("orderstatus", "varchar(1)", "", "")

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.tests;
 
 import com.facebook.presto.testing.MaterializedResult;
-import com.facebook.presto.testing.QueryRunner;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
@@ -27,9 +26,9 @@ import static org.testng.Assert.assertTrue;
 public abstract class AbstractTestIntegrationSmokeTest
         extends AbstractTestQueryFramework
 {
-    protected AbstractTestIntegrationSmokeTest(QueryRunner queryRunner)
+    protected AbstractTestIntegrationSmokeTest(QueryRunnerSupplier supplier)
     {
-        super(queryRunner);
+        super(supplier);
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -23,7 +23,6 @@ import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.testing.Arguments;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
-import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.type.SqlIntervalDayTime;
 import com.facebook.presto.type.SqlIntervalYearMonth;
 import com.facebook.presto.util.DateTimeZoneIndex;
@@ -141,9 +140,9 @@ public abstract class AbstractTestQueries
                     99.0,
                     false));
 
-    protected AbstractTestQueries(QueryRunner queryRunner)
+    protected AbstractTestQueries(QueryRunnerSupplier supplier)
     {
-        super(queryRunner);
+        super(supplier);
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5364,7 +5364,7 @@ public abstract class AbstractTestQueries
                         .put("connector_string", "bar string")
                         .put("connector_long", "11")
                         .build()),
-                queryRunner.getMetadata().getSessionPropertyManager(),
+                getQueryRunner().getMetadata().getSessionPropertyManager(),
                 getSession().getPreparedStatements());
         MaterializedResult result = computeActual(session, "SHOW SESSION");
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -51,7 +51,7 @@ import static org.testng.Assert.fail;
 public abstract class AbstractTestQueryFramework
 {
     private QueryRunnerSupplier queryRunnerSupplier;
-    protected QueryRunner queryRunner;
+    private QueryRunner queryRunner;
     private H2QueryRunner h2QueryRunner;
     private SqlParser sqlParser;
 
@@ -292,6 +292,11 @@ public abstract class AbstractTestQueryFramework
         if (!requirement) {
             throw new SkipException("requirement not met");
         }
+    }
+
+    protected QueryRunner getQueryRunner()
+    {
+        return requireNonNull(queryRunner, "queryRunner is null");
     }
 
     public interface QueryRunnerSupplier

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -38,6 +38,7 @@ import org.skife.jdbi.v2.PreparedBatchPart;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
+import java.io.Closeable;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.ResultSet;
@@ -78,6 +79,7 @@ import static java.lang.String.format;
 import static java.util.Collections.nCopies;
 
 public class H2QueryRunner
+        implements Closeable
 {
     private final Handle handle;
 
@@ -143,6 +145,7 @@ public class H2QueryRunner
         insertRows(tpchMetadata.getTableMetadata(null, tableHandle), handle, createTpchRecordSet(tpchTable, tableHandle.getScaleFactor()));
     }
 
+    @Override
     public void close()
     {
         handle.close();

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestBeginQuery.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestBeginQuery.java
@@ -59,7 +59,7 @@ public class TestBeginQuery
     protected TestBeginQuery()
             throws Exception
     {
-        super(createQueryRunner());
+        super(TestBeginQuery::createQueryRunner);
     }
 
     private static QueryRunner createQueryRunner()

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestBeginQuery.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestBeginQuery.java
@@ -77,16 +77,16 @@ public class TestBeginQuery
             throws Exception
     {
         metadata = new TestMetadata();
-        queryRunner.installPlugin(new TestPlugin(metadata));
-        queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("test", "test", ImmutableMap.of());
-        queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of());
+        getQueryRunner().installPlugin(new TestPlugin(metadata));
+        getQueryRunner().installPlugin(new TpchPlugin());
+        getQueryRunner().createCatalog("test", "test", ImmutableMap.of());
+        getQueryRunner().createCatalog("tpch", "tpch", ImmutableMap.of());
     }
 
     @AfterClass(alwaysRun = true)
     private void tearDown()
     {
-        queryRunner.close();
+        getQueryRunner().close();
     }
 
     @BeforeMethod

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesIndexed.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesIndexed.java
@@ -27,7 +27,7 @@ public class TestDistributedQueriesIndexed
     public TestDistributedQueriesIndexed()
             throws Exception
     {
-        super(createQueryRunner());
+        super(TestDistributedQueriesIndexed::createQueryRunner);
     }
 
     @AfterClass

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesIndexed.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesIndexed.java
@@ -34,7 +34,7 @@ public class TestDistributedQueriesIndexed
     public void destroy()
             throws Exception
     {
-        Closeables.closeQuietly(queryRunner);
+        Closeables.closeQuietly(getQueryRunner());
     }
 
     private static DistributedQueryRunner createQueryRunner()

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesNoHashGeneration.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesNoHashGeneration.java
@@ -23,6 +23,6 @@ public class TestDistributedQueriesNoHashGeneration
     public TestDistributedQueriesNoHashGeneration()
             throws Exception
     {
-        super(createQueryRunner(ImmutableMap.of(), ImmutableMap.of("optimizer.optimize-hash-generation", "false")));
+        super(() -> createQueryRunner(ImmutableMap.of(), ImmutableMap.of("optimizer.optimize-hash-generation", "false")));
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalBinarySpilledQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalBinarySpilledQueries.java
@@ -30,7 +30,7 @@ public class TestLocalBinarySpilledQueries
 {
     public TestLocalBinarySpilledQueries()
     {
-        super(createLocalQueryRunner());
+        super(TestLocalBinarySpilledQueries::createLocalQueryRunner);
     }
 
     private static LocalQueryRunner createLocalQueryRunner()

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -30,7 +30,7 @@ public class TestLocalQueries
 {
     public TestLocalQueries()
     {
-        super(createLocalQueryRunner());
+        super(TestLocalQueries::createLocalQueryRunner);
     }
 
     public static LocalQueryRunner createLocalQueryRunner()

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueriesIndexed.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueriesIndexed.java
@@ -26,7 +26,7 @@ public class TestLocalQueriesIndexed
 {
     public TestLocalQueriesIndexed()
     {
-        super(createLocalQueryRunner());
+        super(TestLocalQueriesIndexed::createLocalQueryRunner);
     }
 
     private static LocalQueryRunner createLocalQueryRunner()

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueryRunner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueryRunner.java
@@ -20,7 +20,7 @@ public class TestLocalQueryRunner
 {
     public TestLocalQueryRunner()
     {
-        super(TestLocalQueries.createLocalQueryRunner());
+        super(TestLocalQueries::createLocalQueryRunner);
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestProcedureCall.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestProcedureCall.java
@@ -17,16 +17,17 @@ import com.facebook.presto.Session;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.metadata.ProcedureRegistry;
 import com.facebook.presto.server.testing.TestingPrestoServer;
-import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.testing.ProcedureTester;
+import com.facebook.presto.tests.tpch.TpchQueryRunner;
 import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
 
 import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
-import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.testng.Assert.assertEquals;
@@ -38,19 +39,23 @@ public class TestProcedureCall
         extends AbstractTestQueryFramework
 {
     private static final String PROCEDURE_SCHEMA = "procedure_schema";
-    private final ProcedureTester tester;
-    private final Session session;
+    private ProcedureTester tester;
+    private Session session;
 
     public TestProcedureCall()
             throws Exception
     {
-        super(createQueryRunner());
+        super(TpchQueryRunner::createQueryRunner);
+    }
 
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
         TestingPrestoServer coordinator = ((DistributedQueryRunner) queryRunner).getCoordinator();
         tester = coordinator.getProcedureTester();
 
         // register procedures in the bogus testing catalog
-        TypeManager typeManager = coordinator.getMetadata().getTypeManager();
         ProcedureRegistry procedureRegistry = coordinator.getMetadata().getProcedureRegistry();
         TestingProcedures procedures = new TestingProcedures(coordinator.getProcedureTester());
         procedureRegistry.addProcedures(
@@ -61,6 +66,14 @@ public class TestProcedureCall
                 .setCatalog(TESTING_CATALOG)
                 .setSchema(PROCEDURE_SCHEMA)
                 .build();
+    }
+
+    @AfterClass
+    public void tearDown()
+            throws Exception
+    {
+        tester = null;
+        session = null;
     }
 
     @Override

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestProcedureCall.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestProcedureCall.java
@@ -52,7 +52,7 @@ public class TestProcedureCall
     public void setUp()
             throws Exception
     {
-        TestingPrestoServer coordinator = ((DistributedQueryRunner) queryRunner).getCoordinator();
+        TestingPrestoServer coordinator = ((DistributedQueryRunner) getQueryRunner()).getCoordinator();
         tester = coordinator.getProcedureTester();
 
         // register procedures in the bogus testing catalog

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
@@ -45,7 +45,7 @@ public class TestQueryPlanDeterminism
     @BeforeClass
     public void setUp()
     {
-        determinismChecker = new PlanDeterminismChecker((LocalQueryRunner) queryRunner);
+        determinismChecker = new PlanDeterminismChecker((LocalQueryRunner) getQueryRunner());
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
@@ -23,6 +23,8 @@ import com.facebook.presto.testing.TestingAccessControlManager;
 import com.facebook.presto.tpch.TpchConnectorFactory;
 import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
 import java.util.List;
 
@@ -33,12 +35,23 @@ import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 public class TestQueryPlanDeterminism
         extends AbstractTestQueries
 {
-    private final PlanDeterminismChecker determinismChecker;
+    private PlanDeterminismChecker determinismChecker;
 
     protected TestQueryPlanDeterminism()
     {
-        super(createLocalQueryRunner());
+        super(TestQueryPlanDeterminism::createLocalQueryRunner);
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
         determinismChecker = new PlanDeterminismChecker((LocalQueryRunner) queryRunner);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        determinismChecker = null;
     }
 
     public static LocalQueryRunner createLocalQueryRunner()
@@ -144,7 +157,7 @@ public class TestQueryPlanDeterminism
     protected void assertUpdate(Session session, @Language("SQL") String sql)
     {
         determinismChecker.checkPlanIsDeterministic(session, sql);
-   }
+    }
 
     @Override
     protected void assertUpdate(@Language("SQL") String sql, long count)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedQueries.java
@@ -13,11 +13,11 @@
  */
 package com.facebook.presto.tests;
 
+import com.facebook.presto.tests.tpch.TpchQueryRunner;
 import com.google.common.base.Strings;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
 import static org.testng.Assert.assertTrue;
 
 public class TestTpchDistributedQueries
@@ -26,7 +26,7 @@ public class TestTpchDistributedQueries
     public TestTpchDistributedQueries()
             throws Exception
     {
-        super(createQueryRunner());
+        super(TpchQueryRunner::createQueryRunner);
     }
 
     @Test


### PR DESCRIPTION
Add constructor that accepts Supplier<QueryRunner>.
Deprecate the constructor that accepts QueryRunner.

TestNG initializes all the test classes at startup. When a QueryRunner
is passes as a constructor parameter, it is create at the TestNG startup.
If there are many classes that extend AbstractTestQueryFramework in single
suite, that means that at startup as many QueryRunners will be created.