### PR TITLE
Fix null handling for many connectors when listing columns

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloMetadata.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloMetadata.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.accumulo.AccumuloErrorCode.ACCUMULO_TABLE_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -409,18 +410,9 @@ public class AccumuloMetadata
 
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        // List all tables if schema or table is null
-        if (prefix.getSchemaName() == null || prefix.getTableName() == null) {
-            return listTables(session, prefix.getSchemaName());
-        }
-
-        // Make sure requested table exists, returning the single table of it does
-        SchemaTableName table = new SchemaTableName(prefix.getSchemaName(), prefix.getTableName());
-        if (getTableHandle(session, table) != null) {
-            return ImmutableList.of(table);
-        }
-
-        // Else, return empty list
-        return ImmutableList.of();
+        return listTables(session, prefix.getSchemaName())
+                .stream()
+                .filter(schematablename -> prefix.matches(schematablename))
+                .collect(Collectors.toList());
     }
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.cassandra.CassandraType.toCassandraType;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -180,10 +181,10 @@ public class CassandraMetadata
 
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        if (prefix.getSchemaName() == null) {
-            return listTables(session, prefix.getSchemaName());
-        }
-        return ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        return listTables(session, prefix.getSchemaName())
+                .stream()
+                .filter(schematablename -> prefix.matches(schematablename))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleMetadata.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleMetadata.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -175,10 +176,10 @@ public class ExampleMetadata
 
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        if (prefix.getSchemaName() == null) {
-            return listTables(session, prefix.getSchemaName());
-        }
-        return ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        return listTables(session, prefix.getSchemaName())
+                .stream()
+                .filter(schematablename -> prefix.matches(schematablename))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/presto-example-http/src/test/java/com/facebook/presto/example/TestExampleMetadata.java
+++ b/presto-example-http/src/test/java/com/facebook/presto/example/TestExampleMetadata.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -27,6 +28,8 @@ import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.net.URL;
+import java.util.List;
+import java.util.Map;
 
 import static com.facebook.presto.example.MetadataUtil.CATALOG_CODEC;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -35,6 +38,7 @@ import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 @Test(singleThreaded = true)
@@ -141,6 +145,23 @@ public class TestExampleMetadata
         // ExampleTableHandle and ExampleColumnHandle passed in.  This is on because
         // it is not possible for the Presto Metadata system to create the handles
         // directly.
+    }
+
+    @Test
+    public void testListTableColumns()
+    {
+        Map<SchemaTableName, List<ColumnMetadata>> tableColumns = metadata.listTableColumns(SESSION, new SchemaTablePrefix());
+        assertTrue(tableColumns.size() == 3);
+
+        tableColumns = metadata.listTableColumns(SESSION, new SchemaTablePrefix("tpch"));
+        assertTrue(tableColumns.size() == 2);
+        assertTrue(tableColumns.containsKey(new SchemaTableName("tpch", "orders")));
+
+        tableColumns = metadata.listTableColumns(SESSION, new SchemaTablePrefix("tpch", "orders"));
+        assertTrue(tableColumns.size() == 1);
+
+        tableColumns = metadata.listTableColumns(SESSION, new SchemaTablePrefix("foo", "bar"));
+        assertTrue(tableColumns.size() == 0);
     }
 
     @Test(expectedExceptions = PrestoException.class)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -343,10 +343,10 @@ public class HiveMetadata
 
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        if (prefix.getSchemaName() == null || prefix.getTableName() == null) {
-            return listTables(session, prefix.getSchemaName());
-        }
-        return ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        return listTables(session, prefix.getSchemaName())
+                .stream()
+                .filter(schematablename -> prefix.matches(schematablename))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
@@ -147,17 +147,14 @@ public class JmxMetadata
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, String schemaNameOrNull)
     {
-        if (JMX_SCHEMA_NAME.equals(schemaNameOrNull)) {
-            return listJmxTables();
+        Builder<SchemaTableName> tableNames = ImmutableList.builder();
+        if (schemaNameOrNull == null || JMX_SCHEMA_NAME.equals(schemaNameOrNull)) {
+            tableNames.addAll(listJmxTables());
         }
-        else if (HISTORY_SCHEMA_NAME.equals(schemaNameOrNull)) {
-            return jmxHistoricalData.getTables().stream()
-                    .map(tableName -> new SchemaTableName(JmxMetadata.HISTORY_SCHEMA_NAME, tableName))
-                    .collect(toList());
+        if (schemaNameOrNull == null || HISTORY_SCHEMA_NAME.equals(schemaNameOrNull)) {
+            tableNames.addAll(listHistoricalTables());
         }
-        else {
-            return ImmutableList.of();
-        }
+        return tableNames.build();
     }
 
     private List<SchemaTableName> listJmxTables()
@@ -168,6 +165,13 @@ public class JmxMetadata
             tableNames.add(new SchemaTableName(JMX_SCHEMA_NAME, objectName.toString().toLowerCase(ENGLISH)));
         }
         return tableNames.build();
+    }
+
+    public List<SchemaTableName> listHistoricalTables()
+    {
+        return jmxHistoricalData.getTables().stream()
+                .map(tableName -> new SchemaTableName(JmxMetadata.HISTORY_SCHEMA_NAME, tableName))
+                .collect(toList());
     }
 
     @Override

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.kafka.KafkaHandleResolver.convertColumnHandle;
 import static com.facebook.presto.kafka.KafkaHandleResolver.convertTableHandle;
@@ -171,7 +172,7 @@ public class KafkaMetadata
 
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
 
-        List<SchemaTableName> tableNames = prefix.getSchemaName() == null ? listTables(session, null) : ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        List<SchemaTableName> tableNames = listTables(session, prefix);
 
         for (SchemaTableName tableName : tableNames) {
             ConnectorTableMetadata tableMetadata = getTableMetadata(tableName);
@@ -181,6 +182,14 @@ public class KafkaMetadata
             }
         }
         return columns.build();
+    }
+
+    private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        return listTables(session, prefix.getSchemaName())
+                .stream()
+                .filter(schematablename -> prefix.matches(schematablename))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileMetadata.java
+++ b/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileMetadata.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.localfile.LocalFileColumnHandle.SERVER_ADDRESS_COLUMN_NAME;
 import static com.facebook.presto.localfile.LocalFileColumnHandle.SERVER_ADDRESS_ORDINAL_POSITION;
@@ -81,7 +82,12 @@ public class LocalFileMetadata
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, String schemaNameOrNull)
     {
-        return localFileTables.getTables();
+        if (schemaNameOrNull == null || schemaNameOrNull.equals(PRESTO_LOGS_SCHEMA)) {
+            return localFileTables.getTables();
+        }
+        else {
+            return ImmutableList.of();
+        }
     }
 
     @Override
@@ -158,9 +164,9 @@ public class LocalFileMetadata
 
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        if (prefix.getSchemaName() == null) {
-            return listTables(session, prefix.getSchemaName());
-        }
-        return ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        return listTables(session, prefix.getSchemaName())
+                .stream()
+                .filter(schematablename -> prefix.matches(schematablename))
+                .collect(Collectors.toList());
     }
 }

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoMetadata.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoMetadata.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Locale.ENGLISH;
@@ -281,10 +282,10 @@ public class MongoMetadata
 
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        if (prefix.getSchemaName() == null) {
-            return listTables(session, prefix.getSchemaName());
-        }
-        return ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        return listTables(session, prefix.getSchemaName())
+                .stream()
+                .filter(schematablename -> prefix.matches(schematablename))
+                .collect(Collectors.toList());
     }
 
     private static List<MongoColumnHandle> buildColumnHandles(ConnectorTableMetadata tableMetadata)

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisMetadata.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisMetadata.java
@@ -215,15 +215,7 @@ public class RedisMetadata
 
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
 
-        List<SchemaTableName> tableNames;
-        if (prefix.getSchemaName() == null) {
-            tableNames = listTables(session, null);
-        }
-        else {
-            tableNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
-        }
-
-        for (SchemaTableName tableName : tableNames) {
+        for (SchemaTableName tableName : listTables(session, prefix)) {
             ConnectorTableMetadata tableMetadata = getTableMetadata(tableName);
             // table can disappear during listing operation
             if (tableMetadata != null) {
@@ -231,6 +223,14 @@ public class RedisMetadata
             }
         }
         return columns.build();
+    }
+
+    private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        return listTables(session, prefix.getSchemaName())
+                .stream()
+                .filter(schematablename -> prefix.matches(schematablename))
+                .collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
Many connectors make the same mistake for handling nulls when listing columns. If the schema name is not null but the table name is, then the constructor to SchemaTableName will throw an exception. This was handled incorrectly by ExampleMetadata, which most connectors seem to have copied from.

This was fixed for Hive in 86566f570812cc9a3cc7621fb32ef7546103259b.