### PR TITLE
Make AstVisitor's type param order same as PlanVisitor's (<C, R>)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -163,7 +163,7 @@ class AggregationAnalyzer
      * visitor returns true if all expressions are constant with respect to the group.
      */
     private class Visitor
-            extends AstVisitor<Boolean, Void>
+            extends AstVisitor<Void, Boolean>
     {
         @Override
         protected Boolean visitExpression(Expression node, Void context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -264,7 +264,7 @@ public class ExpressionAnalyzer
     }
 
     private class Visitor
-            extends StackableAstVisitor<Type, Context>
+            extends StackableAstVisitor<Context, Type>
     {
         private final Scope scope;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/LambdaReferenceExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/LambdaReferenceExtractor.java
@@ -43,7 +43,7 @@ public class LambdaReferenceExtractor
     }
 
     private static class Visitor
-            extends DefaultExpressionTraversalVisitor<Void, ImmutableList.Builder<Expression>>
+            extends DefaultExpressionTraversalVisitor<ImmutableList.Builder<Expression>, Void>
     {
         private final Analysis analysis;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -235,7 +235,7 @@ class StatementAnalyzer
      * (if provided) as ancestor.
      */
     private class Visitor
-            extends DefaultTraversalVisitor<Scope, Optional<Scope>>
+            extends DefaultTraversalVisitor<Optional<Scope>, Scope>
     {
         private final Optional<Scope> outerQueryScope;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/WindowFunctionValidator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/WindowFunctionValidator.java
@@ -22,7 +22,7 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.WINDOW_REQUIRES
 import static java.util.Objects.requireNonNull;
 
 class WindowFunctionValidator
-        extends DefaultExpressionTraversalVisitor<Void, Analysis>
+        extends DefaultExpressionTraversalVisitor<Analysis, Void>
 {
     @Override
     protected Void visitFunctionCall(FunctionCall functionCall, Analysis analysis)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DependencyExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DependencyExtractor.java
@@ -72,7 +72,7 @@ public final class DependencyExtractor
     }
 
     private static class SymbolBuilderVisitor
-            extends DefaultExpressionTraversalVisitor<Void, ImmutableList.Builder<Symbol>>
+            extends DefaultExpressionTraversalVisitor<ImmutableList.Builder<Symbol>, Void>
     {
         @Override
         protected Void visitSymbolReference(SymbolReference node, ImmutableList.Builder<Symbol> builder)
@@ -83,7 +83,7 @@ public final class DependencyExtractor
     }
 
     private static class QualifiedNameBuilderVisitor
-            extends DefaultTraversalVisitor<Void, ImmutableSet.Builder<QualifiedName>>
+            extends DefaultTraversalVisitor<ImmutableSet.Builder<QualifiedName>, Void>
     {
         private final Set<Expression> columnReferences;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DeterminismEvaluator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DeterminismEvaluator.java
@@ -39,7 +39,7 @@ public final class DeterminismEvaluator
     }
 
     private static class Visitor
-            extends DefaultExpressionTraversalVisitor<Void, AtomicBoolean>
+            extends DefaultExpressionTraversalVisitor<AtomicBoolean, Void>
     {
         @Override
         protected Void visitFunctionCall(FunctionCall node, AtomicBoolean deterministic)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
@@ -276,7 +276,7 @@ public final class DomainTranslator
     }
 
     private static class Visitor
-            extends AstVisitor<ExtractionResult, Boolean>
+            extends AstVisitor<Boolean, ExtractionResult>
     {
         private final Metadata metadata;
         private final Session session;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -215,7 +215,7 @@ public final class LiteralInterpreter
     }
 
     private static class LiteralVisitor
-            extends AstVisitor<Object, ConnectorSession>
+            extends AstVisitor<ConnectorSession, Object>
     {
         private final Metadata metadata;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NullabilityAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NullabilityAnalyzer.java
@@ -50,7 +50,7 @@ public final class NullabilityAnalyzer
     }
 
     private static class Visitor
-            extends DefaultExpressionTraversalVisitor<Void, AtomicBoolean>
+            extends DefaultExpressionTraversalVisitor<AtomicBoolean, Void>
     {
         @Override
         protected Void visitCast(Cast node, AtomicBoolean result)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -92,7 +92,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 class RelationPlanner
-        extends DefaultTraversalVisitor<RelationPlan, Void>
+        extends DefaultTraversalVisitor<Void, RelationPlan>
 {
     private final Analysis analysis;
     private final SymbolAllocator symbolAllocator;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SortExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SortExpressionExtractor.java
@@ -94,7 +94,7 @@ public final class SortExpressionExtractor
     }
 
     private static class BuildFieldReferenceFinder
-            extends AstVisitor<Boolean, Void>
+            extends AstVisitor<Void, Boolean>
     {
         private final Set<Integer> buildLayout;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -509,7 +509,7 @@ class SubqueryPlanner
     }
 
     private static class ColumnReferencesExtractor
-            extends DefaultExpressionTraversalVisitor<Void, ImmutableSet.Builder<Expression>>
+            extends DefaultExpressionTraversalVisitor<ImmutableSet.Builder<Expression>, Void>
     {
         private final Set<Expression> columnReferences;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
@@ -343,7 +343,7 @@ public class TransformCorrelatedScalarAggregationToJoin
         private static boolean isSupportedPredicate(Expression predicate)
         {
             AtomicBoolean isSupported = new AtomicBoolean(true);
-            new DefaultTraversalVisitor<Void, AtomicBoolean>()
+            new DefaultTraversalVisitor<AtomicBoolean, Void>()
             {
                 @Override
                 protected Void visitLogicalBinaryExpression(LogicalBinaryExpression node, AtomicBoolean context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -151,7 +151,7 @@ public final class SqlToRowExpressionTranslator
     }
 
     private static class Visitor
-            extends AstVisitor<RowExpression, Void>
+            extends AstVisitor<Void, RowExpression>
     {
         private final FunctionKind functionKind;
         private final IdentityLinkedHashMap<Expression, Type> types;

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
@@ -66,7 +66,7 @@ final class DescribeInputRewrite
     }
 
     private static final class Visitor
-            extends AstVisitor<Node, Void>
+            extends AstVisitor<Void, Node>
     {
         private final Session session;
         private final SqlParser parser;

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeOutputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeOutputRewrite.java
@@ -63,7 +63,7 @@ final class DescribeOutputRewrite
     }
 
     private static final class Visitor
-            extends AstVisitor<Node, Void>
+            extends AstVisitor<Void, Node>
     {
         private final Session session;
         private final SqlParser parser;

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ExplainRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ExplainRewrite.java
@@ -58,7 +58,7 @@ final class ExplainRewrite
     }
 
     private static final class Visitor
-            extends AstVisitor<Node, Void>
+            extends AstVisitor<Void, Node>
     {
         private final Session session;
         private final SqlParser parser;

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -147,7 +147,7 @@ final class ShowQueriesRewrite
     }
 
     private static class Visitor
-            extends AstVisitor<Node, Void>
+            extends AstVisitor<Void, Node>
     {
         private final Metadata metadata;
         private final Session session;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
@@ -64,7 +64,7 @@ import static java.util.Objects.requireNonNull;
  * </pre>
  */
 final class ExpressionVerifier
-        extends AstVisitor<Boolean, Expression>
+        extends AstVisitor<Expression, Boolean>
 {
     private final SymbolAliases symbolAliases;
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -104,7 +104,7 @@ public final class ExpressionFormatter
     }
 
     public static class Formatter
-            extends AstVisitor<String, Void>
+            extends AstVisitor<Void, String>
     {
         private final Optional<List<Expression>> parameters;
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -122,7 +122,7 @@ public final class SqlFormatter
     }
 
     private static class Formatter
-            extends AstVisitor<Void, Integer>
+            extends AstVisitor<Integer, Void>
     {
         private final StringBuilder builder;
         private final Optional<List<Expression>> parameters;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
@@ -71,7 +71,7 @@ public class TreePrinter
 
     public void print(Node root)
     {
-        AstVisitor<Void, Integer> printer = new DefaultTraversalVisitor<Void, Integer>()
+        AstVisitor<Integer, Void> printer = new DefaultTraversalVisitor<Integer, Void>()
         {
             @Override
             protected Void visitNode(Node node, Integer indentLevel)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/testing/TreeAssertions.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/testing/TreeAssertions.java
@@ -64,7 +64,7 @@ public final class TreeAssertions
     private static List<Node> linearizeTree(Node tree)
     {
         ImmutableList.Builder<Node> nodes = ImmutableList.builder();
-        new DefaultTraversalVisitor<Node, Void>()
+        new DefaultTraversalVisitor<Void, Node>()
         {
             @Override
             public Node process(Node node, @Nullable Void context)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AddColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AddColumn.java
@@ -56,7 +56,7 @@ public class AddColumn
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitAddColumn(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AliasedRelation.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AliasedRelation.java
@@ -66,7 +66,7 @@ public class AliasedRelation
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitAliasedRelation(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AllColumns.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AllColumns.java
@@ -61,7 +61,7 @@ public class AllColumns
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitAllColumns(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ArithmeticBinaryExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ArithmeticBinaryExpression.java
@@ -80,7 +80,7 @@ public class ArithmeticBinaryExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitArithmeticBinary(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ArithmeticUnaryExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ArithmeticUnaryExpression.java
@@ -84,7 +84,7 @@ public class ArithmeticUnaryExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitArithmeticUnary(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ArrayConstructor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ArrayConstructor.java
@@ -50,7 +50,7 @@ public class ArrayConstructor
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitArrayConstructor(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -15,7 +15,7 @@ package com.facebook.presto.sql.tree;
 
 import javax.annotation.Nullable;
 
-public abstract class AstVisitor<R, C>
+public abstract class AstVisitor<C, R>
 {
     public R process(Node node)
     {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AtTimeZone.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AtTimeZone.java
@@ -57,7 +57,7 @@ public class AtTimeZone
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitAtTimeZone(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/BetweenPredicate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/BetweenPredicate.java
@@ -66,7 +66,7 @@ public class BetweenPredicate
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitBetweenPredicate(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/BinaryLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/BinaryLiteral.java
@@ -71,7 +71,7 @@ public class BinaryLiteral
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitBinaryLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/BindExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/BindExpression.java
@@ -80,7 +80,7 @@ public class BindExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitBindExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/BooleanLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/BooleanLiteral.java
@@ -54,7 +54,7 @@ public class BooleanLiteral
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitBooleanLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Call.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Call.java
@@ -56,7 +56,7 @@ public final class Call
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitCall(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CallArgument.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CallArgument.java
@@ -66,7 +66,7 @@ public final class CallArgument
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitCallArgument(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cast.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cast.java
@@ -93,7 +93,7 @@ public final class Cast
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitCast(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CharLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CharLiteral.java
@@ -57,7 +57,7 @@ public class CharLiteral
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitCharLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CoalesceExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CoalesceExpression.java
@@ -57,7 +57,7 @@ public class CoalesceExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitCoalesceExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ColumnDefinition.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ColumnDefinition.java
@@ -63,7 +63,7 @@ public final class ColumnDefinition
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitColumnDefinition(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Commit.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Commit.java
@@ -39,7 +39,7 @@ public final class Commit
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitCommit(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ComparisonExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ComparisonExpression.java
@@ -66,7 +66,7 @@ public class ComparisonExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitComparisonExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateSchema.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateSchema.java
@@ -65,7 +65,7 @@ public class CreateSchema
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitCreateSchema(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
@@ -79,7 +79,7 @@ public class CreateTable
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitCreateTable(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTableAsSelect.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTableAsSelect.java
@@ -86,7 +86,7 @@ public class CreateTableAsSelect
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitCreateTableAsSelect(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateView.java
@@ -63,7 +63,7 @@ public class CreateView
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitCreateView(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
@@ -60,7 +60,7 @@ public final class Cube
     }
 
     @Override
-    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    protected <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitCube(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CurrentTime.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CurrentTime.java
@@ -87,7 +87,7 @@ public class CurrentTime
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitCurrentTime(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Deallocate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Deallocate.java
@@ -49,7 +49,7 @@ public class Deallocate
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitDeallocate(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DecimalLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DecimalLiteral.java
@@ -45,7 +45,7 @@ public class DecimalLiteral
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitDecimalLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultExpressionTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultExpressionTraversalVisitor.java
@@ -16,8 +16,8 @@ package com.facebook.presto.sql.tree;
 /**
  * When walking Expressions, don't traverse into SubqueryExpressions
  */
-public abstract class DefaultExpressionTraversalVisitor<R, C>
-        extends DefaultTraversalVisitor<R, C>
+public abstract class DefaultExpressionTraversalVisitor<C, R>
+        extends DefaultTraversalVisitor<C, R>
 {
     @Override
     protected R visitSubqueryExpression(SubqueryExpression node, C context)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -16,8 +16,8 @@ package com.facebook.presto.sql.tree;
 import java.util.Map.Entry;
 import java.util.Set;
 
-public abstract class DefaultTraversalVisitor<R, C>
-        extends AstVisitor<R, C>
+public abstract class DefaultTraversalVisitor<C, R>
+        extends AstVisitor<C, R>
 {
     @Override
     protected R visitExtract(Extract node, C context)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Delete.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Delete.java
@@ -56,7 +56,7 @@ public class Delete
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitDelete(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DereferenceExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DereferenceExpression.java
@@ -48,7 +48,7 @@ public class DereferenceExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitDereferenceExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeInput.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeInput.java
@@ -48,7 +48,7 @@ public class DescribeInput
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitDescribeInput(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeOutput.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeOutput.java
@@ -48,7 +48,7 @@ public class DescribeOutput
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitDescribeOutput(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DoubleLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DoubleLiteral.java
@@ -45,7 +45,7 @@ public class DoubleLiteral
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitDoubleLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropSchema.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropSchema.java
@@ -63,7 +63,7 @@ public final class DropSchema
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitDropSchema(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropTable.java
@@ -55,7 +55,7 @@ public class DropTable
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitDropTable(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropView.java
@@ -55,7 +55,7 @@ public class DropView
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitDropView(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Except.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Except.java
@@ -59,7 +59,7 @@ public class Except
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitExcept(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Execute.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Execute.java
@@ -56,7 +56,7 @@ public class Execute
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitExecute(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExistsPredicate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExistsPredicate.java
@@ -49,7 +49,7 @@ public class ExistsPredicate
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitExists(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Explain.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Explain.java
@@ -68,7 +68,7 @@ public class Explain
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitExplain(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExplainOption.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExplainOption.java
@@ -24,7 +24,7 @@ public abstract class ExplainOption
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitExplainOption(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Expression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Expression.java
@@ -29,7 +29,7 @@ public abstract class Expression
      * Accessible for {@link AstVisitor}, use {@link AstVisitor#process(Node, Object)} instead.
      */
     @Override
-    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    protected <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 public final class ExpressionTreeRewriter<C>
 {
     private final ExpressionRewriter<C> rewriter;
-    private final AstVisitor<Expression, ExpressionTreeRewriter.Context<C>> visitor;
+    private final AstVisitor<Context<C>, Expression> visitor;
 
     public static <C, T extends Expression> T rewriteWith(ExpressionRewriter<C> rewriter, T node)
     {
@@ -57,7 +57,7 @@ public final class ExpressionTreeRewriter<C>
     }
 
     private class RewritingVisitor
-            extends AstVisitor<Expression, ExpressionTreeRewriter.Context<C>>
+            extends AstVisitor<Context<C>, Expression>
     {
         @Override
         protected Expression visitExpression(Expression node, Context<C> context)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Extract.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Extract.java
@@ -82,7 +82,7 @@ public class Extract
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitExtract(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/FieldReference.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/FieldReference.java
@@ -39,7 +39,7 @@ public class FieldReference
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitFieldReference(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/FrameBound.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/FrameBound.java
@@ -87,7 +87,7 @@ public class FrameBound
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitFrameBound(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/FunctionCall.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/FunctionCall.java
@@ -106,7 +106,7 @@ public class FunctionCall
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitFunctionCall(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GenericLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GenericLiteral.java
@@ -62,7 +62,7 @@ public final class GenericLiteral
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitGenericLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Grant.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Grant.java
@@ -78,7 +78,7 @@ public class Grant
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitGrant(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupBy.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupBy.java
@@ -56,7 +56,7 @@ public class GroupBy
     }
 
     @Override
-    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    protected <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitGroupBy(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingElement.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingElement.java
@@ -28,7 +28,7 @@ public abstract class GroupingElement
     public abstract List<Set<Expression>> enumerateGroupingSets();
 
     @Override
-    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    protected <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitGroupingElement(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
@@ -66,7 +66,7 @@ public final class GroupingSets
     }
 
     @Override
-    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    protected <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitGroupingSets(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Identifier.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Identifier.java
@@ -46,7 +46,7 @@ public class Identifier
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitIdentifier(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/IfExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/IfExpression.java
@@ -65,7 +65,7 @@ public class IfExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitIfExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/InListExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/InListExpression.java
@@ -44,7 +44,7 @@ public class InListExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitInListExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/InPredicate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/InPredicate.java
@@ -53,7 +53,7 @@ public class InPredicate
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitInPredicate(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Insert.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Insert.java
@@ -58,7 +58,7 @@ public final class Insert
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitInsert(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Intersect.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Intersect.java
@@ -51,7 +51,7 @@ public class Intersect
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitIntersect(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/IntervalLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/IntervalLiteral.java
@@ -106,7 +106,7 @@ public class IntervalLiteral
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitIntervalLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/IsNotNullPredicate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/IsNotNullPredicate.java
@@ -49,7 +49,7 @@ public class IsNotNullPredicate
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitIsNotNullPredicate(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/IsNullPredicate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/IsNullPredicate.java
@@ -49,7 +49,7 @@ public class IsNullPredicate
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitIsNullPredicate(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Isolation.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Isolation.java
@@ -71,7 +71,7 @@ public final class Isolation
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitIsolationLevel(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Join.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Join.java
@@ -85,7 +85,7 @@ public class Join
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitJoin(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/LambdaArgumentDeclaration.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/LambdaArgumentDeclaration.java
@@ -36,7 +36,7 @@ public class LambdaArgumentDeclaration
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitLambdaArgumentDeclaration(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/LambdaExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/LambdaExpression.java
@@ -55,7 +55,7 @@ public class LambdaExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitLambdaExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/LikeClause.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/LikeClause.java
@@ -62,7 +62,7 @@ public final class LikeClause
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitLikeClause(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/LikePredicate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/LikePredicate.java
@@ -65,7 +65,7 @@ public class LikePredicate
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitLikePredicate(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Literal.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Literal.java
@@ -27,7 +27,7 @@ public abstract class Literal
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/LogicalBinaryExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/LogicalBinaryExpression.java
@@ -83,7 +83,7 @@ public class LogicalBinaryExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitLogicalBinaryExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/LongLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/LongLiteral.java
@@ -52,7 +52,7 @@ public class LongLiteral
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitLongLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Node.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Node.java
@@ -30,7 +30,7 @@ public abstract class Node
     /**
      * Accessible for {@link AstVisitor}, use {@link AstVisitor#process(Node, Object)} instead.
      */
-    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    protected <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitNode(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/NotExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/NotExpression.java
@@ -49,7 +49,7 @@ public class NotExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitNotExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/NullIfExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/NullIfExpression.java
@@ -56,7 +56,7 @@ public class NullIfExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitNullIfExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/NullLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/NullLiteral.java
@@ -29,7 +29,7 @@ public class NullLiteral
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitNullLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/OrderBy.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/OrderBy.java
@@ -52,7 +52,7 @@ public class OrderBy
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitOrderBy(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Parameter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Parameter.java
@@ -46,7 +46,7 @@ public class Parameter
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitParameter(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Prepare.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Prepare.java
@@ -56,7 +56,7 @@ public class Prepare
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitPrepare(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QuantifiedComparisonExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QuantifiedComparisonExpression.java
@@ -76,7 +76,7 @@ public class QuantifiedComparisonExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitQuantifiedComparisonExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Query.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Query.java
@@ -89,7 +89,7 @@ public class Query
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitQuery(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QueryBody.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QueryBody.java
@@ -24,7 +24,7 @@ public abstract class QueryBody
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitQueryBody(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QuerySpecification.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QuerySpecification.java
@@ -122,7 +122,7 @@ public class QuerySpecification
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitQuerySpecification(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Relation.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Relation.java
@@ -24,7 +24,7 @@ public abstract class Relation
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitRelation(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameColumn.java
@@ -63,7 +63,7 @@ public class RenameColumn
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitRenameColumn(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameSchema.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameSchema.java
@@ -56,7 +56,7 @@ public final class RenameSchema
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitRenameSchema(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameTable.java
@@ -56,7 +56,7 @@ public final class RenameTable
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitRenameTable(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ResetSession.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ResetSession.java
@@ -48,7 +48,7 @@ public class ResetSession
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitResetSession(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Revoke.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Revoke.java
@@ -77,7 +77,7 @@ public class Revoke
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitRevoke(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollback.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollback.java
@@ -38,7 +38,7 @@ public final class Rollback
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitRollback(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
@@ -70,7 +70,7 @@ public final class Rollup
     }
 
     @Override
-    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    protected <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitRollup(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Row.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Row.java
@@ -49,7 +49,7 @@ public final class Row
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitRow(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SampledRelation.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SampledRelation.java
@@ -69,7 +69,7 @@ public class SampledRelation
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitSampledRelation(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SearchedCaseExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SearchedCaseExpression.java
@@ -57,7 +57,7 @@ public class SearchedCaseExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitSearchedCaseExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Select.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Select.java
@@ -56,7 +56,7 @@ public class Select
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitSelect(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetOperation.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetOperation.java
@@ -33,7 +33,7 @@ public abstract class SetOperation
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitSetOperation(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetSession.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetSession.java
@@ -55,7 +55,7 @@ public class SetSession
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitSetSession(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCatalogs.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCatalogs.java
@@ -48,7 +48,7 @@ public final class ShowCatalogs
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitShowCatalogs(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowColumns.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowColumns.java
@@ -49,7 +49,7 @@ public class ShowColumns
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitShowColumns(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCreate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCreate.java
@@ -61,7 +61,7 @@ public class ShowCreate
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitShowCreate(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowFunctions.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowFunctions.java
@@ -39,7 +39,7 @@ public class ShowFunctions
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitShowFunctions(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowGrants.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowGrants.java
@@ -58,7 +58,7 @@ public class ShowGrants
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitShowGrants(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowPartitions.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowPartitions.java
@@ -70,7 +70,7 @@ public class ShowPartitions
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitShowPartitions(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSchemas.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSchemas.java
@@ -56,7 +56,7 @@ public class ShowSchemas
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitShowSchemas(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSession.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSession.java
@@ -39,7 +39,7 @@ public class ShowSession
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitShowSession(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowTables.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowTables.java
@@ -59,7 +59,7 @@ public class ShowTables
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitShowTables(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleCaseExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleCaseExpression.java
@@ -65,7 +65,7 @@ public class SimpleCaseExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitSimpleCaseExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleGroupBy.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleGroupBy.java
@@ -57,7 +57,7 @@ public final class SimpleGroupBy
     }
 
     @Override
-    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    protected <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitSimpleGroupBy(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SingleColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SingleColumn.java
@@ -97,7 +97,7 @@ public class SingleColumn
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitSingleColumn(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SortItem.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SortItem.java
@@ -72,7 +72,7 @@ public class SortItem
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitSortItem(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/StackableAstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/StackableAstVisitor.java
@@ -16,8 +16,8 @@ package com.facebook.presto.sql.tree;
 import java.util.LinkedList;
 import java.util.Optional;
 
-public class StackableAstVisitor<R, C>
-        extends AstVisitor<R, StackableAstVisitor.StackableAstVisitorContext<C>>
+public class StackableAstVisitor<C, R>
+        extends AstVisitor<StackableAstVisitor.StackableAstVisitorContext<C>, R>
 {
     public R process(Node node, StackableAstVisitorContext<C> context)
     {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/StartTransaction.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/StartTransaction.java
@@ -50,7 +50,7 @@ public final class StartTransaction
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitStartTransaction(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Statement.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Statement.java
@@ -24,7 +24,7 @@ public abstract class Statement
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitStatement(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/StringLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/StringLiteral.java
@@ -56,7 +56,7 @@ public class StringLiteral
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitStringLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SubqueryExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SubqueryExpression.java
@@ -46,7 +46,7 @@ public class SubqueryExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitSubqueryExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SubscriptExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SubscriptExpression.java
@@ -45,7 +45,7 @@ public class SubscriptExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitSubscriptExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SymbolReference.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SymbolReference.java
@@ -36,7 +36,7 @@ public class SymbolReference
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitSymbolReference(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Table.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Table.java
@@ -48,7 +48,7 @@ public class Table
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitTable(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/TableElement.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/TableElement.java
@@ -24,7 +24,7 @@ public abstract class TableElement
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitTableElement(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/TableSubquery.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/TableSubquery.java
@@ -48,7 +48,7 @@ public class TableSubquery
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitTableSubquery(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/TimeLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/TimeLiteral.java
@@ -46,7 +46,7 @@ public class TimeLiteral
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitTimeLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/TimestampLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/TimestampLiteral.java
@@ -47,7 +47,7 @@ public class TimestampLiteral
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitTimestampLiteral(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/TransactionAccessMode.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/TransactionAccessMode.java
@@ -48,7 +48,7 @@ public final class TransactionAccessMode
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitTransactionAccessMode(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/TransactionMode.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/TransactionMode.java
@@ -26,7 +26,7 @@ public abstract class TransactionMode
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitTransactionMode(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/TryExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/TryExpression.java
@@ -48,7 +48,7 @@ public class TryExpression
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitTryExpression(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Union.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Union.java
@@ -51,7 +51,7 @@ public class Union
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitUnion(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Unnest.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Unnest.java
@@ -57,7 +57,7 @@ public final class Unnest
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitUnnest(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Use.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Use.java
@@ -58,7 +58,7 @@ public final class Use
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitUse(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Values.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Values.java
@@ -50,7 +50,7 @@ public final class Values
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitValues(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/WhenClause.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/WhenClause.java
@@ -53,7 +53,7 @@ public class WhenClause
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitWhenClause(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Window.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Window.java
@@ -63,7 +63,7 @@ public class Window
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitWindow(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/WindowFrame.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/WindowFrame.java
@@ -68,7 +68,7 @@ public class WindowFrame
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitWindowFrame(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/With.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/With.java
@@ -60,7 +60,7 @@ public class With
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitWith(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/WithQuery.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/WithQuery.java
@@ -63,7 +63,7 @@ public class WithQuery
     }
 
     @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    public <C, R> R accept(AstVisitor<C, R> visitor, C context)
     {
         return visitor.visitWithQuery(this, context);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/util/AstUtils.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/util/AstUtils.java
@@ -28,7 +28,7 @@ public class AstUtils
 {
     public static boolean nodeContains(Node node, Node subNode)
     {
-        return new DefaultTraversalVisitor<Boolean, AtomicBoolean>()
+        return new DefaultTraversalVisitor<AtomicBoolean, Boolean>()
         {
             @Override
             public Boolean process(Node node, AtomicBoolean findResultHolder)


### PR DESCRIPTION
This is to align the type parameter order between Plan and Ast visitors. So far they differ (`PlanVisitor<C, R>` vs `AstVisitor<R, C>`), which is confusing. I think we should unify it one way or another. Personally I lean towards the `<R, C>` order, but either will be good as long as they're the same. The other parameter order PR is here: #7919.