### PR TITLE
Use TimeZoneKey to identify client time zone

### DIFF
--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -30,6 +30,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>airline</artifactId>
         </dependency>

--- a/presto-cli/src/main/java/com/facebook/presto/cli/PerfTest.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/PerfTest.java
@@ -286,7 +286,7 @@ public class PerfTest
             if (session.getSchema() != null) {
                 builder.setHeader(PrestoHeaders.PRESTO_SCHEMA, session.getSchema());
             }
-            builder.setHeader(PrestoHeaders.PRESTO_TIME_ZONE, session.getTimeZoneId());
+            builder.setHeader(PrestoHeaders.PRESTO_TIME_ZONE, session.getTimeZone().getId());
             builder.setHeader(USER_AGENT, USER_AGENT_VALUE);
 
             return builder.build();

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.client;
 
+import com.facebook.presto.spi.type.TimeZoneKey;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 
@@ -36,7 +37,7 @@ public class ClientSession
     private final String clientInfo;
     private final String catalog;
     private final String schema;
-    private final String timeZoneId;
+    private final TimeZoneKey timeZone;
     private final Locale locale;
     private final Map<String, String> properties;
     private final Map<String, String> preparedStatements;
@@ -53,7 +54,7 @@ public class ClientSession
                 session.getClientInfo(),
                 catalog,
                 schema,
-                session.getTimeZoneId(),
+                session.getTimeZone().getId(),
                 session.getLocale(),
                 session.getProperties(),
                 session.getPreparedStatements(),
@@ -71,7 +72,7 @@ public class ClientSession
                 session.getClientInfo(),
                 session.getCatalog(),
                 session.getSchema(),
-                session.getTimeZoneId(),
+                session.getTimeZone().getId(),
                 session.getLocale(),
                 properties,
                 session.getPreparedStatements(),
@@ -89,7 +90,7 @@ public class ClientSession
                 session.getClientInfo(),
                 session.getCatalog(),
                 session.getSchema(),
-                session.getTimeZoneId(),
+                session.getTimeZone().getId(),
                 session.getLocale(),
                 session.getProperties(),
                 preparedStatements,
@@ -107,7 +108,7 @@ public class ClientSession
                 session.getClientInfo(),
                 session.getCatalog(),
                 session.getSchema(),
-                session.getTimeZoneId(),
+                session.getTimeZone().getId(),
                 session.getLocale(),
                 session.getProperties(),
                 session.getPreparedStatements(),
@@ -125,7 +126,7 @@ public class ClientSession
                 session.getClientInfo(),
                 session.getCatalog(),
                 session.getSchema(),
-                session.getTimeZoneId(),
+                session.getTimeZone().getId(),
                 session.getLocale(),
                 session.getProperties(),
                 session.getPreparedStatements(),
@@ -173,7 +174,7 @@ public class ClientSession
         this.catalog = catalog;
         this.schema = schema;
         this.locale = locale;
-        this.timeZoneId = requireNonNull(timeZoneId, "timeZoneId is null");
+        this.timeZone = TimeZoneKey.getTimeZoneKey(timeZoneId);
         this.transactionId = transactionId;
         this.debug = debug;
         this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
@@ -220,9 +221,9 @@ public class ClientSession
         return schema;
     }
 
-    public String getTimeZoneId()
+    public TimeZoneKey getTimeZone()
     {
-        return timeZoneId;
+        return timeZone;
     }
 
     public Locale getLocale()
@@ -264,7 +265,7 @@ public class ClientSession
                 .add("clientInfo", clientInfo)
                 .add("catalog", catalog)
                 .add("schema", schema)
-                .add("timeZone", timeZoneId)
+                .add("timeZone", timeZone)
                 .add("locale", locale)
                 .add("properties", properties)
                 .add("transactionId", transactionId)

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.client;
 
+import com.facebook.presto.spi.type.TimeZoneKey;
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -92,7 +93,7 @@ public class StatementClient
     private final AtomicBoolean closed = new AtomicBoolean();
     private final AtomicBoolean gone = new AtomicBoolean();
     private final AtomicBoolean valid = new AtomicBoolean(true);
-    private final String timeZoneId;
+    private final TimeZoneKey timeZone;
     private final long requestTimeoutNanos;
     private final String user;
 
@@ -106,7 +107,7 @@ public class StatementClient
         this.httpClient = httpClient;
         this.responseHandler = createFullJsonResponseHandler(queryResultsCodec);
         this.debug = session.isDebug();
-        this.timeZoneId = session.getTimeZoneId();
+        this.timeZone = session.getTimeZone();
         this.query = query;
         this.requestTimeoutNanos = session.getClientRequestTimeout().roundTo(NANOSECONDS);
         this.user = session.getUser();
@@ -138,7 +139,7 @@ public class StatementClient
         if (session.getSchema() != null) {
             builder.setHeader(PrestoHeaders.PRESTO_SCHEMA, session.getSchema());
         }
-        builder.setHeader(PrestoHeaders.PRESTO_TIME_ZONE, session.getTimeZoneId());
+        builder.setHeader(PrestoHeaders.PRESTO_TIME_ZONE, session.getTimeZone().getId());
         if (session.getLocale() != null) {
             builder.setHeader(PrestoHeaders.PRESTO_LANGUAGE, session.getLocale().toLanguageTag());
         }
@@ -163,9 +164,9 @@ public class StatementClient
         return query;
     }
 
-    public String getTimeZoneId()
+    public TimeZoneKey getTimeZone()
     {
-        return timeZoneId;
+        return timeZone;
     }
 
     public boolean isDebug()

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
@@ -119,7 +119,7 @@ public class PrestoResultSet
         this.client = requireNonNull(client, "client is null");
         requireNonNull(progressCallback, "progressCallback is null");
 
-        this.sessionTimeZone = DateTimeZone.forID(client.getTimeZoneId());
+        this.sessionTimeZone = DateTimeZone.forID(client.getTimeZone().getId());
         this.queryId = client.current().getId();
 
         List<Column> columns = getColumns(client, progressCallback);


### PR DESCRIPTION
Previously, a result of `TimeZone.getDefault().getID()` would be passed
to `DateTimeZone.forID` which would work for some time zones, but not
the others. Especially the fixed offset time zones (e.g. GMT+01:00)
would not work.