### PR TITLE
Support clustering key predicate pushdown(Equal, IN and Range) in Cassandra

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClusteringPredicatesExtractor.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClusteringPredicatesExtractor.java
@@ -13,66 +13,41 @@
  */
 package com.facebook.presto.cassandra;
 
+import com.datastax.driver.core.VersionNumber;
 import com.facebook.presto.cassandra.util.CassandraCqlUtils;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.Range;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.google.common.base.Joiner;
+import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static com.facebook.presto.cassandra.util.CassandraCqlUtils.toCQLCompatibleString;
-import static com.google.common.collect.Sets.cartesianProduct;
 import static java.util.Objects.requireNonNull;
 
 public class CassandraClusteringPredicatesExtractor
 {
     private final List<CassandraColumnHandle> clusteringColumns;
-    private final TupleDomain<ColumnHandle> predicates;
     private final ClusteringPushDownResult clusteringPushDownResult;
+    private final TupleDomain<ColumnHandle> predicates;
 
-    public CassandraClusteringPredicatesExtractor(List<CassandraColumnHandle> clusteringColumns, TupleDomain<ColumnHandle> predicates)
+    public CassandraClusteringPredicatesExtractor(List<CassandraColumnHandle> clusteringColumns, TupleDomain<ColumnHandle> predicates, VersionNumber cassandraVersion)
     {
-        this.clusteringColumns = ImmutableList.copyOf(requireNonNull(clusteringColumns, "clusteringColumns is null"));
+        this.clusteringColumns = ImmutableList.copyOf(clusteringColumns);
         this.predicates = requireNonNull(predicates, "predicates is null");
-        this.clusteringPushDownResult = getClusteringKeysSet(clusteringColumns, predicates);
+        this.clusteringPushDownResult = getClusteringKeysSet(clusteringColumns, predicates, requireNonNull(cassandraVersion, "cassandraVersion is null"));
     }
 
-    public List<String> getClusteringKeyPredicates()
+    public String getClusteringKeyPredicates()
     {
-        Set<List<Object>> pushedDownDomainValues = clusteringPushDownResult.getDomainValues();
-
-        if (pushedDownDomainValues.isEmpty()) {
-            return ImmutableList.of();
-        }
-
-        ImmutableList.Builder<String> clusteringPredicates = ImmutableList.builder();
-        for (List<Object> clusteringKeys : pushedDownDomainValues) {
-            if (clusteringKeys.isEmpty()) {
-                continue;
-            }
-
-            StringBuilder stringBuilder = new StringBuilder();
-
-            for (int i = 0; i < clusteringKeys.size(); i++) {
-                if (i > 0) {
-                    stringBuilder.append(" AND ");
-                }
-
-                stringBuilder.append(CassandraCqlUtils.validColumnName(clusteringColumns.get(i).getName()));
-                stringBuilder.append(" = ");
-                stringBuilder.append(CassandraCqlUtils.cqlValue(toCQLCompatibleString(clusteringKeys.get(i)), clusteringColumns.get(i).getCassandraType()));
-            }
-
-            clusteringPredicates.add(stringBuilder.toString());
-        }
-        return clusteringPredicates.build();
+        return clusteringPushDownResult.getDomainQuery();
     }
 
     public TupleDomain<ColumnHandle> getUnenforcedConstraints()
@@ -87,65 +62,133 @@ public class CassandraClusteringPredicatesExtractor
         return TupleDomain.withColumnDomains(notPushedDown);
     }
 
-    private static ClusteringPushDownResult getClusteringKeysSet(List<CassandraColumnHandle> clusteringColumns, TupleDomain<ColumnHandle> predicates)
+    private static ClusteringPushDownResult getClusteringKeysSet(List<CassandraColumnHandle> clusteringColumns, TupleDomain<ColumnHandle> predicates, VersionNumber cassandraVersion)
     {
         ImmutableMap.Builder<ColumnHandle, Domain> domainsBuilder = ImmutableMap.builder();
-        ImmutableList.Builder<Set<Object>> clusteringColumnValues = ImmutableList.builder();
+        ImmutableList.Builder<String> clusteringColumnSql = ImmutableList.builder();
+        int currentClusteringColumn = 0;
         for (CassandraColumnHandle columnHandle : clusteringColumns) {
             Domain domain = predicates.getDomains().get().get(columnHandle);
-
             if (domain == null) {
                 break;
             }
-
             if (domain.isNullAllowed()) {
-                return new ClusteringPushDownResult(domainsBuilder.build(), ImmutableSet.of());
+                break;
             }
-
-            Set<Object> values = domain.getValues().getValuesProcessor().transform(
+            String predicateString = null;
+            predicateString = domain.getValues().getValuesProcessor().transform(
                     ranges -> {
-                        ImmutableSet.Builder<Object> columnValues = ImmutableSet.builder();
-                        for (Range range : ranges.getOrderedRanges()) {
-                            if (!range.isSingleValue()) {
-                                return ImmutableSet.of();
+                List<Object> singleValues = new ArrayList<>();
+                List<String> rangeConjuncts = new ArrayList<>();
+                String predicate = null;
+
+                for (Range range : ranges.getOrderedRanges()) {
+                    if (range.isAll()) {
+                        return null;
+                    }
+                    if (range.isSingleValue()) {
+                        singleValues.add(CassandraCqlUtils.cqlValue(toCQLCompatibleString(range.getSingleValue()),
+                                columnHandle.getCassandraType()));
+                    }
+                    else {
+                        if (!range.getLow().isLowerUnbounded()) {
+                            switch (range.getLow().getBound()) {
+                                case ABOVE:
+                                    rangeConjuncts.add(CassandraCqlUtils.validColumnName(columnHandle.getName()) + " > "
+                                            + CassandraCqlUtils.cqlValue(toCQLCompatibleString(range.getLow().getValue()),
+                                            columnHandle.getCassandraType()));
+                                    break;
+                                case EXACTLY:
+                                    rangeConjuncts.add(CassandraCqlUtils.validColumnName(columnHandle.getName()) + " >= "
+                                            + CassandraCqlUtils.cqlValue(toCQLCompatibleString(range.getLow().getValue()),
+                                            columnHandle.getCassandraType()));
+                                    break;
+                                case BELOW:
+                                    throw new VerifyException("Low Marker should never use BELOW bound");
+                                default:
+                                    throw new AssertionError("Unhandled bound: " + range.getLow().getBound());
                             }
-                            /* TODO add code to handle a range of values for the last column
-                             * Prior to Cassandra 2.2, only the last clustering column can have a range of values
-                             * Take a look at how this is done in PreparedStatementBuilder.java
-                             */
-
-                            Object value = range.getSingleValue();
-
-                            CassandraType valueType = columnHandle.getCassandraType();
-                            columnValues.add(valueType.validateClusteringKey(value));
                         }
-                        return columnValues.build();
-                    },
-                    discreteValues -> {
-                        if (discreteValues.isWhiteList()) {
-                            return ImmutableSet.copyOf(discreteValues.getValues());
+                        if (!range.getHigh().isUpperUnbounded()) {
+                            switch (range.getHigh().getBound()) {
+                                case ABOVE:
+                                    throw new VerifyException("High Marker should never use ABOVE bound");
+                                case EXACTLY:
+                                    rangeConjuncts.add(CassandraCqlUtils.validColumnName(columnHandle.getName()) + " <= "
+                                            + CassandraCqlUtils.cqlValue(toCQLCompatibleString(range.getHigh().getValue()),
+                                            columnHandle.getCassandraType()));
+                                    break;
+                                case BELOW:
+                                    rangeConjuncts.add(CassandraCqlUtils.validColumnName(columnHandle.getName()) + " < "
+                                            + CassandraCqlUtils.cqlValue(toCQLCompatibleString(range.getHigh().getValue()),
+                                            columnHandle.getCassandraType()));
+                                    break;
+                                default:
+                                    throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
+                            }
                         }
-                        return ImmutableSet.of();
-                    },
-                    allOrNone -> ImmutableSet.of());
+                    }
+                }
 
-            if (!values.isEmpty()) {
-                clusteringColumnValues.add(values);
-                domainsBuilder.put(columnHandle, domain);
+                if (!singleValues.isEmpty() && !rangeConjuncts.isEmpty()) {
+                    return null;
+                }
+                if (!singleValues.isEmpty()) {
+                    if (singleValues.size() == 1) {
+                        predicate = CassandraCqlUtils.validColumnName(columnHandle.getName()) + " = " + singleValues.get(0);
+                    }
+                    else {
+                        predicate = CassandraCqlUtils.validColumnName(columnHandle.getName()) + " IN ("
+                                + Joiner.on(",").join(singleValues) + ")";
+                    }
+                }
+                else if (!rangeConjuncts.isEmpty()) {
+                    predicate = Joiner.on(" AND ").join(rangeConjuncts);
+                }
+                return predicate;
+            }, discreteValues -> {
+                if (discreteValues.isWhiteList()) {
+                    ImmutableList.Builder<Object> discreteValuesList = ImmutableList.builder();
+                    for (Object discreteValue : discreteValues.getValues()) {
+                        discreteValuesList.add(CassandraCqlUtils.cqlValue(toCQLCompatibleString(discreteValue),
+                                columnHandle.getCassandraType()));
+                    }
+                    String predicate = CassandraCqlUtils.validColumnName(columnHandle.getName()) + " IN ("
+                            + Joiner.on(",").join(discreteValuesList.build()) + ")";
+                    return predicate;
+                }
+                return null;
+            }, allOrNone -> null);
+
+            if (predicateString == null) {
+                break;
             }
+            // IN restriction only on last clustering column for Cassandra version = 2.1
+            if (predicateString.contains(" IN (") && cassandraVersion.compareTo(VersionNumber.parse("2.2.0")) < 0 && currentClusteringColumn != (clusteringColumns.size() - 1)) {
+                break;
+            }
+            clusteringColumnSql.add(predicateString);
+            domainsBuilder.put(columnHandle, domain);
+            // Check for last clustering column should only be restricted by range condition
+            if (predicateString.contains(">") || predicateString.contains("<")) {
+                break;
+            }
+            currentClusteringColumn++;
         }
-        return new ClusteringPushDownResult(domainsBuilder.build(), cartesianProduct(clusteringColumnValues.build()));
+        List<String> clusteringColumnPredicates = clusteringColumnSql.build();
+
+        return new ClusteringPushDownResult(domainsBuilder.build(), Joiner.on(" AND ").join(clusteringColumnPredicates));
     }
 
     private static class ClusteringPushDownResult
     {
         private final Map<ColumnHandle, Domain> domains;
-        private final Set<List<Object>> domainValues;
+        private final String domainQuery;
 
-        public ClusteringPushDownResult(Map<ColumnHandle, Domain> domains, Set<List<Object>> domainValues)
+        public ClusteringPushDownResult(Map<ColumnHandle, Domain> domains, String domainQuery)
         {
             this.domains = requireNonNull(ImmutableMap.copyOf(domains));
-            this.domainValues = requireNonNull(ImmutableSet.copyOf(domainValues));
+            this.domainQuery = requireNonNull(domainQuery);
         }
 
         public Map<ColumnHandle, Domain> getDomains()
@@ -153,9 +196,9 @@ public class CassandraClusteringPredicatesExtractor
             return domains;
         }
 
-        public Set<List<Object>> getDomainValues()
+        public String getDomainQuery()
         {
-            return domainValues;
+            return domainQuery;
         }
     }
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraErrorCode.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraErrorCode.java
@@ -22,7 +22,7 @@ import static com.facebook.presto.spi.ErrorType.EXTERNAL;
 public enum CassandraErrorCode
         implements ErrorCodeSupplier
 {
-    CASSANDRA_METADATA_ERROR(0, EXTERNAL);
+    CASSANDRA_METADATA_ERROR(0, EXTERNAL), CASSANDRA_VERSION_ERROR(1, EXTERNAL);
 
     private final ErrorCode errorCode;
 

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
@@ -203,16 +203,16 @@ public class CassandraMetadata
         CassandraTableHandle handle = (CassandraTableHandle) table;
         CassandraPartitionResult partitionResult = partitionManager.getPartitions(handle, constraint.getSummary());
 
-        List<String> clusteringKeyPredicates;
+        String clusteringKeyPredicates = "";
         TupleDomain<ColumnHandle> unenforcedConstraint;
         if (partitionResult.isUnpartitioned()) {
-            clusteringKeyPredicates = ImmutableList.of();
             unenforcedConstraint = partitionResult.getUnenforcedConstraint();
         }
         else {
             CassandraClusteringPredicatesExtractor clusteringPredicatesExtractor = new CassandraClusteringPredicatesExtractor(
                     cassandraSession.getTable(getTableName(handle)).getClusteringKeyColumns(),
-                    partitionResult.getUnenforcedConstraint());
+                    partitionResult.getUnenforcedConstraint(),
+                    cassandraSession.getCassandraVersion());
             clusteringKeyPredicates = clusteringPredicatesExtractor.getClusteringKeyPredicates();
             unenforcedConstraint = clusteringPredicatesExtractor.getUnenforcedConstraints();
         }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
@@ -19,6 +19,7 @@ import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.TokenRange;
+import com.datastax.driver.core.VersionNumber;
 import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
@@ -30,6 +31,8 @@ import java.util.Set;
 public interface CassandraSession
 {
     String PRESTO_COMMENT_METADATA = "Presto Metadata:";
+
+    VersionNumber getCassandraVersion();
 
     String getPartitioner();
 

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraTableLayoutHandle.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraTableLayoutHandle.java
@@ -28,19 +28,19 @@ public final class CassandraTableLayoutHandle
 {
     private final CassandraTableHandle table;
     private final List<CassandraPartition> partitions;
-    private final List<String> clusteringPredicates;
+    private final String clusteringPredicates;
 
     @JsonCreator
     public CassandraTableLayoutHandle(@JsonProperty("table") CassandraTableHandle table)
     {
-        this(table, ImmutableList.of(), ImmutableList.of());
+        this(table, ImmutableList.of(), "");
     }
 
-    public CassandraTableLayoutHandle(CassandraTableHandle table, List<CassandraPartition> partitions, List<String> clusteringPredicates)
+    public CassandraTableLayoutHandle(CassandraTableHandle table, List<CassandraPartition> partitions, String clusteringPredicates)
     {
         this.table = requireNonNull(table, "table is null");
         this.partitions = ImmutableList.copyOf(requireNonNull(partitions, "partition is null"));
-        this.clusteringPredicates = ImmutableList.copyOf(requireNonNull(clusteringPredicates, "clusteringPredicates is null"));
+        this.clusteringPredicates = requireNonNull(clusteringPredicates, "clusteringPredicates is null");
     }
 
     @JsonProperty
@@ -56,7 +56,7 @@ public final class CassandraTableLayoutHandle
     }
 
     @JsonIgnore
-    public List<String> getClusteringPredicates()
+    public String getClusteringPredicates()
     {
         return clusteringPredicates;
     }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/util/TestCassandraClusteringPredicatesExtractor.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/util/TestCassandraClusteringPredicatesExtractor.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.cassandra.util;
 
+import com.datastax.driver.core.VersionNumber;
 import com.facebook.presto.cassandra.CassandraClusteringPredicatesExtractor;
 import com.facebook.presto.cassandra.CassandraColumnHandle;
 import com.facebook.presto.cassandra.CassandraTable;
@@ -26,8 +27,6 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import java.util.List;
-
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static org.testng.Assert.assertEquals;
 
@@ -38,6 +37,7 @@ public class TestCassandraClusteringPredicatesExtractor
     private static CassandraColumnHandle col3;
     private static CassandraColumnHandle col4;
     private static CassandraTable cassandraTable;
+    private static VersionNumber cassandraVersion;
 
     @BeforeTest
     void setUp()
@@ -50,6 +50,8 @@ public class TestCassandraClusteringPredicatesExtractor
 
         cassandraTable = new CassandraTable(
                 new CassandraTableHandle("cassandra", "test", "records"), ImmutableList.of(col1, col2, col3, col4));
+
+        cassandraVersion = VersionNumber.parse("2.1.5");
     }
 
     @Test
@@ -60,9 +62,9 @@ public class TestCassandraClusteringPredicatesExtractor
                         col1, Domain.singleValue(BIGINT, 23L),
                         col2, Domain.singleValue(BIGINT, 34L),
                         col4, Domain.singleValue(BIGINT, 26L)));
-        CassandraClusteringPredicatesExtractor predicatesExtractor = new CassandraClusteringPredicatesExtractor(cassandraTable.getClusteringKeyColumns(), tupleDomain);
-        List<String> predicate = predicatesExtractor.getClusteringKeyPredicates();
-        assertEquals(predicate.get(0), new StringBuilder("\"clusteringKey1\" = 34").toString());
+        CassandraClusteringPredicatesExtractor predicatesExtractor = new CassandraClusteringPredicatesExtractor(cassandraTable.getClusteringKeyColumns(), tupleDomain, cassandraVersion);
+        String predicate = predicatesExtractor.getClusteringKeyPredicates();
+        assertEquals(predicate, new StringBuilder("\"clusteringKey1\" = 34").toString());
     }
 
     @Test
@@ -72,7 +74,7 @@ public class TestCassandraClusteringPredicatesExtractor
                 ImmutableMap.of(
                         col2, Domain.singleValue(BIGINT, 34L),
                         col4, Domain.singleValue(BIGINT, 26L)));
-        CassandraClusteringPredicatesExtractor predicatesExtractor = new CassandraClusteringPredicatesExtractor(cassandraTable.getClusteringKeyColumns(), tupleDomain);
+        CassandraClusteringPredicatesExtractor predicatesExtractor = new CassandraClusteringPredicatesExtractor(cassandraTable.getClusteringKeyColumns(), tupleDomain, cassandraVersion);
         TupleDomain<ColumnHandle> unenforcedPredicates = TupleDomain.withColumnDomains(ImmutableMap.of(col4, Domain.singleValue(BIGINT, 26L)));
         assertEquals(predicatesExtractor.getUnenforcedConstraints(), unenforcedPredicates);
     }

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -230,4 +230,3 @@ Limitations
   query with a partition key as a filter.
 * ``IN`` list filters are only allowed on index (that is, partition key or clustering key) columns.
 * Range (``<`` or ``>`` and ``BETWEEN``) filters can be applied only to the partition keys.
-* Non-equality predicates on clustering keys are not pushed down (only ``=`` and ``IN`` are pushed down) .


### PR DESCRIPTION
**Problem statement:** 
Due to predicate push down for clustering keys was missing, Presto performance was getting hit. It taking entire partition data out of Cassandra and doing the calculation, this can be faster if Presto will pass the partition and clustering keys to Cassandra and do the calculation on the small portion of the data.

I opened this pull request to support Cassandra predicate pushdown on clustering columns(partition key pushdown already available in Presto).

Just for reference - Cassandra allow below restriction in WHERE clause for SELECT statements(except Secondary Index)
**Partition keys restrictions**
The partition key columns support only two operators(except token function): = and IN.
**Clustering column restrictions**
Clustering columns support the =, IN, >, >=, <=, < restrictions. Range restrictions only allowed in the last clustering column being restricted. IN is only supported in the last clustering column in Cassandra version < 2.2.X. 