### PR TITLE
Fix handling of DATE types in AccumuloRecordCursor#getLong

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
@@ -54,6 +54,7 @@ import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Implementation of Presto RecordCursor, responsible for iterating over a Presto split,
@@ -218,7 +219,7 @@ public class AccumuloRecordCursor
             return serializer.getLong(fieldToColumnName[field]);
         }
         else if (type.equals(DATE)) {
-            return serializer.getDate(fieldToColumnName[field]).getTime();
+            return MILLISECONDS.toDays(serializer.getDate(fieldToColumnName[field]).getTime());
         }
         else if (type.equals(INTEGER)) {
             return serializer.getInt(fieldToColumnName[field]);

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/Field.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/Field.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.DAYS;
 
 public class Field
 {
@@ -424,7 +425,7 @@ public class Field
         }
         else if (type.equals(DATE)) {
             if (value instanceof Long) {
-                return new Date((Long) value);
+                return new Date(DAYS.toMillis((Long) value));
             }
 
             if (value instanceof Calendar) {

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/LexicoderRowSerializer.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/LexicoderRowSerializer.java
@@ -52,6 +52,8 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Implementation of {@link AccumuloRowSerializer} that uses Accumulo lexicoders to serialize the values of the Presto columns.
@@ -192,7 +194,7 @@ public class LexicoderRowSerializer
     @Override
     public Date getDate(String name)
     {
-        return new Date(decode(BIGINT, getFieldValue(name)));
+        return new Date(DAYS.toMillis(decode(BIGINT, getFieldValue(name))));
     }
 
     @Override
@@ -340,7 +342,7 @@ public class LexicoderRowSerializer
             toEncode = ((Integer) value).longValue();
         }
         else if (type.equals(DATE) && value instanceof Date) {
-            toEncode = ((Date) value).getTime();
+            toEncode = MILLISECONDS.toDays(((Date) value).getTime());
         }
         else if (type.equals(INTEGER) && value instanceof Integer) {
             toEncode = ((Integer) value).longValue();

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/StringRowSerializer.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/StringRowSerializer.java
@@ -46,6 +46,8 @@ import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Implementation of {@link StringRowSerializer} that encodes and decodes Presto column values as human-readable String objects.
@@ -163,13 +165,13 @@ public class StringRowSerializer
     @Override
     public Date getDate(String name)
     {
-        return new Date(Long.parseLong(getFieldValue(name)));
+        return new Date(DAYS.toMillis(Long.parseLong(getFieldValue(name))));
     }
 
     @Override
     public void setDate(Text text, Date value)
     {
-        text.set(Long.toString(value.getTime()).getBytes(UTF_8));
+        text.set(Long.toString(MILLISECONDS.toDays(value.getTime())).getBytes(UTF_8));
     }
 
     @Override

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/serializers/AbstractTestAccumuloRowSerializer.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/serializers/AbstractTestAccumuloRowSerializer.java
@@ -21,6 +21,8 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
 import java.sql.Date;
@@ -44,6 +46,7 @@ import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
 
 public abstract class AbstractTestAccumuloRowSerializer
@@ -99,16 +102,15 @@ public abstract class AbstractTestAccumuloRowSerializer
     public void testDate()
             throws Exception
     {
+        Date expected = new Date(new DateTime(2001, 2, 3, 4, 5, 6, DateTimeZone.UTC).getMillis());
         AccumuloRowSerializer serializer = serializerClass.getConstructor().newInstance();
-        Type type = DATE;
-        Date expected = new Date(new java.util.Date().getTime());
-        byte[] data = serializer.encode(type, expected);
-        Date actual = new Date(serializer.decode(type, data));
-        assertEquals(actual, expected);
+        byte[] data = serializer.encode(DATE, expected);
 
         deserializeData(serializer, data);
-        actual = serializer.getDate(COLUMN_NAME);
-        assertEquals(actual, expected);
+        Date actual = serializer.getDate(COLUMN_NAME);
+
+        // Convert milliseconds to days so they can be compared regardless of the time of day
+        assertEquals(MILLISECONDS.toDays(actual.getTime()), MILLISECONDS.toDays(expected.getTime()));
     }
 
     @Test


### PR DESCRIPTION
The connector is incorrectly converting the number of days into a Date
object as if the number of days was milliseconds.  This works from a
data perspective, but doesn't align with the intention of using familiar
Java types.  This commit updates the data to use milliseconds while
maintaining backwards compatability with the existing serializers.