### PR TITLE
Remove misleading "HDFS" from Hive error messages

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/HdfsOrcDataSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/HdfsOrcDataSource.java
@@ -54,7 +54,7 @@ public class HdfsOrcDataSource
             throw e;
         }
         catch (Exception e) {
-            String message = format("HDFS error reading from %s at position %s", this, position);
+            String message = format("Error reading from %s at position %s", this, position);
             if (e.getClass().getSimpleName().equals("BlockMissingException")) {
                 throw new PrestoException(HIVE_MISSING_DATA, message, e);
             }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/HdfsParquetDataSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/HdfsParquetDataSource.java
@@ -86,7 +86,7 @@ public class HdfsParquetDataSource
             throw e;
         }
         catch (Exception e) {
-            throw new PrestoException(HIVE_FILESYSTEM_ERROR, format("HDFS error reading from %s at position %s", name, position), e);
+            throw new PrestoException(HIVE_FILESYSTEM_ERROR, format("Error reading from %s at position %s", name, position), e);
         }
     }
 


### PR DESCRIPTION
We could be reading from a different file system such as S3.