### PR TITLE
Fix copying of identity-based collections

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
@@ -22,10 +22,10 @@ import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.facebook.presto.sql.tree.SubqueryExpression;
 import com.facebook.presto.util.maps.IdentityLinkedHashMap;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
 
+import static com.facebook.presto.util.MoreSets.newIdentityHashSet;
 import static java.util.Objects.requireNonNull;
 
 public class ExpressionAnalysis
@@ -55,7 +55,7 @@ public class ExpressionAnalysis
         this.expressionTypes = requireNonNull(expressionTypes, "expressionTypes is null");
         this.expressionCoercions = requireNonNull(expressionCoercions, "expressionCoercions is null");
         this.typeOnlyCoercions = requireNonNull(typeOnlyCoercions, "typeOnlyCoercions is null");
-        this.columnReferences = ImmutableSet.copyOf(requireNonNull(columnReferences, "columnReferences is null"));
+        this.columnReferences = newIdentityHashSet(requireNonNull(columnReferences, "columnReferences is null"));
         this.subqueryInPredicates = requireNonNull(subqueryInPredicates, "subqueryInPredicates is null");
         this.scalarSubqueries = requireNonNull(scalarSubqueries, "subqueryInPredicates is null");
         this.existsSubqueries = requireNonNull(existsSubqueries, "existsSubqueries is null");

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -92,7 +92,6 @@ import com.facebook.presto.type.RowType;
 import com.facebook.presto.util.maps.IdentityLinkedHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.SliceUtf8;
 
 import javax.annotation.Nullable;
@@ -143,6 +142,7 @@ import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.util.DateTimeUtils.parseTimestampLiteral;
 import static com.facebook.presto.util.DateTimeUtils.timeHasTimeZone;
 import static com.facebook.presto.util.DateTimeUtils.timestampHasTimeZone;
+import static com.facebook.presto.util.MoreSets.newIdentityHashSet;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -220,7 +220,7 @@ public class ExpressionAnalyzer
 
     public Set<Expression> getColumnReferences()
     {
-        return ImmutableSet.copyOf(columnReferences);
+        return newIdentityHashSet(columnReferences);
     }
 
     public IdentityLinkedHashMap<Identifier, LambdaArgumentDeclaration> getLambdaArgumentReferences()

--- a/presto-main/src/main/java/com/facebook/presto/util/MoreSets.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/MoreSets.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class MoreSets
+{
+    private MoreSets() {}
+
+    public static <T> Set<T> newIdentityHashSet()
+    {
+        return Sets.newIdentityHashSet();
+    }
+
+    public static <T> Set<T> newIdentityHashSet(Iterable<T> elements)
+    {
+        Set<T> set = newIdentityHashSet();
+        Iterables.addAll(set, requireNonNull(elements, "elements cannot be null"));
+        return set;
+    }
+}


### PR DESCRIPTION
Identity-based set should not be `ImmutableSet.copyOf`-ed, ever.