### PR TITLE
Make db/TestQueues.testBasic deterministic

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueues.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution.resourceGroups.db;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.execution.TestingSessionFactory;
@@ -43,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.presto.execution.QueryState.FAILED;
 import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.execution.QueryState.TERMINAL_QUERY_STATES;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_REJECTED;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -83,36 +85,36 @@ public class TestQueues
 
             // wait for the first "dashboard" query to start
             waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
-            assertEquals(queryManager.getStats().getRunningQueries(), 1);
+            waitForRunningQueryCount(queryRunner, 1);
             // submit second "dashboard" query
             QueryId secondDashboardQuery = createQuery(queryRunner, newDashboardSession(), LONG_LASTING_QUERY);
             MILLISECONDS.sleep(2000);
             // wait for the second "dashboard" query to be queued ("dashboard.${USER}" queue strategy only allows one "dashboard" query to be accepted for execution)
             waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
-            assertEquals(queryManager.getStats().getRunningQueries(), 1);
+            waitForRunningQueryCount(queryRunner, 1);
             // Update db to allow for 1 more running query in dashboard resource group
             dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, null, null, null, null, null, 1L);
             dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, null, null, null, null, null, 3L);
             waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
             QueryId thirdDashboardQuery = createQuery(queryRunner, newDashboardSession(), LONG_LASTING_QUERY);
             waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
-            assertEquals(queryManager.getStats().getRunningQueries(), 2);
+            waitForRunningQueryCount(queryRunner, 2);
             // submit first non "dashboard" query
             QueryId firstNonDashboardQuery = createQuery(queryRunner, newSession(), LONG_LASTING_QUERY);
             // wait for the first non "dashboard" query to start
             waitForQueryState(queryRunner, firstNonDashboardQuery, RUNNING);
-            assertEquals(queryManager.getStats().getRunningQueries(), 3);
+            waitForRunningQueryCount(queryRunner, 3);
             // submit second non "dashboard" query
             QueryId secondNonDashboardQuery = createQuery(queryRunner, newSession(), LONG_LASTING_QUERY);
             // wait for the second non "dashboard" query to start
             waitForQueryState(queryRunner, secondNonDashboardQuery, RUNNING);
-            assertEquals(queryManager.getStats().getRunningQueries(), 4);
+            waitForRunningQueryCount(queryRunner, 4);
             // cancel first "dashboard" query, the second "dashboard" query and second non "dashboard" query should start running
             cancelQuery(queryRunner, firstDashboardQuery);
             waitForQueryState(queryRunner, firstDashboardQuery, FAILED);
             waitForQueryState(queryRunner, thirdDashboardQuery, RUNNING);
-            assertEquals(queryManager.getStats().getRunningQueries(), 4);
-            assertEquals(queryManager.getStats().getCompletedQueries().getTotalCount(), 1);
+            waitForRunningQueryCount(queryRunner, 4);
+            waitForCompleteQueryCount(queryRunner, 1);
         }
     }
 
@@ -160,7 +162,8 @@ public class TestQueues
             ResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
             do {
                 MILLISECONDS.sleep(500);
-            } while (manager.getResourceGroupInfo(
+            }
+            while (manager.getResourceGroupInfo(
                     new ResourceGroupId(new ResourceGroupId(new ResourceGroupId("global"), "user-user"), "dashboard-user")).getMaxRunningQueries() != 1);
             // Cancel query and verify that third query is still queued
             cancelQuery(queryRunner, firstDashboardQuery);
@@ -188,14 +191,16 @@ public class TestQueues
             //MILLISECONDS.sleep(2000);
             do {
                 MILLISECONDS.sleep(500);
-            } while (getSelectors(queryRunner).size() == selectorCount);
+            }
+            while (getSelectors(queryRunner).size() == selectorCount);
             // Verify the query can be submitted
             queryId = createQuery(queryRunner, newRejectionSession(), LONG_LASTING_QUERY);
             waitForQueryState(queryRunner, queryId, RUNNING);
             dao.deleteSelector(4, "user.*", "(?i).*reject.*");
             do {
                 MILLISECONDS.sleep(500);
-            } while (getSelectors(queryRunner).size() != selectorCount);
+            }
+            while (getSelectors(queryRunner).size() != selectorCount);
             // Verify the query cannot be submitted
             queryId = createQuery(queryRunner, newRejectionSession(), LONG_LASTING_QUERY);
             waitForQueryState(queryRunner, queryId, FAILED);
@@ -237,6 +242,35 @@ public class TestQueues
     private static void cancelQuery(DistributedQueryRunner queryRunner, QueryId queryId)
     {
         queryRunner.getCoordinator().getQueryManager().cancelQuery(queryId);
+    }
+
+    private static void waitForCompleteQueryCount(DistributedQueryRunner queryRunner, int expectedCount)
+            throws InterruptedException
+    {
+        waitForQueryCount(queryRunner, TERMINAL_QUERY_STATES, expectedCount);
+    }
+
+    private static void waitForRunningQueryCount(DistributedQueryRunner queryRunner, int expectedCount)
+            throws InterruptedException
+    {
+        waitForQueryCount(queryRunner, ImmutableSet.of(RUNNING), expectedCount);
+    }
+
+    private static void waitForQueryCount(DistributedQueryRunner queryRunner, Set<QueryState> countingStates, int expectedCount)
+            throws InterruptedException
+    {
+        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+        int count;
+        do {
+            MILLISECONDS.sleep(500);
+            count = 0;
+            for (QueryInfo queryInfo : queryManager.getAllQueryInfo()) {
+                if (countingStates.contains(queryInfo.getState())) {
+                    count++;
+                }
+            }
+        }
+        while (count != expectedCount);
     }
 
     private static void waitForQueryState(DistributedQueryRunner queryRunner, QueryId queryId, QueryState expectedQueryState)
@@ -327,7 +361,8 @@ public class TestQueues
         // Selectors are loaded last
         do {
             MILLISECONDS.sleep(500);
-        } while (getSelectors(queryRunner).size() != 3);
+        }
+        while (getSelectors(queryRunner).size() != 3);
     }
 
     private static List<ResourceGroupSelector> getSelectors(DistributedQueryRunner queryRunner)


### PR DESCRIPTION
Instead of asserting the running/completed query count, we wait for the count to reach the expected value.

#7667 