### PR TITLE
Add ApplyNode support to DesugaringOptimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DesugaringOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DesugaringOptimizer.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -42,6 +43,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
+import static com.facebook.presto.sql.planner.ExpressionExtractor.extractExpressionsNonRecursive;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Collections.emptyList;
@@ -86,6 +89,13 @@ public class DesugaringOptimizer
             this.session = session;
             this.types = types;
             this.symbolAllocator = symbolAllocator;
+        }
+
+        @Override
+        public PlanNode visitPlan(PlanNode node, RewriteContext<Void> context)
+        {
+            checkState(extractExpressionsNonRecursive(node).isEmpty(), "Unhandled plan node with expressions");
+            return super.visitPlan(node, context);
         }
 
         @Override
@@ -170,6 +180,16 @@ public class DesugaringOptimizer
                                     .map(this::desugar)
                                     .collect(toImmutableList()))
                             .collect(toImmutableList()));
+        }
+
+        @Override
+        public PlanNode visitApply(ApplyNode node, RewriteContext<Void> context)
+        {
+            PlanNode input = context.rewrite(node.getInput());
+            PlanNode subquery = context.rewrite(node.getSubquery());
+            // ApplyNode.Assignments are synthetic expressions which are meaningful for ApplyNode transformations.
+            // They cannot contain any lambda or "sugared" expression
+            return new ApplyNode(node.getId(), input, subquery, node.getSubqueryAssignments(), node.getCorrelation());
         }
 
         private Expression desugar(Expression expression)


### PR DESCRIPTION
Follow up of: https://github.com/prestodb/presto/pull/7774
Fix for: https://github.com/prestodb/presto/issues/7527

ApplyNode.Assignments are synthetic expressions which are meaningful for ApplyNode transformations. They cannot contain any lambda or "sugared" expression