### PR TITLE
Add a configuration option to disable creating non-managed Hive table

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -169,6 +169,8 @@ Property Name                                      Description                  
                                                    See :ref:`hive-file-based-authorization` for details.
 
 ``hive.non-managed-table-writes-enabled``          Enable writes to non-managed (external) Hive tables.         ``false``
+
+``hive.create-non-managed-table-enabled``          Enable creating non-managed (external) Hive tables.          ``true``
 ================================================== ============================================================ ==========
 
 Amazon S3 Configuration

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -114,6 +114,8 @@ public class HiveClientConfig
     private int fileSystemMaxCacheSize = 1000;
 
     private boolean writesToNonManagedTablesEnabled;
+    private boolean createNonManagedTableEnabled = true;
+
     private boolean tableStatisticsEnabled = true;
 
     public int getMaxInitialSplits()
@@ -873,6 +875,19 @@ public class HiveClientConfig
     public boolean getWritesToNonManagedTablesEnabled()
     {
         return writesToNonManagedTablesEnabled;
+    }
+
+    @Config("hive.create-non-managed-table-enabled")
+    @ConfigDescription("Enable creating non-managed (external) tables")
+    public HiveClientConfig setCreateNonManagedTableEnabled(boolean createNonManagedTableEnabled)
+    {
+        this.createNonManagedTableEnabled = createNonManagedTableEnabled;
+        return this;
+    }
+
+    public boolean isCreateNonManagedTableEnabled()
+    {
+        return createNonManagedTableEnabled;
     }
 
     @Config("hive.table-statistics-enabled")

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -186,6 +186,7 @@ public class HiveMetadata
     private final boolean respectTableFormat;
     private final boolean bucketWritingEnabled;
     private final boolean writesToNonManagedTablesEnabled;
+    private final boolean createNonManagedTableEnabled;
     private final HiveStorageFormat defaultStorageFormat;
     private final TypeTranslator typeTranslator;
     private final String prestoVersion;
@@ -201,6 +202,7 @@ public class HiveMetadata
             boolean respectTableFormat,
             boolean bucketWritingEnabled,
             boolean writesToNonManagedTablesEnabled,
+            boolean createNonManagedTableEnabled,
             HiveStorageFormat defaultStorageFormat,
             TypeManager typeManager,
             LocationService locationService,
@@ -225,6 +227,7 @@ public class HiveMetadata
         this.respectTableFormat = respectTableFormat;
         this.bucketWritingEnabled = bucketWritingEnabled;
         this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
+        this.createNonManagedTableEnabled = createNonManagedTableEnabled;
         this.defaultStorageFormat = requireNonNull(defaultStorageFormat, "defaultStorageFormat is null");
         this.typeTranslator = requireNonNull(typeTranslator, "typeTranslator is null");
         this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
@@ -483,6 +486,10 @@ public class HiveMetadata
         boolean external;
         String externalLocation = getExternalLocation(tableMetadata.getProperties());
         if (externalLocation != null) {
+            if (!createNonManagedTableEnabled) {
+                throw new PrestoException(NOT_SUPPORTED, "Cannot create non-managed Hive table");
+            }
+
             external = true;
             targetPath = getExternalPath(new HdfsContext(session, schemaName, tableName), externalLocation);
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -39,6 +39,7 @@ public class HiveMetadataFactory
     private final boolean bucketWritingEnabled;
     private final boolean skipDeletionForAlter;
     private final boolean writesToNonManagedTablesEnabled;
+    private final boolean createNonManagedTableEnabled;
     private final HiveStorageFormat defaultStorageFormat;
     private final long perTransactionCacheMaximumSize;
     private final ExtendedHiveMetastore metastore;
@@ -80,6 +81,7 @@ public class HiveMetadataFactory
                 hiveClientConfig.isSkipDeletionForAlter(),
                 hiveClientConfig.isBucketWritingEnabled(),
                 hiveClientConfig.getWritesToNonManagedTablesEnabled(),
+                hiveClientConfig.isCreateNonManagedTableEnabled(),
                 hiveClientConfig.getHiveStorageFormat(),
                 hiveClientConfig.getPerTransactionMetastoreCacheMaximumSize(),
                 typeManager,
@@ -103,6 +105,7 @@ public class HiveMetadataFactory
             boolean skipDeletionForAlter,
             boolean bucketWritingEnabled,
             boolean writesToNonManagedTablesEnabled,
+            boolean createNonManagedTableEnabled,
             HiveStorageFormat defaultStorageFormat,
             long perTransactionCacheMaximumSize,
             TypeManager typeManager,
@@ -120,6 +123,7 @@ public class HiveMetadataFactory
         this.skipDeletionForAlter = skipDeletionForAlter;
         this.bucketWritingEnabled = bucketWritingEnabled;
         this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
+        this.createNonManagedTableEnabled = createNonManagedTableEnabled;
         this.defaultStorageFormat = requireNonNull(defaultStorageFormat, "defaultStorageFormat is null");
         this.perTransactionCacheMaximumSize = perTransactionCacheMaximumSize;
 
@@ -162,6 +166,7 @@ public class HiveMetadataFactory
                 respectTableFormat,
                 bucketWritingEnabled,
                 writesToNonManagedTablesEnabled,
+                createNonManagedTableEnabled,
                 defaultStorageFormat,
                 typeManager,
                 locationService,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -527,6 +527,7 @@ public abstract class AbstractTestHiveClient
                 false,
                 true,
                 false,
+                true,
                 HiveStorageFormat.RCBINARY,
                 1000,
                 TYPE_MANAGER,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -91,8 +91,9 @@ public class TestHiveClientConfig
                 .setBucketExecutionEnabled(true)
                 .setBucketWritingEnabled(true)
                 .setFileSystemMaxCacheSize(1000)
-                .setTableStatisticsEnabled(true)
-                .setWritesToNonManagedTablesEnabled(false));
+                .setWritesToNonManagedTablesEnabled(false)
+                .setCreateNonManagedTableEnabled(true)
+                .setTableStatisticsEnabled(true));
     }
 
     @Test
@@ -156,6 +157,7 @@ public class TestHiveClientConfig
                 .put("hive.fs.cache.max-size", "1010")
                 .put("hive.table-statistics-enabled", "false")
                 .put("hive.non-managed-table-writes-enabled", "true")
+                .put("hive.create-non-managed-table-enabled", "false")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -214,8 +216,9 @@ public class TestHiveClientConfig
                 .setBucketExecutionEnabled(false)
                 .setBucketWritingEnabled(false)
                 .setFileSystemMaxCacheSize(1010)
-                .setTableStatisticsEnabled(false)
-                .setWritesToNonManagedTablesEnabled(true);
+                .setWritesToNonManagedTablesEnabled(true)
+                .setCreateNonManagedTableEnabled(false)
+                .setTableStatisticsEnabled(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Add a configuration option using which one can disable creating a non-managed (external) table. This is to prevent the current scenario where one can create an external table to query any data in S3.

The request came from one of our customers who would like an ability to set the config to disable this option. 

Tested manually.
