### PR TITLE
Prune mark distinct columns

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -35,6 +35,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
 import com.facebook.presto.sql.planner.iterative.rule.PruneCrossJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneJoinChildrenColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneJoinColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PruneMarkDistinctColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinFilteringSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
@@ -133,6 +134,7 @@ public class PlanOptimizers
                 new PruneCrossJoinColumns(),
                 new PruneJoinChildrenColumns(),
                 new PruneJoinColumns(),
+                new PruneMarkDistinctColumns(),
                 new PruneSemiJoinColumns(),
                 new PruneSemiJoinFilteringSourceColumns(),
                 new PruneValuesColumns(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneMarkDistinctColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneMarkDistinctColumns.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
+import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictOutputs;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+public class PruneMarkDistinctColumns
+        implements Rule
+{
+    private static final Pattern PATTERN = Pattern.node(ProjectNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        ProjectNode parent = (ProjectNode) node;
+
+        PlanNode child = lookup.resolve(parent.getSource());
+        if (!(child instanceof MarkDistinctNode)) {
+            return Optional.empty();
+        }
+
+        MarkDistinctNode markDistinctNode = (MarkDistinctNode) child;
+
+        Optional<List<Symbol>> prunedOutputs = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
+        if (!prunedOutputs.isPresent()) {
+            return Optional.empty();
+        }
+
+        if (!prunedOutputs.get().contains(markDistinctNode.getMarkerSymbol())) {
+            return Optional.of(
+                    node.replaceChildren(ImmutableList.of(markDistinctNode.getSource())));
+        }
+
+        Set<Symbol> requiredInputs = Streams.concat(
+                prunedOutputs.get().stream()
+                        .filter(symbol -> !symbol.equals(markDistinctNode.getMarkerSymbol())),
+                markDistinctNode.getDistinctSymbols().stream(),
+                markDistinctNode.getHashSymbol().map(Stream::of).orElse(Stream.empty()))
+                .collect(toImmutableSet());
+
+        return restrictOutputs(idAllocator, markDistinctNode.getSource(), requiredInputs)
+                .map(prunedMarkDistinctSource ->
+                        parent.replaceChildren(ImmutableList.of(
+                                markDistinctNode.replaceChildren(ImmutableList.of(
+                                        prunedMarkDistinctSource)))));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/MarkDistinctMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/MarkDistinctMatcher.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.PlanNodeCost;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+public class MarkDistinctMatcher
+        implements Matcher
+{
+    private final PlanTestSymbol markerSymbol;
+    private final List<PlanTestSymbol> distinctSymbols;
+    private final Optional<PlanTestSymbol> hashSymbol;
+
+    public MarkDistinctMatcher(PlanTestSymbol markerSymbol, List<PlanTestSymbol> distinctSymbols, Optional<PlanTestSymbol> hashSymbol)
+    {
+        this.markerSymbol = requireNonNull(markerSymbol, "markerSymbol is null");
+        this.distinctSymbols = ImmutableList.copyOf(distinctSymbols);
+        this.hashSymbol = requireNonNull(hashSymbol, "hashSymbol is null");
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof MarkDistinctNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, PlanNodeCost planNodeCost, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+        MarkDistinctNode markDistinctNode = (MarkDistinctNode) node;
+
+        if (!markDistinctNode.getHashSymbol().equals(hashSymbol.map(alias -> alias.toSymbol(symbolAliases)))) {
+            return NO_MATCH;
+        }
+
+        if (!ImmutableSet.copyOf(markDistinctNode.getDistinctSymbols())
+                .equals(distinctSymbols.stream().map(alias -> alias.toSymbol(symbolAliases)).collect(toImmutableSet()))) {
+            return NO_MATCH;
+        }
+
+        return match(markerSymbol.toString(), markDistinctNode.getMarkerSymbol().toSymbolReference());
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("markerSymbol", markerSymbol)
+                .add("distinctSymbols", distinctSymbols)
+                .add("hashSymbol", hashSymbol)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.planner.plan.IntersectNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
@@ -161,6 +162,29 @@ public final class PlanMatchPattern
         aggregations.entrySet().forEach(
                 aggregation -> result.withAlias(aggregation.getKey(), new AggregationFunctionMatcher(aggregation.getValue())));
         return result;
+    }
+
+    public static PlanMatchPattern markDistinct(
+            String markerSymbol,
+            List<String> distinctSymbols,
+            PlanMatchPattern source)
+    {
+        return node(MarkDistinctNode.class, source).with(new MarkDistinctMatcher(
+                new SymbolAlias(markerSymbol),
+                toSymbolAliases(distinctSymbols),
+                Optional.empty()));
+    }
+
+    public static PlanMatchPattern markDistinct(
+            String markerSymbol,
+            List<String> distinctSymbols,
+            String hashSymbol,
+            PlanMatchPattern source)
+    {
+        return node(MarkDistinctNode.class, source).with(new MarkDistinctMatcher(
+                new SymbolAlias(markerSymbol),
+                toSymbolAliases(distinctSymbols),
+                Optional.of(new SymbolAlias(hashSymbol))));
     }
 
     public static PlanMatchPattern window(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
@@ -40,7 +40,6 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
-import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.iterative.rule.EliminateCrossJoins.getJoinOrder;
 import static com.facebook.presto.sql.planner.iterative.rule.EliminateCrossJoins.isOriginalOrder;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
@@ -65,16 +64,14 @@ public class TestEliminateCrossJoins
                 .setSystemProperty(REORDER_JOINS, "true")
                 .on(crossJoinAndJoin(INNER))
                 .matches(
-                        project(
+                        join(INNER,
+                                ImmutableList.of(aliases -> new EquiJoinClause(new Symbol("cySymbol"), new Symbol("bySymbol"))),
                                 join(INNER,
-                                        ImmutableList.of(aliases -> new EquiJoinClause(new Symbol("cySymbol"), new Symbol("bySymbol"))),
-                                        join(INNER,
-                                                ImmutableList.of(aliases -> new EquiJoinClause(new Symbol("axSymbol"), new Symbol("cxSymbol"))),
-                                                any(),
-                                                any()
-                                        ),
+                                        ImmutableList.of(aliases -> new EquiJoinClause(new Symbol("axSymbol"), new Symbol("cxSymbol"))),
+                                        any(),
                                         any()
-                                )
+                                ),
+                                any()
                         )
                 );
     }
@@ -86,14 +83,12 @@ public class TestEliminateCrossJoins
                 .setSystemProperty(REORDER_JOINS, "true")
                 .on(crossJoinAndJoin(INNER))
                 .matches(
-                        any(
+                        node(JoinNode.class,
                                 node(JoinNode.class,
-                                        node(JoinNode.class,
-                                                node(GroupReference.class),
-                                                node(GroupReference.class)
-                                        ),
+                                        node(GroupReference.class),
                                         node(GroupReference.class)
-                                )
+                                ),
+                                node(GroupReference.class)
                         )
                 );
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneMarkDistinctColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneMarkDistinctColumns.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.markDistinct;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneMarkDistinctColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testMarkerSymbolNotReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneMarkDistinctColumns())
+                .on(p ->
+                {
+                    Symbol key = p.symbol("key", BIGINT);
+                    Symbol key2 = p.symbol("key2", BIGINT);
+                    Symbol mark = p.symbol("mark", BIGINT);
+                    Symbol unused = p.symbol("unused", BIGINT);
+                    return p.project(
+                            Assignments.of(key2, key.toSymbolReference()),
+                            p.markDistinct(mark, ImmutableList.of(key), p.values(key, unused)));
+                })
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("key2", expression("key")),
+                                values(ImmutableList.of("key", "unused"))));
+    }
+
+    @Test
+    public void testSourceSymbolNotReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneMarkDistinctColumns())
+                .on(p ->
+                {
+                    Symbol key = p.symbol("key", BIGINT);
+                    Symbol mark = p.symbol("mark", BIGINT);
+                    Symbol hash = p.symbol("hash", BIGINT);
+                    Symbol unused = p.symbol("unused", BIGINT);
+                    return p.project(
+                            Assignments.identity(mark),
+                            p.markDistinct(
+                                    mark,
+                                    ImmutableList.of(key),
+                                    hash,
+                                    p.values(key, hash, unused)));
+                })
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("mark", expression("mark")),
+                                markDistinct("mark", ImmutableList.of("key"), "hash",
+                                        strictProject(
+                                                ImmutableMap.of(
+                                                        "key", expression("key"),
+                                                        "hash", expression("hash")),
+                                                values(ImmutableList.of("key", "hash", "unused"))))));
+    }
+
+    @Test
+    public void testKeySymbolNotReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneMarkDistinctColumns())
+                .on(p ->
+                {
+                    Symbol key = p.symbol("key", BIGINT);
+                    Symbol mark = p.symbol("mark", BIGINT);
+                    return p.project(
+                            Assignments.identity(mark),
+                            p.markDistinct(mark, ImmutableList.of(key), p.values(key)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testAllOutputsReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneMarkDistinctColumns())
+                .on(p ->
+                {
+                    Symbol key = p.symbol("key", BIGINT);
+                    Symbol mark = p.symbol("mark", BIGINT);
+                    return p.project(
+                            Assignments.identity(key, mark),
+                            p.markDistinct(mark, ImmutableList.of(key), p.values(key)));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -39,6 +39,7 @@ import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
@@ -112,6 +113,16 @@ public class PlanBuilder
     public ProjectNode project(Assignments assignments, PlanNode source)
     {
         return new ProjectNode(idAllocator.getNextId(), source, assignments);
+    }
+
+    public MarkDistinctNode markDistinct(Symbol markerSymbol, List<Symbol> distinctSymbols, PlanNode source)
+    {
+        return new MarkDistinctNode(idAllocator.getNextId(), source, markerSymbol, distinctSymbols, Optional.empty());
+    }
+
+    public MarkDistinctNode markDistinct(Symbol markerSymbol, List<Symbol> distinctSymbols, Symbol hashSymbol, PlanNode source)
+    {
+        return new MarkDistinctNode(idAllocator.getNextId(), source, markerSymbol, distinctSymbols, Optional.of(hashSymbol));
     }
 
     public FilterNode filter(Expression predicate, PlanNode source)


### PR DESCRIPTION
Add PruneMarkDistinctColumns and its associated tooling:
* a builder function for MarkDistinctNode
* a matcher for MarkDistinctNode
* a builder function for the matcher
* the rule itself
* a unit test for the rule
* enabling the rule in presto's rule list

The rule elides the MarkDistinctNode entirely if the mark output is not
used.

https://github.com/prestodb/presto/issues/7154

After rebasing after the commit of PruneSemiJoinColumns, the first commit in this PR is now more stand-alone (it used to also contain the first introduction of `Util.restrictOutputs()`)  so I adjusted the commit message.