### PR TITLE
Make PlanVisitor type param order same as AstVisitor's (<R, C>)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CoefficientBasedCostCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CoefficientBasedCostCalculator.java
@@ -82,7 +82,7 @@ public class CoefficientBasedCostCalculator
     }
 
     private class Visitor
-            extends PlanVisitor<Void, PlanNodeCost>
+            extends PlanVisitor<PlanNodeCost, Void>
     {
         private final Session session;
         private final Map<PlanNodeId, PlanNodeCost> costs;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/PhasedExecutionSchedule.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/PhasedExecutionSchedule.java
@@ -169,7 +169,7 @@ public class PhasedExecutionSchedule
     }
 
     private static class Visitor
-            extends PlanVisitor<PlanFragmentId, Set<PlanFragmentId>>
+            extends PlanVisitor<Set<PlanFragmentId>, PlanFragmentId>
     {
         private final Map<PlanFragmentId, PlanFragment> fragments;
         private final DirectedGraph<PlanFragmentId, DefaultEdge> graph;

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageFieldsToInputParametersRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageFieldsToInputParametersRewriter.java
@@ -47,7 +47,7 @@ public final class PageFieldsToInputParametersRewriter
     }
 
     private static class Visitor
-            implements RowExpressionVisitor<Void, RowExpression>
+            implements RowExpressionVisitor<RowExpression, Void>
     {
         private final Map<Integer, Integer> fieldToParameter = new HashMap<>();
         private final List<Integer> inputChannels = new ArrayList<>();

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeExpressionVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeExpressionVisitor.java
@@ -46,18 +46,18 @@ import static com.facebook.presto.sql.relational.Signatures.TRY;
 import static com.google.common.base.Preconditions.checkState;
 
 public class BytecodeExpressionVisitor
-        implements RowExpressionVisitor<Scope, BytecodeNode>
+        implements RowExpressionVisitor<BytecodeNode, Scope>
 {
     private final CallSiteBinder callSiteBinder;
     private final CachedInstanceBinder cachedInstanceBinder;
-    private final RowExpressionVisitor<Scope, BytecodeNode> fieldReferenceCompiler;
+    private final RowExpressionVisitor<BytecodeNode, Scope> fieldReferenceCompiler;
     private final FunctionRegistry registry;
     private final PreGeneratedExpressions preGeneratedExpressions;
 
     public BytecodeExpressionVisitor(
             CallSiteBinder callSiteBinder,
             CachedInstanceBinder cachedInstanceBinder,
-            RowExpressionVisitor<Scope, BytecodeNode> fieldReferenceCompiler,
+            RowExpressionVisitor<BytecodeNode, Scope> fieldReferenceCompiler,
             FunctionRegistry registry,
             PreGeneratedExpressions preGeneratedExpressions)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CursorProcessorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CursorProcessorCompiler.java
@@ -336,9 +336,9 @@ public class CursorProcessorCompiler
                 .ret();
     }
 
-    private static RowExpressionVisitor<Scope, BytecodeNode> fieldReferenceCompiler(Variable cursorVariable)
+    private static RowExpressionVisitor<BytecodeNode, Scope> fieldReferenceCompiler(Variable cursorVariable)
     {
-        return new RowExpressionVisitor<Scope, BytecodeNode>()
+        return new RowExpressionVisitor<BytecodeNode, Scope>()
         {
             @Override
             public BytecodeNode visitInputReference(InputReferenceExpression node, Scope scope)

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/InputReferenceCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/InputReferenceCompiler.java
@@ -34,7 +34,7 @@ import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType
 import static java.util.Objects.requireNonNull;
 
 class InputReferenceCompiler
-        implements RowExpressionVisitor<Scope, BytecodeNode>
+        implements RowExpressionVisitor<BytecodeNode, Scope>
 {
     private final BiFunction<Scope, Integer, BytecodeExpression> blockResolver;
     private final BiFunction<Scope, Integer, BytecodeExpression> positionResolver;

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
@@ -318,7 +318,7 @@ public class JoinFilterFunctionCompiler
         }
     }
 
-    private static RowExpressionVisitor<Scope, BytecodeNode> fieldReferenceCompiler(
+    private static RowExpressionVisitor<BytecodeNode, Scope> fieldReferenceCompiler(
             final CallSiteBinder callSiteBinder,
             final Variable leftPosition,
             final Variable leftBlocks,

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/LambdaAndTryExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/LambdaAndTryExpressionExtractor.java
@@ -44,7 +44,7 @@ public class LambdaAndTryExpressionExtractor
     }
 
     private static class Visitor
-            implements RowExpressionVisitor<Context, Void>
+            implements RowExpressionVisitor<Void, Context>
     {
         private final ImmutableList.Builder<RowExpression> lambdaAndTryExpressions = ImmutableList.builder();
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/LambdaBytecodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/LambdaBytecodeGenerator.java
@@ -143,9 +143,9 @@ public class LambdaBytecodeGenerator
         return new LambdaExpressionField(staticField, instanceField);
     }
 
-    private static RowExpressionVisitor<Scope, BytecodeNode> variableReferenceCompiler(Map<String, ParameterAndType> parameterMap)
+    private static RowExpressionVisitor<BytecodeNode, Scope> variableReferenceCompiler(Map<String, ParameterAndType> parameterMap)
     {
-        return new RowExpressionVisitor<Scope, BytecodeNode>()
+        return new RowExpressionVisitor<BytecodeNode, Scope>()
         {
             @Override
             public BytecodeNode visitInputReference(InputReferenceExpression node, Scope scope)

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -580,7 +580,7 @@ public class PageFunctionCompiler
         return parameters.build();
     }
 
-    private static RowExpressionVisitor<Scope, BytecodeNode> fieldReferenceCompiler(CallSiteBinder callSiteBinder)
+    private static RowExpressionVisitor<BytecodeNode, Scope> fieldReferenceCompiler(CallSiteBinder callSiteBinder)
     {
         return new InputReferenceCompiler(
                 (scope, field) -> scope.getVariable("block_" + field),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DistributedExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DistributedExecutionPlanner.java
@@ -117,7 +117,7 @@ public class DistributedExecutionPlanner
     }
 
     private final class Visitor
-            extends PlanVisitor<Void, Map<PlanNodeId, SplitSource>>
+            extends PlanVisitor<Map<PlanNodeId, SplitSource>, Void>
     {
         private final Session session;
         private final List<SplitSource> splitSources = new ArrayList<>();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -67,7 +67,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
  * Note: non-deterministic predicates can not be pulled up (so they will be ignored)
  */
 public class EffectivePredicateExtractor
-        extends PlanVisitor<Void, Expression>
+        extends PlanVisitor<Expression, Void>
 {
     public static Expression extract(PlanNode node, Map<Symbol, Type> symbolTypes)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/FragmentTableScanCounter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/FragmentTableScanCounter.java
@@ -49,7 +49,7 @@ public final class FragmentTableScanCounter
     }
 
     private static class Visitor
-            extends PlanVisitor<Void, Integer>
+            extends PlanVisitor<Integer, Void>
     {
         @Override
         public Integer visitTableScan(TableScanNode node, Void context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -574,7 +574,7 @@ public class LocalExecutionPlanner
     }
 
     private class Visitor
-            extends PlanVisitor<LocalExecutionPlanContext, PhysicalOperation>
+            extends PlanVisitor<PhysicalOperation, LocalExecutionPlanContext>
     {
         private final Session session;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -363,7 +363,7 @@ public class PlanFragmenter
     }
 
     private static class SchedulingOrderVisitor
-            extends PlanVisitor<Consumer<PlanNodeId>, Void>
+            extends PlanVisitor<Void, Consumer<PlanNodeId>>
     {
         public List<PlanNodeId> getSchedulingOrder(PlanNode node)
         {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SimplePlanVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SimplePlanVisitor.java
@@ -17,7 +17,7 @@ import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
 
 public class SimplePlanVisitor<C>
-        extends PlanVisitor<C, Void>
+        extends PlanVisitor<Void, C>
 {
     @Override
     protected Void visitPlan(PlanNode node, C context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/GroupReference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/GroupReference.java
@@ -48,7 +48,7 @@ public class GroupReference
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitGroupReference(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -181,7 +181,7 @@ public class AddExchanges
     }
 
     private class Rewriter
-            extends PlanVisitor<Context, PlanWithProperties>
+            extends PlanVisitor<PlanWithProperties, Context>
     {
         private final PlanNodeIdAllocator idAllocator;
         private final SymbolAllocator symbolAllocator;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -104,7 +104,7 @@ public class AddLocalExchanges
     }
 
     private class Rewriter
-            extends PlanVisitor<StreamPreferredProperties, PlanWithProperties>
+            extends PlanVisitor<PlanWithProperties, StreamPreferredProperties>
     {
         private final PlanNodeIdAllocator idAllocator;
         private final Session session;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DistinctOutputQueryUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DistinctOutputQueryUtil.java
@@ -46,7 +46,7 @@ public final class DistinctOutputQueryUtil
     }
 
     private static final class IsDistinctPlanVisitor
-            extends PlanVisitor<Void, Boolean>
+            extends PlanVisitor<Boolean, Void>
     {
         /*
         With the iterative optimizer, plan nodes are replaced with

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
@@ -113,7 +113,7 @@ public class ExpressionEquivalence
     }
 
     private static class CanonicalizationVisitor
-            implements RowExpressionVisitor<Void, RowExpression>
+            implements RowExpressionVisitor<RowExpression, Void>
     {
         @Override
         public RowExpression visitCall(CallExpression call, Void context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -112,7 +112,7 @@ public class HashGenerationOptimizer
     }
 
     private static class Rewriter
-            extends PlanVisitor<HashComputationSet, PlanWithProperties>
+            extends PlanVisitor<PlanWithProperties, HashComputationSet>
     {
         private final PlanNodeIdAllocator idAllocator;
         private final SymbolAllocator symbolAllocator;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -469,7 +469,7 @@ public class IndexJoinOptimizer
         }
 
         private static class Visitor
-                extends PlanVisitor<Set<Symbol>, Map<Symbol, Symbol>>
+                extends PlanVisitor<Map<Symbol, Symbol>, Set<Symbol>>
         {
             @Override
             protected Map<Symbol, Symbol> visitPlan(PlanNode node, Set<Symbol> lookupSymbols)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -135,7 +135,7 @@ class PropertyDerivations
     }
 
     private static class Visitor
-            extends PlanVisitor<List<ActualProperties>, ActualProperties>
+            extends PlanVisitor<ActualProperties, List<ActualProperties>>
     {
         private final Metadata metadata;
         private final Session session;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarQueryUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarQueryUtil.java
@@ -46,7 +46,7 @@ public final class ScalarQueryUtil
     }
 
     private static final class IsScalarPlanVisitor
-            extends PlanVisitor<Void, Boolean>
+            extends PlanVisitor<Boolean, Void>
     {
         private final Optional<Lookup> lookup;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -135,7 +135,7 @@ final class StreamPropertyDerivations
     }
 
     private static class Visitor
-            extends PlanVisitor<List<StreamProperties>, StreamProperties>
+            extends PlanVisitor<StreamProperties, List<StreamProperties>>
     {
         private final Metadata metadata;
         private final Session session;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/joins/JoinGraph.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/joins/JoinGraph.java
@@ -217,7 +217,7 @@ public class JoinGraph
     }
 
     private static class Builder
-            extends PlanVisitor<Context, JoinGraph>
+            extends PlanVisitor<JoinGraph, Context>
     {
         // TODO When com.facebook.presto.sql.planner.optimizations.EliminateCrossJoins is removed, remove 'shallow' flag
         private final boolean shallow;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
@@ -273,7 +273,7 @@ public class AggregationNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitAggregation(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ApplyNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ApplyNode.java
@@ -140,7 +140,7 @@ public class ApplyNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitApply(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AssignUniqueId.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AssignUniqueId.java
@@ -69,7 +69,7 @@ public class AssignUniqueId
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitAssignUniqueId(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/DeleteNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/DeleteNode.java
@@ -83,7 +83,7 @@ public class DeleteNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitDelete(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/DistinctLimitNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/DistinctLimitNode.java
@@ -102,7 +102,7 @@ public class DistinctLimitNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitDistinctLimit(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/EnforceSingleRowNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/EnforceSingleRowNode.java
@@ -60,7 +60,7 @@ public class EnforceSingleRowNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitEnforceSingleRow(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExceptNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExceptNode.java
@@ -35,7 +35,7 @@ public class ExceptNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitExcept(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
@@ -190,7 +190,7 @@ public class ExchangeNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitExchange(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExplainAnalyzeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExplainAnalyzeNode.java
@@ -68,7 +68,7 @@ public class ExplainAnalyzeNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitExplainAnalyze(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/FilterNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/FilterNode.java
@@ -67,7 +67,7 @@ public class FilterNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitFilter(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/GroupIdNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/GroupIdNode.java
@@ -117,7 +117,7 @@ public class GroupIdNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitGroupId(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IndexJoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IndexJoinNode.java
@@ -126,7 +126,7 @@ public class IndexJoinNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitIndexJoin(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IndexSourceNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IndexSourceNode.java
@@ -119,7 +119,7 @@ public class IndexSourceNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitIndexSource(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IntersectNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IntersectNode.java
@@ -37,7 +37,7 @@ public class IntersectNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitIntersect(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -207,7 +207,7 @@ public class JoinNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitJoin(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/LimitNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/LimitNode.java
@@ -82,7 +82,7 @@ public class LimitNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitLimit(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/MarkDistinctNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/MarkDistinctNode.java
@@ -90,7 +90,7 @@ public class MarkDistinctNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitMarkDistinct(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/MetadataDeleteNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/MetadataDeleteNode.java
@@ -79,7 +79,7 @@ public class MetadataDeleteNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitMetadataDelete(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/OutputNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/OutputNode.java
@@ -77,7 +77,7 @@ public class OutputNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitOutput(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNode.java
@@ -83,7 +83,7 @@ public abstract class PlanNode
 
     public abstract PlanNode replaceChildren(List<PlanNode> newChildren);
 
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitPlan(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanRewriter.java
@@ -23,7 +23,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public abstract class PlanRewriter<C, P>
-        extends PlanVisitor<PlanRewriter.RewriteContext<C, P>, PlanRewriter.Result<P>>
+        extends PlanVisitor<PlanRewriter.Result<P>, PlanRewriter.RewriteContext<C, P>>
 {
     public static <C, P> Result<P> rewriteWith(PlanRewriter<C, P> rewriter, PlanNode node)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanVisitor.java
@@ -15,7 +15,7 @@ package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.sql.planner.iterative.GroupReference;
 
-public abstract class PlanVisitor<C, R>
+public abstract class PlanVisitor<R, C>
 {
     protected abstract R visitPlan(PlanNode node, C context);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ProjectNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ProjectNode.java
@@ -87,7 +87,7 @@ public class ProjectNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitProject(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RemoteSourceNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RemoteSourceNode.java
@@ -71,7 +71,7 @@ public class RemoteSourceNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitRemoteSource(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RowNumberNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RowNumberNode.java
@@ -104,7 +104,7 @@ public final class RowNumberNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitRowNumber(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SampleNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SampleNode.java
@@ -101,7 +101,7 @@ public class SampleNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitSample(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SemiJoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SemiJoinNode.java
@@ -134,7 +134,7 @@ public class SemiJoinNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitSemiJoin(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SimplePlanRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SimplePlanRewriter.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public abstract class SimplePlanRewriter<C>
-        extends PlanVisitor<SimplePlanRewriter.RewriteContext<C>, PlanNode>
+        extends PlanVisitor<PlanNode, SimplePlanRewriter.RewriteContext<C>>
 {
     public static <C> PlanNode rewriteWith(SimplePlanRewriter<C> rewriter, PlanNode node)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SortNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SortNode.java
@@ -83,7 +83,7 @@ public class SortNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitSort(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableFinishNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableFinishNode.java
@@ -76,7 +76,7 @@ public class TableFinishNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitTableFinish(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableScanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableScanNode.java
@@ -130,7 +130,7 @@ public class TableScanNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitTableScan(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
@@ -115,7 +115,7 @@ public class TableWriterNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitTableWriter(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TopNNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TopNNode.java
@@ -114,7 +114,7 @@ public class TopNNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitTopN(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TopNRowNumberNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TopNRowNumberNode.java
@@ -135,7 +135,7 @@ public final class TopNRowNumberNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitTopNRowNumber(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/UnionNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/UnionNode.java
@@ -37,7 +37,7 @@ public class UnionNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitUnion(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/UnnestNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/UnnestNode.java
@@ -101,7 +101,7 @@ public class UnnestNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitUnnest(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ValuesNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ValuesNode.java
@@ -67,7 +67,7 @@ public class ValuesNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitValues(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
@@ -154,7 +154,7 @@ public class WindowNode
     }
 
     @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitWindow(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -448,7 +448,7 @@ public class PlanPrinter
     }
 
     private class Visitor
-            extends PlanVisitor<Integer, Void>
+            extends PlanVisitor<Void, Integer>
     {
         private final Map<Symbol, Type> types;
         private final Map<PlanNodeId, PlanNodeCost> costs;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -90,7 +90,7 @@ public final class ValidateDependenciesChecker
     }
 
     private static class Visitor
-            extends PlanVisitor<Set<Symbol>, Void>
+            extends PlanVisitor<Void, Set<Symbol>>
     {
         @Override
         protected Void visitPlan(PlanNode node, Set<Symbol> boundSymbols)

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/CallExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/CallExpression.java
@@ -83,7 +83,7 @@ public final class CallExpression
     }
 
     @Override
-    public <C, R> R accept(RowExpressionVisitor<C, R> visitor, C context)
+    public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
     {
         return visitor.visitCall(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/ConstantExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/ConstantExpression.java
@@ -70,7 +70,7 @@ public final class ConstantExpression
     }
 
     @Override
-    public <C, R> R accept(RowExpressionVisitor<C, R> visitor, C context)
+    public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
     {
         return visitor.visitConstant(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/DeterminismEvaluator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/DeterminismEvaluator.java
@@ -33,7 +33,7 @@ public class DeterminismEvaluator
     }
 
     private static class Visitor
-            implements RowExpressionVisitor<Void, Boolean>
+            implements RowExpressionVisitor<Boolean, Void>
     {
         private final FunctionRegistry registry;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/InputReferenceExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/InputReferenceExpression.java
@@ -60,7 +60,7 @@ public final class InputReferenceExpression
     }
 
     @Override
-    public <C, R> R accept(RowExpressionVisitor<C, R> visitor, C context)
+    public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
     {
         return visitor.visitInputReference(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/LambdaDefinitionExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/LambdaDefinitionExpression.java
@@ -88,7 +88,7 @@ public final class LambdaDefinitionExpression
     }
 
     @Override
-    public <C, R> R accept(RowExpressionVisitor<C, R> visitor, C context)
+    public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
     {
         return visitor.visitLambda(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpression.java
@@ -27,5 +27,5 @@ public abstract class RowExpression
     @Override
     public abstract String toString();
 
-    public abstract <C, R> R accept(RowExpressionVisitor<C, R> visitor, C context);
+    public abstract <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context);
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionVisitor.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.sql.relational;
 
-public interface RowExpressionVisitor<C, R>
+public interface RowExpressionVisitor<R, C>
 {
     R visitCall(CallExpression call, C context);
     R visitInputReference(InputReferenceExpression reference, C context);

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -420,7 +420,7 @@ public final class SqlToRowExpressionTranslator
         }
 
         private static class ChangeTypeVisitor
-                implements RowExpressionVisitor<Void, RowExpression>
+                implements RowExpressionVisitor<RowExpression, Void>
         {
             private final Type targetType;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/VariableReferenceExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/VariableReferenceExpression.java
@@ -55,7 +55,7 @@ public final class VariableReferenceExpression
     }
 
     @Override
-    public <C, R> R accept(RowExpressionVisitor<C, R> visitor, C context)
+    public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
     {
         return visitor.visitVariableReference(this, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
@@ -72,7 +72,7 @@ public class ExpressionOptimizer
     }
 
     private class Visitor
-            implements RowExpressionVisitor<Void, RowExpression>
+            implements RowExpressionVisitor<RowExpression, Void>
     {
         @Override
         public RowExpression visitInputReference(InputReferenceExpression reference, Void context)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchingVisitor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchingVisitor.java
@@ -36,7 +36,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 final class PlanMatchingVisitor
-        extends PlanVisitor<PlanMatchPattern, MatchResult>
+        extends PlanVisitor<MatchResult, PlanMatchPattern>
 {
     private final Metadata metadata;
     private final Session session;


### PR DESCRIPTION
This is to align the type parameter order between Plan and Ast visitors. So far they differ (`PlanVisitor<C, R>` vs `AstVisitor<R, C>`), which is confusing. I think we should unify it one way or another. Personally I lean towards the `<R, C>` order, but either will be good as long as they're the same. The other parameter order PR is here: #7920.