### PR TITLE
Bump tempto version to 1.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.29</dep.slice.version>
         <dep.aws-sdk.version>1.11.30</dep.aws-sdk.version>
-        <dep.tempto.version>1.30</dep.tempto.version>
+        <dep.tempto.version>1.31</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
 
         <cli.skip-execute>true</cli.skip-execute>


### PR DESCRIPTION
The release fixes a bug in rowsEqual assertion to check 
if expected and actual columns count match.
