### PR TITLE
Fix slice big array memory estimate

### DIFF
--- a/presto-array/pom.xml
+++ b/presto-array/pom.xml
@@ -25,5 +25,10 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-array/src/main/java/com/facebook/presto/array/SliceBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/SliceBigArray.java
@@ -14,9 +14,11 @@
 package com.facebook.presto.array;
 
 import io.airlift.slice.Slice;
+import org.openjdk.jol.info.ClassLayout;
 
 public final class SliceBigArray
 {
+    private static final int SLICE_INSTANCE_SIZE = ClassLayout.parseClass(Slice.class).instanceSize();
     private final ObjectBigArray<Slice> array;
     private long sizeOfSlices;
 
@@ -58,12 +60,20 @@ public final class SliceBigArray
     {
         Slice currentValue = array.get(index);
         if (currentValue != null) {
-            sizeOfSlices -= currentValue.length();
+            sizeOfSlices -= getSize(currentValue);
         }
         if (value != null) {
-            sizeOfSlices += value.length();
+            sizeOfSlices += getSize(value);
         }
         array.set(index, value);
+    }
+
+    // For now we approximate the retained size of a slice by object overhead plus length.
+    // In general this is more complicated than that as there may be multiple "view" slices
+    // pointing to the same backing memory of a slice.
+    private long getSize(Slice slice)
+    {
+        return slice.length() + SLICE_INSTANCE_SIZE;
     }
 
     /**


### PR DESCRIPTION
We now include the slice object overhead in our estimates.