### PR TITLE
[WIP] Dynamic partition pruning

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
@@ -39,6 +39,7 @@ import java.util.function.Supplier;
 
 import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -71,7 +72,7 @@ public class HandTpchQuery6
 
         Supplier<PageProjection> projection = new PageFunctionCompiler(localQueryRunner.getMetadata()).compileProjection(field(0, BIGINT));
 
-        FilterAndProjectOperator.FilterAndProjectOperatorFactory tpchQuery6Operator = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        FilterAndProjectOperator.FilterAndProjectOperatorFactory tpchQuery6Operator = synchronousFilterAndProjectOperator(
                 1,
                 new PlanNodeId("test"),
                 () -> new PageProcessor(Optional.of(new TpchQuery6Filter()), ImmutableList.of(projection.get())),

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/PredicateFilterBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/PredicateFilterBenchmark.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 
 import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
 import static com.facebook.presto.metadata.Signature.internalOperator;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -55,7 +56,7 @@ public class PredicateFilterBenchmark
         ExpressionCompiler expressionCompiler = new ExpressionCompiler(localQueryRunner.getMetadata());
         Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(Optional.of(filter), ImmutableList.of(field(0, DOUBLE)));
 
-        FilterAndProjectOperator.FilterAndProjectOperatorFactory filterAndProjectOperator = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        FilterAndProjectOperator.FilterAndProjectOperatorFactory filterAndProjectOperator = synchronousFilterAndProjectOperator(
                 1,
                 new PlanNodeId("test"),
                 pageProcessor,

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSourceOperator.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeUtils;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterSourceOperator
+        implements Operator
+{
+    public static class DynamicFilterSourceOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+        private final List<Type> types;
+        private final List<Integer> filterChannels;
+        private final TupleDomainSource tupleDomainSource;
+
+        private boolean closed;
+
+        public DynamicFilterSourceOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                List<Type> types,
+                List<Integer> filterChannels,
+                Optional<Integer> hashChannel,
+                TupleDomainSource tupleDomainSource)
+        {
+            this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.types = ImmutableList.copyOf(types);
+            this.filterChannels = ImmutableList.<Integer>builder()
+                    .addAll(hashChannel.map(ImmutableList::of).orElse(ImmutableList.of()))
+                    .addAll(filterChannels)
+                    .build();
+            this.tupleDomainSource = requireNonNull(tupleDomainSource, "tupleDomainSource is null");
+        }
+
+        @Override
+        public List<Type> getTypes()
+        {
+            return types;
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, DynamicFilterSourceOperator.class.getSimpleName());
+
+            return new DynamicFilterSourceOperator(operatorContext, types, filterChannels, tupleDomainSource);
+        }
+
+        @Override
+        public void close()
+        {
+            closed = true;
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            throw new UnsupportedOperationException("Parallel dynamic filter build can not be duplicated");
+        }
+    }
+
+    private static final int DEFAULT_POSITIONS_LIMIT = 1000;
+
+    private final OperatorContext operatorContext;
+    private final List<Type> types;
+    private final List<Integer> filterChannels;
+    private final TupleDomainSource tupleDomainSource;
+    private final int positionsLimit;
+
+    private Page page;
+    private boolean finishing;
+    private long positionCount;
+    private List<ImmutableList.Builder<Object>> valuesBuilder;
+    private boolean[] nullsAllowed;
+
+    public DynamicFilterSourceOperator(
+            OperatorContext operatorContext,
+            List<Type> types,
+            List<Integer> filterChannels,
+            TupleDomainSource tupleDomainSource)
+    {
+        this(operatorContext, types, filterChannels, tupleDomainSource, DEFAULT_POSITIONS_LIMIT);
+    }
+
+    public DynamicFilterSourceOperator(
+            OperatorContext operatorContext,
+            List<Type> types,
+            List<Integer> filterChannels,
+            TupleDomainSource tupleDomainSource,
+            int positionsLimit)
+    {
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+        this.types = ImmutableList.copyOf(types);
+        this.filterChannels = ImmutableList.copyOf(filterChannels);
+        this.valuesBuilder = filterChannels.stream().map(channel -> ImmutableList.builder()).collect(toImmutableList());
+        this.nullsAllowed = new boolean[filterChannels.size()];
+        this.tupleDomainSource = requireNonNull(tupleDomainSource, "tupleDomainSource is null");
+
+        checkArgument(positionsLimit > 0, "positionsLimit must be greater than zero");
+        this.positionsLimit = positionsLimit;
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public List<Type> getTypes()
+    {
+        return types;
+    }
+
+    @Override
+    public void finish()
+    {
+        if (finishing) {
+            return;
+        }
+        finishing = true;
+        buildTupleDomain();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finishing && page == null;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return !finishing;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        this.page = page;
+        processPage();
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        Page page = this.page;
+        this.page = null;
+        return page;
+    }
+
+    private void processPage()
+    {
+        positionCount += page.getPositionCount();
+
+        // we don't want to filter if there're too many values
+        if (positionCount > positionsLimit) {
+            return;
+        }
+
+        for (int channelIndex = 0; channelIndex < filterChannels.size(); channelIndex++) {
+            Integer channel = filterChannels.get(channelIndex);
+            for (int position = 0; position < page.getBlock(channel).getPositionCount(); position++) {
+                Object value = TypeUtils.readNativeValue(types.get(channel), page.getBlock(channel), position);
+                if (value == null) {
+                    nullsAllowed[channelIndex] = true;
+                }
+                else {
+                    valuesBuilder.get(channelIndex).add(value);
+                }
+            }
+        }
+    }
+
+    private void buildTupleDomain()
+    {
+        // we don't want to filter if there're too many values
+        if (positionCount > positionsLimit) {
+            tupleDomainSource.addDomain(TupleDomain.all());
+            return;
+        }
+
+        ImmutableMap.Builder<Integer, Domain> domainsBuilder = ImmutableMap.builder();
+        for (int channelIndex = 0; channelIndex < filterChannels.size(); channelIndex++) {
+            Integer channel = filterChannels.get(channelIndex);
+            List<Object> values = valuesBuilder.get(channelIndex).build();
+            Domain domain;
+            if (values.isEmpty()) {
+                domain = Domain.none(types.get(channel));
+            }
+            else {
+                domain = Domain.create(ValueSet.copyOf(types.get(channel), values), nullsAllowed[channelIndex]);
+            }
+            domainsBuilder.put(channel, domain);
+        }
+
+        tupleDomainSource.addDomain(TupleDomain.withColumnDomains(domainsBuilder.build()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorInfo.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.operator.DynamicFilterSourceOperator.DynamicFilterSummary;
 import com.facebook.presto.operator.PartitionedOutputOperator.PartitionedOutputInfo;
 import com.facebook.presto.operator.exchange.LocalExchangeBufferInfo;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -28,7 +29,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = TableFinishInfo.class, name = "tableFinish"),
         @JsonSubTypes.Type(value = SplitOperatorInfo.class, name = "splitOperator"),
         @JsonSubTypes.Type(value = HashCollisionsInfo.class, name = "hashCollisionsInfo"),
-        @JsonSubTypes.Type(value = PartitionedOutputInfo.class, name = "partitionedOutput")
+        @JsonSubTypes.Type(value = PartitionedOutputInfo.class, name = "partitionedOutput"),
+        @JsonSubTypes.Type(value = DynamicFilterSummary.class, name = "dynamicFilterSummary")
 })
 public interface OperatorInfo
 {

--- a/presto-main/src/main/java/com/facebook/presto/operator/TupleDomainSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TupleDomainSource.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.spi.predicate.TupleDomain.columnWiseUnion;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class TupleDomainSource
+{
+    private final int expectedDomains;
+    private final SettableFuture<TupleDomain<Integer>> resultFuture = SettableFuture.create();
+    private List<TupleDomain<Integer>> domains = new ArrayList<>();
+
+    public TupleDomainSource(int expectedDomains)
+    {
+        checkArgument(expectedDomains > 0, "expectedDomains must be greater than zero");
+        this.expectedDomains = expectedDomains;
+    }
+
+    public synchronized ListenableFuture<TupleDomain<Integer>> getDomainFuture()
+    {
+        return resultFuture;
+    }
+
+    public synchronized void addDomain(TupleDomain<Integer> domain)
+    {
+        requireNonNull(domain, "domain must be not null");
+        checkState(domains.size() < expectedDomains);
+        domains.add(domain);
+        if (domains.size() == expectedDomains) {
+            resultFuture.set(columnWiseUnion(domains));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/DynamicTupleFilterFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/DynamicTupleFilterFactory.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
-import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -80,7 +80,7 @@ public class DynamicTupleFilterFactory
     {
         Page filterTuple = getFilterTuple(tuplePage);
         Supplier<PageProcessor> processor = createPageProcessor(filterTuple);
-        return new FilterAndProjectOperatorFactory(filterOperatorId, planNodeId, processor, outputTypes);
+        return synchronousFilterAndProjectOperator(filterOperatorId, planNodeId, processor, outputTypes);
     }
 
     @VisibleForTesting

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/TupleDomainPageFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/TupleDomainPageFilter.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.index;
+
+import com.facebook.presto.operator.project.InputChannels;
+import com.facebook.presto.operator.project.PageFilter;
+import com.facebook.presto.operator.project.SelectedPositions;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+import static com.facebook.presto.operator.project.PageFilter.positionsArrayToSelectedPositions;
+import static com.facebook.presto.operator.project.SelectedPositions.positionsRange;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class TupleDomainPageFilter
+        implements PageFilter
+{
+    private final InputChannels inputChannels;
+    private final List<Integer> filterChannels;
+    @Nullable
+    private final Domain[] domains;
+
+    private boolean[] selectedPositions = new boolean[0];
+
+    public TupleDomainPageFilter(InputChannels inputChannels, List<Integer> filterChannels, TupleDomain<Integer> tupleDomain)
+    {
+        this(inputChannels, filterChannels, getDomains(inputChannels, requireNonNull(tupleDomain, "tupleDomain is null")));
+    }
+
+    private TupleDomainPageFilter(InputChannels inputChannels, List<Integer> filterChannels, @Nullable Domain[] domains)
+    {
+        this.inputChannels = requireNonNull(inputChannels, "inputChannels is null");
+        this.filterChannels = requireNonNull(filterChannels, "filterChannels is null");
+        this.domains = domains;
+    }
+
+    @Nullable
+    private static Domain[] getDomains(InputChannels inputChannels, TupleDomain<Integer> tupleDomain)
+    {
+        if (tupleDomain.getDomains().isPresent()) {
+            Domain[] domains = new Domain[inputChannels.size()];
+            for (int i = 0; i < domains.length; i++) {
+                domains[i] = tupleDomain.getDomains().get().get(i);
+            }
+            return domains;
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public InputChannels getInputChannels()
+    {
+        return inputChannels;
+    }
+
+    @Override
+    public SelectedPositions filter(ConnectorSession session, Page page)
+    {
+        if (domains == null) {
+            return positionsRange(0, page.getPositionCount());
+        }
+
+        if (selectedPositions.length < page.getPositionCount()) {
+            selectedPositions = new boolean[page.getPositionCount()];
+        }
+
+        for (int position = 0; position < page.getPositionCount(); position++) {
+            selectedPositions[position] = matches(page, position);
+        }
+
+        return positionsArrayToSelectedPositions(selectedPositions, page.getPositionCount());
+    }
+
+    private boolean matches(Page page, int position)
+    {
+        for (int channel : filterChannels) {
+            if (!matches(page, position, channel)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean matches(Page page, int position, int channel)
+    {
+        checkState(domains != null, "domains is null");
+        Domain domain = domains[channel];
+        if (domain == null) {
+            return true;
+        }
+        return domain.includesNullableValue(page.getBlock(channel), position);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
@@ -17,14 +17,17 @@ import com.facebook.presto.sql.planner.DependencyExtractor;
 import com.facebook.presto.sql.planner.DeterminismEvaluator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IsNullPredicate;
 import com.facebook.presto.sql.tree.LambdaExpression;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.NotExpression;
+import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -43,6 +46,7 @@ import java.util.function.Predicate;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpressionType.IS_DISTINCT_FROM;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -320,6 +324,20 @@ public final class ExpressionUtils
             public Expression rewriteLambdaExpression(LambdaExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
             {
                 return new LambdaExpression(node.getArguments(), treeRewriter.rewrite(node.getBody(), context));
+            }
+
+            @Override
+            public Expression rewriteFunctionCall(FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                if (node.getName().equals(QualifiedName.of("$INTERNAL$DEFERRED_SYMBOL_REFERENCE"))) {
+                    List<Expression> arguments = node.getArguments();
+                    checkArgument(arguments.size() == 2, "2 arguments are expected");
+                    checkArgument(arguments.stream().allMatch(argument -> argument instanceof Identifier), "arguments are expected to be identifiers");
+                    String source = ((Identifier) arguments.get(0)).getName();
+                    String name = ((Identifier) arguments.get(1)).getName();
+                    return new DeferredSymbolReference(source, name);
+                }
+                return super.rewriteFunctionCall(node, context, treeRewriter);
             }
         }, expression);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DynamicFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DynamicFilter.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilter
+{
+    private final String source;
+    private final Map<Symbol, Symbol> mappings;
+
+    public static DynamicFilter createEmptyDynamicFilter()
+    {
+        return new DynamicFilter(UUID.randomUUID().toString(), ImmutableMap.of());
+    }
+
+    @JsonCreator
+    public DynamicFilter(@JsonProperty("source") String source, @JsonProperty("mappings") Map<Symbol, Symbol> mappings)
+    {
+        this.source = requireNonNull(source, "source is null");
+        this.mappings = ImmutableMap.copyOf(requireNonNull(mappings, "mappings is null"));
+    }
+
+    public String getSource()
+    {
+        return source;
+    }
+
+    public Map<Symbol, Symbol> getMappings()
+    {
+        return mappings;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DynamicFilter that = (DynamicFilter) o;
+        return Objects.equals(source, that.source) &&
+                Objects.equals(mappings, that.mappings);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(source, mappings);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("source", source)
+                .add("mappings", mappings)
+                .toString();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -32,7 +32,6 @@ import com.facebook.presto.operator.EnforceSingleRowOperator;
 import com.facebook.presto.operator.ExchangeClientSupplier;
 import com.facebook.presto.operator.ExchangeOperator.ExchangeOperatorFactory;
 import com.facebook.presto.operator.ExplainAnalyzeOperator.ExplainAnalyzeOperatorFactory;
-import com.facebook.presto.operator.FilterAndProjectOperator;
 import com.facebook.presto.operator.GroupIdOperator;
 import com.facebook.presto.operator.HashAggregationOperator.HashAggregationOperatorFactory;
 import com.facebook.presto.operator.HashBuilderOperator.HashBuilderOperatorFactory;
@@ -185,6 +184,7 @@ import static com.facebook.presto.SystemSessionProperties.isExchangeCompressionE
 import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.operator.DistinctLimitOperator.DistinctLimitOperatorFactory;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.operator.NestedLoopBuildOperator.NestedLoopBuildOperatorFactory;
 import static com.facebook.presto.operator.NestedLoopJoinOperator.NestedLoopJoinOperatorFactory;
 import static com.facebook.presto.operator.TableFinishOperator.TableFinishOperatorFactory;
@@ -1087,7 +1087,7 @@ public class LocalExecutionPlanner
                 else {
                     Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(translatedFilter, translatedProjections);
 
-                    OperatorFactory operatorFactory = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+                    OperatorFactory operatorFactory = synchronousFilterAndProjectOperator(
                             context.getNextOperatorId(),
                             planNodeId,
                             pageProcessor,
@@ -1137,7 +1137,7 @@ public class LocalExecutionPlanner
                 return new PhysicalOperation(operatorFactory, outputMappings);
             }
             else {
-                OperatorFactory operatorFactory = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+                OperatorFactory operatorFactory = synchronousFilterAndProjectOperator(
                         context.getNextOperatorId(),
                         planNodeId,
                         () -> pageProcessor,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -28,6 +28,7 @@ import com.facebook.presto.operator.AssignUniqueIdOperator;
 import com.facebook.presto.operator.CursorProcessor;
 import com.facebook.presto.operator.DeleteOperator.DeleteOperatorFactory;
 import com.facebook.presto.operator.DriverFactory;
+import com.facebook.presto.operator.DynamicFilterSourceOperator.DynamicFilterSourceOperatorFactory;
 import com.facebook.presto.operator.EnforceSingleRowOperator;
 import com.facebook.presto.operator.ExchangeClientSupplier;
 import com.facebook.presto.operator.ExchangeOperator.ExchangeOperatorFactory;
@@ -203,6 +204,7 @@ import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BRO
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.CreateHandle;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.InsertHandle;
@@ -1540,9 +1542,14 @@ public class LocalExecutionPlanner
             PhysicalOperation probeSource = probeNode.accept(this, context);
 
             // Plan build
-            LookupSourceFactory lookupSourceFactory = createLookupSourceFactory(node, buildNode, buildSymbols, buildHashSymbol, probeSource.getLayout(), context);
+            LocalExecutionPlanContext buildContext = context.createSubContext();
+            PhysicalOperation buildSource = buildNode.accept(this, buildContext);
+            List<Integer> buildChannels = ImmutableList.copyOf(getChannelsForSymbols(buildSymbols, buildSource.getLayout()));
+            Optional<Integer> buildHashChannel = buildHashSymbol.map(channelGetter(buildSource));
 
-            OperatorFactory operator = createLookupJoin(node, probeSource, probeSymbols, probeHashSymbol, lookupSourceFactory, context);
+            HashBuilderOperatorFactory hashBuilderOperatorFactory = createHashBuilderOperatorFactory(node, buildContext, buildSource, buildChannels, buildHashChannel, probeSource.getLayout(), context);
+
+            OperatorFactory lookupJoinOperator = createLookupJoin(node, probeSource, probeSymbols, probeHashSymbol, hashBuilderOperatorFactory.getLookupSourceFactory(), context);
 
             ImmutableMap.Builder<Symbol, Integer> outputMappings = ImmutableMap.builder();
             List<Symbol> outputSymbols = node.getOutputSymbols();
@@ -1551,25 +1558,52 @@ public class LocalExecutionPlanner
                 outputMappings.put(symbol, i);
             }
 
-            return new PhysicalOperation(operator, outputMappings.build(), probeSource);
+            // Dynamic filtering
+            if (node.getType() == INNER && node.getCriteria().size() > 0) {
+                OperatorFactory dynamicFilterSource = new DynamicFilterSourceOperatorFactory(
+                        buildContext.getNextOperatorId(),
+                        node.getId(),
+                        buildSource.getTypes(),
+                        buildChannels,
+                        buildHashChannel);
+
+                context.addDriverFactory(
+                        buildContext.isInputDriver(),
+                        false,
+                        ImmutableList.<OperatorFactory>builder()
+                                .addAll(buildSource.getOperatorFactories())
+                                .add(dynamicFilterSource)
+                                .add(hashBuilderOperatorFactory)
+                                .build(),
+                        buildContext.getDriverInstanceCount());
+            }
+            else {
+                context.addDriverFactory(
+                        buildContext.isInputDriver(),
+                        false,
+                        ImmutableList.<OperatorFactory>builder()
+                                .addAll(buildSource.getOperatorFactories())
+                                .add(hashBuilderOperatorFactory)
+                                .build(),
+                        buildContext.getDriverInstanceCount());
+            }
+
+            return new PhysicalOperation(lookupJoinOperator, outputMappings.build(), probeSource);
         }
 
-        private LookupSourceFactory createLookupSourceFactory(
+        private HashBuilderOperatorFactory createHashBuilderOperatorFactory(
                 JoinNode node,
-                PlanNode buildNode,
-                List<Symbol> buildSymbols,
-                Optional<Symbol> buildHashSymbol,
+                LocalExecutionPlanContext buildContext,
+                PhysicalOperation buildSource,
+                List<Integer> buildChannels,
+                Optional<Integer> buildHashChannel,
                 Map<Symbol, Integer> probeLayout,
                 LocalExecutionPlanContext context)
         {
-            LocalExecutionPlanContext buildContext = context.createSubContext();
-            PhysicalOperation buildSource = buildNode.accept(this, buildContext);
             List<Symbol> buildOutputSymbols = node.getOutputSymbols().stream()
                     .filter(symbol -> node.getRight().getOutputSymbols().contains(symbol))
                     .collect(toImmutableList());
             List<Integer> buildOutputChannels = ImmutableList.copyOf(getChannelsForSymbols(buildOutputSymbols, buildSource.getLayout()));
-            List<Integer> buildChannels = ImmutableList.copyOf(getChannelsForSymbols(buildSymbols, buildSource.getLayout()));
-            Optional<Integer> buildHashChannel = buildHashSymbol.map(channelGetter(buildSource));
 
             Optional<JoinFilterFunctionFactory> filterFunctionFactory = node.getFilter()
                     .map(filterExpression -> compileJoinFilterFunction(
@@ -1580,7 +1614,7 @@ public class LocalExecutionPlanner
                             context.getTypes(),
                             context.getSession()));
 
-            HashBuilderOperatorFactory hashBuilderOperatorFactory = new HashBuilderOperatorFactory(
+            return new HashBuilderOperatorFactory(
                     buildContext.getNextOperatorId(),
                     node.getId(),
                     buildSource.getTypes(),
@@ -1593,17 +1627,6 @@ public class LocalExecutionPlanner
                     10_000,
                     buildContext.getDriverInstanceCount().orElse(1),
                     pagesIndexFactory);
-
-            context.addDriverFactory(
-                    buildContext.isInputDriver(),
-                    false,
-                    ImmutableList.<OperatorFactory>builder()
-                            .addAll(buildSource.getOperatorFactories())
-                            .add(hashBuilderOperatorFactory)
-                            .build(),
-                    buildContext.getDriverInstanceCount());
-
-            return hashBuilderOperatorFactory.getLookupSourceFactory();
         }
 
         private JoinFilterFunctionFactory compileJoinFilterFunction(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -83,6 +83,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.sql.analyzer.SemanticExceptions.notSupportedException;
+import static com.facebook.presto.sql.planner.DynamicFilter.createEmptyDynamicFilter;
 import static com.facebook.presto.sql.planner.ExpressionInterpreter.evaluateConstantExpression;
 import static com.facebook.presto.sql.tree.Join.Type.INNER;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -304,7 +305,8 @@ class RelationPlanner
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                createEmptyDynamicFilter());
 
         if (node.getType() != INNER) {
             for (Expression complexExpression : complexJoinExpressions) {
@@ -341,7 +343,8 @@ class RelationPlanner
                     Optional.of(rewrittenFilterCondition),
                     Optional.empty(),
                     Optional.empty(),
-                    Optional.empty());
+                    Optional.empty(),
+                    createEmptyDynamicFilter());
         }
 
         if (node.getType() == INNER) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ApplyDynamicFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ApplyDynamicFilter.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -51,6 +52,10 @@ public class ApplyDynamicFilter
         }
 
         JoinNode join = (JoinNode) node;
+
+        if (join.getType() != INNER) {
+            return Optional.empty();
+        }
 
         List<EquiJoinClause> criteria = join.getCriteria();
         DynamicFilter dynamicFilter = join.getDynamicFilter();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ApplyDynamicFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ApplyDynamicFilter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.DynamicFilter;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.JoinNode.EquiJoinClause;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class ApplyDynamicFilter
+        implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        if (!(node instanceof JoinNode)) {
+            return Optional.empty();
+        }
+
+        JoinNode join = (JoinNode) node;
+
+        List<EquiJoinClause> criteria = join.getCriteria();
+        DynamicFilter dynamicFilter = join.getDynamicFilter();
+
+        Map<Symbol, Symbol> existingMappings = dynamicFilter.getMappings();
+        List<EquiJoinClause> unprocessedClauses = criteria.stream()
+                .filter(c -> !existingMappings.containsKey(c.getRight()))
+                .collect(toImmutableList());
+
+        if (unprocessedClauses.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ImmutableMap.Builder<Symbol, Symbol> mappings = ImmutableMap.builder();
+        mappings.putAll(existingMappings);
+        ImmutableList.Builder<Expression> predicates = ImmutableList.builder();
+
+        for (EquiJoinClause clause : unprocessedClauses) {
+            Symbol probeSymbol = clause.getLeft();
+            Symbol buildSymbol = clause.getRight();
+            Type buildSymbolType = requireNonNull(symbolAllocator.getTypes().get(buildSymbol));
+            Symbol linkingSymbol = symbolAllocator.newSymbol("dynamic_filter_" + buildSymbol.getName(), buildSymbolType);
+            DeferredSymbolReference dynamicFilterReference = new DeferredSymbolReference(dynamicFilter.getSource(), linkingSymbol.getName());
+            predicates.add(new ComparisonExpression(EQUAL, probeSymbol.toSymbolReference(), dynamicFilterReference));
+            mappings.put(buildSymbol, linkingSymbol);
+        }
+
+        DynamicFilter updatedDynamicFilter = new DynamicFilter(dynamicFilter.getSource(), mappings.build());
+
+        return Optional.of(
+                new JoinNode(
+                        join.getId(),
+                        join.getType(),
+                        new FilterNode(idAllocator.getNextId(), join.getLeft(), combineConjuncts(predicates.build())),
+                        join.getRight(),
+                        join.getCriteria(),
+                        join.getOutputSymbols(),
+                        join.getFilter(),
+                        join.getLeftHashSymbol(),
+                        join.getRightHashSymbol(),
+                        join.getDistributionType(),
+                        updatedDynamicFilter));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
 
+import static com.facebook.presto.sql.planner.DynamicFilter.createEmptyDynamicFilter;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -172,7 +173,8 @@ public class EliminateCrossJoins
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),
-                    Optional.empty());
+                    Optional.empty(),
+                    createEmptyDynamicFilter());
         }
 
         List<Expression> filters = graph.getFilters();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.shouldPushAggregationThroughJoin;
+import static com.facebook.presto.sql.planner.DynamicFilter.createEmptyDynamicFilter;
 import static com.facebook.presto.sql.planner.optimizations.DistinctOutputQueryUtil.isDistinct;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -136,7 +137,8 @@ public class PushAggregationThroughOuterJoin
                     join.getFilter(),
                     join.getLeftHashSymbol(),
                     join.getRightHashSymbol(),
-                    join.getDistributionType());
+                    join.getDistributionType(),
+                    join.getDynamicFilter());
         }
         else {
             rewrittenJoin = new JoinNode(
@@ -152,7 +154,8 @@ public class PushAggregationThroughOuterJoin
                     join.getFilter(),
                     join.getLeftHashSymbol(),
                     join.getRightHashSymbol(),
-                    join.getDistributionType());
+                    join.getDistributionType(),
+                    join.getDynamicFilter());
         }
 
         return Optional.of(coalesceWithNullAggregation(rewrittenAggregation, rewrittenJoin, symbolAllocator, idAllocator, lookup));
@@ -215,7 +218,8 @@ public class PushAggregationThroughOuterJoin
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                createEmptyDynamicFilter());
 
         // Add coalesce expressions for all aggregation functions
         Assignments.Builder assignmentsBuilder = Assignments.builder();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -837,7 +837,8 @@ public class AddExchanges
                     node.getFilter(),
                     node.getLeftHashSymbol(),
                     node.getRightHashSymbol(),
-                    node.getDistributionType());
+                    node.getDistributionType(),
+                    node.getDynamicFilter());
 
             return new PlanWithProperties(result, deriveProperties(result, ImmutableList.of(left.getProperties(), right.getProperties())));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CanonicalizeExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CanonicalizeExpressions.java
@@ -85,7 +85,8 @@ public class CanonicalizeExpressions
                             Optional.of(canonicalizedExpression),
                             node.getLeftHashSymbol(),
                             node.getRightHashSymbol(),
-                            node.getDistributionType());
+                            node.getDistributionType(),
+                            node.getDynamicFilter());
                 }
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DesugaringOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DesugaringOptimizer.java
@@ -167,7 +167,8 @@ public class DesugaringOptimizer
                     filter,
                     node.getLeftHashSymbol(),
                     node.getRightHashSymbol(),
-                    node.getDistributionType());
+                    node.getDistributionType(),
+                    node.getDynamicFilter());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DetermineJoinDistributionType.java
@@ -73,7 +73,8 @@ public class DetermineJoinDistributionType
                     node.getFilter(),
                     node.getLeftHashSymbol(),
                     node.getRightHashSymbol(),
-                    Optional.of(targetJoinDistributionType));
+                    Optional.of(targetJoinDistributionType),
+                    node.getDynamicFilter());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -352,7 +352,8 @@ public class HashGenerationOptimizer
                             node.getFilter(),
                             leftHashSymbol,
                             rightHashSymbol,
-                            node.getDistributionType()),
+                            node.getDistributionType(),
+                            node.getDynamicFilter()),
                     hashSymbolsWithParentPreferences);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -188,7 +188,7 @@ public class IndexJoinOptimizer
             }
 
             if (leftRewritten != node.getLeft() || rightRewritten != node.getRight()) {
-                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType());
+                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType(), node.getDynamicFilter());
             }
             return node;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PartialAggregationPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PartialAggregationPushDown.java
@@ -222,7 +222,8 @@ public class PartialAggregationPushDown
                     child.getFilter(),
                     child.getLeftHashSymbol(),
                     child.getRightHashSymbol(),
-                    child.getDistributionType());
+                    child.getDistributionType(),
+                    child.getDynamicFilter());
         }
 
         private AggregationNode replaceAggregationSource(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -217,7 +217,7 @@ public class PruneUnreferencedOutputs
                         .collect(toImmutableList());
             }
 
-            return new JoinNode(node.getId(), node.getType(), left, right, node.getCriteria(), outputSymbols, node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType());
+            return new JoinNode(node.getId(), node.getType(), left, right, node.getCriteria(), outputSymbols, node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType(), node.getDynamicFilter());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -53,6 +53,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
+import static com.facebook.presto.sql.planner.DynamicFilter.createEmptyDynamicFilter;
 import static com.facebook.presto.sql.planner.optimizations.Predicates.isInstanceOfAny;
 import static com.facebook.presto.sql.planner.plan.SimplePlanRewriter.rewriteWith;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
@@ -139,7 +140,8 @@ public class ScalarAggregationToJoinRewriter
                 joinExpression,
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                createEmptyDynamicFilter());
 
         Optional<AggregationNode> aggregationNode = createAggregationNode(
                 scalarAggregation,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedScalarToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedScalarToJoin.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.sql.planner.DynamicFilter.createEmptyDynamicFilter;
 import static java.util.Objects.requireNonNull;
 
 public class TransformUncorrelatedScalarToJoin
@@ -66,7 +67,8 @@ public class TransformUncorrelatedScalarToJoin
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
-                        Optional.empty());
+                        Optional.empty(),
+                        createEmptyDynamicFilter());
             }
             return rewrittenNode;
         }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -72,7 +72,6 @@ import com.facebook.presto.metadata.ViewDefinition;
 import com.facebook.presto.operator.Driver;
 import com.facebook.presto.operator.DriverContext;
 import com.facebook.presto.operator.DriverFactory;
-import com.facebook.presto.operator.FilterAndProjectOperator;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.Operator;
 import com.facebook.presto.operator.OperatorContext;
@@ -180,6 +179,7 @@ import java.util.function.Function;
 
 import static com.facebook.presto.execution.SqlQueryManager.unwrapExecuteStatement;
 import static com.facebook.presto.execution.SqlQueryManager.validateParameters;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.testing.TreeAssertions.assertFormattedSql;
 import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
@@ -804,7 +804,7 @@ public class LocalQueryRunner
                 sqlParser,
                 defaultSession));
 
-        return new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        return synchronousFilterAndProjectOperator(
                 operatorId,
                 planNodeId,
                 () -> new PageProcessor(Optional.empty(), projections.build()),

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.planner.DynamicFilter.createEmptyDynamicFilter;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
@@ -204,7 +205,8 @@ public class TestPhasedExecutionSchedule
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.of(REPLICATED));
+                Optional.of(REPLICATED),
+                createEmptyDynamicFilter());
 
         return createFragment(join);
     }
@@ -226,7 +228,8 @@ public class TestPhasedExecutionSchedule
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.of(PARTITIONED));
+                Optional.of(PARTITIONED),
+                createEmptyDynamicFilter());
 
         return createFragment(planNode);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -74,6 +74,7 @@ import static com.facebook.presto.OutputBuffers.createInitialEmptyOutputBuffers;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.planner.DynamicFilter.createEmptyDynamicFilter;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
@@ -456,7 +457,8 @@ public class TestSourcePartitionedScheduler
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
-                        Optional.of(JoinNode.DistributionType.PARTITIONED)),
+                        Optional.of(JoinNode.DistributionType.PARTITIONED),
+                        createEmptyDynamicFilter()),
                 ImmutableMap.of(symbol, VARCHAR),
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(tableScanNodeId),

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFilterAndProjectOperator.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
 import static com.facebook.presto.spi.function.OperatorType.ADD;
 import static com.facebook.presto.spi.function.OperatorType.BETWEEN;
@@ -93,7 +94,7 @@ public class TestFilterAndProjectOperator
         ExpressionCompiler compiler = new ExpressionCompiler(createTestMetadataManager());
         Supplier<PageProcessor> processor = compiler.compilePageProcessor(Optional.of(filter), ImmutableList.of(field0, add5));
 
-        OperatorFactory operatorFactory = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        OperatorFactory operatorFactory = synchronousFilterAndProjectOperator(
                 0,
                 new PlanNodeId("test"),
                 processor,

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -21,7 +21,6 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.metadata.SqlFunction;
 import com.facebook.presto.operator.CursorProcessor;
 import com.facebook.presto.operator.DriverContext;
-import com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory;
 import com.facebook.presto.operator.Operator;
 import com.facebook.presto.operator.OperatorFactory;
 import com.facebook.presto.operator.ScanFilterAndProjectOperator;
@@ -92,6 +91,7 @@ import static com.facebook.presto.block.BlockAssertions.createSlicesBlock;
 import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.block.BlockAssertions.createTimestampsWithTimezoneBlock;
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
+import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory.synchronousFilterAndProjectOperator;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
@@ -573,7 +573,7 @@ public final class FunctionAssertions
         PageProjection pageProjection = new InterpretedPageProjection(projection, SYMBOL_TYPES, INPUT_MAPPING, metadata, SQL_PARSER, session);
 
         PageProcessor processor = new PageProcessor(pageFilter, ImmutableList.of(pageProjection));
-        OperatorFactory operatorFactory = new FilterAndProjectOperatorFactory(
+        OperatorFactory operatorFactory = synchronousFilterAndProjectOperator(
                 0,
                 new PlanNodeId("test"),
                 () -> processor,
@@ -586,7 +586,7 @@ public final class FunctionAssertions
         try {
             Supplier<PageProcessor> processor = compiler.compilePageProcessor(Optional.of(filter), ImmutableList.of());
 
-            return new FilterAndProjectOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of());
+            return synchronousFilterAndProjectOperator(0, new PlanNodeId("test"), processor, ImmutableList.of());
         }
         catch (Throwable e) {
             if (e instanceof UncheckedExecutionException) {
@@ -600,7 +600,7 @@ public final class FunctionAssertions
     {
         try {
             Supplier<PageProcessor> processor = compiler.compilePageProcessor(filter, ImmutableList.of(projection));
-            return new FilterAndProjectOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of(projection.getType()));
+            return synchronousFilterAndProjectOperator(0, new PlanNodeId("test"), processor, ImmutableList.of(projection.getType()));
         }
         catch (Throwable e) {
             if (e instanceof UncheckedExecutionException) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionSerialization.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionSerialization.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodec;
+import io.airlift.json.JsonCodecFactory;
+import io.airlift.json.ObjectMapperProvider;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+public class TestExpressionSerialization
+{
+    private JsonCodecFactory jsonCodecFactory;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        ObjectMapperProvider mapperProvider = new ObjectMapperProvider();
+        mapperProvider.setJsonSerializers(ImmutableMap.of(Expression.class, new Serialization.ExpressionSerializer()));
+        mapperProvider.setJsonDeserializers(ImmutableMap.of(Expression.class, new Serialization.ExpressionDeserializer(new SqlParser())));
+        jsonCodecFactory = new JsonCodecFactory(mapperProvider);
+    }
+
+    @AfterClass
+    public void tearDown()
+            throws Exception
+    {
+        jsonCodecFactory = null;
+    }
+
+    @Test
+    public void testDeferredSymbolReference()
+            throws Exception
+    {
+        assertJsonSerialization(new DeferredSymbolReference("source", "name"));
+    }
+
+    @Test
+    public void testSymbolReference()
+            throws Exception
+    {
+        assertJsonSerialization(new SymbolReference("symbol"));
+    }
+
+    private void assertJsonSerialization(Expression expression)
+    {
+        JsonCodec<Expression> expressionCodec = jsonCodecFactory.jsonCodec(Expression.class);
+        assertEquals(expressionCodec.fromJson(expressionCodec.toJson(expression)), expression);
+        JsonCodec<ExpressionHolder> expressionHolderCodec = jsonCodecFactory.jsonCodec(ExpressionHolder.class);
+        assertEquals(expressionHolderCodec.fromJson(expressionHolderCodec.toJson(new ExpressionHolder(expression))), new ExpressionHolder(expression));
+        JsonCodec<List<Expression>> expressionListCodec = jsonCodecFactory.listJsonCodec(Expression.class);
+        assertEquals(expressionListCodec.fromJson(expressionListCodec.toJson(ImmutableList.of(expression))), ImmutableList.of(expression));
+        assertEquals(expressionListCodec.fromJson(expressionListCodec.toJson(ImmutableList.of(expression, expression))), ImmutableList.of(expression, expression));
+    }
+
+    public static class ExpressionHolder
+    {
+        private final Expression expression;
+
+        @JsonCreator
+        public ExpressionHolder(@JsonProperty("expression") Expression expression)
+        {
+            this.expression = requireNonNull(expression, "expression is null");
+        }
+
+        @JsonProperty("expression")
+        public Expression getExpression()
+        {
+            return expression;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ExpressionHolder that = (ExpressionHolder) o;
+            return Objects.equals(expression, that.expression);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(expression);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("expression", expression)
+                    .toString();
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -74,6 +74,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.ExpressionUtils.and;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.or;
+import static com.facebook.presto.sql.planner.DynamicFilter.createEmptyDynamicFilter;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static org.testng.Assert.assertEquals;
@@ -462,7 +463,8 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                createEmptyDynamicFilter());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
 
@@ -528,7 +530,8 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                createEmptyDynamicFilter());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
 
@@ -588,7 +591,8 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                createEmptyDynamicFilter());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
 
@@ -651,7 +655,8 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                createEmptyDynamicFilter());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
 
@@ -710,7 +715,8 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                createEmptyDynamicFilter());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node, TYPES);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/DynamicFilterMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/DynamicFilterMatcher.java
@@ -1,0 +1,76 @@
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.sql.planner.DynamicFilter;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.JoinNode.EquiJoinClause;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterMatcher
+{
+    private final String source;
+    private final List<ExpectedValueProvider<EquiJoinClause>> criteria;
+
+    private Map<String, String> expectedMappings;
+
+    public DynamicFilterMatcher(String source, List<ExpectedValueProvider<EquiJoinClause>> criteria)
+    {
+        this.source = requireNonNull(source, "source is null");
+        this.criteria = ImmutableList.copyOf(requireNonNull(criteria, "criteria is null"));
+    }
+
+    public MatchResult match(JoinNode joinNode)
+    {
+        DynamicFilter dynamicFilter = joinNode.getDynamicFilter();
+        if (!source.equals(dynamicFilter.getSource())) {
+            return new MatchResult(false);
+        }
+    }
+
+    public MatchResult match(FilterNode filterNode)
+    {
+        List<Expression> conjunts = extractConjuncts(filterNode.getPredicate());
+        List<ComparisonExpression> equalityPredicates = conjunts.stream()
+                .filter(expression -> expression instanceof ComparisonExpression)
+                .map(ComparisonExpression.class::cast)
+                .filter(comparisonExpression -> comparisonExpression.getType() == EQUAL)
+                .collect(toImmutableList());
+        List<ComparisonExpression> relatedPredicates = equalityPredicates.stream()
+                .filter(predicate -> predicate.getLeft() instanceof DeferredSymbolReference)
+                .filter(relatedPredicates(source))
+                .collect(toImmutableList());
+    }
+
+    private static Predicate<ComparisonExpression> relatedPredicates(String source)
+    {
+        return comparisonExpression -> {
+            Expression right = comparisonExpression.getRight();
+            if (!(right instanceof DeferredSymbolReference)) {
+                return false;
+            }
+            DeferredSymbolReference reference = (DeferredSymbolReference) right;
+            if (!reference.getSource().equals(source)) {
+                return false;
+            }
+
+            return;
+        };
+    }
+
+    private boolean matchMappings(Map<String, String> expectedMappings)
+    {
+
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
 import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.GenericLiteral;
@@ -269,6 +270,20 @@ final class ExpressionVerifier
             return false;
         }
         return symbolAliases.get(((SymbolReference) expected).getName()).equals(actual);
+    }
+
+    @Override
+    protected Boolean visitDeferredSymbolReference(DeferredSymbolReference actual, Expression expected)
+    {
+        if (!(expected instanceof DeferredSymbolReference)) {
+            return false;
+        }
+
+        if (!actual.getSource().equals(((DeferredSymbolReference) expected).getSource())) {
+            return false;
+        }
+
+        return true;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -294,7 +294,12 @@ public final class PlanMatchPattern
     public static PlanMatchPattern filter(String predicate, PlanMatchPattern source)
     {
         Expression expectedPredicate = rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(predicate));
-        return node(FilterNode.class, source).with(new FilterMatcher(expectedPredicate));
+        return filter(expectedPredicate, source);
+    }
+
+    public static PlanMatchPattern filter(Expression expression, PlanMatchPattern source)
+    {
+        return node(FilterNode.class, source).with(new FilterMatcher(expression));
     }
 
     public static PlanMatchPattern apply(List<String> correlationSymbolAliases, Map<String, ExpressionMatcher> subqueryAssignments, PlanMatchPattern inputPattern, PlanMatchPattern subqueryPattern)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestApplyDynamicFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestApplyDynamicFilter.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.DynamicFilter;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
+
+public class TestApplyDynamicFilter
+{
+    private RuleTester tester;
+
+    @BeforeClass
+    public void setUp()
+    {
+        tester = new RuleTester();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(tester);
+        tester = null;
+    }
+
+    @Test
+    public void testNotApplicable()
+            throws Exception
+    {
+        tester.assertThat(new ApplyDynamicFilter())
+                .on(p -> p.values(p.symbol("a", BIGINT)))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNonInnerJoin()
+            throws Exception
+    {
+        tester.assertThat(new ApplyDynamicFilter())
+                .on(p -> p.join(
+                        JoinNode.Type.LEFT,
+                        p.values(p.symbol("COL1", BIGINT)),
+                        p.values(p.symbol("COL2", BIGINT)),
+                        ImmutableList.of(new JoinNode.EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
+                        ImmutableList.of(new Symbol("COL1"), new Symbol("COL2")),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testEmptyJoinCriteria()
+            throws Exception
+    {
+        tester.assertThat(new ApplyDynamicFilter())
+                .on(p -> p.join(
+                        INNER,
+                        p.values(p.symbol("COL1", BIGINT)),
+                        p.values(p.symbol("COL2", BIGINT)),
+                        ImmutableList.of(),
+                        ImmutableList.of(new Symbol("COL1"), new Symbol("COL2")),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testAlreadyProcessed()
+            throws Exception
+    {
+        tester.assertThat(new ApplyDynamicFilter())
+                .on(p -> p.join(
+                        INNER,
+                        p.values(p.symbol("COL1", BIGINT)),
+                        p.values(p.symbol("COL2", BIGINT)),
+                        ImmutableList.of(new JoinNode.EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
+                        ImmutableList.of(new Symbol("COL1"), new Symbol("COL2")),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        new DynamicFilter("dynamic_filter", ImmutableMap.of(new Symbol("COL2"), new Symbol("COL2_ALIAS")))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testSingleJoinCondition()
+            throws Exception
+    {
+        tester.assertThat(new ApplyDynamicFilter())
+                .on(p -> p.join(
+                        INNER,
+                        p.values(p.symbol("COL1", BIGINT)),
+                        p.values(p.symbol("COL2", BIGINT)),
+                        ImmutableList.of(new JoinNode.EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
+                        ImmutableList.of(new Symbol("COL1"), new Symbol("COL2")),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        new DynamicFilter("dynamic_filter", ImmutableMap.of())))
+                .matches(
+                        join(
+                                INNER,
+                                ImmutableList.of(equiJoinClause("COL1", "COL2")),
+                                filter(combineConjuncts(
+                                        new ComparisonExpression(
+                                                EQUAL,
+                                                new SymbolReference("COL1"),
+                                                new DeferredSymbolReference("dynamic_filter", "wat"))),
+                                        values("COL1")),
+                                values("COL2")));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
@@ -37,6 +37,7 @@ import java.util.function.Function;
 
 import static com.facebook.presto.SystemSessionProperties.REORDER_JOINS;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.DynamicFilter.createEmptyDynamicFilter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
@@ -294,7 +295,8 @@ public class TestEliminateCrossJoins
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                createEmptyDynamicFilter());
     }
 
     private ValuesNode values(String... symbols)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.ExpressionUtils;
 import com.facebook.presto.sql.analyzer.TypeSignatureProvider;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.DynamicFilter;
 import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
@@ -370,7 +371,21 @@ public class PlanBuilder
             Optional<Symbol> leftHashSymbol,
             Optional<Symbol> rightHashSymbol)
     {
-        return new JoinNode(idAllocator.getNextId(), type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, Optional.empty(), createEmptyDynamicFilter());
+        return join(type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, createEmptyDynamicFilter());
+    }
+
+    public JoinNode join(
+            JoinNode.Type type,
+            PlanNode left,
+            PlanNode right,
+            List<JoinNode.EquiJoinClause> criteria,
+            List<Symbol> outputSymbols,
+            Optional<Expression> filter,
+            Optional<Symbol> leftHashSymbol,
+            Optional<Symbol> rightHashSymbol,
+            DynamicFilter dynamicFilter)
+    {
+        return new JoinNode(idAllocator.getNextId(), type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, Optional.empty(), dynamicFilter);
     }
 
     public UnionNode union(List<? extends PlanNode> sources, ListMultimap<Symbol, Symbol> outputsToInputs, List<Symbol> outputs)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -65,6 +65,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.sql.planner.DynamicFilter.createEmptyDynamicFilter;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -268,8 +269,8 @@ public class PlanBuilder
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty()
-        );
+                Optional.empty(),
+                createEmptyDynamicFilter());
     }
 
     public ExchangeNode exchange(Consumer<ExchangeBuilder> exchangeBuilderConsumer)
@@ -369,7 +370,7 @@ public class PlanBuilder
             Optional<Symbol> leftHashSymbol,
             Optional<Symbol> rightHashSymbol)
     {
-        return new JoinNode(idAllocator.getNextId(), type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, Optional.empty());
+        return new JoinNode(idAllocator.getNextId(), type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, Optional.empty(), createEmptyDynamicFilter());
     }
 
     public UnionNode union(List<? extends PlanNode> sources, ListMultimap<Symbol, Symbol> outputsToInputs, List<Symbol> outputs)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -30,6 +30,7 @@ import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.CurrentTime;
 import com.facebook.presto.sql.tree.DecimalLiteral;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.ExistsPredicate;
@@ -301,6 +302,14 @@ public final class ExpressionFormatter
         protected String visitSymbolReference(SymbolReference node, Void context)
         {
             return formatIdentifier(node.getName());
+        }
+
+        @Override
+        protected String visitDeferredSymbolReference(DeferredSymbolReference node, Void context)
+        {
+            return "\"$INTERNAL$DEFERRED_SYMBOL_REFERENCE\"(" +
+                    formatIdentifier(node.getSource()) + ", " +
+                    formatIdentifier(node.getName()) + ")";
         }
 
         @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -667,6 +667,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitDeferredSymbolReference(DeferredSymbolReference node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, C context)
     {
         return visitExpression(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DeferredSymbolReference.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DeferredSymbolReference.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class DeferredSymbolReference
+        extends Expression
+{
+    private final String source;
+    private final String name;
+
+    public DeferredSymbolReference(String source, String name)
+    {
+        super(Optional.empty());
+        this.source = requireNonNull(source, "source is null");
+        this.name = requireNonNull(name, "name is null");
+    }
+
+    public String getSource()
+    {
+        return source;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitDeferredSymbolReference(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DeferredSymbolReference that = (DeferredSymbolReference) o;
+        return Objects.equals(source, that.source) &&
+                Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(source, name);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/AllOrNoneValueSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/AllOrNoneValueSet.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.predicate;
 
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -88,6 +89,12 @@ public class AllOrNoneValueSet
         if (!Primitives.wrap(type.getJavaType()).isInstance(value)) {
             throw new IllegalArgumentException(String.format("Value class %s does not match required Type class %s", value.getClass().getName(), Primitives.wrap(type.getJavaType()).getClass().getName()));
         }
+        return all;
+    }
+
+    @Override
+    public boolean containsValue(Block block, int position)
+    {
         return all;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/Domain.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/Domain.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.predicate;
 
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -164,6 +165,11 @@ public final class Domain
     public boolean includesNullableValue(Object value)
     {
         return value == null ? nullAllowed : values.containsValue(value);
+    }
+
+    public boolean includesNullableValue(Block block, int position)
+    {
+        return block.isNull(position) ? nullAllowed : values.containsValue(block, position);
     }
 
     public boolean overlaps(Domain other)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/EquatableValueSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/EquatableValueSet.java
@@ -153,6 +153,12 @@ public class EquatableValueSet
     }
 
     @Override
+    public boolean containsValue(Block block, int position)
+    {
+        return whiteList == entries.contains(ValueEntry.create(type, block, position));
+    }
+
+    @Override
     public DiscreteValues getDiscreteValues()
     {
         return new DiscreteValues()
@@ -292,66 +298,5 @@ public class EquatableValueSet
         return Objects.equals(this.type, other.type)
                 && this.whiteList == other.whiteList
                 && Objects.equals(this.entries, other.entries);
-    }
-
-    public static class ValueEntry
-    {
-        private final Type type;
-        private final Block block;
-
-        @JsonCreator
-        public ValueEntry(
-                @JsonProperty("type") Type type,
-                @JsonProperty("block") Block block)
-        {
-            this.type = requireNonNull(type, "type is null");
-            this.block = requireNonNull(block, "block is null");
-
-            if (block.getPositionCount() != 1) {
-                throw new IllegalArgumentException("Block should only have one position");
-            }
-        }
-
-        public static ValueEntry create(Type type, Object value)
-        {
-            return new ValueEntry(type, Utils.nativeValueToBlock(type, value));
-        }
-
-        @JsonProperty
-        public Type getType()
-        {
-            return type;
-        }
-
-        @JsonProperty
-        public Block getBlock()
-        {
-            return block;
-        }
-
-        public Object getValue()
-        {
-            return Utils.blockToNativeValue(type, block);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return (int) type.hash(block, 0);
-        }
-
-        @Override
-        public boolean equals(Object obj)
-        {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null || getClass() != obj.getClass()) {
-                return false;
-            }
-            final ValueEntry other = (ValueEntry) obj;
-            return Objects.equals(this.type, other.type)
-                    && type.equalTo(this.block, 0, other.block, 0);
-        }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/SortedRangeSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/SortedRangeSet.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.predicate;
 
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -159,6 +160,12 @@ public final class SortedRangeSet
     public boolean containsValue(Object value)
     {
         return includesMarker(Marker.exactly(type, value));
+    }
+
+    @Override
+    public boolean containsValue(Block block, int position)
+    {
+        return includesMarker(Marker.exactly(type, block, position));
     }
 
     boolean includesMarker(Marker marker)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/ValueEntry.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/ValueEntry.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.predicate;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class ValueEntry
+        implements Comparable<ValueEntry>
+{
+    private final Type type;
+    private final Block block;
+    private final int position;
+
+    public ValueEntry(Type type, Block block)
+    {
+        this(type, block, 0);
+    }
+
+    @JsonCreator
+    public ValueEntry(
+            @JsonProperty("type") Type type,
+            @JsonProperty("block") Block block,
+            @JsonProperty("position") int position)
+    {
+        this.type = requireNonNull(type, "type is null");
+        this.block = requireNonNull(block, "block is null");
+        this.position = position;
+    }
+
+    public static ValueEntry create(Type type, Object value)
+    {
+        return new ValueEntry(type, Utils.nativeValueToBlock(type, value));
+    }
+
+    public static ValueEntry create(Type type, Block block, int position)
+    {
+        return new ValueEntry(type, block, position);
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
+    public Block getBlock()
+    {
+        return block;
+    }
+
+    @JsonProperty
+    public int getPosition()
+    {
+        return position;
+    }
+
+    public Object getValue()
+    {
+        return Utils.blockToNativeValue(type, block);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return (int) type.hash(block, position);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final ValueEntry other = (ValueEntry) obj;
+        return Objects.equals(this.type, other.type)
+                && type.equalTo(this.block, this.position, other.block, other.position);
+    }
+
+    @Override
+    public int compareTo(ValueEntry that)
+    {
+        if (!this.type.equals(that.type)) {
+            throw new IllegalArgumentException(String.format("Mismatched types: %s vs %s", this.type, that.type));
+        }
+        return type.compareTo(this.block, this.position, that.block, that.position);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/ValueSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/ValueSet.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.predicate;
 
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -100,6 +101,8 @@ public interface ValueSet
     Object getSingleValue();
 
     boolean containsValue(Object value);
+
+    boolean containsValue(Block block, int position);
 
     /**
      * @return value predicates for equatable Types (but not orderable)

--- a/presto-spi/src/test/java/com/facebook/presto/spi/predicate/TestEquatableValueSet.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/predicate/TestEquatableValueSet.java
@@ -332,7 +332,7 @@ public class TestEquatableValueSet
     public void testUnmodifiableValueEntryIterator()
             throws Exception
     {
-        Iterator<EquatableValueSet.ValueEntry> iterator = EquatableValueSet.of(ID, 1L).getEntries().iterator();
+        Iterator<ValueEntry> iterator = EquatableValueSet.of(ID, 1L).getEntries().iterator();
         iterator.next();
         iterator.remove();
     }


### PR DESCRIPTION
General idea is to collect information on the build side of a join and use it on be probe side but pushed down as low as possible (preferably to the table scan).

First version of DPP would use one of the existing worker -> coordinator channels of communication (for instance `OperatorInfo`, `StageInfo` etc.).
Then, based on so called `DynamicFilterSummary` splits would get extra info on what can be pruned.

---

Dynamic filtering POC was presented in https://github.com/prestodb/presto/pull/8017.

CC: @dain