### PR TITLE
Support MaterializedView in Cassandra connector

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
@@ -54,6 +54,8 @@ public interface CassandraSession
 
     List<CassandraPartition> getPartitions(CassandraTable table, List<Object> filterPrefix);
 
+    boolean isMaterializedView(SchemaTableName schemaTableName);
+
     ResultSet execute(String cql, Object... values);
 
     List<SizeEstimate> getSizeEstimates(String keyspaceName, String tableName);

--- a/presto-product-tests/conf/presto/etc/catalog/cassandra.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/cassandra.properties
@@ -1,2 +1,3 @@
 connector.name=cassandra
 cassandra.contact-points=cassandra
+cassandra.allow-drop-table=true


### PR DESCRIPTION
CachingCassandraSchemaProvider's `loadTable` method may not be efficient since it gets all tables in the schema.

#7363