### PR TITLE
Consider block builder status size when calculating retained size

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 public class ByteArrayBlockBuilder
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ByteArrayBlockBuilder.class).instanceSize();
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ByteArrayBlockBuilder.class).instanceSize() + BlockBuilderStatus.INSTANCE_SIZE;
 
     private BlockBuilderStatus blockBuilderStatus;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 public class IntArrayBlockBuilder
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntArrayBlockBuilder.class).instanceSize();
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntArrayBlockBuilder.class).instanceSize() + BlockBuilderStatus.INSTANCE_SIZE;
 
     private BlockBuilderStatus blockBuilderStatus;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
 public class LongArrayBlockBuilder
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongArrayBlockBuilder.class).instanceSize();
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongArrayBlockBuilder.class).instanceSize() + BlockBuilderStatus.INSTANCE_SIZE;
 
     private BlockBuilderStatus blockBuilderStatus;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 public class ShortArrayBlockBuilder
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ShortArrayBlockBuilder.class).instanceSize();
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ShortArrayBlockBuilder.class).instanceSize() + BlockBuilderStatus.INSTANCE_SIZE;
 
     private BlockBuilderStatus blockBuilderStatus;
 


### PR DESCRIPTION
There is some inconsistency in the way we calculate the retained sizes in block builders. For example, in `FixedWidthBlockBuilder` and `ArrayBlockBuilder` we take `BlockBuilderStatus.INSTANCE_SIZE` into account while in some other block builders we don't. This PR fixes that.