### PR TITLE
Fix No factory for connector sqlserver error in product tests

### DIFF
--- a/presto-product-tests/conf/presto/etc/config.properties
+++ b/presto-product-tests/conf/presto/etc/config.properties
@@ -34,7 +34,8 @@ plugin.bundles=\
   ../../../presto-blackhole/pom.xml,\
   ../../../presto-cassandra/pom.xml,\
   ../../../presto-mysql/pom.xml,\
-  ../../../presto-postgresql/pom.xml
+  ../../../presto-postgresql/pom.xml,\
+  ../../../presto-sqlserver/pom.xml
 
 presto.version=testversion
 distributed-joins-enabled=true


### PR DESCRIPTION
I think that `config.properties` in product tests is missing presto-sqlserver line.
Running without the line fails in intelliJ.
