### PR TITLE
Change the return type of Block's size-related methods to long

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -57,7 +57,7 @@ public class GroupByIdBlock
     }
 
     @Override
-    public int getRegionSizeInBytes(int positionOffset, int length)
+    public long getRegionSizeInBytes(int positionOffset, int length)
     {
         return block.getRegionSizeInBytes(positionOffset, length);
     }
@@ -171,13 +171,13 @@ public class GroupByIdBlock
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return block.getSizeInBytes();
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + block.getRetainedSizeInBytes();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFlattenFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFlattenFunction.java
@@ -32,6 +32,7 @@ import java.lang.invoke.MethodHandle;
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
+import static java.lang.Math.toIntExact;
 
 public class ArrayFlattenFunction
         extends SqlScalarFunction
@@ -84,7 +85,7 @@ public class ArrayFlattenFunction
             return type.createBlockBuilder(new BlockBuilderStatus(), 0).build();
         }
 
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), array.getPositionCount(), array.getSizeInBytes() / array.getPositionCount());
+        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), array.getPositionCount(), toIntExact(array.getSizeInBytes() / array.getPositionCount()));
         for (int i = 0; i < array.getPositionCount(); i++) {
             if (!array.isNull(i)) {
                 Block subArray = (Block) arrayType.getObject(array, i);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayJoin.java
@@ -45,6 +45,7 @@ import static com.facebook.presto.spi.function.OperatorType.CAST;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.util.Reflection.methodHandle;
+import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 
 public final class ArrayJoin
@@ -202,7 +203,7 @@ public final class ArrayJoin
     {
         int numElements = arrayBlock.getPositionCount();
 
-        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(arrayBlock.getSizeInBytes() + delimiter.length() * arrayBlock.getPositionCount());
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(toIntExact(arrayBlock.getSizeInBytes() + delimiter.length() * arrayBlock.getPositionCount()));
 
         for (int i = 0; i < numElements; i++) {
             if (arrayBlock.isNull(i)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
@@ -296,8 +296,7 @@ public class JoinCompiler
                     .append(
                             channel.invoke("get", Object.class, blockIndex)
                                     .cast(type(Block.class))
-                                    .invoke("getRetainedSizeInBytes", int.class)
-                                    .cast(long.class))
+                                    .invoke("getRetainedSizeInBytes", long.class))
                     .longAdd()
                     .putField(sizeField);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -75,6 +75,7 @@ import static com.facebook.presto.util.DateTimeUtils.parseYearMonthInterval;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class LiteralInterpreter
@@ -193,7 +194,7 @@ public final class LiteralInterpreter
         }
 
         if (object instanceof Block) {
-            SliceOutput output = new DynamicSliceOutput(((Block) object).getSizeInBytes());
+            SliceOutput output = new DynamicSliceOutput(toIntExact(((Block) object).getSizeInBytes()));
             BlockSerdeUtil.writeBlock(output, (Block) object);
             object = output.slice();
             // This if condition will evaluate to true: object instanceof Slice && !type.equals(VARCHAR)

--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -187,17 +187,17 @@ public abstract class AbstractTestBlock
     {
         // Asserting on `block` is not very effective because most blocks passed to this method is compact.
         // Therefore, we split the `block` into two and assert again.
-        int expectedBlockSize = copyBlock(block).getSizeInBytes();
+        long expectedBlockSize = copyBlock(block).getSizeInBytes();
         assertEquals(block.getSizeInBytes(), expectedBlockSize);
         assertEquals(block.getRegionSizeInBytes(0, block.getPositionCount()), expectedBlockSize);
 
         List<Block> splitBlock = splitBlock(block, 2);
         Block firstHalf = splitBlock.get(0);
-        int expectedFirstHalfSize = copyBlock(firstHalf).getSizeInBytes();
+        long expectedFirstHalfSize = copyBlock(firstHalf).getSizeInBytes();
         assertEquals(firstHalf.getSizeInBytes(), expectedFirstHalfSize);
         assertEquals(block.getRegionSizeInBytes(0, firstHalf.getPositionCount()), expectedFirstHalfSize);
         Block secondHalf = splitBlock.get(1);
-        int expectedSecondHalfSize = copyBlock(secondHalf).getSizeInBytes();
+        long expectedSecondHalfSize = copyBlock(secondHalf).getSizeInBytes();
         assertEquals(secondHalf.getSizeInBytes(), expectedSecondHalfSize);
         assertEquals(block.getRegionSizeInBytes(firstHalf.getPositionCount(), secondHalf.getPositionCount()), expectedSecondHalfSize);
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestInterleavedBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestInterleavedBlock.java
@@ -80,11 +80,11 @@ public class TestInterleavedBlock
         InterleavedBlock block = blockBuilder.build();
 
         List<Block> splitQuarter = splitBlock(block, 4);
-        int sizeInBytes = block.getSizeInBytes();
-        int quarter1size = splitQuarter.get(0).getSizeInBytes();
-        int quarter2size = splitQuarter.get(1).getSizeInBytes();
-        int quarter3size = splitQuarter.get(2).getSizeInBytes();
-        int quarter4size = splitQuarter.get(3).getSizeInBytes();
+        long sizeInBytes = block.getSizeInBytes();
+        long quarter1size = splitQuarter.get(0).getSizeInBytes();
+        long quarter2size = splitQuarter.get(1).getSizeInBytes();
+        long quarter3size = splitQuarter.get(2).getSizeInBytes();
+        long quarter4size = splitQuarter.get(3).getSizeInBytes();
         double expectedQuarterSizeMin = sizeInBytes * 0.2;
         double expectedQuarterSizeMax = sizeInBytes * 0.3;
         assertTrue(quarter1size > expectedQuarterSizeMin && quarter1size < expectedQuarterSizeMax, format("quarter1size is %s, should be between %s and %s", quarter1size, expectedQuarterSizeMin, expectedQuarterSizeMax));

--- a/presto-main/src/test/java/com/facebook/presto/block/TestVariableWidthBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestVariableWidthBlock.java
@@ -95,11 +95,11 @@ public class TestVariableWidthBlock
         Block block = blockBuilder.build();
 
         List<Block> splitQuarter = splitBlock(block, 4);
-        int sizeInBytes = block.getSizeInBytes();
-        int quarter1size = splitQuarter.get(0).getSizeInBytes();
-        int quarter2size = splitQuarter.get(1).getSizeInBytes();
-        int quarter3size = splitQuarter.get(2).getSizeInBytes();
-        int quarter4size = splitQuarter.get(3).getSizeInBytes();
+        long sizeInBytes = block.getSizeInBytes();
+        long quarter1size = splitQuarter.get(0).getSizeInBytes();
+        long quarter2size = splitQuarter.get(1).getSizeInBytes();
+        long quarter3size = splitQuarter.get(2).getSizeInBytes();
+        long quarter4size = splitQuarter.get(3).getSizeInBytes();
         double expectedQuarterSizeMin = sizeInBytes * 0.2;
         double expectedQuarterSizeMax = sizeInBytes * 0.3;
         assertTrue(quarter1size > expectedQuarterSizeMin && quarter1size < expectedQuarterSizeMax, format("quarter1size is %s, should be between %s and %s", quarter1size, expectedQuarterSizeMin, expectedQuarterSizeMax));

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/Row.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/Row.java
@@ -42,9 +42,9 @@ import static java.util.Objects.requireNonNull;
 public class Row
 {
     private final List<Object> columns;
-    private final int sizeInBytes;
+    private final long sizeInBytes;
 
-    public Row(List<Object> columns, int sizeInBytes)
+    public Row(List<Object> columns, long sizeInBytes)
     {
         this.columns = requireNonNull(columns, "columns is null");
         checkArgument(sizeInBytes >= 0, "sizeInBytes must be >= 0");
@@ -56,7 +56,7 @@ public class Row
         return columns;
     }
 
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return sizeInBytes;
     }
@@ -70,7 +70,7 @@ public class Row
         for (int channel = 0; channel < page.getChannelCount(); channel++) {
             Block block = page.getBlock(channel);
             Type type = types.get(channel);
-            int size;
+            long size;
             Object value = getNativeContainerValue(type, block, position);
             if (value == null) {
                 size = SIZE_OF_BYTE;
@@ -180,7 +180,7 @@ public class Row
 
     private static class RowBuilder
     {
-        private int rowSize;
+        private long rowSize;
         private final List<Object> columns;
 
         public RowBuilder(int columnCount)
@@ -188,7 +188,7 @@ public class Row
             this.columns = new ArrayList<>(columnCount);
         }
 
-        public void add(Object value, int size)
+        public void add(Object value, long size)
         {
             columns.add(value);
             rowSize += size;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -90,7 +90,7 @@ public abstract class AbstractArrayBlock
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
         int positionCount = getPositionCount();
         if (position < 0 || length < 0 || position + length > positionCount) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
@@ -165,7 +165,7 @@ public abstract class AbstractFixedWidthBlock
     }
 
     @Override
-    public int getRegionSizeInBytes(int positionOffset, int length)
+    public long getRegionSizeInBytes(int positionOffset, int length)
     {
         int positionCount = getPositionCount();
         if (positionOffset < 0 || length < 0 || positionOffset + length > positionCount) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractInterleavedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractInterleavedBlock.java
@@ -253,7 +253,7 @@ public abstract class AbstractInterleavedBlock
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
         if (position == 0 && length == getPositionCount()) {
             // Calculation of getRegionSizeInBytes is expensive in this class.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
@@ -141,7 +141,7 @@ public abstract class AbstractMapBlock
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
         int positionCount = getPositionCount();
         if (position < 0 || length < 0 || position + length > positionCount) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
@@ -168,7 +168,7 @@ public abstract class AbstractSingleArrayBlock
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
@@ -224,7 +224,7 @@ public abstract class AbstractSingleMapBlock
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlock.java
@@ -15,7 +15,6 @@ package com.facebook.presto.spi.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
@@ -30,8 +29,8 @@ public class ArrayBlock
     private final Block values;
     private final int[] offsets;
 
-    private int sizeInBytes;
-    private final int retainedSizeInBytes;
+    private long sizeInBytes;
+    private final long retainedSizeInBytes;
 
     public ArrayBlock(int positionCount, boolean[] valueIsNull, int[] offsets, Block values)
     {
@@ -65,7 +64,7 @@ public class ArrayBlock
         this.values = requireNonNull(values);
 
         sizeInBytes = -1;
-        retainedSizeInBytes = intSaturatedCast(INSTANCE_SIZE + values.getRetainedSizeInBytes() + sizeOf(offsets) + sizeOf(valueIsNull));
+        retainedSizeInBytes = INSTANCE_SIZE + values.getRetainedSizeInBytes() + sizeOf(offsets) + sizeOf(valueIsNull);
     }
 
     @Override
@@ -75,7 +74,7 @@ public class ArrayBlock
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         // this is racy but is safe because sizeInBytes is an int and the calculation is stable
         if (sizeInBytes < 0) {
@@ -88,11 +87,11 @@ public class ArrayBlock
     {
         int valueStart = offsets[arrayOffset];
         int valueEnd = offsets[arrayOffset + positionCount];
-        sizeInBytes = intSaturatedCast(values.getRegionSizeInBytes(valueStart, valueEnd - valueStart) + ((Integer.BYTES + Byte.BYTES) * (long) this.positionCount));
+        sizeInBytes = values.getRegionSizeInBytes(valueStart, valueEnd - valueStart) + ((Integer.BYTES + Byte.BYTES) * (long) this.positionCount);
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -21,7 +21,6 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
@@ -45,7 +44,7 @@ public class ArrayBlockBuilder
     private final BlockBuilder values;
     private boolean currentEntryOpened;
 
-    private int retainedSizeInBytes;
+    private long retainedSizeInBytes;
 
     /**
      * Caller of this constructor is responsible for making sure `valuesBlock` is constructed with the same `blockBuilderStatus` as the one in the argument
@@ -93,13 +92,13 @@ public class ArrayBlockBuilder
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return values.getSizeInBytes() + ((Integer.BYTES + Byte.BYTES) * positionCount);
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes + values.getRetainedSizeInBytes();
     }
@@ -215,11 +214,10 @@ public class ArrayBlockBuilder
 
     private void updateDataSize()
     {
-        long size = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(offsets);
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(offsets);
         if (blockBuilderStatus != null) {
-            size += BlockBuilderStatus.INSTANCE_SIZE;
+            retainedSizeInBytes += BlockBuilderStatus.INSTANCE_SIZE;
         }
-        retainedSizeInBytes = intSaturatedCast(size);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -162,18 +162,18 @@ public interface Block
     /**
      * Returns the logical size of this block in memory.
      */
-    int getSizeInBytes();
+    long getSizeInBytes();
 
     /**
      * Returns the logical size of {@code block.getRegion(position, length)} in memory.
      */
-    int getRegionSizeInBytes(int position, int length);
+    long getRegionSizeInBytes(int position, int length);
 
     /**
      * Returns the retained size of this block in memory.
      * This method is called from the inner most execution loop and must be fast.
      */
-    int getRetainedSizeInBytes();
+    long getRetainedSizeInBytes();
 
     /**
      * Get the encoding for this block.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockUtil.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockUtil.java
@@ -76,12 +76,4 @@ final class BlockUtil
         }
         return (int) newSize;
     }
-
-    static int intSaturatedCast(long value)
-    {
-        if (value > Integer.MAX_VALUE) {
-            return Integer.MAX_VALUE;
-        }
-        return (int) value;
-    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class ByteArrayBlock
@@ -32,8 +31,8 @@ public class ByteArrayBlock
     private final boolean[] valueIsNull;
     private final byte[] values;
 
-    private final int sizeInBytes;
-    private final int retainedSizeInBytes;
+    private final long sizeInBytes;
+    private final long retainedSizeInBytes;
 
     public ByteArrayBlock(int positionCount, boolean[] valueIsNull, byte[] values)
     {
@@ -61,24 +60,24 @@ public class ByteArrayBlock
         }
         this.valueIsNull = valueIsNull;
 
-        sizeInBytes = intSaturatedCast((Byte.BYTES + Byte.BYTES) * (long) positionCount);
-        retainedSizeInBytes = intSaturatedCast((INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values)));
+        sizeInBytes = (Byte.BYTES + Byte.BYTES) * (long) positionCount;
+        retainedSizeInBytes = (INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values));
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return sizeInBytes;
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
-        return intSaturatedCast((Byte.BYTES + Byte.BYTES) * (long) length);
+        return (Byte.BYTES + Byte.BYTES) * (long) length;
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 
@@ -41,7 +40,7 @@ public class ByteArrayBlockBuilder
     private boolean[] valueIsNull = new boolean[0];
     private byte[] values = new byte[0];
 
-    private int retainedSizeInBytes;
+    private long retainedSizeInBytes;
 
     public ByteArrayBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
@@ -119,28 +118,27 @@ public class ByteArrayBlockBuilder
 
     private void updateDataSize()
     {
-        long size = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
         if (blockBuilderStatus != null) {
-            size += BlockBuilderStatus.INSTANCE_SIZE;
+            retainedSizeInBytes += BlockBuilderStatus.INSTANCE_SIZE;
         }
-        retainedSizeInBytes = intSaturatedCast(size);
     }
 
     // Copied from ByteArrayBlock
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
-        return intSaturatedCast((Byte.BYTES + Byte.BYTES) * (long) positionCount);
+        return (Byte.BYTES + Byte.BYTES) * positionCount;
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
-        return intSaturatedCast((Byte.BYTES + Byte.BYTES) * (long) length);
+        return (Byte.BYTES + Byte.BYTES) * length;
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -27,7 +27,6 @@ import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.spi.block.DictionaryId.randomDictionaryId;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class DictionaryBlock
@@ -39,8 +38,8 @@ public class DictionaryBlock
     private final Block dictionary;
     private final int idsOffset;
     private final int[] ids;
-    private final int retainedSizeInBytes;
-    private volatile int sizeInBytes = -1;
+    private final long retainedSizeInBytes;
+    private volatile long sizeInBytes = -1;
     private volatile int uniqueIds = -1;
     private final DictionaryId dictionarySourceId;
 
@@ -87,7 +86,7 @@ public class DictionaryBlock
         this.dictionary = dictionary;
         this.ids = ids;
         this.dictionarySourceId = requireNonNull(dictionarySourceId, "dictionarySourceId is null");
-        this.retainedSizeInBytes = toIntExact(INSTANCE_SIZE + dictionary.getRetainedSizeInBytes() + sizeOf(ids));
+        this.retainedSizeInBytes = INSTANCE_SIZE + dictionary.getRetainedSizeInBytes() + sizeOf(ids);
 
         if (dictionaryIsCompacted) {
             this.sizeInBytes = this.retainedSizeInBytes;
@@ -192,7 +191,7 @@ public class DictionaryBlock
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         // this is racy but is safe because sizeInBytes is an int and the calculation is stable
         if (sizeInBytes < 0) {
@@ -221,7 +220,7 @@ public class DictionaryBlock
     }
 
     @Override
-    public int getRegionSizeInBytes(int positionOffset, int length)
+    public long getRegionSizeInBytes(int positionOffset, int length)
     {
         if (positionOffset == 0 && length == getPositionCount()) {
             // Calculation of getRegionSizeInBytes is expensive in this class.
@@ -244,7 +243,7 @@ public class DictionaryBlock
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
@@ -21,7 +21,6 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.List;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static java.util.Objects.requireNonNull;
 
 public class FixedWidthBlock
@@ -72,15 +71,15 @@ public class FixedWidthBlock
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
-        return intSaturatedCast(getRawSlice().length() + valueIsNull.length());
+        return getRawSlice().length() + valueIsNull.length();
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
-        return intSaturatedCast(INSTANCE_SIZE + getRawSlice().getRetainedSize() + valueIsNull.getRetainedSize());
+        return INSTANCE_SIZE + getRawSlice().getRetainedSize() + valueIsNull.getRetainedSize();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -26,7 +26,6 @@ import java.util.List;
 import static com.facebook.presto.spi.block.BlockUtil.MAX_ARRAY_SIZE;
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
@@ -85,19 +84,19 @@ public class FixedWidthBlockBuilder
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
-        return intSaturatedCast(sliceOutput.size() + valueIsNull.size());
+        return sliceOutput.size() + valueIsNull.size();
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         long size = INSTANCE_SIZE + sliceOutput.getRetainedSize() + valueIsNull.getRetainedSize();
         if (blockBuilderStatus != null) {
             size += BlockBuilderStatus.INSTANCE_SIZE;
         }
-        return intSaturatedCast(size);
+        return size;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class IntArrayBlock
@@ -32,8 +31,8 @@ public class IntArrayBlock
     private final boolean[] valueIsNull;
     private final int[] values;
 
-    private final int sizeInBytes;
-    private final int retainedSizeInBytes;
+    private final long sizeInBytes;
+    private final long retainedSizeInBytes;
 
     public IntArrayBlock(int positionCount, boolean[] valueIsNull, int[] values)
     {
@@ -61,24 +60,24 @@ public class IntArrayBlock
         }
         this.valueIsNull = valueIsNull;
 
-        sizeInBytes = intSaturatedCast((Integer.BYTES + Byte.BYTES) * (long) positionCount);
-        retainedSizeInBytes = intSaturatedCast(INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values));
+        sizeInBytes = (Integer.BYTES + Byte.BYTES) * (long) positionCount;
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return sizeInBytes;
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
-        return intSaturatedCast((Integer.BYTES + Byte.BYTES) * (long) length);
+        return (Integer.BYTES + Byte.BYTES) * (long) length;
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 
@@ -42,7 +41,7 @@ public class IntArrayBlockBuilder
     private boolean[] valueIsNull = new boolean[0];
     private int[] values = new int[0];
 
-    private int retainedSizeInBytes;
+    private long retainedSizeInBytes;
 
     public IntArrayBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
@@ -120,28 +119,27 @@ public class IntArrayBlockBuilder
 
     private void updateDataSize()
     {
-        long size = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
         if (blockBuilderStatus != null) {
-            size += BlockBuilderStatus.INSTANCE_SIZE;
+            retainedSizeInBytes += BlockBuilderStatus.INSTANCE_SIZE;
         }
-        retainedSizeInBytes = intSaturatedCast(size);
     }
 
     // Copied from IntArrayBlock
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
-        return intSaturatedCast((Integer.BYTES + Byte.BYTES) * (long) positionCount);
+        return (Integer.BYTES + Byte.BYTES) * positionCount;
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
-        return intSaturatedCast((Integer.BYTES + Byte.BYTES) * (long) length);
+        return (Integer.BYTES + Byte.BYTES) * length;
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlock.java
@@ -15,7 +15,7 @@ package com.facebook.presto.spi.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class InterleavedBlock
         extends AbstractInterleavedBlock
@@ -26,17 +26,17 @@ public class InterleavedBlock
     private final InterleavedBlockEncoding blockEncoding;
     private final int start;
     private final int positionCount;
-    private final int retainedSizeInBytes;
+    private final long retainedSizeInBytes;
 
-    private final AtomicInteger sizeInBytes;
+    private final AtomicLong sizeInBytes;
 
     public InterleavedBlock(Block[] blocks)
     {
         super(blocks.length);
         this.blocks = blocks;
 
-        int sizeInBytes = 0;
-        int retainedSizeInBytes = INSTANCE_SIZE;
+        long sizeInBytes = 0;
+        long retainedSizeInBytes = INSTANCE_SIZE;
         int positionCount = 0;
         int firstSubBlockPositionCount = blocks[0].getPositionCount();
         for (int i = 0; i < getBlockCount(); i++) {
@@ -52,11 +52,11 @@ public class InterleavedBlock
         this.blockEncoding = computeBlockEncoding();
         this.start = 0;
         this.positionCount = positionCount;
-        this.sizeInBytes = new AtomicInteger(sizeInBytes);
+        this.sizeInBytes = new AtomicLong(sizeInBytes);
         this.retainedSizeInBytes = retainedSizeInBytes;
     }
 
-    private InterleavedBlock(Block[] blocks, int start, int positionCount, int retainedSizeInBytes, InterleavedBlockEncoding blockEncoding)
+    private InterleavedBlock(Block[] blocks, int start, int positionCount, long retainedSizeInBytes, InterleavedBlockEncoding blockEncoding)
     {
         super(blocks.length);
         this.blocks = blocks;
@@ -64,7 +64,7 @@ public class InterleavedBlock
         this.positionCount = positionCount;
         this.retainedSizeInBytes = retainedSizeInBytes;
         this.blockEncoding = blockEncoding;
-        this.sizeInBytes = new AtomicInteger(-1);
+        this.sizeInBytes = new AtomicLong(-1);
     }
 
     @Override
@@ -103,9 +103,9 @@ public class InterleavedBlock
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
-        int sizeInBytes = this.sizeInBytes.get();
+        long sizeInBytes = this.sizeInBytes.get();
         if (sizeInBytes < 0) {
             sizeInBytes = 0;
             for (int i = 0; i < getBlockCount(); i++) {
@@ -117,7 +117,7 @@ public class InterleavedBlock
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/InterleavedBlockBuilder.java
@@ -33,10 +33,10 @@ public class InterleavedBlockBuilder
 
     private int positionCount;
     private int currentBlockIndex;
-    private int sizeInBytes;
-    private int startSize;
-    private int retainedSizeInBytes;
-    private int startRetainedSize;
+    private long sizeInBytes;
+    private long startSize;
+    private long retainedSizeInBytes;
+    private long startRetainedSize;
 
     public InterleavedBlockBuilder(List<Type> types, BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
@@ -109,13 +109,13 @@ public class InterleavedBlockBuilder
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return sizeInBytes;
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -164,21 +164,21 @@ public class LazyBlock
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         assureLoaded();
         return block.getSizeInBytes();
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
         assureLoaded();
         return block.getRegionSizeInBytes(position, length);
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         assureLoaded();
         return INSTANCE_SIZE + block.getRetainedSizeInBytes();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.toIntExact;
 
@@ -33,8 +32,8 @@ public class LongArrayBlock
     private final boolean[] valueIsNull;
     private final long[] values;
 
-    private final int sizeInBytes;
-    private final int retainedSizeInBytes;
+    private final long sizeInBytes;
+    private final long retainedSizeInBytes;
 
     public LongArrayBlock(int positionCount, boolean[] valueIsNull, long[] values)
     {
@@ -62,24 +61,24 @@ public class LongArrayBlock
         }
         this.valueIsNull = valueIsNull;
 
-        sizeInBytes = intSaturatedCast((Long.BYTES + Byte.BYTES) * (long) positionCount);
-        retainedSizeInBytes = intSaturatedCast(INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values));
+        sizeInBytes = (Long.BYTES + Byte.BYTES) * (long) positionCount;
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return sizeInBytes;
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
-        return intSaturatedCast((Long.BYTES + Byte.BYTES) * (long) length);
+        return (Long.BYTES + Byte.BYTES) * (long) length;
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 import static java.lang.Math.toIntExact;
@@ -43,7 +42,7 @@ public class LongArrayBlockBuilder
     private boolean[] valueIsNull = new boolean[0];
     private long[] values = new long[0];
 
-    private int retainedSizeInBytes;
+    private long retainedSizeInBytes;
 
     public LongArrayBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
@@ -121,28 +120,27 @@ public class LongArrayBlockBuilder
 
     private void updateDataSize()
     {
-        long size = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
         if (blockBuilderStatus != null) {
-            size += BlockBuilderStatus.INSTANCE_SIZE;
+            retainedSizeInBytes += BlockBuilderStatus.INSTANCE_SIZE;
         }
-        retainedSizeInBytes = intSaturatedCast(size);
     }
 
     // Copied from LongArrayBlock
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
-        return intSaturatedCast((Long.BYTES + Byte.BYTES) * (long) positionCount);
+        return (Long.BYTES + Byte.BYTES) * positionCount;
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
-        return intSaturatedCast((Long.BYTES + Byte.BYTES) * (long) length);
+        return (Long.BYTES + Byte.BYTES) * length;
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlock.java
@@ -19,7 +19,6 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.lang.invoke.MethodHandle;
 
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -38,8 +37,8 @@ public class MapBlock
     private final Block valueBlock;
     private final int[] hashTables; // hash to location in map;
 
-    private int sizeInBytes;
-    private final int retainedSizeInBytes;
+    private long sizeInBytes;
+    private final long retainedSizeInBytes;
 
     /**
      * @param keyBlockNativeEquals (T, Block, int)boolean
@@ -74,8 +73,7 @@ public class MapBlock
         this.hashTables = hashTables;
 
         this.sizeInBytes = -1;
-        this.retainedSizeInBytes = intSaturatedCast(
-                INSTANCE_SIZE + keyBlock.getRetainedSizeInBytes() + valueBlock.getRetainedSizeInBytes() + sizeOf(offsets) + sizeOf(mapIsNull) + sizeOf(hashTables));
+        this.retainedSizeInBytes = INSTANCE_SIZE + keyBlock.getRetainedSizeInBytes() + valueBlock.getRetainedSizeInBytes() + sizeOf(offsets) + sizeOf(mapIsNull) + sizeOf(hashTables);
     }
 
     @Override
@@ -121,7 +119,7 @@ public class MapBlock
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         // this is racy but is safe because sizeInBytes is an int and the calculation is stable
         if (sizeInBytes < 0) {
@@ -142,7 +140,7 @@ public class MapBlock
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -23,7 +23,6 @@ import java.lang.invoke.MethodHandle;
 import java.util.Arrays;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -135,7 +134,7 @@ public class MapBlockBuilder
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return keyBlockBuilder.getSizeInBytes() + valueBlockBuilder.getSizeInBytes() +
                 (Integer.BYTES + Byte.BYTES) * positionCount +
@@ -143,13 +142,13 @@ public class MapBlockBuilder
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         long size = INSTANCE_SIZE + keyBlockBuilder.getRetainedSizeInBytes() + valueBlockBuilder.getRetainedSizeInBytes() + sizeOf(offsets) + sizeOf(mapIsNull) + sizeOf(hashTables);
         if (blockBuilderStatus != null) {
             size += BlockBuilderStatus.INSTANCE_SIZE;
         }
-        return intSaturatedCast(size);
+        return size;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -70,13 +70,13 @@ public class RunLengthEncodedBlock
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return value.getSizeInBytes();
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + value.getRetainedSizeInBytes();
     }
@@ -102,7 +102,7 @@ public class RunLengthEncodedBlock
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
         return value.getSizeInBytes();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class ShortArrayBlock
@@ -32,8 +31,8 @@ public class ShortArrayBlock
     private final boolean[] valueIsNull;
     private final short[] values;
 
-    private final int sizeInBytes;
-    private final int retainedSizeInBytes;
+    private final long sizeInBytes;
+    private final long retainedSizeInBytes;
 
     public ShortArrayBlock(int positionCount, boolean[] valueIsNull, short[] values)
     {
@@ -61,24 +60,24 @@ public class ShortArrayBlock
         }
         this.valueIsNull = valueIsNull;
 
-        sizeInBytes = intSaturatedCast((Short.BYTES + Byte.BYTES) * (long) positionCount);
-        retainedSizeInBytes = intSaturatedCast(INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values));
+        sizeInBytes = (Short.BYTES + Byte.BYTES) * (long) positionCount;
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return sizeInBytes;
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
-        return intSaturatedCast((Short.BYTES + Byte.BYTES) * (long) length);
+        return (Short.BYTES + Byte.BYTES) * (long) length;
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 
@@ -42,7 +41,7 @@ public class ShortArrayBlockBuilder
     private boolean[] valueIsNull = new boolean[0];
     private short[] values = new short[0];
 
-    private int retainedSizeInBytes;
+    private long retainedSizeInBytes;
 
     public ShortArrayBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
@@ -120,28 +119,27 @@ public class ShortArrayBlockBuilder
 
     private void updateDataSize()
     {
-        long size = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
         if (blockBuilderStatus != null) {
-            size += BlockBuilderStatus.INSTANCE_SIZE;
+            retainedSizeInBytes += BlockBuilderStatus.INSTANCE_SIZE;
         }
-        retainedSizeInBytes = intSaturatedCast(size);
     }
 
     // Copied from ShortArrayBlock
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
-        return intSaturatedCast((Short.BYTES + Byte.BYTES) * (long) positionCount);
+        return (Short.BYTES + Byte.BYTES) * positionCount;
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
-        return intSaturatedCast((Short.BYTES + Byte.BYTES) * (long) length);
+        return (Short.BYTES + Byte.BYTES) * length;
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
@@ -23,7 +23,7 @@ public class SingleArrayBlockWriter
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleArrayBlockWriter.class).instanceSize();
 
     private final BlockBuilder blockBuilder;
-    private final int initialBlockBuilderSize;
+    private final long initialBlockBuilderSize;
     private int positionsWritten;
 
     public SingleArrayBlockWriter(BlockBuilder blockBuilder, int start)
@@ -40,13 +40,13 @@ public class SingleArrayBlockWriter
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return blockBuilder.getSizeInBytes() - initialBlockBuilderSize;
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + blockBuilder.getRetainedSizeInBytes();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
@@ -23,7 +23,6 @@ import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.block.AbstractMapBlock.HASH_MULTIPLIER;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
 
@@ -62,17 +61,17 @@ public class SingleMapBlock
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
-        return intSaturatedCast(keyBlock.getRegionSizeInBytes(offset / 2, positionCount / 2) +
+        return keyBlock.getRegionSizeInBytes(offset / 2, positionCount / 2) +
                 valueBlock.getRegionSizeInBytes(offset / 2, positionCount / 2) +
-                sizeOfIntArray(positionCount / 2 * HASH_MULTIPLIER));
+                sizeOfIntArray(positionCount / 2 * HASH_MULTIPLIER);
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
-        return intSaturatedCast(INSTANCE_SIZE + keyBlock.getRetainedSizeInBytes() + valueBlock.getRetainedSizeInBytes() + sizeOf(hashTable));
+        return INSTANCE_SIZE + keyBlock.getRetainedSizeInBytes() + valueBlock.getRetainedSizeInBytes() + sizeOf(hashTable);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
@@ -24,7 +24,7 @@ public class SingleMapBlockWriter
 
     private final BlockBuilder keyBlockBuilder;
     private final BlockBuilder valueBlockBuilder;
-    private final int initialBlockBuilderSize;
+    private final long initialBlockBuilderSize;
     private int positionsWritten;
 
     private boolean writeToValueNext;
@@ -38,13 +38,13 @@ public class SingleMapBlockWriter
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return keyBlockBuilder.getSizeInBytes() + valueBlockBuilder.getSizeInBytes() - initialBlockBuilderSize;
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + keyBlockBuilder.getRetainedSizeInBytes() + valueBlockBuilder.getRetainedSizeInBytes();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class VariableWidthBlock
@@ -37,8 +36,8 @@ public class VariableWidthBlock
     private final int[] offsets;
     private final boolean[] valueIsNull;
 
-    private final int retainedSizeInBytes;
-    private final int sizeInBytes;
+    private final long retainedSizeInBytes;
+    private final long sizeInBytes;
 
     public VariableWidthBlock(int positionCount, Slice slice, int[] offsets, boolean[] valueIsNull)
     {
@@ -71,8 +70,8 @@ public class VariableWidthBlock
         }
         this.valueIsNull = valueIsNull;
 
-        sizeInBytes = intSaturatedCast(offsets[arrayOffset + positionCount] - offsets[arrayOffset] + ((Integer.BYTES + Byte.BYTES) * (long) positionCount));
-        retainedSizeInBytes = intSaturatedCast(INSTANCE_SIZE + slice.getRetainedSize() + sizeOf(valueIsNull) + sizeOf(offsets));
+        sizeInBytes = offsets[arrayOffset + positionCount] - offsets[arrayOffset] + ((Integer.BYTES + Byte.BYTES) * (long) positionCount);
+        retainedSizeInBytes = INSTANCE_SIZE + slice.getRetainedSize() + sizeOf(valueIsNull) + sizeOf(offsets);
     }
 
     @Override
@@ -101,19 +100,19 @@ public class VariableWidthBlock
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
         return sizeInBytes;
     }
 
     @Override
-    public int getRegionSizeInBytes(int position, int length)
+    public long getRegionSizeInBytes(int position, int length)
     {
-        return intSaturatedCast(offsets[arrayOffset + position + length] - offsets[arrayOffset + position] + ((Integer.BYTES + Byte.BYTES) * (long) length));
+        return offsets[arrayOffset + position + length] - offsets[arrayOffset + position] + ((Integer.BYTES + Byte.BYTES) * (long) length);
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import static com.facebook.presto.spi.block.BlockUtil.MAX_ARRAY_SIZE;
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
-import static com.facebook.presto.spi.block.BlockUtil.intSaturatedCast;
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
@@ -97,31 +96,31 @@ public class VariableWidthBlockBuilder
     }
 
     @Override
-    public int getSizeInBytes()
+    public long getSizeInBytes()
     {
-        long arraysSizeInBytes = (Integer.BYTES + Byte.BYTES) * (long) positions;
-        return intSaturatedCast(sliceOutput.size() + arraysSizeInBytes);
+        long arraysSizeInBytes = (Integer.BYTES + Byte.BYTES) * positions;
+        return sliceOutput.size() + arraysSizeInBytes;
     }
 
     @Override
-    public int getRegionSizeInBytes(int positionOffset, int length)
+    public long getRegionSizeInBytes(int positionOffset, int length)
     {
         int positionCount = getPositionCount();
         if (positionOffset < 0 || length < 0 || positionOffset + length > positionCount) {
             throw new IndexOutOfBoundsException("Invalid position " + positionOffset + " length " + length + " in block with " + positionCount + " positions");
         }
-        long arraysSizeInBytes = (Integer.BYTES + Byte.BYTES) * (long) length;
-        return intSaturatedCast(getOffset(positionOffset + length) - getOffset(positionOffset) + arraysSizeInBytes);
+        long arraysSizeInBytes = (Integer.BYTES + Byte.BYTES) * length;
+        return getOffset(positionOffset + length) - getOffset(positionOffset) + arraysSizeInBytes;
     }
 
     @Override
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         long size = INSTANCE_SIZE + sliceOutput.getRetainedSize() + arraysRetainedSizeInBytes;
         if (blockBuilderStatus != null) {
             size += BlockBuilderStatus.INSTANCE_SIZE;
         }
-        return intSaturatedCast(size);
+        return size;
     }
 
     @Override
@@ -260,7 +259,7 @@ public class VariableWidthBlockBuilder
 
     private void updateArraysDataSize()
     {
-        arraysRetainedSizeInBytes = intSaturatedCast(sizeOf(valueIsNull) + sizeOf(offsets));
+        arraysRetainedSizeInBytes = sizeOf(valueIsNull) + sizeOf(offsets);
     }
 
     @Override


### PR DESCRIPTION
Currently the getSizeInBytes/getRegionSizeInBytes/getRetainedSizeInBytes
methods all return integers. To implement these methods Block implementations
usually sum up the size of their internal states and cast that sum to integer
using different cast functions, which are different in different Block implementations,
and occasionally incorrect (using Ints.saturatedCast()).