### PR TITLE
Split splittable LZO

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -177,6 +177,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.anarres.lzo</groupId>
+            <artifactId>lzo-hadoop</artifactId>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -244,12 +249,6 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.anarres.lzo</groupId>
-            <artifactId>lzo-hadoop</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
 import com.google.common.io.CharStreams;
+import com.hadoop.compression.lzo.LzoIndex;
 import io.airlift.units.DataSize;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
@@ -52,6 +53,7 @@ import java.lang.annotation.Annotation;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
@@ -75,6 +77,9 @@ import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitS
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxSplitSize;
 import static com.facebook.presto.hive.HiveUtil.checkCondition;
 import static com.facebook.presto.hive.HiveUtil.getInputFormat;
+import static com.facebook.presto.hive.HiveUtil.getLzopIndexPath;
+import static com.facebook.presto.hive.HiveUtil.isLzopCompressedFile;
+import static com.facebook.presto.hive.HiveUtil.isLzopIndexFile;
 import static com.facebook.presto.hive.HiveUtil.isSplittable;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveSchema;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -503,6 +508,11 @@ public class BackgroundHiveSplitLoader
             Map<Integer, HiveType> columnCoercions)
             throws IOException
     {
+        Path filePath = new Path(path);
+        if (isLzopIndexFile(filePath)) {
+            return Collections.<HiveSplit>emptyIterator();
+        }
+
         boolean forceLocalScheduling = HiveSessionProperties.isForceLocalScheduling(session);
 
         if (splittable) {
@@ -510,6 +520,9 @@ public class BackgroundHiveSplitLoader
 
             return new AbstractIterator<HiveSplit>() {
                 private long chunkOffset = 0;
+                private LzoIndex index = isLzopCompressedFile(filePath) ?
+                    LzoIndex.readIndex(hdfsEnvironment.getFileSystem(session.getUser(), getLzopIndexPath(filePath)), filePath) :
+                    null;
 
                 @Override
                 protected HiveSplit computeNext()
@@ -540,6 +553,17 @@ public class BackgroundHiveSplitLoader
                     // adjust the actual chunk size to account for the overrun when chunks are slightly bigger than necessary (see above)
                     long chunkLength = Math.min(targetChunkSize, blockLocation.getLength() - chunkOffset);
 
+                    // align the end point to the indexed point for lzo compressed file
+                    if (isLzopCompressedFile(filePath)) {
+                        long offset = blockLocation.getOffset() + chunkOffset;
+                        if (index.isEmpty()) {
+                            chunkLength = length - offset;
+                        }
+                        else {
+                            chunkLength = index.alignSliceEndToIndex(offset + chunkLength, length) - offset;
+                        }
+                    }
+
                     HiveSplit result = new HiveSplit(
                             connectorId,
                             table.getDatabaseName(),
@@ -558,10 +582,16 @@ public class BackgroundHiveSplitLoader
 
                     chunkOffset += chunkLength;
 
-                    if (chunkOffset >= blockLocation.getLength()) {
-                        checkState(chunkOffset == blockLocation.getLength(), "Error splitting blocks");
+                    while (chunkOffset >= blockLocation.getLength()) {
+                        // allow overrun for lzo compressed file for intermediate blocks
+                        if (!isLzopCompressedFile(filePath) || blockLocation.getOffset() + blockLocation.getLength() >= length) {
+                            checkState(chunkOffset == blockLocation.getLength(), "Error splitting blocks");
+                        }
                         blockLocationIterator.next();
-                        chunkOffset = 0;
+                        chunkOffset -= blockLocation.getLength();
+                        if (chunkOffset > 0) {
+                            blockLocation = blockLocationIterator.peek();
+                        }
                     }
 
                     return result;


### PR DESCRIPTION
We have merged PR #7588 to support Lzo/Lzop codec for LZO text files(#7348) in master. This PR addresses the splitting of splittable LZO. This is also a part of supporting Thrift data(#7422) because the Thrift data in Twitter are compressed by Lzop compressor and most of them are indexed. 