### PR TITLE
Prefer undistributed plans for TopN and move some rules to iterative optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -801,7 +801,7 @@ public class LocalExecutionPlanner
                     (int) node.getCount(),
                     sortChannels,
                     sortOrders,
-                    node.isPartial(),
+                    node.getStep().equals(TopNNode.Step.PARTIAL),
                     maxPartialAggregationMemorySize);
 
             return new PhysicalOperation(operator, source.getLayout(), source);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -35,6 +35,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughProject;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughSemiJoin;
+import com.facebook.presto.sql.planner.iterative.rule.PushTopNThroughUnion;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveEmptyDelete;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveFullSample;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
@@ -213,7 +214,8 @@ public class PlanOptimizers
         builder.add(new IterativeOptimizer(
                 stats,
                 ImmutableSet.of(
-                        new CreatePartialTopN())));
+                        new CreatePartialTopN(),
+                        new PushTopNThroughUnion())));
 
         if (!forceSingleNode) {
             builder.add(new DetermineJoinDistributionType()); // Must run before AddExchanges

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.iterative.rule.AddIntermediateAggregations;
+import com.facebook.presto.sql.planner.iterative.rule.CreatePartialTopN;
 import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroLimit;
 import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroSample;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
@@ -209,6 +210,10 @@ public class PlanOptimizers
         }
 
         builder.add(new OptimizeMixedDistinctAggregations(metadata));
+        builder.add(new IterativeOptimizer(
+                stats,
+                ImmutableSet.of(
+                        new CreatePartialTopN())));
 
         if (!forceSingleNode) {
             builder.add(new DetermineJoinDistributionType()); // Must run before AddExchanges

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -801,7 +801,7 @@ class QueryPlanner
 
         PlanNode planNode;
         if (limit.isPresent() && !limit.get().equalsIgnoreCase("all")) {
-            planNode = new TopNNode(idAllocator.getNextId(), subPlan.getRoot(), Long.parseLong(limit.get()), orderBySymbols.build(), orderings, false);
+            planNode = new TopNNode(idAllocator.getNextId(), subPlan.getRoot(), Long.parseLong(limit.get()), orderBySymbols.build(), orderings, TopNNode.Step.SINGLE);
         }
         else {
             planNode = new SortNode(idAllocator.getNextId(), subPlan.getRoot(), orderBySymbols.build(), orderings);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CreatePartialTopN.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CreatePartialTopN.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.plan.TopNNode.Step.FINAL;
+import static com.facebook.presto.sql.planner.plan.TopNNode.Step.PARTIAL;
+import static com.facebook.presto.sql.planner.plan.TopNNode.Step.SINGLE;
+
+public class CreatePartialTopN
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        if (!(node instanceof TopNNode)) {
+            return Optional.empty();
+        }
+
+        TopNNode single = (TopNNode) node;
+
+        if (!single.getStep().equals(SINGLE)) {
+            return Optional.empty();
+        }
+
+        PlanNode source = lookup.resolve(single.getSource());
+
+        TopNNode partial = new TopNNode(
+                idAllocator.getNextId(),
+                source,
+                single.getCount(),
+                single.getOrderBy(),
+                single.getOrderings(),
+                PARTIAL);
+
+        return Optional.of(new TopNNode(
+                idAllocator.getNextId(),
+                partial,
+                single.getCount(),
+                single.getOrderBy(),
+                single.getOrderings(),
+                FINAL));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithSort.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithSort.java
@@ -51,6 +51,6 @@ public class MergeLimitWithSort
                         parent.getCount(),
                         child.getOrderBy(),
                         child.getOrderings(),
-                        parent.isPartial()));
+                        parent.isPartial() ? TopNNode.Step.PARTIAL : TopNNode.Step.SINGLE));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithTopN.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeLimitWithTopN.java
@@ -50,6 +50,6 @@ public class MergeLimitWithTopN
                         Math.min(parent.getCount(), child.getCount()),
                         child.getOrderBy(),
                         child.getOrderings(),
-                        parent.isPartial()));
+                        parent.isPartial() ? TopNNode.Step.PARTIAL : TopNNode.Step.SINGLE));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushTopNThroughUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushTopNThroughUnion.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.optimizations.SymbolMapper;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
+import com.facebook.presto.sql.planner.plan.UnionNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.sql.planner.plan.TopNNode.Step.PARTIAL;
+import static com.google.common.collect.Iterables.getLast;
+import static com.google.common.collect.Sets.intersection;
+
+public class PushTopNThroughUnion
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        if (!(node instanceof TopNNode)) {
+            return Optional.empty();
+        }
+
+        TopNNode topNNode = (TopNNode) node;
+
+        if (!topNNode.getStep().equals(PARTIAL)) {
+            return Optional.empty();
+        }
+
+        PlanNode child = lookup.resolve(topNNode.getSource());
+        if (!(child instanceof UnionNode)) {
+            return Optional.empty();
+        }
+        UnionNode unionNode = (UnionNode) child;
+
+        ImmutableList.Builder<PlanNode> sources = ImmutableList.builder();
+
+        for (PlanNode source : unionNode.getSources()) {
+            SymbolMapper.Builder symbolMapper = SymbolMapper.builder();
+            Set<Symbol> sourceOutputSymbols = ImmutableSet.copyOf(source.getOutputSymbols());
+
+            for (Symbol unionOutput : unionNode.getOutputSymbols()) {
+                Set<Symbol> inputSymbols = ImmutableSet.copyOf(unionNode.getSymbolMapping().get(unionOutput));
+                Symbol unionInput = getLast(intersection(inputSymbols, sourceOutputSymbols));
+                symbolMapper.put(unionOutput, unionInput);
+            }
+            sources.add(symbolMapper.build().map(topNNode, source, idAllocator.getNextId()));
+        }
+
+        return Optional.of(new UnionNode(
+                unionNode.getId(),
+                sources.build(),
+                unionNode.getSymbolMapping(),
+                unionNode.getOutputSymbols()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -445,7 +445,7 @@ public class AddExchanges
             switch (node.getStep()) {
                 case SINGLE:
                 case FINAL:
-                    child = planChild(node, context.withPreferredProperties(PreferredProperties.any()));
+                    child = planChild(node, context.withPreferredProperties(PreferredProperties.undistributed()));
                     if (!child.getProperties().isSingleNode()) {
                         child = withDerivedProperties(
                                 gatheringExchange(idAllocator.getNextId(), REMOTE, child.getNode()),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -444,7 +444,7 @@ public class AddExchanges
 
             if (!child.getProperties().isSingleNode()) {
                 child = withDerivedProperties(
-                        new TopNNode(idAllocator.getNextId(), child.getNode(), node.getCount(), node.getOrderBy(), node.getOrderings(), true),
+                        new TopNNode(idAllocator.getNextId(), child.getNode(), node.getCount(), node.getOrderBy(), node.getOrderings(), TopNNode.Step.PARTIAL),
                         child.getProperties());
 
                 child = withDerivedProperties(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -169,7 +169,7 @@ public class AddLocalExchanges
         @Override
         public PlanWithProperties visitTopN(TopNNode node, StreamPreferredProperties parentPreferences)
         {
-            if (node.isPartial()) {
+            if (node.getStep().equals(TopNNode.Step.PARTIAL)) {
                 return planAndEnforceChildren(
                         node,
                         parentPreferences.withoutPreference().withDefaultParallelism(session),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
@@ -179,7 +179,7 @@ public class LimitPushDown
             if (limit != null) {
                 count = Math.min(count, limit.getCount());
             }
-            return new TopNNode(node.getId(), rewrittenSource, count, node.getOrderBy(), node.getOrderings(), node.isPartial());
+            return new TopNNode(node.getId(), rewrittenSource, count, node.getOrderBy(), node.getOrderings(), node.getStep());
         }
 
         @Override
@@ -190,7 +190,7 @@ public class LimitPushDown
 
             PlanNode rewrittenSource = context.rewrite(node.getSource());
             if (limit != null) {
-                return new TopNNode(node.getId(), rewrittenSource, limit.getCount(), node.getOrderBy(), node.getOrderings(), false);
+                return new TopNNode(node.getId(), rewrittenSource, limit.getCount(), node.getOrderBy(), node.getOrderings(), TopNNode.Step.SINGLE);
             }
             else if (rewrittenSource != node.getSource()) {
                 return new SortNode(node.getId(), rewrittenSource, node.getOrderBy(), node.getOrderings());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -558,7 +558,7 @@ public class PruneUnreferencedOutputs
 
             PlanNode source = context.rewrite(node.getSource(), expectedInputs.build());
 
-            return new TopNNode(node.getId(), source, node.getCount(), node.getOrderBy(), node.getOrderings(), node.isPartial());
+            return new TopNNode(node.getId(), source, node.getCount(), node.getOrderBy(), node.getOrderings(), node.getStep());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -459,6 +459,10 @@ final class StreamPropertyDerivations
         @Override
         public StreamProperties visitTopN(TopNNode node, List<StreamProperties> inputProperties)
         {
+            // Partial TopN doesn't guarantee that stream is ordered
+            if (node.getStep().equals(TopNNode.Step.PARTIAL)) {
+                return Iterables.getOnlyElement(inputProperties);
+            }
             return StreamProperties.ordered();
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -110,16 +110,6 @@ public class SymbolMapper
                 node.getGroupIdSymbol().map(this::map));
     }
 
-    public TopNNode map(TopNNode node, PlanNode source)
-    {
-        return map(node, source, node.getId());
-    }
-
-    public TopNNode map(TopNNode node, PlanNode source, PlanNodeIdAllocator idAllocator)
-    {
-        return map(node, source, idAllocator.getNextId());
-    }
-
     public TopNNode map(TopNNode node, PlanNode source, PlanNodeId newNodeId)
     {
         ImmutableList.Builder<Symbol> symbols = ImmutableList.builder();
@@ -136,7 +126,7 @@ public class SymbolMapper
                 node.getCount(),
                 symbols.build(),
                 orderings.build(),
-                node.isPartial());
+                node.getStep());
     }
 
     private List<Symbol> mapAndDistinct(List<Symbol> outputs)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -444,15 +444,8 @@ public class UnaliasSymbolReferences
         {
             PlanNode source = context.rewrite(node.getSource());
 
-            ImmutableList.Builder<Symbol> symbols = ImmutableList.builder();
-            ImmutableMap.Builder<Symbol, SortOrder> orderings = ImmutableMap.builder();
-            for (Symbol symbol : node.getOrderBy()) {
-                Symbol canonical = canonicalize(symbol);
-                symbols.add(canonical);
-                orderings.put(canonical, node.getOrderings().get(symbol));
-            }
-
-            return new TopNNode(node.getId(), source, node.getCount(), symbols.build(), orderings.build(), node.isPartial());
+            SymbolMapper mapper = new SymbolMapper(mapping);
+            return mapper.map(node, source, node.getId());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TopNNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TopNNode.java
@@ -35,11 +35,17 @@ import static java.util.Objects.requireNonNull;
 public class TopNNode
         extends PlanNode
 {
+    public enum Step {
+        SINGLE,
+        PARTIAL,
+        FINAL
+    }
+
     private final PlanNode source;
     private final long count;
     private final List<Symbol> orderBy;
     private final Map<Symbol, SortOrder> orderings;
-    private final boolean partial;
+    private final Step step;
 
     @JsonCreator
     public TopNNode(@JsonProperty("id") PlanNodeId id,
@@ -47,7 +53,7 @@ public class TopNNode
             @JsonProperty("count") long count,
             @JsonProperty("orderBy") List<Symbol> orderBy,
             @JsonProperty("orderings") Map<Symbol, SortOrder> orderings,
-            @JsonProperty("partial") boolean partial)
+            @JsonProperty("step") Step step)
     {
         super(id);
 
@@ -62,7 +68,7 @@ public class TopNNode
         this.count = count;
         this.orderBy = ImmutableList.copyOf(orderBy);
         this.orderings = ImmutableMap.copyOf(orderings);
-        this.partial = partial;
+        this.step = requireNonNull(step, "step is null");
     }
 
     @Override
@@ -101,10 +107,10 @@ public class TopNNode
         return orderings;
     }
 
-    @JsonProperty("partial")
-    public boolean isPartial()
+    @JsonProperty("step")
+    public Step getStep()
     {
-        return partial;
+        return step;
     }
 
     @Override
@@ -116,6 +122,6 @@ public class TopNNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
-        return new TopNNode(getId(), Iterables.getOnlyElement(newChildren), count, orderBy, orderings, partial);
+        return new TopNNode(getId(), Iterables.getOnlyElement(newChildren), count, orderBy, orderings, step);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -238,7 +238,7 @@ public class TestEffectivePredicateExtractor
                                 equals(AE, BE),
                                 equals(BE, CE),
                                 lessThan(CE, bigintLiteral(10)))),
-                1, ImmutableList.of(A), ImmutableMap.of(A, SortOrder.ASC_NULLS_LAST), true);
+                1, ImmutableList.of(A), ImmutableMap.of(A, SortOrder.ASC_NULLS_LAST), TopNNode.Step.PARTIAL);
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnion.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnion.java
@@ -83,14 +83,13 @@ public class TestUnion
                 .where(TestUnion::isRemoteExchange)
                 .findAll();
 
-        assertEquals(remotes.size(), 2, "There should be exactly two RemoteExchanges");
-        assertEquals(((ExchangeNode) remotes.get(0)).getType(), GATHER);
-        assertEquals(((ExchangeNode) remotes.get(1)).getType(), REPARTITION);
+        assertEquals(remotes.size(), 1, "There should be exactly one RemoteExchange");
+        assertEquals(((ExchangeNode) Iterables.getOnlyElement(remotes)).getType(), GATHER);
 
         int numberOfpartialTopN = searchFrom(plan.getRoot())
                 .where(planNode -> planNode instanceof TopNNode && ((TopNNode) planNode).getStep().equals(TopNNode.Step.PARTIAL))
                 .count();
-        assertEquals(numberOfpartialTopN, 1, "There should be exactly one partial TopN node");
+        assertEquals(numberOfpartialTopN, 2, "There should be exactly two partial TopN nodes");
         assertPlanIsFullyDistributed(plan);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnion.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnion.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
 import com.google.common.collect.Iterables;
 import org.testng.annotations.Test;
 
@@ -62,6 +63,34 @@ public class TestUnion
 
         assertEquals(remotes.size(), 1, "There should be exactly one RemoteExchange");
         assertEquals(((ExchangeNode) Iterables.getOnlyElement(remotes)).getType(), GATHER);
+        assertPlanIsFullyDistributed(plan);
+    }
+
+    @Test
+    public void testUnionUnderTopN()
+    {
+        Plan plan = plan(
+                "SELECT * FROM (" +
+                        "   SELECT regionkey FROM nation " +
+                        "   UNION ALL " +
+                        "   SELECT nationkey FROM nation" +
+                        ") t(a) " +
+                        "ORDER BY a LIMIT 1",
+                LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED,
+                false);
+
+        List<PlanNode> remotes = searchFrom(plan.getRoot())
+                .where(TestUnion::isRemoteExchange)
+                .findAll();
+
+        assertEquals(remotes.size(), 2, "There should be exactly two RemoteExchanges");
+        assertEquals(((ExchangeNode) remotes.get(0)).getType(), GATHER);
+        assertEquals(((ExchangeNode) remotes.get(1)).getType(), REPARTITION);
+
+        int numberOfpartialTopN = searchFrom(plan.getRoot())
+                .where(planNode -> planNode instanceof TopNNode && ((TopNNode) planNode).getStep().equals(TopNNode.Step.PARTIAL))
+                .count();
+        assertEquals(numberOfpartialTopN, 1, "There should be exactly one partial TopN node");
         assertPlanIsFullyDistributed(plan);
     }
 
@@ -139,8 +168,8 @@ public class TestUnion
                         .skipOnlyWhen(TestUnion::isNotRemoteGatheringExchange)
                         .findAll()
                         .stream()
-                        .noneMatch(planNode -> planNode instanceof AggregationNode || planNode instanceof JoinNode),
-                "There is an Aggregation or Join between output and first REMOTE GATHER ExchangeNode");
+                        .noneMatch(this::shouldBeDistributed),
+                "There is a node that should be distributed between output and first REMOTE GATHER ExchangeNode");
 
         List<PlanNode> gathers = searchFrom(plan.getRoot())
                 .where(TestUnion::isRemoteGatheringExchange)
@@ -149,6 +178,21 @@ public class TestUnion
                 .collect(toList());
 
         assertEquals(gathers.size(), 1, "Only a single REMOTE GATHER was expected");
+    }
+
+    private boolean shouldBeDistributed(PlanNode planNode)
+    {
+        if (planNode instanceof JoinNode) {
+            return true;
+        }
+        if (planNode instanceof AggregationNode) {
+            // TODO: differentiate aggregation with empty grouping set
+            return true;
+        }
+        if (planNode instanceof TopNNode) {
+            return ((TopNNode) planNode).getStep() == TopNNode.Step.PARTIAL;
+        }
+        return false;
     }
 
     private static void assertAtMostOneAggregationBetweenRemoteExchanges(Plan plan)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5781,6 +5781,18 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testUnionWithTopN()
+    {
+        assertQuery("SELECT * FROM (" +
+                "   SELECT regionkey FROM nation " +
+                "   UNION ALL " +
+                "   SELECT nationkey FROM nation" +
+                ") t(a) " +
+                "ORDER BY a LIMIT 1",
+                "SELECT 0");
+    }
+
+    @Test
     public void testUnionWithJoin()
     {
         assertQuery(


### PR DESCRIPTION
Prefer undistributed plans for TopN and to avoid unnecessary additional exchanges, add new PushTopNThroughUnion optimizer.

This is a follow up worker of previous changes with distributed union.

```    
> explain SELECT * FROM (SELECT regionkey FROM nation UNION ALL SELECT nationkey FROM nation) t(a) ORDER BY a LIMIT 1;
```    
before:
```
     - Output[a] => [regionkey_9:bigint]
             a := regionkey_9
         - TopN[1 by (regionkey_9 ASC_NULLS_LAST)] => [regionkey_9:bigint]
             - LocalExchange[SINGLE] () => regionkey_9:bigint
                 - RemoteExchange[GATHER] => regionkey_9:bigint
                     - TopN[1 by (regionkey_9 ASC_NULLS_LAST)] => [regionkey_9:bigint]
                         - RemoteExchange[REPARTITION] => regionkey_9:bigint
                             - TableScan[tpch:tpch:nation:sf0.01, originalConstraint = true] => [regionkey:bigint]
                                     regionkey := tpch:regionkey
                             - TableScan[tpch:tpch:nation:sf0.01, originalConstraint = true] => [nationkey_2:bigint]
                                     nationkey_2 := tpch:nationkey
```    
after:
```
     - Output[a] => [regionkey_9:bigint]
             a := regionkey_9
         - TopN[1 by (regionkey_9 ASC_NULLS_LAST)] => [regionkey_9:bigint]
             - LocalExchange[SINGLE] () => regionkey_9:bigint
                 - RemoteExchange[GATHER] => regionkey_9:bigint
                     - TopN[1 by (regionkey ASC_NULLS_LAST)] => [regionkey:bigint]
                         - TableScan[tpch:tpch:nation:sf0.01, originalConstraint = true] => [regionkey:bigint]
                                 regionkey := tpch:regionkey
                     - TopN[1 by (nationkey_2 ASC_NULLS_LAST)] => [nationkey_2:bigint]
                         - TableScan[tpch:tpch:nation:sf0.01, originalConstraint = true] => [nationkey_2:bigint]
                                 nationkey_2 := tpch:nationkey
```

Maybe we could also leave additional partial `TopN` between `LocalExchange[SINGLE]` and `RemoteExchange[GATHER]` for  higher concurrency of the final `TopN`?