### PR TITLE
Display buffered bytes by stage on live plan

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
@@ -231,6 +231,7 @@ public class StageStateMachine
         long processedInputDataSize = 0;
         long processedInputPositions = 0;
 
+        long bufferedDataSize = 0;
         long outputDataSize = 0;
         long outputPositions = 0;
 
@@ -272,6 +273,7 @@ public class StageStateMachine
             processedInputDataSize += taskStats.getProcessedInputDataSize().toBytes();
             processedInputPositions += taskStats.getProcessedInputPositions();
 
+            bufferedDataSize += taskInfo.getOutputBuffers().getTotalBufferedBytes();
             outputDataSize += taskStats.getOutputDataSize().toBytes();
             outputPositions += taskStats.getOutputPositions();
 
@@ -312,6 +314,7 @@ public class StageStateMachine
                 rawInputPositions,
                 succinctBytes(processedInputDataSize),
                 processedInputPositions,
+                succinctBytes(bufferedDataSize),
                 succinctBytes(outputDataSize),
                 outputPositions,
                 ImmutableList.copyOf(operatorToStats.values()));

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStats.java
@@ -68,6 +68,7 @@ public class StageStats
     private final DataSize processedInputDataSize;
     private final long processedInputPositions;
 
+    private final DataSize bufferedDataSize;
     private final DataSize outputDataSize;
     private final long outputPositions;
     private final List<OperatorStats> operatorSummaries;
@@ -99,6 +100,7 @@ public class StageStats
         this.rawInputPositions = 0;
         this.processedInputDataSize = null;
         this.processedInputPositions = 0;
+        this.bufferedDataSize = null;
         this.outputDataSize = null;
         this.outputPositions = 0;
         this.operatorSummaries = null;
@@ -138,6 +140,7 @@ public class StageStats
             @JsonProperty("processedInputDataSize") DataSize processedInputDataSize,
             @JsonProperty("processedInputPositions") long processedInputPositions,
 
+            @JsonProperty("bufferedDataSize") DataSize bufferedDataSize,
             @JsonProperty("outputDataSize") DataSize outputDataSize,
             @JsonProperty("outputPositions") long outputPositions,
             @JsonProperty("operatorSummaries") List<OperatorStats> operatorSummaries)
@@ -182,6 +185,7 @@ public class StageStats
         checkArgument(processedInputPositions >= 0, "processedInputPositions is negative");
         this.processedInputPositions = processedInputPositions;
 
+        this.bufferedDataSize = requireNonNull(bufferedDataSize, "bufferedDataSize is null");
         this.outputDataSize = requireNonNull(outputDataSize, "outputDataSize is null");
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
@@ -330,6 +334,12 @@ public class StageStats
     public long getProcessedInputPositions()
     {
         return processedInputPositions;
+    }
+
+    @JsonProperty
+    public DataSize getBufferedDataSize()
+    {
+        return bufferedDataSize;
     }
 
     @JsonProperty

--- a/presto-main/src/main/resources/webapp/assets/plan.js
+++ b/presto-main/src/main/resources/webapp/assets/plan.js
@@ -72,6 +72,8 @@ let StageStatistics = React.createClass({
             <div>
                 <div>
                     Output: { stats.outputDataSize  + " / " +  formatCount(stats.outputPositions) + " rows" }
+                    <br />
+                    Buffered: { stats.bufferedDataSize }
                     <hr />
                     { stage.state }
                     <hr />

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageStats.java
@@ -63,7 +63,8 @@ public class TestStageStats
             22,
 
             new DataSize(23, BYTE),
-            24,
+            new DataSize(24, BYTE),
+            25,
             ImmutableList.of());
 
     @Test
@@ -109,8 +110,9 @@ public class TestStageStats
         assertEquals(actual.getProcessedInputDataSize(), new DataSize(21, BYTE));
         assertEquals(actual.getProcessedInputPositions(), 22);
 
-        assertEquals(actual.getOutputDataSize(), new DataSize(23, BYTE));
-        assertEquals(actual.getOutputPositions(), 24);
+        assertEquals(actual.getBufferedDataSize(), new DataSize(23, BYTE));
+        assertEquals(actual.getOutputDataSize(), new DataSize(24, BYTE));
+        assertEquals(actual.getOutputPositions(), 25);
     }
 
     private static DistributionSnapshot getTestDistribution(int count)


### PR DESCRIPTION
![buffered_bytes](https://cloud.githubusercontent.com/assets/8957547/25121539/53849fcc-2422-11e7-93dd-95a5c0b0ca68.png)
