### PR TITLE
Fix Microsoft ACCEPT_EULA url in product-test doc

### DIFF
--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -255,7 +255,7 @@ be any one of the available profiles:
     ```
 
 Note: SQL Server product-tests use `microsoft/mssql-server-linux` docker container.
-By running SQL Server product tests you accept the license [ACCEPT_EULA](go.microsoft.com/fwlink/?LinkId=746388)
+By running SQL Server product tests you accept the license [ACCEPT_EULA](https://go.microsoft.com/fwlink/?LinkId=746388)
 
 ### Running from IntelliJ
 


### PR DESCRIPTION
Current url (go.microsoft.com/fwlink/?LinkId=746388) become https://github.com/prestodb/presto/blob/master/presto-product-tests/go.microsoft.com/fwlink/?LinkId=746388 and it returns 404 not found.