### PR TITLE
Add intermediate plan validatation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -125,6 +125,8 @@ public class LogicalPlanner
     {
         PlanNode root = planStatement(analysis, analysis.getStatement());
 
+        PlanSanityChecker.validateIntermediatePlan(root, session, metadata, sqlParser, symbolAllocator.getTypes());
+
         if (stage.ordinal() >= Stage.OPTIMIZED.ordinal()) {
             for (PlanOptimizer optimizer : planOptimizers) {
                 root = optimizer.optimize(root, session, symbolAllocator.getTypes(), symbolAllocator, idAllocator);
@@ -134,7 +136,7 @@ public class LogicalPlanner
 
         if (stage.ordinal() >= Stage.OPTIMIZED_AND_VALIDATED.ordinal()) {
             // make sure we produce a valid plan after optimizations run. This is mainly to catch programming errors
-            PlanSanityChecker.validate(root, session, metadata, sqlParser, symbolAllocator.getTypes());
+            PlanSanityChecker.validateFinalPlan(root, session, metadata, sqlParser, symbolAllocator.getTypes());
         }
 
         Map<PlanNodeId, PlanNodeCost> planNodeCosts = costCalculator.calculateCostForPlan(session, symbolAllocator.getTypes(), root);


### PR DESCRIPTION
Add intermediate plan validatation

Check if plan is valid before applying any optimizers.
If plan is invalid then some optimizer may throw very misleading
exception. For example please see the #7773 issue, where access control
error was thrown, but it was caused by unexpected subquery expression
within an plan node tree.

Now the query from #7773 would throw something like below:
```
java.lang.IllegalStateException: Unexpected subquery expression in
logical plan: (SELECT 1

    )
        at
        com.facebook.presto.sql.planner.sanity.NoSubqueryExpressionLeftChecker$1.visitSubqueryExpression(NoSubqueryExpressionLeftChecker.java:43)
        ...
        com.facebook.presto.sql.planner.sanity.PlanSanityChecker.validateIntermediatePlan(PlanSanityChecker.java:54)
        ...
```