### PR TITLE
Cassandra connector allow to override default protocol version

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.cassandra;
 
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.SocketOptions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -50,6 +51,7 @@ public class CassandraClientConfig
     private int nativeProtocolPort = 9042;
     private int partitionSizeForBatchSelect = 100;
     private int splitSize = 1_024;
+    private long splitsPerNode = -1;
     private boolean allowDropTable;
     private String username;
     private String password;
@@ -68,6 +70,7 @@ public class CassandraClientConfig
     private Duration noHostAvailableRetryTimeout = new Duration(1, MINUTES);
     private int speculativeExecutionLimit = 1;
     private Duration speculativeExecutionDelay = new Duration(500, MILLISECONDS);
+    private ProtocolVersion protocolVersion = ProtocolVersion.V3;
 
     @Min(1)
     public int getMaxSchemaRefreshThreads()
@@ -190,6 +193,18 @@ public class CassandraClientConfig
     public CassandraClientConfig setSplitSize(int splitSize)
     {
         this.splitSize = splitSize;
+        return this;
+    }
+
+    public long getSplitsPerNode()
+    {
+        return splitsPerNode;
+    }
+
+    @Config("cassandra.splits-per-node")
+    public CassandraClientConfig setSplitsPerNode(long splitsPerNode)
+    {
+        this.splitsPerNode = splitsPerNode;
         return this;
     }
 
@@ -417,6 +432,18 @@ public class CassandraClientConfig
     public CassandraClientConfig setSpeculativeExecutionDelay(Duration speculativeExecutionDelay)
     {
         this.speculativeExecutionDelay = speculativeExecutionDelay;
+        return this;
+    }
+
+    public ProtocolVersion getProtocolVersion()
+    {
+        return protocolVersion;
+    }
+
+    @Config("cassandra.protocol-version")
+    public CassandraClientConfig setProtocolVersion(String version)
+    {
+        protocolVersion = ProtocolVersion.valueOf(version);
         return this;
     }
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.cassandra;
 
 import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.SocketOptions;
 import com.datastax.driver.core.policies.ConstantSpeculativeExecutionPolicy;
@@ -98,7 +97,7 @@ public class CassandraClientModule
         requireNonNull(extraColumnMetadataCodec, "extraColumnMetadataCodec is null");
 
         Cluster.Builder clusterBuilder = Cluster.builder()
-                .withProtocolVersion(ProtocolVersion.V3);
+                .withProtocolVersion(config.getProtocolVersion());
 
         List<String> contactPoints = requireNonNull(config.getContactPoints(), "contactPoints is null");
         checkArgument(!contactPoints.isEmpty(), "empty contactPoints");

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraClientConfig.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraClientConfig.java
@@ -42,6 +42,7 @@ public class TestCassandraClientConfig
                 .setNativeProtocolPort(9042)
                 .setPartitionSizeForBatchSelect(100)
                 .setSplitSize(1_024)
+                .setSplitsPerNode(-1)
                 .setAllowDropTable(false)
                 .setUsername(null)
                 .setPassword(null)
@@ -59,7 +60,8 @@ public class TestCassandraClientConfig
                 .setWhiteListAddresses("")
                 .setNoHostAvailableRetryTimeout(new Duration(1, MINUTES))
                 .setSpeculativeExecutionLimit(1)
-                .setSpeculativeExecutionDelay(new Duration(500, MILLISECONDS)));
+                .setSpeculativeExecutionDelay(new Duration(500, MILLISECONDS))
+                .setProtocolVersion("V3"));
     }
 
     @Test
@@ -75,6 +77,7 @@ public class TestCassandraClientConfig
                 .put("cassandra.consistency-level", "TWO")
                 .put("cassandra.partition-size-for-batch-select", "77")
                 .put("cassandra.split-size", "1025")
+                .put("cassandra.splits-per-node", "10000")
                 .put("cassandra.allow-drop-table", "true")
                 .put("cassandra.username", "my_username")
                 .put("cassandra.password", "my_password")
@@ -93,6 +96,7 @@ public class TestCassandraClientConfig
                 .put("cassandra.no-host-available-retry-timeout", "3m")
                 .put("cassandra.speculative-execution.limit", "10")
                 .put("cassandra.speculative-execution.delay", "101s")
+                .put("cassandra.protocol-version", "V2")
                 .build();
 
         CassandraClientConfig expected = new CassandraClientConfig()
@@ -105,6 +109,7 @@ public class TestCassandraClientConfig
                 .setConsistencyLevel(ConsistencyLevel.TWO)
                 .setPartitionSizeForBatchSelect(77)
                 .setSplitSize(1_025)
+                .setSplitsPerNode(10_000)
                 .setAllowDropTable(true)
                 .setUsername("my_username")
                 .setPassword("my_password")
@@ -122,7 +127,8 @@ public class TestCassandraClientConfig
                 .setWhiteListAddresses("host1")
                 .setNoHostAvailableRetryTimeout(new Duration(3, MINUTES))
                 .setSpeculativeExecutionLimit(10)
-                .setSpeculativeExecutionDelay(new Duration(101, SECONDS));
+                .setSpeculativeExecutionDelay(new Duration(101, SECONDS))
+                .setProtocolVersion("V2");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraTokenSplitManager.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraTokenSplitManager.java
@@ -39,7 +39,15 @@ public class TestCassandraTokenSplitManager
     {
         EmbeddedCassandra.start();
         session = EmbeddedCassandra.getSession();
-        splitManager = new CassandraTokenSplitManager(session, SPLIT_SIZE);
+        splitManager = new CassandraTokenSplitManager(session, SPLIT_SIZE, -1);
+    }
+
+    @Test
+    public void testCassandraTokenSplitManagerTotalPartitionCountOverride()
+            throws Exception
+    {
+        CassandraTokenSplitManager cassandraTokenSplitManager = new CassandraTokenSplitManager(session, SPLIT_SIZE, 12_345);
+        assertEquals(12_345, cassandraTokenSplitManager.getTotalPartitionsCount(KEYSPACE, TABLE));
     }
 
     @Test

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -77,6 +77,9 @@ Property Name                                      Description
 ``cassandra.password``                             Password used for authentication to the Cassandra cluster.
                                                    This is a global setting used for all connections, regardless
                                                    of the user who is connected to Presto.
+
+``cassandra.protocol-version``                     It is possible to override the protocol version for older Cassandra clusters.
+                                                   This property defaults to V3. Possible values include V2, V3 and V4.
 ================================================== ======================================================================
 
 .. note::
@@ -97,6 +100,11 @@ Property Name                                                 Description
                                                               single partion key column table.
 
 ``cassandra.split-size``                                      Number of keys per split when querying Cassandra.
+
+``cassandra.splits-per-node``                                 Allows to override the number of splits per node. Only use this
+                                                              in case of connecting to Cassandra versions < 2.1.5 (V2 protocol)
+                                                              which lack the system.size_estimates table for automatic detection
+                                                              of the parallelism.
 
 ``cassandra.client.read-timeout``                             Maximum time the Cassandra driver will wait for an
                                                               answer to a query from one Cassandra node. Note that the underlying


### PR DESCRIPTION
Default version was set to V3, breaking compatibility with older versions of Cassandra. This fixes https://github.com/prestodb/presto/issues/7943 