### PR TITLE
Fix column class name for sql array.

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSetMetaData.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSetMetaData.java
@@ -16,6 +16,7 @@ package com.facebook.presto.jdbc;
 import com.google.common.collect.ImmutableList;
 
 import java.math.BigDecimal;
+import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
@@ -226,6 +227,8 @@ public class PrestoResultSetMetaData
                 return Blob.class.getName();
             case Types.CLOB:
                 return Clob.class.getName();
+            case Types.ARRAY:
+            	return Array.class.getName();
         }
         return String.class.getName();
     }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSetMetaData.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSetMetaData.java
@@ -228,7 +228,7 @@ public class PrestoResultSetMetaData
             case Types.CLOB:
                 return Clob.class.getName();
             case Types.ARRAY:
-            	return Array.class.getName();
+                return Array.class.getName();
         }
         return String.class.getName();
     }


### PR DESCRIPTION
When column type is ARRAY, presto returned invalid column class name -
java.lang.String. Fix to returns java.sql.Array.