### PR TITLE
Prevent nulls by requiring override of PlanVisitor.visitPlan

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanVisitor.java
@@ -13,12 +13,9 @@
  */
 package com.facebook.presto.sql.planner.plan;
 
-public class PlanVisitor<C, R>
+public abstract class PlanVisitor<C, R>
 {
-    protected R visitPlan(PlanNode node, C context)
-    {
-        return null;
-    }
+    protected abstract R visitPlan(PlanNode node, C context);
 
     public R visitRemoteSource(RemoteSourceNode node, C context)
     {


### PR DESCRIPTION
`PlanVisitor` is a generic class and does not know the type of context `C`, so should not assume `null` is a good value to return by default.

