### PR TITLE
Avoid the binding operation when generating lambda byte-code

### DIFF
--- a/presto-bytecode/src/main/java/com/facebook/presto/bytecode/DumpBytecodeVisitor.java
+++ b/presto-bytecode/src/main/java/com/facebook/presto/bytecode/DumpBytecodeVisitor.java
@@ -98,6 +98,9 @@ public class DumpBytecodeVisitor
             visitMethod(classDefinition, methodDefinition);
         }
 
+        // print class initializer
+        visitMethod(classDefinition, classDefinition.getClassInitializer());
+
         indentLevel--;
         printLine("}");
         printLine();

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ApplyFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ApplyFunction.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.base.Throwables;
@@ -38,7 +39,7 @@ public final class ApplyFunction
 {
     public static final ApplyFunction APPLY_FUNCTION = new ApplyFunction();
 
-    private static final MethodHandle METHOD_HANDLE = methodHandle(ApplyFunction.class, "apply", Object.class, MethodHandle.class);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(ApplyFunction.class, "apply", ConnectorSession.class, Object.class, MethodHandle.class);
 
     private ApplyFunction()
     {
@@ -81,14 +82,14 @@ public final class ApplyFunction
                 METHOD_HANDLE.asType(
                         METHOD_HANDLE.type()
                                 .changeReturnType(wrap(returnType.getJavaType()))
-                                .changeParameterType(0, wrap(argumentType.getJavaType()))),
+                                .changeParameterType(1, wrap(argumentType.getJavaType()))),
                 isDeterministic());
     }
 
-    public static Object apply(Object input, MethodHandle function)
+    public static Object apply(ConnectorSession session, Object input, MethodHandle function)
     {
         try {
-            return function.invoke(input);
+            return function.invoke(session, input);
         }
         catch (Throwable throwable) {
             throw Throwables.propagate(throwable);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -38,7 +39,9 @@ public final class ArrayFilterFunction
     @TypeParameter("T")
     @TypeParameterSpecialization(name = "T", nativeContainerType = long.class)
     @SqlType("array(T)")
-    public static Block filterLong(@TypeParameter("T") Type elementType,
+    public static Block filterLong(
+            @TypeParameter("T") Type elementType,
+            ConnectorSession session,
             @SqlType("array(T)") Block arrayBlock,
             @SqlType("function(T, boolean)") MethodHandle function)
     {
@@ -52,7 +55,7 @@ public final class ArrayFilterFunction
 
             Boolean keep;
             try {
-                keep = (Boolean) function.invokeExact(input);
+                keep = (Boolean) function.invokeExact(session, input);
             }
             catch (Throwable throwable) {
                 throw Throwables.propagate(throwable);
@@ -67,7 +70,9 @@ public final class ArrayFilterFunction
     @TypeParameter("T")
     @TypeParameterSpecialization(name = "T", nativeContainerType = double.class)
     @SqlType("array(T)")
-    public static Block filterDouble(@TypeParameter("T") Type elementType,
+    public static Block filterDouble(
+            @TypeParameter("T") Type elementType,
+            ConnectorSession session,
             @SqlType("array(T)") Block arrayBlock,
             @SqlType("function(T, boolean)") MethodHandle function)
     {
@@ -81,7 +86,7 @@ public final class ArrayFilterFunction
 
             Boolean keep;
             try {
-                keep = (Boolean) function.invokeExact(input);
+                keep = (Boolean) function.invokeExact(session, input);
             }
             catch (Throwable throwable) {
                 throw Throwables.propagate(throwable);
@@ -96,7 +101,9 @@ public final class ArrayFilterFunction
     @TypeParameter("T")
     @TypeParameterSpecialization(name = "T", nativeContainerType = boolean.class)
     @SqlType("array(T)")
-    public static Block filterBoolean(@TypeParameter("T") Type elementType,
+    public static Block filterBoolean(
+            @TypeParameter("T") Type elementType,
+            ConnectorSession session,
             @SqlType("array(T)") Block arrayBlock,
             @SqlType("function(T, boolean)") MethodHandle function)
     {
@@ -110,7 +117,7 @@ public final class ArrayFilterFunction
 
             Boolean keep;
             try {
-                keep = (Boolean) function.invokeExact(input);
+                keep = (Boolean) function.invokeExact(session, input);
             }
             catch (Throwable throwable) {
                 throw Throwables.propagate(throwable);
@@ -125,7 +132,9 @@ public final class ArrayFilterFunction
     @TypeParameter("T")
     @TypeParameterSpecialization(name = "T", nativeContainerType = Slice.class)
     @SqlType("array(T)")
-    public static Block filterSlice(@TypeParameter("T") Type elementType,
+    public static Block filterSlice(
+            @TypeParameter("T") Type elementType,
+            ConnectorSession session,
             @SqlType("array(T)") Block arrayBlock,
             @SqlType("function(T, boolean)") MethodHandle function)
     {
@@ -139,7 +148,7 @@ public final class ArrayFilterFunction
 
             Boolean keep;
             try {
-                keep = (Boolean) function.invokeExact(input);
+                keep = (Boolean) function.invokeExact(session, input);
             }
             catch (Throwable throwable) {
                 throw Throwables.propagate(throwable);
@@ -154,7 +163,9 @@ public final class ArrayFilterFunction
     @TypeParameter("T")
     @TypeParameterSpecialization(name = "T", nativeContainerType = Block.class)
     @SqlType("array(T)")
-    public static Block filterBlock(@TypeParameter("T") Type elementType,
+    public static Block filterBlock(
+            @TypeParameter("T") Type elementType,
+            ConnectorSession session,
             @SqlType("array(T)") Block arrayBlock,
             @SqlType("function(T, boolean)") MethodHandle function)
     {
@@ -168,7 +179,7 @@ public final class ArrayFilterFunction
 
             Boolean keep;
             try {
-                keep = (Boolean) function.invokeExact(input);
+                keep = (Boolean) function.invokeExact(session, input);
             }
             catch (Throwable throwable) {
                 throw Throwables.propagate(throwable);
@@ -183,7 +194,9 @@ public final class ArrayFilterFunction
     @TypeParameter("T")
     @TypeParameterSpecialization(name = "T", nativeContainerType = void.class)
     @SqlType("array(T)")
-    public static Block filterVoid(@TypeParameter("T") Type elementType,
+    public static Block filterVoid(
+            @TypeParameter("T") Type elementType,
+            ConnectorSession session,
             @SqlType("array(T)") Block arrayBlock,
             @SqlType("function(T, boolean)") MethodHandle function)
     {
@@ -192,7 +205,7 @@ public final class ArrayFilterFunction
         for (int position = 0; position < positionCount; position++) {
             Boolean keep;
             try {
-                keep = (Boolean) function.invokeExact(null);
+                keep = (Boolean) function.invokeExact(session, null);
             }
             catch (Throwable throwable) {
                 throw Throwables.propagate(throwable);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayReduceFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayReduceFunction.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -37,7 +38,7 @@ public final class ArrayReduceFunction
 {
     public static final ArrayReduceFunction ARRAY_REDUCE_FUNCTION = new ArrayReduceFunction();
 
-    private static final MethodHandle METHOD_HANDLE = methodHandle(ArrayReduceFunction.class, "reduce", Type.class, Block.class, Object.class, MethodHandle.class, MethodHandle.class);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(ArrayReduceFunction.class, "reduce", Type.class, ConnectorSession.class, Block.class, Object.class, MethodHandle.class, MethodHandle.class);
 
     private ArrayReduceFunction()
     {
@@ -81,13 +82,14 @@ public final class ArrayReduceFunction
                 ImmutableList.of(false, true, false, false),
                 methodHandle.asType(
                         methodHandle.type()
-                                .changeParameterType(1, Primitives.wrap(intermediateType.getJavaType()))
+                                .changeParameterType(2, Primitives.wrap(intermediateType.getJavaType()))
                                 .changeReturnType(Primitives.wrap(outputType.getJavaType()))),
                 isDeterministic());
     }
 
     public static Object reduce(
             Type inputType,
+            ConnectorSession session,
             Block block,
             Object initialIntermediateValue,
             MethodHandle inputFunction,
@@ -98,14 +100,14 @@ public final class ArrayReduceFunction
         for (int position = 0; position < positionCount; position++) {
             Object input = readNativeValue(inputType, block, position);
             try {
-                intermediateValue = inputFunction.invoke(intermediateValue, input);
+                intermediateValue = inputFunction.invoke(session, intermediateValue, input);
             }
             catch (Throwable throwable) {
                 throw Throwables.propagate(throwable);
             }
         }
         try {
-            return outputFunction.invoke(intermediateValue);
+            return outputFunction.invoke(session, intermediateValue);
         }
         catch (Throwable throwable) {
             throw Throwables.propagate(throwable);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayTransformFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayTransformFunction.java
@@ -27,6 +27,7 @@ import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
@@ -108,7 +109,7 @@ public final class ArrayTransformFunction
                 false,
                 ImmutableList.of(false, false),
                 ImmutableList.of(false, false),
-                methodHandle(generatedClass, "transform", PageBuilder.class, Block.class, MethodHandle.class),
+                methodHandle(generatedClass, "transform", PageBuilder.class, ConnectorSession.class, Block.class, MethodHandle.class),
                 Optional.of(methodHandle(generatedClass, "createPageBuilder")),
                 isDeterministic());
     }
@@ -131,6 +132,7 @@ public final class ArrayTransformFunction
                 .append(newInstance(PageBuilder.class, constantType(binder, new ArrayType(outputType)).invoke("getTypeParameters", List.class)).ret());
 
         // define transform method
+        Parameter session = arg("session", ConnectorSession.class);
         Parameter pageBuilder = arg("pageBuilder", PageBuilder.class);
         Parameter block = arg("block", Block.class);
         Parameter function = arg("function", MethodHandle.class);
@@ -139,7 +141,7 @@ public final class ArrayTransformFunction
                 a(PUBLIC, STATIC),
                 "transform",
                 type(Block.class),
-                ImmutableList.of(pageBuilder, block, function));
+                ImmutableList.of(pageBuilder, session, block, function));
 
         BytecodeBlock body = method.getBody();
         Scope scope = method.getScope();
@@ -188,7 +190,7 @@ public final class ArrayTransformFunction
                 .update(incrementVariable(position, (byte) 1))
                 .body(new BytecodeBlock()
                         .append(loadInputElement)
-                        .append(outputElement.set(function.invoke("invokeExact", outputJavaType, inputElement)))
+                        .append(outputElement.set(function.invoke("invokeExact", outputJavaType, session, inputElement)))
                         .append(writeOutputElement)));
 
         body.append(pageBuilder.invoke("declarePositions", void.class, positionCount));

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/InvokeFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/InvokeFunction.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.base.Throwables;
@@ -39,7 +40,7 @@ public final class InvokeFunction
 {
     public static final InvokeFunction INVOKE_FUNCTION = new InvokeFunction();
 
-    private static final MethodHandle METHOD_HANDLE = methodHandle(InvokeFunction.class, "invoke", MethodHandle.class);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(InvokeFunction.class, "invoke", ConnectorSession.class, MethodHandle.class);
 
     private InvokeFunction()
     {
@@ -84,10 +85,10 @@ public final class InvokeFunction
                 isDeterministic());
     }
 
-    public static Object invoke(MethodHandle function)
+    public static Object invoke(ConnectorSession session, MethodHandle function)
     {
         try {
-            return function.invoke();
+            return function.invoke(session);
         }
         catch (Throwable throwable) {
             throw Throwables.propagate(throwable);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapFilterFunction.java
@@ -27,6 +27,7 @@ import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -128,13 +129,14 @@ public final class MapFilterFunction
                 type(Object.class));
         definition.declareDefaultConstructor(a(PRIVATE));
 
+        Parameter session = arg("session", ConnectorSession.class);
         Parameter block = arg("block", Block.class);
         Parameter function = arg("function", MethodHandle.class);
         MethodDefinition method = definition.declareMethod(
                 a(PUBLIC, STATIC),
                 "filter",
                 type(Block.class),
-                ImmutableList.of(block, function));
+                ImmutableList.of(session, block, function));
 
         BytecodeBlock body = method.getBody();
         Scope scope = method.getScope();
@@ -184,7 +186,7 @@ public final class MapFilterFunction
                 .body(new BytecodeBlock()
                         .append(loadKeyElement)
                         .append(loadValueElement)
-                        .append(keep.set(function.invoke("invokeExact", Boolean.class, keyElement, valueElement)))
+                        .append(keep.set(function.invoke("invokeExact", Boolean.class, session, keyElement, valueElement)))
                         .append(new IfStatement("if (keep != null && keep) ...")
                                 .condition(and(notEqual(keep, constantNull(Boolean.class)), keep.cast(boolean.class)))
                                 .ifTrue(new BytecodeBlock()
@@ -194,6 +196,6 @@ public final class MapFilterFunction
         body.append(blockBuilder.invoke("build", Block.class).ret());
 
         Class<?> generatedClass = defineClass(definition, Object.class, binder.getBindings(), MapFilterFunction.class.getClassLoader());
-        return methodHandle(generatedClass, "filter", Block.class, MethodHandle.class);
+        return methodHandle(generatedClass, "filter", ConnectorSession.class, Block.class, MethodHandle.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformKeyFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformKeyFunction.java
@@ -213,7 +213,7 @@ public final class MapTransformKeyFunction
         BytecodeNode throwDuplicatedKeyException;
         if (!transformedKeyType.equals(UNKNOWN)) {
             writeKeyElement = new BytecodeBlock()
-                    .append(transformedKeyElement.set(function.invoke("invokeExact", transformedKeyJavaType, keyElement, valueElement)))
+                    .append(transformedKeyElement.set(function.invoke("invokeExact", transformedKeyJavaType, session, keyElement, valueElement)))
                     .append(new IfStatement()
                             .condition(equal(transformedKeyElement, constantNull(transformedKeyJavaType)))
                             .ifTrue(throwNullKeyException)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
@@ -27,6 +27,7 @@ import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
@@ -135,13 +136,14 @@ public final class MapTransformValueFunction
         definition.declareDefaultConstructor(a(PRIVATE));
 
         // define transform method
+        Parameter session = arg("session", ConnectorSession.class);
         Parameter block = arg("block", Block.class);
         Parameter function = arg("function", MethodHandle.class);
         MethodDefinition method = definition.declareMethod(
                 a(PUBLIC, STATIC),
                 "transform",
                 type(Block.class),
-                ImmutableList.of(block, function));
+                ImmutableList.of(session, block, function));
 
         BytecodeBlock body = method.getBody();
         Scope scope = method.getScope();
@@ -213,13 +215,13 @@ public final class MapTransformValueFunction
                 .body(new BytecodeBlock()
                         .append(loadKeyElement)
                         .append(loadValueElement)
-                        .append(transformedValueElement.set(function.invoke("invokeExact", transformedValueJavaType, keyElement, valueElement)))
+                        .append(transformedValueElement.set(function.invoke("invokeExact", transformedValueJavaType, session, keyElement, valueElement)))
                         .append(keySqlType.invoke("appendTo", void.class, block, position, blockBuilder))
                         .append(writeTransformedValueElement)));
 
         body.append(blockBuilder.invoke("build", Block.class).ret());
 
         Class<?> generatedClass = defineClass(definition, Object.class, binder.getBindings(), MapTransformValueFunction.class.getClassLoader());
-        return methodHandle(generatedClass, "transform", Block.class, MethodHandle.class);
+        return methodHandle(generatedClass, "transform", ConnectorSession.class, Block.class, MethodHandle.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipWithFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipWithFunction.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -41,7 +42,7 @@ public final class ZipWithFunction
 {
     public static final ZipWithFunction ZIP_WITH_FUNCTION = new ZipWithFunction();
 
-    private static final MethodHandle METHOD_HANDLE = methodHandle(ZipWithFunction.class, "zipWith", Type.class, Type.class, Type.class, Block.class, Block.class, MethodHandle.class);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(ZipWithFunction.class, "zipWith", Type.class, Type.class, Type.class, ConnectorSession.class, Block.class, Block.class, MethodHandle.class);
 
     private ZipWithFunction()
     {
@@ -86,7 +87,7 @@ public final class ZipWithFunction
                 isDeterministic());
     }
 
-    public static Block zipWith(Type leftElementType, Type rightElementType, Type outputElementType, Block leftBlock, Block rightBlock, MethodHandle function)
+    public static Block zipWith(Type leftElementType, Type rightElementType, Type outputElementType, ConnectorSession session, Block leftBlock, Block rightBlock, MethodHandle function)
     {
         checkCondition(leftBlock.getPositionCount() == rightBlock.getPositionCount(), INVALID_FUNCTION_ARGUMENT, "Arrays must have the same length");
         BlockBuilder resultBuilder = outputElementType.createBlockBuilder(new BlockBuilderStatus(), leftBlock.getPositionCount());
@@ -95,7 +96,7 @@ public final class ZipWithFunction
             Object right = readNativeValue(rightElementType, rightBlock, position);
             Object output;
             try {
-                output = function.invoke(left, right);
+                output = function.invoke(session, left, right);
             }
             catch (Throwable throwable) {
                 throw Throwables.propagate(throwable);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/BindCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/BindCodeGenerator.java
@@ -68,7 +68,7 @@ public class BindCodeGenerator
                                                 "insertArguments",
                                                 MethodHandle.class,
                                                 functionVariable,
-                                                constantInt(0),
+                                                constantInt(1),
                                                 newArray(type(Object[].class), ImmutableList.of(valueVariable.cast(Object.class)))))));
 
         return block;

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeExpressionVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeExpressionVisitor.java
@@ -24,10 +24,7 @@ import com.facebook.presto.sql.relational.LambdaDefinitionExpression;
 import com.facebook.presto.sql.relational.RowExpressionVisitor;
 import com.facebook.presto.sql.relational.VariableReferenceExpression;
 
-import java.lang.invoke.MethodHandle;
-
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantTrue;
-import static com.facebook.presto.bytecode.expression.BytecodeExpressions.getStatic;
 import static com.facebook.presto.bytecode.instruction.Constant.loadBoolean;
 import static com.facebook.presto.bytecode.instruction.Constant.loadDouble;
 import static com.facebook.presto.bytecode.instruction.Constant.loadFloat;
@@ -194,8 +191,7 @@ public class BytecodeExpressionVisitor
     {
         checkState(preGeneratedExpressions.getLambdaFieldMap().containsKey(lambda), "lambda expressions map does not contain this lambda definition");
 
-        return getStatic(preGeneratedExpressions.getLambdaFieldMap().get(lambda))
-                .invoke("bindTo", MethodHandle.class, scope.getThis().cast(Object.class));
+        return scope.getThis().getField(preGeneratedExpressions.getLambdaFieldMap().get(lambda).getInstanceField());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeExpressionVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeExpressionVisitor.java
@@ -195,8 +195,7 @@ public class BytecodeExpressionVisitor
         checkState(preGeneratedExpressions.getLambdaFieldMap().containsKey(lambda), "lambda expressions map does not contain this lambda definition");
 
         return getStatic(preGeneratedExpressions.getLambdaFieldMap().get(lambda))
-                .invoke("bindTo", MethodHandle.class, scope.getThis().cast(Object.class))
-                .invoke("bindTo", MethodHandle.class, scope.getVariable("session").cast(Object.class));
+                .invoke("bindTo", MethodHandle.class, scope.getThis().cast(Object.class));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -129,7 +129,7 @@ public class PageFunctionCompiler
             projectionClass = defineClass(classDefinition, PageProjection.class, callSiteBinder.getBindings(), getClass().getClassLoader());
         }
         catch (Exception e) {
-            throw new PrestoException(COMPILER_ERROR, e.getCause());
+            throw new PrestoException(COMPILER_ERROR, e);
         }
 
         return () -> {

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PreGeneratedExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PreGeneratedExpressions.java
@@ -13,8 +13,8 @@
  */
 package com.facebook.presto.sql.gen;
 
-import com.facebook.presto.bytecode.FieldDefinition;
 import com.facebook.presto.bytecode.MethodDefinition;
+import com.facebook.presto.sql.gen.LambdaBytecodeGenerator.LambdaExpressionField;
 import com.facebook.presto.sql.relational.CallExpression;
 import com.facebook.presto.sql.relational.LambdaDefinitionExpression;
 import com.google.common.collect.ImmutableMap;
@@ -26,9 +26,9 @@ import static java.util.Objects.requireNonNull;
 public class PreGeneratedExpressions
 {
     private final Map<CallExpression, MethodDefinition> tryMethodMap;
-    private final Map<LambdaDefinitionExpression, FieldDefinition> lambdaFieldMap;
+    private final Map<LambdaDefinitionExpression, LambdaExpressionField> lambdaFieldMap;
 
-    public PreGeneratedExpressions(Map<CallExpression, MethodDefinition> tryMethodMap, Map<LambdaDefinitionExpression, FieldDefinition> lambdaFieldMap)
+    public PreGeneratedExpressions(Map<CallExpression, MethodDefinition> tryMethodMap, Map<LambdaDefinitionExpression, LambdaExpressionField> lambdaFieldMap)
     {
         this.tryMethodMap = ImmutableMap.copyOf(requireNonNull(tryMethodMap, "tryMethodMap is null"));
         this.lambdaFieldMap = ImmutableMap.copyOf(requireNonNull(lambdaFieldMap, "lambdaFieldMap is null"));
@@ -39,7 +39,7 @@ public class PreGeneratedExpressions
         return tryMethodMap;
     }
 
-    public Map<LambdaDefinitionExpression, FieldDefinition> getLambdaFieldMap()
+    public Map<LambdaDefinitionExpression, LambdaExpressionField> getLambdaFieldMap()
     {
         return lambdaFieldMap;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/LambdaDefinitionExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/LambdaDefinitionExpression.java
@@ -63,7 +63,7 @@ public final class LambdaDefinitionExpression
     @Override
     public String toString()
     {
-        return "(" + Joiner.on("").join(arguments) + ") -> " + body;
+        return "(" + Joiner.on(",").join(arguments) + ") -> " + body;
     }
 
     @Override


### PR DESCRIPTION
Work in progress. Binding lambda method to `this` is not fixed yet. 