### PR TITLE
Update Hadoop artifact versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,19 +338,19 @@
             <dependency>
                 <groupId>com.facebook.presto.hadoop</groupId>
                 <artifactId>hadoop-apache1</artifactId>
-                <version>0.4</version>
+                <version>1.2.1-1</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.presto.hadoop</groupId>
                 <artifactId>hadoop-apache2</artifactId>
-                <version>0.10</version>
+                <version>2.7.3-1</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.presto.hadoop</groupId>
                 <artifactId>hadoop-cdh4</artifactId>
-                <version>0.10</version>
+                <version>4.7.1-1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The artifacts are now versioned based on the upstream versions.