### PR TITLE
Add object overhead to estimated memory size in various state classes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ArrayAggregationStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ArrayAggregationStateFactory.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation.state;
 import com.facebook.presto.array.ObjectBigArray;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import org.openjdk.jol.info.ClassLayout;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,6 +51,7 @@ public class ArrayAggregationStateFactory
             extends AbstractGroupedAccumulatorState
             implements ArrayAggregationState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedArrayAggregationState.class).instanceSize();
         private final ObjectBigArray<BlockBuilder> blockBuilders = new ObjectBigArray<BlockBuilder>();
         private long size;
 
@@ -62,7 +64,7 @@ public class ArrayAggregationStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return size + blockBuilders.sizeOf();
+            return INSTANCE_SIZE + size + blockBuilders.sizeOf();
         }
 
         @Override
@@ -94,17 +96,17 @@ public class ArrayAggregationStateFactory
     public static class SingleArrayAggregationState
             implements ArrayAggregationState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleArrayAggregationState.class).instanceSize();
         private BlockBuilder blockBuilder;
 
         @Override
         public long getEstimatedSize()
         {
-            if (blockBuilder == null) {
-                return 0L;
+            long estimatedSize = INSTANCE_SIZE;
+            if (blockBuilder != null) {
+                estimatedSize += blockBuilder.getRetainedSizeInBytes();
             }
-            else {
-                return blockBuilder.getRetainedSizeInBytes();
-            }
+            return estimatedSize;
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileStateFactory.java
@@ -17,8 +17,8 @@ import com.facebook.presto.array.DoubleBigArray;
 import com.facebook.presto.array.ObjectBigArray;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
 import io.airlift.stats.QuantileDigest;
+import org.openjdk.jol.info.ClassLayout;
 
-import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
 import static java.util.Objects.requireNonNull;
 
 public class DigestAndPercentileStateFactory
@@ -52,6 +52,7 @@ public class DigestAndPercentileStateFactory
             extends AbstractGroupedAccumulatorState
             implements DigestAndPercentileState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedDigestAndPercentileState.class).instanceSize();
         private final ObjectBigArray<QuantileDigest> digests = new ObjectBigArray<>();
         private final DoubleBigArray percentiles = new DoubleBigArray();
         private long size;
@@ -97,13 +98,14 @@ public class DigestAndPercentileStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return size + digests.sizeOf() + percentiles.sizeOf();
+            return INSTANCE_SIZE + size + digests.sizeOf() + percentiles.sizeOf();
         }
     }
 
     public static class SingleDigestAndPercentileState
             implements DigestAndPercentileState
     {
+        public static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleDigestAndPercentileState.class).instanceSize();
         private QuantileDigest digest;
         private double percentile;
 
@@ -140,10 +142,11 @@ public class DigestAndPercentileStateFactory
         @Override
         public long getEstimatedSize()
         {
-            if (digest == null) {
-                return SIZE_OF_DOUBLE;
+            long estimatedSize = INSTANCE_SIZE;
+            if (digest != null) {
+                estimatedSize += digest.estimatedInMemorySizeInBytes();
             }
-            return digest.estimatedInMemorySizeInBytes() + SIZE_OF_DOUBLE;
+            return estimatedSize;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/HistogramStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/HistogramStateFactory.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation.state;
 import com.facebook.presto.array.ObjectBigArray;
 import com.facebook.presto.operator.aggregation.TypedHistogram;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import org.openjdk.jol.info.ClassLayout;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,6 +51,7 @@ public class HistogramStateFactory
             extends AbstractGroupedAccumulatorState
             implements HistogramState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedState.class).instanceSize();
         private final ObjectBigArray<TypedHistogram> typedHistogram = new ObjectBigArray<>();
         private long size;
 
@@ -88,13 +90,14 @@ public class HistogramStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return size + typedHistogram.sizeOf();
+            return INSTANCE_SIZE + size + typedHistogram.sizeOf();
         }
     }
 
     public static class SingleState
             implements HistogramState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleState.class).instanceSize();
         private TypedHistogram typedHistogram;
 
         @Override
@@ -117,10 +120,11 @@ public class HistogramStateFactory
         @Override
         public long getEstimatedSize()
         {
-            if (typedHistogram == null) {
-                return 0;
+            long estimatedSize = INSTANCE_SIZE;
+            if (typedHistogram != null) {
+                estimatedSize += typedHistogram.getEstimatedSize();
             }
-            return typedHistogram.getEstimatedSize();
+            return estimatedSize;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/HyperLogLogStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/HyperLogLogStateFactory.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation.state;
 import com.facebook.presto.array.ObjectBigArray;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
 import io.airlift.stats.cardinality.HyperLogLog;
+import org.openjdk.jol.info.ClassLayout;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,6 +51,7 @@ public class HyperLogLogStateFactory
             extends AbstractGroupedAccumulatorState
             implements HyperLogLogState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedHyperLogLogState.class).instanceSize();
         private final ObjectBigArray<HyperLogLog> hlls = new ObjectBigArray<>();
         private long size;
 
@@ -81,13 +83,14 @@ public class HyperLogLogStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return size + hlls.sizeOf();
+            return INSTANCE_SIZE + size + hlls.sizeOf();
         }
     }
 
     public static class SingleHyperLogLogState
             implements HyperLogLogState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleHyperLogLogState.class).instanceSize();
         private HyperLogLog hll;
 
         @Override
@@ -111,10 +114,11 @@ public class HyperLogLogStateFactory
         @Override
         public long getEstimatedSize()
         {
-            if (hll == null) {
-                return 0;
+            long estimatedSize = INSTANCE_SIZE;
+            if (hll != null) {
+                estimatedSize += hll.estimatedInMemorySize();
             }
-            return hll.estimatedInMemorySize();
+            return estimatedSize;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/KeyValuePairsStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/KeyValuePairsStateFactory.java
@@ -17,6 +17,7 @@ import com.facebook.presto.array.ObjectBigArray;
 import com.facebook.presto.operator.aggregation.KeyValuePairs;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
 import com.facebook.presto.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
 
 import static java.util.Objects.requireNonNull;
 
@@ -60,6 +61,7 @@ public class KeyValuePairsStateFactory
             extends AbstractGroupedAccumulatorState
             implements KeyValuePairsState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedState.class).instanceSize();
         private final Type keyType;
         private final Type valueType;
         private final ObjectBigArray<KeyValuePairs> pairs = new ObjectBigArray<>();
@@ -118,13 +120,14 @@ public class KeyValuePairsStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return size + pairs.sizeOf();
+            return INSTANCE_SIZE + size + pairs.sizeOf();
         }
     }
 
     public static class SingleState
             implements KeyValuePairsState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleState.class).instanceSize();
         private final Type keyType;
         private final Type valueType;
         private KeyValuePairs pair;
@@ -167,10 +170,11 @@ public class KeyValuePairsStateFactory
         @Override
         public long getEstimatedSize()
         {
-            if (pair == null) {
-                return 0;
+            long estimatedSize = INSTANCE_SIZE;
+            if (pair != null) {
+                estimatedSize += pair.estimatedInMemorySize();
             }
-            return pair.estimatedInMemorySize();
+            return estimatedSize;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongDecimalWithOverflowAndLongStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongDecimalWithOverflowAndLongStateFactory.java
@@ -52,6 +52,7 @@ public class LongDecimalWithOverflowAndLongStateFactory
             extends LongDecimalWithOverflowStateFactory.GroupedLongDecimalWithOverflowState
             implements LongDecimalWithOverflowAndLongState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedLongDecimalWithOverflowAndLongState.class).instanceSize();
         private final LongBigArray longs = new LongBigArray();
 
         @Override
@@ -76,7 +77,7 @@ public class LongDecimalWithOverflowAndLongStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return unscaledDecimals.sizeOf() + overflows.sizeOf() + numberOfElements * SingleLongDecimalWithOverflowAndLongState.SIZE;
+            return INSTANCE_SIZE + unscaledDecimals.sizeOf() + overflows.sizeOf() + numberOfElements * SingleLongDecimalWithOverflowAndLongState.SIZE;
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongDecimalWithOverflowStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongDecimalWithOverflowStateFactory.java
@@ -20,7 +20,6 @@ import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
 import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.UNSCALED_DECIMAL_128_SLICE_LENGTH;
-import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static java.util.Objects.requireNonNull;
 
 public class LongDecimalWithOverflowStateFactory
@@ -54,6 +53,7 @@ public class LongDecimalWithOverflowStateFactory
             extends AbstractGroupedAccumulatorState
             implements LongDecimalWithOverflowState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedLongDecimalWithOverflowState.class).instanceSize();
         protected final ObjectBigArray<Slice> unscaledDecimals = new ObjectBigArray<>();
         protected final LongBigArray overflows = new LongBigArray();
         protected long numberOfElements;
@@ -96,14 +96,15 @@ public class LongDecimalWithOverflowStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return unscaledDecimals.sizeOf() + overflows.sizeOf() + numberOfElements * SingleLongDecimalWithOverflowState.SIZE;
+            return INSTANCE_SIZE + unscaledDecimals.sizeOf() + overflows.sizeOf() + numberOfElements * SingleLongDecimalWithOverflowState.SIZE;
         }
     }
 
     public static class SingleLongDecimalWithOverflowState
             implements LongDecimalWithOverflowState
     {
-        public static final int SIZE = ClassLayout.parseClass(Slice.class).instanceSize() + UNSCALED_DECIMAL_128_SLICE_LENGTH + SIZE_OF_LONG;
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleLongDecimalWithOverflowState.class).instanceSize();
+        public static final int SIZE = ClassLayout.parseClass(Slice.class).instanceSize() + UNSCALED_DECIMAL_128_SLICE_LENGTH;
 
         protected Slice unscaledDecimal;
         protected long overflow;
@@ -136,9 +137,9 @@ public class LongDecimalWithOverflowStateFactory
         public long getEstimatedSize()
         {
             if (getLongDecimal() == null) {
-                return SIZE_OF_LONG;
+                return INSTANCE_SIZE;
             }
-            return SIZE;
+            return INSTANCE_SIZE + SIZE;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/MinMaxByNStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/MinMaxByNStateFactory.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation.state;
 import com.facebook.presto.array.ObjectBigArray;
 import com.facebook.presto.operator.aggregation.TypedKeyValueHeap;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import org.openjdk.jol.info.ClassLayout;
 
 public class MinMaxByNStateFactory
         implements AccumulatorStateFactory<MinMaxByNState>
@@ -48,6 +49,7 @@ public class MinMaxByNStateFactory
             extends AbstractGroupedAccumulatorState
             implements MinMaxByNState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedMinMaxByNState.class).instanceSize();
         private final ObjectBigArray<TypedKeyValueHeap> heaps = new ObjectBigArray<>();
         private long size;
 
@@ -60,7 +62,7 @@ public class MinMaxByNStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return heaps.sizeOf() + size;
+            return INSTANCE_SIZE + heaps.sizeOf() + size;
         }
 
         @Override
@@ -90,15 +92,17 @@ public class MinMaxByNStateFactory
     public static class SingleMinMaxByNState
             implements MinMaxByNState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleMinMaxByNState.class).instanceSize();
         private TypedKeyValueHeap typedKeyValueHeap;
 
         @Override
         public long getEstimatedSize()
         {
-            if (typedKeyValueHeap == null) {
-                return 0;
+            long estimatedSize = INSTANCE_SIZE;
+            if (typedKeyValueHeap != null) {
+                estimatedSize += typedKeyValueHeap.getEstimatedSize();
             }
-            return typedKeyValueHeap.getEstimatedSize();
+            return estimatedSize;
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/MinMaxNStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/MinMaxNStateFactory.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation.state;
 import com.facebook.presto.array.ObjectBigArray;
 import com.facebook.presto.operator.aggregation.TypedHeap;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import org.openjdk.jol.info.ClassLayout;
 
 public class MinMaxNStateFactory
         implements AccumulatorStateFactory<MinMaxNState>
@@ -48,6 +49,7 @@ public class MinMaxNStateFactory
             extends AbstractGroupedAccumulatorState
             implements MinMaxNState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedMinMaxNState.class).instanceSize();
         private final ObjectBigArray<TypedHeap> heaps = new ObjectBigArray<>();
         private long size;
 
@@ -60,7 +62,7 @@ public class MinMaxNStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return heaps.sizeOf() + size;
+            return INSTANCE_SIZE + heaps.sizeOf() + size;
         }
 
         @Override
@@ -90,15 +92,17 @@ public class MinMaxNStateFactory
     public static class SingleMinMaxNState
             implements MinMaxNState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleMinMaxNState.class).instanceSize();
         private TypedHeap typedHeap;
 
         @Override
         public long getEstimatedSize()
         {
-            if (typedHeap == null) {
-                return 0;
+            long estimatedSize = INSTANCE_SIZE;
+            if (typedHeap != null) {
+                estimatedSize += typedHeap.getEstimatedSize();
             }
-            return typedHeap.getEstimatedSize();
+            return estimatedSize;
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/MultiKeyValuePairsStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/MultiKeyValuePairsStateFactory.java
@@ -17,6 +17,7 @@ import com.facebook.presto.array.ObjectBigArray;
 import com.facebook.presto.operator.aggregation.MultiKeyValuePairs;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
 import com.facebook.presto.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
 
 import static java.util.Objects.requireNonNull;
 
@@ -60,6 +61,7 @@ public class MultiKeyValuePairsStateFactory
             extends AbstractGroupedAccumulatorState
             implements MultiKeyValuePairsState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedState.class).instanceSize();
         private final Type keyType;
         private final Type valueType;
         private final ObjectBigArray<MultiKeyValuePairs> pairs = new ObjectBigArray<>();
@@ -118,13 +120,14 @@ public class MultiKeyValuePairsStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return size + pairs.sizeOf();
+            return INSTANCE_SIZE + size + pairs.sizeOf();
         }
     }
 
     public static class SingleState
             implements MultiKeyValuePairsState
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleState.class).instanceSize();
         private final Type keyType;
         private final Type valueType;
         private MultiKeyValuePairs pair;
@@ -167,10 +170,11 @@ public class MultiKeyValuePairsStateFactory
         @Override
         public long getEstimatedSize()
         {
-            if (pair == null) {
-                return 0;
+            long estimatedSize = INSTANCE_SIZE;
+            if (pair != null) {
+                estimatedSize += pair.estimatedInMemorySize();
             }
-            return pair.estimatedInMemorySize();
+            return estimatedSize;
         }
     }
 }


### PR DESCRIPTION
Many state classes don't include object overhead in their estimated memory size calculations, this PR fixes that.