### PR TITLE
Support coercion of non-function positions in lambda

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/SignatureBinder.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SignatureBinder.java
@@ -737,7 +737,7 @@ public class SignatureBinder
             if (!appendTypeRelationshipConstraintSolver(constraintsBuilder, formalLambdaReturnTypeSignature, new TypeSignatureProvider(actualReturnType.getTypeSignature()), false)) {
                 return SolverReturnStatus.UNSOLVABLE;
             }
-            if (!appendConstraintSolvers(constraintsBuilder, formalLambdaReturnTypeSignature, new TypeSignatureProvider(actualReturnType.getTypeSignature()), false)) {
+            if (!appendConstraintSolvers(constraintsBuilder, formalLambdaReturnTypeSignature, new TypeSignatureProvider(actualReturnType.getTypeSignature()), allowCoercion)) {
                 return SolverReturnStatus.UNSOLVABLE;
             }
             SolverReturnStatusMerger statusMerger = new SolverReturnStatusMerger();
@@ -834,7 +834,7 @@ public class SignatureBinder
 
             TypeSignature boundSignature = applyBoundVariables(superTypeSignature, bindings.build());
 
-            return satisfiesCoercion(allowCoercion, actualType, boundSignature) ? SolverReturnStatus.UNCHANGED_SATISFIED : SolverReturnStatus.UNSOLVABLE;
+            return satisfiesCoercion(allowCoercion, actualType, boundSignature) ? SolverReturnStatus.UNCHANGED_SATISFIED : SolverReturnStatus.UNCHANGED_NOT_SATISFIED;
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestSignatureBinder.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestSignatureBinder.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.block.BlockEncodingManager;
-import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
@@ -22,6 +21,7 @@ import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.TypeSignatureProvider;
+import com.facebook.presto.type.FunctionType;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -36,9 +36,11 @@ import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.metadata.Signature.withVariadicBound;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
@@ -1009,7 +1011,7 @@ public class TestSignatureBinder
         assertThat(simple)
                 .boundTo("function(integer,integer)")
                 .succeeds();
-        // TODO: This should eventually be supported
+        // TODO: Support coercion of return type of lambda
         assertThat(simple)
                 .boundTo("function(integer,smallint)")
                 .withCoercion()
@@ -1084,6 +1086,26 @@ public class TestSignatureBinder
         assertThat(varargApply)
                 .boundTo("integer", "function(integer, integer)", "function(integer, double)", "function(double, double)")
                 .fails();
+
+        Signature loop = functionSignature()
+                .returnType(parseTypeSignature("T"))
+                .argumentTypes(parseTypeSignature("T"), parseTypeSignature("function(T, T)"))
+                .typeVariableConstraints(typeVariable("T"))
+                .build();
+        assertThat(loop)
+                .boundTo("integer", new TypeSignatureProvider(paramTypes -> new FunctionType(paramTypes, BIGINT).getTypeSignature()))
+                .fails();
+        assertThat(loop)
+                .boundTo("integer", new TypeSignatureProvider(paramTypes -> new FunctionType(paramTypes, BIGINT).getTypeSignature()))
+                .withCoercion()
+                .produces(BoundVariables.builder()
+                        .setTypeVariable("T", BIGINT)
+                        .build());
+        // TODO: Support coercion of return type of lambda
+        assertThat(loop)
+                .withCoercion()
+                .boundTo("integer", new TypeSignatureProvider(paramTypes -> new FunctionType(paramTypes, SMALLINT).getTypeSignature()))
+                .fails();
     }
 
     @Test
@@ -1092,7 +1114,7 @@ public class TestSignatureBinder
     {
         BoundVariables boundVariables = BoundVariables.builder()
                 .setTypeVariable("T1", DOUBLE)
-                .setTypeVariable("T2", BigintType.BIGINT)
+                .setTypeVariable("T2", BIGINT)
                 .setTypeVariable("T3", DecimalType.createDecimalType(5, 3))
                 .setLongVariable("p", 1L)
                 .setLongVariable("s", 2L)
@@ -1175,12 +1197,6 @@ public class TestSignatureBinder
         public BindSignatureAssertion withCoercion()
         {
             allowCoercion = true;
-            return this;
-        }
-
-        public BindSignatureAssertion boundTo(String... arguments)
-        {
-            this.argumentTypes = fromTypes(types(arguments));
             return this;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayReduceFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayReduceFunction.java
@@ -20,6 +20,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.TimeZoneKey.getTimeZoneKey;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.FUNCTION_NOT_FOUND;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static java.util.Arrays.asList;
 
@@ -93,5 +94,13 @@ public class TestArrayReduceFunction
                 "reduce(ARRAY[ARRAY[1, 2], ARRAY[3, 4], ARRAY[5, NULL, 7]], CAST(ARRAY[] AS ARRAY(INTEGER)), (s, x) -> concat(s, x), s -> s)",
                 new ArrayType(INTEGER),
                 asList(1, 2, 3, 4, 5, null, 7));
+    }
+
+    @Test
+    public void testCoercion()
+    {
+        assertFunction("reduce(ARRAY [123456789012345, NULL, 54321], 0, (s, x) -> s + coalesce(x, 0), s -> s)", BIGINT, 123456789066666L);
+        // TODO: Support coercion of return type of lambda
+        assertInvalidFunction("reduce(ARRAY [1, NULL, 2], 0, (s, x) -> CAST (s + x AS TINYINT), s -> s)", FUNCTION_NOT_FOUND);
     }
 }


### PR DESCRIPTION
`f(array(int), int, (*, int)->bigint)` fails during analysis for
`f(array(T), S, (S, T)->S)` because SignatureBinder fails when trying
to match bigint (in function return type) with S (which is presumed to
be int based on parameters seen so far).

An example of such an `f` is reduce function.