### PR TITLE
Set catalog when executing rule tests in transactions

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -148,7 +148,7 @@ public class RuleAssert
         return transaction(transactionManager, accessControl)
                 .singleStatement()
                 .execute(session, session -> {
-                    // metatdata.getCatalogHandle() registers the catalog for the transaction
+                    // metadata.getCatalogHandle() registers the catalog for the transaction
                     session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
                     return transactionSessionConsumer.apply(session);
                 });

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -147,6 +147,10 @@ public class RuleAssert
     {
         return transaction(transactionManager, accessControl)
                 .singleStatement()
-                .execute(session, transactionSessionConsumer);
+                .execute(session, session -> {
+                    // metatdata.getCatalogHandle() registers the catalog for the transaction
+                    session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
+                    return transactionSessionConsumer.apply(session);
+                });
     }
 }


### PR DESCRIPTION
@martint this is a fixup for the commit to execute rule tests in transactions.  I accidentally left out the line for setting the catalog, which is necessary for TableScanNodes to work correctly.