### PR TITLE
protobuf record decoder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <dep.aws-sdk.version>1.11.30</dep.aws-sdk.version>
         <dep.tempto.version>1.27</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
+        <dep.protobuf.version>2.6.1</dep.protobuf.version>
 
         <cli.skip-execute>true</cli.skip-execute>
         <cli.main-class>None</cli.main-class>
@@ -830,6 +831,12 @@
                 <groupId>com.facebook.presto.cassandra</groupId>
                 <artifactId>cassandra-driver</artifactId>
                 <version>3.0.5-1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${dep.protobuf.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <repositories>
-        <repository>
-            <id>repo</id>
-            <releases>
-                <enabled>true</enabled>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <url>file://${project.basedir}/repo</url>
-        </repository>
-    </repositories>
-
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -117,23 +103,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <id>analyze</id>
-                        <goals>
-                            <goal>analyze-only</goal>
-                        </goals>
-                        <configuration>
-                            <failOnWarning>false</failOnWarning>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <repositories>
+        <repository>
+            <id>repo</id>
+            <releases>
+                <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <url>file://${project.basedir}/repo</url>
+        </repository>
+    </repositories>
+
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -82,6 +96,11 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -95,4 +114,45 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>false</failOnWarning>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <protocVersion>${dep.protobuf.version}</protocVersion>
+                            <inputDirectories>
+                                <include>src/test/resources/decoder/protobuf</include>
+                            </inputDirectories>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/DecoderModule.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/DecoderModule.java
@@ -16,6 +16,7 @@ package com.facebook.presto.decoder;
 import com.facebook.presto.decoder.csv.CsvDecoderModule;
 import com.facebook.presto.decoder.dummy.DummyDecoderModule;
 import com.facebook.presto.decoder.json.JsonDecoderModule;
+import com.facebook.presto.decoder.protobuf.ProtobufDecoderModule;
 import com.facebook.presto.decoder.raw.RawDecoderModule;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -38,6 +39,7 @@ public class DecoderModule
         binder.install(new CsvDecoderModule());
         binder.install(new JsonDecoderModule());
         binder.install(new RawDecoderModule());
+        binder.install(new ProtobufDecoderModule());
     }
 
     public static void bindRowDecoder(Binder binder, Class<? extends RowDecoder> decoderClass)

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/protobuf/ProtobufDecoderModule.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/protobuf/ProtobufDecoderModule.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.decoder.protobuf;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import static com.facebook.presto.decoder.DecoderModule.bindFieldDecoder;
+import static com.facebook.presto.decoder.DecoderModule.bindRowDecoder;
+
+/**
+ * Raw decoder guice module.
+ */
+public class ProtobufDecoderModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        bindRowDecoder(binder, ProtobufRowDecoder.class);
+        bindFieldDecoder(binder, ProtobufFieldDecoder.class);
+    }
+}

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/protobuf/ProtobufDecoderModule.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/protobuf/ProtobufDecoderModule.java
@@ -20,7 +20,7 @@ import static com.facebook.presto.decoder.DecoderModule.bindFieldDecoder;
 import static com.facebook.presto.decoder.DecoderModule.bindRowDecoder;
 
 /**
- * Raw decoder guice module.
+ * Protobuf decoder guice module.
  */
 public class ProtobufDecoderModule
         implements Module

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/protobuf/ProtobufFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/protobuf/ProtobufFieldDecoder.java
@@ -29,7 +29,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Default field decoder for raw (byte) columns.
+ * Default field decoder for protobuf object.
  */
 public class ProtobufFieldDecoder
         implements FieldDecoder<Object>

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/protobuf/ProtobufFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/protobuf/ProtobufFieldDecoder.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.decoder.protobuf;
+
+import com.facebook.presto.decoder.DecoderColumnHandle;
+import com.facebook.presto.decoder.FieldDecoder;
+import com.facebook.presto.decoder.FieldValueProvider;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
+
+import java.util.Set;
+
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
+import static com.facebook.presto.spi.type.Varchars.truncateToLength;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Default field decoder for raw (byte) columns.
+ */
+public class ProtobufFieldDecoder
+        implements FieldDecoder<Object>
+{
+    @Override
+    public Set<Class<?>> getJavaTypes()
+    {
+        return ImmutableSet.of(boolean.class, long.class, double.class, Slice.class);
+    }
+
+    @Override
+    public final String getRowDecoderName()
+    {
+        return ProtobufRowDecoder.NAME;
+    }
+
+    @Override
+    public String getFieldDecoderName()
+    {
+        return FieldDecoder.DEFAULT_FIELD_DECODER_NAME;
+    }
+
+    @Override
+    public FieldValueProvider decode(Object value, DecoderColumnHandle columnHandle)
+    {
+        requireNonNull(columnHandle, "columnHandle is null");
+        requireNonNull(value, "value is null");
+        return new ObjectValueProvider(value, columnHandle);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("FieldDecoder[%s/%s]", getRowDecoderName(), getFieldDecoderName());
+    }
+
+    public static class ObjectValueProvider
+            extends FieldValueProvider
+    {
+        protected final Object value;
+        protected final DecoderColumnHandle columnHandle;
+
+        public ObjectValueProvider(Object value, DecoderColumnHandle columnHandle)
+        {
+            this.columnHandle = requireNonNull(columnHandle, "columnHandle is null");
+            this.value = value;
+        }
+
+        @Override
+        public final boolean accept(DecoderColumnHandle columnHandle)
+        {
+            return this.columnHandle.equals(columnHandle);
+        }
+
+        @Override
+        public final boolean isNull()
+        {
+            return value == null;
+        }
+
+        @Override
+        public boolean getBoolean()
+        {
+            return isNull() ? false : (Boolean) value;
+        }
+
+        @Override
+        public long getLong()
+        {
+            return isNull() ? 0L : (Long) value;
+        }
+
+        @Override
+        public double getDouble()
+        {
+            return isNull() ? 0.0d : (Double) value;
+        }
+
+        @Override
+        public Slice getSlice()
+        {
+            if (isNull()) {
+                return EMPTY_SLICE;
+            }
+
+            Slice slice = utf8Slice(value.toString());
+            if (isVarcharType(columnHandle.getType())) {
+                slice = truncateToLength(slice, columnHandle.getType());
+            }
+            return slice;
+        }
+    }
+}

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/protobuf/ProtobufRowDecoder.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/protobuf/ProtobufRowDecoder.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Decoder for raw (direct byte) rows. All field decoders map bytes directly to Presto columns.
+ * Decoder for protobuf object.
  */
 public class ProtobufRowDecoder
         implements RowDecoder

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/protobuf/ProtobufRowDecoder.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/protobuf/ProtobufRowDecoder.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.decoder.protobuf;
+
+import com.facebook.presto.decoder.DecoderColumnHandle;
+import com.facebook.presto.decoder.FieldDecoder;
+import com.facebook.presto.decoder.FieldValueProvider;
+import com.facebook.presto.decoder.RowDecoder;
+import com.google.common.base.Splitter;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.GeneratedMessage;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Decoder for raw (direct byte) rows. All field decoders map bytes directly to Presto columns.
+ */
+public class ProtobufRowDecoder
+        implements RowDecoder
+{
+    public static final String NAME = "protobuf";
+
+    private Method method;
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public boolean decodeRow(byte[] data,
+            Map<String, String> dataMap,
+            Set<FieldValueProvider> fieldValueProviders,
+            List<DecoderColumnHandle> columnHandles,
+            Map<DecoderColumnHandle, FieldDecoder<?>> fieldDecoders)
+    {
+        GeneratedMessage protoRecord = null;
+
+        for (DecoderColumnHandle columnHandle : columnHandles) {
+            if (columnHandle.isInternal()) {
+                continue;
+            }
+
+            @SuppressWarnings("unchecked")
+            FieldDecoder<Object> decoder = (FieldDecoder<Object>) fieldDecoders.get(columnHandle);
+
+            if (decoder != null) {
+                if (protoRecord == null) {
+                    try {
+                        if (method == null) {
+                            String className = columnHandle.getDataFormat();
+                            Class<?> clazz = Class.forName(className);
+                            method = clazz.getDeclaredMethod("parseFrom", byte[].class);
+                        }
+                        protoRecord = (GeneratedMessage) method.invoke(null, data);
+                    }
+                    catch (Exception e) {
+                        return true;
+                    }
+                }
+                Object element = locateElement(protoRecord, columnHandle);
+                fieldValueProviders.add(decoder.decode(element, columnHandle));
+            }
+        }
+
+        return false;
+    }
+
+    private Object locateElement(GeneratedMessage element, DecoderColumnHandle columnHandle)
+    {
+        Object value = element;
+        for (String pathElement : Splitter.on('/').omitEmptyStrings().split(columnHandle.getMapping())) {
+            Descriptors.FieldDescriptor fieldDescriptor = ((GeneratedMessage) value).getDescriptorForType()
+                                                            .findFieldByName(pathElement);
+            value = ((GeneratedMessage) value).getField(fieldDescriptor);
+        }
+        return value;
+    }
+}

--- a/presto-record-decoder/src/test/java/com/facebook/presto/decoder/protobuf/TestProtobufDecoder.java
+++ b/presto-record-decoder/src/test/java/com/facebook/presto/decoder/protobuf/TestProtobufDecoder.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.decoder.protobuf;
+
+import com.facebook.presto.decoder.DecoderColumnHandle;
+import com.facebook.presto.decoder.DecoderTestColumnHandle;
+import com.facebook.presto.decoder.FieldDecoder;
+import com.facebook.presto.decoder.FieldValueProvider;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.decoder.util.DecoderTestUtil.checkValue;
+import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestProtobufDecoder
+{
+    private static final ProtobufFieldDecoder DEFAULT_FIELD_DECODER = new ProtobufFieldDecoder();
+
+    private static Map<DecoderColumnHandle, FieldDecoder<?>> buildMap(List<DecoderColumnHandle> columns)
+    {
+        ImmutableMap.Builder<DecoderColumnHandle, FieldDecoder<?>> map = ImmutableMap.builder();
+        for (DecoderColumnHandle column : columns) {
+            map.put(column, DEFAULT_FIELD_DECODER);
+        }
+        return map.build();
+    }
+
+    @Test
+    public void testSimple()
+    {
+        String className = "com.facebook.presto.decoder.protobuf.MessageSchema$Message";
+        MessageSchema.Message.User user = MessageSchema.Message.User.newBuilder()
+                                            .setId(98247748L)
+                                            .setIdStr("98247748")
+                                            .setScreenName("EKentuckyNews")
+                                            .setGeoEnabled(true)
+                                            .setStatusesCount(7630)
+                                            .build();
+        MessageSchema.Message message = MessageSchema.Message.newBuilder()
+                                            .setCreatedAt("Mon Jul 28 20:38:07 +0000 2014")
+                                            .setId(493857959588286460L)
+                                            .setIdStr("493857959588286465")
+                                            .setSource("<a href=\"http://twitterfeed.com\" rel=\"nofollow\">twitterfeed</a>")
+                                            .setUser(user)
+                                            .build();
+        ProtobufRowDecoder rowDecoder = new ProtobufRowDecoder();
+        DecoderTestColumnHandle row1 = new DecoderTestColumnHandle("", 0, "row1", createVarcharType(100), "source", className, null, false, false, false);
+        DecoderTestColumnHandle row2 = new DecoderTestColumnHandle("", 1, "row2", createVarcharType(10), "user/screen_name", className, null, false, false, false);
+        DecoderTestColumnHandle row3 = new DecoderTestColumnHandle("", 2, "row3", BigintType.BIGINT, "id", className, null, false, false, false);
+        DecoderTestColumnHandle row4 = new DecoderTestColumnHandle("", 3, "row4", BigintType.BIGINT, "user/statuses_count", className, null, false, false, false);
+        DecoderTestColumnHandle row5 = new DecoderTestColumnHandle("", 4, "row5", BooleanType.BOOLEAN, "user/geo_enabled", className, null, false, false, false);
+
+        List<DecoderColumnHandle> columns = ImmutableList.of(row1, row2, row3, row4, row5);
+        Set<FieldValueProvider> providers = new HashSet<>();
+
+        boolean corrupt = rowDecoder.decodeRow(message.toByteArray(), null, providers, columns, buildMap(columns));
+        assertFalse(corrupt);
+
+        assertEquals(providers.size(), columns.size());
+
+        checkValue(providers, row1, "<a href=\"http://twitterfeed.com\" rel=\"nofollow\">twitterfeed</a>");
+        checkValue(providers, row2, "EKentuckyN");
+        checkValue(providers, row3, 493857959588286460L);
+        checkValue(providers, row4, 7630);
+        checkValue(providers, row5, true);
+    }
+}

--- a/presto-record-decoder/src/test/resources/decoder/protobuf/message.proto
+++ b/presto-record-decoder/src/test/resources/decoder/protobuf/message.proto
@@ -1,0 +1,49 @@
+package com.facebook.presto.decoder.protobuf;
+
+option java_outer_classname = "MessageSchema";
+
+message Message {
+    message User {
+        optional int64  id = 1;
+        optional string id_str = 2;
+        optional string name = 3;
+        optional string screen_name = 4;
+        optional string location = 5;
+        optional string url = 6;
+        optional string description = 7;
+        optional bool   protected = 8;
+        optional bool   verified = 9;
+        optional int64  followers_count = 10;
+        optional int64  friends_count = 11;
+        optional int64  listed_count = 12;
+        optional int64  favourites_count = 13;
+        optional int64  statuses_count = 14;
+        optional string created_at = 15;
+        optional int64  utc_offset = 16;
+        optional string time_zone = 17;
+        optional bool   geo_enabled = 18;
+        optional string lang = 19;
+        optional bool   contributors_enabled = 20;
+        optional bool   is_translator = 21;
+        optional string profile_background_color = 22;
+        optional string profile_background_image_url = 23;
+        optional string profile_background_image_url_https = 24;
+        optional bool   profile_background_tile = 25;
+        optional string profile_link_color = 26;
+        optional string profile_sidebar_border_color = 27;
+        optional string profile_sidebar_fill_color = 28;
+        optional string profile_text_color = 29;
+        optional string profile_use_background_image = 30;
+        optional string profile_image_url = 31;
+        optional string profile_image_url_https = 32;
+        optional bool   default_profile = 33;
+        optional bool   default_profile_image = 34;
+    }
+    optional string created_at = 1;
+    optional int64 id = 2;
+    optional string id_str = 3;
+    optional string text = 4;
+    optional string source = 5;
+    optional bool   truncated = 6;
+    optional User user = 14;
+}


### PR DESCRIPTION
add a decoder to decode protobuf serialized object.
Java generated classes need to be in the classpath.  For example, drop the java generated code under PRESTO_HOME/plugin/kafka/