### PR TITLE
Include aggregation mask when rewriting count(1)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
@@ -71,7 +71,8 @@ public class SimplifyCountOverConstant
                 changed = true;
                 assignments.put(symbol, new AggregationNode.Aggregation(
                         new FunctionCall(QualifiedName.of("count"), ImmutableList.of()),
-                        new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT))));
+                        new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT)),
+                        aggregation.getMask()));
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SingleMarkDistinctToGroupBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SingleMarkDistinctToGroupBy.java
@@ -114,6 +114,7 @@ public class SingleMarkDistinctToGroupBy
         FunctionCall call = aggregation.getCall();
         return new AggregationNode.Aggregation(
                 new FunctionCall(call.getName(), call.getWindow(), false, call.getArguments()),
-                aggregation.getSignature());
+                aggregation.getSignature(),
+                Optional.empty());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
@@ -282,13 +282,6 @@ public class AggregationNode
         private final Signature signature;
         private final Optional<Symbol> mask;
 
-        public Aggregation(
-                FunctionCall call,
-                Signature signature)
-        {
-            this(call, signature, Optional.empty());
-        }
-
         @JsonCreator
         public Aggregation(
                 @JsonProperty("call") FunctionCall call,

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -962,6 +962,8 @@ public abstract class AbstractTestQueries
                         "FROM (SELECT count(*) FILTER (WHERE true) AS b)",
                 "SELECT 1");
 
+        assertQuery("SELECT count(1) FILTER (WHERE orderstatus = 'O') FROM orders", "SELECT count(*) FROM orders WHERE orderstatus = 'O'");
+
         // TODO: enable when DISTINCT is allowed with filtered aggregations
         // assertQuery("SELECT count(distinct x) FILTER (where y = 1) FROM (VALUES (2, 1), (1, 2), (1,1)) t(x, y)", "SELECT 2");
         // assertQuery("SELECT sum(DISTINCT x) FILTER (WHERE x > 1) AS x FROM (VALUES (1), (2), (2), (4)) t (x)", "SELECT 6");


### PR DESCRIPTION
SimplifyCountOverConstant was ignoring the mask when rewriting
the aggregation, which resulted in queries producing incorrect
results due to the FILTER (WHERE ...) clause being lost.

Fixes https://github.com/prestodb/presto/issues/7796