### PR TITLE
Fix unsafe access in zstd decompressor

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/zstd/ZstdFrameDecompressor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/zstd/ZstdFrameDecompressor.java
@@ -540,7 +540,7 @@ class ZstdFrameDecompressor
 
     private void copyMatchTail(Object outputBase, long fastOutputLimit, long output, long matchOutputLimit, long matchAddress)
     {
-        if (matchOutputLimit > fastOutputLimit - MIN_MATCH) {
+        if (matchOutputLimit > fastOutputLimit) {
             while (output < fastOutputLimit) {
                 UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
                 matchAddress += SIZE_OF_LONG;
@@ -552,12 +552,11 @@ class ZstdFrameDecompressor
             }
         }
         else {
-            do {
+            while (output < matchOutputLimit) {
                 UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
                 matchAddress += SIZE_OF_LONG;
                 output += SIZE_OF_LONG;
             }
-            while (output < matchOutputLimit);
         }
     }
 


### PR DESCRIPTION
When matchOutputLength differs from fastOutputLength by MINMATCH,
the fast path can end up writing beyond the limit.