### PR TITLE
Run LDAP tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,11 @@ script:
         singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation,authorization
     fi
   - |
+    if [[ -v PRODUCT_TESTS ]]; then
+      presto-product-tests/bin/run_on_docker.sh \
+        singlenode-ldap -g ldap_cli
+    fi
+  - |
     if [[ -v HIVE_TESTS ]]; then
       presto-hive-hadoop2/bin/run_on_docker.sh
     fi


### PR DESCRIPTION
I temporarily removed the other test matrix items and added an additional one to just run the LDAP tests (hopefully they are fast enough to run as part of the existing product tests profile).