### PR TITLE
Do not extract version numbers from unverified version string

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriver.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriver.java
@@ -13,8 +13,6 @@
  */
 package com.facebook.presto.jdbc;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 
 import java.io.Closeable;
@@ -24,10 +22,12 @@ import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
@@ -49,17 +49,18 @@ public class PrestoDriver
     private final QueryExecutor queryExecutor;
 
     static {
-        String version = PrestoDriver.class.getPackage().getImplementationVersion();
-        if (version == null) {
+        Pattern versionPattern = Pattern.compile("^(\\d+)\\.(\\d+)($|[.-])");
+        String version = firstNonNull(PrestoDriver.class.getPackage().getImplementationVersion(), "");
+        Matcher matcher = versionPattern.matcher(version);
+        if (!matcher.find()) {
             DRIVER_VERSION = "unknown";
             DRIVER_VERSION_MAJOR = 0;
             DRIVER_VERSION_MINOR = 0;
         }
         else {
             DRIVER_VERSION = version;
-            List<String> parts = Splitter.on(CharMatcher.anyOf(".-")).limit(3).splitToList(version);
-            DRIVER_VERSION_MAJOR = parseInt(parts.get(0));
-            DRIVER_VERSION_MINOR = parseInt(parts.get(1));
+            DRIVER_VERSION_MAJOR = parseInt(matcher.group(1));
+            DRIVER_VERSION_MINOR = parseInt(matcher.group(2));
         }
 
         try {


### PR DESCRIPTION
This should fix current problems with products tests failing on travis. For some reason `PrestoDriver.class.getPackage().getImplementationVersion()` (based on `git describe`, https://github.com/airlift/airbase/blob/master/pom.xml#L559) is returning abbreviated commit hash. This can happen when git's tags are not present in the repository we build from.

When this is the case, static initializer for `PrestoDriver` would fail with

```
java.lang.NumberFormatException: For input string: "<abbreviated commit hash>"
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
    at java.lang.Integer.parseInt(Integer.java:580)
    at java.lang.Integer.parseInt(Integer.java:615)
```