### PR TITLE
Print position links' sorting expression in explain

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1561,7 +1561,12 @@ public class LocalExecutionPlanner
             Optional<Integer> buildHashChannel = buildHashSymbol.map(channelGetter(buildSource));
 
             Optional<JoinFilterFunctionFactory> filterFunctionFactory = node.getFilter()
-                    .map(filterExpression -> compileJoinFilterFunction(filterExpression, probeLayout, buildSource.getLayout(), context.getTypes(), context.getSession()));
+                    .map(filterExpression -> compileJoinFilterFunction(
+                            filterExpression,
+                            probeLayout,
+                            buildSource.getLayout(),
+                            context.getTypes(),
+                            context.getSession()));
 
             HashBuilderOperatorFactory hashBuilderOperatorFactory = new HashBuilderOperatorFactory(
                     buildContext.getNextOperatorId(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1563,6 +1563,7 @@ public class LocalExecutionPlanner
             Optional<JoinFilterFunctionFactory> filterFunctionFactory = node.getFilter()
                     .map(filterExpression -> compileJoinFilterFunction(
                             filterExpression,
+                            node.getSortExpression(),
                             probeLayout,
                             buildSource.getLayout(),
                             context.getTypes(),
@@ -1596,6 +1597,7 @@ public class LocalExecutionPlanner
 
         private JoinFilterFunctionFactory compileJoinFilterFunction(
                 Expression filterExpression,
+                Optional<Expression> sortExpression,
                 Map<Symbol, Integer> probeLayout,
                 Map<Symbol, Integer> buildLayout,
                 Map<Symbol, Type> types,
@@ -1607,8 +1609,10 @@ public class LocalExecutionPlanner
                     .collect(toImmutableMap(Map.Entry::getValue, entry -> types.get(entry.getKey())));
 
             Expression rewrittenFilter = new SymbolToInputRewriter(joinSourcesLayout).rewrite(filterExpression);
+            Optional<Expression> rewrittenSortExpression = sortExpression.map(
+                    expression -> new SymbolToInputRewriter(buildLayout).rewrite(expression));
 
-            Optional<SortExpression> sortChannel = SortExpressionExtractor.extractSortExpression(buildLayout, rewrittenFilter);
+            Optional<SortExpression> sortChannel = rewrittenSortExpression.map(SortExpression::fromExpression);
 
             IdentityLinkedHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(
                     session,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SortExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SortExpressionExtractor.java
@@ -18,14 +18,15 @@ import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FieldReference;
 import com.facebook.presto.sql.tree.Node;
-import com.google.common.collect.ImmutableSet;
+import com.facebook.presto.sql.tree.SymbolReference;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -49,9 +50,8 @@ public final class SortExpressionExtractor
 {
     private SortExpressionExtractor() {}
 
-    public static Optional<SortExpression> extractSortExpression(Map<Symbol, Integer> buildLayout, Expression filter)
+    public static Optional<Expression> extractSortExpression(Set<Symbol> buildSymbols, Expression filter)
     {
-        Set<Integer> buildFields = ImmutableSet.copyOf(buildLayout.values());
         if (filter instanceof ComparisonExpression) {
             ComparisonExpression comparison = (ComparisonExpression) filter;
             switch (comparison.getType()) {
@@ -59,14 +59,14 @@ public final class SortExpressionExtractor
                 case GREATER_THAN_OR_EQUAL:
                 case LESS_THAN:
                 case LESS_THAN_OR_EQUAL:
-                    Optional<Integer> sortChannel = asBuildFieldReference(buildFields, comparison.getRight());
-                    boolean hasBuildReferencesOnOtherSide = hasBuildFieldReference(buildFields, comparison.getLeft());
+                    Optional<SymbolReference> sortChannel = asBuildSymbolReference(buildSymbols, comparison.getRight());
+                    boolean hasBuildReferencesOnOtherSide = hasBuildSymbolReference(buildSymbols, comparison.getLeft());
                     if (!sortChannel.isPresent()) {
-                        sortChannel = asBuildFieldReference(buildFields, comparison.getLeft());
-                        hasBuildReferencesOnOtherSide = hasBuildFieldReference(buildFields, comparison.getRight());
+                        sortChannel = asBuildSymbolReference(buildSymbols, comparison.getLeft());
+                        hasBuildReferencesOnOtherSide = hasBuildSymbolReference(buildSymbols, comparison.getRight());
                     }
                     if (sortChannel.isPresent() && !hasBuildReferencesOnOtherSide) {
-                        return Optional.of(new SortExpression(sortChannel.get()));
+                        return sortChannel.map(symbolReference -> (Expression) symbolReference);
                     }
                     return Optional.empty();
                 default:
@@ -77,30 +77,32 @@ public final class SortExpressionExtractor
         return Optional.empty();
     }
 
-    private static Optional<Integer> asBuildFieldReference(Set<Integer> buildLayout, Expression expression)
+    private static Optional<SymbolReference> asBuildSymbolReference(Set<Symbol> buildLayout, Expression expression)
     {
-        if (expression instanceof FieldReference) {
-            FieldReference field = (FieldReference) expression;
-            if (buildLayout.contains(field.getFieldIndex())) {
-                return Optional.of(field.getFieldIndex());
+        if (expression instanceof SymbolReference) {
+            SymbolReference symbolReference = (SymbolReference) expression;
+            if (buildLayout.contains(new Symbol(symbolReference.getName()))) {
+                return Optional.of(symbolReference);
             }
         }
         return Optional.empty();
     }
 
-    private static boolean hasBuildFieldReference(Set<Integer> buildLayout, Expression expression)
+    private static boolean hasBuildSymbolReference(Set<Symbol> buildSymbols, Expression expression)
     {
-        return new BuildFieldReferenceFinder(buildLayout).process(expression);
+        return new BuildSymbolReferenceFinder(buildSymbols).process(expression);
     }
 
-    private static class BuildFieldReferenceFinder
+    private static class BuildSymbolReferenceFinder
             extends AstVisitor<Boolean, Void>
     {
-        private final Set<Integer> buildLayout;
+        private final Set<String> buildSymbols;
 
-        public BuildFieldReferenceFinder(Set<Integer> buildLayout)
+        public BuildSymbolReferenceFinder(Set<Symbol> buildSymbols)
         {
-            this.buildLayout = ImmutableSet.copyOf(requireNonNull(buildLayout, "buildLayout is null"));
+            this.buildSymbols = requireNonNull(buildSymbols, "buildSymbols is null").stream()
+                    .map(Symbol::getName)
+                    .collect(toImmutableSet());
         }
 
         @Override
@@ -115,9 +117,9 @@ public final class SortExpressionExtractor
         }
 
         @Override
-        protected Boolean visitFieldReference(FieldReference fieldReference, Void context)
+        protected Boolean visitSymbolReference(SymbolReference symbolReference, Void context)
         {
-            return buildLayout.contains(fieldReference.getFieldIndex());
+            return buildSymbols.contains(symbolReference.getName());
         }
     }
 
@@ -159,6 +161,12 @@ public final class SortExpressionExtractor
             return toStringHelper(this)
                     .add("channel", channel)
                     .toString();
+        }
+
+        public static SortExpression fromExpression(Expression expression)
+        {
+            checkState(expression instanceof FieldReference, "Unsupported expression type [%s]", expression);
+            return new SortExpression(((FieldReference) expression).getFieldIndex());
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.tree.Join;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -27,6 +28,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.sql.planner.SortExpressionExtractor.extractSortExpression;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -166,6 +168,11 @@ public class JoinNode
     public Optional<Expression> getFilter()
     {
         return filter;
+    }
+
+    public Optional<Expression> getSortExpression()
+    {
+        return filter.map(filter -> extractSortExpression(ImmutableSet.copyOf(right.getOutputSymbols()), filter).orElse(null));
     }
 
     @JsonProperty("leftHashSymbol")

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -481,6 +481,7 @@ public class PlanPrinter
                         formatOutputs(node.getOutputSymbols()));
             }
 
+            node.getSortExpression().ifPresent(expression -> print(indent + 2, "SortExpression[%s]", expression));
             printStats(indent + 2, node.getId());
             node.getLeft().accept(this, indent + 1);
             node.getRight().accept(this, indent + 1);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -760,7 +760,8 @@ public class PlanPrinter
 
         private Void visitScanFilterAndProjectInfo(
                 PlanNodeId planNodeId,
-                Optional<FilterNode> filterNode, Optional<ProjectNode> projectNode,
+                Optional<FilterNode> filterNode,
+                Optional<ProjectNode> projectNode,
                 int indent)
         {
             checkState(projectNode.isPresent() || filterNode.isPresent());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestSortExpressionExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestSortExpressionExtractor.java
@@ -13,28 +13,25 @@
  */
 package com.facebook.presto.sql.planner;
 
-import com.facebook.presto.sql.planner.SortExpressionExtractor.SortExpression;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.ComparisonExpressionType;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.FieldReference;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
-import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.testng.AssertJUnit.assertEquals;
 
 public class TestSortExpressionExtractor
 {
-    private static final Map<Symbol, Integer> BUILD_LAYOUT = ImmutableMap.of(
-            new Symbol("b1"), 1,
-            new Symbol("b2"), 2);
+    private static final Set<Symbol> BUILD_SYMBOLS = ImmutableSet.of(new Symbol("b1"), new Symbol("b2"));
 
     @Test
     public void testGetSortExpression()
@@ -42,47 +39,47 @@ public class TestSortExpressionExtractor
         assertGetSortExpression(
                 new ComparisonExpression(
                         ComparisonExpressionType.GREATER_THAN,
-                        new FieldReference(11),
-                        new FieldReference(1)),
-                1);
+                        new SymbolReference("p1"),
+                        new SymbolReference("b1")),
+                "b1");
 
         assertGetSortExpression(
                 new ComparisonExpression(
                         ComparisonExpressionType.LESS_THAN_OR_EQUAL,
-                        new FieldReference(2),
-                        new FieldReference(11)),
-                2);
+                        new SymbolReference("b2"),
+                        new SymbolReference("p1")),
+                "b2");
 
         assertGetSortExpression(
                 new ComparisonExpression(
                         ComparisonExpressionType.GREATER_THAN,
-                        new FieldReference(2),
-                        new FieldReference(11)),
-                2);
+                        new SymbolReference("b2"),
+                        new SymbolReference("p1")),
+                "b2");
 
         assertGetSortExpression(
                 new ComparisonExpression(
                         ComparisonExpressionType.GREATER_THAN,
-                        new FieldReference(1),
-                        new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Type.ADD, new FieldReference(2), new FieldReference(11))));
+                        new SymbolReference("b1"),
+                        new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Type.ADD, new SymbolReference("b2"), new SymbolReference("p1"))));
 
         assertGetSortExpression(
                 new ComparisonExpression(
                         ComparisonExpressionType.GREATER_THAN,
-                        new FunctionCall(QualifiedName.of("sin"), ImmutableList.of(new FieldReference(1))),
-                        new FieldReference(11)));
+                        new FunctionCall(QualifiedName.of("sin"), ImmutableList.of(new SymbolReference("b1"))),
+                        new SymbolReference("p1")));
     }
 
     private static void assertGetSortExpression(Expression expression)
     {
-        Optional<SortExpression> actual = SortExpressionExtractor.extractSortExpression(BUILD_LAYOUT, expression);
+        Optional<Expression> actual = SortExpressionExtractor.extractSortExpression(BUILD_SYMBOLS, expression);
         assertEquals(Optional.empty(), actual);
     }
 
-    private static void assertGetSortExpression(Expression expression, int expectedChannel)
+    private static void assertGetSortExpression(Expression expression, String expectedSymbol)
     {
-        Optional<SortExpression> expected = Optional.of(new SortExpression(expectedChannel));
-        Optional<SortExpression> actual = SortExpressionExtractor.extractSortExpression(BUILD_LAYOUT, expression);
+        Optional<Expression> expected = Optional.of(new SymbolReference(expectedSymbol));
+        Optional<Expression> actual = SortExpressionExtractor.extractSortExpression(BUILD_SYMBOLS, expression);
         assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
For query:
```
presto:tiny> explain SELECT o.orderkey, o.orderdate, l.shipdate FROM orders o JOIN lineitem l ON l.orderkey = o.orderkey AND l.shipdate < o.orderdate + INTERVAL '10' DAY;
```
explain before:
```
 - Output[orderkey, orderdate, shipdate] => [orderkey:bigint, orderdate:date, shipdate:date]                                             
     - RemoteExchange[GATHER] => orderkey:bigint, orderdate:date, shipdate:date                                                          
         - InnerJoin[("orderkey" = "orderkey_0") AND ("expr_3" > "shipdate")] => [orderkey:bigint, orderdate:date, shipdate:date]        
             - ScanProject[table = tpch:tpch:orders:sf0.01, originalConstraint = true] => [expr_3:date, orderkey:bigint, orderdate:date] 
                     expr_3 := ("orderdate" + "$literal$interval day to second"(BIGINT '864000000'))                                     
                     orderkey := tpch:orderkey                                                                                           
                     orderdate := tpch:orderdate                                                                                         
             - LocalExchange[HASH] ("orderkey_0") => orderkey_0:bigint, shipdate:date                                                    
                 - RemoteExchange[REPARTITION] => orderkey_0:bigint, shipdate:date                                                       
                     - TableScan[tpch:tpch:lineitem:sf0.01, originalConstraint = true] => [orderkey_0:bigint, shipdate:date]             
                             orderkey_0 := tpch:orderkey                                                                                 
                             shipdate := tpch:shipdate
```
and after:
```
 - Output[orderkey, orderdate, shipdate] => [orderkey:bigint, orderdate:date, shipdate:date]                                             
     - RemoteExchange[GATHER] => orderkey:bigint, orderdate:date, shipdate:date                                                          
         - InnerJoin[("orderkey" = "orderkey_0") AND ("expr_3" > "shipdate")] => [orderkey:bigint, orderdate:date, shipdate:date]        
                 SortExpression["shipdate"]                                                                                              
             - ScanProject[table = tpch:tpch:orders:sf0.01, originalConstraint = true] => [expr_3:date, orderkey:bigint, orderdate:date] 
                     expr_3 := ("orderdate" + "$literal$interval day to second"(BIGINT '864000000'))                                     
                     orderkey := tpch:orderkey                                                                                           
                     orderdate := tpch:orderdate                                                                                         
             - LocalExchange[HASH] ("orderkey_0") => orderkey_0:bigint, shipdate:date                                                    
                 - RemoteExchange[REPARTITION] => orderkey_0:bigint, shipdate:date                                                       
                     - TableScan[tpch:tpch:lineitem:sf0.01, originalConstraint = true] => [orderkey_0:bigint, shipdate:date]             
                             orderkey_0 := tpch:orderkey                                                                                 
                             shipdate := tpch:shipdate
```