### PR TITLE
Include object overhead in big array sizeOf calculations

### DIFF
--- a/presto-array/src/main/java/com/facebook/presto/array/BlockBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/BlockBigArray.java
@@ -14,9 +14,11 @@
 package com.facebook.presto.array;
 
 import com.facebook.presto.spi.block.Block;
+import org.openjdk.jol.info.ClassLayout;
 
 public final class BlockBigArray
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(BlockBigArray.class).instanceSize();
     private final ObjectBigArray<Block> array;
     private long sizeOfBlocks;
 
@@ -35,7 +37,7 @@ public final class BlockBigArray
      */
     public long sizeOf()
     {
-        return array.sizeOf() + sizeOfBlocks;
+        return INSTANCE_SIZE + array.sizeOf() + sizeOfBlocks;
     }
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/BooleanBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/BooleanBigArray.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.array;
 
 import io.airlift.slice.SizeOf;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
@@ -27,6 +28,7 @@ import static io.airlift.slice.SizeOf.sizeOfBooleanArray;
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class BooleanBigArray
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(BooleanBigArray.class).instanceSize();
     private static final long SIZE_OF_SEGMENT = sizeOfBooleanArray(SEGMENT_SIZE);
 
     private final boolean initialValue;
@@ -55,7 +57,7 @@ public final class BooleanBigArray
      */
     public long sizeOf()
     {
-        return SizeOf.sizeOf(array) + (segments * SIZE_OF_SEGMENT);
+        return INSTANCE_SIZE + SizeOf.sizeOf(array) + (segments * SIZE_OF_SEGMENT);
     }
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/ByteBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/ByteBigArray.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.array;
 
 import io.airlift.slice.SizeOf;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
@@ -27,6 +28,7 @@ import static io.airlift.slice.SizeOf.sizeOfByteArray;
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class ByteBigArray
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ByteBigArray.class).instanceSize();
     private static final long SIZE_OF_SEGMENT = sizeOfByteArray(SEGMENT_SIZE);
 
     private final byte initialValue;
@@ -55,7 +57,7 @@ public final class ByteBigArray
      */
     public long sizeOf()
     {
-        return SizeOf.sizeOf(array) + (segments * SIZE_OF_SEGMENT);
+        return INSTANCE_SIZE + SizeOf.sizeOf(array) + (segments * SIZE_OF_SEGMENT);
     }
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/DoubleBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/DoubleBigArray.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.array;
 
 import io.airlift.slice.SizeOf;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
@@ -27,6 +28,7 @@ import static io.airlift.slice.SizeOf.sizeOfDoubleArray;
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class DoubleBigArray
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DoubleBigArray.class).instanceSize();
     private static final long SIZE_OF_SEGMENT = sizeOfDoubleArray(SEGMENT_SIZE);
 
     private final double initialValue;
@@ -58,7 +60,7 @@ public final class DoubleBigArray
      */
     public long sizeOf()
     {
-        return SizeOf.sizeOf(array) + (segments * SIZE_OF_SEGMENT);
+        return INSTANCE_SIZE + SizeOf.sizeOf(array) + (segments * SIZE_OF_SEGMENT);
     }
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/IntBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/IntBigArray.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.array;
 
 import io.airlift.slice.SizeOf;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
@@ -27,6 +28,7 @@ import static io.airlift.slice.SizeOf.sizeOfIntArray;
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class IntBigArray
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntBigArray.class).instanceSize();
     private static final long SIZE_OF_SEGMENT = sizeOfIntArray(SEGMENT_SIZE);
 
     private final int initialValue;
@@ -58,7 +60,7 @@ public final class IntBigArray
      */
     public long sizeOf()
     {
-        return SizeOf.sizeOf(array) + (segments * SIZE_OF_SEGMENT);
+        return INSTANCE_SIZE + SizeOf.sizeOf(array) + (segments * SIZE_OF_SEGMENT);
     }
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/LongBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/LongBigArray.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.array;
 
 import io.airlift.slice.SizeOf;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
@@ -27,6 +28,7 @@ import static io.airlift.slice.SizeOf.sizeOfLongArray;
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class LongBigArray
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongBigArray.class).instanceSize();
     private static final long SIZE_OF_SEGMENT = sizeOfLongArray(SEGMENT_SIZE);
 
     private final long initialValue;
@@ -58,7 +60,7 @@ public final class LongBigArray
      */
     public long sizeOf()
     {
-        return SizeOf.sizeOf(array) + (segments * SIZE_OF_SEGMENT);
+        return INSTANCE_SIZE + SizeOf.sizeOf(array) + (segments * SIZE_OF_SEGMENT);
     }
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/ObjectBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/ObjectBigArray.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.array;
 
 import io.airlift.slice.SizeOf;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 
@@ -27,6 +28,7 @@ import static io.airlift.slice.SizeOf.sizeOfObjectArray;
 // Copyright (C) 2010-2013 Sebastiano Vigna
 public final class ObjectBigArray<T>
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ObjectBigArray.class).instanceSize();
     private static final long SIZE_OF_SEGMENT = sizeOfObjectArray(SEGMENT_SIZE);
 
     private final Object initialValue;
@@ -55,7 +57,7 @@ public final class ObjectBigArray<T>
      */
     public long sizeOf()
     {
-        return SizeOf.sizeOf(array) + (segments * SIZE_OF_SEGMENT);
+        return INSTANCE_SIZE + SizeOf.sizeOf(array) + (segments * SIZE_OF_SEGMENT);
     }
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/SliceBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/SliceBigArray.java
@@ -18,6 +18,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 public final class SliceBigArray
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(SliceBigArray.class).instanceSize();
     private static final int SLICE_INSTANCE_SIZE = ClassLayout.parseClass(Slice.class).instanceSize();
     private final ObjectBigArray<Slice> array;
     private long sizeOfSlices;
@@ -37,7 +38,7 @@ public final class SliceBigArray
      */
     public long sizeOf()
     {
-        return array.sizeOf() + sizeOfSlices;
+        return INSTANCE_SIZE + array.sizeOf() + sizeOfSlices;
     }
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
@@ -72,11 +72,11 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.add;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantBoolean;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantClass;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantInt;
-import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantLong;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantNull;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantNumber;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.defaultValue;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.equal;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.getStatic;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newInstance;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -403,21 +403,12 @@ public class StateCompiler
                 type(Object.class),
                 type(clazz));
 
-        // Store class size in static field
-        FieldDefinition classSize = definition.declareField(a(PRIVATE, STATIC, FINAL), "CLASS_SIZE", long.class);
-        definition.getClassInitializer()
-                .getBody()
-                .comment("CLASS_SIZE = ClassLayout.parseClass(%s.class).instanceSize()", definition.getName())
-                .push(definition.getType())
-                .invokeStatic(ClassLayout.class, "parseClass", ClassLayout.class, Class.class)
-                .invokeVirtual(ClassLayout.class, "instanceSize", int.class)
-                .intToLong()
-                .putStaticField(classSize);
+        FieldDefinition instanceSize = generateInstanceSize(definition);
 
         // Add getter for class size
         definition.declareMethod(a(PUBLIC), "getEstimatedSize", type(long.class))
                 .getBody()
-                .getStaticField(classSize)
+                .getStaticField(instanceSize)
                 .retLong();
 
         // Generate constructor
@@ -439,6 +430,21 @@ public class StateCompiler
         return defineClass(definition, clazz, classLoader);
     }
 
+    private static FieldDefinition generateInstanceSize(ClassDefinition definition)
+    {
+        // Store instance size in static field
+        FieldDefinition instanceSize = definition.declareField(a(PRIVATE, STATIC, FINAL), "INSTANCE_SIZE", long.class);
+        definition.getClassInitializer()
+                .getBody()
+                .comment("INSTANCE_SIZE = ClassLayout.parseClass(%s.class).instanceSize()", definition.getName())
+                .push(definition.getType())
+                .invokeStatic(ClassLayout.class, "parseClass", ClassLayout.class, Class.class)
+                .invokeVirtual(ClassLayout.class, "instanceSize", int.class)
+                .intToLong()
+                .putStaticField(instanceSize);
+        return instanceSize;
+    }
+
     private static <T> Class<? extends T> generateGroupedStateClass(Class<T> clazz, Map<String, Type> fieldTypes, DynamicClassLoader classLoader)
     {
         ClassDefinition definition = new ClassDefinition(
@@ -447,6 +453,8 @@ public class StateCompiler
                 type(AbstractGroupedAccumulatorState.class),
                 type(clazz),
                 type(GroupedAccumulator.class));
+
+        FieldDefinition instanceSize = generateInstanceSize(definition);
 
         List<StateField> fields = enumerateFields(clazz, fieldTypes);
 
@@ -474,8 +482,8 @@ public class StateCompiler
 
         Variable size = getEstimatedSize.getScope().declareVariable(long.class, "size");
 
-        // initialize size to 0L
-        body.append(size.set(constantLong(0)));
+        // initialize size to the size of the instance
+        body.append(size.set(getStatic(instanceSize)));
 
         // add field to size
         for (FieldDefinition field : fieldDefinitions) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStateCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStateCompiler.java
@@ -13,6 +13,12 @@
  */
 package com.facebook.presto.operator.aggregation;
 
+import com.facebook.presto.array.BlockBigArray;
+import com.facebook.presto.array.BooleanBigArray;
+import com.facebook.presto.array.ByteBigArray;
+import com.facebook.presto.array.DoubleBigArray;
+import com.facebook.presto.array.LongBigArray;
+import com.facebook.presto.array.SliceBigArray;
 import com.facebook.presto.bytecode.DynamicClassLoader;
 import com.facebook.presto.operator.aggregation.state.LongState;
 import com.facebook.presto.operator.aggregation.state.NullableLongState;
@@ -29,12 +35,15 @@ import com.facebook.presto.spi.function.GroupedAccumulatorState;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.type.ArrayType;
 import com.facebook.presto.type.RowType;
+import com.facebook.presto.util.Reflection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Optional;
 
@@ -241,6 +250,27 @@ public class TestStateCompiler
         return slice.length() + SLICE_INSTANCE_SIZE;
     }
 
+    private long getComplexStateRetainedSize(TestComplexState state)
+    {
+        long retainedSize = ClassLayout.parseClass(state.getClass()).instanceSize();
+        Field[] fields = state.getClass().getDeclaredFields();
+        try {
+            for (Field field : fields) {
+                Class type = field.getType();
+                field.setAccessible(true);
+                if (type == BlockBigArray.class || type == BooleanBigArray.class || type == SliceBigArray.class ||
+                        type == ByteBigArray.class || type == DoubleBigArray.class || type == LongBigArray.class) {
+                    MethodHandle sizeOf = Reflection.methodHandle(type, "sizeOf", null);
+                    retainedSize += (long) sizeOf.invokeWithArguments(field.get(state));
+                }
+            }
+        }
+        catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+        return retainedSize;
+    }
+
     @Test
     public void testComplexStateEstimatedSize()
     {
@@ -248,7 +278,8 @@ public class TestStateCompiler
         AccumulatorStateFactory<TestComplexState> factory = StateCompiler.generateStateFactory(TestComplexState.class, fieldMap, new DynamicClassLoader(TestComplexState.class.getClassLoader()));
 
         TestComplexState groupedState = factory.createGroupedState();
-        assertEquals(groupedState.getEstimatedSize(), 76064);
+        long initialRetainedSize = getComplexStateRetainedSize(groupedState);
+        assertEquals(groupedState.getEstimatedSize(), initialRetainedSize);
         for (int i = 0; i < 1000; i++) {
             long retainedSize = 0;
             ((GroupedAccumulatorState) groupedState).setGroupId(i);
@@ -272,7 +303,7 @@ public class TestStateCompiler
             Block map = mapBlockBuilder.build();
             retainedSize += map.getRetainedSizeInBytes();
             groupedState.setAnotherBlock(map);
-            assertEquals(groupedState.getEstimatedSize(), 76064 + retainedSize * (i + 1));
+            assertEquals(groupedState.getEstimatedSize(), initialRetainedSize + retainedSize * (i + 1));
         }
 
         for (int i = 0; i < 1000; i++) {
@@ -298,7 +329,7 @@ public class TestStateCompiler
             Block map = mapBlockBuilder.build();
             retainedSize += map.getRetainedSizeInBytes();
             groupedState.setAnotherBlock(map);
-            assertEquals(groupedState.getEstimatedSize(), 76064 + retainedSize * 1000);
+            assertEquals(groupedState.getEstimatedSize(), initialRetainedSize + retainedSize * 1000);
         }
     }
 


### PR DESCRIPTION
These `sizeOf()` methods are called from various parts of the code to calculate retained sizes, so we should include the shallow sizes of the big array instances.