### PR TITLE
Add additional statistics for WindowOperator in Explain Analyze continued

### DIFF
--- a/presto-docs/src/main/sphinx/sql/explain-analyze.rst
+++ b/presto-docs/src/main/sphinx/sql/explain-analyze.rst
@@ -7,13 +7,16 @@ Synopsis
 
 .. code-block:: none
 
-    EXPLAIN ANALYZE statement
+    EXPLAIN ANALYZE [VERBOSE] statement
 
 Description
 -----------
 
 Execute the statement and show the distributed execution plan of the statement
 along with the cost of each operation.
+
+The ``VERBOSE`` option will give more detailed information and low-level statistics
+They may not be understandable for users not familiar with Presto internals and implementation details.
 
 .. note::
 
@@ -68,6 +71,28 @@ relevant plan nodes). Such statistics are useful when one wants to detect data a
                     $hashvalue_10 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("clerk"), 0))
                     orderdate := tpch:orderdate
                     clerk := tpch:clerk
+
+When ``VERBOSE`` option is used, some operators may report additional information, e.g. for Window Function operator you may notice:
+
+.. code-block:: none
+
+    EXPLAIN ANALYZE VERBOSE SELECT count(clerk) OVER() FROM orders WHERE orderdate > date '1995-01-01';
+
+                                              Query Plan
+    -----------------------------------------------------------------------------------------------
+      ...
+             - Window[] => [clerk:varchar(15), count:bigint]
+                     Cost: {rows: ?, bytes: ?}
+                     CPU fraction: 75.93%, Output: 8130 rows (230.24kB)
+                     Input avg.: 8130.00 lines, Input std.dev.: 0.00%
+                     Active Drivers: [ 1 / 1 ]
+                     Index size: std.dev.: 0.00 bytes , 0.00 rows
+                     Index count per driver: std.dev.: 0.00
+                     Rows per driver: std.dev.: 0.00
+                     Size of partition: std.dev.: 0.00
+                     count := count("clerk")
+     ...
+
 
 See Also
 --------

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.util.Mergeable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExplainAnalyzeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExplainAnalyzeOperator.java
@@ -46,15 +46,17 @@ public class ExplainAnalyzeOperator
         private final QueryPerformanceFetcher queryPerformanceFetcher;
         private final Metadata metadata;
         private final CostCalculator costCalculator;
+        private final boolean verbose;
         private boolean closed;
 
-        public ExplainAnalyzeOperatorFactory(int operatorId, PlanNodeId planNodeId, QueryPerformanceFetcher queryPerformanceFetcher, Metadata metadata, CostCalculator costCalculator)
+        public ExplainAnalyzeOperatorFactory(int operatorId, PlanNodeId planNodeId, QueryPerformanceFetcher queryPerformanceFetcher, Metadata metadata, CostCalculator costCalculator, boolean verbose)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.queryPerformanceFetcher = requireNonNull(queryPerformanceFetcher, "queryPerformanceFetcher is null");
             this.metadata = requireNonNull(metadata, "metadata is null");
             this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
+            this.verbose = verbose;
         }
 
         @Override
@@ -68,7 +70,7 @@ public class ExplainAnalyzeOperator
         {
             checkState(!closed, "Factory is already closed");
             OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, ExplainAnalyzeOperator.class.getSimpleName());
-            return new ExplainAnalyzeOperator(operatorContext, queryPerformanceFetcher, metadata, costCalculator);
+            return new ExplainAnalyzeOperator(operatorContext, queryPerformanceFetcher, metadata, costCalculator, verbose);
         }
 
         @Override
@@ -80,7 +82,7 @@ public class ExplainAnalyzeOperator
         @Override
         public OperatorFactory duplicate()
         {
-            return new ExplainAnalyzeOperatorFactory(operatorId, planNodeId, queryPerformanceFetcher, metadata, costCalculator);
+            return new ExplainAnalyzeOperatorFactory(operatorId, planNodeId, queryPerformanceFetcher, metadata, costCalculator, verbose);
         }
     }
 
@@ -88,15 +90,17 @@ public class ExplainAnalyzeOperator
     private final QueryPerformanceFetcher queryPerformanceFetcher;
     private final Metadata metadata;
     private final CostCalculator costCalculator;
+    private final boolean verbose;
     private boolean finishing;
     private boolean outputConsumed;
 
-    public ExplainAnalyzeOperator(OperatorContext operatorContext, QueryPerformanceFetcher queryPerformanceFetcher, Metadata metadata, CostCalculator costCalculator)
+    public ExplainAnalyzeOperator(OperatorContext operatorContext, QueryPerformanceFetcher queryPerformanceFetcher, Metadata metadata, CostCalculator costCalculator, boolean verbose)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.queryPerformanceFetcher = requireNonNull(queryPerformanceFetcher, "queryPerformanceFetcher is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
+        this.verbose = verbose;
     }
 
     @Override
@@ -151,7 +155,7 @@ public class ExplainAnalyzeOperator
             return null;
         }
 
-        String plan = textDistributedPlan(queryInfo.getOutputStage().get(), metadata, costCalculator, operatorContext.getSession());
+        String plan = textDistributedPlan(queryInfo.getOutputStage().get(), metadata, costCalculator, operatorContext.getSession(), verbose);
         BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 1);
         VARCHAR.writeString(builder, plan);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashCollisionsInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashCollisionsInfo.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.util.Mergeable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinOperatorInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinOperatorInfo.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.operator.LookupJoinOperators.JoinType;
+import com.facebook.presto.util.Mergeable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorInfo.java
@@ -29,7 +29,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = SplitOperatorInfo.class, name = "splitOperator"),
         @JsonSubTypes.Type(value = HashCollisionsInfo.class, name = "hashCollisionsInfo"),
         @JsonSubTypes.Type(value = PartitionedOutputInfo.class, name = "partitionedOutput"),
-        @JsonSubTypes.Type(value = JoinOperatorInfo.class, name = "joinOperatorInfo")
+        @JsonSubTypes.Type(value = JoinOperatorInfo.class, name = "joinOperatorInfo"),
+        @JsonSubTypes.Type(value = WindowInfo.class, name = "windowInfo")
 })
 public interface OperatorInfo
 {

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.util.Mergeable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.util.Mergeable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowInfo.java
@@ -212,7 +212,7 @@ public class WindowInfo
     }
 
     @Immutable
-    private static class IndexInfo
+    public static class IndexInfo
     {
         private final long totalRowsCount;
         private final long sizeInBytes;

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowInfo.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.operator.window.WindowPartition;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.concat;
+
+public class WindowInfo
+        implements Mergeable<WindowInfo>, OperatorInfo
+{
+    private final List<DriverWindowInfo> windowInfos;
+
+    @JsonCreator
+    public WindowInfo(@JsonProperty("windowInfos") List<DriverWindowInfo> windowInfos)
+    {
+        this.windowInfos = ImmutableList.copyOf(windowInfos);
+    }
+
+    @JsonProperty
+    public List<DriverWindowInfo> getWindowInfos()
+    {
+        return windowInfos;
+    }
+
+    @Override
+    public WindowInfo mergeWith(WindowInfo other)
+    {
+        return new WindowInfo(ImmutableList.copyOf(concat(this.windowInfos, other.windowInfos)));
+    }
+
+    @ThreadSafe
+    static class DriverWindowInfoBuilder
+    {
+        private ImmutableList.Builder<IndexInfo> indexInfosBuilder = ImmutableList.builder();
+        private IndexInfoBuilder currentIndexInfoBuilder = null;
+
+        public synchronized void addIndex(PagesIndex index)
+        {
+            if (currentIndexInfoBuilder != null) {
+                Optional<IndexInfo> indexInfo = currentIndexInfoBuilder.build();
+                indexInfo.ifPresent(indexInfosBuilder::add);
+            }
+            currentIndexInfoBuilder = new IndexInfoBuilder(index.getPositionCount(), index.getEstimatedSize().toBytes());
+        }
+
+        public synchronized void addPartition(WindowPartition partition)
+        {
+            checkState(currentIndexInfoBuilder != null, "addIndex must be called before addPartition");
+            currentIndexInfoBuilder.addPartition(partition);
+        }
+
+        public synchronized DriverWindowInfo build()
+        {
+            if (currentIndexInfoBuilder != null) {
+                Optional<IndexInfo> indexInfo = currentIndexInfoBuilder.build();
+                indexInfo.ifPresent(indexInfosBuilder::add);
+                currentIndexInfoBuilder = null;
+            }
+
+            List<IndexInfo> indexInfos = indexInfosBuilder.build();
+            if (indexInfos.size() == 0) {
+                return new DriverWindowInfo(0.0, 0.0, 0.0, 0, 0, 0);
+            }
+            long totalRowsCount = indexInfos.stream()
+                    .mapToLong(IndexInfo::getTotalRowsCount)
+                    .sum();
+            double averageIndexPositions = totalRowsCount / indexInfos.size();
+            double squaredDifferencesPositionsOfIndex = indexInfos.stream()
+                    .mapToDouble(index -> Math.pow(index.getTotalRowsCount() - averageIndexPositions, 2))
+                    .sum();
+            double averageIndexSize = indexInfos.stream()
+                    .mapToLong(IndexInfo::getSizeInBytes)
+                    .average()
+                    .getAsDouble();
+            double squaredDifferencesSizeOfIndex = indexInfos.stream()
+                    .mapToDouble(index -> Math.pow(index.getSizeInBytes() - averageIndexSize, 2))
+                    .sum();
+            double squaredDifferencesSizeInPartition = indexInfos.stream()
+                    .mapToDouble(IndexInfo::getSumSquaredDifferencesSizeInPartition)
+                    .sum();
+
+            long totalPartitionsCount = indexInfos.stream()
+                    .mapToLong(IndexInfo::getNumberOfPartitions)
+                    .sum();
+
+            return new DriverWindowInfo(squaredDifferencesPositionsOfIndex,
+                    squaredDifferencesSizeOfIndex,
+                    squaredDifferencesSizeInPartition,
+                    totalPartitionsCount,
+                    totalRowsCount,
+                    indexInfos.size());
+        }
+    }
+
+    @Immutable
+    public static class DriverWindowInfo
+    {
+        private final double sumSquaredDifferencesPositionsOfIndex; // sum of (indexPositions - averageIndexPositions) ^ 2 for all indexes
+        private final double sumSquaredDifferencesSizeOfIndex; // sum of (indexSize - averageIndexSize) ^ 2 for all indexes
+        private final double sumSquaredDifferencesSizeInPartition; // sum of (partitionSize - averagePartitionSize)^2 for each partition
+        private final long totalPartitionsCount;
+        private final long totalRowsCount;
+        private final long numberOfIndexes;
+
+        @JsonCreator
+        public DriverWindowInfo(
+                @JsonProperty("sumSquaredDifferencesPositionsOfIndex") double sumSquaredDifferencesPositionsOfIndex,
+                @JsonProperty("sumSquaredDifferencesSizeOfIndex") double sumSquaredDifferencesSizeOfIndex,
+                @JsonProperty("sumSquaredDifferencesSizeInPartition") double sumSquaredDifferencesSizeInPartition,
+                @JsonProperty("totalPartitionsCount") long totalPartitionsCount,
+                @JsonProperty("totalRowsCount") long totalRowsCount,
+                @JsonProperty("numberOfIndexes") long numberOfIndexes)
+        {
+            this.sumSquaredDifferencesPositionsOfIndex = sumSquaredDifferencesPositionsOfIndex;
+            this.sumSquaredDifferencesSizeOfIndex = sumSquaredDifferencesSizeOfIndex;
+            this.sumSquaredDifferencesSizeInPartition = sumSquaredDifferencesSizeInPartition;
+            this.totalPartitionsCount = totalPartitionsCount;
+            this.totalRowsCount = totalRowsCount;
+            this.numberOfIndexes = numberOfIndexes;
+        }
+
+        @JsonProperty
+        public double getSumSquaredDifferencesPositionsOfIndex()
+        {
+            return sumSquaredDifferencesPositionsOfIndex;
+        }
+
+        @JsonProperty
+        public double getSumSquaredDifferencesSizeOfIndex()
+        {
+            return sumSquaredDifferencesSizeOfIndex;
+        }
+
+        @JsonProperty
+        public double getSumSquaredDifferencesSizeInPartition()
+        {
+            return sumSquaredDifferencesSizeInPartition;
+        }
+
+        @JsonProperty
+        public long getTotalPartitionsCount()
+        {
+            return totalPartitionsCount;
+        }
+
+        @JsonProperty
+        public long getTotalRowsCount()
+        {
+            return totalRowsCount;
+        }
+
+        @JsonProperty
+        public long getNumberOfIndexes()
+        {
+            return numberOfIndexes;
+        }
+    }
+
+    @ThreadSafe
+    private static class IndexInfoBuilder
+    {
+        private final long rowsNumber;
+        private final long sizeInBytes;
+        private final ImmutableList.Builder<Integer> partitionsSizes = ImmutableList.builder();
+
+        public IndexInfoBuilder(long rowsNumber, long sizeInBytes)
+        {
+            this.rowsNumber = rowsNumber;
+            this.sizeInBytes = sizeInBytes;
+        }
+
+        public synchronized void addPartition(WindowPartition partition)
+        {
+            partitionsSizes.add(partition.getPartitionEnd() - partition.getPartitionStart());
+        }
+
+        public synchronized Optional<IndexInfo> build()
+        {
+            List<Integer> partitions = partitionsSizes.build();
+            if (partitions.size() == 0) {
+                return Optional.empty();
+            }
+            double avgSize = partitions.stream().mapToLong(Integer::longValue).average().getAsDouble();
+            double squaredDifferences = partitions.stream().mapToDouble(size -> Math.pow(size - avgSize, 2)).sum();
+            checkState(partitions.stream().mapToLong(Integer::longValue).sum() == rowsNumber, "Total number of rows in index does not match number of rows in partitions within that index");
+
+            return Optional.of(new IndexInfo(rowsNumber, sizeInBytes, squaredDifferences, partitions.size()));
+        }
+    }
+
+    @Immutable
+    private static class IndexInfo
+    {
+        private final long totalRowsCount;
+        private final long sizeInBytes;
+        private final double sumSquaredDifferencesSizeInPartition; // sum of (partitionSize - averagePartitionSize)^2 for each partition
+        private final long numberOfPartitions;
+
+        public IndexInfo(long totalRowsCount, long sizeInBytes, double sumSquaredDifferencesSizeInPartition, long numberOfPartitions)
+        {
+            this.totalRowsCount = totalRowsCount;
+            this.sizeInBytes = sizeInBytes;
+            this.sumSquaredDifferencesSizeInPartition = sumSquaredDifferencesSizeInPartition;
+            this.numberOfPartitions = numberOfPartitions;
+        }
+
+        public long getTotalRowsCount()
+        {
+            return totalRowsCount;
+        }
+
+        public long getSizeInBytes()
+        {
+            return sizeInBytes;
+        }
+
+        public double getSumSquaredDifferencesSizeInPartition()
+        {
+            return sumSquaredDifferencesSizeInPartition;
+        }
+
+        public long getNumberOfPartitions()
+        {
+            return numberOfPartitions;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowInfo.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.operator.window.WindowPartition;
+import com.facebook.presto.util.Mergeable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowInfo.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
 import javax.annotation.concurrent.Immutable;
-import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.List;
 import java.util.Optional;
@@ -51,13 +50,12 @@ public class WindowInfo
         return new WindowInfo(ImmutableList.copyOf(concat(this.windowInfos, other.windowInfos)));
     }
 
-    @ThreadSafe
     static class DriverWindowInfoBuilder
     {
         private ImmutableList.Builder<IndexInfo> indexInfosBuilder = ImmutableList.builder();
         private IndexInfoBuilder currentIndexInfoBuilder = null;
 
-        public synchronized void addIndex(PagesIndex index)
+        public void addIndex(PagesIndex index)
         {
             if (currentIndexInfoBuilder != null) {
                 Optional<IndexInfo> indexInfo = currentIndexInfoBuilder.build();
@@ -66,13 +64,13 @@ public class WindowInfo
             currentIndexInfoBuilder = new IndexInfoBuilder(index.getPositionCount(), index.getEstimatedSize().toBytes());
         }
 
-        public synchronized void addPartition(WindowPartition partition)
+        public void addPartition(WindowPartition partition)
         {
             checkState(currentIndexInfoBuilder != null, "addIndex must be called before addPartition");
             currentIndexInfoBuilder.addPartition(partition);
         }
 
-        public synchronized DriverWindowInfo build()
+        public DriverWindowInfo build()
         {
             if (currentIndexInfoBuilder != null) {
                 Optional<IndexInfo> indexInfo = currentIndexInfoBuilder.build();
@@ -179,7 +177,6 @@ public class WindowInfo
         }
     }
 
-    @ThreadSafe
     private static class IndexInfoBuilder
     {
         private final long rowsNumber;
@@ -192,12 +189,12 @@ public class WindowInfo
             this.sizeInBytes = sizeInBytes;
         }
 
-        public synchronized void addPartition(WindowPartition partition)
+        public void addPartition(WindowPartition partition)
         {
             partitionsSizes.add(partition.getPartitionEnd() - partition.getPartitionStart());
         }
 
-        public synchronized Optional<IndexInfo> build()
+        public Optional<IndexInfo> build()
         {
             List<Integer> partitions = partitionsSizes.build();
             if (partitions.size() == 0) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
@@ -146,18 +146,18 @@ public class WindowOperator
         public OperatorFactory duplicate()
         {
             return new WindowOperatorFactory(
-                operatorId,
-                planNodeId,
-                sourceTypes,
-                outputChannels,
-                windowFunctionDefinitions,
-                partitionChannels,
-                preGroupedChannels,
-                sortChannels,
-                sortOrder,
-                preSortedChannelPrefix,
-                expectedPositions,
-                pagesIndexFactory);
+                    operatorId,
+                    planNodeId,
+                    sourceTypes,
+                    outputChannels,
+                    windowFunctionDefinitions,
+                    partitionChannels,
+                    preGroupedChannels,
+                    sortChannels,
+                    sortOrder,
+                    preSortedChannelPrefix,
+                    expectedPositions,
+                    pagesIndexFactory);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchangeBufferInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchangeBufferInfo.java
@@ -13,8 +13,8 @@
  */
 package com.facebook.presto.operator.exchange;
 
-import com.facebook.presto.operator.Mergeable;
 import com.facebook.presto.operator.OperatorInfo;
+import com.facebook.presto.util.Mergeable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/WindowPartition.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/WindowPartition.java
@@ -71,6 +71,11 @@ public final class WindowPartition
         updatePeerGroup();
     }
 
+    public int getPartitionStart()
+    {
+        return partitionStart;
+    }
+
     public int getPartitionEnd()
     {
         return partitionEnd;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -608,7 +608,7 @@ public class LocalExecutionPlanner
             checkState(queryPerformanceFetcher.isPresent(), "ExplainAnalyze can only run on coordinator");
             PhysicalOperation source = node.getSource().accept(this, context);
 
-            OperatorFactory operatorFactory = new ExplainAnalyzeOperatorFactory(context.getNextOperatorId(), node.getId(), queryPerformanceFetcher.get(), metadata, costCalculator);
+            OperatorFactory operatorFactory = new ExplainAnalyzeOperatorFactory(context.getNextOperatorId(), node.getId(), queryPerformanceFetcher.get(), metadata, costCalculator, node.isVerbose());
             return new PhysicalOperation(operatorFactory, makeLayout(node), source);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -187,7 +187,7 @@ public class LogicalPlanner
         PlanNode root = underlyingPlan.getRoot();
         Scope scope = analysis.getScope(statement);
         Symbol outputSymbol = symbolAllocator.newSymbol(scope.getRelationType().getFieldByIndex(0));
-        root = new ExplainAnalyzeNode(idAllocator.getNextId(), root, outputSymbol);
+        root = new ExplainAnalyzeNode(idAllocator.getNextId(), root, outputSymbol, statement.isVerbose());
         return new RelationPlan(root, scope, ImmutableList.of(outputSymbol));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -170,7 +170,7 @@ public class UnaliasSymbolReferences
         public PlanNode visitExplainAnalyze(ExplainAnalyzeNode node, RewriteContext<Void> context)
         {
             PlanNode source = context.rewrite(node.getSource());
-            return new ExplainAnalyzeNode(node.getId(), source, canonicalize(node.getOutputSymbol()));
+            return new ExplainAnalyzeNode(node.getId(), source, canonicalize(node.getOutputSymbol()), node.isVerbose());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExplainAnalyzeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExplainAnalyzeNode.java
@@ -31,16 +31,19 @@ public class ExplainAnalyzeNode
 {
     private final PlanNode source;
     private final Symbol outputSymbol;
+    private final boolean verbose;
 
     @JsonCreator
     public ExplainAnalyzeNode(
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("outputSymbol") Symbol outputSymbol)
+            @JsonProperty("outputSymbol") Symbol outputSymbol,
+            @JsonProperty("verbose") boolean verbose)
     {
         super(id);
         this.source = requireNonNull(source, "source is null");
         this.outputSymbol = requireNonNull(outputSymbol, "outputSymbol is null");
+        this.verbose = verbose;
     }
 
     @JsonProperty("outputSymbol")
@@ -53,6 +56,12 @@ public class ExplainAnalyzeNode
     public PlanNode getSource()
     {
         return source;
+    }
+
+    @JsonProperty("verbose")
+    public boolean isVerbose()
+    {
+        return verbose;
     }
 
     @Override
@@ -76,6 +85,6 @@ public class ExplainAnalyzeNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
-        return new ExplainAnalyzeNode(getId(), Iterables.getOnlyElement(newChildren), outputSymbol);
+        return new ExplainAnalyzeNode(getId(), Iterables.getOnlyElement(newChildren), outputSymbol, isVerbose());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -51,7 +51,7 @@ public class PlanNodeStatsSummarizer
                 .flatMap(taskStats -> getPlanNodeStats(taskStats).stream())
                 .collect(toList());
         for (PlanNodeStats stats : planNodeStats) {
-            aggregatedStats.merge(stats.getPlanNodeId(), stats, PlanNodeStats::merge);
+            aggregatedStats.merge(stats.getPlanNodeId(), stats, (left, right) -> left.mergeWith(right));
         }
         return aggregatedStats;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -19,6 +19,7 @@ import com.facebook.presto.operator.HashCollisionsInfo;
 import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.PipelineStats;
 import com.facebook.presto.operator.TaskStats;
+import com.facebook.presto.operator.WindowInfo;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
@@ -28,6 +29,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.util.MoreMaps.mergeMaps;
@@ -71,6 +73,7 @@ public class PlanNodeStatsSummarizer
 
         Map<PlanNodeId, Map<String, OperatorInputStats>> operatorInputStats = new HashMap<>();
         Map<PlanNodeId, Map<String, OperatorHashCollisionsStats>> operatorHashCollisionsStats = new HashMap<>();
+        Map<PlanNodeId, WindowOperatorStats> windowNodeStats = new HashMap<>();
 
         for (PipelineStats pipelineStats : taskStats.getPipelines()) {
             // Due to eventual consistently collected stats, these could be empty
@@ -118,6 +121,12 @@ public class PlanNodeStatsSummarizer
                             (map1, map2) -> mergeMaps(map1, map2, OperatorHashCollisionsStats::merge));
                 }
 
+                // The only statistics we have for Window Functions are very low level, thus displayed only in VERBOSE mode
+                if (operatorStats.getInfo() instanceof WindowInfo) {
+                    WindowInfo windowInfo = (WindowInfo) operatorStats.getInfo();
+                    windowNodeStats.merge(planNodeId, WindowOperatorStats.create(windowInfo), (left, right) -> left.mergeWith(right));
+                }
+
                 planNodeInputPositions.merge(planNodeId, operatorStats.getInputPositions(), Long::sum);
                 planNodeInputBytes.merge(planNodeId, operatorStats.getInputDataSize().toBytes(), Long::sum);
                 processedNodes.add(planNodeId);
@@ -158,7 +167,8 @@ public class PlanNodeStatsSummarizer
                     succinctDataSize(planNodeOutputBytes.getOrDefault(planNodeId, 0L), BYTE),
                     operatorInputStats.get(planNodeId),
                     // Only some operators emit hash collisions statistics
-                    operatorHashCollisionsStats.getOrDefault(planNodeId, emptyMap())));
+                    operatorHashCollisionsStats.getOrDefault(planNodeId, emptyMap()),
+                    Optional.ofNullable(windowNodeStats.get(planNodeId))));
         }
         return stats;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -135,13 +135,14 @@ public class PlanPrinter
     private final StringBuilder output = new StringBuilder();
     private final Metadata metadata;
     private final Optional<Map<PlanNodeId, PlanNodeStats>> stats;
+    private final boolean verbose;
 
     private PlanPrinter(PlanNode plan, Map<Symbol, Type> types, Metadata metadata, CostCalculator costCalculator, Session sesion)
     {
-        this(plan, types, metadata, costCalculator, sesion, 0);
+        this(plan, types, metadata, costCalculator, sesion, 0, false);
     }
 
-    private PlanPrinter(PlanNode plan, Map<Symbol, Type> types, Metadata metadata, CostCalculator costCalculator, Session session, int indent)
+    private PlanPrinter(PlanNode plan, Map<Symbol, Type> types, Metadata metadata, CostCalculator costCalculator, Session session, int indent, boolean verbose)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(types, "types is null");
@@ -150,13 +151,14 @@ public class PlanPrinter
 
         this.metadata = metadata;
         this.stats = Optional.empty();
+        this.verbose = verbose;
 
         Map<PlanNodeId, PlanNodeCost> costs = costCalculator.calculateCostForPlan(session, types, plan);
         Visitor visitor = new Visitor(types, costs, session);
         plan.accept(visitor, indent);
     }
 
-    private PlanPrinter(PlanNode plan, Map<Symbol, Type> types, Metadata metadata, CostCalculator costCalculator, Session session, Map<PlanNodeId, PlanNodeStats> stats, int indent)
+    private PlanPrinter(PlanNode plan, Map<Symbol, Type> types, Metadata metadata, CostCalculator costCalculator, Session session, Map<PlanNodeId, PlanNodeStats> stats, int indent, boolean verbose)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(types, "types is null");
@@ -165,6 +167,7 @@ public class PlanPrinter
 
         this.metadata = metadata;
         this.stats = Optional.of(stats);
+        this.verbose = verbose;
 
         Map<PlanNodeId, PlanNodeCost> costs = costCalculator.calculateCostForPlan(session, types, plan);
         Visitor visitor = new Visitor(types, costs, session);
@@ -184,12 +187,17 @@ public class PlanPrinter
 
     public static String textLogicalPlan(PlanNode plan, Map<Symbol, Type> types, Metadata metadata, CostCalculator costCalculator, Session session, int indent)
     {
-        return new PlanPrinter(plan, types, metadata, costCalculator, session, indent).toString();
+        return textLogicalPlan(plan, types, metadata, costCalculator, session, indent, false);
     }
 
-    public static String textLogicalPlan(PlanNode plan, Map<Symbol, Type> types, Metadata metadata, CostCalculator costCalculator, Session session, Map<PlanNodeId, PlanNodeStats> stats, int indent)
+    public static String textLogicalPlan(PlanNode plan, Map<Symbol, Type> types, Metadata metadata, CostCalculator costCalculator, Session session, int indent, boolean verbose)
     {
-        return new PlanPrinter(plan, types, metadata, costCalculator, session, stats, indent).toString();
+        return new PlanPrinter(plan, types, metadata, costCalculator, session, indent, verbose).toString();
+    }
+
+    public static String textLogicalPlan(PlanNode plan, Map<Symbol, Type> types, Metadata metadata, CostCalculator costCalculator, Session session, Map<PlanNodeId, PlanNodeStats> stats, int indent, boolean verbose)
+    {
+        return new PlanPrinter(plan, types, metadata, costCalculator, session, stats, indent, verbose).toString();
     }
 
     public static String textDistributedPlan(StageInfo outputStageInfo, Metadata metadata, CostCalculator costCalculator, Session session)
@@ -205,7 +213,7 @@ public class PlanPrinter
                 .collect(toImmutableList());
         for (StageInfo stageInfo : allStages) {
             Map<PlanNodeId, PlanNodeStats> aggregatedStats = aggregatePlanNodeStats(stageInfo);
-            builder.append(formatFragment(metadata, costCalculator, session, stageInfo.getPlan(), Optional.of(stageInfo), Optional.of(aggregatedStats)));
+            builder.append(formatFragment(metadata, costCalculator, session, stageInfo.getPlan(), Optional.of(stageInfo), Optional.of(aggregatedStats), verbose));
         }
 
         return builder.toString();
@@ -213,15 +221,20 @@ public class PlanPrinter
 
     public static String textDistributedPlan(SubPlan plan, Metadata metadata, CostCalculator costCalculator, Session session)
     {
+        return textDistributedPlan(plan, metadata, costCalculator, session, false);
+    }
+
+    public static String textDistributedPlan(SubPlan plan, Metadata metadata, CostCalculator costCalculator, Session session, boolean verbose)
+    {
         StringBuilder builder = new StringBuilder();
         for (PlanFragment fragment : plan.getAllFragments()) {
-            builder.append(formatFragment(metadata, costCalculator, session, fragment, Optional.empty(), Optional.empty()));
+            builder.append(formatFragment(metadata, costCalculator, session, fragment, Optional.empty(), Optional.empty(), verbose));
         }
 
         return builder.toString();
     }
 
-    private static String formatFragment(Metadata metadata, CostCalculator costCalculator, Session session, PlanFragment fragment, Optional<StageInfo> stageInfo, Optional<Map<PlanNodeId, PlanNodeStats>> planNodeStats)
+    private static String formatFragment(Metadata metadata, CostCalculator costCalculator, Session session, PlanFragment fragment, Optional<StageInfo> stageInfo, Optional<Map<PlanNodeId, PlanNodeStats>> planNodeStats, boolean verbose)
     {
         StringBuilder builder = new StringBuilder();
         builder.append(format("Fragment %s [%s]\n",
@@ -277,11 +290,11 @@ public class PlanPrinter
         }
 
         if (stageInfo.isPresent()) {
-            builder.append(textLogicalPlan(fragment.getRoot(), fragment.getSymbols(), metadata, costCalculator, session, planNodeStats.get(), 1))
+            builder.append(textLogicalPlan(fragment.getRoot(), fragment.getSymbols(), metadata, costCalculator, session, planNodeStats.get(), 1, verbose))
                     .append("\n");
         }
         else {
-            builder.append(textLogicalPlan(fragment.getRoot(), fragment.getSymbols(), metadata, costCalculator, session, 1))
+            builder.append(textLogicalPlan(fragment.getRoot(), fragment.getSymbols(), metadata, costCalculator, session, 1, verbose))
                     .append("\n");
         }
 
@@ -372,6 +385,11 @@ public class PlanPrinter
         output.append('\n');
 
         printDistributions(indent, nodeStats);
+
+        if (nodeStats.getWindowOperatorStats().isPresent()) {
+            // TODO: Once PlanNodeStats becomes broken into smaller classes, we should rely on toString() method of WindowOperatorStats here
+            printWindowOperatorStats(indent, nodeStats.getWindowOperatorStats().get());
+        }
     }
 
     private void printDistributions(int indent, PlanNodeStats nodeStats)
@@ -437,6 +455,34 @@ public class PlanPrinter
         }
 
         return ImmutableMap.of();
+    }
+
+    private void printWindowOperatorStats(int indent, WindowOperatorStats stats)
+    {
+        if (!verbose) {
+            // these stats are too detailed for non-verbose mode
+            return;
+        }
+
+        output.append(indentString(indent));
+        output.append(format("Active Drivers: [ %d / %d ]", stats.getActiveDrivers(), stats.getTotalDrivers()));
+        output.append('\n');
+
+        output.append(indentString(indent));
+        output.append(format("Index size: std.dev.: %s bytes , %s rows", formatDouble(stats.getIndexSizeStdDev()), formatDouble(stats.getIndexPositionsStdDev())));
+        output.append('\n');
+
+        output.append(indentString(indent));
+        output.append(format("Index count per driver: std.dev.: %s", formatDouble(stats.getIndexCountPerDriverStdDev())));
+        output.append('\n');
+
+        output.append(indentString(indent));
+        output.append(format("Rows per driver: std.dev.: %s", formatDouble(stats.getRowsPerDriverStdDev())));
+        output.append('\n');
+
+        output.append(indentString(indent));
+        output.append(format("Size of partition: std.dev.: %s", formatDouble(stats.getPartitionRowsStdDev())));
+        output.append('\n');
     }
 
     private static String formatDouble(double value)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -194,6 +194,11 @@ public class PlanPrinter
 
     public static String textDistributedPlan(StageInfo outputStageInfo, Metadata metadata, CostCalculator costCalculator, Session session)
     {
+        return textDistributedPlan(outputStageInfo, metadata, costCalculator, session, false);
+    }
+
+    public static String textDistributedPlan(StageInfo outputStageInfo, Metadata metadata, CostCalculator costCalculator, Session session, boolean verbose)
+    {
         StringBuilder builder = new StringBuilder();
         List<StageInfo> allStages = outputStageInfo.getSubStages().stream()
                 .flatMap(stage -> getAllStages(Optional.of(stage)).stream())

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowOperatorStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowOperatorStats.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.planPrinter;
+
+import com.facebook.presto.operator.WindowInfo;
+import com.facebook.presto.operator.WindowInfo.DriverWindowInfo;
+import com.facebook.presto.util.Mergeable;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+class WindowOperatorStats
+        implements Mergeable<WindowOperatorStats>
+{
+    private final int activeDrivers;
+    private final int totalDrivers;
+    private final double positionsInIndexesSumSquaredDiffs;
+    private final double sizeOfIndexesSumSquaredDiffs;
+    private final double indexCountPerDriverSumSquaredDiffs;
+    private final double partitionRowsSumSquaredDiffs;
+    private final double rowCountPerDriverSumSquaredDiffs;
+    private final long totalRowCount;
+    private final long totalIndexesCount;
+    private final long totalPartitionsCount;
+
+    public static WindowOperatorStats create(WindowInfo info)
+    {
+        checkArgument(info.getWindowInfos().size() > 0, "WindowInfo cannot have empty list of DriverWindowInfos");
+
+        int activeDrivers = 0;
+        int totalDrivers = 0;
+
+        double partitionRowsSumSquaredDiffs = 0.0;
+        double positionsInIndexesSumSquaredDiffs = 0.0;
+        double sizeOfIndexesSumSquaredDiffs = 0.0;
+        double indexCountPerDriverSumSquaredDiffs = 0.0;
+        double rowCountPerDriverSumSquaredDiffs = 0.0;
+        long totalRowCount = 0;
+        long totalIndexesCount = 0;
+        long totalPartitionsCount = 0;
+
+        double averageNumberOfIndexes = info.getWindowInfos().stream()
+                .filter(windowInfo -> windowInfo.getTotalRowsCount() > 0)
+                .mapToLong(DriverWindowInfo::getNumberOfIndexes)
+                .average()
+                .getAsDouble();
+
+        double averageNumberOfRows = info.getWindowInfos().stream()
+                .filter(windowInfo -> windowInfo.getTotalRowsCount() > 0)
+                .mapToLong(DriverWindowInfo::getTotalRowsCount)
+                .average()
+                .getAsDouble();
+
+        for (DriverWindowInfo driverWindowInfo : info.getWindowInfos()) {
+            long driverTotalRowsCount = driverWindowInfo.getTotalRowsCount();
+            totalDrivers++;
+            if (driverTotalRowsCount > 0) {
+                long numberOfIndexes = driverWindowInfo.getNumberOfIndexes();
+
+                partitionRowsSumSquaredDiffs += driverWindowInfo.getSumSquaredDifferencesSizeInPartition();
+                totalPartitionsCount += driverWindowInfo.getTotalPartitionsCount();
+
+                totalRowCount += driverWindowInfo.getTotalRowsCount();
+
+                positionsInIndexesSumSquaredDiffs += driverWindowInfo.getSumSquaredDifferencesPositionsOfIndex();
+                sizeOfIndexesSumSquaredDiffs += driverWindowInfo.getSumSquaredDifferencesSizeOfIndex();
+                totalIndexesCount += numberOfIndexes;
+
+                indexCountPerDriverSumSquaredDiffs += (Math.pow(numberOfIndexes - averageNumberOfIndexes, 2));
+                rowCountPerDriverSumSquaredDiffs += (Math.pow(driverTotalRowsCount - averageNumberOfRows, 2));
+                activeDrivers++;
+            }
+        }
+
+        return new WindowOperatorStats(partitionRowsSumSquaredDiffs,
+                positionsInIndexesSumSquaredDiffs,
+                sizeOfIndexesSumSquaredDiffs,
+                indexCountPerDriverSumSquaredDiffs,
+                rowCountPerDriverSumSquaredDiffs,
+                totalRowCount,
+                totalIndexesCount,
+                totalPartitionsCount,
+                activeDrivers,
+                totalDrivers);
+    }
+
+    private WindowOperatorStats(
+            double partitionRowsSumSquaredDiffs,
+            double positionsInIndexesSumSquaredDiffs,
+            double sizeOfIndexesSumSquaredDiffs,
+            double indexCountPerDriverSumSquaredDiffs,
+            double rowCountPerDriverSumSquaredDiffs,
+            long totalRowCount,
+            long totalIndexesCount,
+            long totalPartitionsCount,
+            int activeDrivers,
+            int totalDrivers)
+    {
+        this.partitionRowsSumSquaredDiffs = partitionRowsSumSquaredDiffs;
+        this.positionsInIndexesSumSquaredDiffs = positionsInIndexesSumSquaredDiffs;
+        this.sizeOfIndexesSumSquaredDiffs = sizeOfIndexesSumSquaredDiffs;
+        this.indexCountPerDriverSumSquaredDiffs = indexCountPerDriverSumSquaredDiffs;
+        this.rowCountPerDriverSumSquaredDiffs = rowCountPerDriverSumSquaredDiffs;
+        this.totalRowCount = totalRowCount;
+        this.totalIndexesCount = totalIndexesCount;
+        this.totalPartitionsCount = totalPartitionsCount;
+        this.activeDrivers = activeDrivers;
+        this.totalDrivers = totalDrivers;
+    }
+
+    @Override
+    public WindowOperatorStats mergeWith(WindowOperatorStats other)
+    {
+        return new WindowOperatorStats(
+                partitionRowsSumSquaredDiffs + other.partitionRowsSumSquaredDiffs,
+                positionsInIndexesSumSquaredDiffs + other.positionsInIndexesSumSquaredDiffs,
+                sizeOfIndexesSumSquaredDiffs + other.sizeOfIndexesSumSquaredDiffs,
+                indexCountPerDriverSumSquaredDiffs + other.indexCountPerDriverSumSquaredDiffs,
+                rowCountPerDriverSumSquaredDiffs + other.rowCountPerDriverSumSquaredDiffs,
+                totalRowCount + other.totalRowCount,
+                totalIndexesCount + other.totalIndexesCount,
+                totalPartitionsCount + other.totalPartitionsCount,
+                activeDrivers + other.activeDrivers,
+                totalDrivers + other.totalDrivers);
+    }
+
+    public double getIndexSizeStdDev()
+    {
+        return Math.sqrt(sizeOfIndexesSumSquaredDiffs / totalIndexesCount);
+    }
+
+    public double getIndexPositionsStdDev()
+    {
+        return Math.sqrt(positionsInIndexesSumSquaredDiffs / totalIndexesCount);
+    }
+
+    public double getIndexCountPerDriverStdDev()
+    {
+        return Math.sqrt(indexCountPerDriverSumSquaredDiffs / activeDrivers);
+    }
+
+    public double getPartitionRowsStdDev()
+    {
+        return Math.sqrt(partitionRowsSumSquaredDiffs / totalPartitionsCount);
+    }
+
+    public double getRowsPerDriverStdDev()
+    {
+        return Math.sqrt(rowCountPerDriverSumSquaredDiffs / activeDrivers);
+    }
+
+    public int getActiveDrivers()
+    {
+        return activeDrivers;
+    }
+
+    public int getTotalDrivers()
+    {
+        return totalDrivers;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ExplainRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ExplainRewrite.java
@@ -80,7 +80,7 @@ final class ExplainRewrite
         {
             if (node.isAnalyze()) {
                 Statement statement = (Statement) process(node.getStatement(), context);
-                return new Explain(statement, node.isAnalyze(), node.getOptions());
+                return new Explain(statement, node.isAnalyze(), node.isVerbose(), node.getOptions());
             }
 
             ExplainType.Type planType = LOGICAL;

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -174,6 +174,7 @@ final class ShowQueriesRewrite
             return new Explain(
                     node.getLocation().get(),
                     node.isAnalyze(),
+                    node.isVerbose(),
                     statement,
                     node.getOptions());
         }

--- a/presto-main/src/main/java/com/facebook/presto/util/Mergeable.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/Mergeable.java
@@ -13,7 +13,21 @@
  */
 package com.facebook.presto.util;
 
+import java.util.Optional;
+
 public interface Mergeable<T>
 {
     T mergeWith(T other);
+
+    static <T extends Mergeable<T>> Optional<T> merge(Optional<T> first, Optional<T> second)
+    {
+        if (first.isPresent() && second.isPresent()) {
+            return Optional.of(first.get().mergeWith(second.get()));
+        }
+        else if (first.isPresent()) {
+            return first;
+        }
+
+        return second;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/util/Mergeable.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/Mergeable.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.operator;
+package com.facebook.presto.util;
 
 public interface Mergeable<T>
 {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestVerifyOnlyOneOutputNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestVerifyOnlyOneOutputNode.java
@@ -60,7 +60,8 @@ public class TestVerifyOnlyOneOutputNode
                                                 ),
                                                 Assignments.of()
                                         ), ImmutableList.of(), ImmutableList.of()
-                                ), new Symbol("a")
+                                ), new Symbol("a"),
+                                false
                         ),
                         ImmutableList.of(), ImmutableList.of()
                 );

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -63,7 +63,7 @@ statement
         ON TABLE? qualifiedName FROM grantee=identifier                #revoke
     | SHOW GRANTS
         (ON TABLE? qualifiedName)?                                     #showGrants
-    | EXPLAIN ANALYZE?
+    | EXPLAIN ANALYZE? VERBOSE?
         ('(' explainOption (',' explainOption)* ')')? statement        #explain
     | SHOW CREATE TABLE qualifiedName                                  #showCreateTable
     | SHOW CREATE VIEW qualifiedName                                   #showCreateView
@@ -467,7 +467,7 @@ nonReserved
     | SHOW | SMALLINT | SOME | START | STATS | SUBSTRING | SYSTEM
     | TABLES | TABLESAMPLE | TEXT | TIME | TIMESTAMP | TINYINT | TO | TRANSACTION | TRY_CAST | TYPE
     | UNBOUNDED | UNCOMMITTED | USE
-    | VALIDATE | VIEW
+    | VALIDATE | VERBOSE | VIEW
     | WORK | WRITE
     | YEAR
     | ZONE
@@ -644,6 +644,7 @@ USE: 'USE';
 USING: 'USING';
 VALIDATE: 'VALIDATE';
 VALUES: 'VALUES';
+VERBOSE: 'VERBOSE';
 VIEW: 'VIEW';
 WHEN: 'WHEN';
 WHERE: 'WHERE';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -616,7 +616,7 @@ class AstBuilder
     @Override
     public Node visitExplain(SqlBaseParser.ExplainContext context)
     {
-        return new Explain(getLocation(context), context.ANALYZE() != null, (Statement) visit(context.statement()), visit(context.explainOption(), ExplainOption.class));
+        return new Explain(getLocation(context), context.ANALYZE() != null, context.VERBOSE() != null, (Statement) visit(context.statement()), visit(context.explainOption(), ExplainOption.class));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Explain.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Explain.java
@@ -27,23 +27,25 @@ public class Explain
 {
     private final Statement statement;
     private final boolean analyze;
+    private final boolean verbose;
     private final List<ExplainOption> options;
 
-    public Explain(Statement statement, boolean analyze, List<ExplainOption> options)
+    public Explain(Statement statement, boolean analyze, boolean verbose, List<ExplainOption> options)
     {
-        this(Optional.empty(), analyze, statement, options);
+        this(Optional.empty(), analyze, verbose, statement, options);
     }
 
-    public Explain(NodeLocation location, boolean analyze, Statement statement, List<ExplainOption> options)
+    public Explain(NodeLocation location, boolean analyze, boolean verbose, Statement statement, List<ExplainOption> options)
     {
-        this(Optional.of(location), analyze, statement, options);
+        this(Optional.of(location), analyze, verbose, statement, options);
     }
 
-    private Explain(Optional<NodeLocation> location, boolean analyze, Statement statement, List<ExplainOption> options)
+    private Explain(Optional<NodeLocation> location, boolean analyze, boolean verbose, Statement statement, List<ExplainOption> options)
     {
         super(location);
         this.statement = requireNonNull(statement, "statement is null");
         this.analyze = analyze;
+        this.verbose = verbose;
         if (options == null) {
             this.options = ImmutableList.of();
         }
@@ -60,6 +62,11 @@ public class Explain
     public boolean isAnalyze()
     {
         return analyze;
+    }
+
+    public boolean isVerbose()
+    {
+        return verbose;
     }
 
     public List<ExplainOption> getOptions()

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1571,6 +1571,14 @@ public class TestSqlParser
     }
 
     @Test
+    public void testExplainAnalyzeTypeDistributed()
+            throws Exception
+    {
+        assertStatement("EXPLAIN ANALYZE (type DISTRIBUTED) SELECT * FROM t",
+                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), true, ImmutableList.of(new ExplainType(ExplainType.Type.DISTRIBUTED))));
+    }
+
+    @Test
     public void testJoinPrecedence()
     {
         assertStatement("SELECT * FROM a CROSS JOIN b LEFT JOIN c ON true",

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1547,15 +1547,17 @@ public class TestSqlParser
             throws Exception
     {
         assertStatement("EXPLAIN SELECT * FROM t",
-                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), false, ImmutableList.of()));
+                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), false, false, ImmutableList.of()));
         assertStatement("EXPLAIN (TYPE LOGICAL) SELECT * FROM t",
                 new Explain(
                         simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
+                        false,
                         false,
                         ImmutableList.of(new ExplainType(ExplainType.Type.LOGICAL))));
         assertStatement("EXPLAIN (TYPE LOGICAL, FORMAT TEXT) SELECT * FROM t",
                 new Explain(
                         simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
+                        false,
                         false,
                         ImmutableList.of(
                                 new ExplainType(ExplainType.Type.LOGICAL),
@@ -1563,11 +1565,27 @@ public class TestSqlParser
     }
 
     @Test
+    public void testExplainVerbose()
+            throws Exception
+    {
+        assertStatement("EXPLAIN VERBOSE SELECT * FROM t",
+                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), false, true, ImmutableList.of()));
+    }
+
+    @Test
+    public void testExplainVerboseTypeLogical()
+            throws Exception
+    {
+        assertStatement("EXPLAIN VERBOSE (type LOGICAL) SELECT * FROM t",
+                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), false, true, ImmutableList.of(new ExplainType(ExplainType.Type.LOGICAL))));
+    }
+
+    @Test
     public void testExplainAnalyze()
             throws Exception
     {
         assertStatement("EXPLAIN ANALYZE SELECT * FROM t",
-                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), true, ImmutableList.of()));
+                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), true, false, ImmutableList.of()));
     }
 
     @Test
@@ -1575,7 +1593,23 @@ public class TestSqlParser
             throws Exception
     {
         assertStatement("EXPLAIN ANALYZE (type DISTRIBUTED) SELECT * FROM t",
-                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), true, ImmutableList.of(new ExplainType(ExplainType.Type.DISTRIBUTED))));
+                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), true, false, ImmutableList.of(new ExplainType(ExplainType.Type.DISTRIBUTED))));
+    }
+
+    @Test
+    public void testExplainAnalyzeVerbose()
+            throws Exception
+    {
+        assertStatement("EXPLAIN ANALYZE VERBOSE SELECT * FROM t",
+                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), true, true, ImmutableList.of()));
+    }
+
+    @Test
+    public void testExplainAnalyzeVerboseTypeDistributed()
+            throws Exception
+    {
+        assertStatement("EXPLAIN ANALYZE VERBOSE (type DISTRIBUTED) SELECT * FROM t",
+                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), true, true, ImmutableList.of(new ExplainType(ExplainType.Type.DISTRIBUTED))));
     }
 
     @Test


### PR DESCRIPTION
Statistics are low level, therefore `explain analyze verbose` mode was added (syntax as in PostgreSQL; https://www.postgresql.org/docs/9.6/static/sql-explain.html).

Example output:

NON-VERBOSE

```sql
         - Window[partition by (shipmode)][$hashvalue] => [quantity:double, shipmode:varchar(10), $hashvalue:bigint, sum:double]
                 Cost: 92.60%, Output: 60175 rows (2.08MB)
                 Input avg.: 3760.94 lines, Input std.dev.: 139.24%
                 sum := sum("quantity")
```

---

VERBOSE:
```sql
         - Window[partition by (shipmode)][$hashvalue] => [quantity:double, shipmode:varchar(10), $hashvalue:bigint, sum:double]
                 Cost: 94.33%, Output: 60175 rows (2.08MB)
                 Input avg.: 3760.94 lines, Input std.dev.: 139.24%
                 Active Drivers: [ 6 / 16 ]
                 Index size in bytes: { count: 23, total: 5238332, min: 0, p05: 0, p25: 0, p50: 316238, p75: 329535, p95: 648366, max: 648366 }
                 Rows in partitions per index: { count: 23, total: 60175, min: 0, p05: 0, p25: 0, p50: 0, p75: 8491, p95: 8669, max: 8710 }
                 Rows in partitions per driver: { count: 16, total: 60175, min: 0, p05: 0, p25: 0, p50: 0, p75: 8616, p95: 17192, max: 17192 }
                 sum := sum("quantity")
```

---

- `Active drivers` is a number of operators which had any non-empty data set to process to number of all available drivers.
- `Index size in bytes` is a distribution of the size of index among all the drivers. This may help identify problems when some indexes were bigger than others (data skew / unnecessarily built indexes [possibility to reuse maybe?]).
- `Rows in partitions per index` - how big were partitions per index (index may be built for more than one partition).
- `Rows in partitions per driver` tells us how many rows per partition each driver had to handle (this may help to identify data skew but differently than `index size in bytes` because it's possible to have evenly distributed size of indexes while rows per partition are not, e.g. one big index with single partition and another index with multiple small partitions).

They are very low level statistics. Even advanced Presto user may not understand them but they would be helpful to debug the implementation of WF operator (by us, developers) and identify problems visible at customer's site.
`Explain analyze verbose` simply provides a shortcut to extra information exposed in JSON.

---

Supersedes https://github.com/prestodb/presto/pull/7382.