### PR TITLE
Fix datetime doc - formatting functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -168,10 +168,10 @@ Specifier Description
 ========= ===========
 ``%a``    Abbreviated weekday name (``Sun`` .. ``Sat``)
 ``%b``    Abbreviated month name (``Jan`` .. ``Dec``)
-``%c``    Month, numeric (``0`` .. ``12``)
+``%c``    Month, numeric (``1`` .. ``12`` [#u]_)
 ``%D``    Day of the month with English suffix (``0th``, ``1st``, ``2nd``, ``3rd``, ...)
-``%d``    Day of the month, numeric (``00`` .. ``31``)
-``%e``    Day of the month, numeric (``0`` .. ``31``)
+``%d``    Day of the month, numeric (``01`` .. ``31`` [#u]_)
+``%e``    Day of the month, numeric (``0`` .. ``31`` [#u]_)
 ``%f``    Fraction of second (6 digits for printing: ``000000`` .. ``999000``; 1 - 9 digits for parsing: ``0`` .. ``999999999`` [#f]_)
 ``%H``    Hour (``00`` .. ``23``)
 ``%h``    Hour (``01`` .. ``12``)
@@ -181,7 +181,7 @@ Specifier Description
 ``%k``    Hour (``0`` .. ``23``)
 ``%l``    Hour (``1`` .. ``12``)
 ``%M``    Month name (``January`` .. ``December``)
-``%m``    Month, numeric (``00`` .. ``12``)
+``%m``    Month, numeric (``01`` .. ``12``)
 ``%p``    ``AM`` or ``PM``
 ``%r``    Time, 12-hour (``hh:mm:ss`` followed by ``AM`` or ``PM``)
 ``%S``    Seconds (``00`` .. ``59``)
@@ -192,7 +192,7 @@ Specifier Description
 ``%V``    Week (``01`` .. ``53``), where Sunday is the first day of the week; used with ``%X``
 ``%v``    Week (``01`` .. ``53``), where Monday is the first day of the week; used with ``%x``
 ``%W``    Weekday name (``Sunday`` .. ``Saturday``)
-``%w``    Day of the week (``0`` .. ``6``), where Sunday is the first day of the week
+``%w``    Day of the week (``1`` .. ``7``), where Sunday is the first day of the week [#u]_
 ``%X``    Year for the week where Sunday is the first day of the week, numeric, four digits; used with ``%V``
 ``%x``    Year for the week, where Monday is the first day of the week, numeric, four digits; used with ``%v``
 ``%Y``    Year, numeric, four digits
@@ -203,6 +203,7 @@ Specifier Description
 
 .. [#f] Timestamp is truncated to milliseconds.
 .. [#y] When parsing, two-digit year format assumes range ``1970`` .. ``2069``, so "70" will result in year ``1970`` but "69" will produce ``2069``.
+.. [#u] The function not behave the same as MySQL.
 
 .. warning:: The following specifiers are not currently supported: ``%D %U %u %V %w %X``
 

--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -168,10 +168,10 @@ Specifier Description
 ========= ===========
 ``%a``    Abbreviated weekday name (``Sun`` .. ``Sat``)
 ``%b``    Abbreviated month name (``Jan`` .. ``Dec``)
-``%c``    Month, numeric (``1`` .. ``12`` [#u]_)
+``%c``    Month, numeric (``1`` .. ``12`` [#z]_)
 ``%D``    Day of the month with English suffix (``0th``, ``1st``, ``2nd``, ``3rd``, ...)
-``%d``    Day of the month, numeric (``01`` .. ``31`` [#u]_)
-``%e``    Day of the month, numeric (``1`` .. ``31`` [#u]_)
+``%d``    Day of the month, numeric (``01`` .. ``31`` [#z]_)
+``%e``    Day of the month, numeric (``1`` .. ``31`` [#z]_)
 ``%f``    Fraction of second (6 digits for printing: ``000000`` .. ``999000``; 1 - 9 digits for parsing: ``0`` .. ``999999999`` [#f]_)
 ``%H``    Hour (``00`` .. ``23``)
 ``%h``    Hour (``01`` .. ``12``)
@@ -181,7 +181,7 @@ Specifier Description
 ``%k``    Hour (``0`` .. ``23``)
 ``%l``    Hour (``1`` .. ``12``)
 ``%M``    Month name (``January`` .. ``December``)
-``%m``    Month, numeric (``01`` .. ``12`` [#u]_)
+``%m``    Month, numeric (``01`` .. ``12`` [#z]_)
 ``%p``    ``AM`` or ``PM``
 ``%r``    Time, 12-hour (``hh:mm:ss`` followed by ``AM`` or ``PM``)
 ``%S``    Seconds (``00`` .. ``59``)
@@ -192,7 +192,7 @@ Specifier Description
 ``%V``    Week (``01`` .. ``53``), where Sunday is the first day of the week; used with ``%X``
 ``%v``    Week (``01`` .. ``53``), where Monday is the first day of the week; used with ``%x``
 ``%W``    Weekday name (``Sunday`` .. ``Saturday``)
-``%w``    Day of the week (``0`` .. ``6``), where Sunday is the first day of the week [#v]_
+``%w``    Day of the week (``0`` .. ``6``), where Sunday is the first day of the week [#w]_
 ``%X``    Year for the week where Sunday is the first day of the week, numeric, four digits; used with ``%V``
 ``%x``    Year for the week, where Monday is the first day of the week, numeric, four digits; used with ``%v``
 ``%Y``    Year, numeric, four digits
@@ -203,8 +203,8 @@ Specifier Description
 
 .. [#f] Timestamp is truncated to milliseconds.
 .. [#y] When parsing, two-digit year format assumes range ``1970`` .. ``2069``, so "70" will result in year ``1970`` but "69" will produce ``2069``.
-.. [#u] The function not behave the same as MySQL.
-.. [#v] The function not supported yet, consider using `DAY_OF_WEEK` which using `1-7` values (in MySQL using `0-6` values).
+.. [#w] This specifier is not supported yet. Consider using :func:`day_of_week` (it uses ``1-7`` instead of ``0-6``).
+.. [#z] This specifier does not support ``0`` as a month or day.
 
 .. warning:: The following specifiers are not currently supported: ``%D %U %u %V %w %X``
 

--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -181,7 +181,7 @@ Specifier Description
 ``%k``    Hour (``0`` .. ``23``)
 ``%l``    Hour (``1`` .. ``12``)
 ``%M``    Month name (``January`` .. ``December``)
-``%m``    Month, numeric (``01`` .. ``12``)
+``%m``    Month, numeric (``01`` .. ``12`` [#u]_)
 ``%p``    ``AM`` or ``PM``
 ``%r``    Time, 12-hour (``hh:mm:ss`` followed by ``AM`` or ``PM``)
 ``%S``    Seconds (``00`` .. ``59``)

--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -192,7 +192,7 @@ Specifier Description
 ``%V``    Week (``01`` .. ``53``), where Sunday is the first day of the week; used with ``%X``
 ``%v``    Week (``01`` .. ``53``), where Monday is the first day of the week; used with ``%x``
 ``%W``    Weekday name (``Sunday`` .. ``Saturday``)
-``%w``    Day of the week (``1`` .. ``7``), where Sunday is the first day of the week [#u]_
+``%w``    Day of the week (``0`` .. ``6``), where Sunday is the first day of the week [#v]_
 ``%X``    Year for the week where Sunday is the first day of the week, numeric, four digits; used with ``%V``
 ``%x``    Year for the week, where Monday is the first day of the week, numeric, four digits; used with ``%v``
 ``%Y``    Year, numeric, four digits
@@ -204,6 +204,7 @@ Specifier Description
 .. [#f] Timestamp is truncated to milliseconds.
 .. [#y] When parsing, two-digit year format assumes range ``1970`` .. ``2069``, so "70" will result in year ``1970`` but "69" will produce ``2069``.
 .. [#u] The function not behave the same as MySQL.
+.. [#v] The function not supported yet, consider using `DAY_OF_WEEK` which using `1-7` values (in MySQL using `0-6` values).
 
 .. warning:: The following specifiers are not currently supported: ``%D %U %u %V %w %X``
 

--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -171,7 +171,7 @@ Specifier Description
 ``%c``    Month, numeric (``1`` .. ``12`` [#u]_)
 ``%D``    Day of the month with English suffix (``0th``, ``1st``, ``2nd``, ``3rd``, ...)
 ``%d``    Day of the month, numeric (``01`` .. ``31`` [#u]_)
-``%e``    Day of the month, numeric (``0`` .. ``31`` [#u]_)
+``%e``    Day of the month, numeric (``1`` .. ``31`` [#u]_)
 ``%f``    Fraction of second (6 digits for printing: ``000000`` .. ``999000``; 1 - 9 digits for parsing: ``0`` .. ``999999999`` [#f]_)
 ``%H``    Hour (``00`` .. ``23``)
 ``%h``    Hour (``01`` .. ``12``)


### PR DESCRIPTION
Fix the datetime functions format docs to behave as they are really behave in Presto and not like in MySQL