### PR TITLE
Use varchar for MySQL/PostgreSQL native JSON fields.

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -487,14 +487,6 @@ public class BaseJdbcClient
             case Types.CHAR:
             case Types.NCHAR:
                 return createCharType(min(columnSize, CharType.MAX_LENGTH));
-            case Types.VARCHAR:
-            case Types.NVARCHAR:
-            case Types.LONGVARCHAR:
-            case Types.LONGNVARCHAR:
-                if (columnSize > VarcharType.MAX_LENGTH) {
-                    return createUnboundedVarcharType();
-                }
-                return createVarcharType(columnSize);
             case Types.BINARY:
             case Types.VARBINARY:
             case Types.LONGVARBINARY:
@@ -505,8 +497,16 @@ public class BaseJdbcClient
                 return TIME;
             case Types.TIMESTAMP:
                 return TIMESTAMP;
+            case Types.VARCHAR:
+            case Types.NVARCHAR:
+            case Types.LONGVARCHAR:
+            case Types.LONGNVARCHAR:
+            default:
+                if (columnSize > VarcharType.MAX_LENGTH) {
+                    return createUnboundedVarcharType();
+                }
+                return createVarcharType(columnSize);
         }
-        return null;
     }
 
     protected String toSqlType(Type type)


### PR DESCRIPTION
Fixes https://github.com/prestodb/presto/issues/5649 
Also mentioned in https://github.com/prestodb/presto/issues/5989 https://github.com/prestodb/presto/issues/6614

We noticed that native JSON fields are not supported for our MySQL/PostgreSQL databases.

The changes introduce a new behavior where the field types are not in the cases, it just assumes the type as `varchar`, which is pretty reasonable, giving back users the chance to parse/deal with the data easily in case of missing native support. But open to suggestions!