### PR TITLE
Reduce memory over limitation exception for OrderByOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/OrderByOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OrderByOperator.java
@@ -184,6 +184,11 @@ public class OrderByOperator
         requireNonNull(page, "page is null");
 
         pageIndex.addPage(page);
+
+        if (!operatorContext.trySetMemoryReservation(pageIndex.getEstimatedSize().toBytes())) {
+            pageIndex.compact();
+        }
+
         operatorContext.setMemoryReservation(pageIndex.getEstimatedSize().toBytes());
     }
 


### PR DESCRIPTION
Before OrderByOperator is compacted, we will try to compact the memory first.