### PR TITLE
Dynamic filtering support for inner joins

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
@@ -39,6 +39,7 @@ import java.util.function.Supplier;
 
 import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -71,7 +72,7 @@ public class HandTpchQuery6
 
         Supplier<PageProjection> projection = new PageFunctionCompiler(localQueryRunner.getMetadata()).compileProjection(field(0, BIGINT));
 
-        FilterAndProjectOperator.FilterAndProjectOperatorFactory tpchQuery6Operator = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        FilterAndProjectOperator.FilterAndProjectOperatorFactory tpchQuery6Operator = synchronousFilterAndProjectOperator(
                 1,
                 new PlanNodeId("test"),
                 () -> new PageProcessor(Optional.of(new TpchQuery6Filter()), ImmutableList.of(projection.get())),

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/PredicateFilterBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/PredicateFilterBenchmark.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 
 import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
 import static com.facebook.presto.metadata.Signature.internalOperator;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -55,7 +56,7 @@ public class PredicateFilterBenchmark
         ExpressionCompiler expressionCompiler = new ExpressionCompiler(localQueryRunner.getMetadata());
         Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(Optional.of(filter), ImmutableList.of(field(0, DOUBLE)));
 
-        FilterAndProjectOperator.FilterAndProjectOperatorFactory filterAndProjectOperator = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        FilterAndProjectOperator.FilterAndProjectOperatorFactory filterAndProjectOperator = synchronousFilterAndProjectOperator(
                 1,
                 new PlanNodeId("test"),
                 pageProcessor,

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSourceOperator.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeUtils;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterSourceOperator
+        implements Operator
+{
+    public static class DynamicFilterSourceOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+        private final List<Type> types;
+        private final List<Integer> filterChannels;
+        private final TupleDomainSource tupleDomainSource;
+
+        private boolean closed;
+
+        public DynamicFilterSourceOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                List<Type> types,
+                List<Integer> filterChannels,
+                Optional<Integer> hashChannel,
+                TupleDomainSource tupleDomainSource)
+        {
+            this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.types = ImmutableList.copyOf(types);
+            this.filterChannels = ImmutableList.<Integer>builder()
+                    .addAll(hashChannel.map(ImmutableList::of).orElse(ImmutableList.of()))
+                    .addAll(filterChannels)
+                    .build();
+            this.tupleDomainSource = requireNonNull(tupleDomainSource, "tupleDomainSource is null");
+        }
+
+        @Override
+        public List<Type> getTypes()
+        {
+            return types;
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, DynamicFilterSourceOperator.class.getSimpleName());
+
+            return new DynamicFilterSourceOperator(operatorContext, types, filterChannels, tupleDomainSource);
+        }
+
+        @Override
+        public void close()
+        {
+            closed = true;
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            throw new UnsupportedOperationException("Parallel dynamic filter build can not be duplicated");
+        }
+    }
+
+    private static final int DEFAULT_POSITIONS_LIMIT = 1000;
+
+    private final OperatorContext operatorContext;
+    private final List<Type> types;
+    private final List<Integer> filterChannels;
+    private final TupleDomainSource tupleDomainSource;
+    private final int positionsLimit;
+
+    private Page page;
+    private boolean finishing;
+    private long positionCount;
+    private List<ImmutableList.Builder<Object>> valuesBuilder;
+    private boolean[] nullsAllowed;
+
+    public DynamicFilterSourceOperator(
+            OperatorContext operatorContext,
+            List<Type> types,
+            List<Integer> filterChannels,
+            TupleDomainSource tupleDomainSource)
+    {
+        this(operatorContext, types, filterChannels, tupleDomainSource, DEFAULT_POSITIONS_LIMIT);
+    }
+
+    public DynamicFilterSourceOperator(
+            OperatorContext operatorContext,
+            List<Type> types,
+            List<Integer> filterChannels,
+            TupleDomainSource tupleDomainSource,
+            int positionsLimit)
+    {
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+        this.types = ImmutableList.copyOf(types);
+        this.filterChannels = ImmutableList.copyOf(filterChannels);
+        this.valuesBuilder = filterChannels.stream().map(channel -> ImmutableList.builder()).collect(toImmutableList());
+        this.nullsAllowed = new boolean[filterChannels.size()];
+        this.tupleDomainSource = requireNonNull(tupleDomainSource, "tupleDomainSource is null");
+
+        checkArgument(positionsLimit > 0, "positionsLimit must be greater than zero");
+        this.positionsLimit = positionsLimit;
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public List<Type> getTypes()
+    {
+        return types;
+    }
+
+    @Override
+    public void finish()
+    {
+        if (finishing) {
+            return;
+        }
+        finishing = true;
+        buildTupleDomain();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finishing && page == null;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return !finishing;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        this.page = page;
+        processPage();
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        Page page = this.page;
+        this.page = null;
+        return page;
+    }
+
+    private void processPage()
+    {
+        positionCount += page.getPositionCount();
+
+        // we don't want to filter if there're too many values
+        if (positionCount > positionsLimit) {
+            return;
+        }
+
+        for (int channelIndex = 0; channelIndex < filterChannels.size(); channelIndex++) {
+            Integer channel = filterChannels.get(channelIndex);
+            for (int position = 0; position < page.getBlock(channel).getPositionCount(); position++) {
+                Object value = TypeUtils.readNativeValue(types.get(channel), page.getBlock(channel), position);
+                if (value == null) {
+                    nullsAllowed[channelIndex] = true;
+                }
+                else {
+                    valuesBuilder.get(channelIndex).add(value);
+                }
+            }
+        }
+    }
+
+    private void buildTupleDomain()
+    {
+        // we don't want to filter if there're too many values
+        if (positionCount > positionsLimit) {
+            tupleDomainSource.addDomain(TupleDomain.all());
+            return;
+        }
+
+        ImmutableMap.Builder<Integer, Domain> domainsBuilder = ImmutableMap.builder();
+        for (int channelIndex = 0; channelIndex < filterChannels.size(); channelIndex++) {
+            Integer channel = filterChannels.get(channelIndex);
+            List<Object> values = valuesBuilder.get(channelIndex).build();
+            Domain domain;
+            if (values.isEmpty()) {
+                domain = Domain.none(types.get(channel));
+            }
+            else {
+                domain = Domain.create(ValueSet.copyOf(types.get(channel), values), nullsAllowed[channelIndex]);
+            }
+            domainsBuilder.put(channel, domain);
+        }
+
+        tupleDomainSource.addDomain(TupleDomain.withColumnDomains(domainsBuilder.build()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/TupleDomainSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TupleDomainSource.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.spi.predicate.TupleDomain.columnWiseUnion;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class TupleDomainSource
+{
+    private final int expectedDomains;
+    private final SettableFuture<TupleDomain<Integer>> resultFuture = SettableFuture.create();
+    private List<TupleDomain<Integer>> domains = new ArrayList<>();
+
+    public TupleDomainSource(int expectedDomains)
+    {
+        checkArgument(expectedDomains > 0, "expectedDomains must be greater than zero");
+        this.expectedDomains = expectedDomains;
+    }
+
+    public synchronized ListenableFuture<TupleDomain<Integer>> getDomainFuture()
+    {
+        return resultFuture;
+    }
+
+    public synchronized void addDomain(TupleDomain<Integer> domain)
+    {
+        requireNonNull(domain, "domain must be not null");
+        checkState(domains.size() < expectedDomains);
+        domains.add(domain);
+        if (domains.size() == expectedDomains) {
+            resultFuture.set(columnWiseUnion(domains));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/DynamicTupleFilterFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/DynamicTupleFilterFactory.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
-import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -80,7 +80,7 @@ public class DynamicTupleFilterFactory
     {
         Page filterTuple = getFilterTuple(tuplePage);
         Supplier<PageProcessor> processor = createPageProcessor(filterTuple);
-        return new FilterAndProjectOperatorFactory(filterOperatorId, planNodeId, processor, outputTypes);
+        return synchronousFilterAndProjectOperator(filterOperatorId, planNodeId, processor, outputTypes);
     }
 
     @VisibleForTesting

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/TupleDomainPageFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/TupleDomainPageFilter.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.index;
+
+import com.facebook.presto.operator.project.InputChannels;
+import com.facebook.presto.operator.project.PageFilter;
+import com.facebook.presto.operator.project.SelectedPositions;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+import static com.facebook.presto.operator.project.PageFilter.positionsArrayToSelectedPositions;
+import static com.facebook.presto.operator.project.SelectedPositions.positionsRange;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class TupleDomainPageFilter
+        implements PageFilter
+{
+    private final InputChannels inputChannels;
+    private final List<Integer> filterChannels;
+    @Nullable
+    private final Domain[] domains;
+
+    private boolean[] selectedPositions = new boolean[0];
+
+    public TupleDomainPageFilter(InputChannels inputChannels, List<Integer> filterChannels, TupleDomain<Integer> tupleDomain)
+    {
+        this(inputChannels, filterChannels, getDomains(inputChannels, requireNonNull(tupleDomain, "tupleDomain is null")));
+    }
+
+    private TupleDomainPageFilter(InputChannels inputChannels, List<Integer> filterChannels, @Nullable Domain[] domains)
+    {
+        this.inputChannels = requireNonNull(inputChannels, "inputChannels is null");
+        this.filterChannels = requireNonNull(filterChannels, "filterChannels is null");
+        this.domains = domains;
+    }
+
+    @Nullable
+    private static Domain[] getDomains(InputChannels inputChannels, TupleDomain<Integer> tupleDomain)
+    {
+        if (tupleDomain.getDomains().isPresent()) {
+            Domain[] domains = new Domain[inputChannels.size()];
+            for (int i = 0; i < domains.length; i++) {
+                domains[i] = tupleDomain.getDomains().get().get(i);
+            }
+            return domains;
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public InputChannels getInputChannels()
+    {
+        return inputChannels;
+    }
+
+    @Override
+    public SelectedPositions filter(ConnectorSession session, Page page)
+    {
+        if (domains == null) {
+            return positionsRange(0, page.getPositionCount());
+        }
+
+        if (selectedPositions.length < page.getPositionCount()) {
+            selectedPositions = new boolean[page.getPositionCount()];
+        }
+
+        for (int position = 0; position < page.getPositionCount(); position++) {
+            selectedPositions[position] = matches(page, position);
+        }
+
+        return positionsArrayToSelectedPositions(selectedPositions, page.getPositionCount());
+    }
+
+    private boolean matches(Page page, int position)
+    {
+        for (int channel : filterChannels) {
+            if (!matches(page, position, channel)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean matches(Page page, int position, int channel)
+    {
+        checkState(domains != null, "domains is null");
+        Domain domain = domains[channel];
+        if (domain == null) {
+            return true;
+        }
+        return domain.includesNullableValue(page.getBlock(channel), position);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -27,6 +27,7 @@ import com.facebook.presto.operator.AssignUniqueIdOperator;
 import com.facebook.presto.operator.CursorProcessor;
 import com.facebook.presto.operator.DeleteOperator.DeleteOperatorFactory;
 import com.facebook.presto.operator.DriverFactory;
+import com.facebook.presto.operator.DynamicFilterSourceOperator.DynamicFilterSourceOperatorFactory;
 import com.facebook.presto.operator.EnforceSingleRowOperator;
 import com.facebook.presto.operator.ExchangeClientSupplier;
 import com.facebook.presto.operator.ExchangeOperator.ExchangeOperatorFactory;
@@ -58,6 +59,7 @@ import com.facebook.presto.operator.TableScanOperator.TableScanOperatorFactory;
 import com.facebook.presto.operator.TaskOutputOperator.TaskOutputFactory;
 import com.facebook.presto.operator.TopNOperator.TopNOperatorFactory;
 import com.facebook.presto.operator.TopNRowNumberOperator;
+import com.facebook.presto.operator.TupleDomainSource;
 import com.facebook.presto.operator.ValuesOperator.ValuesOperatorFactory;
 import com.facebook.presto.operator.WindowFunctionDefinition;
 import com.facebook.presto.operator.WindowOperator.WindowOperatorFactory;
@@ -72,6 +74,9 @@ import com.facebook.presto.operator.index.IndexBuildDriverFactoryProvider;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.operator.index.IndexLookupSourceFactory;
 import com.facebook.presto.operator.index.IndexSourceOperator;
+import com.facebook.presto.operator.index.TupleDomainPageFilter;
+import com.facebook.presto.operator.project.InputChannels;
+import com.facebook.presto.operator.project.InputPageProjection;
 import com.facebook.presto.operator.project.InterpretedCursorProcessor;
 import com.facebook.presto.operator.project.InterpretedPageFilter;
 import com.facebook.presto.operator.project.InterpretedPageProjection;
@@ -88,7 +93,9 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.NullableValue;
+import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spiller.SpillerFactory;
 import com.facebook.presto.split.MappedRecordSet;
@@ -155,6 +162,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 
@@ -175,6 +183,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.SystemSessionProperties.getOperatorMemoryLimitBeforeSpill;
 import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
@@ -183,6 +192,7 @@ import static com.facebook.presto.SystemSessionProperties.isExchangeCompressionE
 import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.operator.DistinctLimitOperator.DistinctLimitOperatorFactory;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.asynchronousFilterAndProjectOperator;
 import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.operator.NestedLoopBuildOperator.NestedLoopBuildOperatorFactory;
 import static com.facebook.presto.operator.NestedLoopJoinOperator.NestedLoopJoinOperatorFactory;
@@ -202,6 +212,7 @@ import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BRO
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.CreateHandle;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.InsertHandle;
@@ -215,6 +226,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.util.concurrent.Futures.transform;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
@@ -1529,9 +1541,14 @@ public class LocalExecutionPlanner
             PhysicalOperation probeSource = probeNode.accept(this, context);
 
             // Plan build
-            LookupSourceFactory lookupSourceFactory = createLookupSourceFactory(node, buildNode, buildSymbols, buildHashSymbol, probeSource.getLayout(), context);
+            LocalExecutionPlanContext buildContext = context.createSubContext();
+            PhysicalOperation buildSource = buildNode.accept(this, buildContext);
+            List<Integer> buildChannels = ImmutableList.copyOf(getChannelsForSymbols(buildSymbols, buildSource.getLayout()));
+            Optional<Integer> buildHashChannel = buildHashSymbol.map(channelGetter(buildSource));
 
-            OperatorFactory operator = createLookupJoin(node, probeSource, probeSymbols, probeHashSymbol, lookupSourceFactory, context);
+            HashBuilderOperatorFactory hashBuilderOperatorFactory = createHashBuilderOperatorFactory(node, buildContext, buildSource, buildChannels, buildHashChannel, probeSource.getLayout(), context);
+
+            OperatorFactory lookupJoinOperator = createLookupJoin(node, probeSource, probeSymbols, probeHashSymbol, hashBuilderOperatorFactory.getLookupSourceFactory(), context);
 
             ImmutableMap.Builder<Symbol, Integer> outputMappings = ImmutableMap.builder();
             List<Symbol> outputSymbols = node.getOutputSymbols();
@@ -1540,30 +1557,125 @@ public class LocalExecutionPlanner
                 outputMappings.put(symbol, i);
             }
 
-            return new PhysicalOperation(operator, outputMappings.build(), probeSource);
+            // Dynamic filtering
+            if (node.getType() == INNER && node.getCriteria().size() > 0) {
+                TupleDomainSource tupleDomainSource = new TupleDomainSource(buildContext.getDriverInstanceCount().orElse(1));
+
+                Optional<Integer> probeHashChannel = probeHashSymbol.map(channelGetter(probeSource));
+                List<Integer> probeChannels = ImmutableList.copyOf(getChannelsForSymbols(probeSymbols, probeSource.getLayout()));
+
+                ListenableFuture<TupleDomain<Integer>> buildDomainFuture = tupleDomainSource.getDomainFuture();
+                ListenableFuture<TupleDomain<Integer>> probeDomainFuture = transform(
+                        buildDomainFuture,
+                        domain -> remapChannels(domain, channelsMapping(probeChannels, probeHashChannel, buildChannels, buildHashChannel)));
+
+                List<Type> filterTypes = probeSource.getTypes();
+                InputChannels inputChannels = new InputChannels(IntStream.range(0, filterTypes.size()).boxed().collect(toImmutableList()));
+                List<PageProjection> projections = inputChannels.getInputChannels().stream()
+                        .map(channel -> new InputPageProjection(channel, filterTypes.get(channel)))
+                        .collect(toImmutableList());
+
+                ImmutableList.Builder<Integer> filterChannels = ImmutableList.builder();
+                probeHashChannel.ifPresent(filterChannels::add);
+                filterChannels.addAll(probeChannels);
+
+                Supplier<ListenableFuture<PageProcessor>> pageProcessorSupplier = () ->
+                        transform(probeDomainFuture, domain -> new PageProcessor(
+                                Optional.of(new TupleDomainPageFilter(inputChannels, filterChannels.build(), domain)),
+                                projections));
+
+                PhysicalOperation dynamicFilter = new PhysicalOperation(
+                        asynchronousFilterAndProjectOperator(
+                                context.getNextOperatorId(),
+                                node.getId(),
+                                pageProcessorSupplier,
+                                probeSource.getTypes()),
+                        probeSource.getLayout(),
+                        probeSource);
+
+                OperatorFactory dynamicFilterSource = new DynamicFilterSourceOperatorFactory(
+                        buildContext.getNextOperatorId(),
+                        node.getId(),
+                        buildSource.getTypes(),
+                        buildChannels,
+                        buildHashChannel,
+                        tupleDomainSource);
+
+                context.addDriverFactory(
+                        buildContext.isInputDriver(),
+                        false,
+                        ImmutableList.<OperatorFactory>builder()
+                                .addAll(buildSource.getOperatorFactories())
+                                .add(dynamicFilterSource)
+                                .add(hashBuilderOperatorFactory)
+                                .build(),
+                        buildContext.getDriverInstanceCount());
+
+                return new PhysicalOperation(lookupJoinOperator, outputMappings.build(), dynamicFilter);
+            }
+
+            context.addDriverFactory(
+                    buildContext.isInputDriver(),
+                    false,
+                    ImmutableList.<OperatorFactory>builder()
+                            .addAll(buildSource.getOperatorFactories())
+                            .add(hashBuilderOperatorFactory)
+                            .build(),
+                    buildContext.getDriverInstanceCount());
+
+            return new PhysicalOperation(lookupJoinOperator, outputMappings.build(), probeSource);
         }
 
-        private LookupSourceFactory createLookupSourceFactory(
+        private Map<Integer, Integer> channelsMapping(
+                List<Integer> probeChannels,
+                Optional<Integer> probeHashChannel,
+                List<Integer> buildChannels,
+                Optional<Integer> buildHashChannel)
+        {
+            ImmutableMap.Builder<Integer, Integer> map = ImmutableMap.builder();
+            checkArgument(probeChannels.size() == buildChannels.size());
+            for (int i = 0; i < probeChannels.size(); i++) {
+                map.put(buildChannels.get(i), probeChannels.get(i));
+            }
+            if (buildHashChannel.isPresent() && probeHashChannel.isPresent()) {
+                map.put(buildHashChannel.get(), probeHashChannel.get());
+            }
+            return map.build();
+        }
+
+        private TupleDomain<Integer> remapChannels(TupleDomain<Integer> tupleDomain, Map<Integer, Integer> channelMappings)
+        {
+            Optional<Map<Integer, Domain>> domains = tupleDomain.getDomains();
+            if (!domains.isPresent()) {
+                return tupleDomain;
+            }
+            ImmutableMap.Builder<Integer, Domain> result = ImmutableMap.builder();
+            for (Map.Entry<Integer, Domain> entry : domains.get().entrySet()) {
+                Integer channelMapping = channelMappings.get(entry.getKey());
+                checkState(channelMapping != null, "Expected probe side channel mapping for build's %d not found", entry.getKey());
+                result.put(channelMapping, entry.getValue());
+            }
+            return TupleDomain.withColumnDomains(result.build());
+        }
+
+        private HashBuilderOperatorFactory createHashBuilderOperatorFactory(
                 JoinNode node,
-                PlanNode buildNode,
-                List<Symbol> buildSymbols,
-                Optional<Symbol> buildHashSymbol,
+                LocalExecutionPlanContext buildContext,
+                PhysicalOperation buildSource,
+                List<Integer> buildChannels,
+                Optional<Integer> buildHashChannel,
                 Map<Symbol, Integer> probeLayout,
                 LocalExecutionPlanContext context)
         {
-            LocalExecutionPlanContext buildContext = context.createSubContext();
-            PhysicalOperation buildSource = buildNode.accept(this, buildContext);
             List<Symbol> buildOutputSymbols = node.getOutputSymbols().stream()
                     .filter(symbol -> node.getRight().getOutputSymbols().contains(symbol))
                     .collect(toImmutableList());
             List<Integer> buildOutputChannels = ImmutableList.copyOf(getChannelsForSymbols(buildOutputSymbols, buildSource.getLayout()));
-            List<Integer> buildChannels = ImmutableList.copyOf(getChannelsForSymbols(buildSymbols, buildSource.getLayout()));
-            Optional<Integer> buildHashChannel = buildHashSymbol.map(channelGetter(buildSource));
 
             Optional<JoinFilterFunctionFactory> filterFunctionFactory = node.getFilter()
                     .map(filterExpression -> compileJoinFilterFunction(filterExpression, probeLayout, buildSource.getLayout(), context.getTypes(), context.getSession()));
 
-            HashBuilderOperatorFactory hashBuilderOperatorFactory = new HashBuilderOperatorFactory(
+            return new HashBuilderOperatorFactory(
                     buildContext.getNextOperatorId(),
                     node.getId(),
                     buildSource.getTypes(),
@@ -1576,17 +1688,6 @@ public class LocalExecutionPlanner
                     10_000,
                     buildContext.getDriverInstanceCount().orElse(1),
                     pagesIndexFactory);
-
-            context.addDriverFactory(
-                    buildContext.isInputDriver(),
-                    false,
-                    ImmutableList.<OperatorFactory>builder()
-                            .addAll(buildSource.getOperatorFactories())
-                            .add(hashBuilderOperatorFactory)
-                            .build(),
-                    buildContext.getDriverInstanceCount());
-
-            return hashBuilderOperatorFactory.getLookupSourceFactory();
         }
 
         private JoinFilterFunctionFactory compileJoinFilterFunction(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -31,7 +31,6 @@ import com.facebook.presto.operator.EnforceSingleRowOperator;
 import com.facebook.presto.operator.ExchangeClientSupplier;
 import com.facebook.presto.operator.ExchangeOperator.ExchangeOperatorFactory;
 import com.facebook.presto.operator.ExplainAnalyzeOperator.ExplainAnalyzeOperatorFactory;
-import com.facebook.presto.operator.FilterAndProjectOperator;
 import com.facebook.presto.operator.GroupIdOperator;
 import com.facebook.presto.operator.HashAggregationOperator.HashAggregationOperatorFactory;
 import com.facebook.presto.operator.HashBuilderOperator.HashBuilderOperatorFactory;
@@ -184,6 +183,7 @@ import static com.facebook.presto.SystemSessionProperties.isExchangeCompressionE
 import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.operator.DistinctLimitOperator.DistinctLimitOperatorFactory;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.operator.NestedLoopBuildOperator.NestedLoopBuildOperatorFactory;
 import static com.facebook.presto.operator.NestedLoopJoinOperator.NestedLoopJoinOperatorFactory;
 import static com.facebook.presto.operator.TableFinishOperator.TableFinishOperatorFactory;
@@ -1076,7 +1076,7 @@ public class LocalExecutionPlanner
                 else {
                     Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(translatedFilter, translatedProjections);
 
-                    OperatorFactory operatorFactory = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+                    OperatorFactory operatorFactory = synchronousFilterAndProjectOperator(
                             context.getNextOperatorId(),
                             planNodeId,
                             pageProcessor,
@@ -1126,7 +1126,7 @@ public class LocalExecutionPlanner
                 return new PhysicalOperation(operatorFactory, outputMappings);
             }
             else {
-                OperatorFactory operatorFactory = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+                OperatorFactory operatorFactory = synchronousFilterAndProjectOperator(
                         context.getNextOperatorId(),
                         planNodeId,
                         () -> pageProcessor,

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -70,7 +70,6 @@ import com.facebook.presto.metadata.ViewDefinition;
 import com.facebook.presto.operator.Driver;
 import com.facebook.presto.operator.DriverContext;
 import com.facebook.presto.operator.DriverFactory;
-import com.facebook.presto.operator.FilterAndProjectOperator;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.Operator;
 import com.facebook.presto.operator.OperatorContext;
@@ -178,6 +177,7 @@ import java.util.function.Function;
 
 import static com.facebook.presto.execution.SqlQueryManager.unwrapExecuteStatement;
 import static com.facebook.presto.execution.SqlQueryManager.validateParameters;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.testing.TreeAssertions.assertFormattedSql;
 import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
@@ -792,7 +792,7 @@ public class LocalQueryRunner
                 sqlParser,
                 defaultSession));
 
-        return new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        return synchronousFilterAndProjectOperator(
                 operatorId,
                 planNodeId,
                 () -> new PageProcessor(Optional.empty(), projections.build()),

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFilterAndProjectOperator.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
 import static com.facebook.presto.spi.function.OperatorType.ADD;
 import static com.facebook.presto.spi.function.OperatorType.BETWEEN;
@@ -93,7 +94,7 @@ public class TestFilterAndProjectOperator
         ExpressionCompiler compiler = new ExpressionCompiler(createTestMetadataManager());
         Supplier<PageProcessor> processor = compiler.compilePageProcessor(Optional.of(filter), ImmutableList.of(field0, add5));
 
-        OperatorFactory operatorFactory = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        OperatorFactory operatorFactory = synchronousFilterAndProjectOperator(
                 0,
                 new PlanNodeId("test"),
                 processor,

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -21,7 +21,6 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.metadata.SqlFunction;
 import com.facebook.presto.operator.CursorProcessor;
 import com.facebook.presto.operator.DriverContext;
-import com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory;
 import com.facebook.presto.operator.Operator;
 import com.facebook.presto.operator.OperatorFactory;
 import com.facebook.presto.operator.ScanFilterAndProjectOperator;
@@ -92,6 +91,7 @@ import static com.facebook.presto.block.BlockAssertions.createSlicesBlock;
 import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.block.BlockAssertions.createTimestampsWithTimezoneBlock;
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
@@ -573,7 +573,7 @@ public final class FunctionAssertions
         PageProjection pageProjection = new InterpretedPageProjection(projection, SYMBOL_TYPES, INPUT_MAPPING, metadata, SQL_PARSER, session);
 
         PageProcessor processor = new PageProcessor(pageFilter, ImmutableList.of(pageProjection));
-        OperatorFactory operatorFactory = new FilterAndProjectOperatorFactory(
+        OperatorFactory operatorFactory = synchronousFilterAndProjectOperator(
                 0,
                 new PlanNodeId("test"),
                 () -> processor,
@@ -586,7 +586,7 @@ public final class FunctionAssertions
         try {
             Supplier<PageProcessor> processor = compiler.compilePageProcessor(Optional.of(filter), ImmutableList.of());
 
-            return new FilterAndProjectOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of());
+            return synchronousFilterAndProjectOperator(0, new PlanNodeId("test"), processor, ImmutableList.of());
         }
         catch (Throwable e) {
             if (e instanceof UncheckedExecutionException) {
@@ -600,7 +600,7 @@ public final class FunctionAssertions
     {
         try {
             Supplier<PageProcessor> processor = compiler.compilePageProcessor(filter, ImmutableList.of(projection));
-            return new FilterAndProjectOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of(projection.getType()));
+            return synchronousFilterAndProjectOperator(0, new PlanNodeId("test"), processor, ImmutableList.of(projection.getType()));
         }
         catch (Throwable e) {
             if (e instanceof UncheckedExecutionException) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/AllOrNoneValueSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/AllOrNoneValueSet.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.predicate;
 
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -88,6 +89,12 @@ public class AllOrNoneValueSet
         if (!Primitives.wrap(type.getJavaType()).isInstance(value)) {
             throw new IllegalArgumentException(String.format("Value class %s does not match required Type class %s", value.getClass().getName(), Primitives.wrap(type.getJavaType()).getClass().getName()));
         }
+        return all;
+    }
+
+    @Override
+    public boolean containsValue(Block block, int position)
+    {
         return all;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/Domain.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/Domain.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.predicate;
 
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -164,6 +165,11 @@ public final class Domain
     public boolean includesNullableValue(Object value)
     {
         return value == null ? nullAllowed : values.containsValue(value);
+    }
+
+    public boolean includesNullableValue(Block block, int position)
+    {
+        return block.isNull(position) ? nullAllowed : values.containsValue(block, position);
     }
 
     public boolean overlaps(Domain other)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/EquatableValueSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/EquatableValueSet.java
@@ -153,6 +153,12 @@ public class EquatableValueSet
     }
 
     @Override
+    public boolean containsValue(Block block, int position)
+    {
+        return whiteList == entries.contains(ValueEntry.create(type, block, position));
+    }
+
+    @Override
     public DiscreteValues getDiscreteValues()
     {
         return new DiscreteValues()
@@ -292,66 +298,5 @@ public class EquatableValueSet
         return Objects.equals(this.type, other.type)
                 && this.whiteList == other.whiteList
                 && Objects.equals(this.entries, other.entries);
-    }
-
-    public static class ValueEntry
-    {
-        private final Type type;
-        private final Block block;
-
-        @JsonCreator
-        public ValueEntry(
-                @JsonProperty("type") Type type,
-                @JsonProperty("block") Block block)
-        {
-            this.type = requireNonNull(type, "type is null");
-            this.block = requireNonNull(block, "block is null");
-
-            if (block.getPositionCount() != 1) {
-                throw new IllegalArgumentException("Block should only have one position");
-            }
-        }
-
-        public static ValueEntry create(Type type, Object value)
-        {
-            return new ValueEntry(type, Utils.nativeValueToBlock(type, value));
-        }
-
-        @JsonProperty
-        public Type getType()
-        {
-            return type;
-        }
-
-        @JsonProperty
-        public Block getBlock()
-        {
-            return block;
-        }
-
-        public Object getValue()
-        {
-            return Utils.blockToNativeValue(type, block);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return (int) type.hash(block, 0);
-        }
-
-        @Override
-        public boolean equals(Object obj)
-        {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null || getClass() != obj.getClass()) {
-                return false;
-            }
-            final ValueEntry other = (ValueEntry) obj;
-            return Objects.equals(this.type, other.type)
-                    && type.equalTo(this.block, 0, other.block, 0);
-        }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/SortedRangeSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/SortedRangeSet.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.predicate;
 
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -159,6 +160,12 @@ public final class SortedRangeSet
     public boolean containsValue(Object value)
     {
         return includesMarker(Marker.exactly(type, value));
+    }
+
+    @Override
+    public boolean containsValue(Block block, int position)
+    {
+        return includesMarker(Marker.exactly(type, block, position));
     }
 
     boolean includesMarker(Marker marker)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/ValueEntry.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/ValueEntry.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.predicate;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class ValueEntry
+        implements Comparable<ValueEntry>
+{
+    private final Type type;
+    private final Block block;
+    private final int position;
+
+    public ValueEntry(Type type, Block block)
+    {
+        this(type, block, 0);
+    }
+
+    @JsonCreator
+    public ValueEntry(
+            @JsonProperty("type") Type type,
+            @JsonProperty("block") Block block,
+            @JsonProperty("position") int position)
+    {
+        this.type = requireNonNull(type, "type is null");
+        this.block = requireNonNull(block, "block is null");
+        this.position = position;
+    }
+
+    public static ValueEntry create(Type type, Object value)
+    {
+        return new ValueEntry(type, Utils.nativeValueToBlock(type, value));
+    }
+
+    public static ValueEntry create(Type type, Block block, int position)
+    {
+        return new ValueEntry(type, block, position);
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
+    public Block getBlock()
+    {
+        return block;
+    }
+
+    @JsonProperty
+    public int getPosition()
+    {
+        return position;
+    }
+
+    public Object getValue()
+    {
+        return Utils.blockToNativeValue(type, block);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return (int) type.hash(block, position);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final ValueEntry other = (ValueEntry) obj;
+        return Objects.equals(this.type, other.type)
+                && type.equalTo(this.block, this.position, other.block, other.position);
+    }
+
+    @Override
+    public int compareTo(ValueEntry that)
+    {
+        if (!this.type.equals(that.type)) {
+            throw new IllegalArgumentException(String.format("Mismatched types: %s vs %s", this.type, that.type));
+        }
+        return type.compareTo(this.block, this.position, that.block, that.position);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/ValueSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/ValueSet.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.predicate;
 
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -100,6 +101,8 @@ public interface ValueSet
     Object getSingleValue();
 
     boolean containsValue(Object value);
+
+    boolean containsValue(Block block, int position);
 
     /**
      * @return value predicates for equatable Types (but not orderable)

--- a/presto-spi/src/test/java/com/facebook/presto/spi/predicate/TestEquatableValueSet.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/predicate/TestEquatableValueSet.java
@@ -332,7 +332,7 @@ public class TestEquatableValueSet
     public void testUnmodifiableValueEntryIterator()
             throws Exception
     {
-        Iterator<EquatableValueSet.ValueEntry> iterator = EquatableValueSet.of(ID, 1L).getEntries().iterator();
+        Iterator<ValueEntry> iterator = EquatableValueSet.of(ID, 1L).getEntries().iterator();
         iterator.next();
         iterator.remove();
     }


### PR DESCRIPTION
Simple implementation of a prerequisite to a _dynamic partition pruning_.

On a build side of a join, `DynamicFilterSourceOperator` is building a `TupleDomain` describing which tuples were seen on the build side. Then, on the probe side, we don't have to join rows which don't exist in the said `TupleDomain`.

Benchmarks show no performance degradation.
The benefit will be visible when we extend it into _dynamic partition pruning_ based on this patch.

The extension would cover pushing the filtering down to a table scan and based on extra information (yet to be implemented) coming from splits, they would be able to avoid scanning partitions which don't have any values existing on the build side of the join.