### PR TITLE
Add missing type only coercions during planning UNION

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -539,7 +539,7 @@ class RelationPlanner
             Symbol inputSymbol = oldSymbols.get(i);
             Type inputType = symbolAllocator.getTypes().get(inputSymbol);
             Type outputType = targetColumnTypes[i];
-            if (outputType != inputType && !metadata.getTypeManager().isTypeOnlyCoercion(inputType, outputType)) {
+            if (outputType != inputType) {
                 Expression cast = new Cast(inputSymbol.toSymbolReference(), outputType.getTypeSignature().toString());
                 Symbol outputSymbol = symbolAllocator.newSymbol(cast, outputType);
                 assignments.put(outputSymbol, cast);


### PR DESCRIPTION
Type only coercions were not materialized in logical plan
for outputs of UNION sources.

This is not correct behaviour. Type-only coercions should be present in
logical plan and only removed during execution.

This fixes first query from https://github.com/prestodb/presto/issues/7496