### PR TITLE
Reduce aggregation to complex type memory usage

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractBenchmark.java
@@ -123,9 +123,12 @@ public abstract class AbstractBenchmark
         long outputRows = resultsAvg.get("output_rows").longValue();
         DataSize outputBytes = new DataSize(resultsAvg.get("output_bytes"), BYTE);
 
-        System.out.printf("%35s :: %8.3f cpu ms :: in %5s,  %6s,  %8s,  %8s :: out %5s,  %6s,  %8s,  %8s%n",
+        DataSize memory = new DataSize(resultsAvg.get("peak_memory"), BYTE);
+        System.out.printf("%35s :: %8.3f cpu ms :: %5s peak memory :: in %5s,  %6s,  %8s,  %8s :: out %5s,  %6s,  %8s,  %8s%n",
                 getBenchmarkName(),
                 cpuNanos.getValue(MILLISECONDS),
+
+                formatDataSize(memory, true),
 
                 formatCount(inputRows),
                 formatDataSize(inputBytes, true),

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/ArrayAggregationBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/ArrayAggregationBenchmark.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public class ArrayAggregationBenchmark
+        extends AbstractSqlBenchmark
+{
+    public ArrayAggregationBenchmark(LocalQueryRunner localQueryRunner)
+    {
+        super(localQueryRunner, "sql_double_array_agg", 10, 100, "select array_agg(totalprice) from orders group by orderkey");
+    }
+
+    public static void main(String[] args)
+    {
+        new ArrayAggregationBenchmark(createLocalQueryRunner()).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxByNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxByNAggregationFunction.java
@@ -23,7 +23,6 @@ import com.facebook.presto.operator.aggregation.state.MinMaxByNStateSerializer;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -124,7 +123,7 @@ public abstract class AbstractMinMaxByNAggregationFunction
         Type elementType = outputType.getElementType();
 
         BlockBuilder arrayBlockBuilder = out.beginBlockEntry();
-        BlockBuilder reversedBlockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), heap.getCapacity());
+        BlockBuilder reversedBlockBuilder = elementType.createBlockBuilder(null, heap.getCapacity());
         long startSize = heap.getEstimatedSize();
         heap.popAll(reversedBlockBuilder);
         state.addMemoryUsage(heap.getEstimatedSize() - startSize);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
@@ -23,7 +23,6 @@ import com.facebook.presto.operator.aggregation.state.MinMaxNStateSerializer;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -148,7 +147,7 @@ public abstract class AbstractMinMaxNAggregationFunction
 
         Type elementType = outputType.getElementType();
 
-        BlockBuilder reversedBlockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), heap.getCapacity());
+        BlockBuilder reversedBlockBuilder = elementType.createBlockBuilder(null, heap.getCapacity());
         long startSize = heap.getEstimatedSize();
         heap.popAll(reversedBlockBuilder);
         state.addMemoryUsage(heap.getEstimatedSize() - startSize);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArrayAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArrayAggregationFunction.java
@@ -23,7 +23,6 @@ import com.facebook.presto.operator.aggregation.state.ArrayAggregationStateFacto
 import com.facebook.presto.operator.aggregation.state.ArrayAggregationStateSerializer;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.AccumulatorState;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
@@ -119,7 +118,7 @@ public class ArrayAggregationFunction
     {
         BlockBuilder blockBuilder = state.getBlockBuilder();
         if (blockBuilder == null) {
-            blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 4);
+            blockBuilder = type.createBlockBuilder(null, 4);
             state.setBlockBuilder(blockBuilder);
         }
         long startSize = blockBuilder.getRetainedSizeInBytes();

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleHistogramAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleHistogramAggregation.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.operator.aggregation.state.DoubleHistogramStateSerializer;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.AccumulatorState;
 import com.facebook.presto.spi.function.AccumulatorStateMetadata;
 import com.facebook.presto.spi.function.AggregationFunction;
@@ -96,7 +95,7 @@ public final class DoubleHistogramAggregation
         }
         else {
             Map<Double, Double> value = state.get().getBuckets();
-            BlockBuilder blockBuilder = DoubleType.DOUBLE.createBlockBuilder(new BlockBuilderStatus(), value.size() * 2);
+            BlockBuilder blockBuilder = DoubleType.DOUBLE.createBlockBuilder(null, value.size() * 2);
             for (Map.Entry<Double, Double> entry : value.entrySet()) {
                 DoubleType.DOUBLE.writeDouble(blockBuilder, entry.getKey());
                 DoubleType.DOUBLE.writeDouble(blockBuilder, entry.getValue());

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/KeyValuePairs.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/KeyValuePairs.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -54,8 +53,8 @@ public class KeyValuePairs
     {
         this.keyType = requireNonNull(keyType, "keyType is null");
         this.valueType = requireNonNull(valueType, "valueType is null");
-        keyBlockBuilder = this.keyType.createBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES, expectedValueSize(keyType, EXPECTED_ENTRY_SIZE));
-        valueBlockBuilder = this.valueType.createBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES, expectedValueSize(valueType, EXPECTED_ENTRY_SIZE));
+        keyBlockBuilder = this.keyType.createBlockBuilder(null, EXPECTED_ENTRIES, expectedValueSize(keyType, EXPECTED_ENTRY_SIZE));
+        valueBlockBuilder = this.valueType.createBlockBuilder(null, EXPECTED_ENTRIES, expectedValueSize(valueType, EXPECTED_ENTRY_SIZE));
         hashCapacity = arraySize(EXPECTED_ENTRIES, FILL_RATIO);
         this.maxFill = calculateMaxFill(hashCapacity);
         this.hashMask = hashCapacity - 1;

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MultiKeyValuePairs.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MultiKeyValuePairs.java
@@ -42,8 +42,8 @@ public class MultiKeyValuePairs
     {
         this.keyType = requireNonNull(keyType, "keyType is null");
         this.valueType = requireNonNull(valueType, "valueType is null");
-        keyBlockBuilder = this.keyType.createBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES, expectedValueSize(keyType, EXPECTED_ENTRY_SIZE));
-        valueBlockBuilder = this.valueType.createBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES, expectedValueSize(valueType, EXPECTED_ENTRY_SIZE));
+        keyBlockBuilder = this.keyType.createBlockBuilder(null, EXPECTED_ENTRIES, expectedValueSize(keyType, EXPECTED_ENTRY_SIZE));
+        valueBlockBuilder = this.valueType.createBlockBuilder(null, EXPECTED_ENTRIES, expectedValueSize(valueType, EXPECTED_ENTRY_SIZE));
     }
 
     public MultiKeyValuePairs(Block serialized, Type keyType, Type valueType)
@@ -91,7 +91,7 @@ public class MultiKeyValuePairs
         Block values = valueBlockBuilder.build();
 
         // Merge values of the same key into an array
-        BlockBuilder distinctKeyBlockBuilder = keyType.createBlockBuilder(new BlockBuilderStatus(), keys.getPositionCount(), expectedValueSize(keyType, EXPECTED_ENTRY_SIZE));
+        BlockBuilder distinctKeyBlockBuilder = keyType.createBlockBuilder(null, keys.getPositionCount(), expectedValueSize(keyType, EXPECTED_ENTRY_SIZE));
         ObjectBigArray<BlockBuilder> valueArrayBlockBuilders = new ObjectBigArray<>();
         valueArrayBlockBuilders.ensureCapacity(keys.getPositionCount());
         TypedSet keySet = new TypedSet(keyType, keys.getPositionCount());
@@ -99,7 +99,7 @@ public class MultiKeyValuePairs
             if (!keySet.contains(keys, keyValueIndex)) {
                 keySet.add(keys, keyValueIndex);
                 keyType.appendTo(keys, keyValueIndex, distinctKeyBlockBuilder);
-                BlockBuilder valueArrayBuilder = valueType.createBlockBuilder(new BlockBuilderStatus(), 10, expectedValueSize(valueType, EXPECTED_ENTRY_SIZE));
+                BlockBuilder valueArrayBuilder = valueType.createBlockBuilder(null, 10, expectedValueSize(valueType, EXPECTED_ENTRY_SIZE));
                 valueArrayBlockBuilders.set(keySet.positionOf(keys, keyValueIndex), valueArrayBuilder);
             }
             valueType.appendTo(values, keyValueIndex, valueArrayBlockBuilders.get(keySet.positionOf(keys, keyValueIndex)));

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/RealHistogramAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/RealHistogramAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.AggregationFunction;
 import com.facebook.presto.spi.function.AggregationState;
 import com.facebook.presto.spi.function.CombineFunction;
@@ -63,7 +62,7 @@ public class RealHistogramAggregation
         }
         else {
             Map<Double, Double> value = state.get().getBuckets();
-            BlockBuilder blockBuilder = REAL.createBlockBuilder(new BlockBuilderStatus(), value.size() * 2);
+            BlockBuilder blockBuilder = REAL.createBlockBuilder(null, value.size() * 2);
             for (Map.Entry<Double, Double> entry : value.entrySet()) {
                 REAL.writeLong(blockBuilder, floatToRawIntBits(entry.getKey().floatValue()));
                 REAL.writeLong(blockBuilder, floatToRawIntBits(entry.getValue().floatValue()));

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedHeap.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedHeap.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -43,7 +42,7 @@ public class TypedHeap
         this.type = type;
         this.capacity = capacity;
         this.heapIndex = new int[capacity];
-        this.heapBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), capacity);
+        this.heapBlockBuilder = type.createBlockBuilder(null, capacity);
     }
 
     public int getCapacity()
@@ -171,7 +170,7 @@ public class TypedHeap
         if (heapBlockBuilder.getSizeInBytes() < COMPACT_THRESHOLD_BYTES || heapBlockBuilder.getPositionCount() / positionCount < COMPACT_THRESHOLD_RATIO) {
             return;
         }
-        BlockBuilder newHeapBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), heapBlockBuilder.getPositionCount());
+        BlockBuilder newHeapBlockBuilder = type.createBlockBuilder(null, heapBlockBuilder.getPositionCount());
         for (int i = 0; i < positionCount; i++) {
             type.appendTo(heapBlockBuilder, heapIndex[i], newHeapBlockBuilder);
             heapIndex[i] = i;

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedHistogram.java
@@ -62,7 +62,7 @@ public class TypedHistogram
 
         maxFill = calculateMaxFill(hashCapacity);
         mask = hashCapacity - 1;
-        values = this.type.createBlockBuilder(new BlockBuilderStatus(), hashCapacity);
+        values = this.type.createBlockBuilder(null, hashCapacity);
         hashPositions = new IntBigArray(-1);
         hashPositions.ensureCapacity(hashCapacity);
         counts = new LongBigArray();

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedKeyValueHeap.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedKeyValueHeap.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.type.ArrayType;
 import com.facebook.presto.type.RowType;
@@ -53,8 +52,8 @@ public class TypedKeyValueHeap
         this.valueType = valueType;
         this.capacity = capacity;
         this.heapIndex = new int[capacity];
-        this.keyBlockBuilder = keyType.createBlockBuilder(new BlockBuilderStatus(), capacity);
-        this.valueBlockBuilder = valueType.createBlockBuilder(new BlockBuilderStatus(), capacity);
+        this.keyBlockBuilder = keyType.createBlockBuilder(null, capacity);
+        this.valueBlockBuilder = valueType.createBlockBuilder(null, capacity);
     }
 
     public static Type getSerializedType(Type keyType, Type valueType)
@@ -210,8 +209,8 @@ public class TypedKeyValueHeap
         if (keyBlockBuilder.getSizeInBytes() < COMPACT_THRESHOLD_BYTES || keyBlockBuilder.getPositionCount() / positionCount < COMPACT_THRESHOLD_RATIO) {
             return;
         }
-        BlockBuilder newHeapKeyBlockBuilder = keyType.createBlockBuilder(new BlockBuilderStatus(), keyBlockBuilder.getPositionCount());
-        BlockBuilder newHeapValueBlockBuilder = valueType.createBlockBuilder(new BlockBuilderStatus(), valueBlockBuilder.getPositionCount());
+        BlockBuilder newHeapKeyBlockBuilder = keyType.createBlockBuilder(null, keyBlockBuilder.getPositionCount());
+        BlockBuilder newHeapValueBlockBuilder = valueType.createBlockBuilder(null, valueBlockBuilder.getPositionCount());
         for (int i = 0; i < positionCount; i++) {
             keyType.appendTo(keyBlockBuilder, heapIndex[i], newHeapKeyBlockBuilder);
             valueType.appendTo(valueBlockBuilder, heapIndex[i], newHeapValueBlockBuilder);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.units.DataSize;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
@@ -53,7 +52,7 @@ public class TypedSet
     {
         checkArgument(expectedSize >= 0, "expectedSize must not be negative");
         this.elementType = requireNonNull(elementType, "elementType must not be null");
-        this.elementBlock = elementType.createBlockBuilder(new BlockBuilderStatus(), expectedSize);
+        this.elementBlock = elementType.createBlockBuilder(null, expectedSize);
 
         hashCapacity = arraySize(expectedSize, FILL_RATIO);
         this.maxFill = calculateMaxFill(hashCapacity);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ArrayAggregationStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ArrayAggregationStateSerializer.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation.state;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.type.ArrayType;
@@ -55,7 +54,7 @@ public class ArrayAggregationStateSerializer
     {
         Block stateBlock = (Block) arrayType.getObject(block, index);
         int positionCount = stateBlock.getPositionCount();
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, positionCount);
         for (int i = 0; i < positionCount; i++) {
             elementType.appendTo(stateBlock, i, blockBuilder);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/BenchmarkArrayAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/BenchmarkArrayAggregation.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.ArrayType;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.openjdk.jmh.runner.options.WarmupMode;
+
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static org.openjdk.jmh.annotations.Level.Invocation;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkArrayAggregation
+{
+    private static final int ARRAY_SIZE = 10_000_000;
+
+    @Benchmark
+    @OperationsPerInvocation(ARRAY_SIZE)
+    public void arrayAggregation(BenchmarkData data)
+            throws Throwable
+    {
+        data.getAccumulator().addInput(data.getPage());
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private String name = "array_agg";
+
+        @Param({"BIGINT", "VARCHAR", "DOUBLE", "BOOLEAN"})
+        private String type = "BIGINT";
+
+        private Page page;
+        private Accumulator accumulator;
+
+        @Setup(Invocation)
+        public void setup()
+        {
+            MetadataManager metadata = MetadataManager.createTestMetadataManager();
+            Block block;
+            Type elementType;
+            switch (type) {
+                case "BIGINT":
+                    elementType = BIGINT;
+                    break;
+                case "VARCHAR":
+                    elementType = VARCHAR;
+                    break;
+                case "DOUBLE":
+                    elementType = DOUBLE;
+                    break;
+                case "BOOLEAN":
+                    elementType = BOOLEAN;
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+            ArrayType arrayType = new ArrayType(elementType);
+            Signature signature = new Signature(name, AGGREGATE, arrayType.getTypeSignature(), elementType.getTypeSignature());
+            InternalAggregationFunction function = metadata.getFunctionRegistry().getAggregateFunctionImplementation(signature);
+            accumulator = function.bind(ImmutableList.of(0), Optional.empty()).createAccumulator();
+
+            block = createChannel(ARRAY_SIZE, elementType);
+            page = new Page(block);
+        }
+
+        private static Block createChannel(int arraySize, Type elementType)
+        {
+            BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), arraySize);
+            for (int i = 0; i < arraySize; i++) {
+                if (elementType.getJavaType() == long.class) {
+                    elementType.writeLong(blockBuilder, (long) i);
+                }
+                else if (elementType.getJavaType() == double.class) {
+                    elementType.writeDouble(blockBuilder, ThreadLocalRandom.current().nextDouble());
+                }
+                else if (elementType.getJavaType() == boolean.class) {
+                    elementType.writeBoolean(blockBuilder, ThreadLocalRandom.current().nextBoolean());
+                }
+                else if (elementType.equals(VARCHAR)) {
+                    // make sure the size of a varchar is rather small; otherwise the aggregated slice may overflow
+                    elementType.writeSlice(blockBuilder, Slices.utf8Slice(Long.toString(ThreadLocalRandom.current().nextLong() % 100)));
+                }
+                else {
+                    throw new UnsupportedOperationException();
+                }
+            }
+            return blockBuilder.build();
+        }
+
+        public Accumulator getAccumulator()
+        {
+            return accumulator;
+        }
+
+        public Page getPage()
+        {
+            return page;
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkArrayAggregation().arrayAggregation(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .warmupMode(WarmupMode.BULK)
+                .include(".*" + BenchmarkArrayAggregation.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -28,6 +28,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -16,6 +16,8 @@ package com.facebook.presto.spi.block;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
+import javax.annotation.Nullable;
+
 import java.util.Arrays;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
@@ -28,10 +30,11 @@ public class ArrayBlockBuilder
         extends AbstractArrayBlock
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ArrayBlockBuilder.class).instanceSize() + BlockBuilderStatus.INSTANCE_SIZE;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ArrayBlockBuilder.class).instanceSize();
 
     private int positionCount;
 
+    @Nullable
     private BlockBuilderStatus blockBuilderStatus;
     private boolean initialized;
     private int initialEntryCount;
@@ -74,9 +77,9 @@ public class ArrayBlockBuilder
     /**
      * Caller of this private constructor is responsible for making sure `values` is constructed with the same `blockBuilderStatus` as the one in the argument
      */
-    private ArrayBlockBuilder(BlockBuilderStatus blockBuilderStatus, BlockBuilder values, int expectedEntries)
+    private ArrayBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, BlockBuilder values, int expectedEntries)
     {
-        this.blockBuilderStatus = requireNonNull(blockBuilderStatus, "blockBuilderStatus is null");
+        this.blockBuilderStatus = blockBuilderStatus;
         this.values = requireNonNull(values, "values is null");
         this.initialEntryCount = max(expectedEntries, 1);
 
@@ -189,7 +192,9 @@ public class ArrayBlockBuilder
         valueIsNull[positionCount] = isNull;
         positionCount++;
 
-        blockBuilderStatus.addBytes(Integer.BYTES + Byte.BYTES);
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Integer.BYTES + Byte.BYTES);
+        }
     }
 
     private void growCapacity()
@@ -210,7 +215,11 @@ public class ArrayBlockBuilder
 
     private void updateDataSize()
     {
-        retainedSizeInBytes = intSaturatedCast(INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(offsets));
+        long size = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(offsets);
+        if (blockBuilderStatus != null) {
+            size += BlockBuilderStatus.INSTANCE_SIZE;
+        }
+        retainedSizeInBytes = intSaturatedCast(size);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -15,6 +15,8 @@ package com.facebook.presto.spi.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
+import javax.annotation.Nullable;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -23,13 +25,13 @@ import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
-import static java.util.Objects.requireNonNull;
 
 public class IntArrayBlockBuilder
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntArrayBlockBuilder.class).instanceSize() + BlockBuilderStatus.INSTANCE_SIZE;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntArrayBlockBuilder.class).instanceSize();
 
+    @Nullable
     private BlockBuilderStatus blockBuilderStatus;
     private boolean initialized;
     private int initialEntryCount;
@@ -42,9 +44,9 @@ public class IntArrayBlockBuilder
 
     private int retainedSizeInBytes;
 
-    public IntArrayBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    public IntArrayBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
-        this.blockBuilderStatus = requireNonNull(blockBuilderStatus, "blockBuilderStatus is null");
+        this.blockBuilderStatus = blockBuilderStatus;
         this.initialEntryCount = max(expectedEntries, 1);
 
         updateDataSize();
@@ -60,7 +62,9 @@ public class IntArrayBlockBuilder
         values[positionCount] = value;
 
         positionCount++;
-        blockBuilderStatus.addBytes(Byte.BYTES + Integer.BYTES);
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + Integer.BYTES);
+        }
         return this;
     }
 
@@ -80,7 +84,9 @@ public class IntArrayBlockBuilder
         valueIsNull[positionCount] = true;
 
         positionCount++;
-        blockBuilderStatus.addBytes(Byte.BYTES + Integer.BYTES);
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + Integer.BYTES);
+        }
         return this;
     }
 
@@ -114,7 +120,11 @@ public class IntArrayBlockBuilder
 
     private void updateDataSize()
     {
-        retainedSizeInBytes = intSaturatedCast(INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values));
+        long size = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+        if (blockBuilderStatus != null) {
+            size += BlockBuilderStatus.INSTANCE_SIZE;
+        }
+        retainedSizeInBytes = intSaturatedCast(size);
     }
 
     // Copied from IntArrayBlock

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -15,6 +15,8 @@ package com.facebook.presto.spi.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
+import javax.annotation.Nullable;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -23,13 +25,13 @@ import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
-import static java.util.Objects.requireNonNull;
 
 public class ShortArrayBlockBuilder
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ShortArrayBlockBuilder.class).instanceSize() + BlockBuilderStatus.INSTANCE_SIZE;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ShortArrayBlockBuilder.class).instanceSize();
 
+    @Nullable
     private BlockBuilderStatus blockBuilderStatus;
     private boolean initialized;
     private int initialEntryCount;
@@ -42,9 +44,9 @@ public class ShortArrayBlockBuilder
 
     private int retainedSizeInBytes;
 
-    public ShortArrayBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    public ShortArrayBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
-        this.blockBuilderStatus = requireNonNull(blockBuilderStatus, "blockBuilderStatus is null");
+        this.blockBuilderStatus = blockBuilderStatus;
         this.initialEntryCount = max(expectedEntries, 1);
 
         updateDataSize();
@@ -60,7 +62,9 @@ public class ShortArrayBlockBuilder
         values[positionCount] = (short) value;
 
         positionCount++;
-        blockBuilderStatus.addBytes(Byte.BYTES + Short.BYTES);
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + Short.BYTES);
+        }
         return this;
     }
 
@@ -80,7 +84,9 @@ public class ShortArrayBlockBuilder
         valueIsNull[positionCount] = true;
 
         positionCount++;
-        blockBuilderStatus.addBytes(Byte.BYTES + Short.BYTES);
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + Short.BYTES);
+        }
         return this;
     }
 
@@ -114,7 +120,11 @@ public class ShortArrayBlockBuilder
 
     private void updateDataSize()
     {
-        retainedSizeInBytes = intSaturatedCast(INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values));
+        long size = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+        if (blockBuilderStatus != null) {
+            size += BlockBuilderStatus.INSTANCE_SIZE;
+        }
+        retainedSizeInBytes = intSaturatedCast(size);
     }
 
     // Copied from ShortArrayBlock

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractFixedWidthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractFixedWidthType.java
@@ -40,10 +40,17 @@ public abstract class AbstractFixedWidthType
     @Override
     public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+        }
         return new FixedWidthBlockBuilder(
                 getFixedSize(),
                 blockBuilderStatus,
-                fixedSize == 0 ? expectedEntries : Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / fixedSize));
+                fixedSize == 0 ? expectedEntries : Math.min(expectedEntries, maxBlockSizeInBytes / fixedSize));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
@@ -104,9 +104,16 @@ public abstract class AbstractIntType
     @Override
     public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+        }
         return new IntArrayBlockBuilder(
                 blockBuilderStatus,
-                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / Integer.BYTES));
+                Math.min(expectedEntries, maxBlockSizeInBytes / Integer.BYTES));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
@@ -102,9 +102,16 @@ public abstract class AbstractLongType
     @Override
     public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+        }
         return new LongArrayBlockBuilder(
                 blockBuilderStatus,
-                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / Long.BYTES));
+                Math.min(expectedEntries, maxBlockSizeInBytes / Long.BYTES));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractVariableWidthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractVariableWidthType.java
@@ -31,9 +31,16 @@ public abstract class AbstractVariableWidthType
     @Override
     public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+        }
         return new VariableWidthBlockBuilder(
                 blockBuilderStatus,
-                expectedBytesPerEntry == 0 ? expectedEntries : Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / expectedBytesPerEntry),
+                expectedBytesPerEntry == 0 ? expectedEntries : Math.min(expectedEntries, maxBlockSizeInBytes / expectedBytesPerEntry),
                 expectedBytesPerEntry);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
@@ -41,9 +41,16 @@ public final class BooleanType
     @Override
     public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+        }
         return new ByteArrayBlockBuilder(
                 blockBuilderStatus,
-                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / Byte.BYTES));
+                Math.min(expectedEntries, maxBlockSizeInBytes / Byte.BYTES));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
@@ -112,9 +112,16 @@ public final class DoubleType
     @Override
     public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+        }
         return new LongArrayBlockBuilder(
                 blockBuilderStatus,
-                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / Double.BYTES));
+                Math.min(expectedEntries, maxBlockSizeInBytes / Double.BYTES));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
@@ -44,10 +44,17 @@ final class LongDecimalType
     @Override
     public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+        }
         return new FixedWidthBlockBuilder(
                 getFixedSize(),
                 blockBuilderStatus,
-                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / getFixedSize()));
+                Math.min(expectedEntries, maxBlockSizeInBytes / getFixedSize()));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -42,9 +42,16 @@ final class ShortDecimalType
     @Override
     public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+        }
         return new LongArrayBlockBuilder(
                 blockBuilderStatus,
-                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / getFixedSize()));
+                Math.min(expectedEntries, maxBlockSizeInBytes / getFixedSize()));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
@@ -44,9 +44,16 @@ public final class SmallintType
     @Override
     public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+        }
         return new ShortArrayBlockBuilder(
                 blockBuilderStatus,
-                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / Short.BYTES));
+                Math.min(expectedEntries, maxBlockSizeInBytes / Short.BYTES));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
@@ -44,9 +44,16 @@ public final class TinyintType
     @Override
     public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+        }
         return new ByteArrayBlockBuilder(
                 blockBuilderStatus,
-                Math.min(expectedEntries, blockBuilderStatus.getMaxBlockSizeInBytes() / Byte.BYTES));
+                Math.min(expectedEntries, maxBlockSizeInBytes / Byte.BYTES));
     }
 
     @Override


### PR DESCRIPTION
Make BlockBuilderStatus nullable in various block builders to reduce
the memory usage for functions that aggregate columns into complex
types; e.g., array_agg, map_agg, histogram, min_by, etc. In theory,
the change can reduce memory utilization up to 43%, which is the ratio
of the size of BlockBuilderStatus over the size of BlockBuilder. In
practice, we may observe a memory safe around 25 - 30% for large scale
of data.

Small-scale benchmark for array_agg on double type:
```
before: sql_double_array_agg ::   33.493 cpu ms :: 3.13MB peak memory
after:  sql_double_array_agg ::   33.414 cpu ms :: 2.33MB peak memory
```