### PR TITLE
Wrap remote exception in SimpleHttpResponseHandler

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/SimpleHttpResponseHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/SimpleHttpResponseHandler.java
@@ -67,6 +67,9 @@ public class SimpleHttpResponseHandler<T>
                                 response.getResponseBody()));
                     }
                 }
+                else {
+                    cause = new PrestoException(REMOTE_TASK_ERROR, format("Unexpected response from %s", uri), cause);
+                }
                 callback.fatal(cause);
             }
         }


### PR DESCRIPTION
Wrap the remote exception in SimpleHttpResponseHandler in a
proper PrestoException.

Issue: https://github.com/prestodb/presto/issues/7994