### PR TITLE
Fix read max-data-per-node correctly in memory connector config

### DIFF
--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryConfig.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryConfig.java
@@ -29,7 +29,7 @@ public class MemoryConfig
         return splitsPerNode;
     }
 
-    @Config("splits-per-node")
+    @Config("memory.splits-per-node")
     public MemoryConfig setSplitsPerNode(int splitsPerNode)
     {
         this.splitsPerNode = splitsPerNode;
@@ -42,7 +42,7 @@ public class MemoryConfig
         return maxDataPerNode;
     }
 
-    @Config("max-data-per-node")
+    @Config("memory.max-data-per-node")
     public MemoryConfig setMaxDataPerNode(DataSize maxDataPerNode)
     {
         this.maxDataPerNode = maxDataPerNode;


### PR DESCRIPTION
#7678 
Fixed it.
I tested with 200MB and [here](https://gist.github.com/ebyhr/0d5628252e936e4107b176bbb03a04d2#file-memory-connector-log-L725) is the confirmed result.
