### PR TITLE
Fix comparing varchar for window function tests

### DIFF
--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -17,8 +17,6 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
@@ -125,35 +123,5 @@ public class TestCassandraDistributed
     public void testDescribeOutputNamedAndUnnamed()
     {
         // this connector uses a non-canonical type for varchar columns in tpch
-    }
-
-    @Override
-    public void testWindowFunctionsFromAggregate()
-    {
-        testWindowFunctionsFromAggregate(VARCHAR, VARCHAR, DOUBLE, BIGINT);
-    }
-
-    @Override
-    public void testFullyPartitionedAndPartiallySortedWindowFunction()
-    {
-        testFullyPartitionedAndPartiallySortedWindowFunction(BIGINT, BIGINT, VARCHAR, BIGINT);
-    }
-
-    @Override
-    public void testValueWindowFunctions()
-    {
-        testValueWindowFunctions(BIGINT, VARCHAR, BIGINT, BIGINT);
-    }
-
-    @Override
-    public void testWindowFrames()
-    {
-        testWindowFrames(BIGINT, VARCHAR, BIGINT);
-    }
-
-    @Override
-    public void testWindowFunctionsExpressions()
-    {
-        testWindowFunctionsExpressions(BIGINT, VARCHAR, BIGINT);
     }
 }


### PR DESCRIPTION
Not all connectors properly support bounded varchar, so only compare
the rows and not the expected types, similar to other tests. Also,
these tests are actually for the engine, so we really should not be
running them for each connector, but that's a bigger issue.