### PR TITLE
Execute rule unit tests in transactions

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
@@ -15,9 +15,11 @@ package com.facebook.presto.sql.planner.iterative.rule.test;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.Closeable;
@@ -30,6 +32,8 @@ public class RuleTester
     private final Metadata metadata;
     private final Session session;
     private final LocalQueryRunner queryRunner;
+    private final TransactionManager transactionManager;
+    private final AccessControl accessControl;
 
     public RuleTester()
     {
@@ -45,11 +49,13 @@ public class RuleTester
                 ImmutableMap.<String, String>of());
 
         this.metadata = queryRunner.getMetadata();
+        this.transactionManager = queryRunner.getTransactionManager();
+        this.accessControl = queryRunner.getAccessControl();
     }
 
     public RuleAssert assertThat(Rule rule)
     {
-        return new RuleAssert(metadata, session, rule);
+        return new RuleAssert(metadata, session, rule, transactionManager, accessControl);
     }
 
     @Override


### PR DESCRIPTION
This is necessary in order to be able to get the connector info
for tests involving TableScanNodes.

@martint I originally added this for the rule to push constraints into table scan nodes, but @alandpost needs it for adding tests for PruneUnreferencedOutputs, so I'm extracting it to its own PR. 

See https://github.com/Teradata/presto/commit/5783e812c921b09b43afeebcbac8f70837121f05 for an example of tests that need this change.