### PR TITLE
Add ORD() function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -32,6 +32,10 @@ String Functions
 
     Returns the Unicode code point ``n`` as a single character string.
 
+.. function:: codepoint(string) -> integer
+
+    Returns the Unicode code point of the only character of ``string``.
+
 .. function:: concat(string1, ..., stringN) -> varchar
 
     Returns the concatenation of ``string1``, ``string2``, ``...``, ``stringN``.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -79,6 +79,16 @@ public final class StringFunctions
         }
     }
 
+    @Description("returns Unicode code point of a single character string")
+    @ScalarFunction("codepoint")
+    @SqlType(StandardTypes.INTEGER)
+    public static long codepoint(@SqlType("varchar(1)") Slice slice)
+    {
+        checkCondition(countCodePoints(slice) == 1, INVALID_FUNCTION_ARGUMENT, "Input string must be a single character string");
+
+        return getCodePointAt(slice, 0);
+    }
+
     @Description("count of code points of the given string")
     @ScalarFunction
     @LiteralParameters("x")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -29,10 +29,12 @@ import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.FUNCTION_NOT_FOUND;
 import static com.google.common.base.Strings.repeat;
 import static java.lang.String.format;
 
@@ -70,6 +72,21 @@ public class TestStringFunctions
         assertInvalidFunction("CHR(-1)", "Not a valid Unicode code point: -1");
         assertInvalidFunction("CHR(1234567)", "Not a valid Unicode code point: 1234567");
         assertInvalidFunction("CHR(8589934592)", "Not a valid Unicode code point: 8589934592");
+    }
+
+    @Test
+    public void testCodepoint()
+    {
+        assertFunction("CODEPOINT('x')", INTEGER, 0x78);
+        assertFunction("CODEPOINT('\u840C')", INTEGER, 0x840C);
+
+        assertFunction("CODEPOINT(CHR(128077))", INTEGER, 128077);
+        assertFunction("CODEPOINT(CHR(33804))", INTEGER, 33804);
+
+        assertInvalidFunction("CODEPOINT('hello')", FUNCTION_NOT_FOUND);
+        assertInvalidFunction("CODEPOINT('\u666E\u5217\u65AF\u6258')", FUNCTION_NOT_FOUND);
+
+        assertInvalidFunction("CODEPOINT('')", INVALID_FUNCTION_ARGUMENT);
     }
 
     @Test


### PR DESCRIPTION
Returns the Unicode code point of a single character string.

Closes #7560 