### PR TITLE
Fix name of query.max-age property in product tests configuration

### DIFF
--- a/presto-product-tests/conf/presto/etc/config.properties
+++ b/presto-product-tests/conf/presto/etc/config.properties
@@ -24,7 +24,7 @@ scheduler.http-client.connect-timeout=1m
 scheduler.http-client.idle-timeout=1m
 
 query.client.timeout=5m
-query.max-age=30m
+query.min-expire-age=30m
 
 plugin.bundles=\
   ../../../presto-jmx/pom.xml,\


### PR DESCRIPTION
This fixes
```WARN	main	Bootstrap	Warning: Configuration property 'query.max-age' has been replaced. Use 'query.min-expire-age' instead```.
The config property was renamed in d49f6c615c70bf7338b0b054ad87c76c86865f51.

CC: @fiedukow