### PR TITLE
Introduce INT as an alias for INTEGER, for compatibility with other DBs

### DIFF
--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -31,7 +31,8 @@ INTEGER
 -------
 
     A 32-bit signed two's complement integer with a minimum value of
-    ``-2^31`` and a maximum value of ``2^31 - 1``.
+    ``-2^31`` and a maximum value of ``2^31 - 1``.  The name INT is
+    also available for this type.
 
 BIGINT
 ------

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -20,8 +20,10 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -34,6 +36,12 @@ public class TypeSignature
     private final String base;
     private final List<TypeSignatureParameter> parameters;
     private final boolean calculated;
+
+    private static final Map<String, String> baseNameAliasToCanonical = new TreeMap<String, String>();
+
+    static {
+        baseNameAliasToCanonical.put("int", StandardTypes.INTEGER);
+    }
 
     public TypeSignature(String base, TypeSignatureParameter... parameters)
     {
@@ -100,7 +108,7 @@ public class TypeSignature
                 return VarcharType.createUnboundedVarcharType().getTypeSignature();
             }
             checkArgument(!literalCalculationParameters.contains(signature), "Bad type signature: '%s'", signature);
-            return new TypeSignature(signature, new ArrayList<>());
+            return new TypeSignature(canonicalizeBaseName(signature), new ArrayList<>());
         }
         if (signature.toLowerCase(Locale.ENGLISH).startsWith(StandardTypes.ROW + "(")) {
             return parseRowTypeSignature(signature, literalCalculationParameters);
@@ -125,7 +133,7 @@ public class TypeSignature
                 if (bracketCount == 0) {
                     verify(baseName == null, "Expected baseName to be null");
                     verify(parameterStart == -1, "Expected parameter start to be -1");
-                    baseName = signature.substring(0, i);
+                    baseName = canonicalizeBaseName(signature.substring(0, i));
                     checkArgument(!literalCalculationParameters.contains(baseName), "Bad type signature: '%s'", signature);
                     parameterStart = i + 1;
                 }
@@ -171,7 +179,7 @@ public class TypeSignature
                 if (bracketCount == 0) {
                     verify(baseName == null, "Expected baseName to be null");
                     verify(parameterStart == -1, "Expected parameter start to be -1");
-                    baseName = signature.substring(0, i);
+                    baseName = canonicalizeBaseName(signature.substring(0, i));
                     parameterStart = i + 1;
                     inFieldName = true;
                 }
@@ -223,7 +231,7 @@ public class TypeSignature
                 if (bracketCount == 0) {
                     verify(baseName == null, "Expected baseName to be null");
                     verify(parameterStart == -1, "Expected parameter start to be -1");
-                    baseName = signature.substring(0, i);
+                    baseName = canonicalizeBaseName(signature.substring(0, i));
                     parameterStart = i + 1;
                 }
                 bracketCount++;
@@ -257,7 +265,7 @@ public class TypeSignature
                     if (baseName == null) {
                         verify(parameters.isEmpty(), "Expected no parameters");
                         verify(parameterStart == -1, "Expected parameter start to be -1");
-                        baseName = signature.substring(0, i);
+                        baseName = canonicalizeBaseName(signature.substring(0, i));
                     }
                     parameterStart = i + 1;
                 }
@@ -383,6 +391,15 @@ public class TypeSignature
     private static boolean validateName(String name)
     {
         return name.chars().noneMatch(c -> c == '<' || c == '>' || c == ',');
+    }
+
+    private static String canonicalizeBaseName(String baseName)
+    {
+        String canonicalBaseName = baseNameAliasToCanonical.get(baseName.toLowerCase());
+        if (canonicalBaseName == null) {
+            return baseName;
+        }
+        return canonicalBaseName;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -37,10 +37,11 @@ public class TypeSignature
     private final List<TypeSignatureParameter> parameters;
     private final boolean calculated;
 
-    private static final Map<String, String> baseNameAliasToCanonical = new TreeMap<String, String>();
+    private static final Map<String, String> BASE_NAME_ALIAS_TO_CANONICAL =
+            new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
 
     static {
-        baseNameAliasToCanonical.put("int", StandardTypes.INTEGER);
+        BASE_NAME_ALIAS_TO_CANONICAL.put("int", StandardTypes.INTEGER);
     }
 
     public TypeSignature(String base, TypeSignatureParameter... parameters)
@@ -395,7 +396,7 @@ public class TypeSignature
 
     private static String canonicalizeBaseName(String baseName)
     {
-        String canonicalBaseName = baseNameAliasToCanonical.get(baseName.toLowerCase());
+        String canonicalBaseName = BASE_NAME_ALIAS_TO_CANONICAL.get(baseName);
         if (canonicalBaseName == null) {
             return baseName;
         }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -51,7 +51,7 @@ public class TestTypeSignature
         assertRowSignature(
                 "row(a bigint,b varchar)",
                 rowSignature(namedParameter("a", signature("bigint")), namedParameter("b", varchar())));
-        assertEquals(parseTypeSignature("row(col int)"), parseTypeSignature("row(col integer)"));
+        assertEquals(parseTypeSignature("row(col iNt)"), parseTypeSignature("row(col integer)"));
         assertRowSignature(
                 "ROW(a bigint,b varchar)",
                 "ROW",
@@ -79,7 +79,7 @@ public class TestTypeSignature
                 "row(a decimal(p1,s1),b decimal(p2,s2))",
                 ImmutableSet.of("p1", "s1", "p2", "s2"),
                 rowSignature(namedParameter("a", decimal("p1", "s1")), namedParameter("b", decimal("p2", "s2"))));
-        assertEquals(parseTypeSignature("row(a int(p1))"), parseTypeSignature("row(a integer(p1))"));
+        assertEquals(parseTypeSignature("row(a Int(p1))"), parseTypeSignature("row(a integer(p1))"));
 
         // TODO: remove the following tests when the old style row type has been completely dropped
         assertOldRowSignature(
@@ -99,7 +99,7 @@ public class TestTypeSignature
         assertOldRowSignature(
                 "array(row<bigint,double>('col0','col1'))",
                 array(rowSignature(namedParameter("col0", signature("bigint")), namedParameter("col1", signature("double")))));
-        assertEquals(parseTypeSignature("array(row<int>('col'))"), parseTypeSignature("array(row<integer>('col'))"));
+        assertEquals(parseTypeSignature("array(row<inT>('col'))"), parseTypeSignature("array(row<integer>('col'))"));
         assertOldRowSignature(
                 "row<array(row<bigint,double>('col0','col1'))>('col0')",
                 rowSignature(namedParameter("col0", array(

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -35,7 +35,8 @@ import static org.testng.Assert.fail;
 public class TestTypeSignature
 {
     @Test
-    public void parseSignatureWithLiterals() throws Exception
+    public void parseSignatureWithLiterals()
+            throws Exception
     {
         TypeSignature result = parseTypeSignature("decimal(X,42)", ImmutableSet.of("X"));
         assertEquals(result.getParameters().size(), 2);
@@ -50,6 +51,7 @@ public class TestTypeSignature
         assertRowSignature(
                 "row(a bigint,b varchar)",
                 rowSignature(namedParameter("a", signature("bigint")), namedParameter("b", varchar())));
+        assertEquals(parseTypeSignature("row(col int)"), parseTypeSignature("row(col integer)"));
         assertRowSignature(
                 "ROW(a bigint,b varchar)",
                 "ROW",
@@ -77,6 +79,7 @@ public class TestTypeSignature
                 "row(a decimal(p1,s1),b decimal(p2,s2))",
                 ImmutableSet.of("p1", "s1", "p2", "s2"),
                 rowSignature(namedParameter("a", decimal("p1", "s1")), namedParameter("b", decimal("p2", "s2"))));
+        assertEquals(parseTypeSignature("row(a int(p1))"), parseTypeSignature("row(a integer(p1))"));
 
         // TODO: remove the following tests when the old style row type has been completely dropped
         assertOldRowSignature(
@@ -96,6 +99,7 @@ public class TestTypeSignature
         assertOldRowSignature(
                 "array(row<bigint,double>('col0','col1'))",
                 array(rowSignature(namedParameter("col0", signature("bigint")), namedParameter("col1", signature("double")))));
+        assertEquals(parseTypeSignature("array(row<int>('col'))"), parseTypeSignature("array(row<integer>('col'))"));
         assertOldRowSignature(
                 "row<array(row<bigint,double>('col0','col1'))>('col0')",
                 rowSignature(namedParameter("col0", array(
@@ -149,9 +153,13 @@ public class TestTypeSignature
         assertSignature("bigint", "bigint", ImmutableList.of());
         assertSignature("boolean", "boolean", ImmutableList.of());
         assertSignature("varchar", "varchar", ImmutableList.of(Integer.toString(VarcharType.UNBOUNDED_LENGTH)));
+        assertEquals(parseTypeSignature("int"), parseTypeSignature("integer"));
 
         assertSignature("array(bigint)", "array", ImmutableList.of("bigint"));
+        assertEquals(parseTypeSignature("array(int)"), parseTypeSignature("array(integer)"));
+
         assertSignature("array(array(bigint))", "array", ImmutableList.of("array(bigint)"));
+        assertEquals(parseTypeSignature("array(array(int))"), parseTypeSignature("array(array(integer))"));
         assertSignature(
                 "array(timestamp with time zone)",
                 "array",

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -298,11 +298,11 @@ public abstract class AbstractTestQueries
     public void testRowFieldAccessor()
     {
         //Dereference only
-        assertQuery("SELECT a.col0 FROM (VALUES ROW (CAST(ROW(1, 2) AS ROW(col0 integer, col1 integer)))) AS t (a)", "SELECT 1");
+        assertQuery("SELECT a.col0 FROM (VALUES ROW (CAST(ROW(1, 2) AS ROW(col0 integer, col1 int)))) AS t (a)", "SELECT 1");
         assertQuery("SELECT a.col0 FROM (VALUES ROW (CAST(ROW(1.0, 2.0) AS ROW(col0 integer, col1 integer)))) AS t (a)", "SELECT 1.0");
         assertQuery("SELECT a.col0 FROM (VALUES ROW (CAST(ROW(TRUE, FALSE) AS ROW(col0 boolean, col1 boolean)))) AS t (a)", "SELECT TRUE");
         assertQuery("SELECT a.col1 FROM (VALUES ROW (CAST(ROW(1.0, 'kittens') AS ROW(col0 varchar, col1 varchar)))) AS t (a)", "SELECT 'kittens'");
-        assertQuery("SELECT a.col2.col1 FROM (VALUES ROW(CAST(ROW(1.0, ARRAY[2], row(3, 4.0)) AS ROW(col0 double, col1 array(integer), col2 row(col0 integer, col1 double))))) t(a)", "SELECT 4.0");
+        assertQuery("SELECT a.col2.col1 FROM (VALUES ROW(CAST(ROW(1.0, ARRAY[2], row(3, 4.0)) AS ROW(col0 double, col1 array(int), col2 row(col0 integer, col1 double))))) t(a)", "SELECT 4.0");
 
         // mixture of row field reference and table field reference
         assertQuery("SELECT cast(row(1, t.x) as row(col0 bigint, col1 bigint)).col1 FROM (VALUES 1, 2, 3) t(x)", "SELECT * FROM (VALUES 1, 2, 3)");


### PR DESCRIPTION
Many other databases support INT as an alias for INTEGER, including Oracle, Postgres, and MSSQL.

This patch changes the query parser and the types doc page.  Are there other places in the system that would need changing as well?

Also, the patch doesn't use ImmutableMap because presto-spi, according to the pom.xml, is trying to minimize library use and doesn't pull it in.