### PR TITLE
Allow raptor shards table be scaned faster

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/systemtables/ShardMetadataRecordCursor.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/systemtables/ShardMetadataRecordCursor.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.raptor.RaptorColumnHandle.SHARD_UUID_COLUMN_TYPE;
 import static com.facebook.presto.raptor.metadata.DatabaseShardManager.maxColumn;
@@ -272,7 +273,8 @@ public class ShardMetadataRecordCursor
                     columnNames,
                     TYPES,
                     ImmutableSet.of(getColumnIndex(SHARD_METADATA, SHARD_UUID)),
-                    tupleDomain);
+                    tupleDomain,
+                    Optional.of(format("shards.table_id = %d", tableId)));
             return statement.executeQuery();
         }
         catch (SQLException | DBIException e) {

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/systemtables/TestShardMetadataRecordCursor.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/systemtables/TestShardMetadataRecordCursor.java
@@ -146,6 +146,12 @@ public class TestShardMetadataRecordCursor
                 new MaterializedRow(DEFAULT_PRECISION, schema, table, utf8Slice(uuid3.toString()), null, 300L, 30L, 3L, null, null));
 
         assertEquals(actual, expected);
+
+        try (RecordCursor cursor = new ShardMetadataSystemTable(dbi).cursor(null, SESSION, TupleDomain.all())) {
+            actual = getMaterializedResults(cursor, SHARD_METADATA.getColumns());
+        }
+        assertEquals(actual.size(), 3);
+        assertEquals(actual, expected);
     }
 
     @Test


### PR DESCRIPTION
Push down the predicate to mysql to increase the speed of metadata
query as we already know the table_id in advance.