### PR TITLE
Bytecode generation for MapTransformValueFunction

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
@@ -13,41 +13,67 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import com.facebook.presto.bytecode.BytecodeBlock;
+import com.facebook.presto.bytecode.BytecodeNode;
+import com.facebook.presto.bytecode.ClassDefinition;
+import com.facebook.presto.bytecode.MethodDefinition;
+import com.facebook.presto.bytecode.Parameter;
+import com.facebook.presto.bytecode.Scope;
+import com.facebook.presto.bytecode.Variable;
+import com.facebook.presto.bytecode.control.ForLoop;
+import com.facebook.presto.bytecode.control.IfStatement;
 import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.ErrorCodeSupplier;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.InterleavedBlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.base.Throwables;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
+import com.facebook.presto.sql.gen.CallSiteBinder;
+import com.facebook.presto.sql.gen.SqlTypeBytecodeExpression;
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Primitives;
 
 import java.lang.invoke.MethodHandle;
+import java.util.List;
 
+import static com.facebook.presto.bytecode.Access.FINAL;
+import static com.facebook.presto.bytecode.Access.PRIVATE;
+import static com.facebook.presto.bytecode.Access.PUBLIC;
+import static com.facebook.presto.bytecode.Access.STATIC;
+import static com.facebook.presto.bytecode.Access.a;
+import static com.facebook.presto.bytecode.CompilerUtils.defineClass;
+import static com.facebook.presto.bytecode.CompilerUtils.makeClassName;
+import static com.facebook.presto.bytecode.Parameter.arg;
+import static com.facebook.presto.bytecode.ParameterizedType.type;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.add;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantInt;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantNull;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantString;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.equal;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.getStatic;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.lessThan;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newInstance;
+import static com.facebook.presto.bytecode.instruction.VariableInstruction.incrementVariable;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
-import static com.facebook.presto.spi.type.TypeUtils.writeNativeValue;
+import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public final class MapTransformValueFunction
         extends SqlScalarFunction
 {
     public static final MapTransformValueFunction MAP_TRANSFORM_VALUE_FUNCTION = new MapTransformValueFunction();
-
-    private static final MethodHandle METHOD_HANDLE = methodHandle(
-            MapTransformValueFunction.class,
-            "transform",
-            Type.class,
-            Type.class,
-            Type.class,
-            Block.class,
-            MethodHandle.class);
 
     private MapTransformValueFunction()
     {
@@ -85,31 +111,115 @@ public final class MapTransformValueFunction
         Type keyType = boundVariables.getTypeVariable("K");
         Type valueType = boundVariables.getTypeVariable("V1");
         Type transformedValueType = boundVariables.getTypeVariable("V2");
+        Type resultMapType = typeManager.getParameterizedType(StandardTypes.MAP, ImmutableList.of(
+                TypeSignatureParameter.of(keyType.getTypeSignature()),
+                TypeSignatureParameter.of(transformedValueType.getTypeSignature())));
         return new ScalarFunctionImplementation(
                 false,
                 ImmutableList.of(false, false),
-                METHOD_HANDLE.bindTo(keyType).bindTo(valueType).bindTo(transformedValueType),
+                generateTransform(keyType, valueType, transformedValueType, resultMapType),
                 isDeterministic());
     }
 
-    public static Block transform(Type keyType, Type valueType, Type transformedValueType, Block block, MethodHandle function)
+    private static MethodHandle generateTransform(Type keyType, Type valueType, Type transformedValueType, Type resultMapType)
     {
-        int positionCount = block.getPositionCount();
-        BlockBuilder resultBuilder = new InterleavedBlockBuilder(ImmutableList.of(keyType, transformedValueType), new BlockBuilderStatus(), positionCount);
-        for (int position = 0; position < positionCount; position += 2) {
-            Object key = readNativeValue(keyType, block, position);
-            Object value = readNativeValue(valueType, block, position + 1);
-            Object transformedValue;
-            try {
-                transformedValue = function.invoke(key, value);
-            }
-            catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
-            }
+        CallSiteBinder binder = new CallSiteBinder();
+        Class<?> keyJavaType = Primitives.wrap(keyType.getJavaType());
+        Class<?> valueJavaType = Primitives.wrap(valueType.getJavaType());
+        Class<?> transformedValueJavaType = Primitives.wrap(transformedValueType.getJavaType());
 
-            keyType.appendTo(block, position, resultBuilder);
-            writeNativeValue(transformedValueType, resultBuilder, transformedValue);
+        ClassDefinition definition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                makeClassName("MapTransformValue"),
+                type(Object.class));
+        definition.declareDefaultConstructor(a(PRIVATE));
+
+        // define transform method
+        Parameter block = arg("block", Block.class);
+        Parameter function = arg("function", MethodHandle.class);
+        MethodDefinition method = definition.declareMethod(
+                a(PUBLIC, STATIC),
+                "transform",
+                type(Block.class),
+                ImmutableList.of(block, function));
+
+        BytecodeBlock body = method.getBody();
+        Scope scope = method.getScope();
+        Variable positionCount = scope.declareVariable(int.class, "positionCount");
+        Variable position = scope.declareVariable(int.class, "position");
+        Variable blockBuilder = scope.declareVariable(BlockBuilder.class, "blockBuilder");
+        Variable keyElement = scope.declareVariable(keyJavaType, "keyElement");
+        Variable valueElement = scope.declareVariable(valueJavaType, "valueElement");
+        Variable transformedValueElement = scope.declareVariable(transformedValueJavaType, "transformedValueElement");
+
+        // invoke block.getPositionCount()
+        body.append(positionCount.set(block.invoke("getPositionCount", int.class)));
+
+        // create the interleaved block builder
+        body.append(blockBuilder.set(newInstance(
+                InterleavedBlockBuilder.class,
+                constantType(binder, resultMapType).invoke("getTypeParameters", List.class),
+                newInstance(BlockBuilderStatus.class),
+                positionCount)));
+
+        // throw null key exception block
+        BytecodeNode throwNullKeyException = new BytecodeBlock()
+                .append(newInstance(
+                        PrestoException.class,
+                        getStatic(INVALID_FUNCTION_ARGUMENT.getDeclaringClass(), "INVALID_FUNCTION_ARGUMENT").cast(ErrorCodeSupplier.class),
+                        constantString("map key cannot be null")))
+                .throwObject();
+
+        SqlTypeBytecodeExpression keySqlType = constantType(binder, keyType);
+        BytecodeNode loadKeyElement;
+        if (!keyType.equals(UNKNOWN)) {
+            loadKeyElement = new BytecodeBlock().append(keyElement.set(keySqlType.getValue(block, position).cast(keyJavaType)));
         }
-        return resultBuilder.build();
+        else {
+            // make sure invokeExact will not take uninitialized keys during compile time
+            // but if we reach this point during runtime, it is an exception
+            loadKeyElement = new BytecodeBlock()
+                    .append(keyElement.set(constantNull(keyJavaType)))
+                    .append(throwNullKeyException);
+        }
+
+        SqlTypeBytecodeExpression valueSqlType = constantType(binder, valueType);
+        BytecodeNode loadValueElement;
+        if (!valueType.equals(UNKNOWN)) {
+            loadValueElement = new IfStatement()
+                    .condition(block.invoke("isNull", boolean.class, add(position, constantInt(1))))
+                    .ifTrue(valueElement.set(constantNull(valueJavaType)))
+                    .ifFalse(valueElement.set(valueSqlType.getValue(block, add(position, constantInt(1))).cast(valueJavaType)));
+        }
+        else {
+            loadValueElement = new BytecodeBlock().append(valueElement.set(constantNull(valueJavaType)));
+        }
+
+        BytecodeNode writeTransformedValueElement;
+        if (!transformedValueType.equals(UNKNOWN)) {
+            writeTransformedValueElement = new IfStatement()
+                    .condition(equal(transformedValueElement, constantNull(transformedValueJavaType)))
+                    .ifTrue(blockBuilder.invoke("appendNull", BlockBuilder.class).pop())
+                    .ifFalse(constantType(binder, transformedValueType).writeValue(blockBuilder, transformedValueElement.cast(transformedValueType.getJavaType())));
+        }
+        else {
+            writeTransformedValueElement = new BytecodeBlock().append(blockBuilder.invoke("appendNull", BlockBuilder.class).pop());
+        }
+
+        body.append(new ForLoop()
+                .initialize(position.set(constantInt(0)))
+                .condition(lessThan(position, positionCount))
+                .update(incrementVariable(position, (byte) 2))
+                .body(new BytecodeBlock()
+                        .append(loadKeyElement)
+                        .append(loadValueElement)
+                        .append(transformedValueElement.set(function.invoke("invokeExact", transformedValueJavaType, keyElement, valueElement)))
+                        .append(keySqlType.invoke("appendTo", void.class, block, position, blockBuilder))
+                        .append(writeTransformedValueElement)));
+
+        body.append(blockBuilder.invoke("build", Block.class).ret());
+
+        Class<?> generatedClass = defineClass(definition, Object.class, binder.getBindings(), MapTransformValueFunction.class.getClassLoader());
+        return methodHandle(generatedClass, "transform", Block.class, MethodHandle.class);
     }
 }


### PR DESCRIPTION
This is related to https://github.com/prestodb/presto/issues/7436

Benchmark results:

Before:
```
Benchmark                                          (name)   (type)  Mode  Cnt   Score   Error  Units
BenchmarkTransformValue.benchmark        transform_values   BIGINT  avgt   20  64.830 ± 2.420  ns/op
BenchmarkTransformValue.benchmark        transform_values   DOUBLE  avgt   20  62.140 ± 2.225  ns/op
BenchmarkTransformValue.benchmark        transform_values  VARCHAR  avgt   20  89.144 ± 3.883  ns/op
BenchmarkTransformValue.benchmark  exact_transform_values   BIGINT  avgt   20  50.635 ± 2.510  ns/op
BenchmarkTransformValue.benchmark  exact_transform_values   DOUBLE  avgt   20  46.683 ± 0.580  ns/op
BenchmarkTransformValue.benchmark  exact_transform_values  VARCHAR  avgt   20  74.325 ± 1.145  ns/op
```



After:
```
Benchmark                                          (name)   (type)  Mode  Cnt   Score   Error  Units
BenchmarkTransformValue.benchmark        transform_values   BIGINT  avgt   20  55.218 ± 1.116  ns/op
BenchmarkTransformValue.benchmark        transform_values   DOUBLE  avgt   20  53.021 ± 2.259  ns/op
BenchmarkTransformValue.benchmark        transform_values  VARCHAR  avgt   20  81.336 ± 2.749  ns/op
BenchmarkTransformValue.benchmark  exact_transform_values   BIGINT  avgt   20  50.420 ± 1.304  ns/op
BenchmarkTransformValue.benchmark  exact_transform_values   DOUBLE  avgt   20  47.965 ± 1.345  ns/op
BenchmarkTransformValue.benchmark  exact_transform_values  VARCHAR  avgt   20  77.922 ± 1.746  ns/op
```