### PR TITLE
Print resolved plan when rule test fails

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
@@ -18,11 +18,11 @@ import com.facebook.presto.sql.planner.plan.PlanNode;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.sql.planner.iterative.Plans.resolveGroupReferences;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -91,15 +91,7 @@ public class Memo
 
     private PlanNode extract(PlanNode node)
     {
-        if (node instanceof GroupReference) {
-            return extract(membership.get(((GroupReference) node).getGroupId()));
-        }
-
-        List<PlanNode> children = node.getSources().stream()
-                .map(this::extract)
-                .collect(Collectors.toList());
-
-        return node.replaceChildren(children);
+        return resolveGroupReferences(node, Lookup.from(this::resolve));
     }
 
     public PlanNode replace(int group, PlanNode node, String reason)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Plans.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Plans.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative;
+
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanVisitor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class Plans
+{
+    public static PlanNode resolveGroupReferences(PlanNode node, Lookup lookup)
+    {
+        requireNonNull(node, "node is null");
+        return node.accept(new ResolvingVisitor(lookup), null);
+    }
+
+    private static class ResolvingVisitor
+            extends PlanVisitor<PlanNode, Void>
+    {
+        private final Lookup lookup;
+
+        public ResolvingVisitor(Lookup lookup)
+        {
+            this.lookup = requireNonNull(lookup, "lookup is null");
+        }
+
+        @Override
+        protected PlanNode visitPlan(PlanNode node, Void context)
+        {
+            List<PlanNode> children = node.getSources().stream()
+                    .map(child -> child.accept(this, context))
+                    .collect(Collectors.toList());
+
+            return node.replaceChildren(children);
+        }
+
+        @Override
+        public PlanNode visitGroupReference(GroupReference node, Void context)
+        {
+            return lookup.resolve(node).accept(this, context);
+        }
+    }
+
+    private Plans() {}
+}


### PR DESCRIPTION
Since #7715 rule tests use `Lookup` and test expectations can match plan with `GroupReferences` or without. When a rule test fails, both options should be printed.

### Before
```
java.lang.AssertionError: Plan does not match, expected [

- node(FilterNode)
    FilterMatcher{predicate=(("a" < 42) AND ("b" > 46))}
    - node(ValuesNode)
        ValuesMatcher{outputSymbolAliases={a=0, b=1}, expectedOutputSymbolCount=Optional.empty, expectedRows=Optional.empty}

] but found [

- Filter[filterPredicate = (("a" < 42) AND ("b" > 44))] => [a:bigint, b:bigint]
        Cost: {rows: ?, bytes: ?}
    - GroupReference[2] => [a:bigint, b:bigint]

]
```

### After
```
java.lang.AssertionError: Plan does not match, expected [

- node(FilterNode)
    FilterMatcher{predicate=(("a" < 42) AND ("b" > 46))}
    - node(ValuesNode)
        ValuesMatcher{outputSymbolAliases={a=0, b=1}, expectedOutputSymbolCount=Optional.empty, expectedRows=Optional.empty}

] but found [

- Filter[filterPredicate = (("a" < 42) AND ("b" > 44))] => [a:bigint, b:bigint]
        Cost: {rows: ?, bytes: ?}
    - GroupReference[2] => [a:bigint, b:bigint]

] which resolves to [

- Filter[filterPredicate = (("a" < 42) AND ("b" > 44))] => [a:bigint, b:bigint]
        Cost: {rows: 0, bytes: ?}
    - Values => [a:bigint, b:bigint]
            Cost: {rows: 0, bytes: ?}

] 
```