### PR TITLE
Temporarily remove type check in DomainTranslator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
@@ -459,7 +459,9 @@ public final class DomainTranslator
 
             Type leftType = expressionTypes.get(comparison.getLeft());
             Type rightType = expressionTypes.get(comparison.getRight());
-            checkArgument(leftType.equals(rightType), "left and right type do not match in comparison expression (%s)", comparison);
+
+            // TODO: re-enable this check once we fix the type coercions in the optimizers
+            // checkArgument(leftType.equals(rightType), "left and right type do not match in comparison expression (%s)", comparison);
 
             if (left instanceof Expression == right instanceof Expression) {
                 // we expect one side to be expression and other to be value.


### PR DESCRIPTION
Since implicit coercions are switched to explicit coercions in the planner,
we expect all optimizers to maintain that invariant. The introduction of this check
demonstrates that we have optimizers that break this invriant. To revert to the existing
behavior, we should just remove this check until we can fix the optimizers.