### PR TITLE
Cassandra intermittent failures

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
@@ -156,6 +156,10 @@ public class CassandraClientModule
             ));
         }
 
-        return new NativeCassandraSession(connectorId.toString(), extraColumnMetadataCodec, clusterBuilder.build(), config.getNoHostAvailableRetryTimeout());
+        return new NativeCassandraSession(
+                connectorId.toString(),
+                extraColumnMetadataCodec,
+                new ReopeningCluster(clusterBuilder::build),
+                config.getNoHostAvailableRetryTimeout());
     }
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSession.java
@@ -51,5 +51,7 @@ public interface CassandraSession
 
     ResultSet execute(String cql, Object... values);
 
+    List<SizeEstimate> getSizeEstimates(String keyspaceName, String tableName);
+
     ResultSet execute(Statement statement);
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/ReopeningCluster.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/ReopeningCluster.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cassandra;
+
+import com.datastax.driver.core.CloseFuture;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.DelegatingCluster;
+import io.airlift.log.Logger;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class ReopeningCluster
+        extends DelegatingCluster
+{
+    private static final Logger log = Logger.get(ReopeningCluster.class);
+
+    @GuardedBy("this")
+    private Cluster delegate;
+    @GuardedBy("this")
+    private boolean closed;
+
+    private final Supplier<Cluster> supplier;
+
+    public ReopeningCluster(Supplier<Cluster> supplier)
+    {
+        this.supplier = requireNonNull(supplier, "supplier is null");
+    }
+
+    @Override
+    protected synchronized Cluster delegate()
+    {
+        checkState(!closed, "Cluster has been closed");
+
+        if (delegate == null) {
+            delegate = supplier.get();
+        }
+
+        if (delegate.isClosed()) {
+            log.warn("Cluster has been closed internally");
+            delegate = supplier.get();
+        }
+
+        verify(!delegate.isClosed(), "Newly created cluster has been immediately closed");
+
+        return delegate;
+    }
+
+    @Override
+    public synchronized void close()
+    {
+        closed = true;
+        if (delegate != null) {
+            delegate.close();
+            delegate = null;
+        }
+    }
+
+    @Override
+    public synchronized boolean isClosed()
+    {
+        return closed;
+    }
+
+    @Override
+    public synchronized CloseFuture closeAsync()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/SizeEstimate.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/SizeEstimate.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cassandra;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class SizeEstimate
+{
+    private final String rangeStart;
+    private final String rangeEnd;
+    private final long meanPartitionSize;
+    private final long partitionsCount;
+
+    public SizeEstimate(String rangeStart, String rangeEnd, long meanPartitionSize, long partitionsCount)
+    {
+        this.rangeStart = requireNonNull(rangeStart, "rangeStart is null");
+        this.rangeEnd = requireNonNull(rangeEnd, "rangeEnd is null");
+        this.meanPartitionSize = meanPartitionSize;
+        this.partitionsCount = partitionsCount;
+    }
+
+    public String getRangeStart()
+    {
+        return rangeStart;
+    }
+
+    public String getRangeEnd()
+    {
+        return rangeEnd;
+    }
+
+    public long getMeanPartitionSize()
+    {
+        return meanPartitionSize;
+    }
+
+    public long getPartitionsCount()
+    {
+        return partitionsCount;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SizeEstimate that = (SizeEstimate) o;
+        return meanPartitionSize == that.meanPartitionSize &&
+                partitionsCount == that.partitionsCount &&
+                Objects.equals(rangeStart, that.rangeStart) &&
+                Objects.equals(rangeEnd, that.rangeEnd);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(rangeStart, rangeEnd, meanPartitionSize, partitionsCount);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("rangeStart", rangeStart)
+                .add("rangeEnd", rangeEnd)
+                .add("meanPartitionSize", meanPartitionSize)
+                .add("partitionsCount", partitionsCount)
+                .toString();
+    }
+}

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraQueryRunner.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraQueryRunner.java
@@ -55,9 +55,8 @@ public final class CassandraQueryRunner
             List<TpchTable<?>> tables = TpchTable.getTables();
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createCassandraSession("tpch"), tables);
             for (TpchTable table : tables) {
-                EmbeddedCassandra.flush("tpch", table.getTableName());
+                EmbeddedCassandra.refreshSizeEstimates("tpch", table.getTableName());
             }
-            EmbeddedCassandra.refreshSizeEstimates();
             tpchLoaded = true;
         }
 

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/EmbeddedCassandra.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/EmbeddedCassandra.java
@@ -148,7 +148,14 @@ public final class EmbeddedCassandra
         log.info("Cassandra version: %s", version);
     }
 
-    public static void flush(String keyspace, String table)
+    public static void refreshSizeEstimates(String keyspace, String table)
+            throws Exception
+    {
+        flushTable(keyspace, table);
+        refreshSizeEstimates();
+    }
+
+    private static void flushTable(String keyspace, String table)
             throws Exception
     {
         ManagementFactory
@@ -160,7 +167,7 @@ public final class EmbeddedCassandra
                         new String[] {"java.lang.String", "[Ljava.lang.String;"});
     }
 
-    public static void refreshSizeEstimates()
+    private static void refreshSizeEstimates()
             throws Exception
     {
         ManagementFactory

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraTokenSplitManager.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraTokenSplitManager.java
@@ -49,8 +49,7 @@ public class TestCassandraTokenSplitManager
         createKeyspace(session, KEYSPACE);
         session.execute(format("CREATE TABLE %s.%s (key text PRIMARY KEY)", KEYSPACE, TABLE));
 
-        EmbeddedCassandra.flush(KEYSPACE, TABLE);
-        EmbeddedCassandra.refreshSizeEstimates();
+        EmbeddedCassandra.refreshSizeEstimates(KEYSPACE, TABLE);
 
         List<TokenSplit> splits = splitManager.getSplits(KEYSPACE, TABLE);
         // even for the empty table at least one split must be produced, in case the statistics are inaccurate
@@ -59,8 +58,8 @@ public class TestCassandraTokenSplitManager
         for (int i = 0; i < PARTITION_COUNT; i++) {
             session.execute(format("INSERT INTO %s.%s (key) VALUES ('%s')", KEYSPACE, TABLE, "value" + i));
         }
-        EmbeddedCassandra.flush(KEYSPACE, TABLE);
-        EmbeddedCassandra.refreshSizeEstimates();
+
+        EmbeddedCassandra.refreshSizeEstimates(KEYSPACE, TABLE);
 
         splits = splitManager.getSplits(KEYSPACE, TABLE);
         assertEquals(splits.size(), PARTITION_COUNT / SPLIT_SIZE);

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraTokenSplitManager.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraTokenSplitManager.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.cassandra;
 
 import com.facebook.presto.cassandra.CassandraTokenSplitManager.TokenSplit;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -27,41 +27,46 @@ public class TestCassandraTokenSplitManager
 {
     private static final int SPLIT_SIZE = 100;
     private static final String KEYSPACE = "test_cassandra_token_split_manager_keyspace";
-    private static final String TABLE = "test_cassandra_token_split_manager_table";
     private static final int PARTITION_COUNT = 1000;
 
     private CassandraSession session;
     private CassandraTokenSplitManager splitManager;
 
-    @BeforeMethod
+    @BeforeClass
     public void setUp()
             throws Exception
     {
         EmbeddedCassandra.start();
         session = EmbeddedCassandra.getSession();
+        createKeyspace(session, KEYSPACE);
         splitManager = new CassandraTokenSplitManager(session, SPLIT_SIZE);
     }
 
     @Test
-    public void testCassandraTokenSplitManager()
+    public void testEmptyTable()
             throws Exception
     {
-        createKeyspace(session, KEYSPACE);
-        session.execute(format("CREATE TABLE %s.%s (key text PRIMARY KEY)", KEYSPACE, TABLE));
-
-        EmbeddedCassandra.refreshSizeEstimates(KEYSPACE, TABLE);
-
-        List<TokenSplit> splits = splitManager.getSplits(KEYSPACE, TABLE);
+        String tableName = "empty_table";
+        session.execute(format("CREATE TABLE %s.%s (key text PRIMARY KEY)", KEYSPACE, tableName));
+        EmbeddedCassandra.refreshSizeEstimates(KEYSPACE, tableName);
+        List<TokenSplit> splits = splitManager.getSplits(KEYSPACE, tableName);
         // even for the empty table at least one split must be produced, in case the statistics are inaccurate
         assertEquals(splits.size(), 1);
+        session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));
+    }
 
+    @Test
+    public void testNonEmptyTable()
+            throws Exception
+    {
+        String tableName = "non_empty_table";
+        session.execute(format("CREATE TABLE %s.%s (key text PRIMARY KEY)", KEYSPACE, tableName));
         for (int i = 0; i < PARTITION_COUNT; i++) {
-            session.execute(format("INSERT INTO %s.%s (key) VALUES ('%s')", KEYSPACE, TABLE, "value" + i));
+            session.execute(format("INSERT INTO %s.%s (key) VALUES ('%s')", KEYSPACE, tableName, "value" + i));
         }
-
-        EmbeddedCassandra.refreshSizeEstimates(KEYSPACE, TABLE);
-
-        splits = splitManager.getSplits(KEYSPACE, TABLE);
+        EmbeddedCassandra.refreshSizeEstimates(KEYSPACE, tableName);
+        List<TokenSplit> splits = splitManager.getSplits(KEYSPACE, tableName);
         assertEquals(splits.size(), PARTITION_COUNT / SPLIT_SIZE);
+        session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));
     }
 }


### PR DESCRIPTION
Fixes the failure when table statistics are not yet refreshed when generating splits.

Fixes the failure when NoHostAvailableException is thrown during the session creation. In such case cluster become closed, and must be reopened.