### PR TITLE
Add file based system access control

### DIFF
--- a/presto-docs/src/main/sphinx/security.rst
+++ b/presto-docs/src/main/sphinx/security.rst
@@ -9,3 +9,4 @@ Security
     security/cli
     security/ldap
     security/tls
+    security/built-in-system-access-control

--- a/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -1,0 +1,111 @@
+==============================
+Built-in System Access Control
+==============================
+
+A system access control plugin enforces authorization at a global level,
+before any connector level authorization. You can either use one of the built-in
+plugins in Presto or provide your own by following the guidelines in
+:doc:`/develop/system-access-control`. Presto offers three built-in plugins:
+
+================================================== ============================================================
+Plugin Name                                        Description
+================================================== ============================================================
+``allow-all`` (default value)                      All operations are permitted.
+
+``read-only``                                      Operations that read data or metadata are permitted, but
+                                                   none of the operations that write data or metadata are
+                                                   allowed. See :ref:`read-only-system-access-control` for
+                                                   details.
+
+``file``                                           Authorization checks are enforced using a config file
+                                                   specified by the configuration property ``security.config-file``.
+                                                   See :ref:`file-based-system-access-control` for details.
+================================================== ============================================================
+
+Allow All System Access Control
+===============================
+
+All operations are permitted under this plugin. This plugin is enabled by default.
+
+.. _read-only-system-access-control:
+
+Read Only System Access Control
+===============================
+
+Under this plugin, you are allowed to execute any operation that reads data or
+metadata, such as ``SELECT`` or ``SHOW``. Setting system level or catalog level
+session properties is also permitted. However, any operation that writes data or
+metadata, such as ``CREATE``, ``INSERT`` or ``DELETE``, is prohibited.
+To use this plugin, add an ``etc/access-control.properties``
+file with the following contents:
+
+.. code-block:: none
+
+   access-control.name=read-only
+
+.. _file-based-system-access-control:
+
+File Based System Access Control
+================================
+
+This plugin allows you to specify access control rules in a file. To use this
+plugin, add an ``etc/access-control.properties`` file containing two required
+properties: ``access-control.name``, which must be equal to ``file``, and
+``security.config-file``, which must be equal to the location of the config file.
+For example, if a config file named ``rules.json``
+resides in ``etc``, add an ``etc/access-control.properties`` with the following
+contents:
+
+.. code-block:: none
+
+   access-control.name=file
+   security.config-file=etc/rules.json
+
+The config file consists of a list of access control rules in JSON format. The
+rules are matched in the order specified in the file. All
+regular expressions default to ``.*`` if not specified.
+
+This plugin currently only supports catalog access control rules. If you want
+to limit access on a system level in any other way, you must implement a custom
+SystemAccessControl plugin (see :doc:`/develop/system-access-control`).
+
+Catalog Rules
+-------------
+
+These rules govern the catalogs particular users can access. The user is
+granted access to a catalog based on the first matching rule. If no rule
+matches, access is denied. Each rule is composed of the following fields:
+
+* ``user`` (optional): regex to match against user name.
+* ``catalog`` (optional): regex to match against catalog name.
+* ``allowed`` (required): boolean indicating whether a user has access to the catalog
+
+.. note::
+
+    By default, all users have access to the ``system`` catalog. You can
+    override this behavior by adding a rule.
+
+For example, if you want to allow only the user ``admin`` to access the
+``mysql`` and the ``system`` catalog, allow all users to access the ``hive``
+catalog, and deny all other access, you can use the following rules:
+
+.. code-block:: json
+
+    {
+      "catalogs": [
+        {
+          "user": "admin",
+          "catalog": "(mysql|system)",
+          "allow": true
+        },
+        {
+          "catalog": "hive",
+          "allow": true
+        },
+        {
+          "catalog": "system",
+          "allow": false
+        }
+      ]
+    }
+

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -37,6 +37,11 @@ public interface AccessControl
     Set<String> filterCatalogs(Identity identity, Set<String> catalogs);
 
     /**
+     * Check whether identity is allowed to access catalog
+     */
+    void checkCanAccessCatalog(Identity identity, String catalogName);
+
+    /**
      * Check if identity is allowed to create the specified schema.
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -28,6 +28,7 @@ import com.facebook.presto.transaction.TransactionId;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.log.Logger;
 import io.airlift.stats.CounterStat;
 import org.weakref.jmx.Managed;
@@ -47,6 +48,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.facebook.presto.spi.StandardErrorCode.SERVER_STARTING_UP;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCatalogAccess;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -79,6 +81,7 @@ public class AccessControlManager
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         addSystemAccessControlFactory(new AllowAllSystemAccessControl.Factory());
         addSystemAccessControlFactory(new ReadOnlySystemAccessControl.Factory());
+        addSystemAccessControlFactory(new FileBasedSystemAccessControl.Factory());
     }
 
     public void addSystemAccessControlFactory(SystemAccessControlFactory accessControlFactory)
@@ -157,10 +160,20 @@ public class AccessControlManager
     }
 
     @Override
+    public void checkCanAccessCatalog(Identity identity, String catalogName)
+    {
+        if (filterCatalogs(identity, ImmutableSet.of(catalogName)).isEmpty()) {
+            denyCatalogAccess(catalogName);
+        }
+    }
+
+    @Override
     public void checkCanCreateSchema(TransactionId transactionId, Identity identity, CatalogSchemaName schemaName)
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(schemaName, "schemaName is null");
+
+        authenticationCheck(() -> checkCanAccessCatalog(identity, schemaName.getCatalogName()));
 
         authorizationCheck(() -> systemAccessControl.get().checkCanCreateSchema(identity, schemaName));
 
@@ -176,6 +189,8 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(schemaName, "schemaName is null");
 
+        authenticationCheck(() -> checkCanAccessCatalog(identity, schemaName.getCatalogName()));
+
         authorizationCheck(() -> systemAccessControl.get().checkCanDropSchema(identity, schemaName));
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, schemaName.getCatalogName());
@@ -190,6 +205,8 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(schemaName, "schemaName is null");
 
+        authenticationCheck(() -> checkCanAccessCatalog(identity, schemaName.getCatalogName()));
+
         authorizationCheck(() -> systemAccessControl.get().checkCanRenameSchema(identity, schemaName, newSchemaName));
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, schemaName.getCatalogName());
@@ -203,6 +220,8 @@ public class AccessControlManager
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(catalogName, "catalogName is null");
+
+        authenticationCheck(() -> checkCanAccessCatalog(identity, catalogName));
 
         authorizationCheck(() -> systemAccessControl.get().checkCanShowSchemas(identity, catalogName));
 
@@ -219,6 +238,10 @@ public class AccessControlManager
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(schemaNames, "schemaNames is null");
 
+        if (filterCatalogs(identity, ImmutableSet.of(catalogName)).isEmpty()) {
+            return ImmutableSet.of();
+        }
+
         schemaNames = systemAccessControl.get().filterSchemas(identity, catalogName, schemaNames);
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, catalogName);
@@ -234,6 +257,8 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(tableName, "tableName is null");
 
+        authenticationCheck(() -> checkCanAccessCatalog(identity, tableName.getCatalogName()));
+
         authorizationCheck(() -> systemAccessControl.get().checkCanCreateTable(identity, tableName.asCatalogSchemaTableName()));
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, tableName.getCatalogName());
@@ -247,6 +272,8 @@ public class AccessControlManager
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(tableName, "tableName is null");
+
+        authenticationCheck(() -> checkCanAccessCatalog(identity, tableName.getCatalogName()));
 
         authorizationCheck(() -> systemAccessControl.get().checkCanDropTable(identity, tableName.asCatalogSchemaTableName()));
 
@@ -263,6 +290,8 @@ public class AccessControlManager
         requireNonNull(tableName, "tableName is null");
         requireNonNull(newTableName, "newTableName is null");
 
+        authenticationCheck(() -> checkCanAccessCatalog(identity, tableName.getCatalogName()));
+
         authorizationCheck(() -> systemAccessControl.get().checkCanRenameTable(identity, tableName.asCatalogSchemaTableName(), newTableName.asCatalogSchemaTableName()));
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, tableName.getCatalogName());
@@ -276,6 +305,8 @@ public class AccessControlManager
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(schema, "schema is null");
+
+        authenticationCheck(() -> checkCanAccessCatalog(identity, schema.getCatalogName()));
 
         authorizationCheck(() -> systemAccessControl.get().checkCanShowTablesMetadata(identity, schema));
 
@@ -292,6 +323,10 @@ public class AccessControlManager
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(tableNames, "tableNames is null");
 
+        if (filterCatalogs(identity, ImmutableSet.of(catalogName)).isEmpty()) {
+            return ImmutableSet.of();
+        }
+
         tableNames = systemAccessControl.get().filterTables(identity, catalogName, tableNames);
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, catalogName);
@@ -307,6 +342,8 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(tableName, "tableName is null");
 
+        authenticationCheck(() -> checkCanAccessCatalog(identity, tableName.getCatalogName()));
+
         authorizationCheck(() -> systemAccessControl.get().checkCanAddColumn(identity, tableName.asCatalogSchemaTableName()));
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, tableName.getCatalogName());
@@ -320,6 +357,8 @@ public class AccessControlManager
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(tableName, "tableName is null");
+
+        authenticationCheck(() -> checkCanAccessCatalog(identity, tableName.getCatalogName()));
 
         authorizationCheck(() -> systemAccessControl.get().checkCanRenameColumn(identity, tableName.asCatalogSchemaTableName()));
 
@@ -335,6 +374,8 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(tableName, "tableName is null");
 
+        authenticationCheck(() -> checkCanAccessCatalog(identity, tableName.getCatalogName()));
+
         authorizationCheck(() -> systemAccessControl.get().checkCanSelectFromTable(identity, tableName.asCatalogSchemaTableName()));
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, tableName.getCatalogName());
@@ -348,6 +389,8 @@ public class AccessControlManager
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(tableName, "tableName is null");
+
+        authenticationCheck(() -> checkCanAccessCatalog(identity, tableName.getCatalogName()));
 
         authorizationCheck(() -> systemAccessControl.get().checkCanInsertIntoTable(identity, tableName.asCatalogSchemaTableName()));
 
@@ -363,6 +406,8 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(tableName, "tableName is null");
 
+        authenticationCheck(() -> checkCanAccessCatalog(identity, tableName.getCatalogName()));
+
         authorizationCheck(() -> systemAccessControl.get().checkCanDeleteFromTable(identity, tableName.asCatalogSchemaTableName()));
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, tableName.getCatalogName());
@@ -376,6 +421,8 @@ public class AccessControlManager
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(viewName, "viewName is null");
+
+        authenticationCheck(() -> checkCanAccessCatalog(identity, viewName.getCatalogName()));
 
         authorizationCheck(() -> systemAccessControl.get().checkCanCreateView(identity, viewName.asCatalogSchemaTableName()));
 
@@ -391,6 +438,8 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(viewName, "viewName is null");
 
+        authenticationCheck(() -> checkCanAccessCatalog(identity, viewName.getCatalogName()));
+
         authorizationCheck(() -> systemAccessControl.get().checkCanDropView(identity, viewName.asCatalogSchemaTableName()));
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, viewName.getCatalogName());
@@ -404,6 +453,8 @@ public class AccessControlManager
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(viewName, "viewName is null");
+
+        authenticationCheck(() -> checkCanAccessCatalog(identity, viewName.getCatalogName()));
 
         authorizationCheck(() -> systemAccessControl.get().checkCanSelectFromView(identity, viewName.asCatalogSchemaTableName()));
 
@@ -419,6 +470,8 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(tableName, "tableName is null");
 
+        authenticationCheck(() -> checkCanAccessCatalog(identity, tableName.getCatalogName()));
+
         authorizationCheck(() -> systemAccessControl.get().checkCanCreateViewWithSelectFromTable(identity, tableName.asCatalogSchemaTableName()));
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, tableName.getCatalogName());
@@ -432,6 +485,8 @@ public class AccessControlManager
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(viewName, "viewName is null");
+
+        authenticationCheck(() -> checkCanAccessCatalog(identity, viewName.getCatalogName()));
 
         authorizationCheck(() -> systemAccessControl.get().checkCanCreateViewWithSelectFromView(identity, viewName.asCatalogSchemaTableName()));
 
@@ -448,6 +503,8 @@ public class AccessControlManager
         requireNonNull(tableName, "tableName is null");
         requireNonNull(privilege, "privilege is null");
 
+        authenticationCheck(() -> checkCanAccessCatalog(identity, tableName.getCatalogName()));
+
         authorizationCheck(() -> systemAccessControl.get().checkCanGrantTablePrivilege(identity, privilege, tableName.asCatalogSchemaTableName()));
 
         CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, tableName.getCatalogName());
@@ -462,6 +519,8 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(tableName, "tableName is null");
         requireNonNull(privilege, "privilege is null");
+
+        authenticationCheck(() -> checkCanAccessCatalog(identity, tableName.getCatalogName()));
 
         authorizationCheck(() -> systemAccessControl.get().checkCanRevokeTablePrivilege(identity, privilege, tableName.asCatalogSchemaTableName()));
 
@@ -486,6 +545,8 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(propertyName, "propertyName is null");
+
+        authenticationCheck(() -> checkCanAccessCatalog(identity, catalogName));
 
         authorizationCheck(() -> systemAccessControl.get().checkCanSetCatalogSessionProperty(identity, catalogName, propertyName));
 

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
@@ -38,6 +38,11 @@ public class AllowAllAccessControl
     }
 
     @Override
+    public void checkCanAccessCatalog(Identity identity, String catalogName)
+    {
+    }
+
+    @Override
     public void checkCanCreateSchema(TransactionId transactionId, Identity identity, CatalogSchemaName schemaName)
     {
     }

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
@@ -64,6 +64,11 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
+    public void checkCanAccessCatalog(Identity identity, String catalogName)
+    {
+    }
+
+    @Override
     public Set<String> filterCatalogs(Identity identity, Set<String> catalogs)
     {
         return catalogs;

--- a/presto-main/src/main/java/com/facebook/presto/security/CatalogAccessControlRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/CatalogAccessControlRule.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.security;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
+
+public class CatalogAccessControlRule
+{
+    private final boolean allow;
+    private final Optional<Pattern> userRegex;
+    private final Optional<Pattern> catalogRegex;
+
+    @JsonCreator
+    public CatalogAccessControlRule(
+            @JsonProperty("allow") boolean allow,
+            @JsonProperty("user") Optional<Pattern> userRegex,
+            @JsonProperty("catalog") Optional<Pattern> catalogRegex)
+    {
+        this.allow = allow;
+        this.userRegex = requireNonNull(userRegex, "userRegex is null");
+        this.catalogRegex = requireNonNull(catalogRegex, "catalogRegex is null");
+    }
+
+    public Optional<Boolean> match(String user, String catalog)
+    {
+        if (userRegex.map(regex -> regex.matcher(user).matches()).orElse(true) &&
+                catalogRegex.map(regex -> regex.matcher(catalog).matches()).orElse(true)) {
+            return Optional.of(allow);
+        }
+        return Optional.empty();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -25,6 +25,7 @@ import java.security.Principal;
 import java.util.Set;
 
 import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCatalogAccess;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateSchema;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateView;
@@ -60,6 +61,12 @@ public class DenyAllAccessControl
     public Set<String> filterCatalogs(Identity identity, Set<String> catalogs)
     {
         return ImmutableSet.of();
+    }
+
+    @Override
+    public void checkCanAccessCatalog(Identity identity, String catalogName)
+    {
+        denyCatalogAccess(catalogName);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.security;
+
+import com.facebook.presto.spi.CatalogSchemaName;
+import com.facebook.presto.spi.CatalogSchemaTableName;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.SystemAccessControl;
+import com.facebook.presto.spi.security.SystemAccessControlFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static java.util.Objects.requireNonNull;
+
+public class FileBasedSystemAccessControl
+        implements SystemAccessControl
+{
+    public static final String NAME = "file";
+
+    private final List<CatalogAccessControlRule> catalogRules;
+
+    private FileBasedSystemAccessControl(List<CatalogAccessControlRule> catalogRules)
+    {
+        this.catalogRules = catalogRules;
+    }
+
+    public static class Factory
+            implements SystemAccessControlFactory
+    {
+        private static final String CONFIG_FILE_NAME = "security.config-file";
+
+        @Override
+        public String getName()
+        {
+            return NAME;
+        }
+
+        @Override
+        public SystemAccessControl create(Map<String, String> config)
+        {
+            requireNonNull(config, "config is null");
+
+            String configFileName = config.get(CONFIG_FILE_NAME);
+            checkState(
+                    configFileName != null,
+                    "Security configuration must contain the '%s' property", CONFIG_FILE_NAME);
+
+            try {
+                Path path = Paths.get(configFileName);
+                if (!path.isAbsolute()) {
+                    path = path.toAbsolutePath();
+                }
+                path.toFile().canRead();
+
+                ImmutableList.Builder<CatalogAccessControlRule> catalogRulesBuilder = ImmutableList.builder();
+                catalogRulesBuilder.addAll(jsonCodec(FileBasedSystemAccessControlRules.class)
+                                .fromJson(Files.readAllBytes(path))
+                                .getCatalogRules());
+
+                // Hack to allow Presto Admin to access the "system" catalog for retrieving server status.
+                // todo Change userRegex from ".*" to one particular user that Presto Admin will be restricted to run as
+                catalogRulesBuilder.add(new CatalogAccessControlRule(
+                        true,
+                        Optional.of(Pattern.compile(".*")),
+                        Optional.of(Pattern.compile("system"))));
+
+                return new FileBasedSystemAccessControl(catalogRulesBuilder.build());
+            }
+            catch (SecurityException | IOException | InvalidPathException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
+    public void checkCanSetUser(Principal principal, String userName)
+    {
+    }
+
+    @Override
+    public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
+    {
+    }
+
+    @Override
+    public Set<String> filterCatalogs(Identity identity, Set<String> catalogs)
+    {
+        ImmutableSet.Builder<String> filteredCatalogs = ImmutableSet.builder();
+        for (String catalog : catalogs) {
+            if (canAccessCatalog(identity, catalog)) {
+                filteredCatalogs.add(catalog);
+            }
+        }
+        return filteredCatalogs.build();
+    }
+
+    private boolean canAccessCatalog(Identity identity, String catalogName)
+    {
+        for (CatalogAccessControlRule rule : catalogRules) {
+            Optional<Boolean> allowed = rule.match(identity.getUser(), catalogName);
+            if (allowed.isPresent()) {
+                return allowed.get();
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void checkCanCreateSchema(Identity identity, CatalogSchemaName schema)
+    {
+    }
+
+    @Override
+    public void checkCanDropSchema(Identity identity, CatalogSchemaName schema)
+    {
+    }
+
+    @Override
+    public void checkCanRenameSchema(Identity identity, CatalogSchemaName schema, String newSchemaName)
+    {
+    }
+
+    @Override
+    public void checkCanShowSchemas(Identity identity, String catalogName)
+    {
+    }
+
+    @Override
+    public Set<String> filterSchemas(Identity identity, String catalogName, Set<String> schemaNames)
+    {
+        return schemaNames;
+    }
+
+    @Override
+    public void checkCanCreateTable(Identity identity, CatalogSchemaTableName table)
+    {
+    }
+
+    @Override
+    public void checkCanDropTable(Identity identity, CatalogSchemaTableName table)
+    {
+    }
+
+    @Override
+    public void checkCanRenameTable(Identity identity, CatalogSchemaTableName table, CatalogSchemaTableName newTable)
+    {
+    }
+
+    @Override
+    public void checkCanShowTablesMetadata(Identity identity, CatalogSchemaName schema)
+    {
+    }
+
+    @Override
+    public Set<SchemaTableName> filterTables(Identity identity, String catalogName, Set<SchemaTableName> tableNames)
+    {
+        return tableNames;
+    }
+
+    @Override
+    public void checkCanAddColumn(Identity identity, CatalogSchemaTableName table)
+    {
+    }
+
+    @Override
+    public void checkCanRenameColumn(Identity identity, CatalogSchemaTableName table)
+    {
+    }
+
+    @Override
+    public void checkCanSelectFromTable(Identity identity, CatalogSchemaTableName table)
+    {
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(Identity identity, CatalogSchemaTableName table)
+    {
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(Identity identity, CatalogSchemaTableName table)
+    {
+    }
+
+    @Override
+    public void checkCanCreateView(Identity identity, CatalogSchemaTableName view)
+    {
+    }
+
+    @Override
+    public void checkCanDropView(Identity identity, CatalogSchemaTableName view)
+    {
+    }
+
+    @Override
+    public void checkCanSelectFromView(Identity identity, CatalogSchemaTableName view)
+    {
+    }
+
+    @Override
+    public void checkCanCreateViewWithSelectFromTable(Identity identity, CatalogSchemaTableName table)
+    {
+    }
+
+    @Override
+    public void checkCanCreateViewWithSelectFromView(Identity identity, CatalogSchemaTableName view)
+    {
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity, String catalogName, String propertyName)
+    {
+    }
+
+    @Override
+    public void checkCanGrantTablePrivilege(Identity identity, Privilege privilege, CatalogSchemaTableName table)
+    {
+    }
+
+    @Override
+    public void checkCanRevokeTablePrivilege(Identity identity, Privilege privilege, CatalogSchemaTableName table)
+    {
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCatalogAccess;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static java.util.Objects.requireNonNull;
@@ -110,6 +111,14 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
+    public void checkCanAccessCatalog(Identity identity, String catalogName)
+    {
+        if (!canAccessCatalog(identity, catalogName)) {
+            denyCatalogAccess(catalogName);
+        }
+    }
+
+    @Override
     public Set<String> filterCatalogs(Identity identity, Set<String> catalogs)
     {
         ImmutableSet.Builder<String> filteredCatalogs = ImmutableSet.builder();
@@ -155,6 +164,10 @@ public class FileBasedSystemAccessControl
     @Override
     public Set<String> filterSchemas(Identity identity, String catalogName, Set<String> schemaNames)
     {
+        if (!canAccessCatalog(identity, catalogName)) {
+            return ImmutableSet.of();
+        }
+
         return schemaNames;
     }
 
@@ -181,6 +194,10 @@ public class FileBasedSystemAccessControl
     @Override
     public Set<SchemaTableName> filterTables(Identity identity, String catalogName, Set<SchemaTableName> tableNames)
     {
+        if (!canAccessCatalog(identity, catalogName)) {
+            return ImmutableSet.of();
+        }
+
         return tableNames;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControlRules.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControlRules.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.security;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+public class FileBasedSystemAccessControlRules
+{
+    private final List<CatalogAccessControlRule> catalogRules;
+
+    @JsonCreator
+    public FileBasedSystemAccessControlRules(@JsonProperty("catalogs") Optional<List<CatalogAccessControlRule>> catalogRules)
+    {
+        this.catalogRules = catalogRules.map(ImmutableList::copyOf).orElse(ImmutableList.of());
+    }
+
+    public List<CatalogAccessControlRule> getCatalogRules()
+    {
+        return catalogRules;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/security/ReadOnlySystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/ReadOnlySystemAccessControl.java
@@ -63,6 +63,11 @@ public class ReadOnlySystemAccessControl
     }
 
     @Override
+    public void checkCanAccessCatalog(Identity identity, String catalogName)
+    {
+    }
+
+    @Override
     public void checkCanSelectFromTable(Identity identity, CatalogSchemaTableName table)
     {
     }

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -264,6 +264,11 @@ public class TestAccessControlManager
                 }
 
                 @Override
+                public void checkCanAccessCatalog(Identity identity, String catalogName)
+                {
+                }
+
+                @Override
                 public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
                 {
                     throw new UnsupportedOperationException();

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -276,6 +276,12 @@ public class TestAccessControlManager
                         denySelectTable(table.toString());
                     }
                 }
+
+                @Override
+                public Set<String> filterCatalogs(Identity identity, Set<String> catalogs)
+                {
+                    return catalogs;
+                }
             };
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.security;
+
+import com.facebook.presto.metadata.QualifiedObjectName;
+import com.facebook.presto.spi.CatalogSchemaName;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.security.AccessDeniedException;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.spi.security.Privilege.SELECT;
+import static com.facebook.presto.transaction.TransactionBuilder.transaction;
+import static com.facebook.presto.transaction.TransactionManager.createTestTransactionManager;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class TestFileBasedSystemAccessControl
+{
+    private static final Identity alice = new Identity("alice", Optional.empty());
+    private static final Identity bob = new Identity("bob", Optional.empty());
+    private static final Identity admin = new Identity("admin", Optional.empty());
+    private static final Identity nonAsciiUser = new Identity("\u0194\u0194\u0194", Optional.empty());
+    private static final Set<String> allCatalogs = ImmutableSet.of("secret", "open-to-all", "all-allowed", "alice-catalog", "allowed-absent", "\u0200\u0200\u0200");
+    private static final QualifiedObjectName aliceTable = new QualifiedObjectName("alice-catalog", "schema", "table");
+    private static final QualifiedObjectName aliceView = new QualifiedObjectName("alice-catalog", "schema", "view");
+    private static final CatalogSchemaName aliceSchema = new CatalogSchemaName("alice-catalog", "schema");
+    private TransactionManager transactionManager;
+
+    @Test
+    public void testCatalogOperations()
+    {
+       AccessControlManager accessControlManager = newAccessControlManager();
+
+        transaction(transactionManager, accessControlManager)
+                .execute(transactionId -> {
+                    assertEquals(accessControlManager.filterCatalogs(admin, allCatalogs), allCatalogs);
+                    Set<String> aliceCatalogs = ImmutableSet.of("open-to-all", "alice-catalog", "all-allowed");
+                    assertEquals(accessControlManager.filterCatalogs(alice, allCatalogs), aliceCatalogs);
+                    Set<String> bobCatalogs = ImmutableSet.of("open-to-all", "all-allowed");
+                    assertEquals(accessControlManager.filterCatalogs(bob, allCatalogs), bobCatalogs);
+                    Set<String> nonAsciiUserCatalogs = ImmutableSet.of("open-to-all", "all-allowed", "\u0200\u0200\u0200");
+                    assertEquals(accessControlManager.filterCatalogs(nonAsciiUser, allCatalogs), nonAsciiUserCatalogs);
+                });
+    }
+
+    @Test
+    public void testSchemaOperations()
+    {
+        AccessControlManager accessControlManager = newAccessControlManager();
+
+        transaction(transactionManager, accessControlManager)
+                .execute(transactionId -> {
+                    Set<String> aliceSchemas = ImmutableSet.of("schema");
+                    assertEquals(accessControlManager.filterSchemas(transactionId, alice, "alice-catalog", aliceSchemas), aliceSchemas);
+                    assertEquals(accessControlManager.filterSchemas(transactionId, bob, "alice-catalog", aliceSchemas), ImmutableSet.of());
+
+                    accessControlManager.checkCanCreateSchema(transactionId, alice, aliceSchema);
+                    accessControlManager.checkCanDropSchema(transactionId, alice, aliceSchema);
+                    accessControlManager.checkCanRenameSchema(transactionId, alice, aliceSchema, "new-schema");
+                    accessControlManager.checkCanShowSchemas(transactionId, alice, "alice-catalog");
+                });
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanCreateSchema(transactionId, bob, aliceSchema);
+        }));
+    }
+
+    @Test
+    public void testTableOperations()
+    {
+        AccessControlManager accessControlManager = newAccessControlManager();
+
+        transaction(transactionManager, accessControlManager)
+                .execute(transactionId -> {
+                    Set<SchemaTableName> aliceTables = ImmutableSet.of(new SchemaTableName("schema", "table"));
+                    assertEquals(accessControlManager.filterTables(transactionId, alice, "alice-catalog", aliceTables), aliceTables);
+                    assertEquals(accessControlManager.filterTables(transactionId, bob, "alice-catalog", aliceTables), ImmutableSet.of());
+
+                    accessControlManager.checkCanCreateTable(transactionId, alice, aliceTable);
+                    accessControlManager.checkCanDropTable(transactionId, alice, aliceTable);
+                    accessControlManager.checkCanSelectFromTable(transactionId, alice, aliceTable);
+                    accessControlManager.checkCanInsertIntoTable(transactionId, alice, aliceTable);
+                    accessControlManager.checkCanDeleteFromTable(transactionId, alice, aliceTable);
+                    accessControlManager.checkCanAddColumns(transactionId, alice, aliceTable);
+                    accessControlManager.checkCanRenameColumn(transactionId, alice, aliceTable);
+                });
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanCreateTable(transactionId, bob, aliceTable);
+        }));
+    }
+
+    @Test
+    public void testViewOperations()
+            throws Exception
+    {
+        AccessControlManager accessControlManager = newAccessControlManager();
+
+        transaction(transactionManager, accessControlManager)
+                .execute(transactionId -> {
+                    accessControlManager.checkCanCreateView(transactionId, alice, aliceView);
+                    accessControlManager.checkCanDropView(transactionId, alice, aliceView);
+                    accessControlManager.checkCanSelectFromView(transactionId, alice, aliceView);
+                    accessControlManager.checkCanCreateViewWithSelectFromTable(transactionId, alice, aliceTable);
+                    accessControlManager.checkCanCreateViewWithSelectFromView(transactionId, alice, aliceView);
+                    accessControlManager.checkCanSetCatalogSessionProperty(transactionId, alice, "alice-catalog", "property");
+                    accessControlManager.checkCanGrantTablePrivilege(transactionId, alice, SELECT, aliceTable);
+                    accessControlManager.checkCanRevokeTablePrivilege(transactionId, alice, SELECT, aliceTable);
+                });
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanCreateView(transactionId, bob, aliceView);
+        }));
+    }
+
+    private AccessControlManager newAccessControlManager()
+    {
+        transactionManager = createTestTransactionManager();
+        AccessControlManager accessControlManager =  new AccessControlManager(transactionManager);
+
+        String path = this.getClass().getClassLoader().getResource("catalog.json").getPath();
+        accessControlManager.setSystemAccessControl(FileBasedSystemAccessControl.NAME, ImmutableMap.of("security.config-file", path));
+
+        return accessControlManager;
+    }
+}

--- a/presto-main/src/test/resources/catalog.json
+++ b/presto-main/src/test/resources/catalog.json
@@ -1,0 +1,40 @@
+{
+  "catalogs": [
+    {
+      "user": "admin",
+      "catalog": ".*",
+      "allow": true
+    },
+    {
+      "catalog": "secret",
+      "allow": false
+    },
+    {
+      "user": ".*",
+      "catalog": "open-to-all",
+      "allow": true
+    },
+    {
+      "catalog": "all-allowed",
+      "allow": true
+    },
+    {
+      "user": "alice",
+      "catalog": "alice-catalog",
+      "allow": true
+    },
+    {
+      "user": "bob",
+      "catalog": "alice-catalog",
+      "allow": false
+    },
+    {
+      "catalog": "allowed-absent"
+    },
+    {
+      "user": "\u0194\u0194\u0194",
+      "catalog": "\u0200\u0200\u0200",
+      "allow": true
+    }
+  ]
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
@@ -38,6 +38,16 @@ public class AccessDeniedException
         throw new AccessDeniedException(format("Principal %s cannot become user %s%s", principal, userName, formatExtraInfo(extraInfo)));
     }
 
+    public static void denyCatalogAccess(String catalogName)
+    {
+        denyCatalogAccess(catalogName, null);
+    }
+
+    public static void denyCatalogAccess(String catalogName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot access catalog %s%s", catalogName, formatExtraInfo(extraInfo)));
+    }
+
     public static void denyCreateSchema(String schemaName)
     {
         denyCreateSchema(schemaName, null);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -59,6 +59,13 @@ public interface SystemAccessControl
     void checkCanSetSystemSessionProperty(Identity identity, String propertyName);
 
     /**
+     * Check if identity is allowed to access the specified catalog
+     *
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanAccessCatalog(Identity identity, String catalogName);
+
+    /**
      * Filter the list of catalogs to those visible to the identity.
      */
     default Set<String> filterCatalogs(Identity identity, Set<String> catalogs)


### PR DESCRIPTION
Main motivation for this feature is to add the ability to have access control on catalogs so that administrators can restrict access to certain catalogs to certain users. This can only be done at the system level and cannot be achieved at the connector level. The file based system access control allows you to specify catalog access control rules in a file, similar to the connector level file based access control. 

The current implementation handles only the catalog access control rules. This can be extended in future to allow other types of rules.   

TD review here: https://github.com/Teradata/presto/pull/516