### PR TITLE
Revise 0.171 release notes

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.171.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.171.rst
@@ -14,6 +14,7 @@ General Changes
 * Add support for ``CHAR(n)`` data type to common string functions.
 * Add :func:`codepoint`, :func:`skewness` and :func:`kurtosis` functions.
 * Improve validation of resource group configuration.
+* Fail queries when casting unsupported types to JSON; see :doc:`/functions/json` for supported types.
 
 Web UI Changes
 --------------


### PR DESCRIPTION
Queries with unsupported cast to JSON will fail in 0.171. Make this
explicit in the 0.171 release notes.