### PR TITLE
Fix incorrect date conversion in Row#valueFromString

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/Row.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/Row.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -202,7 +201,7 @@ public class Row
             return Boolean.parseBoolean(str);
         }
         else if (type.equals(DATE)) {
-            return new Date(TimeUnit.MILLISECONDS.toDays(DATE_PARSER.parseDateTime(str).getMillis()));
+            return new Date(DATE_PARSER.parseDateTime(str).getMillis());
         }
         else if (type.equals(DOUBLE)) {
             return Double.parseDouble(str);

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/model/TestRow.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/model/TestRow.java
@@ -22,7 +22,6 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.GregorianCalendar;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -83,7 +82,7 @@ public class TestRow
         Row expected = new Row();
         expected.addField(new Field(AccumuloRowSerializer.getBlockFromArray(VARCHAR, ImmutableList.of("a", "b", "c")), new ArrayType(VARCHAR)));
         expected.addField(true, BOOLEAN);
-        expected.addField(new Field(new Date(TimeUnit.MILLISECONDS.toDays(new GregorianCalendar(1999, 0, 1).getTime().getTime())), DATE));
+        expected.addField(new Field(new Date(new GregorianCalendar(1999, 0, 1).getTime().getTime()), DATE));
         expected.addField(123.45678, DOUBLE);
         expected.addField(new Field(123.45678f, REAL));
         expected.addField(12345678, INTEGER);


### PR DESCRIPTION
Addresses an incorrect test when creating a Date object from a string,
passing in number of days instead of milliseconds.  Note that this
function is only used for testing and doesn't affect the normal
operations of the connector.