### PR TITLE
Remove `Block.reset()`

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/project/InterpretedPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/InterpretedPageProjection.java
@@ -43,7 +43,7 @@ public class InterpretedPageProjection
     private final ExpressionInterpreter evaluator;
     private final InputChannels inputChannels;
     private final boolean deterministic;
-    private final BlockBuilder blockBuilder;
+    private BlockBuilder blockBuilder;
 
     public InterpretedPageProjection(
             Expression expression,
@@ -100,7 +100,7 @@ public class InterpretedPageProjection
             project(page, selectedPositions.getOffset(), selectedPositions.size());
         }
         Block block = blockBuilder.build();
-        blockBuilder.reset(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
         return block;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -148,7 +148,7 @@ public class PageFunctionCompiler
                 type(Object.class),
                 type(PageProjection.class));
 
-        FieldDefinition blockBuilderField = classDefinition.declareField(a(PRIVATE, FINAL), "blockBuilder", BlockBuilder.class);
+        FieldDefinition blockBuilderField = classDefinition.declareField(a(PRIVATE), "blockBuilder", BlockBuilder.class);
 
         CachedInstanceBinder cachedInstanceBinder = new CachedInstanceBinder(classDefinition, callSiteBinder);
         generatePageProjectMethod(classDefinition, blockBuilderField);
@@ -237,7 +237,9 @@ public class PageFunctionCompiler
 
         Variable block = scope.declareVariable(Block.class, "block");
         body.append(block.set(thisVariable.getField(blockBuilder).invoke("build", Block.class)))
-            .append(thisVariable.getField(blockBuilder).invoke("reset", void.class, newInstance(BlockBuilderStatus.class)))
+            .append(thisVariable.setField(
+                    blockBuilder,
+                    thisVariable.getField(blockBuilder).invoke("newBlockBuilderLike", BlockBuilder.class, newInstance(BlockBuilderStatus.class))))
             .append(block.ret());
 
         return method;

--- a/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
@@ -124,7 +124,7 @@ public class TestArrayBlock
         assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
         assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-        blockBuilder.reset(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestByteArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestByteArrayBlock.java
@@ -59,7 +59,7 @@ public class TestByteArrayBlock
         assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
         assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-        blockBuilder.reset(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestFixedWidthBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestFixedWidthBlock.java
@@ -63,7 +63,7 @@ public class TestFixedWidthBlock
             assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
             assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-            blockBuilder.reset(new BlockBuilderStatus());
+            blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
             assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
             assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
         }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestIntArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestIntArrayBlock.java
@@ -59,7 +59,7 @@ public class TestIntArrayBlock
         assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
         assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-        blockBuilder.reset(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestLongArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestLongArrayBlock.java
@@ -60,7 +60,7 @@ public class TestLongArrayBlock
         assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
         assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-        blockBuilder.reset(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestShortArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestShortArrayBlock.java
@@ -59,7 +59,7 @@ public class TestShortArrayBlock
         assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
         assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-        blockBuilder.reset(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestVariableWidthBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestVariableWidthBlock.java
@@ -78,7 +78,7 @@ public class TestVariableWidthBlock
         assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
         assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-        blockBuilder.reset(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/PageBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PageBuilder.java
@@ -104,7 +104,7 @@ public class PageBuilder
         declaredPositions = 0;
 
         for (int i = 0; i < types.size(); i++) {
-            blockBuilders[i].reset(pageBuilderStatus.createBlockBuilderStatus());
+            blockBuilders[i] = blockBuilders[i].newBlockBuilderLike(pageBuilderStatus.createBlockBuilderStatus());
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -223,25 +223,6 @@ public class ArrayBlockBuilder
     }
 
     @Override
-    public void reset(BlockBuilderStatus blockBuilderStatus)
-    {
-        this.blockBuilderStatus = requireNonNull(blockBuilderStatus, "blockBuilderStatus is null");
-
-        initialized = false;
-        initialEntryCount = calculateBlockResetSize(getPositionCount());
-
-        valueIsNull = new boolean[0];
-        offsets = new int[1];
-
-        values.reset(blockBuilderStatus);
-
-        currentEntrySize = 0;
-        positionCount = 0;
-
-        updateDataSize();
-    }
-
-    @Override
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
         int newSize = calculateBlockResetSize(getPositionCount());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayElementBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayElementBlockWriter.java
@@ -133,12 +133,6 @@ public class ArrayElementBlockWriter
     }
 
     @Override
-    public void reset(BlockBuilderStatus blockBuilderStatus)
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
         throw new UnsupportedOperationException();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
@@ -91,11 +91,6 @@ public interface BlockBuilder
     Block build();
 
     /**
-     * Resets the block builder, clearing all of the data.
-     */
-    void reset(BlockBuilderStatus blockBuilderStatus);
-
-    /**
      * Creates a new block builder of the same type based on the current usage statistics of this block builder.
      */
     BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -18,7 +18,6 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -88,22 +87,6 @@ public class ByteArrayBlockBuilder
     public Block build()
     {
         return new ByteArrayBlock(positionCount, valueIsNull, values);
-    }
-
-    @Override
-    public void reset(BlockBuilderStatus blockBuilderStatus)
-    {
-        this.blockBuilderStatus = requireNonNull(blockBuilderStatus, "blockBuilderStatus is null");
-
-        initialized = false;
-        initialEntryCount = calculateBlockResetSize(positionCount);
-
-        valueIsNull = new boolean[0];
-        values = new byte[0];
-
-        positionCount = 0;
-
-        updateDataSize();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -29,7 +29,6 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
-import static java.util.Objects.requireNonNull;
 
 public class FixedWidthBlockBuilder
         extends AbstractFixedWidthBlock
@@ -256,21 +255,6 @@ public class FixedWidthBlockBuilder
             throw new IllegalStateException("Current entry must be closed before the block can be built");
         }
         return new FixedWidthBlock(fixedSize, positionCount, sliceOutput.slice(), valueIsNull.slice());
-    }
-
-    @Override
-    public void reset(BlockBuilderStatus blockBuilderStatus)
-    {
-        this.blockBuilderStatus = requireNonNull(blockBuilderStatus, "blockBuilderStatus is null");
-
-        initialized = false;
-        initialEntryCount = calculateBlockResetSize(positionCount);
-
-        valueIsNull = new DynamicSliceOutput(0);
-        sliceOutput = new DynamicSliceOutput(0);
-
-        positionCount = 0;
-        currentEntrySize = 0;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -91,22 +91,6 @@ public class IntArrayBlockBuilder
     }
 
     @Override
-    public void reset(BlockBuilderStatus blockBuilderStatus)
-    {
-        this.blockBuilderStatus = requireNonNull(blockBuilderStatus, "blockBuilderStatus is null");
-
-        initialized = false;
-        initialEntryCount = calculateBlockResetSize(positionCount);
-
-        valueIsNull = new boolean[0];
-        values = new int[0];
-
-        positionCount = 0;
-
-        updateDataSize();
-    }
-
-    @Override
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
         return new IntArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlockBuilder.java
@@ -253,23 +253,6 @@ public class InterleavedBlockBuilder
     }
 
     @Override
-    public void reset(BlockBuilderStatus blockBuilderStatus)
-    {
-        this.positionCount = 0;
-
-        this.sizeInBytes = 0;
-        this.retainedSizeInBytes = INSTANCE_SIZE;
-        for (BlockBuilder blockBuilder : blockBuilders) {
-            blockBuilder.reset(blockBuilderStatus);
-            this.sizeInBytes += blockBuilder.getSizeInBytes();
-            this.retainedSizeInBytes += blockBuilder.getRetainedSizeInBytes();
-        }
-
-        this.startSize = -1;
-        this.startRetainedSize = -1;
-    }
-
-    @Override
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
         BlockBuilder[] newBlockBuilders = new BlockBuilder[blockBuilders.length];

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -92,22 +92,6 @@ public class LongArrayBlockBuilder
     }
 
     @Override
-    public void reset(BlockBuilderStatus blockBuilderStatus)
-    {
-        this.blockBuilderStatus = requireNonNull(blockBuilderStatus, "blockBuilderStatus is null");
-
-        initialized = false;
-        initialEntryCount = calculateBlockResetSize(positionCount);
-
-        valueIsNull = new boolean[0];
-        values = new long[0];
-
-        positionCount = 0;
-
-        updateDataSize();
-    }
-
-    @Override
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
         return new LongArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -91,22 +91,6 @@ public class ShortArrayBlockBuilder
     }
 
     @Override
-    public void reset(BlockBuilderStatus blockBuilderStatus)
-    {
-        this.blockBuilderStatus = requireNonNull(blockBuilderStatus, "blockBuilderStatus is null");
-
-        initialized = false;
-        initialEntryCount = calculateBlockResetSize(positionCount);
-
-        valueIsNull = new boolean[0];
-        values = new short[0];
-
-        positionCount = 0;
-
-        updateDataSize();
-    }
-
-    @Override
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
         return new ShortArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -296,25 +296,6 @@ public class VariableWidthBlockBuilder
     }
 
     @Override
-    public void reset(BlockBuilderStatus blockBuilderStatus)
-    {
-        this.blockBuilderStatus = requireNonNull(blockBuilderStatus, "blockBuilderStatus is null");
-
-        initialized = false;
-        initialEntryCount = calculateBlockResetSize(positions);
-        initialSliceOutputSize = calculateBlockResetSize(sliceOutput.size());
-
-        valueIsNull = new boolean[0];
-        offsets = new int[1];
-        sliceOutput = new DynamicSliceOutput(0);
-
-        positions = 0;
-        currentEntrySize = 0;
-
-        updateArraysDataSize();
-    }
-
-    @Override
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
         int expectedBytesPerEntry = positions == 0 ? positions : (getOffset(positions) - getOffset(0)) / positions;


### PR DESCRIPTION
It is hard to reason about reset in BlockBuilder because it performs
non-appending operation.

For example, with reduce function, the result from previous invocation of
array_concat may be feed back into array_concat as input. If reset is called
while producing the next result, the input (the previous result) may no
longer be valid.