### PR TITLE
Provide table name isolation in Hive integration tests

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -331,19 +331,11 @@ public abstract class AbstractTestHiveClient
     protected SchemaTableName tablePartitionSchemaChange;
     protected SchemaTableName tablePartitionSchemaChangeNonCanonical;
 
-    protected SchemaTableName temporaryCreateTable;
     protected SchemaTableName temporaryCreateRollbackTable;
-    protected SchemaTableName temporaryCreateEmptyTable;
-    protected SchemaTableName temporaryInsertTable;
-    protected SchemaTableName temporaryInsertIntoNewPartitionTable;
-    protected SchemaTableName temporaryInsertIntoExistingPartitionTable;
     protected SchemaTableName temporaryInsertUnsupportedWriteType;
-    protected SchemaTableName temporaryMetadataDeleteTable;
     protected SchemaTableName temporaryRenameTableOld;
     protected SchemaTableName temporaryRenameTableNew;
     protected SchemaTableName temporaryCreateView;
-    protected SchemaTableName temporaryDeleteInsert;
-    protected SchemaTableName temporaryMismatchSchemaTable;
 
     protected String invalidClientId;
     protected ConnectorTableHandle invalidTableHandle;
@@ -407,19 +399,11 @@ public abstract class AbstractTestHiveClient
         tablePartitionSchemaChange = new SchemaTableName(database, "presto_test_partition_schema_change");
         tablePartitionSchemaChangeNonCanonical = new SchemaTableName(database, "presto_test_partition_schema_change_non_canonical");
 
-        temporaryCreateTable = temporaryTable("create");
         temporaryCreateRollbackTable = temporaryTable("create_rollback");
-        temporaryCreateEmptyTable = temporaryTable("create_empty");
-        temporaryInsertTable = temporaryTable("insert");
-        temporaryInsertIntoExistingPartitionTable = temporaryTable("insert_existing_partitioned");
-        temporaryInsertIntoNewPartitionTable = temporaryTable("insert_new_partitioned");
         temporaryInsertUnsupportedWriteType = temporaryTable("insert_unsupported_type");
-        temporaryMetadataDeleteTable = temporaryTable("metadata_delete");
         temporaryRenameTableOld = temporaryTable("rename_old");
         temporaryRenameTableNew = temporaryTable("rename_new");
         temporaryCreateView = temporaryTable("create_view");
-        temporaryDeleteInsert = temporaryTable("delete_insert");
-        temporaryMismatchSchemaTable = temporaryTable("mismatch_schema");
 
         invalidClientId = "hive";
         invalidTableHandle = new HiveTableHandle(invalidClientId, database, INVALID_TABLE);
@@ -814,6 +798,7 @@ public abstract class AbstractTestHiveClient
             if (storageFormat == JSON) {
                 continue;
             }
+            SchemaTableName temporaryMismatchSchemaTable = temporaryTable("mismatch_schema");
             try {
                 doTestMismatchSchemaTable(
                         temporaryMismatchSchemaTable,
@@ -1693,6 +1678,7 @@ public abstract class AbstractTestHiveClient
             throws Exception
     {
         for (HiveStorageFormat storageFormat : createTableFormats) {
+            SchemaTableName temporaryCreateTable = temporaryTable("create");
             try {
                 doCreateTable(temporaryCreateTable, storageFormat);
             }
@@ -1750,6 +1736,7 @@ public abstract class AbstractTestHiveClient
             throws Exception
     {
         for (HiveStorageFormat storageFormat : createTableFormats) {
+            SchemaTableName temporaryInsertTable = temporaryTable("insert");
             try {
                 doInsert(storageFormat, temporaryInsertTable);
             }
@@ -1764,6 +1751,7 @@ public abstract class AbstractTestHiveClient
             throws Exception
     {
         for (HiveStorageFormat storageFormat : createTableFormats) {
+            SchemaTableName temporaryInsertIntoNewPartitionTable = temporaryTable("insert_new_partitioned");
             try {
                 doInsertIntoNewPartition(storageFormat, temporaryInsertIntoNewPartitionTable);
             }
@@ -1778,6 +1766,7 @@ public abstract class AbstractTestHiveClient
             throws Exception
     {
         for (HiveStorageFormat storageFormat : createTableFormats) {
+            SchemaTableName temporaryInsertIntoExistingPartitionTable = temporaryTable("insert_existing_partitioned");
             try {
                 doInsertIntoExistingPartition(storageFormat, temporaryInsertIntoExistingPartitionTable);
             }
@@ -1804,6 +1793,7 @@ public abstract class AbstractTestHiveClient
             throws Exception
     {
         for (HiveStorageFormat storageFormat : createTableFormats) {
+            SchemaTableName temporaryMetadataDeleteTable = temporaryTable("metadata_delete");
             try {
                 doTestMetadataDelete(storageFormat, temporaryMetadataDeleteTable);
             }
@@ -1818,6 +1808,7 @@ public abstract class AbstractTestHiveClient
             throws Exception
     {
         for (HiveStorageFormat storageFormat : createTableFormats) {
+            SchemaTableName temporaryCreateEmptyTable = temporaryTable("create_empty");
             try {
                 doCreateEmptyTable(temporaryCreateEmptyTable, storageFormat, CREATE_TABLE_COLUMNS);
             }
@@ -3145,31 +3136,25 @@ public abstract class AbstractTestHiveClient
     public void testTransactionDeleteInsert()
             throws Exception
     {
-        try {
-            doTestTransactionDeleteInsert(
-                    RCBINARY,
-                    temporaryDeleteInsert,
-                    true,
-                    ImmutableList.<TransactionDeleteInsertTestCase>builder()
-                            .add(new TransactionDeleteInsertTestCase(false, false, ROLLBACK_RIGHT_AWAY, Optional.empty()))
-                            .add(new TransactionDeleteInsertTestCase(false, false, ROLLBACK_AFTER_DELETE, Optional.empty()))
-                            .add(new TransactionDeleteInsertTestCase(false, false, ROLLBACK_AFTER_BEGIN_INSERT, Optional.empty()))
-                            .add(new TransactionDeleteInsertTestCase(false, false, ROLLBACK_AFTER_APPEND_PAGE, Optional.empty()))
-                            .add(new TransactionDeleteInsertTestCase(false, false, ROLLBACK_AFTER_SINK_FINISH, Optional.empty()))
-                            .add(new TransactionDeleteInsertTestCase(false, false, ROLLBACK_AFTER_FINISH_INSERT, Optional.empty()))
-                            .add(new TransactionDeleteInsertTestCase(false, false, COMMIT, Optional.of(new AddPartitionFailure())))
-                            .add(new TransactionDeleteInsertTestCase(false, false, COMMIT, Optional.of(new DirectoryRenameFailure())))
-                            .add(new TransactionDeleteInsertTestCase(false, false, COMMIT, Optional.of(new FileRenameFailure())))
-                            .add(new TransactionDeleteInsertTestCase(true, false, COMMIT, Optional.of(new DropPartitionFailure())))
-                            .add(new TransactionDeleteInsertTestCase(true, true, COMMIT, Optional.empty()))
-                            .build());
-        }
-        finally {
-            dropTable(temporaryDeleteInsert);
-        }
+        doTestTransactionDeleteInsert(
+                RCBINARY,
+                true,
+                ImmutableList.<TransactionDeleteInsertTestCase>builder()
+                        .add(new TransactionDeleteInsertTestCase(false, false, ROLLBACK_RIGHT_AWAY, Optional.empty()))
+                        .add(new TransactionDeleteInsertTestCase(false, false, ROLLBACK_AFTER_DELETE, Optional.empty()))
+                        .add(new TransactionDeleteInsertTestCase(false, false, ROLLBACK_AFTER_BEGIN_INSERT, Optional.empty()))
+                        .add(new TransactionDeleteInsertTestCase(false, false, ROLLBACK_AFTER_APPEND_PAGE, Optional.empty()))
+                        .add(new TransactionDeleteInsertTestCase(false, false, ROLLBACK_AFTER_SINK_FINISH, Optional.empty()))
+                        .add(new TransactionDeleteInsertTestCase(false, false, ROLLBACK_AFTER_FINISH_INSERT, Optional.empty()))
+                        .add(new TransactionDeleteInsertTestCase(false, false, COMMIT, Optional.of(new AddPartitionFailure())))
+                        .add(new TransactionDeleteInsertTestCase(false, false, COMMIT, Optional.of(new DirectoryRenameFailure())))
+                        .add(new TransactionDeleteInsertTestCase(false, false, COMMIT, Optional.of(new FileRenameFailure())))
+                        .add(new TransactionDeleteInsertTestCase(true, false, COMMIT, Optional.of(new DropPartitionFailure())))
+                        .add(new TransactionDeleteInsertTestCase(true, true, COMMIT, Optional.empty()))
+                        .build());
     }
 
-    protected void doTestTransactionDeleteInsert(HiveStorageFormat storageFormat, SchemaTableName tableName, boolean allowInsertExisting, List<TransactionDeleteInsertTestCase> testCases)
+    protected void doTestTransactionDeleteInsert(HiveStorageFormat storageFormat, boolean allowInsertExisting, List<TransactionDeleteInsertTestCase> testCases)
             throws Exception
     {
         // There are 4 types of operations on a partition: add, drop, alter (drop then add), insert existing.
@@ -3218,35 +3203,32 @@ public abstract class AbstractTestHiveClient
                         .rows(insertData.getMaterializedRows())
                         .build();
 
-        boolean dirtyState = true;
         for (TransactionDeleteInsertTestCase testCase : testCases) {
-            if (dirtyState) {
-                // re-initialize the table
-                dropTable(tableName);
+            SchemaTableName temporaryDeleteInsert = temporaryTable("delete_insert");
+            try {
                 createEmptyTable(
-                        tableName,
+                        temporaryDeleteInsert,
                         storageFormat,
                         ImmutableList.of(new Column("col1", HIVE_LONG, Optional.empty())),
                         ImmutableList.of(new Column("pk1", HIVE_STRING, Optional.empty()), new Column("pk2", HIVE_STRING, Optional.empty())));
-                insertData(tableName, beforeData);
-                dirtyState = false;
+                insertData(temporaryDeleteInsert, beforeData);
+                try {
+                    doTestTransactionDeleteInsert(
+                            storageFormat,
+                            temporaryDeleteInsert,
+                            domainToDrop,
+                            insertData,
+                            testCase.isExpectCommitedData() ? afterData : beforeData,
+                            testCase.getTag(),
+                            testCase.isExpectQuerySucceed(),
+                            testCase.getConflictTrigger());
+                }
+                catch (AssertionError e) {
+                    throw new AssertionError(format("Test case: %s", testCase.toString()), e);
+                }
             }
-            try {
-                doTestTransactionDeleteInsert(
-                        storageFormat,
-                        tableName,
-                        domainToDrop,
-                        insertData,
-                        testCase.isExpectCommitedData() ? afterData : beforeData,
-                        testCase.getTag(),
-                        testCase.isExpectQuerySucceed(),
-                        testCase.getConflictTrigger());
-            }
-            catch (AssertionError e) {
-                throw new AssertionError(format("Test case: %s", testCase.toString()), e);
-            }
-            if (testCase.isExpectCommitedData()) {
-                dirtyState = true;
+            finally {
+                dropTable(temporaryDeleteInsert);
             }
         }
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -331,12 +331,6 @@ public abstract class AbstractTestHiveClient
     protected SchemaTableName tablePartitionSchemaChange;
     protected SchemaTableName tablePartitionSchemaChangeNonCanonical;
 
-    protected SchemaTableName temporaryCreateRollbackTable;
-    protected SchemaTableName temporaryInsertUnsupportedWriteType;
-    protected SchemaTableName temporaryRenameTableOld;
-    protected SchemaTableName temporaryRenameTableNew;
-    protected SchemaTableName temporaryCreateView;
-
     protected String invalidClientId;
     protected ConnectorTableHandle invalidTableHandle;
 
@@ -398,12 +392,6 @@ public abstract class AbstractTestHiveClient
         tableBucketedDoubleFloat = new SchemaTableName(database, "presto_test_bucketed_by_double_float");
         tablePartitionSchemaChange = new SchemaTableName(database, "presto_test_partition_schema_change");
         tablePartitionSchemaChangeNonCanonical = new SchemaTableName(database, "presto_test_partition_schema_change_non_canonical");
-
-        temporaryCreateRollbackTable = temporaryTable("create_rollback");
-        temporaryInsertUnsupportedWriteType = temporaryTable("insert_unsupported_type");
-        temporaryRenameTableOld = temporaryTable("rename_old");
-        temporaryRenameTableNew = temporaryTable("rename_new");
-        temporaryCreateView = temporaryTable("create_view");
 
         invalidClientId = "hive";
         invalidTableHandle = new HiveTableHandle(invalidClientId, database, INVALID_TABLE);
@@ -1648,6 +1636,8 @@ public abstract class AbstractTestHiveClient
     @Test
     public void testRenameTable()
     {
+        SchemaTableName temporaryRenameTableOld = temporaryTable("rename_old");
+        SchemaTableName temporaryRenameTableNew = temporaryTable("rename_new");
         try {
             createDummyTable(temporaryRenameTableOld);
 
@@ -1692,6 +1682,7 @@ public abstract class AbstractTestHiveClient
     public void testTableCreationRollback()
             throws Exception
     {
+        SchemaTableName temporaryCreateRollbackTable = temporaryTable("create_rollback");
         try {
             Path stagingPathRoot;
             try (Transaction transaction = newTransaction()) {
@@ -1780,6 +1771,7 @@ public abstract class AbstractTestHiveClient
     public void testInsertUnsupportedWriteType()
             throws Exception
     {
+        SchemaTableName temporaryInsertUnsupportedWriteType = temporaryTable("insert_unsupported_type");
         try {
             doInsertUnsupportedWriteType(ORC, temporaryInsertUnsupportedWriteType);
         }
@@ -1821,8 +1813,9 @@ public abstract class AbstractTestHiveClient
     @Test
     public void testViewCreation()
     {
+        SchemaTableName temporaryCreateView = temporaryTable("create_view");
         try {
-            verifyViewCreation();
+            verifyViewCreation(temporaryCreateView);
         }
         finally {
             try (Transaction transaction = newTransaction()) {
@@ -1869,7 +1862,7 @@ public abstract class AbstractTestHiveClient
         }
     }
 
-    private void verifyViewCreation()
+    private void verifyViewCreation(SchemaTableName temporaryCreateView)
     {
         // replace works for new view
         doCreateView(temporaryCreateView, true);


### PR DESCRIPTION
Some tests fail when run on a MapR container because
there is a small delay between the time a metadata operation
completes and the time those changes take effect on the MapR
file system. This caused a number of race conditions.