### PR TITLE
Update block size estimates when creating new page builders in group by hash

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -235,6 +235,13 @@ public class ArrayBlockBuilder
     }
 
     @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        int newSize = calculateBlockResetSize(getPositionCount());
+        return new ArrayBlockBuilder(blockBuilderStatus, values.newBlockBuilderLike(blockBuilderStatus), new int[newSize + 1], new boolean[newSize]);
+    }
+
+    @Override
     public String toString()
     {
         StringBuilder sb = new StringBuilder("ArrayBlockBuilder{");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayElementBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayElementBlockWriter.java
@@ -139,6 +139,12 @@ public class ArrayElementBlockWriter
     }
 
     @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String toString()
     {
         StringBuilder sb = new StringBuilder("ArrayElementBlockWriter{");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
@@ -94,4 +94,9 @@ public interface BlockBuilder
      * Resets the block builder, clearing all of the data.
      */
     void reset(BlockBuilderStatus blockBuilderStatus);
+
+    /**
+     * Creates a new block builder of the same type based on the current usage statistics of this block builder.
+     */
+    BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -102,6 +102,12 @@ public class ByteArrayBlockBuilder
         updateDataSize();
     }
 
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        return new ByteArrayBlockBuilder(blockBuilderStatus, positionCount);
+    }
+
     private void growCapacity()
     {
         int newSize = BlockUtil.calculateNewArraySize(values.length);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -233,6 +233,12 @@ public class FixedWidthBlockBuilder
     }
 
     @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        return new FixedWidthBlockBuilder(fixedSize, blockBuilderStatus, calculateBlockResetSize(positionCount));
+    }
+
+    @Override
     public String toString()
     {
         StringBuilder sb = new StringBuilder("FixedWidthBlockBuilder{");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -102,6 +102,12 @@ public class IntArrayBlockBuilder
         updateDataSize();
     }
 
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        return new IntArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+    }
+
     private void growCapacity()
     {
         int newSize = BlockUtil.calculateNewArraySize(values.length);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlockBuilder.java
@@ -270,6 +270,16 @@ public class InterleavedBlockBuilder
     }
 
     @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        BlockBuilder[] newBlockBuilders = new BlockBuilder[blockBuilders.length];
+        for (int i = 0; i < blockBuilders.length; i++) {
+            newBlockBuilders[i] = blockBuilders[i].newBlockBuilderLike(blockBuilderStatus);
+        }
+        return new InterleavedBlockBuilder(newBlockBuilders);
+    }
+
+    @Override
     public String toString()
     {
         StringBuilder sb = new StringBuilder("InterleavedBlock{");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -103,6 +103,12 @@ public class LongArrayBlockBuilder
         updateDataSize();
     }
 
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        return new LongArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+    }
+
     private void growCapacity()
     {
         int newSize = BlockUtil.calculateNewArraySize(values.length);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -102,6 +102,12 @@ public class ShortArrayBlockBuilder
         updateDataSize();
     }
 
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        return new ShortArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+    }
+
     private void growCapacity()
     {
         int newSize = BlockUtil.calculateNewArraySize(values.length);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -275,6 +275,13 @@ public class VariableWidthBlockBuilder
         updateArraysDataSize();
     }
 
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        int expectedBytesPerEntry = positions == 0 ? positions : (getOffset(positions) - getOffset(0)) / positions;
+        return new VariableWidthBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positions), expectedBytesPerEntry);
+    }
+
     private int getOffset(int position)
     {
         return offsets[position];


### PR DESCRIPTION
In `MultiChannelGroupByHash` for every new page started a brand new `PageBuilder` gets instantiated and each new page builder starts with a rough estimate for the number of expected entries. Typically `PageBuilder::reset()` is used to update these estimates, but due to the way `MultiChannelGroupByHash` works right now it cannot call `reset()` and this may result in a waste of memory due to the inaccuracy of these estimates.  This PR fixes that by updating these estimates through a new method added to the `PageBuilder`. I have seen up to ~20% memory savings with synthetic benchmarks. 

