### PR TITLE
PrestoS3FileSystem Fix for KMS encrypted Files

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -337,7 +337,6 @@ public class PrestoS3FileSystem
             long decryptedLength = metadata.getContentLength();
 
             try (FSDataInputStream inputStream = this.open(path)) {
-
                 int eofOffset = 25;
                 long startingPos = (decryptedLength > eofOffset) ? decryptedLength - eofOffset : 0;
 


### PR DESCRIPTION
When files are stored on S3 with KMS client-side encryption, the PrestoS3FileSystem does not process the decrypted file size properly.  It instead was relying on the 'x-amz-unencrypted-content-length' S3 meta data property to be set with the proper decryption size (which is not normally set)  OR just used the Content size returned by the S3 HTTP request which was for the encrypted file size.  

When the encrypted files are in the Parquet format, this incorrect size causes the Parquet magic number validation to fail as those are at the end of the file thus not allowing those files to be read.

Relates to issues:
- https://github.com/prestodb/presto/issues/7103
- https://github.com/prestodb/presto/issues/7186