### PR TITLE
ObjectID fix for MongoDB connector

### DIFF
--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -145,9 +145,9 @@ public class MongoSession
         ImmutableSet.Builder<String> builder = ImmutableSet.builder();
 
         builder.addAll(ImmutableList.copyOf(client.getDatabase(schema).listCollectionNames()).stream()
-                            .filter(name -> !name.equals(schemaCollection))
-                            .filter(name -> !SYSTEM_TABLES.contains(name))
-                            .collect(toSet()));
+                .filter(name -> !name.equals(schemaCollection))
+                .filter(name -> !SYSTEM_TABLES.contains(name))
+                .collect(toSet()));
         builder.addAll(getTableMetadataNames(schema));
 
         return builder.build();
@@ -287,30 +287,30 @@ public class MongoSession
                 Document rangeConjuncts = new Document();
                 if (!range.getLow().isLowerUnbounded()) {
                     switch (range.getLow().getBound()) {
-                    case ABOVE:
-                        rangeConjuncts.put(GT_OP, range.getLow().getValue());
-                        break;
-                    case EXACTLY:
-                        rangeConjuncts.put(GTE_OP, range.getLow().getValue());
-                        break;
-                    case BELOW:
-                        throw new IllegalArgumentException("Low Marker should never use BELOW bound: " + range);
-                    default:
-                        throw new AssertionError("Unhandled bound: " + range.getLow().getBound());
+                        case ABOVE:
+                            rangeConjuncts.put(GT_OP, range.getLow().getValue());
+                            break;
+                        case EXACTLY:
+                            rangeConjuncts.put(GTE_OP, range.getLow().getValue());
+                            break;
+                        case BELOW:
+                            throw new IllegalArgumentException("Low Marker should never use BELOW bound: " + range);
+                        default:
+                            throw new AssertionError("Unhandled bound: " + range.getLow().getBound());
                     }
                 }
                 if (!range.getHigh().isUpperUnbounded()) {
                     switch (range.getHigh().getBound()) {
-                    case ABOVE:
-                        throw new IllegalArgumentException("High Marker should never use ABOVE bound: " + range);
-                    case EXACTLY:
-                        rangeConjuncts.put(LTE_OP, range.getHigh().getValue());
-                        break;
-                    case BELOW:
-                        rangeConjuncts.put(LT_OP, range.getHigh().getValue());
-                        break;
-                    default:
-                        throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
+                        case ABOVE:
+                            throw new IllegalArgumentException("High Marker should never use ABOVE bound: " + range);
+                        case EXACTLY:
+                            rangeConjuncts.put(LTE_OP, range.getHigh().getValue());
+                            break;
+                        case BELOW:
+                            rangeConjuncts.put(LT_OP, range.getHigh().getValue());
+                            break;
+                        default:
+                            throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
                     }
                 }
                 // If rangeConjuncts is null, then the range was ALL, which should already have been checked for
@@ -334,8 +334,8 @@ public class MongoSession
         }
 
         return orPredicate(disjuncts.stream()
-                            .map(disjunct -> new Document(name, disjunct))
-                            .collect(toList()));
+                .map(disjunct -> new Document(name, disjunct))
+                .collect(toList()));
     }
 
     private static Object translateValue(Object source)
@@ -442,8 +442,8 @@ public class MongoSession
         }
 
         fields.addAll(columns.stream()
-                        .map(MongoColumnHandle::getDocument)
-                        .collect(toList()));
+                .map(MongoColumnHandle::getDocument)
+                .collect(toList()));
 
         metadata.append(FIELDS_KEY, fields);
 
@@ -539,8 +539,8 @@ public class MongoSession
             Set<TypeSignature> signatures = subTypes.stream().map(t -> t.get()).collect(toSet());
             if (signatures.size() == 1) {
                 typeSignature = new TypeSignature(StandardTypes.ARRAY, signatures.stream()
-                                                                        .map(s -> TypeSignatureParameter.of(s))
-                                                                        .collect(Collectors.toList()));
+                        .map(s -> TypeSignatureParameter.of(s))
+                        .collect(Collectors.toList()));
             }
             else {
                 // TODO: presto cli doesn't handle empty field name row type yet

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -70,7 +70,8 @@ public class TestMongoIntegrationSmokeTest
                 ", 3.14 _double" +
                 ", true _boolean" +
                 ", DATE '1980-05-07' _date" +
-                ", TIMESTAMP '1980-05-07 11:22:33.456' _timestamp";
+                ", TIMESTAMP '1980-05-07 11:22:33.456' _timestamp" +
+                ", ObjectId('ffffffffffffffffffffffff') _objectid";
 
         assertUpdate(query, 1);
 
@@ -150,6 +151,14 @@ public class TestMongoIntegrationSmokeTest
         assertOneNotNullResult("SELECT col[DATE '2014-09-30'] FROM tmp_map6");
         assertUpdate("CREATE TABLE tmp_map7 AS SELECT MAP(ARRAY[TIMESTAMP '2001-08-22 03:04:05.321'], ARRAY[TIMESTAMP '2001-08-22 03:04:05.321']) AS col", 1);
         assertOneNotNullResult("SELECT col[TIMESTAMP '2001-08-22 03:04:05.321'] FROM tmp_map7");
+    }
+
+    @Test
+    public void testObjectIds()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE tmp_objectid AS SELECT ObjectId('ffffffffffffffffffffffff') AS id", 1);
+        assertOneNotNullResult("SELECT id FROM tmp_objectid WHERE id = ObjectId('ffffffffffffffffffffffff')");
     }
 
     private void assertOneNotNullResult(String query)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -230,6 +230,9 @@ public class TestingPrestoClient
         else if (type instanceof DecimalType) {
             return new BigDecimal((String) value);
         }
+        else if (type.toString().equals("ObjectId")) {
+            return value;
+        }
         else {
             throw new AssertionError("unhandled type: " + type);
         }


### PR DESCRIPTION
When querying using an ObjectId it returns 0 results even the ObjectId is present in the database. Solved by checking the type when translating values.