### PR TITLE
Add --exit-on-error client option and make sure CLI return -1 on failure

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -105,6 +105,9 @@ public class ClientOptions
     @Option(name = "--execute", title = "execute", description = "Execute specified statements and exit")
     public String execute;
 
+    @Option(name = "--exit-on-error", title = "exit-on-error", description = "exit when any query from --execute or --file failed and return -1")
+    public boolean exitOnErr = false;
+
     @Option(name = "--output-format", title = "output-format", description = "Output format for batch mode [ALIGNED, VERTICAL, CSV, TSV, CSV_HEADER, TSV_HEADER, NULL] (default: CSV)")
     public OutputFormat outputFormat = OutputFormat.CSV;
 


### PR DESCRIPTION
The old version of CLI allows several statements submitted and continues to run no matter the previous statement succeeded or not, and also would not  return -1 once a query failed.
When --exit-on-error enabled, this problem will fixed, and only be efficient with --execute or --file.

    presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
    presto-cli/src/main/java/com/facebook/presto/cli/Console.java