### PR TITLE
Finish Operator once it is unblocked

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -317,7 +317,7 @@ public class Driver
                 }
 
                 // if current operator is finished...
-                if (current.isFinished() && !next.isFinished() && isBlocked(next).isDone()) {
+                if (current.isFinished() && isBlocked(next).isDone()) {
                     // let next operator know there will be no more data
                     next.getOperatorContext().startIntervalTimer();
                     next.finish();

--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -317,7 +317,7 @@ public class Driver
                 }
 
                 // if current operator is finished...
-                if (current.isFinished()) {
+                if (current.isFinished() && !next.isFinished() && isBlocked(next).isDone()) {
                     // let next operator know there will be no more data
                     next.getOperatorContext().startIntervalTimer();
                     next.finish();


### PR DESCRIPTION
Avoid calling `Operator#finish()` when the operator is not yet ready to
finish, as indicated by `Operator#isBlocked()`.