### PR TITLE
Add flag to enable modification on hive external table

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -56,6 +56,7 @@ public class HiveClientConfig
     private int domainCompactionThreshold = 100;
     private boolean forceLocalScheduling;
     private boolean recursiveDirWalkerEnabled;
+    private boolean hiveExternalTableWritable;
 
     private int maxConcurrentFileRenames = 20;
 
@@ -189,10 +190,21 @@ public class HiveClientConfig
         this.recursiveDirWalkerEnabled = recursiveDirWalkerEnabled;
         return this;
     }
+    @Config("hive.external-table-writable")
+    public HiveClientConfig setHiveExternalTableWritable(boolean hiveExternalTableWritable)
+    {
+        this.hiveExternalTableWritable = hiveExternalTableWritable;
+        return this;
+    }
 
     public boolean getRecursiveDirWalkerEnabled()
     {
         return recursiveDirWalkerEnabled;
+    }
+        
+    public boolean getHiveExternalTableWritable()
+    {
+        return hiveExternalTableWritable;
     }
 
     public DateTimeZone getDateTimeZone()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -764,7 +764,7 @@ public class HiveMetadata
             throw new TableNotFoundException(tableName);
         }
 
-        checkTableIsWritable(table.get());
+        checkTableIsWritable(table.get(), session);
 
         for (Column column : table.get().getDataColumns()) {
             if (!isWritableType(column.getType())) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -40,6 +40,7 @@ public final class HiveSessionProperties
     private static final String RCFILE_OPTIMIZED_READER_ENABLED = "rcfile_optimized_reader_enabled";
     private static final String RCFILE_OPTIMIZED_WRITER_ENABLED = "rcfile_optimized_writer_enabled";
     private static final String RCFILE_OPTIMIZED_WRITER_VALIDATE = "rcfile_optimized_writer_validate";
+    private static final String HIVE_EXTERNAL_TABLE_WRITABLE = "hive_external_table_writable";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -111,6 +112,11 @@ public final class HiveSessionProperties
                         RCFILE_OPTIMIZED_WRITER_VALIDATE,
                         "Experimental: RCFile: Validate writer files",
                         true,
+                        false),
+                booleanSessionProperty(
+                        HIVE_EXTERNAL_TABLE_WRITABLE,
+                        "Enable writable Hive external tables",
+                        config.getHiveExternalTableWritable(),                       
                         false));
     }
 
@@ -184,6 +190,11 @@ public final class HiveSessionProperties
         return session.getProperty(RCFILE_OPTIMIZED_WRITER_VALIDATE, Boolean.class);
     }
 
+    public static boolean getHiveExternalTableWritable(ConnectorSession session)
+    {
+        return session.getProperty(HIVE_EXTERNAL_TABLE_WRITABLE, Boolean.class);
+    }
+    
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)
     {
         return new PropertyMetadata<>(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
 import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
@@ -96,6 +97,7 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_DATABASE_LOCATION_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
+import static com.facebook.presto.hive.HiveSessionProperties.getHiveExternalTableWritable;
 import static com.facebook.presto.hive.HiveSplitManager.PRESTO_OFFLINE;
 import static com.facebook.presto.hive.HiveUtil.checkCondition;
 import static com.facebook.presto.hive.HiveUtil.isArrayType;
@@ -330,10 +332,10 @@ public final class HiveWriteUtils
         throw new PrestoException(NOT_SUPPORTED, "unsupported type: " + type);
     }
 
-    public static void checkTableIsWritable(Table table)
+    public static void checkTableIsWritable(Table table, ConnectorSession session)
     {
-        if (!table.getTableType().equals(MANAGED_TABLE.toString())) {
-            throw new PrestoException(NOT_SUPPORTED, "Cannot write to non-managed Hive table");
+        if (!getHiveExternalTableWritable(session) && !table.getTableType().equals(MANAGED_TABLE.toString())) {
+            throw new PrestoException(NOT_SUPPORTED, "Cannot write to Hive external table");
         }
 
         checkWritable(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -90,7 +90,8 @@ public class TestHiveClientConfig
                 .setSkipDeletionForAlter(false)
                 .setBucketExecutionEnabled(true)
                 .setBucketWritingEnabled(true)
-                .setFileSystemMaxCacheSize(1000));
+                .setFileSystemMaxCacheSize(1000)
+                .setHiveExternalTableWritable(false));
     }
 
     @Test
@@ -154,6 +155,7 @@ public class TestHiveClientConfig
                 .put("hive.bucket-execution", "false")
                 .put("hive.bucket-writing", "false")
                 .put("hive.fs.cache.max-size", "1010")
+                .put("hive.external-table-writable", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -213,7 +215,8 @@ public class TestHiveClientConfig
                 .setSkipDeletionForAlter(true)
                 .setBucketExecutionEnabled(false)
                 .setBucketWritingEnabled(false)
-                .setFileSystemMaxCacheSize(1010);
+                .setFileSystemMaxCacheSize(1010)
+                .setHiveExternalTableWritable(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Add flag to enable modification on hive external table, based on https://github.com/prestodb/presto/pull/5462 , presto disabled modification on hive-external table from presto. But we think we can add one flag to control this behavior. 
Because we wanna keep updated with community, we already push this change for our internal usage. And this flag can provide a option for presto user whether to enable or disable hive external table modification. And this flag is based on catalog config file, so user can have multiple catalog for hive, but only enable the one they want to use to modify hive external table. So, it's pretty flexible. 