### PR TITLE
Support user based authorization on tables in raptor

### DIFF
--- a/presto-main/etc/catalog/raptor.properties
+++ b/presto-main/etc/catalog/raptor.properties
@@ -11,3 +11,4 @@ metadata.db.filename=mem:raptor;DB_CLOSE_DELAY=-1
 #metadata.db.type=mysql
 #metadata.db.connections.max=500
 storage.data-directory=var/data
+security.enabled=false

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -217,7 +217,7 @@ public class InformationSchemaPageSourceProvider
         for (GrantInfo grant : grants) {
             for (PrivilegeInfo privilegeInfo : grant.getPrivilegeInfo()) {
                 table.add(
-                        grant.getGrantor().orElse(null),
+                        grant.getGrantor().isPresent() ? grant.getGrantor().get().getUser() : null,
                         grant.getIdentity().getUser(),
                         catalogName,
                         grant.getSchemaTableName().getSchemaName(),

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -51,7 +51,12 @@ public class TestingConnectorSession
 
     public TestingConnectorSession(List<PropertyMetadata<?>> properties)
     {
-        this("user", Optional.of("test"), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of());
+        this("user", properties);
+    }
+
+    public TestingConnectorSession(String user, List<PropertyMetadata<?>> properties)
+    {
+        this(user, Optional.of("test"), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of());
     }
 
     public TestingConnectorSession(

--- a/presto-raptor/pom.xml
+++ b/presto-raptor/pom.xml
@@ -43,6 +43,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>
@@ -184,6 +189,16 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <!-- for testing -->

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorAccessControl.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorAccessControl.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor;
+
+import com.facebook.presto.raptor.metadata.ForMetadata;
+import com.facebook.presto.raptor.metadata.MetadataDao;
+import com.facebook.presto.raptor.metadata.RaptorGrantInfo;
+import com.facebook.presto.raptor.metadata.RaptorPrivilegeInfo;
+import com.facebook.presto.raptor.metadata.RaptorPrivilegeInfo.RaptorPrivilege;
+import com.facebook.presto.raptor.security.IdentityManager;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.connector.ConnectorAccessControl;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo;
+import com.google.inject.Inject;
+import org.skife.jdbi.v2.IDBI;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.raptor.metadata.RaptorPrivilegeInfo.RaptorPrivilege.DELETE;
+import static com.facebook.presto.raptor.metadata.RaptorPrivilegeInfo.RaptorPrivilege.INSERT;
+import static com.facebook.presto.raptor.metadata.RaptorPrivilegeInfo.RaptorPrivilege.OWNERSHIP;
+import static com.facebook.presto.raptor.metadata.RaptorPrivilegeInfo.RaptorPrivilege.SELECT;
+import static com.facebook.presto.raptor.metadata.RaptorPrivilegeInfo.toRaptorPrivilege;
+import static com.facebook.presto.raptor.util.DatabaseUtil.onDemandDao;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateSchema;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateViewWithSelect;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDeleteTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropSchema;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyGrantTablePrivilege;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyInsertTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameColumn;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameSchema;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
+import static java.util.Objects.requireNonNull;
+
+public class RaptorAccessControl
+        implements ConnectorAccessControl
+{
+    private static final String INFORMATION_SCHEMA_NAME = "information_schema";
+
+    private final MetadataDao dao;
+    private final IdentityManager identityManager;
+    private final String connectorId;
+
+    @Inject
+    public RaptorAccessControl(@ForMetadata IDBI dbi, IdentityManager identityManager, RaptorConnectorId connectorId)
+    {
+        this.dao = onDemandDao(dbi, MetadataDao.class);
+        this.identityManager = requireNonNull(identityManager, "identityManager is null");
+        this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
+    }
+
+    public void checkCanCreateSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+        if (!isAdmin(transactionHandle, identity)) {
+            denyCreateSchema(schemaName);
+        }
+    }
+
+    public void checkCanDropSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+        if (!isSchemaOwner(transactionHandle, identity, schemaName)) {
+            denyDropSchema(schemaName);
+        }
+    }
+
+    public void checkCanRenameSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName, String newSchemaName)
+    {
+        if (!isAdmin(transactionHandle, identity) || !isSchemaOwner(transactionHandle, identity, schemaName)) {
+            denyRenameSchema(schemaName, newSchemaName);
+        }
+    }
+
+    public void checkCanShowSchemas(ConnectorTransactionHandle transactionHandle, Identity identity)
+    {
+    }
+
+    public Set<String> filterSchemas(ConnectorTransactionHandle transactionHandle, Identity identity, Set<String> schemaNames)
+    {
+        return schemaNames;
+    }
+
+    public void checkCanCreateTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        if (!isSchemaOwner(transactionHandle, identity, tableName.getSchemaName())) {
+            denyCreateTable(tableName.toString());
+        }
+    }
+
+    public void checkCanDropTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTablePermission(transactionHandle, identity, tableName, OWNERSHIP)) {
+            denyDropTable(tableName.toString());
+        }
+    }
+
+    public void checkCanRenameTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName, SchemaTableName newTableName)
+    {
+        if (!checkTablePermission(transactionHandle, identity, tableName, OWNERSHIP)) {
+            denyRenameTable(tableName.toString(), newTableName.toString());
+        }
+    }
+
+    public void checkCanShowTablesMetadata(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+    }
+
+    public Set<SchemaTableName> filterTables(ConnectorTransactionHandle transactionHandle, Identity identity, Set<SchemaTableName> tableNames)
+    {
+        return tableNames;
+    }
+
+    public void checkCanAddColumn(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTablePermission(transactionHandle, identity, tableName, OWNERSHIP)) {
+            denyAddColumn(tableName.toString());
+        }
+    }
+
+    public void checkCanRenameColumn(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTablePermission(transactionHandle, identity, tableName, OWNERSHIP)) {
+            denyRenameColumn(tableName.toString());
+        }
+    }
+
+    public void checkCanSelectFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTablePermission(transactionHandle, identity, tableName, SELECT)) {
+            denySelectTable(tableName.toString());
+        }
+    }
+
+    public void checkCanInsertIntoTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTablePermission(transactionHandle, identity, tableName, INSERT)) {
+            denyInsertTable(tableName.toString());
+        }
+    }
+
+    public void checkCanDeleteFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTablePermission(transactionHandle, identity, tableName, DELETE)) {
+            denyDeleteTable(tableName.toString());
+        }
+    }
+
+    public void checkCanCreateView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
+    {
+        if (!isSchemaOwner(transactionHandle, identity, viewName.getSchemaName())) {
+            denyCreateView(viewName.toString());
+        }
+    }
+
+    public void checkCanDropView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
+    {
+        // todo: add check for this
+    }
+
+    public void checkCanSelectFromView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
+    {
+        // todo: add check for this
+    }
+
+    public void checkCanCreateViewWithSelectFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTablePermission(transactionHandle, identity, tableName, SELECT)) {
+            denySelectTable(tableName.toString());
+        }
+        else if (!getGrantOptionForPrivilege(transactionHandle, identity, Privilege.SELECT, tableName)) {
+            denyCreateViewWithSelect(tableName.toString());
+        }
+    }
+
+    public void checkCanCreateViewWithSelectFromView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
+    {
+        // todo: add check for this
+    }
+
+    public void checkCanSetCatalogSessionProperty(Identity identity, String propertyName)
+    {
+        if (!isAdmin(null, identity)) {
+            denySetCatalogSessionProperty(connectorId, propertyName);
+        }
+    }
+
+    public void checkCanGrantTablePrivilege(ConnectorTransactionHandle transactionHandle, Identity identity, Privilege privilege, SchemaTableName tableName)
+    {
+        if (checkTablePermission(transactionHandle, identity, tableName, OWNERSHIP)) {
+            return;
+        }
+
+        RaptorPrivilegeInfo.RaptorPrivilege raptorPrivilege = toRaptorPrivilege(privilege);
+        if (raptorPrivilege == null || !getGrantOptionForPrivilege(transactionHandle, identity, privilege, tableName)) {
+            denyGrantTablePrivilege(privilege.name(), tableName.toString());
+        }
+    }
+
+    public void checkCanRevokeTablePrivilege(ConnectorTransactionHandle transactionHandle, Identity identity, Privilege privilege, SchemaTableName tableName)
+    {
+        if (checkTablePermission(transactionHandle, identity, tableName, OWNERSHIP)) {
+            return;
+        }
+
+        RaptorPrivilegeInfo.RaptorPrivilege raptorPrivilege = toRaptorPrivilege(privilege);
+        if (raptorPrivilege == null || !getGrantOptionForPrivilege(transactionHandle, identity, privilege, tableName)) {
+            denyRevokeTablePrivilege(privilege.name(), tableName.toString());
+        }
+    }
+
+    private boolean checkTablePermission(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName, RaptorPrivilegeInfo.RaptorPrivilege... requiredPrivileges)
+    {
+        if (INFORMATION_SCHEMA_NAME.equals(tableName.getSchemaName())) {
+            return true;
+        }
+
+        List<RaptorGrantInfo> raptorGrantInfos = dao.getGrantInfos(tableName.getSchemaName(), tableName.getTableName(), identity.getUser());
+
+        long maskOnFile = raptorGrantInfos.stream()
+                .map(RaptorGrantInfo::getPrivilegeInfo)
+                .flatMap(Set::stream)
+                .map(RaptorPrivilegeInfo::getRaptorPrivilege)
+                .mapToLong(RaptorPrivilege::getMaskValue)
+                .reduce(0, (a, b) -> a | b);
+
+        long maskRequired = Arrays.stream(requiredPrivileges)
+                .mapToLong(RaptorPrivilege::getMaskValue)
+                .reduce(0, (a, b) -> a | b);
+
+        return maskOnFile != 0 &&
+                (maskOnFile & maskRequired) == maskRequired;
+    }
+
+    private boolean getGrantOptionForPrivilege(ConnectorTransactionHandle transaction, Identity identity, Privilege privilege, SchemaTableName tableName)
+    {
+        List<RaptorGrantInfo> grantInfos = dao.getGrantInfos(tableName.getSchemaName(), tableName.getTableName(), identity.getUser());
+
+        if (grantInfos == null) {
+            return false;
+        }
+
+        Set<PrivilegeInfo> privileges = grantInfos.stream()
+                .map(RaptorGrantInfo::getPrivilegeInfo)
+                .flatMap(Set::stream)
+                .map(RaptorPrivilegeInfo::toPrivilegeInfo)
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
+
+        return privileges.contains(new PrivilegeInfo(privilege, true));
+    }
+
+    private boolean isAdmin(ConnectorTransactionHandle transaction, Identity identity)
+    {
+        return identityManager.isAdmin(transaction, identity);
+    }
+
+    private boolean isSchemaOwner(ConnectorTransactionHandle transaction, Identity identity, String schemaName)
+    {
+        return identityManager.isSchemaOwner(transaction, identity, schemaName);
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnectorFactory.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnectorFactory.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.raptor;
 
 import com.facebook.presto.raptor.backup.BackupModule;
+import com.facebook.presto.raptor.security.SecurityModule;
 import com.facebook.presto.raptor.storage.StorageModule;
 import com.facebook.presto.raptor.util.RebindSafeMBeanServer;
 import com.facebook.presto.spi.ConnectorHandleResolver;
@@ -85,6 +86,7 @@ public class RaptorConnectorFactory
                     metadataModule,
                     new BackupModule(backupProviders),
                     new StorageModule(connectorId),
+                    new SecurityModule(),
                     new RaptorModule(connectorId));
 
             Injector injector = app

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
@@ -39,6 +39,12 @@ public interface MetadataDao
             "FROM tables t\n" +
             "JOIN columns c ON (t.table_id = c.table_id)\n";
 
+    String TABLE_PREVILEGE_SELECT = "" +
+            "SELECT t.schema_name, t.table_name,\n" +
+            "  p.grantor, p.grantee, p.privilege_mask, p.is_grantable, p.with_hierarchy\n" +
+            "FROM tables t\n" +
+            "JOIN table_privileges p ON (t.table_id = p.table_id)\n";
+
     @SqlQuery(TABLE_INFORMATION_SELECT +
             "WHERE t.table_id = :tableId")
     @Mapper(TableMapper.class)
@@ -310,4 +316,22 @@ public interface MetadataDao
     @SqlUpdate("UPDATE tables SET maintenance_blocked = NULL\n" +
             "WHERE maintenance_blocked IS NOT NULL")
     void unblockAllMaintenance();
+
+    @SqlQuery(TABLE_PREVILEGE_SELECT +
+            "WHERE t.schema_name = :schemaName\n" +
+            "  AND t.table_name = :tableName\n" +
+            "  AND p.grantee = :grantee")
+    @Mapper(RaptorGrantInfo.Mapper.class)
+    List<RaptorGrantInfo> getGrantInfos(@Bind("schemaName") String schemaName, @Bind("tableName") String tableName, @Bind("grantee") String grantee);
+
+    @SqlUpdate("REPLACE INTO table_privileges (table_id, grantee, grantor, privilege_mask, is_grantable, with_hierarchy)\n" +
+            "VALUES (:tableId, :grantee, :grantor, :privilegeMask, :isGrantable, :withHierarchy)")
+    void insertTablePrivileges(@Bind("tableId") long tableId, @Bind("grantee") String grantee, @Bind("grantor") String grantor,
+            @Bind("privilegeMask") long privilegeMask, @Bind("isGrantable") boolean isGrantable, @Bind("withHierarchy") boolean withHierarchy);
+
+    @SqlUpdate("DELETE from table_privileges\n" +
+            "WHERE table_id = :tableId\n" +
+            "  AND grantee = :grantee\n" +
+            "  AND privilege_mask = :privilegeMask")
+    void removeTablePrivileges(@Bind("tableId") long tableId, @Bind("grantee") String grantee, @Bind("privilegeMask") long privilegeMask);
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
@@ -324,6 +324,12 @@ public interface MetadataDao
     @Mapper(RaptorGrantInfo.Mapper.class)
     List<RaptorGrantInfo> getGrantInfos(@Bind("schemaName") String schemaName, @Bind("tableName") String tableName, @Bind("grantee") String grantee);
 
+    @SqlQuery(TABLE_PREVILEGE_SELECT +
+            "WHERE t.schema_name = :schemaName\n" +
+            "  AND t.table_name = :tableName")
+    @Mapper(RaptorGrantInfo.Mapper.class)
+    List<RaptorGrantInfo> getGrantInfos(@Bind("schemaName") String schemaName, @Bind("tableName") String tableName);
+
     @SqlUpdate("REPLACE INTO table_privileges (table_id, grantee, grantor, privilege_mask, is_grantable, with_hierarchy)\n" +
             "VALUES (:tableId, :grantee, :grantor, :privilegeMask, :isGrantable, :withHierarchy)")
     void insertTablePrivileges(@Bind("tableId") long tableId, @Bind("grantee") String grantee, @Bind("grantor") String grantor,

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/RaptorGrantInfo.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/RaptorGrantInfo.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.metadata;
+
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.security.GrantInfo;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.PrivilegeInfo;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+public class RaptorGrantInfo
+{
+    private final Set<RaptorPrivilegeInfo> privilegeInfo;
+    private final Identity grantee;
+    private final SchemaTableName schemaTableName;
+    private final Optional<Identity> grantor;
+    private final Optional<Boolean> withHierarchy;
+
+    public RaptorGrantInfo(Set<RaptorPrivilegeInfo> privilegeInfo, Identity grantee, SchemaTableName schemaTableName, Optional<Identity> grantor, Optional<Boolean> withHierarchy)
+    {
+        this.privilegeInfo = requireNonNull(privilegeInfo, "privilegeInfo is null");
+        this.grantee = requireNonNull(grantee, "grantee is null");
+        this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
+        this.grantor = requireNonNull(grantor, "grantor is null");
+        this.withHierarchy = requireNonNull(withHierarchy, "withHierarchy is null");
+    }
+
+    public Set<RaptorPrivilegeInfo> getPrivilegeInfo()
+    {
+        return privilegeInfo;
+    }
+
+    public Identity getGrantee()
+    {
+        return grantee;
+    }
+
+    public SchemaTableName getSchemaTableName()
+    {
+        return schemaTableName;
+    }
+
+    public Optional<Identity> getGrantor()
+    {
+        return grantor;
+    }
+
+    public Optional<Boolean> getWithHierarchy()
+    {
+        return withHierarchy;
+    }
+
+    public GrantInfo toGrantInfo()
+    {
+        Set<PrivilegeInfo> privileges = privilegeInfo.stream()
+                .map(RaptorPrivilegeInfo::toPrivilegeInfo)
+                .flatMap(Set::stream)
+                .collect(toImmutableSet());
+
+        return new GrantInfo(privileges, grantee, schemaTableName, grantor, withHierarchy);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(privilegeInfo, grantee, schemaTableName, grantor, withHierarchy);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        com.facebook.presto.spi.security.GrantInfo grantInfo = (com.facebook.presto.spi.security.GrantInfo) o;
+        return Objects.equals(privilegeInfo, grantInfo.getPrivilegeInfo()) &&
+                Objects.equals(grantee, grantInfo.getIdentity()) &&
+                Objects.equals(schemaTableName, grantInfo.getSchemaTableName()) &&
+                Objects.equals(grantor, grantInfo.getGrantor()) &&
+                Objects.equals(withHierarchy, grantInfo.getWithHierarchy());
+    }
+
+    public static class Mapper
+            implements ResultSetMapper<RaptorGrantInfo>
+    {
+        @Override
+        public RaptorGrantInfo map(int index, ResultSet r, StatementContext ctx)
+                throws SQLException
+        {
+            int privilegeMask = r.getInt("privilege_mask");
+            boolean grantOption = r.getBoolean("is_grantable");
+            Set<RaptorPrivilegeInfo> privileges = RaptorPrivilegeInfo.fromMaskValue(privilegeMask, grantOption);
+
+            SchemaTableName name = new SchemaTableName(
+                    r.getString("schema_name"),
+                    r.getString("table_name"));
+
+            Identity grantee = r.getString("grantee") == null ? null : new Identity(r.getString("grantee"), Optional.empty());
+            Identity grantor = r.getString("grantor") == null ? null : new Identity(r.getString("grantor"), Optional.empty());
+
+            return new RaptorGrantInfo(privileges,
+                    grantee,
+                    name,
+                    Optional.ofNullable(grantor),
+                    Optional.ofNullable(r.getBoolean("with_hierarchy")));
+        }
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/RaptorPrivilegeInfo.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/RaptorPrivilegeInfo.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.metadata;
+
+import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.raptor.metadata.RaptorPrivilegeInfo.RaptorPrivilege.DELETE;
+import static com.facebook.presto.raptor.metadata.RaptorPrivilegeInfo.RaptorPrivilege.INSERT;
+import static com.facebook.presto.raptor.metadata.RaptorPrivilegeInfo.RaptorPrivilege.OWNERSHIP;
+import static com.facebook.presto.raptor.metadata.RaptorPrivilegeInfo.RaptorPrivilege.SELECT;
+import static com.facebook.presto.raptor.metadata.RaptorPrivilegeInfo.RaptorPrivilege.UPDATE;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class RaptorPrivilegeInfo
+{
+    private final RaptorPrivilege raptorPrivilege;
+    private final boolean grantOption;
+    public RaptorPrivilegeInfo(RaptorPrivilege raptorPrivilege, boolean grantOption)
+    {
+        this.raptorPrivilege = requireNonNull(raptorPrivilege, "raptorPrivilege is null");
+        this.grantOption = grantOption;
+    }
+
+    public static RaptorPrivilege toRaptorPrivilege(Privilege privilege)
+    {
+        switch (privilege) {
+            case SELECT:
+                return SELECT;
+            case INSERT:
+                return INSERT;
+            case DELETE:
+                return DELETE;
+            case UPDATE:
+                return UPDATE;
+        }
+        return null;
+    }
+
+    public static Set<RaptorPrivilegeInfo> fromMaskValue(long maskValue, boolean grantOption)
+    {
+        ImmutableSet.Builder<RaptorPrivilegeInfo> privileges = ImmutableSet.builder();
+        if (SELECT.contained(maskValue)) {
+            privileges.add(new RaptorPrivilegeInfo(SELECT, grantOption));
+        }
+        if (DELETE.contained(maskValue)) {
+            privileges.add(new RaptorPrivilegeInfo(DELETE, grantOption));
+        }
+        if (INSERT.contained(maskValue)) {
+            privileges.add(new RaptorPrivilegeInfo(INSERT, grantOption));
+        }
+        if (UPDATE.contained(maskValue)) {
+            privileges.add(new RaptorPrivilegeInfo(UPDATE, grantOption));
+        }
+        if (OWNERSHIP.contained(maskValue)) {
+            privileges.add(new RaptorPrivilegeInfo(OWNERSHIP, grantOption));
+        }
+
+        return privileges.build();
+    }
+
+    public static long toMaskValue(Set<RaptorPrivilegeInfo> privileges)
+    {
+        long mask = 0;
+        for (RaptorPrivilegeInfo privilege : privileges) {
+            mask |= privilege.getRaptorPrivilege().getMaskValue();
+        }
+
+        return mask;
+    }
+
+    public RaptorPrivilege getRaptorPrivilege()
+    {
+        return raptorPrivilege;
+    }
+
+    public boolean isGrantOption()
+    {
+        return grantOption;
+    }
+
+    public Set<PrivilegeInfo> toPrivilegeInfo()
+    {
+        switch (getRaptorPrivilege()) {
+            case SELECT:
+                return ImmutableSet.of(new PrivilegeInfo(Privilege.SELECT, isGrantOption()));
+            case INSERT:
+                return ImmutableSet.of(new PrivilegeInfo(Privilege.INSERT, isGrantOption()));
+            case DELETE:
+                return ImmutableSet.of(new PrivilegeInfo(Privilege.DELETE, isGrantOption()));
+            case UPDATE:
+                return ImmutableSet.of(new PrivilegeInfo(Privilege.UPDATE, isGrantOption()));
+            case OWNERSHIP:
+                return Arrays.asList(Privilege.values()).stream()
+                        .map(privilege -> new PrivilegeInfo(privilege, Boolean.TRUE))
+                        .collect(Collectors.toSet());
+        }
+        return null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(raptorPrivilege, grantOption);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RaptorPrivilegeInfo ratporPrivilegeInfo = (RaptorPrivilegeInfo) o;
+        return Objects.equals(raptorPrivilege, ratporPrivilegeInfo.raptorPrivilege) &&
+                Objects.equals(grantOption, ratporPrivilegeInfo.grantOption);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("privilege", raptorPrivilege)
+                .add("grantOption", grantOption)
+                .toString();
+    }
+
+    public enum RaptorPrivilege
+    {
+        SELECT(1),      // 0001
+        INSERT(2),      // 0010
+        UPDATE(4),      // 0100
+        DELETE(8),      // 1000
+        OWNERSHIP(31);  // 1111
+
+        private final long maskValue;
+
+        RaptorPrivilege(long maskValue)
+        {
+            this.maskValue = maskValue;
+        }
+
+        public long getMaskValue()
+        {
+            return maskValue;
+        }
+
+        public boolean contained(long maskValue)
+        {
+            return (this.maskValue & maskValue) == this.maskValue;
+        }
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/SchemaDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/SchemaDao.java
@@ -160,4 +160,16 @@ public interface SchemaDao
             "  FOREIGN KEY (table_id) REFERENCES tables (table_id)\n" +
             ")")
     void createTableShardOrganizerJobs();
+
+    @SqlUpdate("CREATE TABLE IF NOT EXISTS table_privileges (\n" +
+            "  table_id BIGINT NOT NULL,\n" +
+            "  grantee VARCHAR(255),\n" +
+            "  grantor VARCHAR(255),\n" +
+            "  privilege_mask BIGINT,\n" +
+            "  is_grantable BOOLEAN,\n" +
+            "  with_hierarchy BOOLEAN,\n" +
+            "  PRIMARY KEY (table_id, grantee, privilege_mask),\n" +
+            "  FOREIGN KEY (table_id) REFERENCES tables (table_id) ON DELETE CASCADE\n" +
+            ")")
+    void createTableTablePrivileges();
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/SchemaDaoUtil.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/SchemaDaoUtil.java
@@ -58,6 +58,7 @@ public final class SchemaDaoUtil
         dao.createTableDeletedShards();
         dao.createTableBuckets();
         dao.createTableShardOrganizerJobs();
+        dao.createTableTablePrivileges();
     }
 
     private static void sleep(Duration duration)

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/security/FileBasedIdentityConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/security/FileBasedIdentityConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.security;
+
+import io.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+public class FileBasedIdentityConfig
+{
+    private String groupsFileName;
+    private String schemaOwnersFileName;
+
+    @NotNull
+    public String getGroupsFileName()
+    {
+        return groupsFileName;
+    }
+
+    @Config("security.roles-file")
+    public FileBasedIdentityConfig setGroupsFileName(String groupsFileName)
+    {
+        this.groupsFileName = groupsFileName;
+        return this;
+    }
+
+    @NotNull
+    public String getSchemaOwnersFileName()
+    {
+        return schemaOwnersFileName;
+    }
+
+    @Config("security.schema-owners-file")
+    public FileBasedIdentityConfig setSchemaOwnersFileName(String schemaOwnersFileName)
+    {
+        this.schemaOwnersFileName = schemaOwnersFileName;
+        return this;
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/security/FileBasedIdentityManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/security/FileBasedIdentityManager.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.security;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.security.Identity;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_ERROR;
+
+public class FileBasedIdentityManager
+        implements IdentityManager
+{
+    private final Map<String, Role> roles;
+    private final Map<String, SchemaOwners> schemaOwners;
+
+    @Inject
+    public FileBasedIdentityManager(FileBasedIdentityConfig config)
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            this.roles = mapper.readValue(Paths.get(config.getGroupsFileName()).toFile(), new TypeReference<Map<String, Role>>() {});
+            this.schemaOwners = mapper.readValue(Paths.get(config.getSchemaOwnersFileName()).toFile(), new TypeReference<Map<String, SchemaOwners>>() {});
+        }
+        catch (IOException e) {
+            throw new PrestoException(RAPTOR_ERROR, "failed to load identity config", e);
+        }
+    }
+
+    @Override
+    public boolean belongsToRole(ConnectorTransactionHandle transaction, Identity identity, String role)
+    {
+        if (role.equalsIgnoreCase(PUBLIC_ROLE)) {
+            return true;
+        }
+
+        Role roleToCheck = roles.get(role);
+
+        return roleToCheck != null && roleToCheck.hasUser(identity.getUser());
+    }
+
+    @Override
+    public boolean isSchemaOwner(ConnectorTransactionHandle transaction, Identity identity, String schemaName)
+    {
+        SchemaOwners owners = schemaOwners.get(schemaName);
+        if (owners == null) {
+            return false;
+        }
+        if (owners.getUsers().contains(identity.getUser())) {
+            return true;
+        }
+
+        return owners.getRoles().stream()
+                .map(roles::get)
+                .anyMatch(g -> g != null && g.hasUser(identity.getUser()));
+    }
+
+    private static class Role
+    {
+        private final Set<String> users;
+
+        @JsonCreator
+        Role(@JsonProperty("users") Set<String> users)
+        {
+            this.users = users;
+        }
+
+        public Set<String> getUsers()
+        {
+            return users;
+        }
+
+        public boolean hasUser(String user)
+        {
+            return users.contains(user);
+        }
+    }
+
+    private static class SchemaOwners
+    {
+        private final Set<String> roles;
+        private final Set<String> users;
+
+        @JsonCreator
+        SchemaOwners(@JsonProperty("roles") Set<String> roles, @JsonProperty("users") Set<String> users)
+        {
+            this.roles = roles;
+            this.users = users;
+        }
+
+        public Set<String> getRoles()
+        {
+            return roles;
+        }
+
+        public Set<String> getUsers()
+        {
+            return users;
+        }
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/security/IdentityManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/security/IdentityManager.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.security;
+
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.security.Identity;
+
+public interface IdentityManager
+{
+    String ADMIN_ROLE = "admin";
+    String PUBLIC_ROLE = "public";
+
+    default boolean isAdmin(ConnectorTransactionHandle transaction, Identity identity)
+    {
+        return belongsToRole(transaction, identity, ADMIN_ROLE);
+    }
+
+    boolean belongsToRole(ConnectorTransactionHandle transaction, Identity identity, String role);
+
+    boolean isSchemaOwner(ConnectorTransactionHandle transaction, Identity identity, String schemaName);
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/security/SecurityConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/security/SecurityConfig.java
@@ -15,19 +15,35 @@ package com.facebook.presto.raptor.security;
 
 import io.airlift.configuration.Config;
 
+import javax.validation.constraints.NotNull;
+
 public class SecurityConfig
 {
     private boolean enabled;
+    private String identityManager = "file";
 
     public boolean isEnabled()
     {
         return enabled;
     }
 
+    @NotNull
+    public String getIdentityManager()
+    {
+        return identityManager;
+    }
+
     @Config("security.enabled")
     public SecurityConfig setEnabled(boolean enabled)
     {
         this.enabled = enabled;
+        return this;
+    }
+
+    @Config("security.identity-manager")
+    public SecurityConfig setIdentityManager(String identityManager)
+    {
+        this.identityManager = identityManager;
         return this;
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/security/SecurityConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/security/SecurityConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.security;
+
+import io.airlift.configuration.Config;
+
+public class SecurityConfig
+{
+    private boolean enabled;
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    @Config("security.enabled")
+    public SecurityConfig setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+        return this;
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/security/SecurityModule.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/security/SecurityModule.java
@@ -34,8 +34,15 @@ public class SecurityModule
                 SecurityConfig.class,
                 config -> config.isEnabled(),
                 binder -> {
-                    install(new FileBasedIdentityModule());
                     binder.bind(ConnectorAccessControl.class).to(RaptorAccessControl.class).in(Scopes.SINGLETON);
+                }));
+
+        install(installModuleIf(
+                SecurityConfig.class,
+                config -> config.isEnabled()
+                        && config.getIdentityManager().equalsIgnoreCase("file"),
+                binder -> {
+                    install(new FileBasedIdentityModule());
                 }));
 
         install(installModuleIf(

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/security/SecurityModule.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/security/SecurityModule.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.security;
+
+import com.facebook.presto.plugin.base.security.AllowAllAccessControl;
+import com.facebook.presto.raptor.RaptorAccessControl;
+import com.facebook.presto.spi.connector.ConnectorAccessControl;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+
+import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class SecurityModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder ignored)
+    {
+        install(installModuleIf(
+                SecurityConfig.class,
+                config -> config.isEnabled(),
+                binder -> {
+                    install(new FileBasedIdentityModule());
+                    binder.bind(ConnectorAccessControl.class).to(RaptorAccessControl.class).in(Scopes.SINGLETON);
+                }));
+
+        install(installModuleIf(
+                SecurityConfig.class,
+                config -> !config.isEnabled(),
+                binder -> {
+                    binder.bind(ConnectorAccessControl.class).to(AllowAllAccessControl.class).in(Scopes.SINGLETON);
+                }));
+    }
+
+    private static class FileBasedIdentityModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            configBinder(binder).bindConfig(FileBasedIdentityConfig.class);
+            binder.bind(IdentityManager.class).to(FileBasedIdentityManager.class).in(Scopes.SINGLETON);
+        }
+    }
+}

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorAccessControl.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorAccessControl.java
@@ -165,7 +165,7 @@ public class TestRaptorAccessControl
     @Test
     public void checkCanDropTable()
     {
-        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1), true);
 
         try {
             accessControl.checkCanDropTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
@@ -180,7 +180,7 @@ public class TestRaptorAccessControl
     @Test
     public void checkCanRenameTable()
     {
-        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1), true);
 
         try {
             accessControl.checkCanRenameTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1, TABLE_TEST2_TABLE2);
@@ -210,7 +210,7 @@ public class TestRaptorAccessControl
     @Test
     public void checkCanAddColumn()
     {
-        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1), true);
 
         try {
             accessControl.checkCanAddColumn(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
@@ -225,7 +225,7 @@ public class TestRaptorAccessControl
     @Test
     public void checkCanRenameColumn()
     {
-        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1), true);
 
         try {
             accessControl.checkCanRenameColumn(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
@@ -240,7 +240,7 @@ public class TestRaptorAccessControl
     @Test
     public void checkCanSelectFromTable()
     {
-        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1), true);
 
         try {
             accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
@@ -258,7 +258,7 @@ public class TestRaptorAccessControl
     @Test
     public void checkCanInsertIntoTable()
     {
-        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1), true);
 
         try {
             accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
@@ -276,7 +276,7 @@ public class TestRaptorAccessControl
     @Test
     public void checkCanDeleteFromTable()
     {
-        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1), true);
 
         try {
             accessControl.checkCanDeleteFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
@@ -307,7 +307,7 @@ public class TestRaptorAccessControl
     @Test
     public void checkCanGrantTablePrivilege()
     {
-        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1), true);
         accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER1, SELECT, TABLE_TEST1_TABLE1, USER2.getUser(), false);
 
         try {
@@ -332,7 +332,7 @@ public class TestRaptorAccessControl
     @Test
     public void checkCanRevokeTablePrivilege()
     {
-        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1), true);
         accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER1, SELECT, TABLE_TEST1_TABLE1, USER2.getUser(), false);
 
         try {
@@ -356,7 +356,7 @@ public class TestRaptorAccessControl
     @Test
     public void checkCanSelectFromTableByRole()
     {
-        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1), true);
 
         try {
             accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
@@ -373,7 +373,7 @@ public class TestRaptorAccessControl
     @Test
     public void checkCanSelectAndDeleteFromTableByRole()
     {
-        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1), true);
 
         try {
             accessControl.checkCanDeleteFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorAccessControl.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorAccessControl.java
@@ -1,0 +1,364 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor;
+
+import com.facebook.presto.raptor.metadata.SchemaDaoUtil;
+import com.facebook.presto.raptor.metadata.ShardManager;
+import com.facebook.presto.raptor.security.FileBasedIdentityConfig;
+import com.facebook.presto.raptor.security.FileBasedIdentityManager;
+import com.facebook.presto.raptor.security.IdentityManager;
+import com.facebook.presto.raptor.storage.StorageManagerConfig;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.security.AccessDeniedException;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.facebook.presto.testing.TestingNodeManager;
+import com.google.common.collect.ImmutableSet;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
+import static com.facebook.presto.raptor.metadata.TestDatabaseShardManager.createShardManager;
+import static com.facebook.presto.spi.security.Privilege.DELETE;
+import static com.facebook.presto.spi.security.Privilege.INSERT;
+import static com.facebook.presto.spi.security.Privilege.SELECT;
+import static com.facebook.presto.spi.security.Privilege.UPDATE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.google.common.base.Ticker.systemTicker;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+@Test(singleThreaded = true)
+public class TestRaptorAccessControl
+{
+    private static final ConnectorSession SESSION_USER1 = new TestingConnectorSession(
+            "user1", new RaptorSessionProperties(new StorageManagerConfig()).getSessionProperties());
+    private static final ConnectorSession SESSION_USER2 = new TestingConnectorSession(
+            "user2", new RaptorSessionProperties(new StorageManagerConfig()).getSessionProperties());
+    private static final SchemaTableName TABLE_TEST1_TABLE1 = new SchemaTableName("test1", "table1");
+    private static final SchemaTableName TABLE_TEST2_TABLE2 = new SchemaTableName("test2", "table2");
+    private static final ConnectorTransactionHandle TRANSACTION_HANDLE = new ConnectorTransactionHandle() {};
+    private static final Identity USER1 = new Identity("user1", Optional.empty());
+    private static final Identity USER2 = new Identity("user2", Optional.empty());
+
+    private RaptorAccessControl accessControl;
+    private DBI dbi;
+    private Handle dummyHandle;
+    private RaptorMetadata metadata;
+    private IdentityManager identityManager;
+
+    @BeforeMethod
+    public void setup()
+    {
+        dbi = new DBI("jdbc:h2:mem:test" + System.nanoTime());
+        dummyHandle = dbi.open();
+        SchemaDaoUtil.createTablesWithRetry(dbi);
+        RaptorConnectorId connectorId = new RaptorConnectorId("raptor");
+
+        NodeManager nodeManager = new TestingNodeManager();
+        NodeSupplier nodeSupplier = nodeManager::getWorkerNodes;
+        ShardManager shardManager = createShardManager(dbi, nodeSupplier, systemTicker());
+        metadata = new RaptorMetadata(connectorId.toString(), dbi, shardManager);
+
+        FileBasedIdentityConfig config = new FileBasedIdentityConfig();
+        config.setGroupsFileName(getResourceFile("roles.json"));
+        config.setSchemaOwnersFileName(getResourceFile("schema_owners.json"));
+        identityManager = new FileBasedIdentityManager(config);
+
+        accessControl = new RaptorAccessControl(dbi, identityManager, connectorId);
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        dummyHandle.close();
+    }
+
+    @Test
+    public void testCheckCanCreateSchema()
+    {
+        try {
+            accessControl.checkCanCreateSchema(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1.getSchemaName());
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControl.checkCanCreateSchema(TRANSACTION_HANDLE, USER1, TABLE_TEST1_TABLE1.getSchemaName());
+    }
+
+    @Test
+    public void testCheckCanDropSchema()
+    {
+        try {
+            accessControl.checkCanDropSchema(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1.getSchemaName());
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControl.checkCanDropSchema(TRANSACTION_HANDLE, USER1, TABLE_TEST1_TABLE1.getSchemaName());
+    }
+
+    @Test
+    public void checkCanRenameSchema()
+    {
+        try {
+            accessControl.checkCanRenameSchema(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1.getSchemaName(), TABLE_TEST2_TABLE2.getSchemaName());
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControl.checkCanRenameSchema(TRANSACTION_HANDLE, USER1, TABLE_TEST1_TABLE1.getSchemaName(), TABLE_TEST2_TABLE2.getSchemaName());
+    }
+
+    @Test
+    public void testCheckCanShowSchemas()
+    {
+        accessControl.checkCanShowSchemas(TRANSACTION_HANDLE, USER1);
+    }
+
+    @Test
+    public void testFilterSchemas()
+    {
+        Set<String> names = ImmutableSet.of("test1", "test2");
+        Set<String> filtedNames = accessControl.filterSchemas(TRANSACTION_HANDLE, USER1, names);
+
+        assertEquals(filtedNames, names);
+    }
+
+    @Test
+    public void checkCanCreateTable()
+    {
+        try {
+            accessControl.checkCanCreateTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControl.checkCanCreateTable(TRANSACTION_HANDLE, USER1, TABLE_TEST1_TABLE1);
+    }
+
+    @Test
+    public void checkCanDropTable()
+    {
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+
+        try {
+            accessControl.checkCanDropTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControl.checkCanDropTable(TRANSACTION_HANDLE, USER1, TABLE_TEST1_TABLE1);
+    }
+
+    @Test
+    public void checkCanRenameTable()
+    {
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+
+        try {
+            accessControl.checkCanRenameTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1, TABLE_TEST2_TABLE2);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControl.checkCanRenameTable(TRANSACTION_HANDLE, USER1, TABLE_TEST1_TABLE1, TABLE_TEST2_TABLE2);
+    }
+
+    @Test
+    public void checkCanShowTablesMetadata()
+    {
+        accessControl.checkCanShowTablesMetadata(TRANSACTION_HANDLE, USER1, TABLE_TEST1_TABLE1.getSchemaName());
+    }
+
+    @Test
+    public void filterTables()
+    {
+        Set<SchemaTableName> tables = ImmutableSet.of(TABLE_TEST1_TABLE1, TABLE_TEST2_TABLE2);
+        Set<SchemaTableName> filteredTables = accessControl.filterTables(TRANSACTION_HANDLE, USER1, tables);
+
+        assertEquals(filteredTables, tables);
+    }
+
+    @Test
+    public void checkCanAddColumn()
+    {
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+
+        try {
+            accessControl.checkCanAddColumn(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControl.checkCanAddColumn(TRANSACTION_HANDLE, USER1, TABLE_TEST1_TABLE1);
+    }
+
+    @Test
+    public void checkCanRenameColumn()
+    {
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+
+        try {
+            accessControl.checkCanRenameColumn(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControl.checkCanRenameColumn(TRANSACTION_HANDLE, USER1, TABLE_TEST1_TABLE1);
+    }
+
+    @Test
+    public void checkCanSelectFromTable()
+    {
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+
+        try {
+            accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, USER1, TABLE_TEST1_TABLE1);
+
+        metadata.grantTablePrivileges(SESSION_USER1, TABLE_TEST1_TABLE1, ImmutableSet.of(SELECT), USER2.getUser(), false);
+        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+    }
+
+    @Test
+    public void checkCanInsertIntoTable()
+    {
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+
+        try {
+            accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, USER1, TABLE_TEST1_TABLE1);
+
+        metadata.grantTablePrivileges(SESSION_USER1, TABLE_TEST1_TABLE1, ImmutableSet.of(INSERT), USER2.getUser(), false);
+        accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+    }
+
+    @Test
+    public void checkCanDeleteFromTable()
+    {
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+
+        try {
+            accessControl.checkCanDeleteFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControl.checkCanDeleteFromTable(TRANSACTION_HANDLE, USER1, TABLE_TEST1_TABLE1);
+
+        metadata.grantTablePrivileges(SESSION_USER1, TABLE_TEST1_TABLE1, ImmutableSet.of(DELETE), USER2.getUser(), false);
+        accessControl.checkCanDeleteFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+    }
+
+    @Test
+    public void checkCanSetCatalogSessionProperty()
+    {
+        try {
+            accessControl.checkCanSetCatalogSessionProperty(USER2, "property");
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControl.checkCanSetCatalogSessionProperty(USER1, "property");
+    }
+
+    @Test
+    public void checkCanGrantTablePrivilege()
+    {
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER1, SELECT, TABLE_TEST1_TABLE1);
+
+        try {
+            accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER2, SELECT, TABLE_TEST1_TABLE1);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        metadata.grantTablePrivileges(SESSION_USER1, TABLE_TEST1_TABLE1, ImmutableSet.of(SELECT, INSERT), USER2.getUser(), true);
+
+        accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER2, SELECT, TABLE_TEST1_TABLE1);
+        accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER2, INSERT, TABLE_TEST1_TABLE1);
+        try {
+            accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER2, UPDATE, TABLE_TEST1_TABLE1);
+        }
+        catch (AccessDeniedException expected) {
+        }
+    }
+
+    @Test
+    public void checkCanRevokeTablePrivilege()
+    {
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+        accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER1, SELECT, TABLE_TEST1_TABLE1);
+
+        try {
+            accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER2, SELECT, TABLE_TEST1_TABLE1);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        metadata.grantTablePrivileges(SESSION_USER1, TABLE_TEST1_TABLE1, ImmutableSet.of(SELECT, INSERT), USER2.getUser(), true);
+        accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER2, SELECT, TABLE_TEST1_TABLE1);
+        accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER2, INSERT, TABLE_TEST1_TABLE1);
+        try {
+            accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER2, UPDATE, TABLE_TEST1_TABLE1);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+    }
+
+    private String getResourceFile(String name)
+    {
+        return this.getClass().getClassLoader().getResource(name).getFile();
+    }
+
+    private static ConnectorTableMetadata getTableMeta(SchemaTableName name)
+    {
+        return tableMetadataBuilder(name).column("col1", BIGINT).build();
+    }
+}

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorAccessControl.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorAccessControl.java
@@ -308,10 +308,10 @@ public class TestRaptorAccessControl
     public void checkCanGrantTablePrivilege()
     {
         metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
-        accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER1, SELECT, TABLE_TEST1_TABLE1);
+        accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER1, SELECT, TABLE_TEST1_TABLE1, USER2.getUser(), false);
 
         try {
-            accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER2, SELECT, TABLE_TEST1_TABLE1);
+            accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER2, SELECT, TABLE_TEST1_TABLE1, USER1.getUser(), false);
             fail();
         }
         catch (AccessDeniedException expected) {
@@ -319,10 +319,11 @@ public class TestRaptorAccessControl
 
         metadata.grantTablePrivileges(SESSION_USER1, TABLE_TEST1_TABLE1, ImmutableSet.of(SELECT, INSERT), USER2.getUser(), true);
 
-        accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER2, SELECT, TABLE_TEST1_TABLE1);
-        accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER2, INSERT, TABLE_TEST1_TABLE1);
+        accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER2, SELECT, TABLE_TEST1_TABLE1, USER1.getUser(), false);
+        accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER2, INSERT, TABLE_TEST1_TABLE1, USER1.getUser(), false);
         try {
-            accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER2, UPDATE, TABLE_TEST1_TABLE1);
+            accessControl.checkCanGrantTablePrivilege(TRANSACTION_HANDLE, USER2, UPDATE, TABLE_TEST1_TABLE1, USER1.getUser(), false);
+            fail();
         }
         catch (AccessDeniedException expected) {
         }
@@ -332,20 +333,62 @@ public class TestRaptorAccessControl
     public void checkCanRevokeTablePrivilege()
     {
         metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
-        accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER1, SELECT, TABLE_TEST1_TABLE1);
+        accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER1, SELECT, TABLE_TEST1_TABLE1, USER2.getUser(), false);
 
         try {
-            accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER2, SELECT, TABLE_TEST1_TABLE1);
+            accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER2, SELECT, TABLE_TEST1_TABLE1, USER1.getUser(), false);
             fail();
         }
         catch (AccessDeniedException expected) {
         }
 
         metadata.grantTablePrivileges(SESSION_USER1, TABLE_TEST1_TABLE1, ImmutableSet.of(SELECT, INSERT), USER2.getUser(), true);
-        accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER2, SELECT, TABLE_TEST1_TABLE1);
-        accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER2, INSERT, TABLE_TEST1_TABLE1);
+        accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER2, SELECT, TABLE_TEST1_TABLE1, USER1.getUser(), false);
+        accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER2, INSERT, TABLE_TEST1_TABLE1, USER1.getUser(), false);
         try {
-            accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER2, UPDATE, TABLE_TEST1_TABLE1);
+            accessControl.checkCanRevokeTablePrivilege(TRANSACTION_HANDLE, USER2, UPDATE, TABLE_TEST1_TABLE1, USER1.getUser(), false);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+    }
+
+    @Test
+    public void checkCanSelectFromTableByRole()
+    {
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+
+        try {
+            accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        metadata.grantTablePrivileges(SESSION_USER1, TABLE_TEST1_TABLE1, ImmutableSet.of(SELECT), "users", false);
+
+        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+    }
+
+    @Test
+    public void checkCanSelectAndDeleteFromTableByRole()
+    {
+        metadata.createTable(SESSION_USER1, getTableMeta(TABLE_TEST1_TABLE1));
+
+        try {
+            accessControl.checkCanDeleteFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+            fail();
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        metadata.grantTablePrivileges(SESSION_USER1, TABLE_TEST1_TABLE1, ImmutableSet.of(SELECT, DELETE), "users", false);
+
+        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+        accessControl.checkCanDeleteFromTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
+
+        try {
+            accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, USER2, TABLE_TEST1_TABLE1);
             fail();
         }
         catch (AccessDeniedException expected) {

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
@@ -15,6 +15,7 @@ package com.facebook.presto.raptor;
 
 import com.facebook.presto.PagesIndexPageSorter;
 import com.facebook.presto.operator.PagesIndex;
+import com.facebook.presto.plugin.base.security.AllowAllAccessControl;
 import com.facebook.presto.raptor.metadata.MetadataDao;
 import com.facebook.presto.raptor.metadata.ShardManager;
 import com.facebook.presto.raptor.metadata.TableColumn;
@@ -89,6 +90,7 @@ public class TestRaptorConnector
                 new RaptorSessionProperties(config),
                 new RaptorTableProperties(typeRegistry),
                 ImmutableSet.of(),
+                new AllowAllAccessControl(),
                 dbi);
     }
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorMetadata.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorMetadata.java
@@ -808,7 +808,7 @@ public class TestRaptorMetadata
     @Test
     public void testCreateTableTablePrivileges()
     {
-        metadata.createTable(SESSION, getOrdersTable());
+        metadata.createTable(SESSION, getOrdersTable(), true);
 
         List<GrantInfo> grantInfos = metadata.listTablePrivileges(SESSION, new SchemaTablePrefix(DEFAULT_TEST_ORDERS.getSchemaName(), "non_exists"));
         assertTrue(grantInfos.isEmpty());
@@ -835,7 +835,7 @@ public class TestRaptorMetadata
     @Test
     public void testGrantTablePrivilege()
     {
-        metadata.createTable(SESSION, getOrdersTable());
+        metadata.createTable(SESSION, getOrdersTable(), true);
 
         List<GrantInfo> grantInfos = metadata.listTablePrivileges(SESSION_USER2,
                 new SchemaTablePrefix(DEFAULT_TEST_ORDERS.getSchemaName(), DEFAULT_TEST_ORDERS.getTableName()));
@@ -862,7 +862,7 @@ public class TestRaptorMetadata
     @Test
     public void testRevokeTablePrivilege()
     {
-        metadata.createTable(SESSION, getOrdersTable());
+        metadata.createTable(SESSION, getOrdersTable(), true);
 
         metadata.grantTablePrivileges(SESSION,
                 DEFAULT_TEST_ORDERS,

--- a/presto-raptor/src/test/resources/roles.json
+++ b/presto-raptor/src/test/resources/roles.json
@@ -1,0 +1,8 @@
+{
+  "admin" : {
+    "users" : [ "user1"]
+  },
+  "users" : {
+    "users" : [ "user2", "user3" ]
+  }
+}

--- a/presto-raptor/src/test/resources/schema_owners.json
+++ b/presto-raptor/src/test/resources/schema_owners.json
@@ -1,0 +1,10 @@
+{
+  "test2" : {
+    "roles" : [ "admin", "user" ],
+    "users" : [ "user5" ]
+  },
+  "test1" : {
+    "roles" : [ "admin" ],
+    "users" : [ "user5", "user6" ]
+  }
+}


### PR DESCRIPTION
This implements M1 in #8106.

Added a table called table_privileges to the raptor metadata DB.
Authorizations are performed based on this table.

Added implementation of ConnectorAccessControl to raptor. By default,
AllowAllAccessControl will be used. So this change is backward
compatible.

Role based authorization are currently not supported in this PR. The role concept in the json file is just for schema ownership management.