### PR TITLE
Fix LDAP product tests for newer versions of docker compose

### DIFF
--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -49,3 +49,6 @@ fi
 export_canonical_path PRODUCT_TESTS_JAR
 
 export HIVE_PROXY_PORT=${HIVE_PROXY_PORT:-1180}
+
+export LDAP_SERVER_HOST=${LDAP_SERVER_HOST:-doesntmatter}
+export LDAP_SERVER_IP=${LDAP_SERVER_IP:-127.0.1.1}


### PR DESCRIPTION
Newer versions of docker-compose fails for invalid host ":" when those variables are not set.
These variables are only being used when it is required to substitute ldap server with the external one,
say, ActiveDirectory, which cannot be deployed with docker.

As a solution the default dummy values has been set for those variables just to do not leave them empty.