### PR TITLE
Optimize single value IN predicate

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -703,6 +703,12 @@ public class ExpressionInterpreter
             if (hasUnresolvedValue) {
                 Type type = type(node.getValue());
                 List<Expression> expressionValues = toExpressions(values, types);
+
+                // transform IN expression with single literal value into an equality comparison
+                if (expressionValues.size() == 1) {
+                    return new ComparisonExpression(ComparisonExpressionType.EQUAL, toExpression(value, type), expressionValues.get(0));
+                }
+
                 List<Expression> simplifiedExpressionValues = Stream.concat(
                         expressionValues.stream()
                                 .filter(DeterminismEvaluator::isDeterministic)

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -414,6 +414,9 @@ public class TestExpressionInterpreter
 
         assertOptimizedEquals("bound_long in (2, 4, unbound_long, unbound_long2, 9)", "1234 in (unbound_long, unbound_long2)");
         assertOptimizedEquals("unbound_long in (2, 4, bound_long, unbound_long2, 5)", "unbound_long in (2, 4, 1234, unbound_long2, 5)");
+
+        assertOptimizedEquals("unbound_long in (2)", "unbound_long = 2");
+        assertOptimizedEquals("unbound_long in (unbound_long2)", "unbound_long = unbound_long2");
     }
 
     @Test


### PR DESCRIPTION
Added a rule in the iterative optimizer to transform single value
IN predicate into equality.

#7430 