### PR TITLE
Relax TypeParameters restriction for ScalarImpl constructors

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/ConstructorWithInvalidTypeParameters.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/ConstructorWithInvalidTypeParameters.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+
+public final class ConstructorWithInvalidTypeParameters
+{
+    @TypeParameter("K")
+    @TypeParameter("V")
+    public ConstructorWithInvalidTypeParameters(@TypeParameter("K(varchar)") Type type) {}
+
+    @ScalarFunction
+    @TypeParameter("K")
+    @TypeParameter("V")
+    @SqlType(StandardTypes.BIGINT)
+    public long good1(
+            @TypeParameter("MAP(K,V)") Type type,
+            @SqlType(StandardTypes.BIGINT) long value)
+    {
+        return value;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/ConstructorWithValidTypeParameters.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/ConstructorWithValidTypeParameters.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+
+public final class ConstructorWithValidTypeParameters
+{
+    @TypeParameter("K")
+    @TypeParameter("V")
+    public ConstructorWithValidTypeParameters(@TypeParameter("MAP(K,V)") Type type) {}
+
+    @ScalarFunction
+    @TypeParameter("K")
+    @TypeParameter("V")
+    @SqlType(StandardTypes.BIGINT)
+    public long good1(
+            @TypeParameter("MAP(K,V)") Type type,
+            @SqlType(StandardTypes.BIGINT) long value)
+    {
+        return value;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestScalarValidation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestScalarValidation.java
@@ -367,6 +367,18 @@ public class TestScalarValidation
         }
     }
 
+    @Test
+    public void testValidTypeParametersForConstructors()
+    {
+        extractScalars(ConstructorWithValidTypeParameters.class);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Expected type parameter not to take parameters, but got K on method .*")
+    public void testInvalidTypeParametersForConstructors()
+    {
+        extractScalars(ConstructorWithInvalidTypeParameters.class);
+    }
+
     private static void extractParametricScalar(Class<?> clazz)
     {
         new FunctionListBuilder().scalar(clazz);


### PR DESCRIPTION
When a TypeParameter is used in a constructor, it has to be
annotated. This disallow some concrete types to be passed in to a
constructor, e.g.: array(map(varchar, integer)). This patch relaxes
the restriction by allows StandardTypes to be used in a signature
without annotation.