### PR TITLE
Do not support non-deterministic SortExpressions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SortExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SortExpressionExtractor.java
@@ -32,7 +32,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Currently this class handles only simple expressions like:
  *
- * A.a < B.x.
+ * A.a < B.x
  *
  * It could be extended to handle any expressions like:
  *
@@ -52,6 +52,10 @@ public final class SortExpressionExtractor
 
     public static Optional<Expression> extractSortExpression(Set<Symbol> buildSymbols, Expression filter)
     {
+        if (!DeterminismEvaluator.isDeterministic(filter)) {
+            return Optional.empty();
+        }
+
         if (filter instanceof ComparisonExpression) {
             ComparisonExpression comparison = (ComparisonExpression) filter;
             switch (comparison.getType()) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestSortExpressionExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestSortExpressionExtractor.java
@@ -60,6 +60,19 @@ public class TestSortExpressionExtractor
         assertGetSortExpression(
                 new ComparisonExpression(
                         ComparisonExpressionType.GREATER_THAN,
+                        new SymbolReference("b2"),
+                        new FunctionCall(QualifiedName.of("sin"), ImmutableList.of(new SymbolReference("p1")))),
+                "b2");
+
+        assertGetSortExpression(
+                new ComparisonExpression(
+                        ComparisonExpressionType.GREATER_THAN,
+                        new SymbolReference("b2"),
+                        new FunctionCall(QualifiedName.of("random"), ImmutableList.of(new SymbolReference("p1")))));
+
+        assertGetSortExpression(
+                new ComparisonExpression(
+                        ComparisonExpressionType.GREATER_THAN,
                         new SymbolReference("b1"),
                         new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Type.ADD, new SymbolReference("b2"), new SymbolReference("p1"))));
 


### PR DESCRIPTION
For the following query:

```
SELECT count(*)
FROM
    customer c1 JOIN customer c2 ON c1.nationkey=c2.nationkey
WHERE
    c1.custkey - RANDOM(c1.custkey) < c2.custkey
```

presto returned ~16000 rows instead of ~69000.

When using SortExpression, SortedPositionLinks assumes that once a filtering
function returns false for one row, it must be false for all the the following rows.
This is not true for non-deterministic functions.