### PR TITLE
Make it possible to choose regex library on a per-query basis

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -491,6 +491,8 @@ public class FunctionRegistry
                 .scalars(JoniRegexpCasts.class)
                 .scalars(CharacterStringCasts.class)
                 .scalars(CharOperators.class)
+                .scalars(JoniRegexpFunctions.class)
+                .scalars(Re2JRegexpFunctions.class)
                 .scalar(DecimalOperators.Negation.class)
                 .scalar(DecimalOperators.HashCode.class)
                 .functions(IDENTITY_CAST, CAST_FROM_UNKNOWN)
@@ -574,15 +576,6 @@ public class FunctionRegistry
                 .function(TRY_CAST);
 
         builder.function(new ArrayAggregationFunction(featuresConfig.isLegacyArrayAgg()));
-
-        switch (featuresConfig.getRegexLibrary()) {
-            case JONI:
-                builder.scalars(JoniRegexpFunctions.class);
-                break;
-            case RE2J:
-                builder.scalars(Re2JRegexpFunctions.class);
-                break;
-        }
 
         addFunctions(builder.getFunctions());
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -255,7 +255,7 @@ public class LocalQueryRunner
 
         this.sqlParser = new SqlParser();
         this.nodeManager = new InMemoryNodeManager();
-        this.typeRegistry = new TypeRegistry();
+        this.typeRegistry = new TypeRegistry(ImmutableSet.of(), featuresConfig);
         this.pageSorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory());
         this.pageIndexerFactory = new GroupByHashPageIndexerFactory(new JoinCompiler());
         this.indexManager = new IndexManager();

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -25,6 +25,8 @@ import com.facebook.presto.spi.type.TypeParameter;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.RegexLibrary;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -82,6 +84,8 @@ import static java.util.Objects.requireNonNull;
 public final class TypeRegistry
         implements TypeManager
 {
+    private final RegexLibrary regexLibrary;
+
     private final ConcurrentMap<TypeSignature, Type> types = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ParametricType> parametricTypes = new ConcurrentHashMap<>();
 
@@ -92,10 +96,21 @@ public final class TypeRegistry
         this(ImmutableSet.of());
     }
 
-    @Inject
     public TypeRegistry(Set<Type> types)
     {
+        this(types, new FeaturesConfig().getRegexLibrary());
+    }
+
+    @Inject
+    public TypeRegistry(Set<Type> types, FeaturesConfig featuresConfig)
+    {
+        this(types, featuresConfig.getRegexLibrary());
+    }
+
+    public TypeRegistry(Set<Type> types, RegexLibrary regexLibrary)
+    {
         requireNonNull(types, "types is null");
+        this.regexLibrary = requireNonNull(regexLibrary, "regexLibrary is null");
 
         // Manually register UNKNOWN type without a verifyTypeClass call since it is a special type that can not be used by functions
         this.types.put(UNKNOWN.getTypeSignature(), UNKNOWN);
@@ -494,9 +509,9 @@ public final class TypeRegistry
             case StandardTypes.VARCHAR: {
                 switch (resultTypeBase) {
                     case JoniRegexpType.NAME:
-                        return Optional.of(JONI_REGEXP);
+                        return regexLibrary == RegexLibrary.JONI ? Optional.of(JONI_REGEXP) : Optional.empty();
                     case Re2JRegexpType.NAME:
-                        return Optional.of(RE2J_REGEXP);
+                        return regexLibrary == RegexLibrary.RE2J ? Optional.of(RE2J_REGEXP) : Optional.empty();
                     case LikePatternType.NAME:
                         return Optional.of(LIKE_PATTERN);
                     case JsonPathType.NAME:
@@ -513,9 +528,9 @@ public final class TypeRegistry
                         CharType charType = (CharType) sourceType;
                         return Optional.of(createVarcharType(charType.getLength()));
                     case JoniRegexpType.NAME:
-                        return Optional.of(JONI_REGEXP);
+                        return regexLibrary == RegexLibrary.JONI ? Optional.of(JONI_REGEXP) : Optional.empty();
                     case Re2JRegexpType.NAME:
-                        return Optional.of(RE2J_REGEXP);
+                        return regexLibrary == RegexLibrary.RE2J ? Optional.of(RE2J_REGEXP) : Optional.empty();
                     case LikePatternType.NAME:
                         return Optional.of(LIKE_PATTERN);
                     case JsonPathType.NAME:


### PR DESCRIPTION
Due to the complexity involved, when RE2J was introduced into
Presto as a regular expression library, we decided against having
a session property that swtiches between the two libraries.

This config makes the config property control which implicit cast
to turn on (instead of which set of functions to register). This
way, it is possible to choose the regex library by using an
explicit cast in the query.