### PR TITLE
Empty position links

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ArrayPositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ArrayPositionLinks.java
@@ -30,6 +30,7 @@ public final class ArrayPositionLinks
     public static class Builder implements PositionLinks.Builder
     {
         private final int[] positionLinks;
+        private int size;
 
         private Builder(int size)
         {
@@ -40,6 +41,7 @@ public final class ArrayPositionLinks
         @Override
         public int link(int left, int right)
         {
+            size++;
             positionLinks[left] = right;
             return left;
         }
@@ -48,6 +50,12 @@ public final class ArrayPositionLinks
         public Function<Optional<JoinFilterFunction>, PositionLinks> build()
         {
             return filterFunction -> new ArrayPositionLinks(positionLinks);
+        }
+
+        @Override
+        public int size()
+        {
+            return size;
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/PositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PositionLinks.java
@@ -52,5 +52,15 @@ public interface PositionLinks
          * since JoinFilterFunction is not thread safe...
          */
         Function<Optional<JoinFilterFunction>, PositionLinks> build();
+
+        /**
+         * @return number of linked elements
+         */
+        int size();
+
+        default boolean isEmpty()
+        {
+            return size() == 0;
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/SortedPositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SortedPositionLinks.java
@@ -156,6 +156,12 @@ public final class SortedPositionLinks
                         lessThanFunction.get());
             };
         }
+
+        @Override
+        public int size()
+        {
+            return positionLinks.size();
+        }
     }
 
     private final PositionLinks positionLinks;

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -54,6 +54,7 @@ import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static java.lang.String.format;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.openjdk.jmh.annotations.Mode.AverageTime;
 import static org.openjdk.jmh.annotations.Scope.Thread;
 
@@ -63,7 +64,7 @@ import static org.openjdk.jmh.annotations.Scope.Thread;
 @BenchmarkMode(AverageTime)
 @Fork(3)
 @Warmup(iterations = 5)
-@Measurement(iterations = 20)
+@Measurement(iterations = 10, time = 2, timeUnit = SECONDS)
 public class BenchmarkHashBuildAndJoinOperators
 {
     private static final int HASH_BUILD_OPERATOR_ID = 1;
@@ -75,7 +76,7 @@ public class BenchmarkHashBuildAndJoinOperators
     public static class BuildContext
     {
         protected static final int ROWS_PER_PAGE = 1024;
-        protected static final int BUILD_ROWS_NUMBER = 700_000;
+        protected static final int BUILD_ROWS_NUMBER = 8_000_000;
 
         @Param({"varchar", "bigint", "all"})
         protected String hashColumns;
@@ -161,7 +162,7 @@ public class BenchmarkHashBuildAndJoinOperators
     public static class JoinContext
             extends BuildContext
     {
-        protected static final int PROBE_ROWS_NUMBER = 700_000;
+        protected static final int PROBE_ROWS_NUMBER = 1_400_000;
 
         @Param({"0.1", "1", "2"})
         protected double matchRate;

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -79,13 +79,13 @@ public class BenchmarkHashBuildAndJoinOperators
         protected static final int BUILD_ROWS_NUMBER = 8_000_000;
 
         @Param({"varchar", "bigint", "all"})
-        protected String hashColumns;
+        protected String hashColumns = "bigint";
 
         @Param({"false", "true"})
-        protected boolean buildHashEnabled;
+        protected boolean buildHashEnabled = false;
 
         @Param({"1", "5"})
-        protected int buildRowsRepetition;
+        protected int buildRowsRepetition = 1;
 
         protected ExecutorService executor;
         protected List<Page> buildPages;
@@ -165,10 +165,10 @@ public class BenchmarkHashBuildAndJoinOperators
         protected static final int PROBE_ROWS_NUMBER = 1_400_000;
 
         @Param({"0.1", "1", "2"})
-        protected double matchRate;
+        protected double matchRate = 1;
 
         @Param({"bigint", "all"})
-        protected String outputColumns;
+        protected String outputColumns = "bigint";
 
         protected List<Page> probePages;
         protected List<Integer> outputChannels;


### PR DESCRIPTION
Do not use PositionLinks if they are empty

When all position links are empty do not allocate memory for them and short cut returning of "no next position". This is common case for example when join key is a primary key in the build table.

This reduce memory footprint by couple of percents and speeds up join a little bit when data structures for LookupSource do not fit into CPU cache.

Results with following parameters:
```
hashColumns = "bigint"
buildHashEnabled = false
buildRowsRepetition = 1
matchRate = 1
ouptutColumns = "bigint"
```

Before:
```
Benchmark                                             Mode  Cnt    Score   Error  Units
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash  avgt   30  195.306 ± 3.291  ms/op
```
After:
```
Benchmark                                             Mode  Cnt    Score   Error  Units
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash  avgt   30  187.437 ± 4.679  ms/op
```