### PR TITLE
Add event clients to hive client

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -80,6 +80,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>event</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>json</artifactId>
         </dependency>
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -31,12 +31,14 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
+import io.airlift.event.client.EventClient;
 
 import javax.inject.Singleton;
 
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
@@ -89,12 +91,13 @@ public class HiveClientModule
         binder.bind(TypeManager.class).toInstance(typeManager);
         binder.bind(PageIndexerFactory.class).toInstance(pageIndexerFactory);
 
-        Multibinder<HiveRecordCursorProvider> recordCursorProviderBinder = Multibinder.newSetBinder(binder, HiveRecordCursorProvider.class);
+        Multibinder<HiveRecordCursorProvider> recordCursorProviderBinder = newSetBinder(binder, HiveRecordCursorProvider.class);
         recordCursorProviderBinder.addBinding().to(ParquetRecordCursorProvider.class).in(Scopes.SINGLETON);
         recordCursorProviderBinder.addBinding().to(ColumnarTextHiveRecordCursorProvider.class).in(Scopes.SINGLETON);
         recordCursorProviderBinder.addBinding().to(ColumnarBinaryHiveRecordCursorProvider.class).in(Scopes.SINGLETON);
         recordCursorProviderBinder.addBinding().to(GenericHiveRecordCursorProvider.class).in(Scopes.SINGLETON);
 
+        newSetBinder(binder, EventClient.class).addBinding().to(HiveEventClient.class).in(Scopes.SINGLETON);
         binder.bind(HivePartitionManager.class).in(Scopes.SINGLETON);
         binder.bind(LocationService.class).to(HiveLocationService.class).in(Scopes.SINGLETON);
         binder.bind(TableParameterCodec.class).in(Scopes.SINGLETON);
@@ -107,13 +110,13 @@ public class HiveClientModule
 
         jsonCodecBinder(binder).bindJsonCodec(PartitionUpdate.class);
 
-        Multibinder<HivePageSourceFactory> pageSourceFactoryBinder = Multibinder.newSetBinder(binder, HivePageSourceFactory.class);
+        Multibinder<HivePageSourceFactory> pageSourceFactoryBinder = newSetBinder(binder, HivePageSourceFactory.class);
         pageSourceFactoryBinder.addBinding().to(OrcPageSourceFactory.class).in(Scopes.SINGLETON);
         pageSourceFactoryBinder.addBinding().to(DwrfPageSourceFactory.class).in(Scopes.SINGLETON);
         pageSourceFactoryBinder.addBinding().to(ParquetPageSourceFactory.class).in(Scopes.SINGLETON);
         pageSourceFactoryBinder.addBinding().to(RcFilePageSourceFactory.class).in(Scopes.SINGLETON);
 
-        Multibinder<HiveFileWriterFactory> fileWriterFactoryBinder = Multibinder.newSetBinder(binder, HiveFileWriterFactory.class);
+        Multibinder<HiveFileWriterFactory> fileWriterFactoryBinder = newSetBinder(binder, HiveFileWriterFactory.class);
         fileWriterFactoryBinder.addBinding().to(RcFileFileWriterFactory.class).in(Scopes.SINGLETON);
 
         binder.bind(PrestoS3FileSystemStats.class).toInstance(PrestoS3FileSystem.getFileSystemStats());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.event.client.EventModule;
 import io.airlift.json.JsonModule;
 import org.weakref.jmx.guice.MBeanModule;
 
@@ -83,6 +84,7 @@ public class HiveConnectorFactory
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(
+                    new EventModule(),
                     new MBeanModule(),
                     new JsonModule(),
                     new HiveClientModule(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveEventClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveEventClient.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import io.airlift.event.client.AbstractEventClient;
+import io.airlift.log.Logger;
+
+import java.io.IOException;
+
+public class HiveEventClient
+        extends AbstractEventClient
+{
+    private static final Logger log = Logger.get(HiveEventClient.class);
+
+    @Override
+    public <T> void postEvent(T event)
+            throws IOException
+    {
+        if (!(event instanceof WriteCompletedEvent)) {
+            return;
+        }
+        WriteCompletedEvent writeCompletedEvent = (WriteCompletedEvent) event;
+        log.info("File created: query: %s, schema: %s, table: %s, partition: '%s', format: %s, size: %s, path: %s",
+                writeCompletedEvent.getQueryId(),
+                writeCompletedEvent.getSchemaName(),
+                writeCompletedEvent.getTableName(),
+                writeCompletedEvent.getPartitionName(),
+                writeCompletedEvent.getStorageFormat(),
+                writeCompletedEvent.getBytes(),
+                writeCompletedEvent.getPath());
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
@@ -19,12 +19,14 @@ import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorPageSink;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListeningExecutorService;
+import io.airlift.event.client.EventClient;
 import io.airlift.json.JsonCodec;
 
 import javax.inject.Inject;
@@ -50,6 +52,9 @@ public class HivePageSinkProvider
     private final LocationService locationService;
     private final ListeningExecutorService writeVerificationExecutor;
     private final JsonCodec<PartitionUpdate> partitionUpdateCodec;
+    private final NodeManager nodeManager;
+    private final EventClient eventClient;
+    private final HiveSessionProperties hiveSessionProperties;
 
     @Inject
     public HivePageSinkProvider(
@@ -60,7 +65,10 @@ public class HivePageSinkProvider
             TypeManager typeManager,
             HiveClientConfig config,
             LocationService locationService,
-            JsonCodec<PartitionUpdate> partitionUpdateCodec)
+            JsonCodec<PartitionUpdate> partitionUpdateCodec,
+            NodeManager nodeManager,
+            EventClient eventClient,
+            HiveSessionProperties hiveSessionProperties)
     {
         this.fileWriterFactories = ImmutableSet.copyOf(requireNonNull(fileWriterFactories, "fileWriterFactories is null"));
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -74,6 +82,9 @@ public class HivePageSinkProvider
         this.locationService = requireNonNull(locationService, "locationService is null");
         this.writeVerificationExecutor = listeningDecorator(newFixedThreadPool(config.getWriteValidationThreads(), daemonThreadsNamed("hive-write-validation-%s")));
         this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.eventClient = requireNonNull(eventClient, "eventClient is null");
+        this.hiveSessionProperties = requireNonNull(hiveSessionProperties, "hiveSessionProperties is null");
     }
 
     @Override
@@ -110,7 +121,10 @@ public class HivePageSinkProvider
                 typeManager,
                 hdfsEnvironment,
                 immutablePartitions,
-                session);
+                session,
+                nodeManager,
+                eventClient,
+                hiveSessionProperties);
 
         return new HivePageSink(
                 writerFactory,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/WriteCompletedEvent.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/WriteCompletedEvent.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import io.airlift.event.client.EventField;
+import io.airlift.event.client.EventType;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+@EventType("WriteCompletedEvent")
+public class WriteCompletedEvent
+{
+    private final String queryId;
+    private final String path;
+    private final String schemaName;
+    private final String tableName;
+    private final String partitionName;
+    private final String storageFormat;
+    private final String writerImplementation;
+    private final String prestoVersion;
+    private final String serverAddress;
+    private final String principal;
+    private final String environment;
+    private final Map<String, String> sessionProperties;
+    private final Long bytes;
+    private final long rows;
+
+    public WriteCompletedEvent(
+            String queryId,
+            String path,
+            String schemaName,
+            String tableName,
+            @Nullable String partitionName,
+            String storageFormat,
+            String writerImplementation,
+            String prestoVersion,
+            String serverAddress,
+            @Nullable String principal,
+            String environment,
+            Map<String, String> sessionProperties,
+            @Nullable Long bytes,
+            long rows)
+    {
+        this.queryId = requireNonNull(queryId, "queryId is null");
+        this.path = requireNonNull(path, "path is null");
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.partitionName = partitionName;
+        this.storageFormat = requireNonNull(storageFormat, "storageFormat is null");
+        this.writerImplementation = requireNonNull(writerImplementation, "writerImplementation is null");
+        this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
+        this.serverAddress = requireNonNull(serverAddress, "serverAddress is null");
+        this.principal = principal;
+        this.environment = requireNonNull(environment, "environment is null");
+        this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
+        this.bytes = bytes;
+        this.rows = rows;
+    }
+
+    @EventField
+    public String getQueryId()
+    {
+        return queryId;
+    }
+
+    @EventField
+    public String getPath()
+    {
+        return path;
+    }
+
+    @EventField
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @EventField
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @Nullable
+    @EventField
+    public String getPartitionName()
+    {
+        return partitionName;
+    }
+
+    @EventField
+    public String getStorageFormat()
+    {
+        return storageFormat;
+    }
+
+    @EventField
+    public String getWriterImplementation()
+    {
+        return writerImplementation;
+    }
+
+    @EventField
+    public String getPrestoVersion()
+    {
+        return prestoVersion;
+    }
+
+    @EventField
+    public String getServerAddress()
+    {
+        return serverAddress;
+    }
+
+    @Nullable
+    @EventField
+    public String getPrincipal()
+    {
+        return principal;
+    }
+
+    @EventField
+    public String getEnvironment()
+    {
+        return environment;
+    }
+
+    @EventField
+    public Map<String, String> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    @Nullable
+    @EventField
+    public Long getBytes()
+    {
+        return bytes;
+    }
+
+    @EventField
+    public long getRows()
+    {
+        return rows;
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -77,6 +77,7 @@ import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.TestingConnectorSession;
+import com.facebook.presto.testing.TestingNodeManager;
 import com.facebook.presto.type.ArrayType;
 import com.facebook.presto.type.MapType;
 import com.google.common.collect.ImmutableList;
@@ -555,7 +556,10 @@ public abstract class AbstractTestHiveClient
                 TYPE_MANAGER,
                 new HiveClientConfig(),
                 locationService,
-                partitionUpdateCodec);
+                partitionUpdateCodec,
+                new TestingNodeManager("fake-environment"),
+                new HiveEventClient(),
+                new HiveSessionProperties(hiveClientConfig));
         pageSourceProvider = new HivePageSourceProvider(hiveClientConfig, hdfsEnvironment, getDefaultHiveRecordCursorProvider(hiveClientConfig), getDefaultHiveDataStreamFactories(hiveClientConfig), TYPE_MANAGER);
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -47,6 +47,7 @@ import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.TestingConnectorSession;
+import com.facebook.presto.testing.TestingNodeManager;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -205,7 +206,10 @@ public abstract class AbstractTestHiveClientS3
                 TYPE_MANAGER,
                 new HiveClientConfig(),
                 locationService,
-                partitionUpdateCodec);
+                partitionUpdateCodec,
+                new TestingNodeManager("fake-environment"),
+                new HiveEventClient(),
+                new HiveSessionProperties(hiveClientConfig));
         pageSourceProvider = new HivePageSourceProvider(hiveClientConfig, hdfsEnvironment, getDefaultHiveRecordCursorProvider(hiveClientConfig), getDefaultHiveDataStreamFactories(hiveClientConfig), TYPE_MANAGER);
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.TestingConnectorSession;
+import com.facebook.presto.testing.TestingNodeManager;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -237,7 +238,10 @@ public class TestHivePageSink
                 TYPE_MANAGER,
                 config,
                 new HiveLocationService(hdfsEnvironment),
-                partitionUpdateCodec);
+                partitionUpdateCodec,
+                new TestingNodeManager("fake-environment"),
+                new HiveEventClient(),
+                new HiveSessionProperties(config));
         return provider.createPageSink(transaction, getSession(config), handle);
     }
 


### PR DESCRIPTION
Add new event type to presto-hive so that hive page sink may post
information when a write finishes. For now, a dummy event client is
added to just print out a log line.