### PR TITLE
Add stats to block size read from Orc file

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/FileFormatDataSourceStats.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/FileFormatDataSourceStats.java
@@ -24,6 +24,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public class FileFormatDataSourceStats
 {
     private final DistributionStat readBytes = new DistributionStat();
+    private final DistributionStat loadedBlockBytes = new DistributionStat();
     private final TimeStat time0Bto100KB = new TimeStat(MILLISECONDS);
     private final TimeStat time100KBto1MB = new TimeStat(MILLISECONDS);
     private final TimeStat time1MBto10MB = new TimeStat(MILLISECONDS);
@@ -34,6 +35,13 @@ public class FileFormatDataSourceStats
     public DistributionStat getReadBytes()
     {
         return readBytes;
+    }
+
+    @Managed
+    @Nested
+    public DistributionStat getLoadedBlockBytes()
+    {
+        return loadedBlockBytes;
     }
 
     @Managed
@@ -79,5 +87,10 @@ public class FileFormatDataSourceStats
         else {
             time10MBPlus.add(nanos, NANOSECONDS);
         }
+    }
+
+    public void addLoadedBlockSize(long bytes)
+    {
+        loadedBlockBytes.add(bytes);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.orc;
 
+import com.facebook.presto.hive.FileFormatDataSourceStats;
 import com.facebook.presto.hive.HiveColumnHandle;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDataSource;
@@ -60,17 +61,22 @@ public class OrcPageSource
 
     private final AggregatedMemoryContext systemMemoryContext;
 
+    private final FileFormatDataSourceStats stats;
+
     public OrcPageSource(
             OrcRecordReader recordReader,
             OrcDataSource orcDataSource,
             List<HiveColumnHandle> columns,
             TypeManager typeManager,
-            AggregatedMemoryContext systemMemoryContext)
+            AggregatedMemoryContext systemMemoryContext,
+            FileFormatDataSourceStats stats)
     {
         this.recordReader = requireNonNull(recordReader, "recordReader is null");
         this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
 
         int size = requireNonNull(columns, "columns is null").size();
+
+        this.stats = requireNonNull(stats, "stats is null");
 
         this.constantBlocks = new Block[size];
         this.hiveColumnIndexes = new int[size];
@@ -145,7 +151,7 @@ public class OrcPageSource
                     blocks[fieldId] = constantBlocks[fieldId].getRegion(0, batchSize);
                 }
                 else {
-                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(hiveColumnIndexes[fieldId], type));
+                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(hiveColumnIndexes[fieldId], type, stats));
                 }
             }
             return new Page(batchSize, blocks);
@@ -212,12 +218,14 @@ public class OrcPageSource
         private final int expectedBatchId = batchId;
         private final int columnIndex;
         private final Type type;
+        private final FileFormatDataSourceStats stats;
         private boolean loaded;
 
-        public OrcBlockLoader(int columnIndex, Type type)
+        public OrcBlockLoader(int columnIndex, Type type, FileFormatDataSourceStats stats)
         {
             this.columnIndex = columnIndex;
             this.type = requireNonNull(type, "type is null");
+            this.stats = requireNonNull(stats, "stats is null");
         }
 
         @Override
@@ -239,6 +247,8 @@ public class OrcPageSource
                 }
                 throw new PrestoException(HIVE_CURSOR_ERROR, e);
             }
+
+            stats.addLoadedBlockSize(lazyBlock.getSizeInBytes());
 
             loaded = true;
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
@@ -190,7 +190,8 @@ public class OrcPageSourceFactory
                     orcDataSource,
                     physicalColumns,
                     typeManager,
-                    systemMemoryUsage);
+                    systemMemoryUsage,
+                    stats);
         }
         catch (Exception e) {
             try {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
@@ -155,7 +155,8 @@ public class TestOrcPageSourceMemoryTracking
         // Numbers used in assertions in this test may change when implementation is modified,
         // feel free to change them if they break in the future
 
-        ConnectorPageSource pageSource = testPreparer.newPageSource();
+        FileFormatDataSourceStats stats = new FileFormatDataSourceStats();
+        ConnectorPageSource pageSource = testPreparer.newPageSource(stats);
 
         assertEquals(pageSource.getSystemMemoryUsage(), 0);
 
@@ -221,6 +222,7 @@ public class TestOrcPageSourceMemoryTracking
         assertTrue(pageSource.isFinished());
         assertEquals(pageSource.getSystemMemoryUsage(), 0);
         pageSource.close();
+        assertEquals((int) stats.getLoadedBlockBytes().getAllTime().getCount(), 50);
     }
 
     @Test
@@ -360,9 +362,9 @@ public class TestOrcPageSourceMemoryTracking
             fileSplit = createTestFile(tempFilePath, new OrcOutputFormat(), serde, null, testColumns, NUM_ROWS);
         }
 
-        public ConnectorPageSource newPageSource()
+        public ConnectorPageSource newPageSource(FileFormatDataSourceStats stats)
         {
-            OrcPageSourceFactory orcPageSourceFactory = new OrcPageSourceFactory(TYPE_MANAGER, false, HDFS_ENVIRONMENT, new FileFormatDataSourceStats());
+            OrcPageSourceFactory orcPageSourceFactory = new OrcPageSourceFactory(TYPE_MANAGER, false, HDFS_ENVIRONMENT, stats);
             return HivePageSourceProvider.createHivePageSource(
                     ImmutableSet.of(),
                     ImmutableSet.of(orcPageSourceFactory),
@@ -385,7 +387,7 @@ public class TestOrcPageSourceMemoryTracking
 
         public SourceOperator newTableScanOperator(DriverContext driverContext)
         {
-            ConnectorPageSource pageSource = newPageSource();
+            ConnectorPageSource pageSource = newPageSource(new FileFormatDataSourceStats());
             SourceOperatorFactory sourceOperatorFactory = new TableScanOperatorFactory(
                     0,
                     new PlanNodeId("0"),
@@ -400,7 +402,7 @@ public class TestOrcPageSourceMemoryTracking
 
         public SourceOperator newScanFilterAndProjectOperator(DriverContext driverContext)
         {
-            ConnectorPageSource pageSource = newPageSource();
+            ConnectorPageSource pageSource = newPageSource(new FileFormatDataSourceStats());
             ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
             for (int i = 0; i < types.size(); i++) {
                 projectionsBuilder.add(field(i, types.get(i)));


### PR DESCRIPTION
A cell in a table can be huge. A worker can OOM when reading too many
large cells. Export block size to monitor the distribution of loaded
blocks.