### PR TITLE
Update mysql-connector to 5.1.41

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.35</version>
+                <version>5.1.41</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The previous version is from 2015. A few bug fixes are included in newer
versions of mysql driver.