### PR TITLE
Reduce the memory footprint of map_agg and map_union

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
@@ -314,12 +314,12 @@ public class BigintGroupByHash
 
     private static int calculateMaxFill(int hashSize)
     {
-        checkArgument(hashSize > 0, "hashCapacity must greater than 0");
+        checkArgument(hashSize > 0, "hashSize must be greater than 0");
         int maxFill = (int) Math.ceil(hashSize * FILL_RATIO);
         if (maxFill == hashSize) {
             maxFill--;
         }
-        checkArgument(hashSize > maxFill, "hashCapacity must be larger than maxFill");
+        checkArgument(hashSize > maxFill, "hashSize must be larger than maxFill");
         return maxFill;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -416,7 +416,7 @@ public class MultiChannelGroupByHash
 
     private static int calculateMaxFill(int hashSize)
     {
-        checkArgument(hashSize > 0, "hashSize must greater than 0");
+        checkArgument(hashSize > 0, "hashSize must be greater than 0");
         int maxFill = (int) Math.ceil(hashSize * FILL_RATIO);
         if (maxFill == hashSize) {
             maxFill--;

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/KeyValuePairs.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/KeyValuePairs.java
@@ -13,13 +13,22 @@
  */
 package com.facebook.presto.operator.aggregation;
 
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.Arrays;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static com.facebook.presto.type.TypeUtils.expectedValueSize;
+import static com.facebook.presto.type.TypeUtils.hashPosition;
+import static com.facebook.presto.type.TypeUtils.positionEqualsPosition;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static it.unimi.dsi.fastutil.HashCommon.arraySize;
 import static java.util.Objects.requireNonNull;
 
 public class KeyValuePairs
@@ -27,21 +36,31 @@ public class KeyValuePairs
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(KeyValuePairs.class).instanceSize();
     private static final int EXPECTED_ENTRIES = 10;
     private static final int EXPECTED_ENTRY_SIZE = 16;
+    private static final float FILL_RATIO = 0.75f;
+    private static final int EMPTY_SLOT = -1;
 
-    private final TypedSet keySet;
     private final BlockBuilder keyBlockBuilder;
     private final Type keyType;
 
     private final BlockBuilder valueBlockBuilder;
     private final Type valueType;
 
+    private int[] keyPositionByHash;
+    private int hashCapacity;
+    private int maxFill;
+    private int hashMask;
+
     public KeyValuePairs(Type keyType, Type valueType)
     {
         this.keyType = requireNonNull(keyType, "keyType is null");
         this.valueType = requireNonNull(valueType, "valueType is null");
-        this.keySet = new TypedSet(keyType, EXPECTED_ENTRIES);
         keyBlockBuilder = this.keyType.createBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES, expectedValueSize(keyType, EXPECTED_ENTRY_SIZE));
         valueBlockBuilder = this.valueType.createBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES, expectedValueSize(valueType, EXPECTED_ENTRY_SIZE));
+        hashCapacity = arraySize(EXPECTED_ENTRIES, FILL_RATIO);
+        this.maxFill = calculateMaxFill(hashCapacity);
+        this.hashMask = hashCapacity - 1;
+        keyPositionByHash = new int[hashCapacity];
+        Arrays.fill(keyPositionByHash, EMPTY_SLOT);
     }
 
     public KeyValuePairs(Block serialized, Type keyType, Type valueType)
@@ -82,19 +101,18 @@ public class KeyValuePairs
         long size = INSTANCE_SIZE;
         size += keyBlockBuilder.getRetainedSizeInBytes();
         size += valueBlockBuilder.getRetainedSizeInBytes();
-        size += keySet.getRetainedSizeInBytes();
+        size += sizeOf(keyPositionByHash);
         return size;
     }
 
     /**
-     * Only add this key value pair if we haven't met this key before.
+     * Only add this key value pair if we haven't seen this key before.
      * Otherwise, ignore it.
      */
     public void add(Block key, Block value, int keyPosition, int valuePosition)
     {
-        if (!keySet.contains(key, keyPosition)) {
-            keySet.add(key, keyPosition);
-            keyType.appendTo(key, keyPosition, keyBlockBuilder);
+        if (!keyExists(key, keyPosition)) {
+            addKey(key, keyPosition);
             if (value.isNull(valuePosition)) {
                 valueBlockBuilder.appendNull();
             }
@@ -102,5 +120,71 @@ public class KeyValuePairs
                 valueType.appendTo(value, valuePosition, valueBlockBuilder);
             }
         }
+    }
+
+    private boolean keyExists(Block key, int position)
+    {
+        checkArgument(position >= 0, "position is negative");
+        return keyPositionByHash[getHashPositionOfKey(key, position)] != EMPTY_SLOT;
+    }
+
+    private void addKey(Block key, int position)
+    {
+        checkArgument(position >= 0, "position is negative");
+        keyType.appendTo(key, position, keyBlockBuilder);
+        int hashPosition = getHashPositionOfKey(key, position);
+        if (keyPositionByHash[hashPosition] == EMPTY_SLOT) {
+            keyPositionByHash[hashPosition] = keyBlockBuilder.getPositionCount() - 1;
+            if (keyBlockBuilder.getPositionCount() >= maxFill) {
+                rehash();
+            }
+        }
+    }
+
+    private int getHashPositionOfKey(Block key, int position)
+    {
+        int hashPosition = getMaskedHash(hashPosition(keyType, key, position));
+        while (true) {
+            if (keyPositionByHash[hashPosition] == EMPTY_SLOT) {
+                return hashPosition;
+            }
+            else if (positionEqualsPosition(keyType, keyBlockBuilder, keyPositionByHash[hashPosition], key, position)) {
+                return hashPosition;
+            }
+            hashPosition = getMaskedHash(hashPosition + 1);
+        }
+    }
+
+    private void rehash()
+    {
+        long newCapacityLong = hashCapacity * 2L;
+        if (newCapacityLong > Integer.MAX_VALUE) {
+            throw new PrestoException(GENERIC_INSUFFICIENT_RESOURCES, "Size of hash table cannot exceed 1 billion entries");
+        }
+        int newCapacity = (int) newCapacityLong;
+        hashCapacity = newCapacity;
+        hashMask = newCapacity - 1;
+        maxFill = calculateMaxFill(newCapacity);
+        keyPositionByHash = new int[newCapacity];
+        Arrays.fill(keyPositionByHash, EMPTY_SLOT);
+        for (int position = 0; position < keyBlockBuilder.getPositionCount(); position++) {
+            keyPositionByHash[getHashPositionOfKey(keyBlockBuilder, position)] = position;
+        }
+    }
+
+    private static int calculateMaxFill(int hashSize)
+    {
+        checkArgument(hashSize > 0, "hashSize must be greater than 0");
+        int maxFill = (int) Math.ceil(hashSize * FILL_RATIO);
+        if (maxFill == hashSize) {
+            maxFill--;
+        }
+        checkArgument(hashSize > maxFill, "hashSize must be larger than maxFill");
+        return maxFill;
+    }
+
+    private int getMaskedHash(long rawHash)
+    {
+        return (int) (rawHash & hashMask);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedHistogram.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.array.IntBigArray;
 import com.facebook.presto.array.LongBigArray;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -26,6 +27,7 @@ import io.airlift.units.DataSize;
 import org.openjdk.jol.info.ClassLayout;
 
 import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalLimit;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -40,6 +42,7 @@ public class TypedHistogram
     private static final float FILL_RATIO = 0.9f;
     private static final long FOUR_MEGABYTES = new DataSize(4, MEGABYTE).toBytes();
 
+    private int hashCapacity;
     private int maxFill;
     private int mask;
 
@@ -55,15 +58,15 @@ public class TypedHistogram
 
         checkArgument(expectedSize > 0, "expectedSize must be greater than zero");
 
-        int hashSize = arraySize(expectedSize, FILL_RATIO);
+        hashCapacity = arraySize(expectedSize, FILL_RATIO);
 
-        maxFill = calculateMaxFill(hashSize);
-        mask = hashSize - 1;
-        values = this.type.createBlockBuilder(new BlockBuilderStatus(), hashSize);
+        maxFill = calculateMaxFill(hashCapacity);
+        mask = hashCapacity - 1;
+        values = this.type.createBlockBuilder(new BlockBuilderStatus(), hashCapacity);
         hashPositions = new IntBigArray(-1);
-        hashPositions.ensureCapacity(hashSize);
+        hashPositions.ensureCapacity(hashCapacity);
         counts = new LongBigArray();
-        counts.ensureCapacity(hashSize);
+        counts.ensureCapacity(hashCapacity);
     }
 
     public TypedHistogram(Block block, Type type, int expectedSize)
@@ -143,7 +146,7 @@ public class TypedHistogram
 
         // increase capacity, if necessary
         if (values.getPositionCount() >= maxFill) {
-            rehash(maxFill * 2);
+            rehash();
         }
 
         if (getEstimatedSize() > FOUR_MEGABYTES) {
@@ -151,13 +154,17 @@ public class TypedHistogram
         }
     }
 
-    private void rehash(int size)
+    private void rehash()
     {
-        int newSize = arraySize(size + 1, FILL_RATIO);
+        long newCapacityLong = hashCapacity * 2L;
+        if (newCapacityLong > Integer.MAX_VALUE) {
+            throw new PrestoException(GENERIC_INSUFFICIENT_RESOURCES, "Size of hash table cannot exceed 1 billion entries");
+        }
+        int newCapacity = (int) newCapacityLong;
 
-        int newMask = newSize - 1;
+        int newMask = newCapacity - 1;
         IntBigArray newHashPositions = new IntBigArray(-1);
-        newHashPositions.ensureCapacity(newSize);
+        newHashPositions.ensureCapacity(newCapacity);
 
         for (int i = 0; i < values.getPositionCount(); i++) {
             // find an empty slot for the address
@@ -170,8 +177,9 @@ public class TypedHistogram
             newHashPositions.set(hashPosition, i);
         }
 
+        hashCapacity = newCapacity;
         mask = newMask;
-        maxFill = calculateMaxFill(newSize);
+        maxFill = calculateMaxFill(newCapacity);
         hashPositions = newHashPositions;
 
         this.counts.ensureCapacity(maxFill);
@@ -184,7 +192,7 @@ public class TypedHistogram
 
     private static int calculateMaxFill(int hashSize)
     {
-        checkArgument(hashSize > 0, "hashSize must greater than 0");
+        checkArgument(hashSize > 0, "hashSize must be greater than 0");
         int maxFill = (int) Math.ceil(hashSize * FILL_RATIO);
         if (maxFill == hashSize) {
             maxFill--;


### PR DESCRIPTION
I moved the key deduping logic from `TypedSet` to `KeyValuePairs` to prevent holding onto the blocks in #7421. Instead of keeping references to individual block elements I now hold indices into the `keyBlockBuilder` to maintain a single copy of the keys. With this change I see ~30-40% less memory being used with the test query in #7342.

Fixes #7342.
Supersedes #7421.