### PR TITLE
Source union

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/FragmentTableScanCounter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/FragmentTableScanCounter.java
@@ -30,13 +30,13 @@ public final class FragmentTableScanCounter
 {
     private FragmentTableScanCounter() {}
 
-    public static boolean hasMultipleSources(List<PlanNode> nodes)
+    public static int countSources(List<PlanNode> nodes)
     {
         int count = 0;
         for (PlanNode node : nodes) {
             count += node.accept(new Visitor(), null);
         }
-        return count > 1;
+        return count;
     }
 
     public static boolean hasMultipleSources(PlanNode... nodes)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -29,7 +29,6 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.DependencyExtractor;
 import com.facebook.presto.sql.planner.DomainTranslator;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
-import com.facebook.presto.sql.planner.FragmentTableScanCounter;
 import com.facebook.presto.sql.planner.LookupSymbolResolver;
 import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5860,6 +5860,26 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testUnionWithAggregationAndTableScan()
+    {
+        assertQuery(
+                "SELECT orderkey, 1 FROM orders " +
+                        "UNION ALL " +
+                        "SELECT orderkey, count(*) FROM orders GROUP BY 1",
+                "SELECT orderkey, 1 FROM orders " +
+                        "UNION ALL " +
+                        "SELECT orderkey, count(*) FROM orders GROUP BY orderkey");
+
+        assertQuery(
+                "SELECT orderkey, count(*) FROM orders GROUP BY 1 " +
+                        "UNION ALL " +
+                        "SELECT orderkey, 1 FROM orders",
+                "SELECT orderkey, count(*) FROM orders GROUP BY orderkey " +
+                        "UNION ALL " +
+                        "SELECT orderkey, 1 FROM orders");
+    }
+
+    @Test
     public void testUnionWithAggregationAndJoin()
     {
         assertQuery(


### PR DESCRIPTION
Addresses https://github.com/prestodb/presto/issues/7877

This is more of a hot fix I think, than a real solution. Why Presto can not handle stages that have inputs that one is source distributed and other is hash distributed? Like this fragment:

```
 Fragment 1 [HASH]
     Output layout: [suppkey_18, expr_19]
     Output partitioning: SINGLE []
     - LocalExchange[ROUND_ROBIN] () => suppkey_18:bigint, expr_19:bigint
         - ScanProject[table = tpch:tpch:supplier:sf0.01, originalConstraint = true] => [expr_4:bigint, suppkey:bigint]
                 expr_4 := BIGINT '1'
                 suppkey := tpch:suppkey
         - Aggregate(FINAL)[suppkey_5] => [suppkey_5:bigint, count:bigint]
                 count := "count"("count_24")
             - LocalExchange[HASH][$hashvalue] ("suppkey_5") => suppkey_5:bigint, count_24:bigint, $hashvalue:bigint
                 - RemoteSource[2] => [suppkey_5:bigint, count_24:bigint, $hashvalue_25:bigint]
```

Is there any fundamental problem with that? Or is it difficult because requires changes in lots of places? I tried to add support for that, but after hitting 3rd `checkState` I gave up.