### PR TITLE
Extend ConnectorSession with getProperties

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -125,6 +125,12 @@ public class FullConnectorSession
     }
 
     @Override
+    public Map<String, String> getProperties()
+    {
+        return properties;
+    }
+
+    @Override
     public String toString()
     {
         return toStringHelper(this)

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -112,6 +113,27 @@ public class TestingConnectorSession
             return type.cast(metadata.getDefaultValue());
         }
         return type.cast(metadata.decode(value));
+    }
+
+    @Override
+    public Map<String, String> getProperties()
+    {
+        Map<String, String> result = new HashMap<>();
+        for (String key : properties.keySet()) {
+            PropertyMetadata<?> metadata = properties.get(key);
+            if (metadata == null) {
+                throw new PrestoException(INVALID_SESSION_PROPERTY, "Empty metadata for property " + key);
+            }
+            String value;
+            if (propertyValues.get(key) == null) {
+                value = metadata.getDefaultValue().toString();
+            }
+            else {
+                value = metadata.decode(propertyValues.get(key)).toString();
+            }
+            result.put(key, value);
+        }
+        return result;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.type.TimeZoneKey;
 
 import java.util.Locale;
+import java.util.Map;
 
 public interface ConnectorSession
 {
@@ -36,4 +37,6 @@ public interface ConnectorSession
     long getStartTime();
 
     <T> T getProperty(String name, Class<T> type);
+
+    Map<String, String> getProperties();
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
@@ -22,6 +22,7 @@ import io.airlift.slice.DynamicSliceOutput;
 import org.testng.annotations.Test;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
@@ -69,6 +70,12 @@ public class TestDictionaryBlockEncoding
         public <T> T getProperty(String name, Class<T> type)
         {
             throw new PrestoException(INVALID_SESSION_PROPERTY, "Unknown session property " + name);
+        }
+
+        @Override
+        public Map<String, String> getProperties()
+        {
+            throw new PrestoException(INVALID_SESSION_PROPERTY, "No properties exist");
         }
     };
 

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockEncoding.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockEncoding.java
@@ -22,6 +22,7 @@ import io.airlift.slice.DynamicSliceOutput;
 import org.testng.annotations.Test;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
@@ -68,6 +69,12 @@ public class TestVariableWidthBlockEncoding
         public <T> T getProperty(String name, Class<T> type)
         {
             throw new PrestoException(INVALID_SESSION_PROPERTY, "Unknown session property " + name);
+        }
+
+        @Override
+        public Map<String, String> getProperties()
+        {
+            throw new PrestoException(INVALID_SESSION_PROPERTY, "No properties exist");
         }
     };
 


### PR DESCRIPTION
There are cases we might be interested getting all the properties in a
connector session. Add an interface to expose them.