### PR TITLE
Apply canonicalization recursively for join nodes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CanonicalizeExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CanonicalizeExpressions.java
@@ -78,8 +78,8 @@ public class CanonicalizeExpressions
                     return new JoinNode(
                             node.getId(),
                             node.getType(),
-                            node.getLeft(),
-                            node.getRight(),
+                            context.rewrite(node.getLeft()),
+                            context.rewrite(node.getRight()),
                             node.getCriteria(),
                             node.getOutputSymbols(),
                             Optional.of(canonicalizedExpression),
@@ -89,7 +89,7 @@ public class CanonicalizeExpressions
                 }
             }
 
-            return node;
+            return context.defaultRewrite(node);
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalize.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalize.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+
+public class TestCanonicalize
+        extends BasePlanTest
+{
+    @Test
+    public void testJoin()
+            throws Exception
+    {
+        assertPlan("SELECT *\n" +
+                        "FROM (\n" +
+                        "    SELECT EXTRACT(DAY FROM DATE '2017-01-01')\n" +
+                        ") t\n" +
+                        "CROSS JOIN (VALUES 1)",
+                anyTree(
+                        join(INNER, ImmutableList.of(), Optional.empty(),
+                                project(
+                                        ImmutableMap.of("X", expression("BIGINT '1'")),
+                                        values(ImmutableMap.of())),
+                                values(ImmutableMap.of()))));
+    }
+}


### PR DESCRIPTION
When canonicalization of expression for joins was moved to the optimizer
(commit 4c175ed28dc61cd73b8e82ad89a5135d95b820a1), the code had a bug
where it wouldn't recurse and apply the transformations to the children
of the join node.

Fixes https://github.com/prestodb/presto/issues/7577