### PR TITLE
Fix a bug where the Kafka connector metadata class would throw an exception on null (wildcard) table name

### DIFF
--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
@@ -110,6 +110,15 @@ public class KafkaMetadata
         return getTableMetadata(convertTableHandle(tableHandle).toSchemaTableName());
     }
 
+    private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        if (prefix.getSchemaName() == null || prefix.getTableName() == null) {
+            return listTables(session, prefix.getSchemaName());
+        }
+
+        return ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+    }
+
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, String schemaNameOrNull)
     {
@@ -171,7 +180,7 @@ public class KafkaMetadata
 
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
 
-        List<SchemaTableName> tableNames = prefix.getSchemaName() == null ? listTables(session, null) : ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        List<SchemaTableName> tableNames = listTables(session, prefix);
 
         for (SchemaTableName tableName : tableNames) {
             ConnectorTableMetadata tableMetadata = getTableMetadata(tableName);

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
@@ -15,6 +15,7 @@ package com.facebook.presto.kafka;
 
 import com.facebook.presto.kafka.util.EmbeddedKafka;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -39,6 +40,14 @@ public class TestKafkaIntegrationSmokeTest
     {
         super(() -> createKafkaQueryRunner(embeddedKafka, ORDERS));
         this.embeddedKafka = embeddedKafka;
+    }
+
+    @Test
+    public void testKafkaEngineWillNotFailMetaQuery()
+    {
+        getQueryRunner().createCatalog("kafka", "kafka", ImmutableMap.of());
+
+        assertQuery("SELECT * FROM system.jdbc.columns WHERE TABLE_CAT = 'kafka' AND TABLE_NAME LIKE '%'");
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -15,6 +15,8 @@ package com.facebook.presto.tests;
 
 import com.facebook.presto.testing.MaterializedResult;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -147,6 +149,14 @@ public abstract class AbstractTestIntegrationSmokeTest
                 "line 1:31: Column name 'A' specified more than once");
         assertQueryFails("CREATE TABLE test (a integer, OrderKey integer, LIKE orders INCLUDING PROPERTIES)",
                 "line 1:49: Column name 'orderkey' specified more than once");
+    }
+
+    @Test
+    public void testKafkaEngineWillNotFailMetaQuery()
+    {
+        getQueryRunner().createCatalog("kafka", "kafka", ImmutableMap.of());
+
+        assertQuery("SELECT * FROM system.jdbc.columns WHERE TABLE_CAT = 'kafka' AND TABLE_NAME LIKE '%'");
     }
 
     private MaterializedResult getExpectedTableDescription(boolean dateSupported, boolean parametrizedVarchar)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -151,14 +151,6 @@ public abstract class AbstractTestIntegrationSmokeTest
                 "line 1:49: Column name 'orderkey' specified more than once");
     }
 
-    @Test
-    public void testKafkaEngineWillNotFailMetaQuery()
-    {
-        getQueryRunner().createCatalog("kafka", "kafka", ImmutableMap.of());
-
-        assertQuery("SELECT * FROM system.jdbc.columns WHERE TABLE_CAT = 'kafka' AND TABLE_NAME LIKE '%'");
-    }
-
     private MaterializedResult getExpectedTableDescription(boolean dateSupported, boolean parametrizedVarchar)
     {
         String orderDateType;


### PR DESCRIPTION
It is common for JDBC clients (such as JetBrains' [DataGrip](https://www.jetbrains.com/datagrip/)) to make metadata queries that discovery the tables and columns in a schema.

This pull request addresses an issue with a specific type of query where the Kafka connector is requested to show all the tables or columns in a specific schema. An example is as follows:

```
SELECT TABLE_CAT, TABLE_SCHEM, TABLE_NAME, COLUMN_NAME, DATA_TYPE,
  TYPE_NAME, COLUMN_SIZE, BUFFER_LENGTH, DECIMAL_DIGITS, NUM_PREC_RADIX,
  NULLABLE, REMARKS, COLUMN_DEF, SQL_DATA_TYPE, SQL_DATETIME_SUB,
  CHAR_OCTET_LENGTH, ORDINAL_POSITION, IS_NULLABLE,
  SCOPE_CATALOG, SCOPE_SCHEMA, SCOPE_TABLE,
  SOURCE_DATA_TYPE, IS_AUTOINCREMENT, IS_GENERATEDCOLUMN
FROM system.jdbc.columns

WHERE TABLE_CAT = 'kafka' AND TABLE_SCHEM LIKE 'blah' AND TABLE_NAME LIKE '%' AND COLUMN_NAME LIKE '%'
ORDER BY TABLE_CAT, TABLE_SCHEM, TABLE_NAME, ORDINAL_POSITION
```

Assuming the `kafka` catalog uses the kafka connector, on current master this causes the following exception:

```
java.lang.NullPointerException: tableName is null
	at com.facebook.presto.spi.SchemaUtil.checkNotEmpty(SchemaUtil.java:25)
	at com.facebook.presto.spi.SchemaTableName.<init>(SchemaTableName.java:43)
	at com.facebook.presto.kafka.KafkaMetadata.listTableColumns(KafkaMetadata.java:174)
	at com.facebook.presto.metadata.MetadataManager.listTableColumns(MetadataManager.java:397)
	at com.facebook.presto.connector.system.jdbc.ColumnJdbcTable.cursor(ColumnJdbcTable.java:125)
	at com.facebook.presto.connector.system.SystemPageSourceProvider$1.cursor(SystemPageSourceProvider.java:126)
	at com.facebook.presto.split.MappedRecordSet.cursor(MappedRecordSet.java:53)
	at com.facebook.presto.spi.RecordPageSource.<init>(RecordPageSource.java:37)
	at com.facebook.presto.connector.system.SystemPageSourceProvider.createPageSource(SystemPageSourceProvider.java:105)
	at com.facebook.presto.split.PageSourceManager.createPageSource(PageSourceManager.java:56)
	at com.facebook.presto.operator.ScanFilterAndProjectOperator.getOutput(ScanFilterAndProjectOperator.java:222)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:378)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:301)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:622)
	at com.facebook.presto.execution.TaskExecutor$PrioritizedSplitRunner.process(TaskExecutor.java:555)
	at com.facebook.presto.execution.TaskExecutor$Runner.run(TaskExecutor.java:691)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

This pull request makes the Kafka connector metadata code have better null checks, modelled after the usage from the Hive connector.