### PR TITLE
Increase timeout to prevent random test failures

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -144,7 +144,7 @@ public class TestHiveSplitSource
             hiveSplitSource.addToQueue(new TestSplit(33));
 
             // wait for thread to get the split
-            ConnectorSplit split = splits.get(200, TimeUnit.MILLISECONDS);
+            ConnectorSplit split = splits.get(800, TimeUnit.MILLISECONDS);
             assertSame(split.getInfo(), 33);
         }
         finally {


### PR DESCRIPTION
The test fails at random in PR builds.