### PR TITLE
Add reference counting for BlockBigArray

### DIFF
--- a/presto-array/pom.xml
+++ b/presto-array/pom.xml
@@ -22,6 +22,11 @@
         </dependency>
 
         <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
         </dependency>
@@ -29,6 +34,13 @@
         <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/presto-array/src/main/java/com/facebook/presto/array/BlockBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/BlockBigArray.java
@@ -20,6 +20,7 @@ public final class BlockBigArray
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(BlockBigArray.class).instanceSize();
     private final ObjectBigArray<Block> array;
+    private final ReferenceCountMap trackedObjects = new ReferenceCountMap();
     private long sizeOfBlocks;
 
     public BlockBigArray()
@@ -37,7 +38,7 @@ public final class BlockBigArray
      */
     public long sizeOf()
     {
-        return INSTANCE_SIZE + array.sizeOf() + sizeOfBlocks;
+        return INSTANCE_SIZE + array.sizeOf() + sizeOfBlocks + trackedObjects.sizeOf();
     }
 
     /**
@@ -60,10 +61,30 @@ public final class BlockBigArray
     {
         Block currentValue = array.get(index);
         if (currentValue != null) {
-            sizeOfBlocks -= currentValue.getRetainedSizeInBytes();
+            currentValue.retainedBytesForEachPart((object, size) -> {
+                if (currentValue == object) {
+                    // track instance size separately as the reference count for an instance is always 1
+                    sizeOfBlocks -= size;
+                    return;
+                }
+                if (trackedObjects.decrementReference(object) == 0) {
+                    // decrement the size only when it is the last reference
+                    sizeOfBlocks -= size;
+                }
+            });
         }
         if (value != null) {
-            sizeOfBlocks += value.getRetainedSizeInBytes();
+            value.retainedBytesForEachPart((object, size) -> {
+                if (value == object) {
+                    // track instance size separately as the reference count for an instance is always 1
+                    sizeOfBlocks += size;
+                    return;
+                }
+                if (trackedObjects.incrementReference(object) == 1) {
+                    // increment the size only when it is the first reference
+                    sizeOfBlocks += size;
+                }
+            });
         }
         array.set(index, value);
     }

--- a/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.array;
+
+import io.airlift.slice.SizeOf;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenCustomHashMap;
+import org.openjdk.jol.info.ClassLayout;
+
+public final class ReferenceCountMap
+        extends Object2IntOpenCustomHashMap<Object>
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ReferenceCountMap.class).instanceSize();
+
+    /**
+     * Two different blocks can share the same underlying data
+     * Use the map to avoid memory over counting
+     */
+    public ReferenceCountMap()
+    {
+        super(new ObjectStrategy());
+    }
+
+    /**
+     * Increments the reference count of an object by 1 and returns the updated reference count
+     */
+    public int incrementReference(Object key)
+    {
+        return addTo(key, 1) + 1;
+    }
+
+    /**
+     * Decrements the reference count of an object by 1 and returns the updated reference count
+     */
+    public int decrementReference(Object key)
+    {
+        int previousCount = addTo(key, -1);
+        if (previousCount == 1) {
+            remove(key);
+        }
+        return previousCount - 1;
+    }
+
+    /**
+     * Returns the size of this map in bytes.
+     */
+    public long sizeOf()
+    {
+        return INSTANCE_SIZE + SizeOf.sizeOf(key) + SizeOf.sizeOf(value) + SizeOf.sizeOf(used);
+    }
+
+    private static final class ObjectStrategy
+            implements Strategy<Object>
+    {
+        @Override
+        public int hashCode(Object object)
+        {
+            return System.identityHashCode(object);
+        }
+
+        @Override
+        public boolean equals(Object left, Object right)
+        {
+            return left == right;
+        }
+    }
+}

--- a/presto-array/src/test/java/com/facebook/presto/array/TestBlockBigArray.java
+++ b/presto-array/src/test/java/com/facebook/presto/array/TestBlockBigArray.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.array;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.IntArrayBlockBuilder;
+import org.openjdk.jol.info.ClassLayout;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestBlockBigArray
+{
+    @Test
+    public void testRetainedSizeWithOverlappingBlocks()
+    {
+        int entries = 123;
+        BlockBuilder blockBuilder = new IntArrayBlockBuilder(new BlockBuilderStatus(), entries);
+        for (int i = 0; i < entries; i++) {
+            blockBuilder.writeInt(i);
+        }
+        Block block = blockBuilder.build();
+
+        // Verify we do not over count
+        int arraySize = 456;
+        int blocks = 7890;
+        BlockBigArray blockBigArray = new BlockBigArray();
+        blockBigArray.ensureCapacity(arraySize);
+        for (int i = 0; i < blocks; i++) {
+            blockBigArray.set(i % arraySize, block.getRegion(0, entries));
+        }
+
+        ReferenceCountMap referenceCountMap = new ReferenceCountMap();
+        referenceCountMap.incrementReference(block);
+        long expectedSize = ClassLayout.parseClass(BlockBigArray.class).instanceSize()
+                + referenceCountMap.sizeOf()
+                + (new ObjectBigArray()).sizeOf()
+                + block.getRetainedSizeInBytes() + (arraySize - 1) * ClassLayout.parseClass(block.getClass()).instanceSize();
+        assertEquals(blockBigArray.sizeOf(), expectedSize);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -20,6 +20,7 @@ import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -180,6 +181,13 @@ public class GroupByIdBlock
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + block.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(block, block.getRetainedSizeInBytes());
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -57,6 +57,12 @@
         </dependency>
 
         <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>test</scope>

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlock.java
@@ -15,6 +15,8 @@ package com.facebook.presto.spi.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.function.BiConsumer;
+
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
@@ -94,6 +96,15 @@ public class ArrayBlock
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, values.getRetainedSizeInBytes());
+        consumer.accept(offsets, sizeOf(offsets));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -19,6 +19,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -101,6 +102,15 @@ public class ArrayBlockBuilder
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes + values.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, values.getRetainedSizeInBytes());
+        consumer.accept(offsets, sizeOf(offsets));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi.block;
 import io.airlift.slice.Slice;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 public interface Block
 {
@@ -174,6 +175,16 @@ public interface Block
      * This method is called from the inner most execution loop and must be fast.
      */
     long getRetainedSizeInBytes();
+
+    /**
+     * {@code consumer} visits each of the internal data container and accepts the size for it.
+     * This method can be helpful in cases such as memory counting for internal data structure.
+     * Also, the method should be non-recursive, only visit the elements at the top level,
+     * and specifically should not call retainedBytesForEachPart on nested blocks
+     * {@code consumer} should be called at least once with the current block and
+     * must include the instance size of the current block
+     */
+    void retainedBytesForEachPart(BiConsumer<Object, Long> consumer);
 
     /**
      * Get the encoding for this block.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
@@ -17,6 +17,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -80,6 +81,14 @@ public class ByteArrayBlock
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -141,6 +142,14 @@ public class ByteArrayBlockBuilder
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.spi.block.DictionaryId.randomDictionaryId;
@@ -246,6 +247,14 @@ public class DictionaryBlock
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(dictionary, dictionary.getRetainedSizeInBytes());
+        consumer.accept(ids, sizeOf(ids));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
@@ -19,6 +19,7 @@ import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
 import static java.util.Objects.requireNonNull;
@@ -80,6 +81,14 @@ public class FixedWidthBlock
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + getRawSlice().getRetainedSize() + valueIsNull.getRetainedSize();
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(slice, (long) slice.getRetainedSize());
+        consumer.accept(valueIsNull, (long) valueIsNull.getRetainedSize());
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -22,6 +22,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.MAX_ARRAY_SIZE;
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
@@ -97,6 +98,14 @@ public class FixedWidthBlockBuilder
             size += BlockBuilderStatus.INSTANCE_SIZE;
         }
         return size;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(sliceOutput, (long) sliceOutput.getRetainedSize());
+        consumer.accept(valueIsNull, (long) valueIsNull.getRetainedSize());
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
@@ -17,6 +17,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -80,6 +81,14 @@ public class IntArrayBlock
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
@@ -142,6 +143,14 @@ public class IntArrayBlockBuilder
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlock.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi.block;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
 
 public class InterleavedBlock
         extends AbstractInterleavedBlock
@@ -120,6 +121,13 @@ public class InterleavedBlock
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(blocks, retainedSizeInBytes - INSTANCE_SIZE);
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlockBuilder.java
@@ -18,6 +18,7 @@ import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static java.util.Objects.requireNonNull;
 
@@ -118,6 +119,13 @@ public class InterleavedBlockBuilder
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(blockBuilders, retainedSizeInBytes - INSTANCE_SIZE);
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     private void recordStartSizesIfNecessary(BlockBuilder blockBuilder)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static java.util.Objects.requireNonNull;
 
@@ -182,6 +183,16 @@ public class LazyBlock
     {
         assureLoaded();
         return INSTANCE_SIZE + block.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        // do not support LazyBlock (for now) for the following two reasons:
+        // (1) the method is mainly used for inspecting the identity and size of each element to prevent over counting
+        // (2) the method should be non-recursive and only inspects blocks at the top level;
+        //     given LazyBlock is a wrapper for other blocks, it is not meaningful to only inspect the top-level elements
+        throw new UnsupportedOperationException(getClass().getName());
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -17,6 +17,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -81,6 +82,14 @@ public class LongArrayBlock
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
@@ -143,6 +144,14 @@ public class LongArrayBlockBuilder
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlock.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.lang.invoke.MethodHandle;
+import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.String.format;
@@ -143,6 +144,17 @@ public class MapBlock
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(keyBlock, keyBlock.getRetainedSizeInBytes());
+        consumer.accept(valueBlock, valueBlock.getRetainedSizeInBytes());
+        consumer.accept(offsets, sizeOf(offsets));
+        consumer.accept(mapIsNull, sizeOf(mapIsNull));
+        consumer.accept(hashTables, sizeOf(hashTables));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 
 import java.lang.invoke.MethodHandle;
 import java.util.Arrays;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -149,6 +150,17 @@ public class MapBlockBuilder
             size += BlockBuilderStatus.INSTANCE_SIZE;
         }
         return size;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(keyBlockBuilder, keyBlockBuilder.getRetainedSizeInBytes());
+        consumer.accept(valueBlockBuilder, valueBlockBuilder.getRetainedSizeInBytes());
+        consumer.accept(offsets, sizeOf(offsets));
+        consumer.accept(mapIsNull, sizeOf(mapIsNull));
+        consumer.accept(hashTables, sizeOf(hashTables));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -19,6 +19,7 @@ import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
 import static java.lang.String.format;
@@ -79,6 +80,13 @@ public class RunLengthEncodedBlock
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + value.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(value, value.getRetainedSizeInBytes());
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
@@ -17,6 +17,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -80,6 +81,14 @@ public class ShortArrayBlock
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
@@ -142,6 +143,14 @@ public class ShortArrayBlockBuilder
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
@@ -16,6 +16,8 @@ package com.facebook.presto.spi.block;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.function.BiConsumer;
+
 public class SingleArrayBlockWriter
         extends AbstractSingleArrayBlock
         implements BlockBuilder
@@ -49,6 +51,13 @@ public class SingleArrayBlockWriter
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + blockBuilder.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(blockBuilder, blockBuilder.getRetainedSizeInBytes());
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
@@ -20,6 +20,7 @@ import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.lang.invoke.MethodHandle;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.block.AbstractMapBlock.HASH_MULTIPLIER;
@@ -72,6 +73,15 @@ public class SingleMapBlock
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + keyBlock.getRetainedSizeInBytes() + valueBlock.getRetainedSizeInBytes() + sizeOf(hashTable);
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(keyBlock, keyBlock.getRetainedSizeInBytes());
+        consumer.accept(valueBlock, valueBlock.getRetainedSizeInBytes());
+        consumer.accept(hashTable, sizeOf(hashTable));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
@@ -16,6 +16,8 @@ package com.facebook.presto.spi.block;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.function.BiConsumer;
+
 public class SingleMapBlockWriter
         extends AbstractSingleMapBlock
         implements BlockBuilder
@@ -47,6 +49,14 @@ public class SingleMapBlockWriter
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + keyBlockBuilder.getRetainedSizeInBytes() + valueBlockBuilder.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(keyBlockBuilder, keyBlockBuilder.getRetainedSizeInBytes());
+        consumer.accept(valueBlockBuilder, valueBlockBuilder.getRetainedSizeInBytes());
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -123,6 +124,13 @@ public class SliceArrayBlock
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, retainedSizeInBytes - INSTANCE_SIZE);
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
@@ -20,6 +20,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
@@ -115,6 +116,15 @@ public class VariableWidthBlock
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(slice, (long) slice.getRetainedSize());
+        consumer.accept(offsets, sizeOf(offsets));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.MAX_ARRAY_SIZE;
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
@@ -121,6 +122,15 @@ public class VariableWidthBlockBuilder
             size += BlockBuilderStatus.INSTANCE_SIZE;
         }
         return size;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(sliceOutput, (long) sliceOutput.getRetainedSize());
+        consumer.accept(offsets, sizeOf(offsets));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestBlockRetainedSizeBreakdown.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestBlockRetainedSizeBreakdown.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import it.unimi.dsi.fastutil.Hash.Strategy;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenCustomHashMap;
+import org.testng.annotations.Test;
+
+import java.util.function.BiConsumer;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.TypeUtils.writeNativeValue;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertEquals;
+
+public class TestBlockRetainedSizeBreakdown
+{
+    private static final int EXPECTED_ENTRIES = 100;
+
+    private int objectSize;
+    private final Object2LongOpenCustomHashMap<Object> trackedObjects = new Object2LongOpenCustomHashMap<>(new ObjectStrategy());
+
+    private final BiConsumer<Object, Long> consumer = (object, size) -> {
+        objectSize += size;
+        trackedObjects.addTo(object, 1);
+    };
+
+    @Test
+    public void testArrayBlock()
+    {
+        BlockBuilder arrayBlockBuilder = new ArrayBlockBuilder(BIGINT, new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        for (int i = 0; i < EXPECTED_ENTRIES; i++) {
+            BlockBuilder arrayElementBuilder = arrayBlockBuilder.beginBlockEntry();
+            writeNativeValue(BIGINT, arrayElementBuilder, castIntegerToObect(i, BIGINT));
+            arrayBlockBuilder.closeEntry();
+        }
+        checkRetainedSize(arrayBlockBuilder.build(), false);
+    }
+
+    @Test
+    public void testByteArrayBlock()
+    {
+        BlockBuilder blockBuilder = new ByteArrayBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        for (int i = 0; i < EXPECTED_ENTRIES; i++) {
+            blockBuilder.writeByte(i);
+        }
+        checkRetainedSize(blockBuilder.build(), false);
+    }
+
+    @Test
+    public void testDictionaryBlock()
+    {
+        Block keyDictionaryBlock = createSliceArrayBlock(EXPECTED_ENTRIES);
+        int[] keyIds = new int[EXPECTED_ENTRIES];
+        for (int i = 0; i < keyIds.length; i++) {
+            keyIds[i] = i;
+        }
+        checkRetainedSize(new DictionaryBlock(EXPECTED_ENTRIES, keyDictionaryBlock, keyIds), false);
+    }
+
+    @Test
+    public void testFixedWidthBlock()
+    {
+        BlockBuilder blockBuilder = new FixedWidthBlockBuilder(8, new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        writeEntries(EXPECTED_ENTRIES, blockBuilder, DOUBLE);
+        checkRetainedSize(blockBuilder.build(), true);
+    }
+
+    @Test
+    public void testIntArrayBlock()
+    {
+        BlockBuilder blockBuilder = new IntArrayBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        writeEntries(EXPECTED_ENTRIES, blockBuilder, INTEGER);
+        checkRetainedSize(blockBuilder.build(), false);
+    }
+
+    @Test
+    public void testInterleavedBlock()
+    {
+        BlockBuilder blockBuilder = new InterleavedBlockBuilder(ImmutableList.of(INTEGER, INTEGER), new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        writeEntries(EXPECTED_ENTRIES, blockBuilder, INTEGER);
+        checkRetainedSize(blockBuilder.build(), false);
+    }
+
+    @Test
+    public void testLongArrayBlock()
+    {
+        BlockBuilder blockBuilder = new LongArrayBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        writeEntries(EXPECTED_ENTRIES, blockBuilder, BIGINT);
+        checkRetainedSize(blockBuilder.build(), false);
+    }
+
+    @Test
+    public void testRunLengthEncodedBlock()
+    {
+        BlockBuilder blockBuilder = new LongArrayBlockBuilder(new BlockBuilderStatus(), 1);
+        writeEntries(1, blockBuilder, BIGINT);
+        checkRetainedSize(new RunLengthEncodedBlock(blockBuilder.build(), 1), false);
+    }
+
+    @Test
+    public void testShortArrayBlock()
+    {
+        BlockBuilder blockBuilder = new ShortArrayBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        for (int i = 0; i < EXPECTED_ENTRIES; i++) {
+            blockBuilder.writeShort(i);
+        }
+        checkRetainedSize(blockBuilder.build(), false);
+    }
+
+    @Test
+    public void testSliceArrayBlock()
+    {
+        checkRetainedSize(createSliceArrayBlock(EXPECTED_ENTRIES), true);
+    }
+
+    @Test
+    public void testVariableWidthBlock()
+    {
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES, 4);
+        writeEntries(EXPECTED_ENTRIES, blockBuilder, VARCHAR);
+        checkRetainedSize(blockBuilder.build(), false);
+    }
+
+    private static final class ObjectStrategy
+            implements Strategy<Object>
+    {
+        @Override
+        public int hashCode(Object object)
+        {
+            return System.identityHashCode(object);
+        }
+
+        @Override
+        public boolean equals(Object left, Object right)
+        {
+            return left == right;
+        }
+    }
+
+    private void checkRetainedSize(Block block, boolean getRegionCreateNewObjects)
+    {
+        objectSize = 0;
+        trackedObjects.clear();
+
+        block.retainedBytesForEachPart(consumer);
+        assertEquals(objectSize, block.getRetainedSizeInBytes());
+
+        Block copyBlock = block.getRegion(0, block.getPositionCount() / 2);
+        copyBlock.retainedBytesForEachPart(consumer);
+        assertEquals(objectSize, block.getRetainedSizeInBytes() + copyBlock.getRetainedSizeInBytes());
+
+        assertEquals(trackedObjects.getLong(block), 1);
+        assertEquals(trackedObjects.getLong(copyBlock), 1);
+        trackedObjects.remove(block);
+        trackedObjects.remove(copyBlock);
+        for (long value : trackedObjects.values()) {
+            assertEquals(value, getRegionCreateNewObjects ? 1 : 2);
+        }
+    }
+
+    private static void writeEntries(int expectedEntries, BlockBuilder blockBuilder, Type type)
+    {
+        for (int i = 0; i < expectedEntries; i++) {
+            writeNativeValue(type, blockBuilder, castIntegerToObect(i, type));
+        }
+    }
+
+    private static Object castIntegerToObect(int value, Type type)
+    {
+        if (type == INTEGER || type == TINYINT || type == BIGINT) {
+            return (long) value;
+        }
+        if (type == VARCHAR) {
+            return String.valueOf(value);
+        }
+        if (type == DOUBLE) {
+            return (double) value;
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    private static Block createSliceArrayBlock(int entries)
+    {
+        Slice[] sliceArray = new Slice[entries];
+        for (int i = 0; i < entries; i++) {
+            sliceArray[i] = utf8Slice(i + "");
+        }
+        return new SliceArrayBlock(sliceArray.length, sliceArray);
+    }
+}


### PR DESCRIPTION
Add a map in BlockBigArray to track the underlying data of the blocks it sets. The map aims to avoid overcounting the memory usage.