### PR TITLE
Avoid calling unreflect repeatedly in MethodHandleUtil

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/system/KillQueryProcedure.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/KillQueryProcedure.java
@@ -22,12 +22,16 @@ import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;
 
+import java.lang.invoke.MethodHandle;
+
 import static com.facebook.presto.spi.type.StandardTypes.VARCHAR;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.util.Objects.requireNonNull;
 
 public class KillQueryProcedure
 {
+    private static final MethodHandle KILL_QUERY = methodHandle(KillQueryProcedure.class, "killQuery", String.class);
+
     private final QueryManager queryManager;
 
     @Inject
@@ -48,6 +52,6 @@ public class KillQueryProcedure
                 "runtime",
                 "kill_query",
                 ImmutableList.of(new Argument("query_id", VARCHAR)),
-                methodHandle(getClass(), "killQuery", String.class).bindTo(this));
+                KILL_QUERY.bindTo(this));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/TryCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/TryCodeGenerator.java
@@ -57,6 +57,7 @@ public class TryCodeGenerator
         implements BytecodeGenerator
 {
     private static final String EXCEPTION_HANDLER_NAME = "tryExpressionExceptionHandler";
+    private static final MethodHandle EXCEPTION_HANDLER = methodHandle(TryCodeGenerator.class, EXCEPTION_HANDLER_NAME, PrestoException.class);
 
     private final Map<CallExpression, MethodDefinition> tryMethodsMap;
 
@@ -101,7 +102,7 @@ public class TryCodeGenerator
         BytecodeNode innerExpression = innerRowExpression.accept(innerExpressionVisitor, calleeMethodScope);
 
         MethodType exceptionHandlerType = methodType(returnType, PrestoException.class);
-        MethodHandle exceptionHandler = methodHandle(TryCodeGenerator.class, EXCEPTION_HANDLER_NAME, PrestoException.class).asType(exceptionHandlerType);
+        MethodHandle exceptionHandler = EXCEPTION_HANDLER.asType(exceptionHandlerType);
         Binding binding = callSiteBinder.bind(exceptionHandler);
 
         method.comment("Try projection: %s", innerRowExpression.toString());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MethodHandleUtil.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MethodHandleUtil.java
@@ -23,9 +23,17 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.lang.invoke.MethodType.methodType;
 
 public final class MethodHandleUtil
 {
+    private static final MethodHandle GET_LONG = methodHandle(Type.class, "getLong", Block.class, int.class);
+    private static final MethodHandle GET_DOUBLE = methodHandle(Type.class, "getDouble", Block.class, int.class);
+    private static final MethodHandle GET_BOOLEAN = methodHandle(Type.class, "getBoolean", Block.class, int.class);
+    private static final MethodHandle GET_SLICE = methodHandle(Type.class, "getSlice", Block.class, int.class);
+    private static final MethodHandle GET_BLOCK = methodHandle(Type.class, "getObject", Block.class, int.class).asType(methodType(Block.class, Type.class, Block.class, int.class));
+    private static final MethodHandle GET_UNKNOWN = methodHandle(MethodHandleUtil.class, "unknownGetter", Type.class, Block.class, int.class);
+
     private MethodHandleUtil()
     {
     }
@@ -109,23 +117,22 @@ public final class MethodHandleUtil
 
         MethodHandle methodHandle;
         if (javaType == long.class) {
-            methodHandle = methodHandle(Type.class, "getLong", Block.class, int.class);
+            methodHandle = GET_LONG;
         }
         else if (javaType == double.class) {
-            methodHandle = methodHandle(Type.class, "getDouble", Block.class, int.class);
+            methodHandle = GET_DOUBLE;
         }
         else if (javaType == boolean.class) {
-            methodHandle = methodHandle(Type.class, "getBoolean", Block.class, int.class);
+            methodHandle = GET_BOOLEAN;
         }
         else if (javaType == Slice.class) {
-            methodHandle = methodHandle(Type.class, "getSlice", Block.class, int.class);
+            methodHandle = GET_SLICE;
         }
         else if (javaType == Block.class) {
-            MethodHandle getObjectMethodHandle = methodHandle(Type.class, "getObject", Block.class, int.class);
-            methodHandle = getObjectMethodHandle.asType(getObjectMethodHandle.type().changeReturnType(Block.class));
+            methodHandle = GET_BLOCK;
         }
         else if (javaType == void.class) {
-            methodHandle = methodHandle(MethodHandleUtil.class, "unknownGetter", Type.class, Block.class, int.class);
+            methodHandle = GET_UNKNOWN;
         }
         else {
             throw new IllegalArgumentException("Unknown java type " + javaType + " from type " + type);


### PR DESCRIPTION
Calling unreflect leads to creation of JNI global weak references, which
G1 cannot efficiently collect.