### PR TITLE
Fix performance regression in ExchangeClient

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
@@ -45,7 +45,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.facebook.presto.execution.buffer.PageCompression.UNCOMPRESSED;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
@@ -394,7 +393,6 @@ public class ExchangeClient
         {
             requireNonNull(client, "client is null");
             requireNonNull(pages, "pages is null");
-            checkArgument(!pages.isEmpty(), "pages is empty");
             return ExchangeClient.this.addPages(pages);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
@@ -339,16 +339,18 @@ public final class HttpPageBufferClient
                     return;
                 }
 
-                // add pages
-                if (!pages.isEmpty()) {
-                    if (clientCallback.addPages(HttpPageBufferClient.this, pages)) {
-                        pagesReceived.addAndGet(pages.size());
-                        rowsReceived.addAndGet(pages.stream().mapToLong(SerializedPage::getPositionCount).sum());
-                    }
-                    else {
-                        pagesRejected.addAndGet(pages.size());
-                        rowsRejected.addAndGet(pages.stream().mapToLong(SerializedPage::getPositionCount).sum());
-                    }
+                // add pages:
+                // addPages must be called regardless of whether pages is an empty list because
+                // clientCallback can keep stats of requests and responses. For example, it may
+                // keep track of how often a client returns empty response and adjust request
+                // frequency or buffer size.
+                if (clientCallback.addPages(HttpPageBufferClient.this, pages)) {
+                    pagesReceived.addAndGet(pages.size());
+                    rowsReceived.addAndGet(pages.stream().mapToLong(SerializedPage::getPositionCount).sum());
+                }
+                else {
+                    pagesRejected.addAndGet(pages.size());
+                    rowsRejected.addAndGet(pages.stream().mapToLong(SerializedPage::getPositionCount).sum());
                 }
 
                 synchronized (HttpPageBufferClient.this) {


### PR DESCRIPTION
ExchangeClient.addPages was not called for empty responses. This skews
averageBytesPerRequest significantly, causing degraded performance for
certain queries.

When clientCount reduces to a small number like 9, and when almost all
buffers are empty, fetching a single page can take more than a minute
when there are 300 remote sources because the client has to long poll
each one.

This regression was introduced in 0.168 by 5cd644f