### PR TITLE
Fix and Rewrite complex type casting to JSON

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToJsonCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToJsonCast.java
@@ -24,32 +24,38 @@ import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.facebook.presto.util.JsonUtil.JsonGeneratorWriter;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.json.ObjectMapperProvider;
+import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
+import io.airlift.slice.SliceOutput;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandle;
-import java.util.ArrayList;
-import java.util.List;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.JsonOperators.JSON_FACTORY;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static com.facebook.presto.util.JsonUtil.canCastToJson;
+import static com.facebook.presto.util.JsonUtil.createJsonGenerator;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 
 public class ArrayToJsonCast
         extends SqlOperator
 {
     public static final ArrayToJsonCast ARRAY_TO_JSON = new ArrayToJsonCast();
     private static final Supplier<ObjectMapper> OBJECT_MAPPER = Suppliers.memoize(() -> new ObjectMapperProvider().get().registerModule(new SimpleModule().addSerializer(Slice.class, new SliceSerializer())));
-    private static final MethodHandle METHOD_HANDLE = methodHandle(ArrayToJsonCast.class, "toJson", Type.class, ConnectorSession.class, Block.class);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(ArrayToJsonCast.class, "toJson", JsonGeneratorWriter.class, ConnectorSession.class, Block.class);
 
     private ArrayToJsonCast()
     {
@@ -66,23 +72,29 @@ public class ArrayToJsonCast
         checkArgument(arity == 1, "Expected arity to be 1");
         Type type = boundVariables.getTypeVariable("T");
         Type arrayType = typeManager.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(TypeSignatureParameter.of(type.getTypeSignature())));
+        checkCondition(canCastToJson(arrayType), INVALID_CAST_ARGUMENT, "Cannot cast %s to JSON", arrayType);
 
-        MethodHandle methodHandle = METHOD_HANDLE.bindTo(arrayType);
+        JsonGeneratorWriter writer = JsonGeneratorWriter.createJsonGeneratorWriter(type);
+        MethodHandle methodHandle = METHOD_HANDLE.bindTo(writer);
         return new ScalarFunctionImplementation(false, ImmutableList.of(false), methodHandle, isDeterministic());
     }
 
-    public static Slice toJson(Type arrayType, ConnectorSession session, Block array)
+    public static Slice toJson(JsonGeneratorWriter writer, ConnectorSession session, Block block)
     {
-        Type elementType = arrayType.getTypeParameters().get(0);
-        List<Object> objectValues = new ArrayList<>(array.getPositionCount());
-        for (int i = 0; i < array.getPositionCount(); i++) {
-            objectValues.add(JsonFunctions.getJsonObjectValue(elementType, session, array, i));
-        }
         try {
-            return Slices.utf8Slice(OBJECT_MAPPER.get().writeValueAsString(objectValues));
+            SliceOutput output = new DynamicSliceOutput(40);
+            try (JsonGenerator jsonGenerator = createJsonGenerator(JSON_FACTORY, output)) {
+                jsonGenerator.writeStartArray();
+                for (int i = 0; i < block.getPositionCount(); i++) {
+                    writer.writeJsonValue(jsonGenerator, block, i, session);
+                }
+                jsonGenerator.writeEndArray();
+            }
+            return output.slice();
         }
-        catch (JsonProcessingException e) {
-            throw Throwables.propagate(e);
+        catch (IOException e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonOperators.java
@@ -258,18 +258,18 @@ public final class JsonOperators
     @ScalarOperator(CAST)
     @LiteralParameters("x")
     @SqlType(JSON)
-    public static Slice castFromVarchar(@SqlType("varchar(x)") Slice slice)
+    public static Slice castFromVarchar(@SqlType("varchar(x)") Slice value)
             throws IOException
     {
         try {
-            SliceOutput output = new DynamicSliceOutput(slice.length() + 2);
+            SliceOutput output = new DynamicSliceOutput(value.length() + 2);
             try (JsonGenerator jsonGenerator = createJsonGenerator(JSON_FACTORY, output)) {
-                jsonGenerator.writeString(slice.toStringUtf8());
+                jsonGenerator.writeString(value.toStringUtf8());
             }
             return output.slice();
         }
         catch (IOException e) {
-            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to %s", slice.toStringUtf8(), JSON));
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to %s", value.toStringUtf8(), JSON));
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonOperators.java
@@ -41,11 +41,13 @@ import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.type.StandardTypes.BIGINT;
 import static com.facebook.presto.spi.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.spi.type.StandardTypes.DATE;
 import static com.facebook.presto.spi.type.StandardTypes.DOUBLE;
 import static com.facebook.presto.spi.type.StandardTypes.INTEGER;
 import static com.facebook.presto.spi.type.StandardTypes.JSON;
 import static com.facebook.presto.spi.type.StandardTypes.TIMESTAMP;
 import static com.facebook.presto.spi.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.util.DateTimeUtils.printDate;
 import static com.facebook.presto.util.DateTimeUtils.printTimestampWithoutTimeZone;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static com.facebook.presto.util.JsonUtil.createJsonGenerator;
@@ -353,6 +355,23 @@ public final class JsonOperators
             SliceOutput output = new DynamicSliceOutput(25);
             try (JsonGenerator jsonGenerator = createJsonGenerator(JSON_FACTORY, output)) {
                 jsonGenerator.writeString(printTimestampWithoutTimeZone(session.getTimeZoneKey(), value));
+            }
+            return output.slice();
+        }
+        catch (IOException e) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to %s", value, JSON));
+        }
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(JSON)
+    public static Slice castFromDate(ConnectorSession session, @SqlType(DATE) long value)
+            throws IOException
+    {
+        try {
+            SliceOutput output = new DynamicSliceOutput(12);
+            try (JsonGenerator jsonGenerator = createJsonGenerator(JSON_FACTORY, output)) {
+                jsonGenerator.writeString(printDate((int) value));
             }
             return output.slice();
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToJsonCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToJsonCast.java
@@ -17,44 +17,42 @@ import com.facebook.presto.annotation.UsedByGeneratedCode;
 import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.SqlOperator;
-import com.facebook.presto.server.SliceSerializer;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.MapType;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import io.airlift.json.ObjectMapperProvider;
+import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
+import io.airlift.slice.SliceOutput;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandle;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.JsonOperators.JSON_FACTORY;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static com.facebook.presto.util.JsonUtil.JsonGeneratorWriter;
+import static com.facebook.presto.util.JsonUtil.ObjectKeyProvider;
+import static com.facebook.presto.util.JsonUtil.canCastToJson;
+import static com.facebook.presto.util.JsonUtil.createJsonGenerator;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 
 public class MapToJsonCast
         extends SqlOperator
 {
     public static final MapToJsonCast MAP_TO_JSON = new MapToJsonCast();
-    private static final Supplier<ObjectMapper> OBJECT_MAPPER = Suppliers.memoize(() -> new ObjectMapperProvider().get().registerModule(new SimpleModule().addSerializer(Slice.class, new SliceSerializer()).addSerializer(Map.class, new MapSerializer())));
-    private static final MethodHandle METHOD_HANDLE = methodHandle(MapToJsonCast.class, "toJson", Type.class, Type.class, ConnectorSession.class, Block.class);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(MapToJsonCast.class, "toJson",  ObjectKeyProvider.class, JsonGeneratorWriter.class, ConnectorSession.class, Block.class);
 
     private MapToJsonCast()
     {
@@ -71,45 +69,40 @@ public class MapToJsonCast
         checkArgument(arity == 1, "Expected arity to be 1");
         Type keyType = boundVariables.getTypeVariable("K");
         Type valueType = boundVariables.getTypeVariable("V");
+        Type mapType = new MapType(keyType, valueType);
+        checkCondition(canCastToJson(mapType), INVALID_CAST_ARGUMENT, "Cannot cast %s to JSON", mapType);
 
-        MethodHandle methodHandle = METHOD_HANDLE.bindTo(keyType);
-        methodHandle = methodHandle.bindTo(valueType);
+        ObjectKeyProvider provider = ObjectKeyProvider.createObjectKeyProvider(keyType);
+        JsonGeneratorWriter writer = JsonGeneratorWriter.createJsonGeneratorWriter(valueType);
+        MethodHandle methodHandle = METHOD_HANDLE.bindTo(provider).bindTo(writer);
 
         return new ScalarFunctionImplementation(false, ImmutableList.of(false), methodHandle, isDeterministic());
     }
 
     @UsedByGeneratedCode
-    public static Slice toJson(Type keyType, Type valueType, ConnectorSession session, Block block)
+    public static Slice toJson(ObjectKeyProvider provider, JsonGeneratorWriter writer, ConnectorSession session, Block block)
     {
-        Map<Object, Object> map = new HashMap<>();
-        for (int i = 0; i < block.getPositionCount(); i += 2) {
-            map.put(JsonFunctions.getJsonObjectValue(keyType, session, block, i), JsonFunctions.getJsonObjectValue(valueType, session, block, i + 1));
-        }
         try {
-            return Slices.utf8Slice(OBJECT_MAPPER.get().writeValueAsString(map));
-        }
-        catch (JsonProcessingException e) {
-            throw Throwables.propagate(e);
-        }
-    }
+            Map<String, Integer> orderedKeyToValuePosition = new TreeMap<>();
+            for (int i = 0; i < block.getPositionCount(); i += 2) {
+                String objectKey = provider.getObjectKey(block, i);
+                orderedKeyToValuePosition.put(objectKey, i + 1);
+            }
 
-    // Unfortunately this has to be a raw Map, since Map<?, ?> doesn't seem to work in Jackson
-    private static class MapSerializer
-            extends JsonSerializer<Map>
-    {
-        @Override
-        public void serialize(Map map, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
-                throws IOException
-        {
-            Map<String, Object> orderedMap = new TreeMap<>();
-            for (Map.Entry<?, ?> entry : ((Map<?, ?>) map).entrySet()) {
-                orderedMap.put(entry.getKey().toString(), entry.getValue());
+            SliceOutput output = new DynamicSliceOutput(40);
+            try (JsonGenerator jsonGenerator = createJsonGenerator(JSON_FACTORY, output)) {
+                jsonGenerator.writeStartObject();
+                for (Map.Entry<String, Integer> entry : orderedKeyToValuePosition.entrySet()) {
+                    jsonGenerator.writeFieldName(entry.getKey());
+                    writer.writeJsonValue(jsonGenerator, block, entry.getValue(), session);
+                }
+                jsonGenerator.writeEndObject();
             }
-            jsonGenerator.writeStartObject();
-            for (Map.Entry<String, Object> entry : orderedMap.entrySet()) {
-                jsonGenerator.writeObjectField(entry.getKey(), entry.getValue());
-            }
-            jsonGenerator.writeEndObject();
+            return output.slice();
+        }
+        catch (IOException e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToJsonCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToJsonCast.java
@@ -24,33 +24,41 @@ import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.facebook.presto.util.JsonUtil.JsonGeneratorWriter;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.json.ObjectMapperProvider;
+import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
+import io.airlift.slice.SliceOutput;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.facebook.presto.metadata.Signature.withVariadicBound;
-import static com.facebook.presto.operator.scalar.JsonFunctions.getJsonObjectValue;
+import static com.facebook.presto.operator.scalar.JsonOperators.JSON_FACTORY;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static com.facebook.presto.util.JsonUtil.JsonGeneratorWriter.createJsonGeneratorWriter;
+import static com.facebook.presto.util.JsonUtil.canCastToJson;
+import static com.facebook.presto.util.JsonUtil.createJsonGenerator;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 
 public class RowToJsonCast
         extends SqlOperator
 {
     public static final RowToJsonCast ROW_TO_JSON = new RowToJsonCast();
     private static final Supplier<ObjectMapper> OBJECT_MAPPER = Suppliers.memoize(() -> new ObjectMapperProvider().get().registerModule(new SimpleModule().addSerializer(Slice.class, new SliceSerializer())));
-    private static final MethodHandle METHOD_HANDLE = methodHandle(RowToJsonCast.class, "toJson", Type.class, ConnectorSession.class, Block.class);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(RowToJsonCast.class, "toJson", List.class, ConnectorSession.class, Block.class);
 
     private RowToJsonCast()
     {
@@ -66,22 +74,35 @@ public class RowToJsonCast
     {
         checkArgument(arity == 1, "Expected arity to be 1");
         Type type = boundVariables.getTypeVariable("T");
-        MethodHandle methodHandle = METHOD_HANDLE.bindTo(type);
+        checkCondition(canCastToJson(type), INVALID_CAST_ARGUMENT, "Cannot cast %s to JSON", type);
+
+        List<Type> fieldTypes = type.getTypeParameters();
+        List<JsonGeneratorWriter> fieldWriters = new ArrayList<>(fieldTypes.size());
+        for (int i = 0; i < fieldTypes.size(); i++) {
+            fieldWriters.add(createJsonGeneratorWriter(fieldTypes.get(i)));
+        }
+        MethodHandle methodHandle = METHOD_HANDLE.bindTo(fieldWriters);
+
         return new ScalarFunctionImplementation(false, ImmutableList.of(false), methodHandle, isDeterministic());
     }
 
     @UsedByGeneratedCode
-    public static Slice toJson(Type rowType, ConnectorSession session, Block row)
+    public static Slice toJson(List<JsonGeneratorWriter> fieldWriters, ConnectorSession session, Block block)
     {
-        List<Object> objectValue = new ArrayList<>(row.getPositionCount());
-        for (int i = 0; i < row.getPositionCount(); i++) {
-            objectValue.add(getJsonObjectValue(rowType.getTypeParameters().get(i), session, row, i));
-        }
         try {
-            return Slices.utf8Slice(OBJECT_MAPPER.get().writeValueAsString(objectValue));
+            SliceOutput output = new DynamicSliceOutput(40);
+            try (JsonGenerator jsonGenerator = createJsonGenerator(JSON_FACTORY, output)) {
+                jsonGenerator.writeStartArray();
+                for (int i = 0; i < block.getPositionCount(); i++) {
+                    fieldWriters.get(i).writeJsonValue(jsonGenerator, block, i, session);
+                }
+                jsonGenerator.writeEndArray();
+            }
+            return output.slice();
         }
-        catch (JsonProcessingException e) {
-            throw Throwables.propagate(e);
+        catch (IOException e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
@@ -13,6 +13,17 @@
  */
 package com.facebook.presto.util;
 
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Decimals;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.RowType;
+import com.facebook.presto.type.UnknownType;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -22,6 +33,22 @@ import io.airlift.slice.SliceOutput;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Decimals.decodeUnscaledValue;
+import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.type.JsonType.JSON;
+import static com.facebook.presto.util.JsonUtil.ObjectKeyProvider.createObjectKeyProvider;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.String.format;
 
 public final class JsonUtil
 {
@@ -37,5 +64,423 @@ public final class JsonUtil
             throws IOException
     {
         return factory.createGenerator((OutputStream) output);
+    }
+
+    public static boolean canCastToJson(Type type)
+    {
+        String baseType = type.getTypeSignature().getBase();
+        if (baseType.equals(UnknownType.NAME) ||
+                baseType.equals(StandardTypes.BOOLEAN) ||
+                baseType.equals(StandardTypes.TINYINT) ||
+                baseType.equals(StandardTypes.SMALLINT) ||
+                baseType.equals(StandardTypes.INTEGER) ||
+                baseType.equals(StandardTypes.BIGINT) ||
+                baseType.equals(StandardTypes.REAL) ||
+                baseType.equals(StandardTypes.DOUBLE) ||
+                baseType.equals(StandardTypes.DECIMAL) ||
+                baseType.equals(StandardTypes.VARCHAR) ||
+                baseType.equals(StandardTypes.JSON)) {
+            return true;
+        }
+        if (type instanceof ArrayType) {
+            return canCastToJson(((ArrayType) type).getElementType());
+        }
+        if (type instanceof MapType) {
+            return isValidJsonObjectKeyType(((MapType) type).getKeyType()) && canCastToJson(((MapType) type).getValueType());
+        }
+        if (type instanceof RowType) {
+            return type.getTypeParameters().stream().allMatch(JsonUtil::canCastToJson);
+        }
+        return false;
+    }
+
+    private static boolean isValidJsonObjectKeyType(Type type)
+    {
+        String baseType = type.getTypeSignature().getBase();
+        return baseType.equals(UnknownType.NAME) ||
+                baseType.equals(StandardTypes.BOOLEAN) ||
+                baseType.equals(StandardTypes.TINYINT) ||
+                baseType.equals(StandardTypes.SMALLINT) ||
+                baseType.equals(StandardTypes.INTEGER) ||
+                baseType.equals(StandardTypes.BIGINT) ||
+                baseType.equals(StandardTypes.REAL) ||
+                baseType.equals(StandardTypes.DOUBLE) ||
+                baseType.equals(StandardTypes.DECIMAL) ||
+                baseType.equals(StandardTypes.VARCHAR);
+    }
+
+    // transform the map key into string for use as JSON object key
+    public interface ObjectKeyProvider
+    {
+        String getObjectKey(Block block, int position);
+
+        static ObjectKeyProvider createObjectKeyProvider(Type type)
+        {
+            String baseType = type.getTypeSignature().getBase();
+            switch (baseType) {
+                case UnknownType.NAME:
+                    return (block, position) -> null;
+                case StandardTypes.BOOLEAN:
+                    return (block, position) -> type.getBoolean(block, position) ? "true" : "false";
+                case StandardTypes.TINYINT:
+                case StandardTypes.SMALLINT:
+                case StandardTypes.INTEGER:
+                case StandardTypes.BIGINT:
+                    return (block, position) -> String.valueOf(type.getLong(block, position));
+                case StandardTypes.REAL:
+                    return (block, position) -> String.valueOf(intBitsToFloat((int) type.getLong(block, position)));
+                case StandardTypes.DOUBLE:
+                    return (block, position) -> String.valueOf(type.getDouble(block, position));
+                case StandardTypes.DECIMAL:
+                    DecimalType decimalType = (DecimalType) type;
+                    if (isShortDecimal(decimalType)) {
+                        return (block, position) -> Decimals.toString(decimalType.getLong(block, position), decimalType.getScale());
+                    }
+                    else {
+                        return (block, position) -> Decimals.toString(
+                                decodeUnscaledValue(type.getSlice(block, position)),
+                                decimalType.getScale());
+                    }
+                case StandardTypes.VARCHAR:
+                    return (block, position) -> type.getSlice(block, position).toStringUtf8();
+                default:
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Unsupported type: %s", type));
+            }
+        }
+    }
+
+    // given block and position, write to JsonGenerator
+    public interface JsonGeneratorWriter
+    {
+        // write a Json value into the JsonGenerator, provided by block and position
+        void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException;
+
+        static JsonGeneratorWriter createJsonGeneratorWriter(Type type)
+        {
+            String baseType = type.getTypeSignature().getBase();
+            switch (baseType) {
+                case UnknownType.NAME:
+                    return new UnknownJsonGeneratorWriter();
+                case StandardTypes.BOOLEAN:
+                    return new BooleanJsonGeneratorWriter();
+                case StandardTypes.TINYINT:
+                case StandardTypes.SMALLINT:
+                case StandardTypes.INTEGER:
+                case StandardTypes.BIGINT:
+                    return new LongJsonGeneratorWriter(type);
+                case StandardTypes.REAL:
+                    return new RealJsonGeneratorWriter();
+                case StandardTypes.DOUBLE:
+                    return new DoubleJsonGeneratorWriter();
+                case StandardTypes.DECIMAL:
+                    if (isShortDecimal(type)) {
+                        return new ShortDecimalJsonGeneratorWriter((DecimalType) type);
+                    }
+                    else {
+                        return new LongDeicmalJsonGeneratorWriter((DecimalType) type);
+                    }
+                case StandardTypes.VARCHAR:
+                    return new VarcharJsonGeneratorWriter(type);
+                case StandardTypes.JSON:
+                    return new JsonJsonGeneratorWriter();
+                case StandardTypes.ARRAY:
+                    ArrayType arrayType = (ArrayType) type;
+                    return new ArrayJsonGeneratorWriter(
+                            arrayType,
+                            createJsonGeneratorWriter(arrayType.getElementType()));
+                case StandardTypes.MAP:
+                    MapType mapType = (MapType) type;
+                    return new MapJsonGeneratorWriter(
+                            mapType,
+                            createObjectKeyProvider(mapType.getKeyType()),
+                            createJsonGeneratorWriter(mapType.getValueType()));
+                case StandardTypes.ROW:
+                    List<Type> fieldTypes = type.getTypeParameters();
+                    List<JsonGeneratorWriter> fieldWriters = new ArrayList<>(fieldTypes.size());
+                    for (int i = 0; i < fieldTypes.size(); i++) {
+                        fieldWriters.add(createJsonGeneratorWriter(fieldTypes.get(i)));
+                    }
+                    return new RowJsonGeneratorWriter((RowType) type, fieldWriters);
+                default:
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Unsupported type: %s", type));
+            }
+        }
+    }
+
+    private static class UnknownJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException
+        {
+            jsonGenerator.writeNull();
+        }
+    }
+
+    private static class BooleanJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                boolean value = BOOLEAN.getBoolean(block, position);
+                jsonGenerator.writeBoolean(value);
+            }
+        }
+    }
+
+    private static class LongJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        private final Type type;
+
+        public LongJsonGeneratorWriter(Type type)
+        {
+            this.type = type;
+        }
+
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                long value = type.getLong(block, position);
+                jsonGenerator.writeNumber(value);
+            }
+        }
+    }
+
+    private static class RealJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                float value = intBitsToFloat((int) REAL.getLong(block, position));
+                jsonGenerator.writeNumber(value);
+            }
+        }
+    }
+
+    private static class DoubleJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                double value = DOUBLE.getDouble(block, position);
+                jsonGenerator.writeNumber(value);
+            }
+        }
+    }
+
+    private static class ShortDecimalJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        private final DecimalType type;
+
+        public ShortDecimalJsonGeneratorWriter(DecimalType type)
+        {
+            this.type = type;
+        }
+
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                BigDecimal value = BigDecimal.valueOf(type.getLong(block, position), type.getScale());
+                jsonGenerator.writeNumber(value);
+            }
+        }
+    }
+
+    private static class LongDeicmalJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        private final DecimalType type;
+
+        public LongDeicmalJsonGeneratorWriter(DecimalType type)
+        {
+            this.type = type;
+        }
+
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                BigDecimal value = new BigDecimal(
+                        decodeUnscaledValue(type.getSlice(block, position)),
+                        type.getScale());
+                jsonGenerator.writeNumber(value);
+            }
+        }
+    }
+
+    private static class VarcharJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        private final Type type;
+
+        public VarcharJsonGeneratorWriter(Type type)
+        {
+            this.type = type;
+        }
+
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                Slice value = type.getSlice(block, position);
+                jsonGenerator.writeString(value.toStringUtf8());
+            }
+        }
+    }
+
+    private static class JsonJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                Slice value = JSON.getSlice(block, position);
+                jsonGenerator.writeRawValue(value.toStringUtf8());
+            }
+        }
+    }
+
+    private static class ArrayJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        private final ArrayType type;
+        private final JsonGeneratorWriter elementWriter;
+
+        public ArrayJsonGeneratorWriter(ArrayType type, JsonGeneratorWriter elementWriter)
+        {
+            this.type = type;
+            this.elementWriter = elementWriter;
+        }
+
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                Block arrayBlock = type.getObject(block, position);
+                jsonGenerator.writeStartArray();
+                for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
+                    elementWriter.writeJsonValue(jsonGenerator, arrayBlock, i, session);
+                }
+                jsonGenerator.writeEndArray();
+            }
+        }
+    }
+
+    private static class MapJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        private final MapType type;
+        private final ObjectKeyProvider keyProvider;
+        private final JsonGeneratorWriter valueWriter;
+
+        public MapJsonGeneratorWriter(MapType type, ObjectKeyProvider keyProvider, JsonGeneratorWriter valueWriter)
+        {
+            this.type = type;
+            this.keyProvider = keyProvider;
+            this.valueWriter = valueWriter;
+        }
+
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                Block mapBlock = type.getObject(block, position);
+                Map<String, Integer> orderedKeyToValuePosition = new TreeMap<>();
+                for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
+                    String objectKey = keyProvider.getObjectKey(mapBlock, i);
+                    orderedKeyToValuePosition.put(objectKey, i + 1);
+                }
+
+                jsonGenerator.writeStartObject();
+                for (Map.Entry<String, Integer> entry : orderedKeyToValuePosition.entrySet()) {
+                    jsonGenerator.writeFieldName(entry.getKey());
+                    valueWriter.writeJsonValue(jsonGenerator, mapBlock, entry.getValue(), session);
+                }
+                jsonGenerator.writeEndObject();
+            }
+        }
+    }
+
+    private static class RowJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        private final RowType type;
+        private final List<JsonGeneratorWriter> fieldWriters;
+
+        public RowJsonGeneratorWriter(RowType type, List<JsonGeneratorWriter> fieldWriters)
+        {
+            this.type = type;
+            this.fieldWriters = fieldWriters;
+        }
+
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position, ConnectorSession session)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                Block rowBlock = type.getObject(block, position);
+                jsonGenerator.writeStartArray();
+                for (int i = 0; i < rowBlock.getPositionCount(); i++) {
+                    fieldWriters.get(i).writeJsonValue(jsonGenerator, rowBlock, i, session);
+                }
+                jsonGenerator.writeEndArray();
+            }
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -162,6 +162,10 @@ public class TestArrayOperators
                 "CAST(ARRAY[from_unixtime(1), null] AS JSON)",
                 JSON,
                 format("[\"%s\",null]", sqlTimestamp(1000).toString()));
+        assertFunction(
+                "CAST(ARRAY[DATE '2001-08-22', DATE '2001-08-23', null] AS JSON)",
+                JSON,
+                "[\"2001-08-22\",\"2001-08-23\",null]");
 
         assertFunction(
                 "cast(ARRAY[ARRAY[1, 2], ARRAY[3, null], ARRAY[], ARRAY[null, null], null] AS JSON)",

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -62,6 +62,7 @@ import static com.facebook.presto.util.StructuralTestUtil.arrayBlockOf;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.testng.Assert.assertEquals;
@@ -156,6 +157,11 @@ public class TestArrayOperators
                 "cast(ARRAY[JSON '123', JSON '3.14', JSON 'false', JSON '\"abc\"', JSON '[1, \"a\", null]', JSON '{\"a\": 1, \"b\": \"str\", \"c\": null}', JSON 'null', null] AS JSON)",
                 JSON,
                 "[123,3.14,false,\"abc\",[1,\"a\",null],{\"a\":1,\"b\":\"str\",\"c\":null},null,null]");
+
+        assertFunction(
+                "CAST(ARRAY[from_unixtime(1), null] AS JSON)",
+                JSON,
+                format("[\"%s\",null]", sqlTimestamp(1000).toString()));
 
         assertFunction(
                 "cast(ARRAY[ARRAY[1, 2], ARRAY[3, null], ARRAY[], ARRAY[null, null], null] AS JSON)",

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -135,14 +135,40 @@ public class TestArrayOperators
     public void testArrayToJson()
             throws Exception
     {
-        assertFunction("CAST(ARRAY [1, 2, 3] AS JSON)", JSON, "[1,2,3]");
-        assertFunction("CAST(ARRAY [1, NULL, 3] AS JSON)", JSON, "[1,null,3]");
-        assertFunction("CAST(ARRAY [1, 2.0, 3] AS JSON)", JSON, "[1.0,2.0,3.0]");
-        assertFunction("CAST(ARRAY [1.0, 2.5, 3.0] AS JSON)", JSON, "[1.0,2.5,3.0]");
-        assertFunction("CAST(ARRAY ['puppies', 'kittens'] AS JSON)", JSON, "[\"puppies\",\"kittens\"]");
-        assertFunction("CAST(ARRAY [TRUE, FALSE] AS JSON)", JSON, "[true,false]");
-        assertFunction("CAST(ARRAY [from_unixtime(1)] AS JSON)", JSON, "[\"" + sqlTimestamp(1000) + "\"]");
-        assertFunction("CAST(ARRAY [ARRAY [1], ARRAY [2, 3]] AS JSON)", JSON, "[[1],[2,3]]");
+        assertFunction("cast(cast (null as ARRAY<BIGINT>) AS JSON)", JSON, null);
+        assertFunction("cast(ARRAY[] AS JSON)", JSON, "[]");
+        assertFunction("cast(ARRAY[null, null] AS JSON)", JSON, "[null,null]");
+
+        assertFunction("cast(ARRAY[true, false, null] AS JSON)", JSON, "[true,false,null]");
+
+        assertFunction("cast(cast(ARRAY[1, 2, null] AS ARRAY<TINYINT>) AS JSON)", JSON, "[1,2,null]");
+        assertFunction("cast(cast(ARRAY[12345, -12345, null] AS ARRAY<SMALLINT>) AS JSON)", JSON, "[12345,-12345,null]");
+        assertFunction("cast(cast(ARRAY[123456789, -123456789, null] AS ARRAY<INTEGER>) AS JSON)", JSON, "[123456789,-123456789,null]");
+        assertFunction("cast(cast(ARRAY[1234567890123456789, -1234567890123456789, null] AS ARRAY<BIGINT>) AS JSON)", JSON, "[1234567890123456789,-1234567890123456789,null]");
+
+        assertFunction("CAST(CAST(ARRAY[3.14, nan(), infinity(), -infinity(), null] AS ARRAY<REAL>) AS JSON)", JSON, "[3.14,\"NaN\",\"Infinity\",\"-Infinity\",null]");
+        assertFunction("CAST(ARRAY[3.14, 1e-323, 1e308, nan(), infinity(), -infinity(), null] AS JSON)", JSON, "[3.14,1.0E-323,1.0E308,\"NaN\",\"Infinity\",\"-Infinity\",null]");
+        assertFunction("CAST(ARRAY[DECIMAL '3.14', null] AS JSON)", JSON, "[3.14,null]");
+        assertFunction("CAST(ARRAY[DECIMAL '12345678901234567890.123456789012345678', null] AS JSON)", JSON, "[12345678901234567890.123456789012345678,null]");
+
+        assertFunction("cast(ARRAY['a', 'bb', null] AS JSON)", JSON, "[\"a\",\"bb\",null]");
+        assertFunction(
+                "cast(ARRAY[JSON '123', JSON '3.14', JSON 'false', JSON '\"abc\"', JSON '[1, \"a\", null]', JSON '{\"a\": 1, \"b\": \"str\", \"c\": null}', JSON 'null', null] AS JSON)",
+                JSON,
+                "[123,3.14,false,\"abc\",[1,\"a\",null],{\"a\":1,\"b\":\"str\",\"c\":null},null,null]");
+
+        assertFunction(
+                "cast(ARRAY[ARRAY[1, 2], ARRAY[3, null], ARRAY[], ARRAY[null, null], null] AS JSON)",
+                JSON,
+                "[[1,2],[3,null],[],[null,null],null]");
+        assertFunction(
+                "cast(ARRAY[MAP(ARRAY['b', 'a'], ARRAY[2, 1]), MAP(ARRAY['three', 'none'], ARRAY[3, null]), MAP(), MAP(ARRAY['h2', 'h1'], ARRAY[null, null]), null] AS JSON)",
+                JSON,
+                "[{\"a\":1,\"b\":2},{\"none\":null,\"three\":3},{},{\"h1\":null,\"h2\":null},null]");
+        assertFunction(
+                "cast(ARRAY[ROW(1, 2), ROW(3, CAST(null as INTEGER)), CAST(ROW(null, null) AS ROW(INTEGER, INTEGER)), null] AS JSON)",
+                JSON,
+                "[[1,2],[3,null],[null,null],null]");
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestJsonOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestJsonOperators.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.type;
 
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.type.SqlTimestamp;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -196,5 +198,17 @@ public class TestJsonOperators
         assertFunction("cast(cast (null as varchar) as JSON)", JSON, null);
         assertFunction("cast('abc' as JSON)", JSON, "\"abc\"");
         assertFunction("cast('\"a\":2' as JSON)", JSON, "\"\\\"a\\\":2\"");
+    }
+
+    @Test
+    public void testCastFromTimestamp()
+    {
+        assertFunction("cast(cast (null as timestamp) as JSON)", JSON, null);
+        assertFunction("CAST(from_unixtime(1) AS JSON)", JSON, "\"" + sqlTimestamp(1000).toString() + "\"");
+    }
+
+    private static SqlTimestamp sqlTimestamp(long millisUtc)
+    {
+        return new SqlTimestamp(millisUtc, TEST_SESSION.getTimeZoneKey());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestJsonOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestJsonOperators.java
@@ -134,7 +134,7 @@ public class TestJsonOperators
             throws Exception
     {
         assertFunction("cast(cast(null as decimal(5,2)) as JSON)", JSON, null);
-        assertFunction("cast(3.14 as JSON)", JSON, "3.14");
+        assertFunction("cast(DECIMAL '3.14' as JSON)", JSON, "3.14");
         assertFunction("cast(DECIMAL '12345678901234567890.123456789012345678' as JSON)", JSON, "12345678901234567890.123456789012345678");
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -59,6 +59,7 @@ import static com.facebook.presto.util.StructuralTestUtil.mapBlockOf;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Double.doubleToLongBits;
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 
@@ -252,6 +253,11 @@ public class TestMapOperators
                 "CAST(MAP(ARRAY[1, 2, 3, 5, 8, 13, 21, 34], ARRAY[JSON '123', JSON '3.14', JSON 'false', JSON '\"abc\"', JSON '[1, \"a\", null]', JSON '{\"a\": 1, \"b\": \"str\", \"c\": null}', JSON 'null', null]) AS JSON)",
                 JSON,
                 "{\"1\":123,\"13\":{\"a\":1,\"b\":\"str\",\"c\":null},\"2\":3.14,\"21\":null,\"3\":false,\"34\":null,\"5\":\"abc\",\"8\":[1,\"a\",null]}");
+
+        assertFunction(
+                "CAST(MAP(ARRAY[1, 2], ARRAY[from_unixtime(1), null]) AS JSON)",
+                JSON,
+                format("{\"1\":\"%s\",\"2\":null}", sqlTimestamp(1000).toString()));
 
         assertFunction(
                 "cast(MAP(ARRAY[1, 2, 3, 5, 8], ARRAY[ARRAY[1, 2], ARRAY[3, null], ARRAY[], ARRAY[null, null], null]) AS JSON)",
@@ -600,5 +606,10 @@ public class TestMapOperators
         long hashResult = mapType.hash(mapArrayBuilder.build(), 0);
 
         assertOperator(HASH_CODE, inputString, BIGINT, hashResult);
+    }
+
+    private static SqlTimestamp sqlTimestamp(long millisUtc)
+    {
+        return new SqlTimestamp(millisUtc, TEST_SESSION.getTimeZoneKey());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -171,7 +171,6 @@ public class TestMapOperators
         assertFunction("CAST(MAP(ARRAY['puppies'], ARRAY['kittens']) AS JSON)", JSON, "{\"puppies\":\"kittens\"}");
         assertFunction("CAST(MAP(ARRAY[TRUE], ARRAY[2]) AS JSON)", JSON, "{\"true\":2}");
         assertFunction("CAST(MAP(ARRAY['1'], ARRAY[from_unixtime(1)]) AS JSON)", JSON, "{\"1\":\"" + new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey()) + "\"}");
-        assertFunction("CAST(MAP(ARRAY[from_unixtime(1)], ARRAY[1.0]) AS JSON)", JSON, "{\"" + new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey()) + "\":1.0}");
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -163,14 +163,108 @@ public class TestMapOperators
     public void testMapToJson()
             throws Exception
     {
+        // Test key ordering
         assertFunction("CAST(MAP(ARRAY[7,5,3,1], ARRAY[8,6,4,2]) AS JSON)", JSON, "{\"1\":2,\"3\":4,\"5\":6,\"7\":8}");
         assertFunction("CAST(MAP(ARRAY[1,3,5,7], ARRAY[2,4,6,8]) AS JSON)", JSON, "{\"1\":2,\"3\":4,\"5\":6,\"7\":8}");
-        assertFunction("CAST(MAP(ARRAY [1, 3], ARRAY[2, NULL]) AS JSON)", JSON, "{\"1\":2,\"3\":null}");
-        assertFunction("CAST(MAP(ARRAY [1, 3], ARRAY [2.0, 4.0]) AS JSON)", JSON, "{\"1\":2.0,\"3\":4.0}");
-        assertFunction("CAST(MAP(ARRAY[1.0, 2.0], ARRAY[ ARRAY[1, 2], ARRAY[3]]) AS JSON)", JSON, "{\"1.0\":[1,2],\"2.0\":[3]}");
-        assertFunction("CAST(MAP(ARRAY['puppies'], ARRAY['kittens']) AS JSON)", JSON, "{\"puppies\":\"kittens\"}");
-        assertFunction("CAST(MAP(ARRAY[TRUE], ARRAY[2]) AS JSON)", JSON, "{\"true\":2}");
-        assertFunction("CAST(MAP(ARRAY['1'], ARRAY[from_unixtime(1)]) AS JSON)", JSON, "{\"1\":\"" + new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey()) + "\"}");
+
+        // Test null value
+        assertFunction("cast(cast (null as MAP<BIGINT, BIGINT>) AS JSON)", JSON, null);
+        assertFunction("cast(MAP() AS JSON)", JSON, "{}");
+        assertFunction("cast(MAP(ARRAY[1, 2], ARRAY[null, null]) AS JSON)", JSON, "{\"1\":null,\"2\":null}");
+
+        // Test key types
+        assertFunction("CAST(MAP(ARRAY[true, false], ARRAY[1, 2]) AS JSON)", JSON, "{\"false\":2,\"true\":1}");
+
+        assertFunction(
+                "cast(MAP(cast(ARRAY[1, 2, 3] AS ARRAY<TINYINT>), ARRAY[5, 8, null]) AS JSON)",
+                JSON,
+                "{\"1\":5,\"2\":8,\"3\":null}");
+        assertFunction(
+                "cast(MAP(cast(ARRAY[12345, 12346, 12347] AS ARRAY<SMALLINT>), ARRAY[5, 8, null]) AS JSON)",
+                JSON,
+                "{\"12345\":5,\"12346\":8,\"12347\":null}");
+        assertFunction(
+                "cast(MAP(cast(ARRAY[123456789,123456790,123456791] AS ARRAY<INTEGER>), ARRAY[5, 8, null]) AS JSON)",
+                JSON,
+                "{\"123456789\":5,\"123456790\":8,\"123456791\":null}");
+        assertFunction(
+                "cast(MAP(cast(ARRAY[1234567890123456111,1234567890123456222,1234567890123456777] AS ARRAY<BIGINT>), ARRAY[111, 222, null]) AS JSON)",
+                JSON,
+                "{\"1234567890123456111\":111,\"1234567890123456222\":222,\"1234567890123456777\":null}");
+
+        assertFunction(
+                "cast(MAP(cast(ARRAY[3.14, 1e10, 1e20] AS ARRAY<REAL>), ARRAY[null, 10, 20]) AS JSON)",
+                JSON,
+                "{\"1.0E10\":10,\"1.0E20\":20,\"3.14\":null}");
+
+        assertFunction(
+                "cast(MAP(ARRAY[1e-323,1e308,nan()], ARRAY[-323,308,null]) AS JSON)",
+                JSON,
+                "{\"1.0E-323\":-323,\"1.0E308\":308,\"NaN\":null}");
+        assertFunction(
+                "cast(MAP(ARRAY[DECIMAL '3.14', DECIMAL '0.01'], ARRAY[0.14, null]) AS JSON)",
+                JSON,
+                "{\"0.01\":null,\"3.14\":0.14}");
+
+        assertFunction(
+                "cast(MAP(ARRAY[DECIMAL '12345678901234567890.1234567890666666', DECIMAL '0.0'], ARRAY[666666, null]) AS JSON)",
+                JSON,
+                "{\"0.0000000000000000\":null,\"12345678901234567890.1234567890666666\":666666}");
+
+        assertFunction("CAST(MAP(ARRAY['a', 'bb', 'ccc'], ARRAY[1, 2, 3]) AS JSON)", JSON, "{\"a\":1,\"bb\":2,\"ccc\":3}");
+
+        // Test value types
+        assertFunction("cast(MAP(ARRAY[1, 2, 3], ARRAY[true, false, null]) AS JSON)", JSON, "{\"1\":true,\"2\":false,\"3\":null}");
+
+        assertFunction(
+                "cast(MAP(ARRAY[1, 2, 3], cast(ARRAY[5, 8, null] AS ARRAY<TINYINT>)) AS JSON)",
+                JSON,
+                "{\"1\":5,\"2\":8,\"3\":null}");
+        assertFunction(
+                "cast(MAP(ARRAY[1, 2, 3], cast(ARRAY[12345, -12345, null] AS ARRAY<SMALLINT>)) AS JSON)",
+                JSON,
+                "{\"1\":12345,\"2\":-12345,\"3\":null}");
+        assertFunction(
+                "cast(MAP(ARRAY[1, 2, 3], cast(ARRAY[123456789, -123456789, null] AS ARRAY<INTEGER>)) AS JSON)",
+                JSON,
+                "{\"1\":123456789,\"2\":-123456789,\"3\":null}");
+        assertFunction(
+                "cast(MAP(ARRAY[1, 2, 3], cast(ARRAY[1234567890123456789, -1234567890123456789, null] AS ARRAY<BIGINT>)) AS JSON)",
+                JSON,
+                "{\"1\":1234567890123456789,\"2\":-1234567890123456789,\"3\":null}");
+
+        assertFunction(
+                "CAST(MAP(ARRAY[1, 2, 3, 5, 8], CAST(ARRAY[3.14, nan(), infinity(), -infinity(), null] AS ARRAY<REAL>)) AS JSON)",
+                JSON,
+                "{\"1\":3.14,\"2\":\"NaN\",\"3\":\"Infinity\",\"5\":\"-Infinity\",\"8\":null}");
+        assertFunction(
+                "CAST(MAP(ARRAY[1, 2, 3, 5, 8, 13, 21], ARRAY[3.14, 1e-323, 1e308, nan(), infinity(), -infinity(), null]) AS JSON)",
+                JSON,
+                "{\"1\":3.14,\"13\":\"-Infinity\",\"2\":1.0E-323,\"21\":null,\"3\":1.0E308,\"5\":\"NaN\",\"8\":\"Infinity\"}");
+        assertFunction("CAST(MAP(ARRAY[1, 2], ARRAY[DECIMAL '3.14', null]) AS JSON)", JSON, "{\"1\":3.14,\"2\":null}");
+        assertFunction(
+                "CAST(MAP(ARRAY[1, 2], ARRAY[DECIMAL '12345678901234567890.123456789012345678', null]) AS JSON)",
+                JSON,
+                "{\"1\":12345678901234567890.123456789012345678,\"2\":null}");
+
+        assertFunction("cast(MAP(ARRAY[1, 2, 3], ARRAY['a', 'bb', null]) AS JSON)", JSON, "{\"1\":\"a\",\"2\":\"bb\",\"3\":null}");
+        assertFunction(
+                "CAST(MAP(ARRAY[1, 2, 3, 5, 8, 13, 21, 34], ARRAY[JSON '123', JSON '3.14', JSON 'false', JSON '\"abc\"', JSON '[1, \"a\", null]', JSON '{\"a\": 1, \"b\": \"str\", \"c\": null}', JSON 'null', null]) AS JSON)",
+                JSON,
+                "{\"1\":123,\"13\":{\"a\":1,\"b\":\"str\",\"c\":null},\"2\":3.14,\"21\":null,\"3\":false,\"34\":null,\"5\":\"abc\",\"8\":[1,\"a\",null]}");
+
+        assertFunction(
+                "cast(MAP(ARRAY[1, 2, 3, 5, 8], ARRAY[ARRAY[1, 2], ARRAY[3, null], ARRAY[], ARRAY[null, null], null]) AS JSON)",
+                JSON,
+                "{\"1\":[1,2],\"2\":[3,null],\"3\":[],\"5\":[null,null],\"8\":null}");
+        assertFunction(
+                "cast(MAP(ARRAY[1, 2, 8, 5, 3], ARRAY[MAP(ARRAY['b', 'a'], ARRAY[2, 1]), MAP(ARRAY['three', 'none'], ARRAY[3, null]), MAP(), MAP(ARRAY['h2', 'h1'], ARRAY[null, null]), null]) AS JSON)",
+                JSON,
+                "{\"1\":{\"a\":1,\"b\":2},\"2\":{\"none\":null,\"three\":3},\"3\":null,\"5\":{\"h1\":null,\"h2\":null},\"8\":{}}");
+        assertFunction(
+                "cast(MAP(ARRAY[1, 2, 3, 5], ARRAY[ROW(1, 2), ROW(3, CAST(null as INTEGER)), CAST(ROW(null, null) AS ROW(INTEGER, INTEGER)), null]) AS JSON)",
+                JSON,
+                "{\"1\":[1,2],\"2\":[3,null],\"3\":[null,null],\"5\":null}");
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -258,6 +258,10 @@ public class TestMapOperators
                 "CAST(MAP(ARRAY[1, 2], ARRAY[from_unixtime(1), null]) AS JSON)",
                 JSON,
                 format("{\"1\":\"%s\",\"2\":null}", sqlTimestamp(1000).toString()));
+        assertFunction(
+                "CAST(MAP(ARRAY[2, 5, 3], ARRAY[DATE '2001-08-22', DATE '2001-08-23', null]) AS JSON)",
+                JSON,
+                "{\"2\":\"2001-08-22\",\"3\":null,\"5\":\"2001-08-23\"}");
 
         assertFunction(
                 "cast(MAP(ARRAY[1, 2, 3, 5, 8], ARRAY[ARRAY[1, 2], ARRAY[3, null], ARRAY[], ARRAY[null, null], null]) AS JSON)",

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -86,6 +86,10 @@ public class TestRowOperators
                 "CAST(ROW('a', 'bb', CAST(null as VARCHAR), JSON '123', JSON '3.14', JSON 'false', JSON '\"abc\"', JSON '[1, \"a\", null]', JSON '{\"a\": 1, \"b\": \"str\", \"c\": null}', JSON 'null', CAST(null AS JSON)) AS JSON)",
                 JSON,
                 "[\"a\",\"bb\",null,123,3.14,false,\"abc\",[1,\"a\",null],{\"a\":1,\"b\":\"str\",\"c\":null},null,null]");
+        assertFunction(
+                "CAST(ROW(DATE '2001-08-22', DATE '2001-08-23', null) AS JSON)",
+                JSON,
+                "[\"2001-08-22\",\"2001-08-23\",null]");
 
         assertFunction(
                 "CAST(ROW(from_unixtime(1), cast(null as TIMESTAMP)) AS JSON)",

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -88,6 +88,11 @@ public class TestRowOperators
                 "[\"a\",\"bb\",null,123,3.14,false,\"abc\",[1,\"a\",null],{\"a\":1,\"b\":\"str\",\"c\":null},null,null]");
 
         assertFunction(
+                "CAST(ROW(from_unixtime(1), cast(null as TIMESTAMP)) AS JSON)",
+                JSON,
+                format("[\"%s\",null]", sqlTimestamp(1000).toString()));
+
+        assertFunction(
                 "cast(ROW(ARRAY[1, 2], ARRAY[3, null], ARRAY[], ARRAY[null, null], CAST(null AS ARRAY<BIGINT>)) AS JSON)",
                 JSON,
                 "[[1,2],[3,null],[],[null,null],null]");
@@ -253,5 +258,10 @@ public class TestRowOperators
             assertFunction(base + operator + greater, BOOLEAN, lessOrInequalityOperators.contains(operator));
             assertFunction(greater + operator + base, BOOLEAN, greaterOrInequalityOperators.contains(operator));
         }
+    }
+
+    private static SqlTimestamp sqlTimestamp(long millisUtc)
+    {
+        return new SqlTimestamp(millisUtc, TEST_SESSION.getTimeZoneKey());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -66,6 +66,41 @@ public class TestRowOperators
     public void testRowToJson()
             throws Exception
     {
+        assertFunction("cast(cast (null as ROW(BIGINT, VARCHAR)) AS JSON)", JSON, null);
+        assertFunction("cast(ROW(null, null) as json)", JSON, "[null,null]");
+
+        assertFunction("cast(ROW(true, false, null) AS JSON)", JSON, "[true,false,null]");
+
+        assertFunction(
+                "cast(cast(ROW(12, 12345, 123456789, 1234567890123456789, null, null, null, null) AS ROW(TINYINT, SMALLINT, INTEGER, BIGINT, TINYINT, SMALLINT, INTEGER, BIGINT)) AS JSON)",
+                JSON,
+                "[12,12345,123456789,1234567890123456789,null,null,null,null]");
+
+        assertFunction(
+                "CAST(ROW(CAST(3.14 AS REAL), 3.1415, 1e308, DECIMAL '3.14', DECIMAL '12345678901234567890.123456789012345678', CAST(null AS REAL), CAST(null AS DOUBLE), CAST(null AS DECIMAL)) AS JSON)",
+                JSON,
+                "[3.14,3.1415,1.0E308,3.14,12345678901234567890.123456789012345678,null,null,null]"
+        );
+
+        assertFunction(
+                "CAST(ROW('a', 'bb', CAST(null as VARCHAR), JSON '123', JSON '3.14', JSON 'false', JSON '\"abc\"', JSON '[1, \"a\", null]', JSON '{\"a\": 1, \"b\": \"str\", \"c\": null}', JSON 'null', CAST(null AS JSON)) AS JSON)",
+                JSON,
+                "[\"a\",\"bb\",null,123,3.14,false,\"abc\",[1,\"a\",null],{\"a\":1,\"b\":\"str\",\"c\":null},null,null]");
+
+        assertFunction(
+                "cast(ROW(ARRAY[1, 2], ARRAY[3, null], ARRAY[], ARRAY[null, null], CAST(null AS ARRAY<BIGINT>)) AS JSON)",
+                JSON,
+                "[[1,2],[3,null],[],[null,null],null]");
+        assertFunction(
+                "cast(ROW(MAP(ARRAY['b', 'a'], ARRAY[2, 1]), MAP(ARRAY['three', 'none'], ARRAY[3, null]), MAP(), MAP(ARRAY['h2', 'h1'], ARRAY[null, null]), CAST(NULL as MAP<VARCHAR, BIGINT>)) AS JSON)",
+                JSON,
+                "[{\"a\":1,\"b\":2},{\"none\":null,\"three\":3},{},{\"h1\":null,\"h2\":null},null]");
+        assertFunction(
+                "cast(ROW(ROW(1, 2), ROW(3, CAST(null as INTEGER)), CAST(ROW(null, null) AS ROW(INTEGER, INTEGER)), null) AS JSON)",
+                JSON,
+                "[[1,2],[3,null],[null,null],null]");
+
+        // other miscellaneous tests
         assertFunction("CAST(ROW(1, 2) AS JSON)", JSON, "[1,2]");
         assertFunction("CAST(CAST(ROW(1, 2) AS ROW(a BIGINT, b BIGINT)) AS JSON)", JSON, "[1,2]");
         assertFunction("CAST(ROW(1, NULL) AS JSON)", JSON, "[1,null]");
@@ -74,7 +109,6 @@ public class TestRowOperators
         assertFunction("CAST(ROW(1.0, 2.5) AS JSON)", JSON, "[1.0,2.5]");
         assertFunction("CAST(ROW(1.0, 'kittens') AS JSON)", JSON, "[1.0,\"kittens\"]");
         assertFunction("CAST(ROW(TRUE, FALSE) AS JSON)", JSON, "[true,false]");
-        assertFunction("CAST(ROW(from_unixtime(1)) AS JSON)", JSON, "[\"" + new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey()) + "\"]");
         assertFunction("CAST(ROW(FALSE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0, 4.0])) AS JSON)", JSON, "[false,[1,2],{\"1\":2.0,\"3\":4.0}]");
     }
 


### PR DESCRIPTION
Work in progress. Will have a separate commit for CAST ROW to JSON.

The current implementation of casting complex type to JSON is based on `Type.getObjectValue()`, which should not be used for CAST but only for REST service.

This has various issues:
1. `Type.getObjectValue()` should only be used for REST service, not for CAST purpose.
2. Various issues for nested data type (https://github.com/prestodb/presto/issues/7226, https://github.com/prestodb/presto/issues/7328)
3. Inconsistent behavior of CAST `ARRAY<X>/MAP<X>` to JSON vs. CAST `X` to JSON. For example, currently  `DATE`/`TIME`/`TIMESTAMP`/`INTERVAL` are not supported for casting to JSON, but `ARRAY<DATE>/MAP<DATE>`... are supported. 