### PR TITLE
Remove catalog part of MySQL JDBC URI

### DIFF
--- a/presto-main/etc/catalog/mysql.properties
+++ b/presto-main/etc/catalog/mysql.properties
@@ -1,4 +1,4 @@
 connector.name=mysql
-connection-url=jdbc:mysql://mysql:13306/test
+connection-url=jdbc:mysql://mysql:13306
 connection-user=root
 connection-password=swarm

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClientModule.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClientModule.java
@@ -16,19 +16,37 @@ package com.facebook.presto.plugin.mysql;
 import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.JdbcClient;
 import com.google.inject.Binder;
-import com.google.inject.Module;
 import com.google.inject.Scopes;
+import com.mysql.jdbc.Driver;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
 
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class MySqlClientModule
-        implements Module
+        extends AbstractConfigurationAwareModule
 {
     @Override
-    public void configure(Binder binder)
+    protected void setup(Binder binder)
     {
         binder.bind(JdbcClient.class).to(MySqlClient.class).in(Scopes.SINGLETON);
-        configBinder(binder).bindConfig(BaseJdbcConfig.class);
+        ensureCatalogIsEmpty(buildConfigObject(BaseJdbcConfig.class).getConnectionUrl());
         configBinder(binder).bindConfig(MySqlConfig.class);
+    }
+
+    private static void ensureCatalogIsEmpty(String connectionUrl)
+    {
+        try {
+            Driver driver = new Driver();
+            Properties urlProperties = driver.parseURL(connectionUrl, null);
+            checkArgument(urlProperties != null, "Invalid JDBC URL for MySQL connector");
+            checkArgument(driver.database(urlProperties) == null, "Database (catalog) must not be specified in JDBC URL for MySQL connector");
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlPlugin.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlPlugin.java
@@ -29,6 +29,6 @@ public class TestMySqlPlugin
     {
         Plugin plugin = new MySqlPlugin();
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
-        factory.create("test", ImmutableMap.of("connection-url", "test"), new TestingConnectorContext());
+        factory.create("test", ImmutableMap.of("connection-url", "jdbc:mysql://test"), new TestingConnectorContext());
     }
 }

--- a/presto-product-tests/conf/presto/etc/catalog/mysql.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/mysql.properties
@@ -1,4 +1,4 @@
 connector.name=mysql
-connection-url=jdbc:mysql://mysql:13306/test
+connection-url=jdbc:mysql://mysql:13306
 connection-user=root
 connection-password=swarm

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -28,6 +28,7 @@ public final class TestGroups
     public static final String BLACKHOLE_CONNECTOR = "blackhole";
     public static final String SMOKE = "smoke";
     public static final String JDBC = "jdbc";
+    public static final String MYSQL = "mysql";
     public static final String SIMBA_JDBC = "simba_jdbc";
     public static final String QUERY_ENGINE = "qe";
     public static final String COMPARISON = "comparison";

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/mysql/CreateTableAsSelect.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/mysql/CreateTableAsSelect.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.mysql;
+
+import com.teradata.tempto.AfterTestWithContext;
+import com.teradata.tempto.BeforeTestWithContext;
+import com.teradata.tempto.ProductTest;
+import com.teradata.tempto.Requires;
+import com.teradata.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements.ImmutableNationTable;
+import com.teradata.tempto.query.QueryResult;
+import io.airlift.log.Logger;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.tests.TestGroups.JDBC;
+import static com.facebook.presto.tests.TestGroups.MYSQL;
+import static com.facebook.presto.tests.utils.QueryExecutors.onMySql;
+import static com.teradata.tempto.assertions.QueryAssert.Row.row;
+import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static com.teradata.tempto.query.QueryExecutor.query;
+import static java.lang.String.format;
+
+public class CreateTableAsSelect
+        extends ProductTest
+{
+    private static final String TABLE_NAME = "test.nation_tmp";
+
+    @BeforeTestWithContext
+    @AfterTestWithContext
+    public void dropTestTable()
+    {
+        try {
+            onMySql().executeQuery(format("DROP TABLE IF EXISTS %s", TABLE_NAME));
+        }
+        catch (Exception e) {
+            Logger.get(getClass()).warn(e, "failed to drop table");
+        }
+    }
+
+    @Requires(ImmutableNationTable.class)
+    @Test(groups = {JDBC, MYSQL})
+    public void testCreateTableAsSelect()
+    {
+        QueryResult queryResult = query(format("CREATE TABLE mysql.%s AS SELECT * FROM nation", TABLE_NAME));
+        assertThat(queryResult).containsOnly(row(25));
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/QueryExecutors.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/QueryExecutors.java
@@ -39,5 +39,10 @@ public class QueryExecutors
         return testContext().getDependency(QueryExecutor.class, "sqlserver");
     }
 
+    public static QueryExecutor onMySql()
+    {
+        return testContext().getDependency(QueryExecutor.class, "mysql");
+    }
+
     private QueryExecutors() {}
 }


### PR DESCRIPTION
Providing catalog (DB name) makes BaseJDBCClient create a SQL containing catalog.schema.table_name, which is not correct for MySQL.
This caused failure of CTAS on product tests MySQL configuration.

---

Verification (334d677) allows:
jdbc:mysql://mysql:13306
jdbc:mysql://mysql:13306/
jdbc:mysql://mysql:13306/?param=val

but does not allow:
jdbc:mysql://mysql:13306/db
nor
jdbc:mysql://mysql:13306/db?param=val