### PR TITLE
Fix creating empty tables in presto-memory

### DIFF
--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryDataFragment.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryDataFragment.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.memory;
+
+import com.facebook.presto.spi.HostAddress;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.json.JsonCodec;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static java.util.Objects.requireNonNull;
+
+public class MemoryDataFragment
+{
+    private static final JsonCodec<MemoryDataFragment> MEMORY_DATA_FRAGMENT_CODEC = jsonCodec(MemoryDataFragment.class);
+
+    private final HostAddress hostAddress;
+    private final long rows;
+
+    @JsonCreator
+    public MemoryDataFragment(
+            @JsonProperty("hostAddress") HostAddress hostAddress,
+            @JsonProperty("rows") long rows)
+    {
+        this.hostAddress = requireNonNull(hostAddress, "hostAddress is null");
+        checkArgument(rows >= 0, "Rows number can not be negative");
+        this.rows = rows;
+    }
+
+    @JsonProperty
+    public HostAddress getHostAddress()
+    {
+        return hostAddress;
+    }
+
+    @JsonProperty
+    public long getRows()
+    {
+        return rows;
+    }
+
+    public Slice toSlice()
+    {
+        return Slices.wrappedBuffer(MEMORY_DATA_FRAGMENT_CODEC.toJsonBytes(this));
+    }
+
+    public static MemoryDataFragment fromSlice(Slice fragment)
+    {
+        return MEMORY_DATA_FRAGMENT_CODEC.fromJson(fragment.getBytes());
+    }
+
+    public static MemoryDataFragment merge(MemoryDataFragment a, MemoryDataFragment b)
+    {
+        checkArgument(a.getHostAddress().equals(b.getHostAddress()), "Can not merge fragments from different hosts");
+        return new MemoryDataFragment(a.getHostAddress(), a.getRows() + b.getRows());
+    }
+}

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryMetadata.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryMetadata.java
@@ -40,11 +40,11 @@ import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -64,8 +64,8 @@ public class MemoryMetadata
     private final NodeManager nodeManager;
     private final String connectorId;
     private final AtomicLong nextTableId = new AtomicLong();
-    private final Map<String, Long> tableIds = new ConcurrentHashMap<>();
-    private final Map<Long, MemoryTableHandle> tables = new ConcurrentHashMap<>();
+    private final Map<String, Long> tableIds = new HashMap<>();
+    private final Map<Long, MemoryTableHandle> tables = new HashMap<>();
 
     @Inject
     public MemoryMetadata(NodeManager nodeManager, MemoryConnectorId connectorId)

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryPageSourceProvider.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryPageSourceProvider.java
@@ -51,11 +51,17 @@ public final class MemoryPageSourceProvider
         long tableId = memorySplit.getTableHandle().getTableId();
         int partNumber = memorySplit.getPartNumber();
         int totalParts = memorySplit.getTotalPartsPerWorker();
+        long expectedRows = memorySplit.getExpectedRows();
 
         List<Integer> columnIndexes = columns.stream()
                 .map(MemoryColumnHandle.class::cast)
                 .map(MemoryColumnHandle::getColumnIndex).collect(toList());
-        List<Page> pages = pagesStore.getPages(tableId, partNumber, totalParts, columnIndexes);
+        List<Page> pages = pagesStore.getPages(
+                tableId,
+                partNumber,
+                totalParts,
+                columnIndexes,
+                expectedRows);
 
         return new FixedPageSource(pages);
     }

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryPagesStore.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryPagesStore.java
@@ -42,18 +42,18 @@ public class MemoryPagesStore
     @GuardedBy("this")
     private long currentBytes = 0;
 
+    private final Map<Long, TableData> tables = new HashMap<>();
+
     @Inject
     public MemoryPagesStore(MemoryConfig config)
     {
         this.maxBytes = config.getMaxDataPerNode().toBytes();
     }
 
-    private final Map<Long, List<Page>> pages = new HashMap<>();
-
     public synchronized void initialize(long tableId)
     {
-        if (!pages.containsKey(tableId)) {
-            pages.put(tableId, new ArrayList<>());
+        if (!tables.containsKey(tableId)) {
+            tables.put(tableId, new TableData());
         }
     }
 
@@ -69,21 +69,30 @@ public class MemoryPagesStore
         }
         currentBytes = newSize;
 
-        List<Page> tablePages = pages.get(tableId);
-        tablePages.add(page);
+        TableData tableData = tables.get(tableId);
+        tableData.add(page);
     }
 
-    public synchronized List<Page> getPages(Long tableId, int partNumber, int totalParts, List<Integer> columnIndexes)
+    public synchronized List<Page> getPages(
+            Long tableId,
+            int partNumber,
+            int totalParts,
+            List<Integer> columnIndexes,
+            long expectedRows)
     {
         if (!contains(tableId)) {
             throw new PrestoException(MISSING_DATA, "Failed to find table on a worker.");
         }
+        TableData tableData = tables.get(tableId);
+        if (tableData.getRows() < expectedRows) {
+            throw new PrestoException(MISSING_DATA,
+                    format("Expected to find [%s] rows on a worker, but found [%s].", expectedRows, tableData.getRows()));
+        }
 
-        List<Page> tablePages = pages.get(tableId);
         ImmutableList.Builder<Page> partitionedPages = ImmutableList.builder();
 
-        for (int i = partNumber; i < tablePages.size(); i += totalParts) {
-            partitionedPages.add(getColumns(tablePages.get(i), columnIndexes));
+        for (int i = partNumber; i < tableData.getPages().size(); i += totalParts) {
+            partitionedPages.add(getColumns(tableData.getPages().get(i), columnIndexes));
         }
 
         return partitionedPages.build();
@@ -91,7 +100,7 @@ public class MemoryPagesStore
 
     public synchronized boolean contains(Long tableId)
     {
-        return pages.containsKey(tableId);
+        return tables.containsKey(tableId);
     }
 
     public synchronized void cleanUp(Set<Long> activeTableIds)
@@ -110,14 +119,14 @@ public class MemoryPagesStore
         }
         long latestTableId  = Collections.max(activeTableIds);
 
-        for (Iterator<Map.Entry<Long, List<Page>>> tablePages = pages.entrySet().iterator(); tablePages.hasNext(); ) {
-            Map.Entry<Long, List<Page>> tablePagesEntry = tablePages.next();
+        for (Iterator<Map.Entry<Long, TableData>> tableDataIterator = tables.entrySet().iterator(); tableDataIterator.hasNext(); ) {
+            Map.Entry<Long, TableData> tablePagesEntry = tableDataIterator.next();
             Long tableId = tablePagesEntry.getKey();
             if (tableId < latestTableId && !activeTableIds.contains(tableId)) {
-                for (Page removedPage : tablePagesEntry.getValue()) {
+                for (Page removedPage : tablePagesEntry.getValue().getPages()) {
                     currentBytes -= removedPage.getRetainedSizeInBytes();
                 }
-                tablePages.remove();
+                tableDataIterator.remove();
             }
         }
     }
@@ -132,5 +141,27 @@ public class MemoryPagesStore
         }
 
         return new Page(page.getPositionCount(), outputBlocks);
+    }
+
+    private static final class TableData
+    {
+        private List<Page> pages = new ArrayList<>();
+        private long rows;
+
+        public void add(Page page)
+        {
+            pages.add(page);
+            rows += page.getPositionCount();
+        }
+
+        private List<Page> getPages()
+        {
+            return pages;
+        }
+
+        private long getRows()
+        {
+            return rows;
+        }
     }
 }

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplit.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplit.java
@@ -33,13 +33,15 @@ public class MemorySplit
     private final int totalPartsPerWorker; // how many concurrent reads there will be from one worker
     private final int partNumber; // part of the pages on one worker that this splits is responsible
     private final List<HostAddress> addresses;
+    private final long expectedRows;
 
     @JsonCreator
     public MemorySplit(
             @JsonProperty("tableHandle") MemoryTableHandle tableHandle,
             @JsonProperty("partNumber") int partNumber,
             @JsonProperty("totalPartsPerWorker") int totalPartsPerWorker,
-            @JsonProperty("addresses") List<HostAddress> addresses)
+            @JsonProperty("addresses") List<HostAddress> addresses,
+            @JsonProperty("expectedRows") long expectedRows)
     {
         checkState(partNumber >= 0, "partNumber must be >= 0");
         checkState(totalPartsPerWorker >= 1, "totalPartsPerWorker must be >= 1");
@@ -49,6 +51,7 @@ public class MemorySplit
         this.partNumber = partNumber;
         this.totalPartsPerWorker = totalPartsPerWorker;
         this.addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
+        this.expectedRows = expectedRows;
     }
 
     @JsonProperty
@@ -86,6 +89,12 @@ public class MemorySplit
     public List<HostAddress> getAddresses()
     {
         return addresses;
+    }
+
+    @JsonProperty
+    public long getExpectedRows()
+    {
+        return expectedRows;
     }
 
     @Override

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplit.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplit.java
@@ -32,7 +32,7 @@ public class MemorySplit
     private final MemoryTableHandle tableHandle;
     private final int totalPartsPerWorker; // how many concurrent reads there will be from one worker
     private final int partNumber; // part of the pages on one worker that this splits is responsible
-    private final List<HostAddress> addresses;
+    private final HostAddress address;
     private final long expectedRows;
 
     @JsonCreator
@@ -40,7 +40,7 @@ public class MemorySplit
             @JsonProperty("tableHandle") MemoryTableHandle tableHandle,
             @JsonProperty("partNumber") int partNumber,
             @JsonProperty("totalPartsPerWorker") int totalPartsPerWorker,
-            @JsonProperty("addresses") List<HostAddress> addresses,
+            @JsonProperty("address") HostAddress address,
             @JsonProperty("expectedRows") long expectedRows)
     {
         checkState(partNumber >= 0, "partNumber must be >= 0");
@@ -50,7 +50,7 @@ public class MemorySplit
         this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
         this.partNumber = partNumber;
         this.totalPartsPerWorker = totalPartsPerWorker;
-        this.addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
+        this.address = requireNonNull(address, "address is null");
         this.expectedRows = expectedRows;
     }
 
@@ -85,10 +85,15 @@ public class MemorySplit
     }
 
     @JsonProperty
+    public HostAddress getAddress()
+    {
+        return address;
+    }
+
     @Override
     public List<HostAddress> getAddresses()
     {
-        return addresses;
+        return ImmutableList.of(address);
     }
 
     @JsonProperty

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplitManager.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplitManager.java
@@ -52,7 +52,7 @@ public final class MemorySplitManager
                                 layout.getTable(),
                                 i,
                                 splitsPerNode,
-                                ImmutableList.of(dataFragment.getHostAddress()),
+                                dataFragment.getHostAddress(),
                                 dataFragment.getRows()));
             }
         }

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplitManager.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplitManager.java
@@ -18,7 +18,6 @@ import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.FixedSplitSource;
-import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.common.collect.ImmutableList;
@@ -43,17 +42,18 @@ public final class MemorySplitManager
     {
         MemoryTableLayoutHandle layout = (MemoryTableLayoutHandle) layoutHandle;
 
-        List<HostAddress> hosts = layout.getTable().getHosts();
+        List<MemoryDataFragment> dataFragments = layout.getDataFragments();
 
         ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
-        for (HostAddress host : hosts) {
+        for (MemoryDataFragment dataFragment : dataFragments) {
             for (int i = 0; i < splitsPerNode; i++) {
                 splits.add(
                         new MemorySplit(
                                 layout.getTable(),
                                 i,
                                 splitsPerNode,
-                                ImmutableList.of(host)));
+                                ImmutableList.of(dataFragment.getHostAddress()),
+                                dataFragment.getRows()));
             }
         }
         return new FixedSplitSource(splits.build());

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryTableHandle.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryTableHandle.java
@@ -15,7 +15,6 @@ package com.facebook.presto.plugin.memory;
 
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableMetadata;
-import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,20 +34,17 @@ public final class MemoryTableHandle
     private final String tableName;
     private final Long tableId;
     private final List<MemoryColumnHandle> columnHandles;
-    private final List<HostAddress> hosts;
 
     public MemoryTableHandle(
             String connectorId,
             Long tableId,
-            ConnectorTableMetadata tableMetadata,
-            List<HostAddress> hosts)
+            ConnectorTableMetadata tableMetadata)
     {
         this(connectorId,
                 tableMetadata.getTable().getSchemaName(),
                 tableMetadata.getTable().getTableName(),
                 tableId,
-                MemoryColumnHandle.extractColumnHandles(tableMetadata.getColumns()),
-                hosts);
+                MemoryColumnHandle.extractColumnHandles(tableMetadata.getColumns()));
     }
 
     @JsonCreator
@@ -57,15 +53,13 @@ public final class MemoryTableHandle
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("tableId") Long tableId,
-            @JsonProperty("columnHandles") List<MemoryColumnHandle> columnHandles,
-            @JsonProperty("hosts") List<HostAddress> hosts)
+            @JsonProperty("columnHandles") List<MemoryColumnHandle> columnHandles)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.tableId = requireNonNull(tableId, "tableId is null");
         this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
-        this.hosts = requireNonNull(hosts, "hosts is null");
     }
 
     @JsonProperty
@@ -96,12 +90,6 @@ public final class MemoryTableHandle
     public List<MemoryColumnHandle> getColumnHandles()
     {
         return columnHandles;
-    }
-
-    @JsonProperty
-    public List<HostAddress> getHosts()
-    {
-        return hosts;
     }
 
     public ConnectorTableMetadata toTableMetadata()

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryTableLayoutHandle.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryTableLayoutHandle.java
@@ -17,23 +17,35 @@ import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 import static java.util.Objects.requireNonNull;
 
 public class MemoryTableLayoutHandle
         implements ConnectorTableLayoutHandle
 {
     private final MemoryTableHandle table;
+    private final List<MemoryDataFragment> dataFragments;
 
     @JsonCreator
-    public MemoryTableLayoutHandle(@JsonProperty("table") MemoryTableHandle table)
+    public MemoryTableLayoutHandle(
+            @JsonProperty("table") MemoryTableHandle table,
+            @JsonProperty("dataFragments") List<MemoryDataFragment> dataFragments)
     {
         this.table = requireNonNull(table, "table is null");
+        this.dataFragments = requireNonNull(dataFragments, "dataFragments is null");
     }
 
     @JsonProperty
     public MemoryTableHandle getTable()
     {
         return table;
+    }
+
+    @JsonProperty
+    public List<MemoryDataFragment> getDataFragments()
+    {
+        return dataFragments;
     }
 
     public String getConnectorId()

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/MemoryQueryRunner.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/MemoryQueryRunner.java
@@ -30,6 +30,8 @@ import static io.airlift.testing.Closeables.closeAllSuppress;
 
 public final class MemoryQueryRunner
 {
+    public static final String CATALOG = "memory";
+
     private MemoryQueryRunner() {}
 
     public static DistributedQueryRunner createQueryRunner()
@@ -42,7 +44,7 @@ public final class MemoryQueryRunner
             throws Exception
     {
         Session session = testSessionBuilder()
-                .setCatalog("memory")
+                .setCatalog(CATALOG)
                 .setSchema("default")
                 .build();
 
@@ -50,7 +52,7 @@ public final class MemoryQueryRunner
 
         try {
             queryRunner.installPlugin(new MemoryPlugin());
-            queryRunner.createCatalog("memory", "memory", ImmutableMap.of());
+            queryRunner.createCatalog(CATALOG, "memory", ImmutableMap.of());
 
             queryRunner.installPlugin(new TpchPlugin());
             queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of());

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryMetadata.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryMetadata.java
@@ -52,7 +52,7 @@ public class TestMemoryMetadata
     @Test
     public void tableIsCreatedAfterCommits()
     {
-        assertThatNoTableIsCreated();
+        assertNoTables();
 
         SchemaTableName schemaTableName = new SchemaTableName("default", "temp_table");
 
@@ -71,7 +71,7 @@ public class TestMemoryMetadata
     @Test
     public void tableAlreadyExists()
     {
-        assertThatNoTableIsCreated();
+        assertNoTables();
 
         SchemaTableName test1Table = new SchemaTableName("default", "test1");
         SchemaTableName test2Table = new SchemaTableName("default", "test2");
@@ -102,7 +102,7 @@ public class TestMemoryMetadata
     @Test
     public void testActiveTableIds()
     {
-        assertThatNoTableIsCreated();
+        assertNoTables();
 
         SchemaTableName firstTableName = new SchemaTableName("default", "first_table");
         metadata.createTable(SESSION, new ConnectorTableMetadata(firstTableName, ImmutableList.of(), ImmutableMap.of()));
@@ -126,7 +126,7 @@ public class TestMemoryMetadata
     @Test
     public void testReadTableBeforeCreationCompleted()
     {
-        assertThatNoTableIsCreated();
+        assertNoTables();
 
         SchemaTableName tableName = new SchemaTableName("default", "temp_table");
 
@@ -170,7 +170,7 @@ public class TestMemoryMetadata
         assertEquals(metadata.listTables(SESSION, "default"), ImmutableList.of());
     }
 
-    private void assertThatNoTableIsCreated()
+    private void assertNoTables()
     {
         assertEquals(metadata.listTables(SESSION, null), ImmutableList.of(), "No table was expected");
     }

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryMetadata.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryMetadata.java
@@ -115,6 +115,27 @@ public class TestMemoryMetadata
         metadata.finishCreateTable(SESSION, table, ImmutableList.of());
     }
 
+    @Test
+    public void testCreateSchema()
+    {
+        assertEquals(metadata.listSchemaNames(SESSION), ImmutableList.of("default"));
+        metadata.createSchema(SESSION, "test", ImmutableMap.of());
+        assertEquals(metadata.listSchemaNames(SESSION), ImmutableList.of("default", "test"));
+        assertEquals(metadata.listTables(SESSION, "test"), ImmutableList.of());
+
+        SchemaTableName tableName = new SchemaTableName("test", "first_table");
+        metadata.createTable(
+                SESSION,
+                new ConnectorTableMetadata(
+                        tableName,
+                        ImmutableList.of(),
+                        ImmutableMap.of()));
+
+        assertEquals(metadata.listTables(SESSION, null), ImmutableList.of(tableName));
+        assertEquals(metadata.listTables(SESSION, "test"), ImmutableList.of(tableName));
+        assertEquals(metadata.listTables(SESSION, "default"), ImmutableList.of());
+    }
+
     private void assertThatNoTableIsCreated()
     {
         assertEquals(metadata.listTables(SESSION, null), ImmutableList.of(), "No table was expected");

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryPagesStore.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryPagesStore.java
@@ -38,6 +38,7 @@ import static org.testng.Assert.assertTrue;
 public class TestMemoryPagesStore
 {
     public static final ConnectorSession SESSION = new TestingConnectorSession(ImmutableList.of());
+    private static final int POSITIONS_PER_PAGE = 0;
 
     private MemoryPagesStore pagesStore;
     private MemoryPageSinkProvider pageSinkProvider;
@@ -46,14 +47,14 @@ public class TestMemoryPagesStore
     public void setUp()
     {
         pagesStore = new MemoryPagesStore(new MemoryConfig().setMaxDataPerNode(new DataSize(1, DataSize.Unit.MEGABYTE)));
-        pageSinkProvider = new MemoryPageSinkProvider(pagesStore);
+        pageSinkProvider = new MemoryPageSinkProvider(pagesStore, HostAddress.fromString("localhost:8080"));
     }
 
     @Test
     public void testCreateEmptyTable()
     {
         createTable(0L, 0L);
-        assertEquals(pagesStore.getPages(0L, 0, 1, ImmutableList.of(0)), ImmutableList.of());
+        assertEquals(pagesStore.getPages(0L, 0, 1, ImmutableList.of(0), 0), ImmutableList.of());
     }
 
     @Test
@@ -61,19 +62,28 @@ public class TestMemoryPagesStore
     {
         createTable(0L, 0L);
         insertToTable(0L, 0L);
-        assertEquals(pagesStore.getPages(0L, 0, 1, ImmutableList.of(0)).size(), 1);
+        assertEquals(pagesStore.getPages(0L, 0, 1, ImmutableList.of(0), POSITIONS_PER_PAGE).size(), 1);
+    }
+
+    @Test
+    public void testInsertPageWithoutCreate()
+    {
+        insertToTable(0L, 0L);
+        assertEquals(pagesStore.getPages(0L, 0, 1, ImmutableList.of(0), POSITIONS_PER_PAGE).size(), 1);
     }
 
     @Test(expectedExceptions = PrestoException.class)
     public void testReadFromUnknownTable()
     {
-        pagesStore.getPages(0L, 0, 1, ImmutableList.of(0));
+        pagesStore.getPages(0L, 0, 1, ImmutableList.of(0), 0);
     }
 
     @Test(expectedExceptions = PrestoException.class)
-    public void testWriteToUnknownTable()
+    public void testTryToReadFromEmptyTable()
     {
-        insertToTable(0L, 0L);
+        createTable(0L, 0L);
+        assertEquals(pagesStore.getPages(0L, 0, 1, ImmutableList.of(0), 0), ImmutableList.of());
+        pagesStore.getPages(0L, 0, 1, ImmutableList.of(0), 42);
     }
 
     @Test
@@ -140,8 +150,7 @@ public class TestMemoryPagesStore
                         "schema",
                         format("table_%d", tableId),
                         tableId,
-                        ImmutableList.of(),
-                        ImmutableList.of(HostAddress.fromString("localhost:8080"))),
+                        ImmutableList.of()),
                 ImmutableSet.copyOf(activeTableIds));
     }
 
@@ -153,21 +162,20 @@ public class TestMemoryPagesStore
                         "schema",
                         format("table_%d", tableId),
                         tableId,
-                        ImmutableList.of(),
-                        ImmutableList.of(HostAddress.fromString("localhost:8080"))),
+                        ImmutableList.of()),
                 ImmutableSet.copyOf(activeTableIds));
     }
 
     private static Page createPage()
     {
-        BlockBuilder blockBuilder = BIGINT.createFixedSizeBlockBuilder(1);
+        BlockBuilder blockBuilder = BIGINT.createFixedSizeBlockBuilder(POSITIONS_PER_PAGE);
         BIGINT.writeLong(blockBuilder, 42L);
         return new Page(0, blockBuilder.build());
     }
 
     private static Page createOneMegaBytePage()
     {
-        BlockBuilder blockBuilder = BIGINT.createFixedSizeBlockBuilder(1);
+        BlockBuilder blockBuilder = BIGINT.createFixedSizeBlockBuilder(POSITIONS_PER_PAGE);
         while (blockBuilder.getRetainedSizeInBytes() < 1024 * 1024) {
             BIGINT.writeLong(blockBuilder, 42L);
         }

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryPagesStore.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryPagesStore.java
@@ -139,7 +139,8 @@ public class TestMemoryPagesStore
                         "test",
                         "schema",
                         format("table_%d", tableId),
-                        tableId, ImmutableList.of(),
+                        tableId,
+                        ImmutableList.of(),
                         ImmutableList.of(HostAddress.fromString("localhost:8080"))),
                 ImmutableSet.copyOf(activeTableIds));
     }

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
@@ -13,12 +13,10 @@
  */
 package com.facebook.presto.plugin.memory;
 
-import com.facebook.presto.Session;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.QueryRunner;
-import com.google.common.collect.Iterables;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -48,7 +46,7 @@ public class TestMemorySmoke
             throws SQLException
     {
         int tablesBeforeCreate = listMemoryTables().size();
-        queryRunner.execute("CREATE TABLE test as SELECT * FROM tpch.tiny.nation");
+        queryRunner.execute("CREATE TABLE test AS SELECT * FROM tpch.tiny.nation");
         assertEquals(listMemoryTables().size(), tablesBeforeCreate + 1);
 
         queryRunner.execute(format("DROP TABLE test"));
@@ -59,12 +57,12 @@ public class TestMemorySmoke
     public void createTableWhenTableIsAlreadyCreated()
             throws SQLException
     {
-        String createTableSql = "CREATE TABLE nation as SELECT * FROM tpch.tiny.nation";
+        String createTableSql = "CREATE TABLE nation AS SELECT * FROM tpch.tiny.nation";
         try {
             queryRunner.execute(createTableSql);
             fail("Expected exception to be thrown here!");
         }
-        catch (RuntimeException ex) { // it has to RuntimeException as FailureInfo$FailureException is private
+        catch (RuntimeException ex) { // it has to be RuntimeException as FailureInfo$FailureException is private
             assertTrue(ex.getMessage().equals("line 1:1: Destination table 'memory.default.nation' already exists"));
         }
     }
@@ -73,15 +71,15 @@ public class TestMemorySmoke
     public void select()
             throws SQLException
     {
-        queryRunner.execute("CREATE TABLE test_select as SELECT * FROM tpch.tiny.nation");
+        queryRunner.execute("CREATE TABLE test_select AS SELECT * FROM tpch.tiny.nation");
 
-        assertThatQueryReturnsSameValueAs("SELECT * FROM test_select ORDER BY nationkey", "SELECT * FROM tpch.tiny.nation ORDER BY nationkey");
+        assertQuery("SELECT * FROM test_select ORDER BY nationkey", "SELECT * FROM tpch.tiny.nation ORDER BY nationkey");
 
-        assertThatQueryReturnsValue("INSERT INTO test_select SELECT * FROM tpch.tiny.nation", 25L);
+        assertQueryResult("INSERT INTO test_select SELECT * FROM tpch.tiny.nation", 25L);
 
-        assertThatQueryReturnsValue("INSERT INTO test_select SELECT * FROM tpch.tiny.nation", 25L);
+        assertQueryResult("INSERT INTO test_select SELECT * FROM tpch.tiny.nation", 25L);
 
-        assertThatQueryReturnsValue("SELECT count(*) FROM test_select", 75L);
+        assertQueryResult("SELECT count(*) FROM test_select", 75L);
     }
 
     @Test
@@ -89,9 +87,9 @@ public class TestMemorySmoke
             throws SQLException
     {
         queryRunner.execute("CREATE TABLE test_empty (a BIGINT)");
-        assertThatQueryReturnsValue("SELECT count(*) FROM test_empty", 0L);
-        assertThatQueryReturnsValue("INSERT INTO test_empty SELECT nationkey FROM tpch.tiny.nation", 25L);
-        assertThatQueryReturnsValue("SELECT count(*) FROM test_empty", 25L);
+        assertQueryResult("SELECT count(*) FROM test_empty", 0L);
+        assertQueryResult("INSERT INTO test_empty SELECT nationkey FROM tpch.tiny.nation", 25L);
+        assertQueryResult("SELECT count(*) FROM test_empty", 25L);
     }
 
     @Test
@@ -99,31 +97,31 @@ public class TestMemorySmoke
             throws SQLException
     {
         queryRunner.execute("CREATE TABLE filtered_out AS SELECT nationkey FROM tpch.tiny.nation WHERE nationkey < 0");
-        assertThatQueryReturnsValue("SELECT count(*) FROM filtered_out", 0L);
-        assertThatQueryReturnsValue("INSERT INTO filtered_out SELECT nationkey FROM tpch.tiny.nation", 25L);
-        assertThatQueryReturnsValue("SELECT count(*) FROM filtered_out", 25L);
+        assertQueryResult("SELECT count(*) FROM filtered_out", 0L);
+        assertQueryResult("INSERT INTO filtered_out SELECT nationkey FROM tpch.tiny.nation", 25L);
+        assertQueryResult("SELECT count(*) FROM filtered_out", 25L);
     }
 
     @Test
     public void selectFromEmptyTable()
             throws SQLException
     {
-        queryRunner.execute("CREATE TABLE test_select_empty as SELECT * FROM tpch.tiny.nation WHERE nationkey > 1000");
+        queryRunner.execute("CREATE TABLE test_select_empty AS SELECT * FROM tpch.tiny.nation WHERE nationkey > 1000");
 
-        assertThatQueryReturnsValue("SELECT count(*) FROM test_select_empty", 0L);
+        assertQueryResult("SELECT count(*) FROM test_select_empty", 0L);
     }
 
     @Test
     public void selectSingleRow()
     {
-        assertThatQueryReturnsSameValueAs("SELECT * FROM nation WHERE nationkey = 1", "SELECT * FROM tpch.tiny.nation WHERE nationkey = 1");
+        assertQuery("SELECT * FROM nation WHERE nationkey = 1", "SELECT * FROM tpch.tiny.nation WHERE nationkey = 1");
     }
 
     @Test
     public void selectColumnsSubset()
             throws SQLException
     {
-        assertThatQueryReturnsSameValueAs("SELECT nationkey, regionkey FROM nation ORDER BY nationkey", "SELECT nationkey, regionkey FROM tpch.tiny.nation ORDER BY nationkey");
+        assertQuery("SELECT nationkey, regionkey FROM nation ORDER BY nationkey", "SELECT nationkey, regionkey FROM tpch.tiny.nation ORDER BY nationkey");
     }
 
     private List<QualifiedObjectName> listMemoryTables()
@@ -131,31 +129,25 @@ public class TestMemorySmoke
         return queryRunner.listTables(queryRunner.getDefaultSession(), "memory", "default");
     }
 
-    private void assertThatQueryReturnsValue(String sql, Object expected)
+    private void assertQueryResult(String sql, Object... expected)
     {
-        assertThatQueryReturnsValue(sql, expected, null);
+        MaterializedResult rows = queryRunner.execute(sql);
+        assertEquals(rows.getRowCount(), expected.length);
+
+        for (int i = 0; i < expected.length; i++) {
+            MaterializedRow materializedRow = rows.getMaterializedRows().get(i);
+            int fieldCount = materializedRow.getFieldCount();
+            assertTrue(fieldCount == 1, format("Expected only one column, but got '%d'", fieldCount));
+            Object value = materializedRow.getField(0);
+            assertEquals(value, expected[i]);
+            assertTrue(materializedRow.getFieldCount() == 1);
+        }
     }
 
-    private void assertThatQueryReturnsValue(String sql, Object expected, Session session)
+    private void assertQuery(String sql, String expected)
     {
-        MaterializedResult rows = session == null ? queryRunner.execute(sql) : queryRunner.execute(session, sql);
-        MaterializedRow materializedRow = Iterables.getOnlyElement(rows);
-        int fieldCount = materializedRow.getFieldCount();
-        assertTrue(fieldCount == 1, format("Expected only one column, but got '%d'", fieldCount));
-        Object value = materializedRow.getField(0);
-        assertEquals(value, expected);
-        assertTrue(Iterables.getOnlyElement(rows).getFieldCount() == 1);
-    }
-
-    private void assertThatQueryReturnsSameValueAs(String sql, String compareSql)
-    {
-        assertThatQueryReturnsSameValueAs(sql, compareSql, null);
-    }
-
-    private void assertThatQueryReturnsSameValueAs(String sql, String compareSql, Session session)
-    {
-        MaterializedResult rows = session == null ? queryRunner.execute(sql) : queryRunner.execute(session, sql);
-        MaterializedResult expectedRows = session == null ? queryRunner.execute(compareSql) : queryRunner.execute(session, compareSql);
+        MaterializedResult rows = queryRunner.execute(sql);
+        MaterializedResult expectedRows = queryRunner.execute(expected);
 
         assertEquals(rows, expectedRows);
     }

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
@@ -42,7 +42,7 @@ public class TestMemorySmoke
     }
 
     @Test
-    public void createAndDropTable()
+    public void testCreateAndDropTable()
             throws SQLException
     {
         int tablesBeforeCreate = listMemoryTables().size();
@@ -55,7 +55,7 @@ public class TestMemorySmoke
 
     // it has to be RuntimeException as FailureInfo$FailureException is private
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "line 1:1: Destination table 'memory.default.nation' already exists")
-    public void createTableWhenTableIsAlreadyCreated()
+    public void testCreateTableWhenTableIsAlreadyCreated()
             throws SQLException
     {
         String createTableSql = "CREATE TABLE nation AS SELECT * FROM tpch.tiny.nation";
@@ -63,7 +63,7 @@ public class TestMemorySmoke
     }
 
     @Test
-    public void select()
+    public void testSelect()
             throws SQLException
     {
         queryRunner.execute("CREATE TABLE test_select AS SELECT * FROM tpch.tiny.nation");
@@ -78,7 +78,7 @@ public class TestMemorySmoke
     }
 
     @Test
-    public void createTableWithNoData()
+    public void testCreateTableWithNoData()
             throws SQLException
     {
         queryRunner.execute("CREATE TABLE test_empty (a BIGINT)");
@@ -88,7 +88,7 @@ public class TestMemorySmoke
     }
 
     @Test
-    public void createFilteredOutTable()
+    public void testCreateFilteredOutTable()
             throws SQLException
     {
         queryRunner.execute("CREATE TABLE filtered_out AS SELECT nationkey FROM tpch.tiny.nation WHERE nationkey < 0");
@@ -98,7 +98,7 @@ public class TestMemorySmoke
     }
 
     @Test
-    public void selectFromEmptyTable()
+    public void testSelectFromEmptyTable()
             throws SQLException
     {
         queryRunner.execute("CREATE TABLE test_select_empty AS SELECT * FROM tpch.tiny.nation WHERE nationkey > 1000");
@@ -107,20 +107,20 @@ public class TestMemorySmoke
     }
 
     @Test
-    public void selectSingleRow()
+    public void testSelectSingleRow()
     {
         assertQuery("SELECT * FROM nation WHERE nationkey = 1", "SELECT * FROM tpch.tiny.nation WHERE nationkey = 1");
     }
 
     @Test
-    public void selectColumnsSubset()
+    public void testSelectColumnsSubset()
             throws SQLException
     {
         assertQuery("SELECT nationkey, regionkey FROM nation ORDER BY nationkey", "SELECT nationkey, regionkey FROM tpch.tiny.nation ORDER BY nationkey");
     }
 
     @Test
-    public void createTableInNonDefaultSchema()
+    public void testCreateTableInNonDefaultSchema()
     {
         queryRunner.execute(format("CREATE SCHEMA %s.schema1", CATALOG));
         queryRunner.execute(format("CREATE SCHEMA %s.schema2", CATALOG));

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
@@ -85,6 +85,26 @@ public class TestMemorySmoke
     }
 
     @Test
+    public void createTableWithNoData()
+            throws SQLException
+    {
+        queryRunner.execute("CREATE TABLE test_empty (a BIGINT)");
+        assertThatQueryReturnsValue("SELECT count(*) FROM test_empty", 0L);
+        assertThatQueryReturnsValue("INSERT INTO test_empty SELECT nationkey FROM tpch.tiny.nation", 25L);
+        assertThatQueryReturnsValue("SELECT count(*) FROM test_empty", 25L);
+    }
+
+    @Test
+    public void createFilteredOutTable()
+            throws SQLException
+    {
+        queryRunner.execute("CREATE TABLE filtered_out AS SELECT nationkey FROM tpch.tiny.nation WHERE nationkey < 0");
+        assertThatQueryReturnsValue("SELECT count(*) FROM filtered_out", 0L);
+        assertThatQueryReturnsValue("INSERT INTO filtered_out SELECT nationkey FROM tpch.tiny.nation", 25L);
+        assertThatQueryReturnsValue("SELECT count(*) FROM filtered_out", 25L);
+    }
+
+    @Test
     public void selectFromEmptyTable()
             throws SQLException
     {

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
@@ -28,7 +28,6 @@ import static com.facebook.presto.plugin.memory.MemoryQueryRunner.createQueryRun
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static java.lang.String.format;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 @Test(singleThreaded = true)
 public class TestMemorySmoke
@@ -54,18 +53,13 @@ public class TestMemorySmoke
         assertEquals(listMemoryTables().size(), tablesBeforeCreate);
     }
 
-    @Test
+    // it has to be RuntimeException as FailureInfo$FailureException is private
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "line 1:1: Destination table 'memory.default.nation' already exists")
     public void createTableWhenTableIsAlreadyCreated()
             throws SQLException
     {
         String createTableSql = "CREATE TABLE nation AS SELECT * FROM tpch.tiny.nation";
-        try {
-            queryRunner.execute(createTableSql);
-            fail("Expected exception to be thrown here!");
-        }
-        catch (RuntimeException ex) { // it has to be RuntimeException as FailureInfo$FailureException is private
-            assertTrue(ex.getMessage().equals("line 1:1: Destination table 'memory.default.nation' already exists"));
-        }
+        queryRunner.execute(createTableSql);
     }
 
     @Test

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryWorkerCrash.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryWorkerCrash.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.memory;
+
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import io.airlift.units.Duration;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.plugin.memory.MemoryQueryRunner.createQueryRunner;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static io.airlift.testing.Assertions.assertLessThan;
+import static io.airlift.units.Duration.nanosSince;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.fail;
+
+@Test(singleThreaded = true)
+public class TestMemoryWorkerCrash
+{
+    private DistributedQueryRunner queryRunner;
+
+    @BeforeMethod
+    public void setUp()
+            throws Exception
+    {
+        queryRunner = createQueryRunner();
+    }
+
+    @Test
+    public void tableAccessAfterWorkerCrash()
+            throws Exception
+    {
+        queryRunner.execute("CREATE TABLE test_nation as SELECT * FROM tpch.tiny.nation");
+        assertQuery("SELECT * FROM test_nation ORDER BY nationkey", "SELECT * FROM tpch.tiny.nation ORDER BY nationkey");
+        closeWorker();
+        assertFails("SELECT * FROM test_nation ORDER BY nationkey", "No nodes available to run query");
+        queryRunner.execute("INSERT INTO test_nation SELECT * FROM tpch.tiny.nation");
+        assertFails("SELECT * FROM test_nation ORDER BY nationkey", "No nodes available to run query");
+
+        queryRunner.execute("CREATE TABLE test_region as SELECT * FROM tpch.tiny.region");
+        assertQuery("SELECT * FROM test_region ORDER BY regionkey", "SELECT * FROM tpch.tiny.region ORDER BY regionkey");
+    }
+
+    private void closeWorker()
+            throws Exception
+    {
+        int nodeCount = queryRunner.getNodeCount();
+        TestingPrestoServer worker = queryRunner.getServers().stream()
+            .filter(server -> !server.isCoordinator())
+            .findAny()
+            .orElseThrow(() -> new IllegalStateException("No worker nodes"));
+        worker.close();
+        waitForNodes(nodeCount - 1);
+    }
+
+    private void assertQuery(String sql, String expected)
+    {
+        MaterializedResult rows = queryRunner.execute(sql);
+        MaterializedResult expectedRows = queryRunner.execute(expected);
+
+        assertEquals(rows, expectedRows);
+    }
+
+    private void assertFails(String sql, String expectedMessage)
+    {
+        try {
+            queryRunner.execute(sql);
+        }
+        catch (RuntimeException ex) {
+            // pass
+            assertEquals(ex.getMessage(), expectedMessage);
+            return;
+        }
+        fail("Query should fail");
+    }
+
+    private void waitForNodes(int numberOfNodes)
+            throws InterruptedException
+    {
+        long start = System.nanoTime();
+        while (queryRunner.getCoordinator().refreshNodes().getActiveNodes().size() < numberOfNodes) {
+            assertLessThan(nanosSince(start), new Duration(10, SECONDS));
+            MILLISECONDS.sleep(10);
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/prestodb/presto/issues/7733

Previously following scenario would fail:
```
CREATE TABLE memory.default.test (a BIGINT);
INSERT INTO memory.default.test SELECT nationkey FROM tpch.tiny.nation;
```
with an error message, that table test was not found on a worker.

It is fixed by allowing to "initialize" table on writes (not as it was before only on creates) and by moving sanity checks for detecting worker crashes to asserting expected number of rows per worker.

There are two additional small commits, that add support for non default schemas.