### PR TITLE
Inline Throwables.propagate

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloConnectorFactory.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloConnectorFactory.java
@@ -56,7 +56,8 @@ public class AccumuloConnectorFactory
             return injector.getInstance(AccumuloConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-atop/src/main/java/com/facebook/presto/atop/AtopConnectorFactory.java
+++ b/presto-atop/src/main/java/com/facebook/presto/atop/AtopConnectorFactory.java
@@ -92,7 +92,8 @@ public class AtopConnectorFactory
             return injector.getInstance(AtopConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-atop/src/main/java/com/facebook/presto/atop/AtopPageSource.java
+++ b/presto-atop/src/main/java/com/facebook/presto/atop/AtopPageSource.java
@@ -111,7 +111,8 @@ public class AtopPageSource
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
             try {
                 atop = atopFactory.create(table, date);

--- a/presto-atop/src/test/java/com/facebook/presto/atop/TestingAtopFactory.java
+++ b/presto-atop/src/test/java/com/facebook/presto/atop/TestingAtopFactory.java
@@ -100,7 +100,8 @@ public class TestingAtopFactory
                 reader.close();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnectorFactory.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnectorFactory.java
@@ -73,7 +73,8 @@ public class JdbcConnectorFactory
             return injector.getInstance(JdbcConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
@@ -256,7 +256,8 @@ public class JdbcRecordCursor
             // do nothing
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -271,6 +272,7 @@ public class JdbcRecordCursor
                 e.addSuppressed(closeException);
             }
         }
-        return Throwables.propagate(e);
+        Throwables.throwIfUnchecked(e);
+        throw new RuntimeException(e);
     }
 }

--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
@@ -246,7 +246,8 @@ public class BenchmarkQueryRunner
         }
         catch (InterruptedException interruptedException) {
             Thread.currentThread().interrupt();
-            throw Throwables.propagate(interruptedException);
+            Throwables.throwIfUnchecked(interruptedException);
+            throw new RuntimeException(interruptedException);
         }
     }
 

--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/PrestoBenchmarkDriver.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/PrestoBenchmarkDriver.java
@@ -162,7 +162,8 @@ public class PrestoBenchmarkDriver
             }
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         finally {
             System.setOut(out);

--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/RegexTemplate.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/RegexTemplate.java
@@ -38,7 +38,8 @@ public class RegexTemplate
             NAMED_GROUPS_METHOD.setAccessible(true);
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -62,7 +63,8 @@ public class RegexTemplate
             namedGroups = (Map<String, Integer>) NAMED_GROUPS_METHOD.invoke(pattern);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         ImmutableSortedMap<Integer, String> sortedGroups = ImmutableSortedMap.copyOf(ImmutableBiMap.copyOf(namedGroups).inverse());
         this.fieldNames = ImmutableList.copyOf(sortedGroups.values());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/JsonAvgBenchmarkResultWriter.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/JsonAvgBenchmarkResultWriter.java
@@ -86,7 +86,8 @@ public class JsonAvgBenchmarkResultWriter
             outputStream.write(json.getBytes(UTF_8));
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/JsonBenchmarkResultWriter.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/JsonBenchmarkResultWriter.java
@@ -38,7 +38,8 @@ public class JsonBenchmarkResultWriter
             jsonGenerator.writeArrayFieldStart("samples");
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -54,7 +55,8 @@ public class JsonBenchmarkResultWriter
             jsonGenerator.writeEndObject();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         return this;
     }
@@ -68,7 +70,8 @@ public class JsonBenchmarkResultWriter
             jsonGenerator.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/OdsBenchmarkResultWriter.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/OdsBenchmarkResultWriter.java
@@ -40,7 +40,8 @@ public class OdsBenchmarkResultWriter
             jsonGenerator.writeStartArray();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -58,7 +59,8 @@ public class OdsBenchmarkResultWriter
             }
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         return this;
     }
@@ -71,7 +73,8 @@ public class OdsBenchmarkResultWriter
             jsonGenerator.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SimpleLineBenchmarkResultWriter.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SimpleLineBenchmarkResultWriter.java
@@ -44,7 +44,8 @@ public class SimpleLineBenchmarkResultWriter
             writer.flush();
         }
         catch (IOException e) {
-            Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         return this;
     }

--- a/presto-bytecode/src/main/java/com/facebook/presto/bytecode/DynamicClassLoader.java
+++ b/presto-bytecode/src/main/java/com/facebook/presto/bytecode/DynamicClassLoader.java
@@ -74,7 +74,8 @@ public class DynamicClassLoader
                 }
                 catch (ClassNotFoundException e) {
                     // this should never happen
-                    throw Throwables.propagate(e);
+                    Throwables.throwIfUnchecked(e);
+                    throw new RuntimeException(e);
                 }
             }
             return classes;

--- a/presto-bytecode/src/test/java/com/facebook/presto/bytecode/expression/TestInvokeDynamicBytecodeExpression.java
+++ b/presto-bytecode/src/test/java/com/facebook/presto/bytecode/expression/TestInvokeDynamicBytecodeExpression.java
@@ -47,7 +47,8 @@ public class TestInvokeDynamicBytecodeExpression
             TEST_BOOTSTRAP_METHOD = TestInvokeDynamicBytecodeExpression.class.getMethod("bootstrap", MethodHandles.Lookup.class, String.class, MethodType.class, String.class);
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-bytecode/src/test/java/com/facebook/presto/bytecode/expression/TestSetFieldBytecodeExpression.java
+++ b/presto-bytecode/src/test/java/com/facebook/presto/bytecode/expression/TestSetFieldBytecodeExpression.java
@@ -86,7 +86,8 @@ public class TestSetFieldBytecodeExpression
             return clazz.getField(name);
         }
         catch (NoSuchFieldException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CachingCassandraSchemaProvider.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CachingCassandraSchemaProvider.java
@@ -230,7 +230,8 @@ public class CachingCassandraSchemaProvider
         catch (ExecutionException | UncheckedExecutionException e) {
             Throwable t = e.getCause();
             Throwables.propagateIfInstanceOf(t, exceptionClass);
-            throw Throwables.propagate(t);
+            Throwables.throwIfUnchecked(t);
+            throw new RuntimeException(t);
         }
     }
 

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraConnectorFactory.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraConnectorFactory.java
@@ -84,7 +84,8 @@ public class CassandraConnectorFactory
             return injector.getInstance(CassandraConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -394,7 +394,8 @@ public class Console
             logging.configure(config);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         finally {
             System.setOut(out);

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -179,7 +179,8 @@ public class Query
             handler.processRows(client);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -193,7 +194,8 @@ public class Query
             client.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -370,10 +370,13 @@ public class StatementClient
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         catch (ExecutionException e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
         catch (TimeoutException e) {
             return false;

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleClient.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleClient.java
@@ -88,7 +88,8 @@ public class ExampleClient
                 return lookupSchemas(metadataUri, catalogCodec);
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         };
     }

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleConnectorFactory.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleConnectorFactory.java
@@ -60,7 +60,8 @@ public class ExampleConnectorFactory
             return injector.getInstance(ExampleConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleRecordCursor.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleRecordCursor.java
@@ -63,7 +63,8 @@ public class ExampleRecordCursor
             totalBytes = input.getCount();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleRecordSet.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleRecordSet.java
@@ -48,7 +48,8 @@ public class ExampleRecordSet
             byteSource = Resources.asByteSource(split.getUri().toURL());
         }
         catch (MalformedURLException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -524,7 +524,8 @@ public class BackgroundHiveSplitLoader
                         addresses = toHostAddress(blockLocation.getHosts());
                     }
                     catch (IOException e) {
-                        throw Throwables.propagate(e);
+                        Throwables.throwIfUnchecked(e);
+                        throw new RuntimeException(e);
                     }
 
                     long targetChunkSize;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursor.java
@@ -256,7 +256,8 @@ class ColumnarBinaryHiveRecordCursor<K>
                 bytes = fieldData.getData();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             int start = fieldData.getStart();
@@ -422,7 +423,8 @@ class ColumnarBinaryHiveRecordCursor<K>
                 bytes = fieldData.getData();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             int start = fieldData.getStart();
@@ -482,7 +484,8 @@ class ColumnarBinaryHiveRecordCursor<K>
                 bytes = fieldData.getData();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             int start = fieldData.getStart();
@@ -534,7 +537,8 @@ class ColumnarBinaryHiveRecordCursor<K>
                 bytes = fieldData.getData();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             int start = fieldData.getStart();
@@ -574,7 +578,8 @@ class ColumnarBinaryHiveRecordCursor<K>
                 bytes = fieldData.getData();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             int start = fieldData.getStart();
@@ -642,7 +647,8 @@ class ColumnarBinaryHiveRecordCursor<K>
                 bytes = fieldData.getData();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             int start = fieldData.getStart();
@@ -749,7 +755,8 @@ class ColumnarBinaryHiveRecordCursor<K>
             recordReader.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursor.java
@@ -244,7 +244,8 @@ class ColumnarTextHiveRecordCursor<K>
                 bytes = fieldData.getData();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             int start = fieldData.getStart();
@@ -312,7 +313,8 @@ class ColumnarTextHiveRecordCursor<K>
                 bytes = fieldData.getData();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             int start = fieldData.getStart();
@@ -378,7 +380,8 @@ class ColumnarTextHiveRecordCursor<K>
                 bytes = fieldData.getData();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             int start = fieldData.getStart();
@@ -430,7 +433,8 @@ class ColumnarTextHiveRecordCursor<K>
                 bytes = fieldData.getData();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             int start = fieldData.getStart();
@@ -485,7 +489,8 @@ class ColumnarTextHiveRecordCursor<K>
                 bytes = fieldData.getData();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             int start = fieldData.getStart();
@@ -546,7 +551,8 @@ class ColumnarTextHiveRecordCursor<K>
                 bytes = fieldData.getData();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             int start = fieldData.getStart();
@@ -651,7 +657,8 @@ class ColumnarTextHiveRecordCursor<K>
             recordReader.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
@@ -524,7 +524,8 @@ class GenericHiveRecordCursor<K, V extends Writable>
             recordReader.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
@@ -133,7 +133,8 @@ public class HiveConnectorFactory
                     classLoader);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
@@ -237,7 +237,8 @@ public class HivePageSource
             delegate.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -275,7 +275,8 @@ public final class HiveUtil
             return (boolean) method.invoke(inputFormat, fileSystem, path);
         }
         catch (InvocationTargetException | IllegalAccessException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -292,7 +293,8 @@ public final class HiveUtil
             return (StructObjectInspector) inspector;
         }
         catch (SerDeException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -172,7 +172,8 @@ public final class HiveWriteUtils
             return result;
         }
         catch (SerDeException | ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -563,17 +563,20 @@ public class PrestoS3FileSystem
                                         throw new UnrecoverableS3OperationException(path, e);
                                 }
                             }
-                            throw Throwables.propagate(e);
+                            Throwables.throwIfUnchecked(e);
+                            throw new RuntimeException(e);
                         }
                     });
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         catch (Exception e) {
             Throwables.propagateIfInstanceOf(e, IOException.class);
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -589,7 +592,8 @@ public class PrestoS3FileSystem
             return new LocatedFileStatus(status, fakeLocation);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -820,11 +824,13 @@ public class PrestoS3FileSystem
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
             catch (Exception e) {
                 Throwables.propagateIfInstanceOf(e, IOException.class);
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -902,17 +908,20 @@ public class PrestoS3FileSystem
                                             throw new UnrecoverableS3OperationException(path, e);
                                     }
                                 }
-                                throw Throwables.propagate(e);
+                                Throwables.throwIfUnchecked(e);
+                                throw new RuntimeException(e);
                             }
                         });
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
             catch (Exception e) {
                 Throwables.propagateIfInstanceOf(e, IOException.class);
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RcFileFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RcFileFileWriterFactory.java
@@ -135,7 +135,8 @@ public class RcFileFileWriterFactory
                                 fileSystem.getFileStatus(path).getLen());
                     }
                     catch (IOException e) {
-                        throw Throwables.propagate(e);
+                        Throwables.throwIfUnchecked(e);
+                        throw new RuntimeException(e);
                     }
                 });
             }
@@ -159,7 +160,8 @@ public class RcFileFileWriterFactory
                     validationInputFactory));
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RecordFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RecordFileWriter.java
@@ -184,7 +184,8 @@ public class RecordFileWriter
             return result;
         }
         catch (SerDeException | ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RetryDriver.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RetryDriver.java
@@ -156,7 +156,8 @@ public class RetryDriver
                 }
                 catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
-                    throw Throwables.propagate(ie);
+                    Throwables.throwIfUnchecked(ie);
+                    throw new RuntimeException(ie);
                 }
             }
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosAuthentication.java
@@ -64,7 +64,8 @@ public class KerberosAuthentication
             return loginContext.getSubject();
         }
         catch (LoginException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -74,7 +75,8 @@ public class KerberosAuthentication
             return new KerberosPrincipal(getServerPrincipal(principal, InetAddress.getLocalHost().getCanonicalHostName()));
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosHiveMetastoreAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosHiveMetastoreAuthentication.java
@@ -79,7 +79,8 @@ public class KerberosHiveMetastoreAuthentication
             return new TUGIAssumingTransport(saslTransport, authentication.getUserGroupInformation());
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/SimpleHadoopAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/SimpleHadoopAuthentication.java
@@ -28,7 +28,8 @@ public class SimpleHadoopAuthentication
             return UserGroupInformation.getCurrentUser();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -240,7 +240,9 @@ public class CachingHiveMetastore
             return cache.get(key);
         }
         catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 
@@ -250,7 +252,9 @@ public class CachingHiveMetastore
             return cache.getAll(keys);
         }
         catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/ThriftHiveMetastore.java
@@ -124,7 +124,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -148,7 +149,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -188,7 +190,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -216,7 +219,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -241,7 +245,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -266,7 +271,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -291,7 +297,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -316,7 +323,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -344,7 +352,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -369,7 +378,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -398,7 +408,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -427,7 +438,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -451,7 +463,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -486,7 +499,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -511,7 +525,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -536,7 +551,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -561,7 +577,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -589,7 +606,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -615,7 +633,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -689,7 +708,8 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -728,7 +748,8 @@ public class ThriftHiveMetastore
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -845,6 +866,7 @@ public class ThriftHiveMetastore
         if (throwable instanceof InterruptedException) {
             Thread.currentThread().interrupt();
         }
-        throw Throwables.propagate(throwable);
+        Throwables.throwIfUnchecked(throwable);
+        throw new RuntimeException(throwable);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
@@ -173,7 +173,8 @@ public class OrcPageSource
             recordReader.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -307,7 +307,8 @@ public class ParquetHiveRecordCursor
             recordReader.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -373,7 +374,8 @@ public class ParquetHiveRecordCursor
             Throwables.propagateIfInstanceOf(e, PrestoException.class);
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
             String message = format("Error opening Hive split %s (offset=%s, length=%s): %s", path, start, length, e.getMessage());
             if (e.getClass().getSimpleName().equals("BlockMissingException")) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -252,7 +252,8 @@ public class ParquetPageSource
             parquetReader.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -503,7 +503,8 @@ public abstract class AbstractTestHiveClientS3
                 }
             }
             catch (Exception e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
             finally {
                 invalidateTable(databaseName, tableName);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
@@ -524,7 +524,8 @@ public class TestOrcPageSourceMemoryTracking
             flushStripe.invoke(writer);
         }
         catch (ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -556,7 +557,8 @@ public class TestOrcPageSourceMemoryTracking
             return constructor;
         }
         catch (ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestPrestoS3FileSystem.java
@@ -434,7 +434,8 @@ public class TestPrestoS3FileSystem
             return (T) field.get(instance);
         }
         catch (ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingHiveCluster.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingHiveCluster.java
@@ -43,7 +43,8 @@ public class TestingHiveCluster
             return new HiveMetastoreClientFactory(config, new NoHiveMetastoreAuthentication()).create(host, port);
         }
         catch (TTransportException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -334,7 +334,8 @@ public enum FileFormat
             conf.set("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/MockHiveMetastoreClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/MockHiveMetastoreClient.java
@@ -195,7 +195,8 @@ public class MockHiveMetastoreClient
                 return new Partition(ImmutableList.copyOf(Warehouse.getPartValuesFromPartName(name)), TEST_DATABASE, TEST_TABLE, 0, 0, DEFAULT_STORAGE_DESCRIPTOR, ImmutableMap.of());
             }
             catch (MetaException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         });
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -257,7 +257,8 @@ public class ParquetTester
                 file.delete();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriver.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriver.java
@@ -66,7 +66,8 @@ public class PrestoDriver
             DriverManager.registerDriver(new PrestoDriver());
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
@@ -20,6 +20,7 @@ import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.jdbc.ColumnInfo.Nullable;
+import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -62,7 +63,6 @@ import java.util.function.Consumer;
 
 import static com.facebook.presto.jdbc.ColumnInfo.setTypeInfo;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static com.google.common.base.Throwables.propagate;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Iterators.concat;
 import static com.google.common.collect.Iterators.transform;
@@ -1771,7 +1771,9 @@ public class PrestoResultSet
             while (client.isValid()) {
                 if (Thread.currentThread().isInterrupted()) {
                     client.close();
-                    throw propagate(new SQLException("ResultSet thread was interrupted"));
+                    Throwable throwable = new SQLException("ResultSet thread was interrupted");
+                    Throwables.throwIfUnchecked(throwable);
+                    throw new RuntimeException(throwable);
                 }
 
                 QueryResults results = client.current();
@@ -1784,7 +1786,9 @@ public class PrestoResultSet
             }
 
             if (client.isFailed()) {
-                throw propagate(resultsException(client.finalResults()));
+                Throwable throwable = resultsException(client.finalResults());
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
 
             return endOfData();

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxConnectorFactory.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxConnectorFactory.java
@@ -79,7 +79,8 @@ public class JmxConnectorFactory
             return injector.getInstance(JmxConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorFactory.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorFactory.java
@@ -90,7 +90,8 @@ public class KafkaConnectorFactory
             return injector.getInstance(KafkaConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSimpleConsumerManager.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSimpleConsumerManager.java
@@ -83,7 +83,9 @@ public class KafkaSimpleConsumerManager
             return consumerCache.get(host);
         }
         catch (ExecutionException e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaTableDescriptionSupplier.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaTableDescriptionSupplier.java
@@ -109,7 +109,8 @@ public class KafkaTableDescriptionSupplier
         }
         catch (IOException e) {
             log.warn(e, "Error: ");
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/JsonEncoder.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/JsonEncoder.java
@@ -38,7 +38,8 @@ public class JsonEncoder
             return objectMapper.writeValueAsBytes(o);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileConnectorFactory.java
+++ b/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileConnectorFactory.java
@@ -60,7 +60,8 @@ public class LocalFileConnectorFactory
             return injector.getInstance(LocalFileConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileRecordCursor.java
+++ b/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileRecordCursor.java
@@ -130,7 +130,8 @@ public class LocalFileRecordCursor
             return new FilesReader(table.getTimestampColumn(), fileNames.iterator(), predicate);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -171,7 +172,8 @@ public class LocalFileRecordCursor
             return fields != null;
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -271,7 +271,8 @@ public class InformationSchemaPageSourceProvider
                                     value = ((Slice) methodHandles.get(columnHandle).invokeWithArguments(entry.getValue().getValue())).toStringUtf8();
                                 }
                                 catch (Throwable throwable) {
-                                    throw Throwables.propagate(throwable);
+                                    Throwables.throwIfUnchecked(throwable);
+                                    throw new RuntimeException(throwable);
                                 }
                             }
                             else {

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
@@ -215,7 +215,8 @@ public class QueryMonitor
             logQueryTimeline(queryInfo);
         }
         catch (JsonProcessingException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -130,7 +130,8 @@ public class DataDefinitionExecution<T extends Statement>
         catch (Throwable e) {
             fail(e);
             if (!(e instanceof RuntimeException)) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryQueueRuleFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryQueueRuleFactory.java
@@ -69,7 +69,8 @@ public class QueryQueueRuleFactory
                 managerSpec = mapper.readValue(file, ManagerSpec.class);
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
             Map<String, QueryQueueDefinition> definitions = new HashMap<>();
             for (Map.Entry<String, QueueSpec> queue : managerSpec.getQueues().entrySet()) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -169,7 +169,8 @@ public class SqlTaskExecution
             catch (Throwable e) {
                 // planning failed
                 taskStateMachine.failed(e);
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             // index driver factories

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -406,7 +406,8 @@ public class SqlQueryScheduler
         }
         catch (Throwable t) {
             queryStateMachine.transitionToFailed(t);
-            throw Throwables.propagate(t);
+            Throwables.throwIfUnchecked(t);
+            throw new RuntimeException(t);
         }
         finally {
             RuntimeException closeError = new RuntimeException();

--- a/presto-main/src/main/java/com/facebook/presto/metadata/AbstractTypedJacksonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/AbstractTypedJacksonModule.java
@@ -112,7 +112,9 @@ public abstract class AbstractTypedJacksonModule<T>
             }
             catch (ExecutionException e) {
                 propagateIfInstanceOf(e.getCause(), IOException.class);
-                throw Throwables.propagate(e.getCause());
+                Throwable throwable = e.getCause();
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -851,7 +851,9 @@ public class FunctionRegistry
             return specializedWindowCache.getUnchecked(getSpecializedFunctionKey(signature));
         }
         catch (UncheckedExecutionException e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 
@@ -864,7 +866,9 @@ public class FunctionRegistry
             return specializedAggregationCache.getUnchecked(getSpecializedFunctionKey(signature));
         }
         catch (UncheckedExecutionException e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 
@@ -877,7 +881,9 @@ public class FunctionRegistry
             return specializedScalarCache.getUnchecked(getSpecializedFunctionKey(signature));
         }
         catch (UncheckedExecutionException e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 
@@ -887,7 +893,9 @@ public class FunctionRegistry
             return specializedFunctionKeyCache.getUnchecked(signature);
         }
         catch (UncheckedExecutionException e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
@@ -389,7 +389,8 @@ public class ExchangeClient
     {
         Throwable t = failure.get();
         if (t != null) {
-            throw Throwables.propagate(t);
+            Throwables.throwIfUnchecked(t);
+            throw new RuntimeException(t);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExplainAnalyzeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExplainAnalyzeOperator.java
@@ -162,7 +162,8 @@ public class ExplainAnalyzeOperator
                 TimeUnit.MILLISECONDS.sleep(100);
             }
             catch (InterruptedException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
         return isFinalStageInfo(stageInfo);

--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
@@ -567,7 +567,8 @@ public final class HttpPageBufferClient
                     return createPagesResponse(taskInstanceId, token, nextToken, pages, complete);
                 }
                 catch (IOException e) {
-                    throw Throwables.propagate(e);
+                    Throwables.throwIfUnchecked(e);
+                    throw new RuntimeException(e);
                 }
             }
             catch (PageTransportErrorException e) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/PageSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PageSourceOperator.java
@@ -63,7 +63,8 @@ public class PageSourceOperator
             pageSource.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -166,7 +166,8 @@ public class ScanFilterAndProjectOperator
                 pageSource.close();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
         else if (cursor != null) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -199,7 +199,8 @@ public class TableScanOperator
                 source.close();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
             systemMemoryContext.setBytes(source.getSystemMemoryUsage());
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/BindableAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/BindableAggregationFunction.java
@@ -120,7 +120,8 @@ public class BindableAggregationFunction
                     outputType);
         }
         catch (IllegalAccessException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
 
         AccumulatorFactoryBinder factory = new LazyAccumulatorFactoryBinder(metadata, classLoader);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
@@ -64,7 +64,8 @@ public class GenericAccumulatorFactory
             return accumulatorConstructor.newInstance(stateSerializer, stateFactory, inputChannels, maskChannel);
         }
         catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -75,7 +76,8 @@ public class GenericAccumulatorFactory
             return accumulatorConstructor.newInstance(stateSerializer, stateFactory, ImmutableList.of(), Optional.empty());
         }
         catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -86,7 +88,8 @@ public class GenericAccumulatorFactory
             return groupedAccumulatorConstructor.newInstance(stateSerializer, stateFactory, inputChannels, maskChannel);
         }
         catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -97,7 +100,8 @@ public class GenericAccumulatorFactory
             return groupedAccumulatorConstructor.newInstance(stateSerializer, stateFactory, ImmutableList.of(), maskChannel);
         }
         catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactoryBinder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactoryBinder.java
@@ -54,7 +54,8 @@ public class GenericAccumulatorFactoryBinder
                     Optional.class);
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -190,7 +190,8 @@ public class SpillableHashAggregationBuilder
         }
         catch (InterruptedException | ExecutionException e) {
             Thread.currentThread().interrupt();
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
@@ -144,7 +144,8 @@ public class StateCompiler
                 return (AccumulatorStateSerializer<T>) metadata.stateSerializerClass().getConstructor().newInstance();
             }
             catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -169,7 +170,8 @@ public class StateCompiler
             return (AccumulatorStateSerializer<T>) serializerClass.newInstance();
         }
         catch (InstantiationException | IllegalAccessException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -311,7 +313,8 @@ public class StateCompiler
             return clazz.getMethod(field.getSetterName(), field.getType());
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -321,7 +324,8 @@ public class StateCompiler
             return clazz.getMethod(field.getGetterName());
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -343,7 +347,8 @@ public class StateCompiler
                 return (AccumulatorStateFactory<T>) metadata.stateFactoryClass().getConstructor().newInstance();
             }
             catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -391,7 +396,8 @@ public class StateCompiler
             return (AccumulatorStateFactory<T>) factoryClass.newInstance();
         }
         catch (InstantiationException | IllegalAccessException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/FieldSetFilteringRecordSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/FieldSetFilteringRecordSet.java
@@ -194,7 +194,8 @@ public class FieldSetFilteringRecordSet
                 }
             }
             catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
@@ -203,7 +203,8 @@ public class IndexLoader
                     for (UpdateRequest request : requests) {
                         request.failed(t);
                     }
-                    Throwables.propagate(t);
+                    Throwables.throwIfUnchecked(t);
+                    throw new RuntimeException(t);
                 }
 
                 // Try loading just my request

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ApplyFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ApplyFunction.java
@@ -91,7 +91,8 @@ public final class ApplyFunction
             return function.invoke(input);
         }
         catch (Throwable throwable) {
-            throw Throwables.propagate(throwable);
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
@@ -122,7 +122,8 @@ public final class ArrayConstructor
             methodHandle = lookup().unreflect(method);
         }
         catch (ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         List<Boolean> nullableParameters = ImmutableList.copyOf(Collections.nCopies(stackTypes.size(), true));
         return new ScalarFunctionImplementation(false, nullableParameters, methodHandle, isDeterministic());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
@@ -55,7 +55,8 @@ public final class ArrayFilterFunction
                 keep = (Boolean) function.invokeExact(input);
             }
             catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
             if (TRUE.equals(keep)) {
                 elementType.appendTo(arrayBlock, position, resultBuilder);
@@ -84,7 +85,8 @@ public final class ArrayFilterFunction
                 keep = (Boolean) function.invokeExact(input);
             }
             catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
             if (TRUE.equals(keep)) {
                 elementType.appendTo(arrayBlock, position, resultBuilder);
@@ -113,7 +115,8 @@ public final class ArrayFilterFunction
                 keep = (Boolean) function.invokeExact(input);
             }
             catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
             if (TRUE.equals(keep)) {
                 elementType.appendTo(arrayBlock, position, resultBuilder);
@@ -142,7 +145,8 @@ public final class ArrayFilterFunction
                 keep = (Boolean) function.invokeExact(input);
             }
             catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
             if (TRUE.equals(keep)) {
                 elementType.appendTo(arrayBlock, position, resultBuilder);
@@ -171,7 +175,8 @@ public final class ArrayFilterFunction
                 keep = (Boolean) function.invokeExact(input);
             }
             catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
             if (TRUE.equals(keep)) {
                 elementType.appendTo(arrayBlock, position, resultBuilder);
@@ -195,7 +200,8 @@ public final class ArrayFilterFunction
                 keep = (Boolean) function.invokeExact(null);
             }
             catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
             if (TRUE.equals(keep)) {
                 resultBuilder.appendNull();

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayReduceFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayReduceFunction.java
@@ -101,14 +101,16 @@ public final class ArrayReduceFunction
                 intermediateValue = inputFunction.invoke(intermediateValue, input);
             }
             catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
         }
         try {
             return outputFunction.invoke(intermediateValue);
         }
         catch (Throwable throwable) {
-            throw Throwables.propagate(throwable);
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/InvokeFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/InvokeFunction.java
@@ -90,7 +90,8 @@ public final class InvokeFunction
             return function.invoke();
         }
         catch (Throwable throwable) {
-            throw Throwables.propagate(throwable);
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonExtract.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonExtract.java
@@ -140,7 +140,8 @@ public final class JsonExtract
             return null;
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformKeyFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformKeyFunction.java
@@ -112,7 +112,8 @@ public final class MapTransformKeyFunction
                 transformedKey = function.invoke(key, value);
             }
             catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
 
             if (transformedKey == null) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
@@ -104,7 +104,8 @@ public final class MapTransformValueFunction
                 transformedValue = function.invoke(key, value);
             }
             catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
 
             keyType.appendTo(block, position, resultBuilder);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipWithFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipWithFunction.java
@@ -98,7 +98,8 @@ public final class ZipWithFunction
                 output = function.invoke(left, right);
             }
             catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
             writeNativeValue(outputElementType, resultBuilder, output);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/ReflectionWindowFunctionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/ReflectionWindowFunctionSupplier.java
@@ -50,7 +50,8 @@ public class ReflectionWindowFunctionSupplier<T extends WindowFunction>
             }
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -66,10 +67,13 @@ public class ReflectionWindowFunctionSupplier<T extends WindowFunction>
             }
         }
         catch (InvocationTargetException e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PagesResponseWriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PagesResponseWriter.java
@@ -51,7 +51,8 @@ public class PagesResponseWriter
             LIST_GENERIC_TOKEN = List.class.getMethod("get", int.class).getGenericReturnType();
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginDiscovery.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginDiscovery.java
@@ -125,7 +125,8 @@ final class PluginDiscovery
             return new ClassReader(toByteArray(in));
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/security/LdapFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/LdapFilter.java
@@ -123,7 +123,8 @@ public class LdapFilter
             closeContext(createDirContext(environment));
         }
         catch (NamingException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -187,7 +188,8 @@ public class LdapFilter
         catch (ExecutionException e) {
             Throwable cause = e.getCause();
             propagateIfInstanceOf(cause, AuthenticationException.class);
-            throw Throwables.propagate(cause);
+            Throwables.throwIfUnchecked(cause);
+            throw new RuntimeException(cause);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/security/SpnegoFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/SpnegoFilter.java
@@ -116,7 +116,8 @@ public class SpnegoFilter
                     ACCEPT_ONLY));
         }
         catch (LoginException | UnknownHostException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -127,7 +128,8 @@ public class SpnegoFilter
             loginContext.logout();
         }
         catch (LoginException e) {
-            Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -282,7 +284,8 @@ public class SpnegoFilter
                 return action.get();
             }
             catch (GSSException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         });
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -282,7 +282,8 @@ public class TestingPrestoServer
             }
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         finally {
             deleteRecursively(baseDataDir);

--- a/presto-main/src/main/java/com/facebook/presto/sql/FunctionInvoker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/FunctionInvoker.java
@@ -86,7 +86,8 @@ public class FunctionInvoker
             return method.invokeWithArguments(actualArguments);
         }
         catch (Throwable throwable) {
-            throw Throwables.propagate(throwable);
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/Bootstrap.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/Bootstrap.java
@@ -34,7 +34,8 @@ public final class Bootstrap
             BOOTSTRAP_METHOD = Bootstrap.class.getMethod("bootstrap", MethodHandles.Lookup.class, String.class, MethodType.class, long.class);
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -58,7 +59,8 @@ public final class Bootstrap
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/ExpressionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/ExpressionCompiler.java
@@ -104,7 +104,8 @@ public class ExpressionCompiler
                 return cursorProcessor.newInstance();
             }
             catch (ReflectiveOperationException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         };
     }
@@ -117,7 +118,8 @@ public class ExpressionCompiler
                 return pageProcessor.newInstance();
             }
             catch (ReflectiveOperationException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         };
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/IsolatedClass.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/IsolatedClass.java
@@ -64,7 +64,8 @@ public final class IsolatedClass
             return ByteStreams.toByteArray(stream);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
@@ -132,7 +132,9 @@ public class JoinCompiler
                     joinChannels));
         }
         catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 
@@ -154,7 +156,9 @@ public class JoinCompiler
                     joinChannels)));
         }
         catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 
@@ -729,7 +733,8 @@ public class JoinCompiler
                 constructor = joinHashSupplierClass.getConstructor(ConnectorSession.class, PagesHashStrategy.class, LongArrayList.class, List.class, Optional.class);
             }
             catch (NoSuchMethodException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -745,7 +750,8 @@ public class JoinCompiler
                 return constructor.newInstance(session, pagesHashStrategy, addresses, channels, filterFunctionFactory);
             }
             catch (Exception e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }
@@ -760,7 +766,8 @@ public class JoinCompiler
                 constructor = pagesHashStrategyClass.getConstructor(List.class, Optional.class);
             }
             catch (NoSuchMethodException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -770,7 +777,8 @@ public class JoinCompiler
                 return constructor.newInstance(channels, hashChannel);
             }
             catch (Exception e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
@@ -382,7 +382,8 @@ public class JoinFilterFunctionCompiler
                 isolatedJoinFilterFunctionConstructor = isolatedJoinFilterFunction.getConstructor(InternalJoinFilterFunction.class, LongArrayList.class, List.class);
             }
             catch (NoSuchMethodException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -394,7 +395,8 @@ public class JoinFilterFunctionCompiler
                 return isolatedJoinFilterFunctionConstructor.newInstance(internalJoinFilterFunction, addresses, channels);
             }
             catch (ReflectiveOperationException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
@@ -117,7 +117,9 @@ public class JoinProbeCompiler
             return operatorFactoryFactory.createHashJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeOutputChannelTypes, joinType);
         }
         catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 
@@ -159,7 +161,8 @@ public class JoinProbeCompiler
                 joinProbeFactory = joinProbeFactoryClass.newInstance();
             }
             catch (Exception e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -477,7 +480,8 @@ public class JoinProbeCompiler
                 constructor = joinProbeClass.getConstructor(LookupSource.class, Page.class);
             }
             catch (NoSuchMethodException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -488,7 +492,8 @@ public class JoinProbeCompiler
                 return constructor.newInstance(lookupSource, page);
             }
             catch (Exception e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }
@@ -571,7 +576,8 @@ public class JoinProbeCompiler
                 constructor = operatorFactoryClass.getConstructor(int.class, PlanNodeId.class, LookupSourceFactory.class, List.class, List.class, JoinType.class, JoinProbeFactory.class);
             }
             catch (NoSuchMethodException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -587,7 +593,8 @@ public class JoinProbeCompiler
                 return constructor.newInstance(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeOutputTypes, joinType, joinProbeFactory);
             }
             catch (Exception e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/OrderingCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/OrderingCompiler.java
@@ -94,7 +94,9 @@ public class OrderingCompiler
             return pagesIndexOrderings.get(new PagesIndexComparatorCacheKey(sortTypes, sortChannels, sortOrders));
         }
         catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -1350,7 +1350,8 @@ public class ExpressionInterpreter
                 if (throwable instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
                 }
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
         }
         if (handle.type().parameterCount() > 0 && handle.type().parameterType(0) == ConnectorSession.class) {
@@ -1379,7 +1380,8 @@ public class ExpressionInterpreter
             if (throwable instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            throw Throwables.propagate(throwable);
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -286,7 +286,8 @@ public final class LiteralInterpreter
                     return ExpressionInterpreter.invoke(session, operator, ImmutableList.of(utf8Slice(node.getValue())));
                 }
                 catch (Throwable throwable) {
-                    throw Throwables.propagate(throwable);
+                    Throwables.throwIfUnchecked(throwable);
+                    throw new RuntimeException(throwable);
                 }
             }
 
@@ -302,7 +303,8 @@ public final class LiteralInterpreter
                 return ExpressionInterpreter.invoke(session, operator, ImmutableList.of(utf8Slice(node.getValue())));
             }
             catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -1200,7 +1200,8 @@ public class PlanPrinter
             return "<UNREPRESENTABLE VALUE>";
         }
         catch (Throwable throwable) {
-            throw Throwables.propagate(throwable);
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -536,7 +536,8 @@ public class LocalQueryRunner
             return builder.get().build();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         finally {
             lock.readLock().unlock();

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeJsonUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeJsonUtils.java
@@ -74,7 +74,8 @@ public final class TypeJsonUtils
             return stackRepresentationToObjectHelper(session, jsonParser, type);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
@@ -86,7 +86,8 @@ public final class TypeUtils
             }
         }
         catch (Throwable throwable) {
-            throw Throwables.propagate(throwable);
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/concurrent/TestFairBatchExecutor.java
+++ b/presto-main/src/test/java/com/facebook/presto/concurrent/TestFairBatchExecutor.java
@@ -149,7 +149,8 @@ public class TestFairBatchExecutor
                     }
                     catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
-                        throw Throwables.propagate(e);
+                        Throwables.throwIfUnchecked(e);
+                        throw new RuntimeException(e);
                     }
                 }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskExecutorSimulator.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskExecutorSimulator.java
@@ -300,7 +300,8 @@ public class TaskExecutorSimulator
                 }
                 catch (Throwable e) {
                     future.setException(e);
-                    throw Throwables.propagate(e);
+                    Throwables.throwIfUnchecked(e);
+                    throw new RuntimeException(e);
                 }
             });
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCommitTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCommitTask.java
@@ -97,7 +97,9 @@ public class TestCommitTask
                 fail();
             }
             catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
+                Throwable throwable = e.getCause();
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
         }
         catch (PrestoException e) {
@@ -127,7 +129,9 @@ public class TestCommitTask
                 fail();
             }
             catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
+                Throwable throwable = e.getCause();
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
         }
         catch (PrestoException e) {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestRollbackTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestRollbackTask.java
@@ -96,7 +96,9 @@ public class TestRollbackTask
                 fail();
             }
             catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
+                Throwable throwable = e.getCause();
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
         }
         catch (PrestoException e) {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStartTransactionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStartTransactionTask.java
@@ -89,7 +89,9 @@ public class TestStartTransactionTask
                 fail();
             }
             catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
+                Throwable throwable = e.getCause();
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
         }
         catch (PrestoException e) {
@@ -120,7 +122,9 @@ public class TestStartTransactionTask
                 fail();
             }
             catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
+                Throwable throwable = e.getCause();
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
         }
         catch (PrestoException e) {
@@ -206,7 +210,9 @@ public class TestStartTransactionTask
                 fail();
             }
             catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
+                Throwable throwable = e.getCause();
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
         }
         catch (SemanticException e) {
@@ -242,7 +248,9 @@ public class TestStartTransactionTask
                 fail();
             }
             catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
+                Throwable throwable = e.getCause();
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
             }
         }
         catch (SemanticException e) {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStateMachine.java
@@ -241,10 +241,12 @@ public class TestStateMachine
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
             catch (Exception e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         });
 
@@ -279,7 +281,8 @@ public class TestStateMachine
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         });
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
@@ -84,7 +84,8 @@ public final class OperatorAssertion
             return toPages(operator, input);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -104,7 +105,8 @@ public final class OperatorAssertion
             return toPages(operator);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
@@ -505,10 +505,12 @@ public class TestHttpPageBufferClient
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
             catch (BrokenBarrierException | TimeoutException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
@@ -254,7 +254,8 @@ public class BenchmarkArrayFilter
                     keep = (Boolean) function.invokeExact(input);
                 }
                 catch (Throwable throwable) {
-                    throw Throwables.propagate(throwable);
+                    Throwables.throwIfUnchecked(throwable);
+                    throw new RuntimeException(throwable);
                 }
                 if (TRUE.equals(keep)) {
                     block.writePositionTo(position, resultBuilder);

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -1613,7 +1613,8 @@ public class TestExpressionCompiler
                 callable.call();
             }
             catch (Exception e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryConnectorFactory.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryConnectorFactory.java
@@ -60,7 +60,8 @@ public class MemoryConnectorFactory
             return injector.getInstance(MemoryConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-ml/src/main/java/com/facebook/presto/ml/AbstractSvmModel.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/AbstractSvmModel.java
@@ -62,7 +62,8 @@ public abstract class AbstractSvmModel
             return Files.readAllBytes(file.toPath());
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         finally {
             if (file != null) {
@@ -87,10 +88,12 @@ public abstract class AbstractSvmModel
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         finally {
             service.shutdownNow();

--- a/presto-ml/src/main/java/com/facebook/presto/ml/EvaluateClassifierPredictionsStateSerializer.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/EvaluateClassifierPredictionsStateSerializer.java
@@ -57,7 +57,8 @@ public class EvaluateClassifierPredictionsStateSerializer
             VARCHAR.writeSlice(out, Slices.utf8Slice(OBJECT_MAPPER.writeValueAsString(jsonState)));
         }
         catch (JsonProcessingException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -70,7 +71,8 @@ public class EvaluateClassifierPredictionsStateSerializer
             jsonState = OBJECT_MAPPER.readValue(slice.getBytes(), new TypeReference<Map<String, Map<String, Integer>>>() {});
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         state.addMemoryUsage(slice.length());
         state.getTruePositives().putAll(jsonState.getOrDefault(TRUE_POSITIVES, ImmutableMap.of()));

--- a/presto-ml/src/main/java/com/facebook/presto/ml/ModelUtils.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/ModelUtils.java
@@ -154,7 +154,8 @@ public final class ModelUtils
             return (Model) deserialize.invoke(null, new Object[] {data});
         }
         catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-ml/src/main/java/com/facebook/presto/ml/SvmClassifier.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/SvmClassifier.java
@@ -54,7 +54,8 @@ public class SvmClassifier
             return new SvmClassifier(model);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-ml/src/main/java/com/facebook/presto/ml/SvmRegressor.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/SvmRegressor.java
@@ -54,7 +54,8 @@ public class SvmRegressor
             return new SvmRegressor(model);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoClientConfig.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoClientConfig.java
@@ -124,7 +124,8 @@ public class MongoClientConfig
                 }
             }
             catch (NumberFormatException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
         return builder.build();

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoConnectorFactory.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoConnectorFactory.java
@@ -70,7 +70,8 @@ public class MongoConnectorFactory
             return injector.getInstance(MongoConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -233,7 +233,8 @@ public class MongoSession
         catch (ExecutionException | UncheckedExecutionException e) {
             Throwable t = e.getCause();
             Throwables.propagateIfInstanceOf(t, exceptionClass);
-            throw Throwables.propagate(t);
+            Throwables.throwIfUnchecked(t);
+            throw new RuntimeException(t);
         }
     }
 

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -74,7 +74,8 @@ public class MySqlClient
             return schemaNames.build();
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -754,7 +754,8 @@ public class OrcTester
             writer.getClass().getMethod("enterLowMemoryMode").invoke(writer);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -766,7 +767,8 @@ public class OrcTester
             return writerField.get(instance);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -778,7 +780,8 @@ public class OrcTester
             writerField.set(instance, value);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
@@ -52,7 +52,8 @@ public class PostgreSqlClient
             execute(connection, sql.toString());
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
@@ -234,7 +234,8 @@ public class TestHiveStorageFormats
             }
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/querystats/HttpQueryStatsClient.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/querystats/HttpQueryStatsClient.java
@@ -85,7 +85,8 @@ public class HttpQueryStatsClient
                 return Optional.of(queryStats);
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnectorFactory.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnectorFactory.java
@@ -96,7 +96,8 @@ public class RaptorConnectorFactory
             return injector.getInstance(RaptorConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/BackupManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/BackupManager.java
@@ -108,7 +108,8 @@ public class BackupManager
             }
             catch (Throwable t) {
                 stats.incrementBackupFailure();
-                throw Throwables.propagate(t);
+                Throwables.throwIfUnchecked(t);
+                throw new RuntimeException(t);
             }
         }
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
@@ -623,7 +623,9 @@ public class DatabaseShardManager
             return bucketAssignmentsCache.getUnchecked(distributionId);
         }
         catch (UncheckedExecutionException | ExecutionError e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 
@@ -672,7 +674,8 @@ public class DatabaseShardManager
             return existingShards.build();
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -728,7 +731,9 @@ public class DatabaseShardManager
             return nodeIdCache.getUnchecked(nodeIdentifier);
         }
         catch (UncheckedExecutionException | ExecutionError e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/SchemaDaoUtil.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/SchemaDaoUtil.java
@@ -67,7 +67,8 @@ public final class SchemaDaoUtil
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
@@ -252,7 +252,8 @@ public class OrcFileWriter
             return constructor;
         }
         catch (ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -332,7 +332,8 @@ public class OrcStorageManager
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
             catch (ExecutionException e) {
                 propagateIfInstanceOf(e.getCause(), PrestoException.class);

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/OrganizationJob.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/OrganizationJob.java
@@ -59,7 +59,8 @@ class OrganizationJob
             runJob(organizationSet.getTableId(), organizationSet.getBucketNumber(), organizationSet.getShards());
         }
         catch (Throwable e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardOrganizerUtil.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardOrganizerUtil.java
@@ -131,7 +131,8 @@ public class ShardOrganizerUtil
             }
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         return indexInfoBuilder.build();
     }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizer.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizer.java
@@ -62,7 +62,8 @@ public class TestShardOrganizer
                     MILLISECONDS.sleep(10);
                 }
                 catch (InterruptedException e) {
-                    throw Throwables.propagate(e);
+                    Throwables.throwIfUnchecked(e);
+                    throw new RuntimeException(e);
                 }
             };
         }

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/AircompressorCompressor.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/AircompressorCompressor.java
@@ -63,7 +63,8 @@ public class AircompressorCompressor
                 return new CompressedSliceOutput(compressionStream, compressedOutput, this, () -> { });
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/HadoopCompressor.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/HadoopCompressor.java
@@ -64,7 +64,8 @@ public class HadoopCompressor
                 return new CompressedSliceOutput(compressionStream, bufferedOutput, this, () -> CodecPool.returnCompressor(compressor));
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/DateEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/DateEncoding.java
@@ -78,7 +78,8 @@ public class DateEncoding
             }
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/TimestampEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/TimestampEncoding.java
@@ -83,7 +83,8 @@ public class TimestampEncoding
             }
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -99,7 +100,8 @@ public class TimestampEncoding
             }
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
+++ b/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
@@ -216,7 +216,8 @@ public class RcFileTester
                     return columnarSerDe;
                 }
                 catch (SerDeException e) {
-                    throw Throwables.propagate(e);
+                    Throwables.throwIfUnchecked(e);
+                    throw new RuntimeException(e);
                 }
             }
 
@@ -566,7 +567,8 @@ public class RcFileTester
             slice.setBytes(0, in, slice.length());
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
 
         List<Long> syncPositionsBruteForce = new ArrayList<>();

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisConnectorFactory.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisConnectorFactory.java
@@ -92,7 +92,8 @@ public class RedisConnectorFactory
             return injector.getInstance(RedisConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisJedisManager.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisJedisManager.java
@@ -79,7 +79,9 @@ public class RedisJedisManager
             return jedisPoolCache.get(host);
         }
         catch (ExecutionException e) {
-            throw Throwables.propagate(e.getCause());
+            Throwable throwable = e.getCause();
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisRecordCursor.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisRecordCursor.java
@@ -330,7 +330,8 @@ public class RedisRecordCursor
             }
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         return true;
     }
@@ -366,7 +367,8 @@ public class RedisRecordCursor
             }
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         return true;
     }

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisSplitManager.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisSplitManager.java
@@ -78,7 +78,8 @@ public class RedisSplitManager
                 numberOfKeys = jedis.zcount(redisTableHandle.getKeyName(), "-inf", "+inf");
             }
             catch (Exception e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisTableDescriptionSupplier.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisTableDescriptionSupplier.java
@@ -97,7 +97,8 @@ public class RedisTableDescriptionSupplier
         }
         catch (IOException e) {
             log.warn(e, "Error: ");
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestMinimalFunctionality.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestMinimalFunctionality.java
@@ -104,7 +104,8 @@ public class TestMinimalFunctionality
             }
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-redis/src/test/java/com/facebook/presto/redis/util/JsonEncoder.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/util/JsonEncoder.java
@@ -28,7 +28,8 @@ public class JsonEncoder
             return objectMapper.writeValueAsString(o);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/FileResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/FileResourceGroupConfigurationManager.java
@@ -51,7 +51,8 @@ public class FileResourceGroupConfigurationManager
             managerSpec = codec.fromJson(Files.readAllBytes(Paths.get(config.getConfigFile())));
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         this.rootGroups = managerSpec.getRootGroups();
         this.cpuQuotaPeriodMillis = managerSpec.getCpuQuotaPeriod();

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/FileResourceGroupConfigurationManagerFactory.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/FileResourceGroupConfigurationManagerFactory.java
@@ -61,7 +61,8 @@ public class FileResourceGroupConfigurationManagerFactory
             return injector.getInstance(FileResourceGroupConfigurationManager.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbResourceGroupConfigurationManagerFactory.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbResourceGroupConfigurationManagerFactory.java
@@ -61,7 +61,8 @@ public class DbResourceGroupConfigurationManagerFactory
             return injector.getInstance(DbResourceGroupConfigurationManager.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -276,7 +276,8 @@ public class DistributedQueryRunner
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
         log.info("Announced catalog %s (%s) in %s", catalogName, connectorId, nanosSince(start));
@@ -356,7 +357,8 @@ public class DistributedQueryRunner
             closer.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingDiscoveryServer.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingDiscoveryServer.java
@@ -87,7 +87,8 @@ public class TestingDiscoveryServer
             }
         }
         catch (Exception e) {
-            Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         finally {
             FileUtils.deleteRecursively(tempDir);

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2ResourceGroupConfigurationManagerFactory.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2ResourceGroupConfigurationManagerFactory.java
@@ -62,7 +62,8 @@ public class H2ResourceGroupConfigurationManagerFactory
             return injector.getInstance(DbResourceGroupConfigurationManager.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/JsonEventClient.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/JsonEventClient.java
@@ -56,7 +56,8 @@ public class JsonEventClient
             out.println(buffer.toString().trim());
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/PrestoVerifier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/PrestoVerifier.java
@@ -158,7 +158,8 @@ public class PrestoVerifier
             }
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
@@ -458,10 +458,12 @@ public class Validator
                 }
                 catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    throw Throwables.propagate(e);
+                    Throwables.throwIfUnchecked(e);
+                    throw new RuntimeException(e);
                 }
                 catch (Exception e) {
-                    throw Throwables.propagate(e);
+                    Throwables.throwIfUnchecked(e);
+                    throw new RuntimeException(e);
                 }
             }
         }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Verifier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Verifier.java
@@ -244,7 +244,8 @@ public class Verifier
             return completionService.take().get();
         }
         catch (ExecutionException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Inline Throwables.propagate

Inline Throwables.propagate since it is deprecated.
Using deprecated method around the project pollutes compilation output
and it is bad by definition.
