### PR TITLE
Fix off-by-one error when reading FSE table

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/zstd/FseTableReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/zstd/FseTableReader.java
@@ -48,7 +48,7 @@ class FseTableReader
         int remaining = (1 << tableLog) + 1;
         threshold = 1 << tableLog;
 
-        while ((remaining > 1) && symbolNumber < maxSymbol) {
+        while (remaining > 1 && symbolNumber <= maxSymbol) {
             if (previousIsZero) {
                 int n0 = symbolNumber;
                 while ((bitStream & 0xFFFF) == 0xFFFF) {


### PR DESCRIPTION
The code was incorrectly comparing with < instead of <=