### PR TITLE
Remove duplicate test codes in FunctionAssertions

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -277,17 +277,6 @@ public final class FunctionAssertions
 
         List<Object> results = new ArrayList<>();
 
-        //
-        // If the projection does not need bound values, execute query using full engine
-        if (!needsBoundValue(projectionExpression)) {
-            MaterializedResult result = runner.execute("SELECT " + projection);
-            assertType(result.getTypes(), expectedType);
-            assertEquals(result.getTypes().size(), 1);
-            assertEquals(result.getMaterializedRows().size(), 1);
-            Object queryResult = Iterables.getOnlyElement(result.getMaterializedRows()).getField(0);
-            results.add(queryResult);
-        }
-
         // execute as standalone operator
         OperatorFactory operatorFactory = compileFilterProject(Optional.empty(), projectionRowExpression, compiler);
         assertType(operatorFactory.getTypes(), expectedType);


### PR DESCRIPTION
These lines are introduced in [Here](https://github.com/prestodb/presto/pull/1201/commits/5c6905626a88992060f3b95b5f228cb57d76f9be#diff-b63d93afb39aba46ce1905a9f62a021cR222) . And they are the same as 313-322


If this copy of code is not intended, we could remove it to accelerate test speed.

@haozhun @fiedukow 