### PR TITLE
Call MethodHandles::unreflect in Reflection utils

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/Reflection.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/Reflection.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.StandardErrorCode;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
@@ -73,14 +74,27 @@ public final class Reflection
      * method in a tight loop can create significant GC pressure and significantly increase
      * application pause time.
      */
-    public static MethodHandle methodHandle(Method method)
+    public static MethodHandle methodHandle(StandardErrorCode errorCode, Method method)
     {
         try {
             return MethodHandles.lookup().unreflect(method);
         }
         catch (IllegalAccessException e) {
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+            throw new PrestoException(errorCode, e);
         }
+    }
+
+    /**
+     * Returns a MethodHandle corresponding to the specified method.
+     * <p>
+     * Warning: The way Oracle JVM implements producing MethodHandle for a method involves creating
+     * JNI global weak references. G1 processes such references serially. As a result, calling this
+     * method in a tight loop can create significant GC pressure and significantly increase
+     * application pause time.
+     */
+    public static MethodHandle methodHandle(Method method)
+    {
+        return methodHandle(GENERIC_INTERNAL_ERROR, method);
     }
 
     /**
@@ -110,6 +124,24 @@ public final class Reflection
             return MethodHandles.lookup().unreflectConstructor(clazz.getConstructor(parameterTypes));
         }
         catch (IllegalAccessException | NoSuchMethodException e) {
+            throw new PrestoException(errorCode, e);
+        }
+    }
+
+    /**
+     * Returns a MethodHandle corresponding to the specified constructor.
+     * <p>
+     * Warning: The way Oracle JVM implements producing MethodHandle for a constructor involves
+     * creating JNI global weak references. G1 processes such references serially. As a result,
+     * calling this method in a tight loop can create significant GC pressure and significantly
+     * increase application pause time.
+     */
+    public static MethodHandle constructorMethodHandle(StandardErrorCode errorCode, Constructor constructor)
+    {
+        try {
+            return MethodHandles.lookup().unreflectConstructor(constructor);
+        }
+        catch (IllegalAccessException e) {
             throw new PrestoException(errorCode, e);
         }
     }


### PR DESCRIPTION
Since unreflect calls caused GC issues recently unifying their callsites
will help us better track their usage.