### PR TITLE
Spill in explain analyze, query summary and web UI

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
@@ -194,6 +194,7 @@ Parallelism: 2.5
             reprintLine(perNodeSummary);
 
             out.println(String.format("Parallelism: %.1f", parallelism));
+            out.println("Spilled: " + stats.getSpilledDataSize());
         }
 
         // 0:32 [2.12GB, 15M rows] [67MB/s, 463K rows/s]
@@ -281,6 +282,7 @@ Parallelism: 2.5
                 reprintLine(perNodeSummary);
 
                 reprintLine(String.format("Parallelism: %.1f", parallelism));
+                reprintLine("Spilled: " + stats.getSpilledDataSize());
             }
 
             verify(terminalWidth >= 75); // otherwise handled above

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementStats.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementStats.java
@@ -15,6 +15,7 @@ package com.facebook.presto.client;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.units.DataSize;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -43,6 +44,7 @@ public class StatementStats
     private final long processedRows;
     private final long processedBytes;
     private final StageStats rootStage;
+    private final DataSize spilledDataSize;
 
     @JsonCreator
     public StatementStats(
@@ -59,7 +61,8 @@ public class StatementStats
             @JsonProperty("wallTimeMillis") long wallTimeMillis,
             @JsonProperty("processedRows") long processedRows,
             @JsonProperty("processedBytes") long processedBytes,
-            @JsonProperty("rootStage") StageStats rootStage)
+            @JsonProperty("rootStage") StageStats rootStage,
+            @JsonProperty("spilledDataSize") DataSize spilledDataSize)
     {
         this.state = requireNonNull(state, "state is null");
         this.queued = queued;
@@ -75,6 +78,7 @@ public class StatementStats
         this.processedRows = processedRows;
         this.processedBytes = processedBytes;
         this.rootStage = rootStage;
+        this.spilledDataSize = spilledDataSize;
     }
 
     @NotNull
@@ -172,6 +176,12 @@ public class StatementStats
         return OptionalDouble.of(min(100, (completedSplits * 100.0) / totalSplits));
     }
 
+    @JsonProperty
+    public DataSize getSpilledDataSize()
+    {
+        return spilledDataSize;
+    }
+
     @Override
     public String toString()
     {
@@ -190,6 +200,7 @@ public class StatementStats
                 .add("processedRows", processedRows)
                 .add("processedBytes", processedBytes)
                 .add("rootStage", rootStage)
+                .add("spilledDataSize", spilledDataSize)
                 .toString();
     }
 
@@ -214,6 +225,7 @@ public class StatementStats
         private long processedRows;
         private long processedBytes;
         private StageStats rootStage;
+        private DataSize spilledDataSize;
 
         private Builder() {}
 
@@ -301,6 +313,12 @@ public class StatementStats
             return this;
         }
 
+        public Builder setSpilledDataSize(DataSize spilledDataSize)
+        {
+            this.spilledDataSize = spilledDataSize;
+            return this;
+        }
+
         public StatementStats build()
         {
             return new StatementStats(
@@ -317,7 +335,8 @@ public class StatementStats
                     wallTimeMillis,
                     processedRows,
                     processedBytes,
-                    rootStage);
+                    rootStage,
+                    spilledDataSize);
         }
     }
 }

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
@@ -89,7 +89,7 @@ public class TestProgressMonitor
                 nextUriId == null ? null : server.url(format("/v1/statement/%s/%s", queryId, nextUriId)).uri(),
                 responseColumns,
                 data,
-                new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
+                new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null, null),
                 null,
                 null,
                 null);

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -328,6 +328,8 @@ public class QueryStateMachine
         boolean fullyBlocked = rootStage.isPresent();
         Set<BlockedReason> blockedReasons = new HashSet<>();
 
+        long spilledBytes = 0;
+
         ImmutableList.Builder<OperatorStats> operatorStatsSummary = ImmutableList.builder();
         boolean completeInfo = true;
         for (StageInfo stageInfo : getAllStages(rootStage)) {
@@ -363,6 +365,7 @@ public class QueryStateMachine
                 processedInputDataSize += stageStats.getProcessedInputDataSize().toBytes();
                 processedInputPositions += stageStats.getProcessedInputPositions();
             }
+            spilledBytes += stageStats.getSpilledDataSize().toBytes();
             completeInfo = completeInfo && stageInfo.isCompleteInfo();
             operatorStatsSummary.addAll(stageInfo.getStageStats().getOperatorSummaries());
         }
@@ -417,6 +420,7 @@ public class QueryStateMachine
                 processedInputPositions,
                 succinctBytes(outputDataSize),
                 outputPositions,
+                succinctBytes(spilledBytes),
                 operatorStatsSummary.build());
 
         return new QueryInfo(queryId,

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -82,6 +82,8 @@ public class QueryStats
 
     private final List<OperatorStats> operatorSummaries;
 
+    private final DataSize spilledDataSize;
+
     @VisibleForTesting
     public QueryStats()
     {
@@ -119,6 +121,7 @@ public class QueryStats
         this.processedInputPositions = 0;
         this.outputDataSize = null;
         this.outputPositions = 0;
+        this.spilledDataSize = null;
         this.operatorSummaries = null;
     }
 
@@ -166,6 +169,8 @@ public class QueryStats
 
             @JsonProperty("outputDataSize") DataSize outputDataSize,
             @JsonProperty("outputPositions") long outputPositions,
+
+            @JsonProperty("spilledDataSize") DataSize spilledDataSize,
 
             @JsonProperty("operatorSummaries") List<OperatorStats> operatorSummaries)
     {
@@ -221,6 +226,9 @@ public class QueryStats
         this.outputDataSize = requireNonNull(outputDataSize, "outputDataSize is null");
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
+
+        this.spilledDataSize = requireNonNull(spilledDataSize, "spilledDataSize is null");
+
         this.operatorSummaries = ImmutableList.copyOf(requireNonNull(operatorSummaries, "operatorSummaries is null"));
     }
 
@@ -436,6 +444,12 @@ public class QueryStats
     public long getOutputPositions()
     {
         return outputPositions;
+    }
+
+    @JsonProperty
+    public DataSize getSpilledDataSize()
+    {
+        return spilledDataSize;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
@@ -239,6 +239,8 @@ public class StageStateMachine
         boolean fullyBlocked = true;
         Set<BlockedReason> blockedReasons = new HashSet<>();
 
+        long spilledBytes = 0;
+
         Map<String, OperatorStats> operatorToStats = new HashMap<>();
         for (TaskInfo taskInfo : taskInfos) {
             TaskState taskState = taskInfo.getTaskStatus().getState();
@@ -278,6 +280,8 @@ public class StageStateMachine
             bufferedDataSize += taskInfo.getOutputBuffers().getTotalBufferedBytes();
             outputDataSize += taskStats.getOutputDataSize().toBytes();
             outputPositions += taskStats.getOutputPositions();
+
+            spilledBytes += taskStats.getSpilledDataSize().toBytes();
 
             for (PipelineStats pipeline : taskStats.getPipelines()) {
                 for (OperatorStats operatorStats : pipeline.getOperatorSummaries()) {
@@ -320,6 +324,7 @@ public class StageStateMachine
                 succinctBytes(bufferedDataSize),
                 succinctBytes(outputDataSize),
                 outputPositions,
+                succinctBytes(spilledBytes),
                 ImmutableList.copyOf(operatorToStats.values()));
 
         ExecutionFailureInfo failureInfo = null;

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStats.java
@@ -72,6 +72,9 @@ public class StageStats
     private final DataSize bufferedDataSize;
     private final DataSize outputDataSize;
     private final long outputPositions;
+
+    private final DataSize spilledDataSize;
+
     private final List<OperatorStats> operatorSummaries;
 
     @VisibleForTesting
@@ -105,6 +108,7 @@ public class StageStats
         this.bufferedDataSize = null;
         this.outputDataSize = null;
         this.outputPositions = 0;
+        this.spilledDataSize = null;
         this.operatorSummaries = null;
     }
 
@@ -146,6 +150,9 @@ public class StageStats
             @JsonProperty("bufferedDataSize") DataSize bufferedDataSize,
             @JsonProperty("outputDataSize") DataSize outputDataSize,
             @JsonProperty("outputPositions") long outputPositions,
+
+            @JsonProperty("spilledDataSize") DataSize spilledDataSize,
+
             @JsonProperty("operatorSummaries") List<OperatorStats> operatorSummaries)
     {
         this.schedulingComplete = schedulingComplete;
@@ -194,6 +201,9 @@ public class StageStats
         this.outputDataSize = requireNonNull(outputDataSize, "outputDataSize is null");
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
+
+        this.spilledDataSize = requireNonNull(spilledDataSize, "spilledDataSize is null");
+
         this.operatorSummaries = ImmutableList.copyOf(requireNonNull(operatorSummaries, "operatorSummaries is null"));
     }
 
@@ -363,6 +373,12 @@ public class StageStats
     public long getOutputPositions()
     {
         return outputPositions;
+    }
+
+    @JsonProperty
+    public DataSize getSpilledDataSize()
+    {
+        return spilledDataSize;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -82,6 +82,7 @@ public class DriverContext
 
     private final List<OperatorContext> operatorContexts = new CopyOnWriteArrayList<>();
     private final boolean partitioned;
+    private final AtomicLong spilledBytes = new AtomicLong();
 
     public DriverContext(PipelineContext pipelineContext, Executor executor, boolean partitioned)
     {
@@ -204,6 +205,7 @@ public class DriverContext
 
     public ListenableFuture<?> reserveSpill(long bytes)
     {
+        spilledBytes.getAndAdd(bytes);
         return pipelineContext.reserveSpill(bytes);
     }
 
@@ -407,6 +409,7 @@ public class DriverContext
                 processedInputPositions,
                 outputDataSize.convertToMostSuccinctDataSize(),
                 outputPositions,
+                succinctBytes(spilledBytes.get()),
                 ImmutableList.copyOf(transform(operatorContexts, OperatorContext::getOperatorStats)));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverStats.java
@@ -63,6 +63,8 @@ public class DriverStats
     private final DataSize outputDataSize;
     private final long outputPositions;
 
+    private final DataSize spilledDataSize;
+
     private final List<OperatorStats> operatorStats;
 
     public DriverStats()
@@ -93,6 +95,8 @@ public class DriverStats
 
         this.outputDataSize = new DataSize(0, BYTE);
         this.outputPositions = 0;
+
+        this.spilledDataSize = new DataSize(0, BYTE);
 
         this.operatorStats = ImmutableList.of();
     }
@@ -126,6 +130,8 @@ public class DriverStats
             @JsonProperty("outputDataSize") DataSize outputDataSize,
             @JsonProperty("outputPositions") long outputPositions,
 
+            @JsonProperty("spilledDataSize") DataSize spilledDataSize,
+
             @JsonProperty("operatorStats") List<OperatorStats> operatorStats)
     {
         this.createTime = requireNonNull(createTime, "createTime is null");
@@ -157,6 +163,8 @@ public class DriverStats
         this.outputDataSize = requireNonNull(outputDataSize, "outputDataSize is null");
         Preconditions.checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
+
+        this.spilledDataSize = requireNonNull(spilledDataSize, "spilledDataSize is null");
 
         this.operatorStats = ImmutableList.copyOf(requireNonNull(operatorStats, "operatorStats is null"));
     }
@@ -287,6 +295,12 @@ public class DriverStats
     public long getOutputPositions()
     {
         return outputPositions;
+    }
+
+    @JsonProperty
+    public DataSize getSpilledDataSize()
+    {
+        return spilledDataSize;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -86,7 +86,7 @@ public class OperatorContext
 
     private final AtomicLong memoryReservation = new AtomicLong();
     private final OperatorSystemMemoryContext systemMemoryContext;
-    private final SpillContext spillContext;
+    private final OperatorSpillContext spillContext;
 
     private final AtomicReference<Supplier<OperatorInfo>> infoSupplier = new AtomicReference<>();
     private final boolean collectTimings;
@@ -396,6 +396,8 @@ public class OperatorContext
                 succinctBytes(outputDataSize.getTotalCount()),
                 outputPositions.getTotalCount(),
 
+                succinctBytes(spillContext.getSpilledBytes()),
+
                 new Duration(blockedWallNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
 
                 finishCalls.get(),
@@ -514,6 +516,7 @@ public class OperatorContext
         private final DriverContext driverContext;
 
         private long reservedBytes;
+        private long spilledBytes;
 
         public OperatorSpillContext(DriverContext driverContext)
         {
@@ -525,6 +528,7 @@ public class OperatorContext
         {
             if (bytes > 0) {
                 driverContext.reserveSpill(bytes);
+                spilledBytes += bytes;
             }
             else {
                 checkArgument(reservedBytes + bytes >= 0, "tried to free %s spilled bytes from %s bytes reserved", -bytes, reservedBytes);
@@ -538,7 +542,13 @@ public class OperatorContext
         {
             return toStringHelper(this)
                     .add("usedBytes", reservedBytes)
+                    .add("spilledBytes", spilledBytes)
                     .toString();
+        }
+
+        public long getSpilledBytes()
+        {
+            return spilledBytes;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -55,6 +55,8 @@ public class OperatorStats
     private final DataSize outputDataSize;
     private final long outputPositions;
 
+    private final DataSize spilledDataSize;
+
     private final Duration blockedWall;
 
     private final long finishCalls;
@@ -91,6 +93,8 @@ public class OperatorStats
             @JsonProperty("getOutputUser") Duration getOutputUser,
             @JsonProperty("outputDataSize") DataSize outputDataSize,
             @JsonProperty("outputPositions") long outputPositions,
+
+            @JsonProperty("spilledDataSize") DataSize spilledDataSize,
 
             @JsonProperty("blockedWall") Duration blockedWall,
 
@@ -130,6 +134,8 @@ public class OperatorStats
         this.outputDataSize = requireNonNull(outputDataSize, "outputDataSize is null");
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
+
+        this.spilledDataSize = requireNonNull(spilledDataSize, "spilledDataSize is null");
 
         this.blockedWall = requireNonNull(blockedWall, "blockedWall is null");
 
@@ -254,6 +260,12 @@ public class OperatorStats
     }
 
     @JsonProperty
+    public DataSize getSpilledDataSize()
+    {
+        return spilledDataSize;
+    }
+
+    @JsonProperty
     public Duration getBlockedWall()
     {
         return blockedWall;
@@ -342,6 +354,7 @@ public class OperatorStats
         long memoryReservation = this.memoryReservation.toBytes();
         long systemMemoryReservation = this.systemMemoryReservation.toBytes();
         Optional<BlockedReason> blockedReason = this.blockedReason;
+        long spilledBytes = this.spilledDataSize.toBytes();
 
         Mergeable<OperatorInfo> base = getMergeableInfoOrNull(info);
         for (OperatorStats operator : operators) {
@@ -363,6 +376,8 @@ public class OperatorStats
             getOutputUser += operator.getGetOutputUser().roundTo(NANOSECONDS);
             outputDataSize += operator.getOutputDataSize().toBytes();
             outputPositions += operator.getOutputPositions();
+
+            spilledBytes += operator.getSpilledDataSize().toBytes();
 
             finishCalls += operator.getFinishCalls();
             finishWall += operator.getFinishWall().roundTo(NANOSECONDS);
@@ -405,6 +420,8 @@ public class OperatorStats
                 new Duration(getOutputUser, NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 succinctBytes(outputDataSize),
                 outputPositions,
+
+                succinctBytes(spilledBytes),
 
                 new Duration(blockedWall, NANOSECONDS).convertToMostSuccinctTimeUnit(),
 
@@ -457,6 +474,7 @@ public class OperatorStats
                 getOutputUser,
                 outputDataSize,
                 outputPositions,
+                spilledDataSize,
                 blockedWall,
                 finishCalls,
                 finishWall,

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
@@ -86,6 +86,7 @@ public class PipelineContext
     private final CounterStat outputPositions = new CounterStat();
 
     private final ConcurrentMap<Integer, OperatorStats> operatorSummaries = new ConcurrentHashMap<>();
+    private final AtomicLong spilledBytes = new AtomicLong();
 
     public PipelineContext(int pipelineId, TaskContext taskContext, Executor executor, boolean inputPipeline, boolean outputPipeline)
     {
@@ -233,6 +234,7 @@ public class PipelineContext
 
     public synchronized ListenableFuture<?> reserveSpill(long bytes)
     {
+        spilledBytes.getAndAdd(bytes);
         return taskContext.reserveSpill(bytes);
     }
 
@@ -466,6 +468,8 @@ public class PipelineContext
 
                 succinctBytes(outputDataSize),
                 outputPositions,
+
+                succinctBytes(spilledBytes.get()),
 
                 ImmutableList.copyOf(operatorSummaries.values()),
                 drivers);

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineStats.java
@@ -74,6 +74,8 @@ public class PipelineStats
     private final DataSize outputDataSize;
     private final long outputPositions;
 
+    private final DataSize spilledDataSize;
+
     private final List<OperatorStats> operatorSummaries;
     private final List<DriverStats> drivers;
 
@@ -117,6 +119,8 @@ public class PipelineStats
 
             @JsonProperty("outputDataSize") DataSize outputDataSize,
             @JsonProperty("outputPositions") long outputPositions,
+
+            @JsonProperty("spilledDataSize") DataSize spilledDataSize,
 
             @JsonProperty("operatorSummaries") List<OperatorStats> operatorSummaries,
             @JsonProperty("drivers") List<DriverStats> drivers)
@@ -169,6 +173,8 @@ public class PipelineStats
         this.outputDataSize = requireNonNull(outputDataSize, "outputDataSize is null");
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
+
+        this.spilledDataSize = requireNonNull(spilledDataSize, "spilledDataSize is null");
 
         this.operatorSummaries = ImmutableList.copyOf(requireNonNull(operatorSummaries, "operatorSummaries is null"));
         this.drivers = ImmutableList.copyOf(requireNonNull(drivers, "drivers is null"));
@@ -352,6 +358,12 @@ public class PipelineStats
     }
 
     @JsonProperty
+    public DataSize getSpilledDataSize()
+    {
+        return spilledDataSize;
+    }
+
+    @JsonProperty
     public List<OperatorStats> getOperatorSummaries()
     {
         return operatorSummaries;
@@ -395,6 +407,7 @@ public class PipelineStats
                 processedInputPositions,
                 outputDataSize,
                 outputPositions,
+                spilledDataSize,
                 operatorSummaries.stream()
                         .map(OperatorStats::summarize)
                         .collect(Collectors.toList()),

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -79,6 +79,8 @@ public class TaskContext
     @GuardedBy("cumulativeMemoryLock")
     private long lastTaskStatCallNanos = 0;
 
+    private final AtomicLong spilledBytes = new AtomicLong();
+
     public TaskContext(QueryContext queryContext,
             TaskStateMachine taskStateMachine,
             Executor executor,
@@ -168,6 +170,7 @@ public class TaskContext
     public synchronized ListenableFuture<?> reserveSpill(long bytes)
     {
         checkArgument(bytes >= 0, "bytes is negative");
+        spilledBytes.getAndAdd(bytes);
         return queryContext.reserveSpill(bytes);
     }
 
@@ -396,6 +399,7 @@ public class TaskContext
                 processedInputPositions,
                 succinctBytes(outputDataSize),
                 outputPositions,
+                succinctBytes(spilledBytes.get()),
                 pipelineStats);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -71,6 +71,8 @@ public class TaskStats
     private final DataSize outputDataSize;
     private final long outputPositions;
 
+    private final DataSize spilledDataSize;
+
     private final List<PipelineStats> pipelines;
 
     public TaskStats(DateTime createTime, DateTime endTime)
@@ -104,6 +106,7 @@ public class TaskStats
                 0,
                 new DataSize(0, BYTE),
                 0,
+                new DataSize(0, BYTE),
                 ImmutableList.of());
     }
 
@@ -144,6 +147,8 @@ public class TaskStats
 
             @JsonProperty("outputDataSize") DataSize outputDataSize,
             @JsonProperty("outputPositions") long outputPositions,
+
+            @JsonProperty("spilledDataSize") DataSize spilledDataSize,
 
             @JsonProperty("pipelines") List<PipelineStats> pipelines)
     {
@@ -195,6 +200,8 @@ public class TaskStats
         this.outputDataSize = requireNonNull(outputDataSize, "outputDataSize is null");
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
+
+        this.spilledDataSize = requireNonNull(spilledDataSize, "spilledDataSize is null");
 
         this.pipelines = ImmutableList.copyOf(requireNonNull(pipelines, "pipelines is null"));
     }
@@ -366,6 +373,12 @@ public class TaskStats
     }
 
     @JsonProperty
+    public DataSize getSpilledDataSize()
+    {
+        return spilledDataSize;
+    }
+
+    @JsonProperty
     public List<PipelineStats> getPipelines()
     {
         return pipelines;
@@ -415,6 +428,7 @@ public class TaskStats
                 processedInputPositions,
                 outputDataSize,
                 outputPositions,
+                spilledDataSize,
                 ImmutableList.of());
     }
 
@@ -450,6 +464,7 @@ public class TaskStats
                 processedInputPositions,
                 outputDataSize,
                 outputPositions,
+                spilledDataSize,
                 pipelines.stream()
                         .map(PipelineStats::summarize)
                         .collect(Collectors.toList()));

--- a/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
@@ -633,6 +633,7 @@ public class StatementResource
                     .setProcessedRows(queryStats.getRawInputPositions())
                     .setProcessedBytes(queryStats.getRawInputDataSize().toBytes())
                     .setRootStage(toStageStats(outputStage))
+                    .setSpilledDataSize(queryStats.getSpilledDataSize())
                     .build();
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
@@ -37,6 +37,8 @@ public class PlanNodeStats
     private final long planNodeInputPositions;
     private final DataSize planNodeInputDataSize;
     private final long planNodeOutputPositions;
+    private final DataSize planNodeSpilledDataSize;
+
     private final DataSize planNodeOutputDataSize;
 
     private final Map<String, OperatorInputStats> operatorInputStats;
@@ -49,6 +51,7 @@ public class PlanNodeStats
             DataSize planNodeInputDataSize,
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
+            DataSize planNodeSpilledDataSize,
             Map<String, OperatorInputStats> operatorInputStats,
             Map<String, OperatorHashCollisionsStats> operatorHashCollisionsStats)
     {
@@ -59,6 +62,7 @@ public class PlanNodeStats
         this.planNodeInputDataSize = planNodeInputDataSize;
         this.planNodeOutputPositions = planNodeOutputPositions;
         this.planNodeOutputDataSize = planNodeOutputDataSize;
+        this.planNodeSpilledDataSize = planNodeSpilledDataSize;
 
         this.operatorInputStats = requireNonNull(operatorInputStats, "operatorInputStats is null");
         this.operatorHashCollisionsStats = requireNonNull(operatorHashCollisionsStats, "operatorHashCollisionsStats is null");
@@ -161,6 +165,11 @@ public class PlanNodeStats
                         entry -> entry.getValue().getWeightedExpectedHashCollisions() / operatorInputStats.get(entry.getKey()).getInputPositions()));
     }
 
+    public DataSize getPlanNodeSpilledDataSize()
+    {
+        return planNodeSpilledDataSize;
+    }
+
     public static PlanNodeStats merge(PlanNodeStats left, PlanNodeStats right)
     {
         checkArgument(left.getPlanNodeId().equals(right.getPlanNodeId()), "planNodeIds do not match. %s != %s", left.getPlanNodeId(), right.getPlanNodeId());
@@ -169,6 +178,7 @@ public class PlanNodeStats
         DataSize planNodeInputDataSize = succinctBytes(left.planNodeInputDataSize.toBytes() + right.planNodeInputDataSize.toBytes());
         long planNodeOutputPositions = left.planNodeOutputPositions + right.planNodeOutputPositions;
         DataSize planNodeOutputDataSize = succinctBytes(left.planNodeOutputDataSize.toBytes() + right.planNodeOutputDataSize.toBytes());
+        DataSize planNodeSpilledDataSize = succinctBytes(left.getPlanNodeSpilledDataSize().toBytes() + right.getPlanNodeSpilledDataSize().toBytes());
 
         Map<String, OperatorInputStats> operatorInputStats = mergeMaps(left.operatorInputStats, right.operatorInputStats, OperatorInputStats::merge);
         Map<String, OperatorHashCollisionsStats> operatorHashCollisionsStats = mergeMaps(left.operatorHashCollisionsStats, right.operatorHashCollisionsStats, OperatorHashCollisionsStats::merge);
@@ -178,6 +188,7 @@ public class PlanNodeStats
                 new Duration(left.getPlanNodeWallTime().toMillis() + right.getPlanNodeWallTime().toMillis(), MILLISECONDS),
                 planNodeInputPositions, planNodeInputDataSize,
                 planNodeOutputPositions, planNodeOutputDataSize,
+                planNodeSpilledDataSize,
                 operatorInputStats,
                 operatorHashCollisionsStats);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -34,6 +34,7 @@ import static com.facebook.presto.util.MoreMaps.mergeMaps;
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Lists.reverse;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.succinctBytes;
 import static io.airlift.units.DataSize.succinctDataSize;
 import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -68,6 +69,7 @@ public class PlanNodeStatsSummarizer
         Map<PlanNodeId, Long> planNodeOutputPositions = new HashMap<>();
         Map<PlanNodeId, Long> planNodeOutputBytes = new HashMap<>();
         Map<PlanNodeId, Long> planNodeWallMillis = new HashMap<>();
+        Map<PlanNodeId, Long> planNodeSpilledBytes = new HashMap<>();
 
         Map<PlanNodeId, Map<String, OperatorInputStats>> operatorInputStats = new HashMap<>();
         Map<PlanNodeId, Map<String, OperatorHashCollisionsStats>> operatorHashCollisionsStats = new HashMap<>();
@@ -128,14 +130,16 @@ public class PlanNodeStatsSummarizer
             for (OperatorStats operatorStats : reverse(pipelineStats.getOperatorSummaries())) {
                 PlanNodeId planNodeId = operatorStats.getPlanNodeId();
 
-                // An "internal" pipeline like a hash build, links to another pipeline which is the actual output for this plan node
-                if (operatorStats.getPlanNodeId().equals(outputPlanNode) && !pipelineStats.isOutputPipeline()) {
-                    continue;
-                }
                 if (processedNodes.contains(planNodeId)) {
                     continue;
                 }
 
+                planNodeSpilledBytes.merge(planNodeId, operatorStats.getSpilledDataSize().toBytes(), Long::sum);
+
+                // An "internal" pipeline like a hash build, links to another pipeline which is the actual output for this plan node
+                if (operatorStats.getPlanNodeId().equals(outputPlanNode) && !pipelineStats.isOutputPipeline()) {
+                    continue;
+                }
                 planNodeOutputPositions.merge(planNodeId, operatorStats.getOutputPositions(), Long::sum);
                 planNodeOutputBytes.merge(planNodeId, operatorStats.getOutputDataSize().toBytes(), Long::sum);
                 processedNodes.add(planNodeId);
@@ -156,6 +160,7 @@ public class PlanNodeStatsSummarizer
                     // and therefore only have wall time, but no output stats
                     planNodeOutputPositions.getOrDefault(planNodeId, 0L),
                     succinctDataSize(planNodeOutputBytes.getOrDefault(planNodeId, 0L), BYTE),
+                    succinctBytes(planNodeSpilledBytes.get(entry.getKey())),
                     operatorInputStats.get(planNodeId),
                     // Only some operators emit hash collisions statistics
                     operatorHashCollisionsStats.getOrDefault(planNodeId, emptyMap())));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -101,6 +101,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.airlift.slice.Slice;
+import io.airlift.units.DataSize;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -225,12 +226,16 @@ public class PlanPrinter
 
         if (stageStats.isPresent()) {
             builder.append(indentString(1))
-                    .append(format("CPU: %s, Input: %s (%s), Output: %s (%s)\n",
+                    .append(format("CPU: %s, Input: %s (%s), Output: %s (%s)",
                             stageStats.get().getTotalCpuTime(),
                             formatPositions(stageStats.get().getProcessedInputPositions()),
                             stageStats.get().getProcessedInputDataSize(),
                             formatPositions(stageStats.get().getOutputPositions()),
                             stageStats.get().getOutputDataSize()));
+            if (isNonZero(stageStats.get().getSpilledDataSize())) {
+                builder.append(", Spilled " + stageStats.get().getSpilledDataSize());
+            }
+            builder.append("\n");
         }
 
         PartitioningScheme partitioningScheme = fragment.getPartitioningScheme();
@@ -273,6 +278,11 @@ public class PlanPrinter
         }
 
         return builder.toString();
+    }
+
+    private static boolean isNonZero(DataSize dataSize)
+    {
+        return dataSize != null && dataSize.getValue() != 0;
     }
 
     public static String graphvizLogicalPlan(PlanNode plan, Map<Symbol, Type> types)
@@ -355,6 +365,9 @@ public class PlanPrinter
         if (printFiltered) {
             double filtered = 100.0d * (nodeStats.getPlanNodeInputPositions() - nodeStats.getPlanNodeOutputPositions()) / nodeStats.getPlanNodeInputPositions();
             output.append(", Filtered: " + formatDouble(filtered) + "%");
+        }
+        if (isNonZero(nodeStats.getPlanNodeSpilledDataSize())) {
+            output.append(", Spilled: " + nodeStats.getPlanNodeSpilledDataSize());
         }
         output.append('\n');
 

--- a/presto-main/src/main/resources/com/facebook/presto/server/plan.html
+++ b/presto-main/src/main/resources/com/facebook/presto/server/plan.html
@@ -181,6 +181,7 @@ function update(graph, query)
                 ) +
                 "<div>Memory: " + stats.totalMemoryReservation + "</div>" +
                 "<div>Splits: Q:" + stats.queuedDrivers + ", R:" + stats.runningDrivers + ", F:" + stats.completedDrivers + "</div>" +
+                "<div>Spilled: " + stats.spilledDataSize + "</div>" +
 
                 "<hr>" +
                 "<div>Input: " + stats.processedInputDataSize + " / " + formatCount(stats.processedInputPositions) + " rows</div>";

--- a/presto-main/src/main/resources/webapp/assets/query.js
+++ b/presto-main/src/main/resources/webapp/assets/query.js
@@ -1217,6 +1217,14 @@ let QueryDetail = React.createClass({
                                                 { formatDataSizeBytes(query.queryStats.cumulativeMemory / 1000.0, "") + " seconds" }
                                             </td>
                                         </tr>
+                                        <tr>
+                                            <td className="info-title">
+                                                Spilled Data
+                                            </td>
+                                            <td className="info-text">
+                                                { query.queryStats.spilledDataSize }
+                                            </td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </div>

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -143,6 +143,7 @@ public class MockQueryExecution
 
                         new DataSize(28, BYTE),
                         29,
+                        new DataSize(29, BYTE),
                         ImmutableList.of()),
                 ImmutableMap.of(),
                 ImmutableSet.of(),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -71,6 +71,7 @@ public class TestQueryStats
 
             new DataSize(28, BYTE),
             29,
+            new DataSize(30, BYTE),
             ImmutableList.of());
 
     @Test
@@ -127,5 +128,7 @@ public class TestQueryStats
 
         assertEquals(actual.getOutputDataSize(), new DataSize(28, BYTE));
         assertEquals(actual.getOutputPositions(), 29);
+
+        assertEquals(actual.getSpilledDataSize(), new DataSize(30, BYTE));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageStats.java
@@ -66,6 +66,7 @@ public class TestStageStats
             new DataSize(23, BYTE),
             new DataSize(24, BYTE),
             25,
+            new DataSize(26, BYTE),
             ImmutableList.of());
 
     @Test
@@ -115,6 +116,8 @@ public class TestStageStats
         assertEquals(actual.getBufferedDataSize(), new DataSize(23, BYTE));
         assertEquals(actual.getOutputDataSize(), new DataSize(24, BYTE));
         assertEquals(actual.getOutputPositions(), 25);
+
+        assertEquals(actual.getSpilledDataSize(), new DataSize(26, BYTE));
     }
 
     private static DistributionSnapshot getTestDistribution(int count)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriverStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriverStats.java
@@ -58,6 +58,7 @@ public class TestDriverStats
             new DataSize(17, BYTE),
             18,
 
+            new DataSize(19, BYTE),
             ImmutableList.of(TestOperatorStats.EXPECTED));
 
     @Test
@@ -100,5 +101,6 @@ public class TestDriverStats
 
         assertEquals(actual.getOperatorStats().size(), 1);
         assertExpectedOperatorStats(actual.getOperatorStats().get(0));
+        assertEquals(actual.getSpilledDataSize(), new DataSize(19, BYTE));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -54,6 +54,8 @@ public class TestOperatorStats
             new DataSize(13, BYTE),
             14,
 
+            new DataSize(23, BYTE),
+
             new Duration(15, NANOSECONDS),
 
             16,
@@ -88,6 +90,8 @@ public class TestOperatorStats
             new Duration(12, NANOSECONDS),
             new DataSize(13, BYTE),
             14,
+
+            new DataSize(23, BYTE),
 
             new Duration(15, NANOSECONDS),
 
@@ -144,6 +148,8 @@ public class TestOperatorStats
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(21, BYTE));
         assertEquals(actual.getInfo().getClass(), SplitOperatorInfo.class);
         assertEquals(((SplitOperatorInfo) actual.getInfo()).getSplitInfo(), NON_MERGEABLE_INFO.getSplitInfo());
+
+        assertEquals(actual.getSpilledDataSize(), new DataSize(23, BYTE));
     }
 
     @Test
@@ -179,6 +185,7 @@ public class TestOperatorStats
         assertEquals(actual.getMemoryReservation(), new DataSize(3 * 20, BYTE));
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(3 * 21, BYTE));
         assertEquals(actual.getInfo(), null);
+        assertEquals(actual.getSpilledDataSize(), new DataSize(3 * 23, BYTE));
     }
 
     @Test
@@ -215,5 +222,7 @@ public class TestOperatorStats
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(3 * 21, BYTE));
         assertEquals(actual.getInfo().getClass(), PartitionedOutputInfo.class);
         assertEquals(((PartitionedOutputInfo) actual.getInfo()).getPagesAdded(), 3 * MERGEABLE_INFO.getPagesAdded());
+
+        assertEquals(actual.getSpilledDataSize(), new DataSize(3 * 23, BYTE));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPipelineStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPipelineStats.java
@@ -72,6 +72,8 @@ public class TestPipelineStats
             new DataSize(17, BYTE),
             18,
 
+            new DataSize(19, BYTE),
+
             ImmutableList.of(TestOperatorStats.EXPECTED),
             ImmutableList.of(TestDriverStats.EXPECTED));
 
@@ -127,6 +129,7 @@ public class TestPipelineStats
 
         assertEquals(actual.getDrivers().size(), 1);
         assertExpectedDriverStats(actual.getDrivers().get(0));
+        assertEquals(actual.getSpilledDataSize(), new DataSize(19, BYTE));
     }
 
     private static DistributionSnapshot getTestDistribution(int count)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
@@ -65,6 +65,8 @@ public class TestTaskStats
             new DataSize(22, BYTE),
             23,
 
+            new DataSize(24, BYTE),
+
             ImmutableList.of(TestPipelineStats.EXPECTED));
 
     @Test
@@ -116,5 +118,6 @@ public class TestTaskStats
 
         assertEquals(actual.getPipelines().size(), 1);
         assertExpectedPipelineStats(actual.getPipelines().get(0));
+        assertEquals(actual.getSpilledDataSize(), new DataSize(24, BYTE));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -85,6 +85,7 @@ public class TestBasicQueryInfo
                                 30,
                                 DataSize.valueOf("31GB"),
                                 32,
+                                DataSize.valueOf("33GB"),
                                 ImmutableList.of()),
                         ImmutableMap.of(),
                         ImmutableSet.of(),

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -256,6 +256,7 @@ public class TestQueryStateInfo
                         30,
                         DataSize.valueOf("31GB"),
                         32,
+                        DataSize.valueOf("33GB"),
                         ImmutableList.of()),
                 ImmutableMap.of(),
                 ImmutableSet.of(),

--- a/presto-product-tests/src/test/resources/com/facebook/presto/tests/querystats/single_query_info_response.json
+++ b/presto-product-tests/src/test/resources/com/facebook/presto/tests/querystats/single_query_info_response.json
@@ -51,6 +51,7 @@
     "processedInputPositions": 0,
     "outputDataSize": "0B",
     "outputPositions": 0,
+    "spilledDataSize": "0B",
     "operatorSummaries": []
   },
   "setSessionProperties": {},
@@ -169,7 +170,8 @@
       "processedInputDataSize": "0B",
       "processedInputPositions": 0,
       "outputDataSize": "0B",
-      "outputPositions": 0
+      "outputPositions": 0,
+      "spilledDataSize": "0B"
     },
     "tasks": [
       {
@@ -220,6 +222,7 @@
           "processedInputPositions": 0,
           "outputDataSize": "0B",
           "outputPositions": 0,
+          "spilledDataSize": "0B",
           "pipelines": []
         },
         "failures": []
@@ -377,7 +380,8 @@
           "processedInputDataSize": "0B",
           "processedInputPositions": 0,
           "outputDataSize": "0B",
-          "outputPositions": 0
+          "outputPositions": 0,
+          "spilledDataSize": "0B"
         },
         "tasks": [],
         "subStages": [],


### PR DESCRIPTION
This pull request adds optional information about spilled data volume in a couple contexts, including raw JSON, explain analyze output, query summary and the web UI. Not to clutter the already packed views, if there is no spilled data the "Spilled data" label is not included. 