### PR TITLE
Add support for BETWEEN to expression matcher

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
@@ -247,7 +247,7 @@ final class ExpressionVerifier
     {
         if (expectedExpression instanceof BetweenPredicate) {
             BetweenPredicate expected = (BetweenPredicate) expectedExpression;
-            return process(actual.getMin(), expected.getMin()) && process(actual.getMax(), expected.getMax());
+            return process(actual.getValue(), expected.getValue()) && process(actual.getMin(), expected.getMin()) && process(actual.getMax(), expected.getMax());
         }
 
         return false;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.BetweenPredicate;
 import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CoalesceExpression;
@@ -238,6 +239,17 @@ final class ExpressionVerifier
                 return process(actual.getLeft(), expected.getLeft()) && process(actual.getRight(), expected.getRight());
             }
         }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitBetweenPredicate(BetweenPredicate actual, Expression expectedExpression)
+    {
+        if (expectedExpression instanceof BetweenPredicate) {
+            BetweenPredicate expected = (BetweenPredicate) expectedExpression;
+            return process(actual.getMin(), expected.getMin()) && process(actual.getMax(), expected.getMax());
+        }
+
         return false;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TestExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TestExpressionVerifier.java
@@ -57,6 +57,17 @@ public class TestExpressionVerifier
         assertTrue(verifier.process(expression("CAST(orderkey AS varchar)"), expression("CAST(X AS varchar)")));
     }
 
+    @Test
+    public void testBetween()
+            throws Exception
+    {
+        ExpressionVerifier verifier = new ExpressionVerifier(SymbolAliases.builder().build());
+        assertTrue(verifier.process(expression("X BETWEEN 1 AND 2"), expression("X BETWEEN 1 AND 2")));
+        assertFalse(verifier.process(expression("X BETWEEN 2 AND 4"), expression("X BETWEEN 1 AND 2")));
+        assertFalse(verifier.process(expression("X BETWEEN 1 AND 2"), expression("X BETWEEN '1' AND '2'")));
+        assertFalse(verifier.process(expression("X BETWEEN 1 AND 2"), expression("X BETWEEN 4 AND 7")));
+    }
+
     private Expression expression(String sql)
     {
         return rewriteIdentifiersToSymbolReferences(parser.createExpression(sql));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TestExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TestExpressionVerifier.java
@@ -61,11 +61,21 @@ public class TestExpressionVerifier
     public void testBetween()
             throws Exception
     {
-        ExpressionVerifier verifier = new ExpressionVerifier(SymbolAliases.builder().build());
-        assertTrue(verifier.process(expression("X BETWEEN 1 AND 2"), expression("X BETWEEN 1 AND 2")));
-        assertFalse(verifier.process(expression("X BETWEEN 2 AND 4"), expression("X BETWEEN 1 AND 2")));
-        assertFalse(verifier.process(expression("X BETWEEN 1 AND 2"), expression("X BETWEEN '1' AND '2'")));
-        assertFalse(verifier.process(expression("X BETWEEN 1 AND 2"), expression("X BETWEEN 4 AND 7")));
+        SymbolAliases symbolAliases = SymbolAliases.builder()
+                .put("X", new SymbolReference("orderkey"))
+                .put("Y", new SymbolReference("custkey"))
+                .build();
+
+        ExpressionVerifier verifier = new ExpressionVerifier(symbolAliases);
+        // Complete match
+        assertTrue(verifier.process(expression("orderkey BETWEEN 1 AND 2"), expression("X BETWEEN 1 AND 2")));
+        // Different value
+        assertFalse(verifier.process(expression("orderkey BETWEEN 1 AND 2"), expression("Y BETWEEN 1 AND 2")));
+        assertFalse(verifier.process(expression("custkey BETWEEN 1 AND 2"), expression("X BETWEEN 1 AND 2")));
+        // Different min or max
+        assertFalse(verifier.process(expression("orderkey BETWEEN 2 AND 4"), expression("X BETWEEN 1 AND 2")));
+        assertFalse(verifier.process(expression("orderkey BETWEEN 1 AND 2"), expression("X BETWEEN '1' AND '2'")));
+        assertFalse(verifier.process(expression("orderkey BETWEEN 1 AND 2"), expression("X BETWEEN 4 AND 7")));
     }
 
     private Expression expression(String sql)


### PR DESCRIPTION
This PR adds support for BETWEEN to expression matcher.
And establishes the possibility for rules for optimizing some date functions in a later PR.