### PR TITLE
Support NULL on left side of semi join

### DIFF
--- a/presto-docs/src/main/sphinx/functions/comparison.rst
+++ b/presto-docs/src/main/sphinx/functions/comparison.rst
@@ -153,9 +153,3 @@ Expression              Meaning
 ====================    ===========
 
 ``ANY`` and ``SOME`` have the same meaning and can be used interchangeably.
-
-.. note::
-
-    Currently, the expression ``A`` in ``A = ANY (...)`` or ``A <> ALL (...)``
-    must not be ``NULL`` for any of the queried rows. Otherwise, the query will fail.
-    This limitation is needed to ensure correct results and may be dropped in the future.

--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -763,12 +763,6 @@ standard rules for nulls. The subquery must produce exactly one column::
     FROM nation
     WHERE regionkey IN (SELECT regionkey FROM region)
 
-.. note::
-
-    Currently, the expression on the left hand side of ``IN`` must
-    not be ``NULL`` for any of the queried rows. Otherwise, the query will fail.
-    This limitation is needed to ensure correct results and may be dropped in the future.
-
 Scalar Subquery
 ^^^^^^^^^^^^^^^
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/ChannelSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ChannelSet.java
@@ -53,6 +53,11 @@ public class ChannelSet
         return hash.getGroupCount();
     }
 
+    public boolean isEmpty()
+    {
+        return size() == 0;
+    }
+
     public boolean containsNull()
     {
         return containsNull;

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashSemiJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashSemiJoinOperator.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.operator.SetBuilderOperator.SetSupplier;
 import com.facebook.presto.spi.Page;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
@@ -25,7 +24,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 
-import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -176,9 +174,12 @@ public class HashSemiJoinOperator
         // update hashing strategy to use probe cursor
         for (int position = 0; position < page.getPositionCount(); position++) {
             if (probeJoinPage.getBlock(0).isNull(position)) {
-                throw new PrestoException(
-                        NOT_SUPPORTED,
-                        "NULL values are not allowed on the probe side of SemiJoin operator. See the query plan for details.");
+                if (channelSet.isEmpty()) {
+                    BOOLEAN.writeBoolean(blockBuilder, false);
+                }
+                else {
+                    blockBuilder.appendNull();
+                }
             }
             else {
                 boolean contains = channelSet.contains(position, probeJoinPage);

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
@@ -56,6 +56,7 @@ public class PartitionedOutputOperator
         private final List<Integer> partitionChannels;
         private final List<Optional<NullableValue>> partitionConstants;
         private final OutputBuffer outputBuffer;
+        private final boolean replicatesAnyRow;
         private final OptionalInt nullChannel;
         private final DataSize maxMemory;
 
@@ -63,6 +64,7 @@ public class PartitionedOutputOperator
                 PartitionFunction partitionFunction,
                 List<Integer> partitionChannels,
                 List<Optional<NullableValue>> partitionConstants,
+                boolean replicatesAnyRow,
                 OptionalInt nullChannel,
                 OutputBuffer outputBuffer,
                 DataSize maxMemory)
@@ -70,6 +72,7 @@ public class PartitionedOutputOperator
             this.partitionFunction = requireNonNull(partitionFunction, "partitionFunction is null");
             this.partitionChannels = requireNonNull(partitionChannels, "partitionChannels is null");
             this.partitionConstants = requireNonNull(partitionConstants, "partitionConstants is null");
+            this.replicatesAnyRow = replicatesAnyRow;
             this.nullChannel = requireNonNull(nullChannel, "nullChannel is null");
             this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
             this.maxMemory = requireNonNull(maxMemory, "maxMemory is null");
@@ -91,6 +94,7 @@ public class PartitionedOutputOperator
                     partitionFunction,
                     partitionChannels,
                     partitionConstants,
+                    replicatesAnyRow,
                     nullChannel,
                     outputBuffer,
                     serdeFactory,
@@ -108,6 +112,7 @@ public class PartitionedOutputOperator
         private final PartitionFunction partitionFunction;
         private final List<Integer> partitionChannels;
         private final List<Optional<NullableValue>> partitionConstants;
+        private final boolean replicatesAnyRow;
         private final OptionalInt nullChannel;
         private final OutputBuffer outputBuffer;
         private final PagesSerdeFactory serdeFactory;
@@ -121,6 +126,7 @@ public class PartitionedOutputOperator
                 PartitionFunction partitionFunction,
                 List<Integer> partitionChannels,
                 List<Optional<NullableValue>> partitionConstants,
+                boolean replicatesAnyRow,
                 OptionalInt nullChannel,
                 OutputBuffer outputBuffer,
                 PagesSerdeFactory serdeFactory,
@@ -133,6 +139,7 @@ public class PartitionedOutputOperator
             this.partitionFunction = requireNonNull(partitionFunction, "partitionFunction is null");
             this.partitionChannels = requireNonNull(partitionChannels, "partitionChannels is null");
             this.partitionConstants = requireNonNull(partitionConstants, "partitionConstants is null");
+            this.replicatesAnyRow = replicatesAnyRow;
             this.nullChannel = requireNonNull(nullChannel, "nullChannel is null");
             this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
             this.serdeFactory = requireNonNull(serdeFactory, "serdeFactory is null");
@@ -156,6 +163,7 @@ public class PartitionedOutputOperator
                     partitionFunction,
                     partitionChannels,
                     partitionConstants,
+                    replicatesAnyRow,
                     nullChannel,
                     outputBuffer,
                     serdeFactory,
@@ -178,6 +186,7 @@ public class PartitionedOutputOperator
                     partitionFunction,
                     partitionChannels,
                     partitionConstants,
+                    replicatesAnyRow,
                     nullChannel,
                     outputBuffer,
                     serdeFactory,
@@ -198,6 +207,7 @@ public class PartitionedOutputOperator
             PartitionFunction partitionFunction,
             List<Integer> partitionChannels,
             List<Optional<NullableValue>> partitionConstants,
+            boolean replicatesAnyRow,
             OptionalInt nullChannel,
             OutputBuffer outputBuffer,
             PagesSerdeFactory serdeFactory,
@@ -209,6 +219,7 @@ public class PartitionedOutputOperator
                 partitionFunction,
                 partitionChannels,
                 partitionConstants,
+                replicatesAnyRow,
                 nullChannel,
                 outputBuffer,
                 serdeFactory,
@@ -298,14 +309,17 @@ public class PartitionedOutputOperator
         private final List<Optional<Block>> partitionConstants;
         private final PagesSerde serde;
         private final List<PageBuilder> pageBuilders;
+        private final boolean replicatesAnyRow;
         private final OptionalInt nullChannel; // when present, send the position to every partition if this channel is null.
         private final AtomicLong rowsAdded = new AtomicLong();
         private final AtomicLong pagesAdded = new AtomicLong();
+        private boolean hasAnyRowBeenReplicated;
 
         public PagePartitioner(
                 PartitionFunction partitionFunction,
                 List<Integer> partitionChannels,
                 List<Optional<NullableValue>> partitionConstants,
+                boolean replicatesAnyRow,
                 OptionalInt nullChannel,
                 OutputBuffer outputBuffer,
                 PagesSerdeFactory serdeFactory,
@@ -317,6 +331,7 @@ public class PartitionedOutputOperator
             this.partitionConstants = requireNonNull(partitionConstants, "partitionConstants is null").stream()
                     .map(constant -> constant.map(NullableValue::asBlock))
                     .collect(toImmutableList());
+            this.replicatesAnyRow = replicatesAnyRow;
             this.nullChannel = requireNonNull(nullChannel, "nullChannel is null");
             this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
             this.sourceTypes = requireNonNull(sourceTypes, "sourceTypes is null");
@@ -351,10 +366,13 @@ public class PartitionedOutputOperator
 
             Page partitionFunctionArgs = getPartitionFunctionArguments(page);
             for (int position = 0; position < page.getPositionCount(); position++) {
-                if (nullChannel.isPresent() && page.getBlock(nullChannel.getAsInt()).isNull(position)) {
+                boolean shouldReplicate = (replicatesAnyRow && !hasAnyRowBeenReplicated) ||
+                        nullChannel.isPresent() && page.getBlock(nullChannel.getAsInt()).isNull(position);
+                if (shouldReplicate) {
                     for (PageBuilder pageBuilder : pageBuilders) {
                         appendRow(pageBuilder, page, position);
                     }
+                    hasAnyRowBeenReplicated = true;
                 }
                 else {
                     int partition = partitionFunction.getPartition(partitionFunctionArgs, position);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -81,6 +81,7 @@ public class EffectivePredicateExtractor
             entry -> {
                 SymbolReference reference = entry.getKey().toSymbolReference();
                 Expression expression = entry.getValue();
+                // TODO: this is not correct with respect to NULLs ('reference IS NULL' would be correct, rather than 'reference = NULL')
                 // TODO: switch this to 'IS NOT DISTINCT FROM' syntax when EqualityInference properly supports it
                 return new ComparisonExpression(ComparisonExpressionType.EQUAL, reference, expression);
             };

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -347,8 +347,8 @@ public class LocalExecutionPlanner
         Set<Symbol> partitioningColumns = partitioningScheme.getPartitioning().getColumns();
 
         // partitioningColumns expected to have one column in the normal case, and zero columns when partitioning on a constant
-        checkArgument(!partitioningScheme.isReplicateNulls() || partitioningColumns.size() <= 1);
-        if (partitioningScheme.isReplicateNulls() && partitioningColumns.size() == 1) {
+        checkArgument(!partitioningScheme.isReplicateNullsAndAny() || partitioningColumns.size() <= 1);
+        if (partitioningScheme.isReplicateNullsAndAny() && partitioningColumns.size() == 1) {
             nullChannel = OptionalInt.of(outputLayout.indexOf(getOnlyElement(partitioningColumns)));
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -357,7 +357,14 @@ public class LocalExecutionPlanner
                 plan,
                 outputLayout,
                 types,
-                new PartitionedOutputFactory(partitionFunction, partitionChannels, partitionConstants, nullChannel, outputBuffer, maxPagePartitioningBufferSize));
+                new PartitionedOutputFactory(
+                        partitionFunction,
+                        partitionChannels,
+                        partitionConstants,
+                        partitioningScheme.isReplicateNullsAndAny(),
+                        nullChannel,
+                        outputBuffer,
+                        maxPagePartitioningBufferSize));
     }
 
     public LocalExecutionPlan plan(Session session,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PartitioningScheme.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PartitioningScheme.java
@@ -32,7 +32,7 @@ public class PartitioningScheme
     private final Partitioning partitioning;
     private final List<Symbol> outputLayout;
     private final Optional<Symbol> hashColumn;
-    private final boolean replicateNulls;
+    private final boolean replicateNullsAndAny;
     private final Optional<int[]> bucketToPartition;
 
     public PartitioningScheme(Partitioning partitioning, List<Symbol> outputLayout)
@@ -60,7 +60,7 @@ public class PartitioningScheme
             @JsonProperty("partitioning") Partitioning partitioning,
             @JsonProperty("outputLayout") List<Symbol> outputLayout,
             @JsonProperty("hashColumn") Optional<Symbol> hashColumn,
-            @JsonProperty("replicateNulls") boolean replicateNulls,
+            @JsonProperty("replicateNullsAndAny") boolean replicateNullsAndAny,
             @JsonProperty("bucketToPartition") Optional<int[]> bucketToPartition)
     {
         this.partitioning = requireNonNull(partitioning, "partitioning is null");
@@ -74,8 +74,8 @@ public class PartitioningScheme
         hashColumn.ifPresent(column -> checkArgument(outputLayout.contains(column),
                 "Output layout (%s) don't include hash column (%s)", outputLayout, column));
 
-        checkArgument(!replicateNulls || columns.size() <= 1, "Must have at most one partitioning column when nullPartition is REPLICATE.");
-        this.replicateNulls = replicateNulls;
+        checkArgument(!replicateNullsAndAny || columns.size() <= 1, "Must have at most one partitioning column when nullPartition is REPLICATE.");
+        this.replicateNullsAndAny = replicateNullsAndAny;
         this.bucketToPartition = requireNonNull(bucketToPartition, "bucketToPartition is null");
     }
 
@@ -98,9 +98,9 @@ public class PartitioningScheme
     }
 
     @JsonProperty
-    public boolean isReplicateNulls()
+    public boolean isReplicateNullsAndAny()
     {
-        return replicateNulls;
+        return replicateNullsAndAny;
     }
 
     @JsonProperty
@@ -111,7 +111,7 @@ public class PartitioningScheme
 
     public PartitioningScheme withBucketToPartition(Optional<int[]> bucketToPartition)
     {
-        return new PartitioningScheme(partitioning, outputLayout, hashColumn, replicateNulls, bucketToPartition);
+        return new PartitioningScheme(partitioning, outputLayout, hashColumn, replicateNullsAndAny, bucketToPartition);
     }
 
     public PartitioningScheme translateOutputLayout(List<Symbol> newOutputLayout)
@@ -126,7 +126,7 @@ public class PartitioningScheme
                 .map(outputLayout::indexOf)
                 .map(newOutputLayout::get);
 
-        return new PartitioningScheme(newPartitioning, newOutputLayout, newHashSymbol, replicateNulls, bucketToPartition);
+        return new PartitioningScheme(newPartitioning, newOutputLayout, newHashSymbol, replicateNullsAndAny, bucketToPartition);
     }
 
     @Override
@@ -141,14 +141,14 @@ public class PartitioningScheme
         PartitioningScheme that = (PartitioningScheme) o;
         return Objects.equals(partitioning, that.partitioning) &&
                 Objects.equals(outputLayout, that.outputLayout) &&
-                replicateNulls == that.replicateNulls &&
+                replicateNullsAndAny == that.replicateNullsAndAny &&
                 Objects.equals(bucketToPartition, that.bucketToPartition);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(partitioning, outputLayout, replicateNulls, bucketToPartition);
+        return Objects.hash(partitioning, outputLayout, replicateNullsAndAny, bucketToPartition);
     }
 
     @Override
@@ -158,7 +158,7 @@ public class PartitioningScheme
                 .add("partitioning", partitioning)
                 .add("outputLayout", outputLayout)
                 .add("hashChannel", hashColumn)
-                .add("replicateNulls", replicateNulls)
+                .add("replicateNullsAndAny", replicateNullsAndAny)
                 .add("bucketToPartition", bucketToPartition)
                 .toString();
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -488,7 +488,7 @@ public class HashGenerationOptimizer
                                     .collect(toImmutableList()))
                             .build(),
                     partitionSymbols.map(newHashSymbols::get),
-                    partitioningScheme.isReplicateNulls(),
+                    partitioningScheme.isReplicateNullsAndAny(),
                     partitioningScheme.getBucketToPartition());
 
             // add hash symbols to sources

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PartialAggregationPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PartialAggregationPushDown.java
@@ -108,7 +108,7 @@ public class PartialAggregationPushDown
             // the cardinality of the stream (i.e., gather or repartition)
             ExchangeNode exchange = (ExchangeNode) child;
             if ((exchange.getType() != GATHER && exchange.getType() != REPARTITION) ||
-                    exchange.getPartitioningScheme().isReplicateNulls()) {
+                    exchange.getPartitioningScheme().isReplicateNullsAndAny()) {
                 return context.defaultRewrite(node);
             }
 
@@ -186,7 +186,7 @@ public class PartialAggregationPushDown
                     exchange.getPartitioningScheme().getPartitioning(),
                     partial.getOutputSymbols(),
                     exchange.getPartitioningScheme().getHashColumn(),
-                    exchange.getPartitioningScheme().isReplicateNulls(),
+                    exchange.getPartitioningScheme().isReplicateNullsAndAny(),
                     exchange.getPartitioningScheme().getBucketToPartition());
 
             return new ExchangeNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PreferredProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PreferredProperties.java
@@ -68,10 +68,10 @@ class PreferredProperties
                 .build();
     }
 
-    public static PreferredProperties partitionedWithNullsReplicated(Set<Symbol> columns)
+    public static PreferredProperties partitionedWithNullsAndAnyReplicated(Set<Symbol> columns)
     {
         return builder()
-                .global(Global.distributed(PartitioningProperties.partitioned(columns).withNullsReplicated(true)))
+                .global(Global.distributed(PartitioningProperties.partitioned(columns).withNullsAndAnyReplicated(true)))
                 .build();
     }
 
@@ -89,10 +89,10 @@ class PreferredProperties
                 .build();
     }
 
-    public static PreferredProperties partitionedWithNullsReplicated(Partitioning partitioning)
+    public static PreferredProperties partitionedWithNullsAndAnyReplicated(Partitioning partitioning)
     {
         return builder()
-                .global(Global.distributed(PartitioningProperties.partitioned(partitioning).withNullsReplicated(true)))
+                .global(Global.distributed(PartitioningProperties.partitioned(partitioning).withNullsAndAnyReplicated(true)))
                 .build();
     }
 
@@ -305,20 +305,20 @@ class PreferredProperties
     {
         private final Set<Symbol> partitioningColumns;
         private final Optional<Partitioning> partitioning; // Specific partitioning requested
-        private final boolean nullsReplicated;
+        private final boolean nullsAndAnyReplicated;
 
-        private PartitioningProperties(Set<Symbol> partitioningColumns, Optional<Partitioning> partitioning, boolean nullsReplicated)
+        private PartitioningProperties(Set<Symbol> partitioningColumns, Optional<Partitioning> partitioning, boolean nullsAndAnyReplicated)
         {
             this.partitioningColumns = ImmutableSet.copyOf(requireNonNull(partitioningColumns, "partitioningColumns is null"));
             this.partitioning = requireNonNull(partitioning, "function is null");
-            this.nullsReplicated = nullsReplicated;
+            this.nullsAndAnyReplicated = nullsAndAnyReplicated;
 
             checkArgument(!partitioning.isPresent() || partitioning.get().getColumns().equals(partitioningColumns), "Partitioning input must match partitioningColumns");
         }
 
-        public PartitioningProperties withNullsReplicated(boolean nullsReplicated)
+        public PartitioningProperties withNullsAndAnyReplicated(boolean nullsAndAnyReplicated)
         {
-            return new PartitioningProperties(partitioningColumns, partitioning, nullsReplicated);
+            return new PartitioningProperties(partitioningColumns, partitioning, nullsAndAnyReplicated);
         }
 
         public static PartitioningProperties partitioned(Partitioning partitioning)
@@ -346,9 +346,9 @@ class PreferredProperties
             return partitioning;
         }
 
-        public boolean isNullsReplicated()
+        public boolean isNullsAndAnyReplicated()
         {
-            return nullsReplicated;
+            return nullsAndAnyReplicated;
         }
 
         public PartitioningProperties mergeWithParent(PartitioningProperties parent)
@@ -358,8 +358,8 @@ class PreferredProperties
                 return this;
             }
 
-            // Partitioning with different null replication cannot be compared
-            if (nullsReplicated != parent.nullsReplicated) {
+            // Partitioning with different replication cannot be compared
+            if (nullsAndAnyReplicated != parent.nullsAndAnyReplicated) {
                 return this;
             }
 
@@ -371,7 +371,7 @@ class PreferredProperties
 
             // Otherwise partition on any common columns if available
             Set<Symbol> common = Sets.intersection(partitioningColumns, parent.partitioningColumns);
-            return common.isEmpty() ? this : partitioned(common).withNullsReplicated(nullsReplicated);
+            return common.isEmpty() ? this : partitioned(common).withNullsAndAnyReplicated(nullsAndAnyReplicated);
         }
 
         public Optional<PartitioningProperties> translate(Function<Symbol, Optional<Symbol>> translator)
@@ -388,7 +388,7 @@ class PreferredProperties
             }
 
             if (!partitioning.isPresent()) {
-                return Optional.of(new PartitioningProperties(newPartitioningColumns, Optional.empty(), nullsReplicated));
+                return Optional.of(new PartitioningProperties(newPartitioningColumns, Optional.empty(), nullsAndAnyReplicated));
             }
 
             Optional<Partitioning> newPartitioning = partitioning.get().translate(translator, symbol -> Optional.empty());
@@ -396,13 +396,13 @@ class PreferredProperties
                 return Optional.empty();
             }
 
-            return Optional.of(new PartitioningProperties(newPartitioningColumns, newPartitioning, nullsReplicated));
+            return Optional.of(new PartitioningProperties(newPartitioningColumns, newPartitioning, nullsAndAnyReplicated));
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(partitioningColumns, partitioning, nullsReplicated);
+            return Objects.hash(partitioningColumns, partitioning, nullsAndAnyReplicated);
         }
 
         @Override
@@ -417,7 +417,7 @@ class PreferredProperties
             final PartitioningProperties other = (PartitioningProperties) obj;
             return Objects.equals(this.partitioningColumns, other.partitioningColumns)
                     && Objects.equals(this.partitioning, other.partitioning)
-                    && this.nullsReplicated == other.nullsReplicated;
+                    && this.nullsAndAnyReplicated == other.nullsAndAnyReplicated;
         }
 
         @Override
@@ -426,7 +426,7 @@ class PreferredProperties
             return toStringHelper(this)
                     .add("partitioningColumns", partitioningColumns)
                     .add("partitioning", partitioning)
-                    .add("nullsReplicated", nullsReplicated)
+                    .add("nullsAndAnyReplicated", nullsAndAnyReplicated)
                     .toString();
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ProjectionPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ProjectionPushDown.java
@@ -163,7 +163,7 @@ public class ProjectionPushDown
                     exchange.getPartitioningScheme().getPartitioning(),
                     outputBuilder.build(),
                     exchange.getPartitioningScheme().getHashColumn(),
-                    exchange.getPartitioningScheme().isReplicateNulls(),
+                    exchange.getPartitioningScheme().isReplicateNullsAndAny(),
                     exchange.getPartitioningScheme().getBucketToPartition());
 
             return new ExchangeNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -123,7 +123,7 @@ class PropertyDerivations
         verify(node.getOutputSymbols().containsAll(localPropertyColumns), "Node-level local properties contain columns not present in node's output");
 
         // TODO: ideally this logic would be somehow moved to PlanSanityChecker
-        verify(node instanceof SemiJoinNode || inputProperties.stream().noneMatch(ActualProperties::isNullsReplicated) || output.isNullsReplicated(),
+        verify(node instanceof SemiJoinNode || inputProperties.stream().noneMatch(ActualProperties::isNullsAndAnyReplicated) || output.isNullsAndAnyReplicated(),
                 "SemiJoinNode is the only node that can strip null replication");
 
         return output;
@@ -435,7 +435,7 @@ class PropertyDerivations
         @Override
         public ActualProperties visitExchange(ExchangeNode node, List<ActualProperties> inputProperties)
         {
-            checkArgument(node.getScope() != REMOTE || inputProperties.stream().noneMatch(ActualProperties::isNullsReplicated), "Null replicated inputs should not be remotely exchanged");
+            checkArgument(node.getScope() != REMOTE || inputProperties.stream().noneMatch(ActualProperties::isNullsAndAnyReplicated), "Null-and-any replicated inputs should not be remotely exchanged");
 
             Set<Map.Entry<Symbol, NullableValue>> entries = null;
             for (int sourceIndex = 0; sourceIndex < node.getSources().size(); sourceIndex++) {
@@ -472,7 +472,7 @@ class PropertyDerivations
                             .global(partitionedOn(
                                     node.getPartitioningScheme().getPartitioning(),
                                     Optional.of(node.getPartitioningScheme().getPartitioning()))
-                                    .withReplicatedNulls(node.getPartitioningScheme().isReplicateNulls()))
+                                    .withReplicatedNulls(node.getPartitioningScheme().isReplicateNullsAndAny()))
                             .constants(constants)
                             .build();
                 case REPLICATE:

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -148,7 +148,7 @@ public class PruneUnreferencedOutputs
                     node.getPartitioningScheme().getPartitioning(),
                     newOutputSymbols,
                     node.getPartitioningScheme().getHashColumn(),
-                    node.getPartitioningScheme().isReplicateNulls(),
+                    node.getPartitioningScheme().isReplicateNullsAndAny(),
                     node.getPartitioningScheme().getBucketToPartition());
 
             ImmutableList.Builder<PlanNode> rewrittenSources = ImmutableList.builder();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -276,7 +276,7 @@ public class UnaliasSymbolReferences
                     node.getPartitioningScheme().getPartitioning().translate(this::canonicalize),
                     outputs.build(),
                     canonicalize(node.getPartitioningScheme().getHashColumn()),
-                    node.getPartitioningScheme().isReplicateNulls(),
+                    node.getPartitioningScheme().isReplicateNullsAndAny(),
                     node.getPartitioningScheme().getBucketToPartition());
 
             return new ExchangeNode(node.getId(), node.getType(), node.getScope(), partitioningScheme, sources, inputs);
@@ -726,7 +726,7 @@ public class UnaliasSymbolReferences
                     scheme.getPartitioning().translate(this::canonicalize),
                     outputs.build(),
                     canonicalize(scheme.getHashColumn()),
-                    scheme.isReplicateNulls(),
+                    scheme.isReplicateNullsAndAny(),
                     scheme.getBucketToPartition());
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
@@ -88,7 +88,7 @@ public class ExchangeNode
         checkArgument(scope != LOCAL || partitioningScheme.getPartitioning().getArguments().stream().allMatch(ArgumentBinding::isVariable),
                 "local exchanges do not support constant partition function arguments");
 
-        checkArgument(scope != REMOTE || type == Type.REPARTITION || !partitioningScheme.isReplicateNulls(), "Only REPARTITION can remotely replicate nulls");
+        checkArgument(scope != REMOTE || type == Type.REPARTITION || !partitioningScheme.isReplicateNullsAndAny(), "Only REPARTITION can replicate remotely");
 
         this.type = type;
         this.sources = sources;
@@ -102,7 +102,7 @@ public class ExchangeNode
         return partitionedExchange(id, scope, child, partitioningColumns, hashColumns, false);
     }
 
-    public static ExchangeNode partitionedExchange(PlanNodeId id, Scope scope, PlanNode child, List<Symbol> partitioningColumns, Optional<Symbol> hashColumns, boolean nullsReplicated)
+    public static ExchangeNode partitionedExchange(PlanNodeId id, Scope scope, PlanNode child, List<Symbol> partitioningColumns, Optional<Symbol> hashColumns, boolean replicateNullsAndAny)
     {
         return partitionedExchange(
                 id,
@@ -112,7 +112,7 @@ public class ExchangeNode
                         Partitioning.create(FIXED_HASH_DISTRIBUTION, partitioningColumns),
                         child.getOutputSymbols(),
                         hashColumns,
-                        nullsReplicated,
+                        replicateNullsAndAny,
                         Optional.empty()));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -235,7 +235,7 @@ public class PlanPrinter
                 .append(format("Output layout: [%s]\n",
                         Joiner.on(", ").join(partitioningScheme.getOutputLayout())));
 
-        boolean replicateNulls = partitioningScheme.isReplicateNulls();
+        boolean replicateNullsAndAny = partitioningScheme.isReplicateNullsAndAny();
         List<String> arguments = partitioningScheme.getPartitioning().getArguments().stream()
                 .map(argument -> {
                     if (argument.isConstant()) {
@@ -247,8 +247,8 @@ public class PlanPrinter
                 })
                 .collect(toImmutableList());
         builder.append(indentString(1));
-        if (replicateNulls) {
-            builder.append(format("Output partitioning: %s (replicate nulls) [%s]%s\n",
+        if (replicateNullsAndAny) {
+            builder.append(format("Output partitioning: %s (replicate nulls and any) [%s]%s\n",
                     partitioningScheme.getPartitioning().getHandle(),
                     Joiner.on(", ").join(arguments),
                     formatHash(partitioningScheme.getHashColumn())));
@@ -1038,7 +1038,7 @@ public class PlanPrinter
             if (node.getScope() == Scope.LOCAL) {
                 print(indent, "- LocalExchange[%s%s]%s (%s) => %s",
                         node.getPartitioningScheme().getPartitioning().getHandle(),
-                        node.getPartitioningScheme().isReplicateNulls() ? " - REPLICATE NULLS" : "",
+                        node.getPartitioningScheme().isReplicateNullsAndAny() ? " - REPLICATE NULLS AND ANY" : "",
                         formatHash(node.getPartitioningScheme().getHashColumn()),
                         Joiner.on(", ").join(node.getPartitioningScheme().getPartitioning().getArguments()),
                         formatOutputs(node.getOutputSymbols()));
@@ -1047,7 +1047,7 @@ public class PlanPrinter
                 print(indent, "- %sExchange[%s%s]%s => %s",
                         UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, node.getScope().toString()),
                         node.getType(),
-                        node.getPartitioningScheme().isReplicateNulls() ? " - REPLICATE NULLS" : "",
+                        node.getPartitioningScheme().isReplicateNullsAndAny() ? " - REPLICATE NULLS AND ANY" : "",
                         formatHash(node.getPartitioningScheme().getHashColumn()),
                         formatOutputs(node.getOutputSymbols()));
             }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
@@ -175,8 +175,7 @@ public class TestHashSemiJoinOperator
         OperatorAssertion.assertOperatorEquals(joinOperatorFactory, driverContext, probeInput, expected, hashEnabled, ImmutableList.of(probeTypes.size()));
     }
 
-    //Disabled till #6622 is fixed
-    @Test(dataProvider = "hashEnabledValues", enabled = false)
+    @Test(dataProvider = "hashEnabledValues")
     public void testProbeSideNulls(boolean hashEnabled)
             throws Exception
     {
@@ -226,8 +225,7 @@ public class TestHashSemiJoinOperator
         OperatorAssertion.assertOperatorEquals(joinOperatorFactory, driverContext, probeInput, expected, hashEnabled, ImmutableList.of(probeTypes.size()));
     }
 
-    //Disabled till #6622 is fixed
-    @Test(dataProvider = "hashEnabledValues", enabled = false)
+    @Test(dataProvider = "hashEnabledValues")
     public void testProbeAndBuildNulls(boolean hashEnabled)
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
@@ -23,6 +23,7 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTre
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 
@@ -42,5 +43,27 @@ public class TestPredicatePushdown
                                                 tableScan("lineitem", ImmutableMap.of(
                                                         "LINEITEM_OK", "orderkey",
                                                         "LINEITEM_LINENUMBER", "linenumber")))))));
+    }
+
+    @Test
+    public void testPushDownToLhsOfSemiJoin()
+    {
+        assertPlan("SELECT quantity FROM (SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders)) " +
+                        "WHERE linenumber = 2",
+                anyTree(
+                        semiJoin("LINE_ORDER_KEY", "ORDERS_ORDER_KEY", "SEMI_JOIN_RESULT",
+                                anyTree(
+                                        filter("LINE_NUMBER = 2",
+                                                tableScan("lineitem", ImmutableMap.of(
+                                                        "LINE_ORDER_KEY", "orderkey",
+                                                        "LINE_NUMBER", "linenumber",
+                                                        "LINE_QUANTITY", "quantity")
+                                                )
+                                        )
+                                ),
+                                anyTree(tableScan("orders", ImmutableMap.of("ORDERS_ORDER_KEY", "orderkey")))
+                        )
+                )
+        );
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -44,6 +44,7 @@ import java.util.OptionalLong;
 import static com.facebook.presto.sql.SqlFormatter.formatSql;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static java.lang.String.format;
@@ -243,7 +244,7 @@ public abstract class AbstractTestQueryFramework
 
     private static void assertExceptionMessage(String sql, Exception exception, @Language("RegExp") String regex)
     {
-        if (!exception.getMessage().matches(regex)) {
+        if (!nullToEmpty(exception.getMessage()).matches(regex)) {
             fail(format("Expected exception message '%s' to match '%s' for query: %s", exception.getMessage(), regex, sql), exception);
         }
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -93,7 +93,7 @@ public final class QueryAssertions
             expectedResults = h2QueryRunner.execute(session, expected, actualResults.getTypes());
         }
         catch (RuntimeException ex) {
-            fail("Execution of 'expected' query failed: " + actual, ex);
+            fail("Execution of 'expected' query failed: " + expected, ex);
         }
         log.info("FINISHED in presto: %s, h2: %s, total: %s", actualTime, nanosSince(expectedStart), nanosSince(start));
 


### PR DESCRIPTION
- predicate push down for semi join's build side got disabled
- new replication mode "replicate nulls and any row"
- nulls on left side of `IN` are correctly supported now
- there is session flag unlocking old behavior 

Fixes #6991. Related to #7208, #6622