### PR TITLE
Change build dependency from CDH4 to Hadoop 1.x

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -39,7 +39,7 @@
 
         <dependency>
             <groupId>com.facebook.presto.hadoop</groupId>
-            <artifactId>hadoop-cdh4</artifactId>
+            <artifactId>hadoop-apache1</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -112,7 +112,7 @@
 
         <dependency>
             <groupId>com.facebook.presto.hadoop</groupId>
-            <artifactId>hadoop-cdh4</artifactId>
+            <artifactId>hadoop-apache1</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Use 1.x to ensure compatibility with the older APIs.