### PR TITLE
Add unit tests for block retained size

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/block/TestSliceArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestSliceArrayBlock.java
@@ -25,8 +25,15 @@ public class TestSliceArrayBlock
     public void test()
     {
         Slice[] expectedValues = createExpectedValues(100);
-        assertVariableWithValues(expectedValues);
-        assertVariableWithValues((Slice[]) alternatingNullValues(expectedValues));
+        assertVariableWithValues(expectedValues, false);
+        assertVariableWithValues((Slice[]) alternatingNullValues(expectedValues), false);
+    }
+
+    @Test
+    public void testDistinctSlices()
+    {
+        Slice[] expectedValues = createExpectedUniqueValues(100);
+        assertVariableWithValues(expectedValues, true);
     }
 
     @Test
@@ -38,9 +45,9 @@ public class TestSliceArrayBlock
         assertBlockFilteredPositions(expectedValues, block, Ints.asList(0, 2, 4, 6, 7, 9, 10, 16));
     }
 
-    private void assertVariableWithValues(Slice[] expectedValues)
+    private void assertVariableWithValues(Slice[] expectedValues, boolean valueSlicesAreDistinct)
     {
-        SliceArrayBlock block = new SliceArrayBlock(expectedValues.length, expectedValues);
+        SliceArrayBlock block = new SliceArrayBlock(expectedValues.length, expectedValues, valueSlicesAreDistinct);
         assertBlock(block, expectedValues);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestSliceArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestSliceArrayBlock.java
@@ -25,15 +25,8 @@ public class TestSliceArrayBlock
     public void test()
     {
         Slice[] expectedValues = createExpectedValues(100);
-        assertVariableWithValues(expectedValues, false);
-        assertVariableWithValues((Slice[]) alternatingNullValues(expectedValues), false);
-    }
-
-    @Test
-    public void testDistinctSlices()
-    {
-        Slice[] expectedValues = createExpectedUniqueValues(100);
-        assertVariableWithValues(expectedValues, true);
+        assertVariableWithValues(expectedValues);
+        assertVariableWithValues((Slice[]) alternatingNullValues(expectedValues));
     }
 
     @Test
@@ -45,9 +38,9 @@ public class TestSliceArrayBlock
         assertBlockFilteredPositions(expectedValues, block, Ints.asList(0, 2, 4, 6, 7, 9, 10, 16));
     }
 
-    private void assertVariableWithValues(Slice[] expectedValues, boolean valueSlicesAreDistinct)
+    private void assertVariableWithValues(Slice[] expectedValues)
     {
-        SliceArrayBlock block = new SliceArrayBlock(expectedValues.length, expectedValues, valueSlicesAreDistinct);
+        SliceArrayBlock block = new SliceArrayBlock(expectedValues.length, expectedValues);
         assertBlock(block, expectedValues);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
@@ -72,7 +72,7 @@ public class SliceDictionaryStreamReader
     @Nonnull
     private Slice[] stripeDictionary = new Slice[1];
 
-    private SliceArrayBlock dictionaryBlock = new SliceArrayBlock(stripeDictionary.length, stripeDictionary, true);
+    private SliceArrayBlock dictionaryBlock = new SliceArrayBlock(stripeDictionary.length, stripeDictionary);
 
     @Nonnull
     private InputStreamSource<LongInputStream> stripeDictionaryLengthStreamSource = missingStreamSource(LongInputStream.class);
@@ -197,7 +197,7 @@ public class SliceDictionaryStreamReader
         // only update the block if the array changed to prevent creation of new Block objects, since
         // the engine currently uses identity equality to test if dictionaries are the same
         if (dictionaryBlock.getValues() != dictionary) {
-            dictionaryBlock = new SliceArrayBlock(dictionary.length, dictionary, true);
+            dictionaryBlock = new SliceArrayBlock(dictionary.length, dictionary);
         }
     }
 


### PR DESCRIPTION
This PR adds unit tests for block retained sizes which have been biting us for some time.