### PR TITLE
Fix race condition in Driver interruption

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.split.PageSourceProvider;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
@@ -52,13 +53,14 @@ import java.util.function.Function;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Throwables.getRootCause;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
@@ -202,7 +204,7 @@ public class TestDriver
             fail("Expected InterruptedException");
         }
         catch (ExecutionException e) {
-            checkArgument(getRootCause(e) instanceof InterruptedException, "Expected root cause exception to be an instance of InterruptedException");
+            assertDriverInterrupted(e.getCause());
         }
     }
 
@@ -295,8 +297,15 @@ public class TestDriver
             fail("Expected InterruptedException");
         }
         catch (ExecutionException e) {
-            checkArgument(getRootCause(e) instanceof InterruptedException, "Expected root cause exception to be an instance of InterruptedException");
+            assertDriverInterrupted(e.getCause());
         }
+    }
+
+    private void assertDriverInterrupted(Throwable cause)
+    {
+        checkArgument(cause instanceof PrestoException, "Expected root cause exception to be an instance of PrestoException");
+        assertEquals(((PrestoException) cause).getErrorCode(), GENERIC_INTERNAL_ERROR.toErrorCode());
+        assertEquals(cause.getMessage(), "Driver was interrupted");
     }
 
     private static Split newMockSplit()


### PR DESCRIPTION
When the Diver is closed there is a race between interrupting the current
driver thread and the driver thread releasing the lock. In very rare cases,
This can result in a thread being interrupted while procing another driver.

When a task finishes all Drivers are closed and any pending work interrupted.
This interruption should never result in a query failure because the driver
is only closed when the task is already complete. This change detects this
situation and fails with a new error containing the stack of the interrupting
thread.