### PR TITLE
fix the syntax of TypeCalculation

### DIFF
--- a/presto-parser/src/main/antlr4/com/facebook/presto/type/TypeCalculation.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/type/TypeCalculation.g4
@@ -15,6 +15,8 @@
 //TODO: consider using the SQL grammar for this
 grammar TypeCalculation;
 
+// workaround for:
+//  https://github.com/antlr/antlr4/issues/118
 typeCalculation
     : expression EOF
     ;

--- a/presto-parser/src/main/antlr4/com/facebook/presto/type/TypeCalculation.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/type/TypeCalculation.g4
@@ -16,7 +16,7 @@
 grammar TypeCalculation;
 
 typeCalculation
-    : expression
+    : expression EOF
     ;
 
 expression


### PR DESCRIPTION
According to https://github.com/antlr/antlr4/issues/118, incorrect error message might be returned if start rule doesn't contains EOF.