### PR TITLE
Add cassandra.properties to presto-main/etc/catalog

### DIFF
--- a/presto-main/etc/catalog/cassandra.properties
+++ b/presto-main/etc/catalog/cassandra.properties
@@ -1,0 +1,3 @@
+connector.name=cassandra
+cassandra.contact-points=cassandra
+cassandra.schema-cache-ttl=0s


### PR DESCRIPTION
Add cassandra properties to presto-main/etc/catalog similar to
what we have for other connectors.