### PR TITLE
Increase S3 client default max retry count

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -276,7 +276,7 @@ Property Name                         Description                               
 ===================================== =========================================================== ===============
 ``hive.s3.max-error-retries``         Maximum number of error retries, set on the S3 client.      ``10``
 
-``hive.s3.max-client-retries``        Maximum number of read attempts to retry.                   ``3``
+``hive.s3.max-client-retries``        Maximum number of read attempts to retry.                   ``5``
 
 ``hive.s3.max-backoff-time``          Use exponential backoff starting at 1 second up to          ``10 minutes``
                                       this maximum value when communicating with S3.

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveS3Config.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveS3Config.java
@@ -42,7 +42,7 @@ public class HiveS3Config
     private String s3EncryptionMaterialsProvider;
     private String s3KmsKeyId;
     private String s3SseKmsKeyId;
-    private int s3MaxClientRetries = 3;
+    private int s3MaxClientRetries = 5;
     private int s3MaxErrorRetries = 10;
     private Duration s3MaxBackoffTime = new Duration(10, TimeUnit.MINUTES);
     private Duration s3MaxRetryTime = new Duration(10, TimeUnit.MINUTES);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveS3Config.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveS3Config.java
@@ -45,7 +45,7 @@ public class TestHiveS3Config
                 .setS3SseKmsKeyId(null)
                 .setS3KmsKeyId(null)
                 .setS3EncryptionMaterialsProvider(null)
-                .setS3MaxClientRetries(3)
+                .setS3MaxClientRetries(5)
                 .setS3MaxErrorRetries(10)
                 .setS3MaxBackoffTime(new Duration(10, TimeUnit.MINUTES))
                 .setS3MaxRetryTime(new Duration(10, TimeUnit.MINUTES))


### PR DESCRIPTION
The default max S3 backoff time is `10m` so we have some headroom for retrying more when reading from S3.