### PR TITLE
Fix node state returned by FailureDetector

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/failureDetector/HeartbeatFailureDetector.java
+++ b/presto-main/src/main/java/com/facebook/presto/failureDetector/HeartbeatFailureDetector.java
@@ -162,11 +162,12 @@ public class HeartbeatFailureDetector
                 }
 
                 Exception lastFailureException = task.getStats().getLastFailureException();
-                if (lastFailureException instanceof SocketTimeoutException || lastFailureException instanceof UnknownHostException) {
+                if (lastFailureException instanceof ConnectException) {
                     return GONE;
                 }
 
-                if (lastFailureException instanceof ConnectException) {
+                if (lastFailureException instanceof SocketTimeoutException) {
+                    // TODO: distinguish between process unresponsiveness (e.g GC pause) and host reboot
                     return UNRESPONSIVE;
                 }
 


### PR DESCRIPTION
- "GONE" means either the host or the Presto process is gone. So
ConnectException will be considered as "GONE".
- SocketTimeoutException can happen when host is gone, or host is up but
the process is not listening. Consider it as "UNRESPONSIVE" for now.