### PR TITLE
Remove finished queries in QueryStateInfoResource

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/QueryStateInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryStateInfoResource.java
@@ -60,6 +60,7 @@ public class QueryStateInfoResource
         }
         List<QueryInfo> userQueries = queryManager.getAllQueryInfo().stream()
                 .filter(queryInfo -> Pattern.matches(user, queryInfo.getSession().getUser()))
+                .filter(queryInfo -> !queryInfo.getState().isDone())
                 .collect(toImmutableList());
 
         Map<ResourceGroupId, ResourceGroupInfo> rootResourceGroupInfos = userQueries.stream()


### PR DESCRIPTION
The API is for monitor running queries. We probably won't display finished queries. Remove it to reduce response size. Alternatively we can add a separate parameter to filter query state, which might be a better approach in general. Let me know.