### PR TITLE
Fix race-condition in Driver checking memory overuse [spilljoin, revocable]

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -270,7 +270,7 @@ public class Driver
 
                 // check if operator is blocked
                 Operator current = operators.get(0);
-                ListenableFuture<?> blocked = isBlocked(current);
+                ListenableFuture<?> blocked = getBlockedFuture(current);
                 if (!blocked.isDone()) {
                     current.getOperatorContext().recordBlocked(blocked);
                     return blocked;
@@ -289,10 +289,10 @@ public class Driver
                 Operator next = operators.get(i + 1);
 
                 // skip blocked operators
-                if (!isBlocked(current).isDone()) {
+                if (!getBlockedFuture(current).isDone()) {
                     continue;
                 }
-                if (!isBlocked(next).isDone()) {
+                if (!getBlockedFuture(next).isDone()) {
                     continue;
                 }
 
@@ -330,7 +330,7 @@ public class Driver
                 List<Operator> blockedOperators = new ArrayList<>();
                 List<ListenableFuture<?>> blockedFutures = new ArrayList<>();
                 for (Operator operator : operators) {
-                    ListenableFuture<?> blocked = isBlocked(operator);
+                    ListenableFuture<?> blocked = getBlockedFuture(operator);
                     if (!blocked.isDone()) {
                         blockedOperators.add(operator);
                         blockedFutures.add(blocked);
@@ -457,7 +457,7 @@ public class Driver
         }
     }
 
-    private static ListenableFuture<?> isBlocked(Operator operator)
+    private static ListenableFuture<?> getBlockedFuture(Operator operator)
     {
         ListenableFuture<?> blocked = operator.isBlocked();
         if (blocked.isDone()) {


### PR DESCRIPTION
Before the commit, if `Operator#isBlocked()` returned a not-done-yet
`Future` that became done before returning from
`Driver#isBlocked(Operator)`, the `Operator` would end up being called
even though it should be not called due to memory over-allocation.

This commit closes this possibility by returning a `boolean` from
`Driver#isBlocked(Operator)` so that the value does not change before
computing it and testing it main `Driver` loop.