### PR TITLE
Remove recursive computeIfAbsent method call

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/PhasedExecutionSchedule.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/PhasedExecutionSchedule.java
@@ -184,7 +184,13 @@ public class PhasedExecutionSchedule
 
         public Set<PlanFragmentId> processFragment(PlanFragmentId planFragmentId)
         {
-            return fragmentSources.computeIfAbsent(planFragmentId, fragmentId -> processFragment(fragments.get(fragmentId)));
+            if (fragmentSources.containsKey(planFragmentId)) {
+                return fragmentSources.get(planFragmentId);
+            }
+
+            Set<PlanFragmentId> fragment = processFragment(fragments.get(planFragmentId));
+            fragmentSources.put(planFragmentId, fragment);
+            return fragment;
         }
 
         private Set<PlanFragmentId> processFragment(PlanFragment fragment)


### PR DESCRIPTION
Recursive computeIfAbsent (that modifies the same
collection) may corrupt HashMap,
see: http://bugs.java.com/bugdatabase/view_bug.do?bug_id=8172951

also see: https://github.com/Teradata/presto/pull/555#discussion_r117630317