### PR TITLE
Fix validation of floating point values in verifier

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
@@ -18,6 +18,7 @@ import com.facebook.presto.jdbc.PrestoStatement;
 import com.facebook.presto.jdbc.QueryStats;
 import com.facebook.presto.spi.type.SqlVarbinary;
 import com.facebook.presto.verifier.Validator.ChangedRow.Changed;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
@@ -35,7 +36,6 @@ import com.google.common.util.concurrent.UncheckedTimeoutException;
 import io.airlift.units.Duration;
 
 import java.math.BigDecimal;
-import java.math.MathContext;
 import java.sql.Array;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -716,16 +716,33 @@ public class Validator
         return x instanceof Byte || x instanceof Short || x instanceof Integer || x instanceof Long;
     }
 
-    private static int precisionCompare(double a, double b, int precision)
+    //adapted from http://floating-point-gui.de/errors/comparison/
+    private static boolean isClose(double a, double b, double epsilon)
     {
+        double absA = Math.abs(a);
+        double absB = Math.abs(b);
+        double diff = Math.abs(a - b);
+
         if (!isFinite(a) || !isFinite(b)) {
-            return Double.compare(a, b);
+            return Double.compare(a, b) == 0;
         }
 
-        MathContext context = new MathContext(precision);
-        BigDecimal x = new BigDecimal(a).round(context);
-        BigDecimal y = new BigDecimal(b).round(context);
-        return x.compareTo(y);
+        // a or b is zero or both are extremely close to it
+        // relative error is less meaningful here
+        if (a == 0 || b == 0 || diff < Float.MIN_NORMAL) {
+            return diff < (epsilon * Float.MIN_NORMAL);
+        }
+        else {
+            // use relative error
+            return diff / Math.min((absA + absB), Float.MAX_VALUE) < epsilon;
+        }
+    }
+
+    @VisibleForTesting
+    static int precisionCompare(double a, double b, int precision)
+    {
+        //we don't care whether a is smaller than b or not when they are not close since we will fail verification anyway
+        return isClose(a, b, Math.pow(10, -1 * (precision - 1))) ? 0 : -1;
     }
 
     public static class ChangedRow

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/TestValidator.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/TestValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.verifier.Validator.precisionCompare;
+import static java.lang.Double.NaN;
+import static org.testng.Assert.assertEquals;
+
+public class TestValidator
+{
+    @Test
+    public void testDoubleComparison()
+            throws Exception
+    {
+        assertEquals(precisionCompare(0.9045, 0.9045000000000001, 3), 0);
+        assertEquals(precisionCompare(0.9045, 0.9045000000000001, 2), 0);
+        assertEquals(precisionCompare(0.9041, 0.9042, 3), 0);
+        assertEquals(precisionCompare(0.9041, 0.9042, 4), 0);
+        assertEquals(precisionCompare(0.9042, 0.9041, 4), 0);
+        assertEquals(precisionCompare(-0.9042, -0.9041, 4), 0);
+        assertEquals(precisionCompare(-0.9042, -0.9041, 3), 0);
+        assertEquals(precisionCompare(0.899, 0.901, 3), 0);
+        assertEquals(precisionCompare(NaN, NaN, 4), Double.compare(NaN, NaN));
+    }
+}


### PR DESCRIPTION
Truncation is better than rounding up the floating point values before comparison.

For example, 0.9045 vs. 0.9045000000000001. With rounding mode half_up (default) we end up with 0.904 vs. 0.905 verification to fail. I think what we really want is truncating to a given precision.