### PR TITLE
Improve verifier error message

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
@@ -252,7 +252,10 @@ public class Validator
         for (String prequeryString : query.getPreQueries()) {
             QueryResult queryResult = executor.apply(prequeryString);
             preQueryResults.add(queryResult);
-            if (queryResult.getState() != State.SUCCESS) {
+            if (queryResult.getState() == State.TIMEOUT) {
+                return queryResult;
+            }
+            else if (queryResult.getState() != State.SUCCESS) {
                 return new QueryResult(State.FAILED_TO_SETUP, queryResult.getException(), queryResult.getWallTime(), queryResult.getCpuTime(), queryResult.getQueryId(), ImmutableList.of());
             }
         }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Verifier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Verifier.java
@@ -36,6 +36,7 @@ import java.util.regex.Pattern;
 import static com.facebook.presto.spi.StandardErrorCode.PAGE_TRANSPORT_TIMEOUT;
 import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_MISMATCH;
 import static com.facebook.presto.spi.StandardErrorCode.TOO_MANY_REQUESTS_FAILED;
+import static com.facebook.presto.verifier.QueryResult.State.SUCCESS;
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -201,7 +202,7 @@ public class Verifier
             if (e != null && shouldAddStackTrace(e)) {
                 errorMessage += getStackTraceAsString(e);
             }
-            else {
+            if (control.getState() == SUCCESS && test.getState() == SUCCESS) {
                 errorMessage += validator.getResultsComparison(precision).trim();
             }
         }


### PR DESCRIPTION
* If test query timed out during set up, mark as TIMEOUT rather than FAILED_TO_SETUP.
* Only compare results if both control and test queries are SUCCESS.