### PR TITLE
Lookup stub to use outside of iterative optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Lookup.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Lookup.java
@@ -15,6 +15,8 @@ package com.facebook.presto.sql.planner.iterative;
 
 import com.facebook.presto.sql.planner.plan.PlanNode;
 
+import static com.google.common.base.Verify.verify;
+
 public interface Lookup
 {
     /**
@@ -25,4 +27,16 @@ public interface Lookup
      * argument as is.
      */
     PlanNode resolve(PlanNode node);
+
+    /**
+     * A Lookup implementation that does not perform lookup. It satisfies contract
+     * by rejecting {@link GroupReference}-s.
+     */
+    static Lookup noLookup()
+    {
+        return node -> {
+            verify(!(node instanceof GroupReference), "Unexpected GroupReference");
+            return node;
+        };
+    }
 }


### PR DESCRIPTION
When code needs to support both old and iterative optimizers it needs
one API to lookup that works without Memo too.