### PR TITLE
Prefer undistributed plans for the output

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -219,7 +219,7 @@ public class AddExchanges
         @Override
         public PlanWithProperties visitOutput(OutputNode node, Context context)
         {
-            PlanWithProperties child = planChild(node, context.withPreferredProperties(PreferredProperties.any()));
+            PlanWithProperties child = planChild(node, context.withPreferredProperties(PreferredProperties.undistributed()));
 
             if (!child.getProperties().isSingleNode()) {
                 child = withDerivedProperties(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnion.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnion.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.Iterables;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -44,6 +45,23 @@ public class TestUnion
     public TestUnion(Map<String, String> sessionProperties)
     {
         super(sessionProperties);
+    }
+
+    @Test
+    public void testSimpleUnion()
+    {
+        Plan plan = plan(
+                "SELECT suppkey FROM supplier UNION ALL SELECT nationkey FROM nation",
+                LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED,
+                false);
+
+        List<PlanNode> remotes = searchFrom(plan.getRoot())
+                .where(TestUnion::isRemoteExchange)
+                .findAll();
+
+        assertEquals(remotes.size(), 1, "There should be exactly one RemoteExchange");
+        assertEquals(((ExchangeNode) Iterables.getOnlyElement(remotes)).getType(), GATHER);
+        assertPlanIsFullyDistributed(plan);
     }
 
     @Test


### PR DESCRIPTION
Addresses: https://github.com/prestodb/presto/issues/7886

This allows UnionNodes which are just under OutputNode to
collapse into single RemoteExchange[GATHER] instead of
RemoteExchange[ROUND_ROBIN] followed by RemoteExchange[GATHER]

For example before:
```
> explain (type distributed) SELECT suppkey FROM supplier UNION ALL SELECT nationkey FROM nation

 Fragment 0 [SINGLE]
     Output layout: [suppkey_8]
     Output partitioning: SINGLE []
     - Output[suppkey] => [suppkey_8:bigint]
             suppkey := suppkey_8
         - RemoteSource[1] => [suppkey_8:bigint]

 Fragment 1 [ROUND_ROBIN]
     Output layout: [suppkey_8]
     Output partitioning: SINGLE []
     - RemoteSource[2,3] => [suppkey_8:bigint]

 Fragment 2 [SOURCE]
     Output layout: [suppkey]
     Output partitioning: ROUND_ROBIN []
     - TableScan[tpch:tpch:supplier:sf0.01, originalConstraint = true] => [suppkey:bigint]
             suppkey := tpch:suppkey

 Fragment 3 [SOURCE]
     Output layout: [nationkey_2]
     Output partitioning: ROUND_ROBIN []
     - TableScan[tpch:tpch:nation:sf0.01, originalConstraint = true] => [nationkey_2:bigint]
             nationkey_2 := tpch:nationkey
```
and after:
```
 Fragment 0 [SINGLE]
     Output layout: [suppkey_8]
     Output partitioning: SINGLE []
     - Output[suppkey] => [suppkey_8:bigint]
             suppkey := suppkey_8
         - RemoteSource[1,2] => [suppkey_8:bigint]

 Fragment 1 [SOURCE]
     Output layout: [suppkey]
     Output partitioning: SINGLE []
     - TableScan[tpch:tpch:supplier:sf0.01, originalConstraint = true] => [suppkey:bigint]
             suppkey := tpch:suppkey

 Fragment 2 [SOURCE]
     Output layout: [nationkey_2]
     Output partitioning: SINGLE []
     - TableScan[tpch:tpch:nation:sf0.01, originalConstraint = true] => [nationkey_2:bigint]
             nationkey_2 := tpch:nationkey
```