### PR TITLE
Fix keySet(), entrySet(), values() in IdentityLinkedHashMap

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/maps/IdentityLinkedHashMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/maps/IdentityLinkedHashMap.java
@@ -65,7 +65,8 @@ public final class IdentityLinkedHashMap<K, V>
     @Override
     public boolean containsValue(Object value)
     {
-        return delegate.containsValue(value);
+        return delegate.values().stream()
+                .anyMatch(containedValue -> containedValue == value);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/util/maps/IdentityLinkedHashMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/maps/IdentityLinkedHashMap.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.Collections.unmodifiableCollection;
+import static java.util.Objects.requireNonNull;
 
 public class IdentityLinkedHashMap<K, V>
         implements Map<K, V>
@@ -73,6 +74,7 @@ public class IdentityLinkedHashMap<K, V>
     @Override
     public V put(K key, V value)
     {
+        requireNonNull(key, "key is null");
         return delegate.put(equivalence.wrap(key), value);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/util/maps/IdentityLinkedHashMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/maps/IdentityLinkedHashMap.java
@@ -87,7 +87,7 @@ public class IdentityLinkedHashMap<K, V>
     @Override
     public void putAll(Map<? extends K, ? extends V> map)
     {
-        map.entrySet().forEach(e -> delegate.put(equivalence.wrap(e.getKey()), e.getValue()));
+        map.forEach(this::put);
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/util/maps/TestIdentityLinkedHashMap.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/maps/TestIdentityLinkedHashMap.java
@@ -13,14 +13,18 @@
  */
 package com.facebook.presto.util.maps;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.stream.IntStream.range;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -72,17 +76,25 @@ public class TestIdentityLinkedHashMap
     @Test
     public void testStableIterationOrder()
     {
-        Set<String> keys = ImmutableSet.of("All", "your", "base", "are", "belong", "to", "us");
-        Map<String, Integer> expectedMap = Maps.asMap(keys, String::length);
+        List<String> keys = ImmutableList.of("All", "your", "base", "are", "belong", "to", "us");
+        List<Integer> expectedValues = keys.stream().map(String::length).collect(toImmutableList());
 
         range(0, 10).forEach(attempt -> {
             IdentityLinkedHashMap<String, Integer> map = new IdentityLinkedHashMap<>();
 
             keys.forEach(i -> map.put(i, i.length()));
 
-            assertEquals(map.keySet(), keys);
-            assertEquals(map.values(), expectedMap.values());
-            assertEquals(map.entrySet(), expectedMap.entrySet());
+            assertEquals(ImmutableList.copyOf(map.keySet()), keys);
+            assertEquals(ImmutableList.copyOf(map.keySet().iterator()), keys);
+            assertEquals(map.keySet().stream().collect(toImmutableList()), keys);
+
+            assertEquals(ImmutableList.copyOf(map.values()), expectedValues);
+            assertEquals(ImmutableList.copyOf(map.values().iterator()), expectedValues);
+            assertEquals(map.values().stream().collect(toImmutableList()), expectedValues);
+
+            assertEquals(ImmutableList.copyOf(map.entrySet()).stream().map(Entry::getKey).collect(toImmutableList()), keys);
+            assertEquals(ImmutableList.copyOf(map.entrySet()::iterator).stream().map(Entry::getKey).collect(toImmutableList()), keys);
+            assertEquals(map.entrySet().stream().map(Entry::getKey).collect(toImmutableList()), keys);
         });
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/util/maps/TestIdentityLinkedHashMap.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/maps/TestIdentityLinkedHashMap.java
@@ -27,7 +27,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
 
-public class IdentityLinkedHashMapTest
+public class TestIdentityLinkedHashMap
 {
     @Test
     public void testUsesIdentityAsEquivalenceForKeys()

--- a/presto-main/src/test/java/com/facebook/presto/util/maps/TestIdentityLinkedHashMap.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/maps/TestIdentityLinkedHashMap.java
@@ -41,12 +41,18 @@ public class TestIdentityLinkedHashMap
 {
     private final BigDecimal key;
     private final BigDecimal equalToKey;
+    private final BigDecimal value;
+    private final BigDecimal equalToValue;
 
     public TestIdentityLinkedHashMap()
     {
         key = new BigDecimal("3.141592");
         equalToKey = new BigDecimal(key.toString());
         checkState(key.equals(equalToKey));
+
+        value = new BigDecimal("42");
+        equalToValue = new BigDecimal(value.toString());
+        checkState(value.equals(equalToValue));
     }
 
     @Test
@@ -131,6 +137,37 @@ public class TestIdentityLinkedHashMap
         assertEquals(keySet.size(), 0);
         assertEquals(map.size(), 0);
         assertTrue(keySet.isEmpty());
+        assertTrue(map.isEmpty());
+    }
+
+    @Test(dataProvider = "identityHashMaps")
+    public void testEntrySetIsIdentityBased(Supplier<Map<BigDecimal, BigDecimal>> mapSupplier)
+    {
+        Map<BigDecimal, BigDecimal> map = mapSupplier.get();
+        map.put(key, value);
+        Set<Entry<BigDecimal, BigDecimal>> entrySet = map.entrySet();
+
+        assertTrue(entrySet.contains(Maps.immutableEntry(key, value)));
+        assertFalse(entrySet.contains(Maps.immutableEntry(equalToKey, value)));
+
+        assertFalse(entrySet.contains(Maps.immutableEntry(key, equalToValue)));
+        assertFalse(entrySet.contains(Maps.immutableEntry(equalToKey, equalToValue)));
+
+        assertFalse(entrySet.contains(Maps.immutableEntry(key, (BigDecimal) null)));
+        assertFalse(entrySet.contains(Maps.immutableEntry(equalToKey, (BigDecimal) null)));
+
+        assertFalse(entrySet.remove(Maps.immutableEntry(equalToKey, equalToValue)));
+        assertFalse(entrySet.remove(Maps.immutableEntry(equalToKey, value)));
+        assertFalse(entrySet.remove(Maps.immutableEntry(key, equalToValue)));
+        assertFalse(entrySet.remove(Maps.immutableEntry(key, (BigDecimal) null)));
+
+        assertEquals(entrySet.size(), 1);
+
+        assertTrue(entrySet.remove(Maps.immutableEntry(key, value))); // modification
+
+        assertEquals(entrySet.size(), 0);
+        assertEquals(map.size(), 0);
+        assertTrue(entrySet.isEmpty());
         assertTrue(map.isEmpty());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/util/maps/TestIdentityLinkedHashMap.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/maps/TestIdentityLinkedHashMap.java
@@ -21,6 +21,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -169,6 +170,23 @@ public class TestIdentityLinkedHashMap
         assertEquals(map.size(), 0);
         assertTrue(entrySet.isEmpty());
         assertTrue(map.isEmpty());
+    }
+
+    @Test(dataProvider = "identityHashMaps")
+    public void testValuesCollectionIsIdentity(Supplier<Map<BigDecimal, BigDecimal>> mapSupplier)
+    {
+        Map<BigDecimal, BigDecimal> map = mapSupplier.get();
+        map.put(key, value);
+        Collection<BigDecimal> values = map.values();
+
+        assertTrue(values.contains(value));
+        assertFalse(values.contains(equalToValue));
+        assertFalse(values.remove(equalToValue));
+        assertEquals(values.size(), 1);
+
+        assertTrue(values.remove(value));
+
+        assertEquals(values.size(), 0);
     }
 
     @Test(dataProvider = "identityHashMaps")

--- a/presto-main/src/test/java/com/facebook/presto/util/maps/TestIdentityLinkedHashMap.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/maps/TestIdentityLinkedHashMap.java
@@ -171,6 +171,15 @@ public class TestIdentityLinkedHashMap
         assertTrue(map.isEmpty());
     }
 
+    @Test(dataProvider = "identityHashMaps")
+    public void testContainsValueIsIdentityBased(Supplier<Map<BigDecimal, BigDecimal>> mapSupplier)
+    {
+        Map<BigDecimal, BigDecimal> map = mapSupplier.get();
+        map.put(key, value);
+        assertTrue(map.containsValue(value));
+        assertFalse(map.containsValue(equalToValue));
+    }
+
     @DataProvider
     public Object[][] identityHashMaps()
     {


### PR DESCRIPTION
`IdentityLinkedHashMap` is an identity-based hash map (with stable iteration order).

But `newSetFromMap(new IdentityLinkedHashMap())` is _not_ an identity-based set. Since such sets are used extensively during analysis, they _must_ be correct.