### PR TITLE
Rule tests with Lookup

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/GroupReference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/GroupReference.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.iterative;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.sql.planner.plan.PlanVisitor;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -44,6 +45,12 @@ public class GroupReference
     public List<PlanNode> getSources()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public <C, R> R accept(PlanVisitor<C, R> visitor, C context)
+    {
+        return visitor.visitGroupReference(this, context);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -71,14 +71,7 @@ public class IterativeOptimizer
         }
 
         Memo memo = new Memo(idAllocator, plan);
-
-        Lookup lookup = node -> {
-            if (node instanceof GroupReference) {
-                return memo.getNode(((GroupReference) node).getGroupId());
-            }
-
-            return node;
-        };
+        Lookup lookup = Lookup.from(memo::resolve);
 
         Duration timeout = SystemSessionProperties.getOptimizerTimeout(session);
         exploreGroup(memo.getRootGroup(), new Context(memo, lookup, idAllocator, symbolAllocator, System.nanoTime(), timeout.toMillis(), session));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Lookup.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Lookup.java
@@ -15,6 +15,8 @@ package com.facebook.presto.sql.planner.iterative;
 
 import com.facebook.presto.sql.planner.plan.PlanNode;
 
+import static com.google.common.base.Verify.verify;
+
 public interface Lookup
 {
     /**
@@ -25,4 +27,16 @@ public interface Lookup
      * argument as is.
      */
     PlanNode resolve(PlanNode node);
+
+    /**
+     * A Lookup implementation that does not perform lookup. It satisfies contract
+     * by rejecting {@link GroupReference}-s.
+     */
+    static Lookup noLookup()
+    {
+        return node -> {
+            verify(!(node instanceof GroupReference), "Unexpected GroupReference");
+            return node;
+        };
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Lookup.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Lookup.java
@@ -15,6 +15,8 @@ package com.facebook.presto.sql.planner.iterative;
 
 import com.facebook.presto.sql.planner.plan.PlanNode;
 
+import java.util.function.Function;
+
 import static com.google.common.base.Verify.verify;
 
 public interface Lookup
@@ -36,6 +38,17 @@ public interface Lookup
     {
         return node -> {
             verify(!(node instanceof GroupReference), "Unexpected GroupReference");
+            return node;
+        };
+    }
+
+    static Lookup from(Function<GroupReference, PlanNode> resolver)
+    {
+        return node -> {
+            if (node instanceof GroupReference) {
+                return resolver.apply((GroupReference) node);
+            }
+
             return node;
         };
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
@@ -79,6 +79,11 @@ public class Memo
         return membership.get(group);
     }
 
+    public PlanNode resolve(GroupReference groupReference)
+    {
+        return getNode(groupReference.getGroupId());
+    }
+
     public PlanNode extract()
     {
         return extract(getNode(rootGroup));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanVisitor.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.sql.planner.plan;
 
+import com.facebook.presto.sql.planner.iterative.GroupReference;
+
 public abstract class PlanVisitor<C, R>
 {
     protected abstract R visitPlan(PlanNode node, C context);
@@ -183,6 +185,11 @@ public abstract class PlanVisitor<C, R>
     }
 
     public R visitAssignUniqueId(AssignUniqueId node, C context)
+    {
+        return visitPlan(node, context);
+    }
+
+    public R visitGroupReference(GroupReference node, C context)
     {
         return visitPlan(node, context);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -35,6 +35,7 @@ import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.SubPlan;
 import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.AssignUniqueId;
@@ -1041,6 +1042,14 @@ public class PlanPrinter
         {
             print(indent, "- AssignUniqueId => [%s]", formatOutputs(node.getOutputSymbols()));
             printStats(indent + 2, node.getId());
+
+            return processChildren(node, indent + 1);
+        }
+
+        @Override
+        public Void visitGroupReference(GroupReference node, Integer indent)
+        {
+            print(indent, "- GroupReference[%s] => [%s]", node.getGroupId(), formatOutputs(node.getOutputSymbols()));
 
             return processChildren(node, indent + 1);
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.assertions;
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.iterative.Lookup;
 
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.textLogicalPlan;
 import static java.lang.String.format;
@@ -26,7 +27,12 @@ public final class PlanAssert
 
     public static void assertPlan(Session session, Metadata metadata, Plan actual, PlanMatchPattern pattern)
     {
-        MatchResult matches = actual.getRoot().accept(new PlanMatchingVisitor(session, metadata), pattern);
+        assertPlan(session, metadata, actual, Lookup.noLookup(), pattern);
+    }
+
+    public static void assertPlan(Session session, Metadata metadata, Plan actual, Lookup lookup, PlanMatchPattern pattern)
+    {
+        MatchResult matches = actual.getRoot().accept(new PlanMatchingVisitor(session, metadata, lookup), pattern);
         if (!matches.isMatch()) {
             String logicalPlan = textLogicalPlan(actual.getRoot(), actual.getTypes(), metadata, session);
             throw new AssertionError(format("Plan does not match, expected [\n\n%s\n] but found [\n\n%s\n]", pattern, logicalPlan));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -21,6 +21,8 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Memo;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.planPrinter.PlanPrinter;
@@ -91,7 +93,11 @@ public class RuleAssert
     public void matches(PlanMatchPattern pattern)
     {
         SymbolAllocator symbolAllocator = new SymbolAllocator(symbols);
-        Optional<PlanNode> result = rule.apply(plan, x -> x, idAllocator, symbolAllocator, session);
+
+        Memo memo = new Memo(idAllocator, plan);
+        Lookup lookup = Lookup.from(memo::resolve);
+
+        Optional<PlanNode> result = rule.apply(memo.getNode(memo.getRootGroup()), lookup, idAllocator, symbolAllocator, session);
         Map<Symbol, Type> types = symbolAllocator.getTypes();
 
         if (!result.isPresent()) {
@@ -120,6 +126,6 @@ public class RuleAssert
                     actual.getOutputSymbols()));
         }
 
-        assertPlan(session, metadata, new Plan(actual, types), pattern);
+        assertPlan(session, metadata, new Plan(actual, types), lookup, pattern);
     }
 }


### PR DESCRIPTION
Allow unit-testing of how a rule interacts with Lookup and whether returned node has GroupReference(s) as source(s) where applicable.

Extracted from #7715. See that PR for usage example.