### PR TITLE
Fix nondeterministic WF test

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3748,23 +3748,23 @@ public abstract class AbstractTestQueries
             throws Exception
     {
         MaterializedResult actual = computeActual("SELECT " +
-                "sum(discount) OVER(PARTITION BY suppkey ORDER BY receiptdate)," +
-                "lag(quantity, 1) OVER(PARTITION BY suppkey ORDER BY orderkey)" +
-                "FROM lineitem " +
+                "sum(size) OVER(PARTITION BY type ORDER BY brand)," +
+                "lag(partkey, 1) OVER(PARTITION BY type ORDER BY name)" +
+                "FROM part " +
                 "ORDER BY 1, 2 " +
                 "LIMIT 10");
 
-        MaterializedResult expected = resultBuilder(getSession(), DOUBLE, DOUBLE)
-                .row(0.0, 8.0)
-                .row(0.0, 13.0)
-                .row(0.0, 17.0)
-                .row(0.0, 33.0)
-                .row(0.0, 33.0)
-                .row(0.0, 40.0)
-                .row(0.0, 42.0)
-                .row(0.01, 6.0)
-                .row(0.01, 8.0)
-                .row(0.01, 18.0)
+        MaterializedResult expected = resultBuilder(getSession(), BIGINT, BIGINT)
+                .row(1L, 315L)
+                .row(1L, 881L)
+                .row(1L, 1009L)
+                .row(3L, 1087L)
+                .row(3L, 1187L)
+                .row(3L, 1529L)
+                .row(4L, 969L)
+                .row(5L, 151L)
+                .row(5L, 505L)
+                .row(5L, 872L)
                 .build();
 
         assertEquals(actual, expected);


### PR DESCRIPTION
Lag function is not deterministic when there are duplicates in ORDER BY column.
Test wouldn't fail intermittently because there's a fixed order in processing WF functions in Presto currently.
However, there is more than one correct result for a Lag function when there are duplicates in ORDER BY column.

E.g.:
for `select lag(x) over(order by y) from (values (1,2),(2,2),(3,3)) t(x,y)` both results are correct:
NULL, 1, 2
and
NULL, 2, 1

because (1,2) could be ordered either before or after (2,2).

That's why ORDER BY column for lag function in the test was changed to part.name which does not have duplicates.
Also, removed floating point numbers, to avoid inaccuracy problems.

---

Test was introduced here: https://github.com/prestodb/presto/pull/6814/commits/6e88b0670ff3e95f390214a374f7bdba93d3173e to cover `ReorderWindows` correctness cases. The test after rewrite preserves the same features: both WFs have the same `partition by` but different `order by`. Also, `lag` function has a constant parameter.

---

SQLServer even marks the `lag` function as nondeterministic in their documentation (see https://msdn.microsoft.com/en-us/library/hh231256.aspx#Anchor_3).