### PR TITLE
Add additional information to the ExchangeClientStatus

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
@@ -92,6 +92,8 @@ public class ExchangeClient
 
     private final SystemMemoryUsageListener systemMemoryUsageListener;
 
+    // ExchangeClientStatus.mergeWith assumes all clients have the same bufferCapacity.
+    // Please change that method accordingly when this assumption becomes not true.
     public ExchangeClient(
             DataSize bufferCapacity,
             DataSize maxResponseSize,

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
@@ -26,7 +26,9 @@ public class ExchangeClientStatus
         implements OperatorInfo
 {
     private final long bufferedBytes;
+    private final long maxBufferedBytes;
     private final long averageBytesPerRequest;
+    private final long successfulRequestsCount;
     private final int bufferedPages;
     private final boolean noMoreLocations;
     private final List<PageBufferClientStatus> pageBufferClientStatuses;
@@ -34,13 +36,17 @@ public class ExchangeClientStatus
     @JsonCreator
     public ExchangeClientStatus(
             @JsonProperty("bufferedBytes") long bufferedBytes,
+            @JsonProperty("maxBufferedBytes") long maxBufferedBytes,
             @JsonProperty("averageBytesPerRequest") long averageBytesPerRequest,
+            @JsonProperty("successfulRequestsCount") long successFullRequestsCount,
             @JsonProperty("bufferedPages") int bufferedPages,
             @JsonProperty("noMoreLocations") boolean noMoreLocations,
             @JsonProperty("pageBufferClientStatuses") List<PageBufferClientStatus> pageBufferClientStatuses)
     {
         this.bufferedBytes = bufferedBytes;
+        this.maxBufferedBytes = maxBufferedBytes;
         this.averageBytesPerRequest = averageBytesPerRequest;
+        this.successfulRequestsCount = successFullRequestsCount;
         this.bufferedPages = bufferedPages;
         this.noMoreLocations = noMoreLocations;
         this.pageBufferClientStatuses = ImmutableList.copyOf(requireNonNull(pageBufferClientStatuses, "pageBufferClientStatuses is null"));
@@ -53,9 +59,21 @@ public class ExchangeClientStatus
     }
 
     @JsonProperty
+    public long getMaxBufferedBytes()
+    {
+        return maxBufferedBytes;
+    }
+
+    @JsonProperty
     public long getAverageBytesPerRequest()
     {
         return averageBytesPerRequest;
+    }
+
+    @JsonProperty
+    public long getSuccessfulRequestsCount()
+    {
+        return successfulRequestsCount;
     }
 
     @JsonProperty
@@ -82,7 +100,9 @@ public class ExchangeClientStatus
     {
         return toStringHelper(this)
                 .add("bufferBytes", bufferedBytes)
+                .add("maxBufferBytes", maxBufferedBytes)
                 .add("averageBytesPerRequest", averageBytesPerRequest)
+                .add("successfulRequestsCount", successfulRequestsCount)
                 .add("bufferedPages", bufferedPages)
                 .add("noMoreLocations", noMoreLocations)
                 .add("pageBufferClientStatuses", pageBufferClientStatuses)

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
@@ -124,10 +124,10 @@ public class ExchangeClientStatus
 
     private static long mergeAvgs(long value1, long count1, long value2, long count2)
     {
-        if (count1 < 1) {
+        if (count1 == 0) {
             return value2;
         }
-        if (count2 < 1) {
+        if (count2 == 0) {
             return value1;
         }
         // AVG_n+m = AVG_n * n / (n + m) + AVG_m * m / (n + m)

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
@@ -23,7 +23,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class ExchangeClientStatus
-        implements OperatorInfo
+        implements Mergeable<ExchangeClientStatus>, OperatorInfo
 {
     private final long bufferedBytes;
     private final long maxBufferedBytes;
@@ -107,5 +107,30 @@ public class ExchangeClientStatus
                 .add("noMoreLocations", noMoreLocations)
                 .add("pageBufferClientStatuses", pageBufferClientStatuses)
                 .toString();
+    }
+
+    @Override
+    public ExchangeClientStatus mergeWith(ExchangeClientStatus other)
+    {
+        return new ExchangeClientStatus(
+                (bufferedBytes + other.bufferedBytes) / 2,
+                Math.max(maxBufferedBytes, other.maxBufferedBytes),
+                mergeAvgs(averageBytesPerRequest, successfulRequestsCount, other.averageBytesPerRequest, other.successfulRequestsCount),
+                successfulRequestsCount + other.successfulRequestsCount,
+                bufferedPages + other.bufferedPages,
+                noMoreLocations && other.noMoreLocations, // if at least one has some locations, mergee has some too
+                ImmutableList.of()); // pageBufferClientStatuses may be long, so we don't want to combine the lists
+    }
+
+    private static long mergeAvgs(long value1, long count1, long value2, long count2)
+    {
+        if (count1 < 1) {
+            return value2;
+        }
+        if (count2 < 1) {
+            return value1;
+        }
+        // AVG_n+m = AVG_n * n / (n + m) + AVG_m * m / (n + m)
+        return (value1 * count1 / (count1 + count2)) + (value2 * count2 / (count1 + count2));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
@@ -113,7 +113,7 @@ public class ExchangeClientStatus
     public ExchangeClientStatus mergeWith(ExchangeClientStatus other)
     {
         return new ExchangeClientStatus(
-                (bufferedBytes + other.bufferedBytes) / 2,
+                (bufferedBytes + other.bufferedBytes) / 2, // this is correct as long as all clients have the same buffer size (capacity)
                 Math.max(maxBufferedBytes, other.maxBufferedBytes),
                 mergeAvgs(averageBytesPerRequest, successfulRequestsCount, other.averageBytesPerRequest, other.successfulRequestsCount),
                 successfulRequestsCount + other.successfulRequestsCount,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -29,7 +29,7 @@ import static org.testng.Assert.assertEquals;
 
 public class TestOperatorStats
 {
-    private static final ExchangeClientStatus NON_MERGEABLE_INFO = new ExchangeClientStatus(0, 1, 2, false, ImmutableList.of());
+    private static final ExchangeClientStatus NON_MERGEABLE_INFO = new ExchangeClientStatus(0, 0, 1, 1, 2, false, ImmutableList.of());
     private static final PartitionedOutputInfo MERGEABLE_INFO = new PartitionedOutputInfo(1, 2);
 
     public static final OperatorStats EXPECTED = new OperatorStats(

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.operator.PartitionedOutputOperator.PartitionedOutputInfo;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
-import com.google.common.collect.ImmutableList;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -29,7 +28,7 @@ import static org.testng.Assert.assertEquals;
 
 public class TestOperatorStats
 {
-    private static final ExchangeClientStatus NON_MERGEABLE_INFO = new ExchangeClientStatus(0, 0, 1, 1, 2, false, ImmutableList.of());
+    private static final SplitOperatorInfo NON_MERGEABLE_INFO = new SplitOperatorInfo("some_info");
     private static final PartitionedOutputInfo MERGEABLE_INFO = new PartitionedOutputInfo(1, 2);
 
     public static final OperatorStats EXPECTED = new OperatorStats(
@@ -143,8 +142,8 @@ public class TestOperatorStats
 
         assertEquals(actual.getMemoryReservation(), new DataSize(20, BYTE));
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(21, BYTE));
-        assertEquals(actual.getInfo().getClass(), ExchangeClientStatus.class);
-        assertEquals(((ExchangeClientStatus) actual.getInfo()).getAverageBytesPerRequest(), NON_MERGEABLE_INFO.getAverageBytesPerRequest());
+        assertEquals(actual.getInfo().getClass(), SplitOperatorInfo.class);
+        assertEquals(((SplitOperatorInfo) actual.getInfo()).getSplitInfo(), NON_MERGEABLE_INFO.getSplitInfo());
     }
 
     @Test


### PR DESCRIPTION
This is prerequisite work for extending the EXPLAIN ANALYZE functionality to include more information about exchanges.

---

By making `ExchangeClientStatus` mergeable, we allow reading statistics after a query is already finished.