### PR TITLE
Lookup-usage fixes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeSearcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeSearcher.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.sql.planner.optimizations;
 
-import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.google.common.collect.ImmutableList;
@@ -22,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import static com.facebook.presto.sql.planner.iterative.Lookup.noLookup;
 import static com.facebook.presto.sql.planner.optimizations.Predicates.alwaysTrue;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -34,7 +34,7 @@ public class PlanNodeSearcher
     @Deprecated
     public static PlanNodeSearcher searchFrom(PlanNode node)
     {
-        return new PlanNodeSearcher(node);
+        return searchFrom(node, noLookup());
     }
 
     public static PlanNodeSearcher searchFrom(PlanNode node, Lookup lookup)
@@ -46,15 +46,6 @@ public class PlanNodeSearcher
     private final Lookup lookup;
     private Predicate<PlanNode> where = alwaysTrue();
     private Predicate<PlanNode> skipOnly = alwaysTrue();
-
-    @Deprecated
-    public PlanNodeSearcher(PlanNode planNode)
-    {
-        this(planNode, (node) -> {
-            checkArgument(!(node instanceof GroupReference), "GroupReference cannot occur in non-iterative plan");
-            return node;
-        });
-    }
 
     public PlanNodeSearcher(PlanNode node, Lookup lookup)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedScalarAggregationToJoin.java
@@ -29,6 +29,7 @@ import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.sql.planner.iterative.Lookup.noLookup;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.planner.optimizations.Predicates.isInstanceOfAny;
 import static com.facebook.presto.sql.planner.plan.SimplePlanRewriter.rewriteWith;
@@ -108,7 +109,7 @@ public class TransformCorrelatedScalarAggregationToJoin
                         .skipOnlyWhen(isInstanceOfAny(ProjectNode.class, EnforceSingleRowNode.class))
                         .findFirst();
                 if (aggregation.isPresent() && aggregation.get().getGroupingKeys().isEmpty()) {
-                    ScalarAggregationToJoinRewriter scalarAggregationToJoinRewriter = new ScalarAggregationToJoinRewriter(functionRegistry, symbolAllocator, idAllocator);
+                    ScalarAggregationToJoinRewriter scalarAggregationToJoinRewriter = new ScalarAggregationToJoinRewriter(functionRegistry, symbolAllocator, idAllocator, noLookup());
                     return scalarAggregationToJoinRewriter.rewriteScalarAggregation(rewrittenNode, aggregation.get());
                 }
             }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -147,11 +147,7 @@ public class RuleAssert
         Lookup lookup = Lookup.from(memo::resolve);
         Optional<PlanNode> result = inTransaction(session -> rule.apply(memo.getNode(memo.getRootGroup()), lookup, idAllocator, symbolAllocator, session));
 
-        return new RuleApplication(
-                memo,
-                lookup,
-                symbolAllocator.getTypes(),
-                result);
+        return new RuleApplication(lookup, symbolAllocator.getTypes(), result);
     }
 
     private String formatPlan(PlanNode plan, Map<Symbol, Type> types)
@@ -172,14 +168,12 @@ public class RuleAssert
 
     private static class RuleApplication
     {
-        private final Memo memo;
         private final Lookup lookup;
         private final Map<Symbol, Type> types;
         private final Optional<PlanNode> result;
 
-        public RuleApplication(Memo memo, Lookup lookup, Map<Symbol, Type> types, Optional<PlanNode> result)
+        public RuleApplication(Lookup lookup, Map<Symbol, Type> types, Optional<PlanNode> result)
         {
-            this.memo = requireNonNull(memo, "memo is null");
             this.lookup = requireNonNull(lookup, "lookup is null");
             this.types = requireNonNull(types, "types is null");
             this.result = requireNonNull(result, "result is null");

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -40,6 +40,7 @@ import java.util.function.Function;
 import static com.facebook.presto.sql.planner.assertions.PlanAssert.assertPlan;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.fail;
 
 public class RuleAssert
@@ -91,39 +92,35 @@ public class RuleAssert
 
     public void doesNotFire()
     {
-        SymbolAllocator symbolAllocator = new SymbolAllocator(symbols);
-        Optional<PlanNode> result = inTransaction(session -> rule.apply(plan, x -> x, idAllocator, symbolAllocator, session));
+        RuleApplication ruleApplication = applyRule();
 
-        if (result.isPresent()) {
+        if (ruleApplication.wasRuleApplied()) {
             fail(String.format(
                     "Expected %s to not fire for:\n%s",
                     rule.getClass().getName(),
-                    inTransaction(session -> PlanPrinter.textLogicalPlan(plan, symbolAllocator.getTypes(), metadata, costCalculator, session, 2))));
+                    inTransaction(session -> PlanPrinter.textLogicalPlan(plan, ruleApplication.types, metadata, costCalculator, session, 2))));
         }
     }
 
     public void matches(PlanMatchPattern pattern)
     {
-        SymbolAllocator symbolAllocator = new SymbolAllocator(symbols);
-        Memo memo = new Memo(idAllocator, plan);
-        Lookup lookup = Lookup.from(memo::resolve);
-        Optional<PlanNode> result = inTransaction(session -> rule.apply(memo.getNode(memo.getRootGroup()), lookup, idAllocator, symbolAllocator, session));
-        Map<Symbol, Type> types = symbolAllocator.getTypes();
+        RuleApplication ruleApplication = applyRule();
+        Map<Symbol, Type> types = ruleApplication.types;
 
-        if (!result.isPresent()) {
+        if (!ruleApplication.wasRuleApplied()) {
             fail(String.format(
                     "%s did not fire for:\n%s",
                     rule.getClass().getName(),
-                    inTransaction(session -> PlanPrinter.textLogicalPlan(plan, types, metadata, costCalculator, session, 2))));
+                    formatPlan(plan, types)));
         }
 
-        PlanNode actual = result.get();
+        PlanNode actual = ruleApplication.getResult();
 
         if (actual == plan) { // plans are not comparable, so we can only ensure they are not the same instance
             fail(String.format(
                     "%s: rule fired but return the original plan:\n%s",
                     rule.getClass().getName(),
-                    inTransaction(session -> PlanPrinter.textLogicalPlan(plan, types, metadata, costCalculator, session, 2))));
+                    formatPlan(plan, types)));
         }
 
         if (!ImmutableSet.copyOf(plan.getOutputSymbols()).equals(ImmutableSet.copyOf(actual.getOutputSymbols()))) {
@@ -138,9 +135,28 @@ public class RuleAssert
 
         inTransaction(session -> {
             Map<PlanNodeId, PlanNodeCost> planNodeCosts = costCalculator.calculateCostForPlan(session, types, actual);
-            assertPlan(session, metadata, costCalculator, new Plan(actual, types, planNodeCosts), lookup, pattern);
+            assertPlan(session, metadata, costCalculator, new Plan(actual, types, planNodeCosts), ruleApplication.lookup, pattern);
             return null;
         });
+    }
+
+    private RuleApplication applyRule()
+    {
+        SymbolAllocator symbolAllocator = new SymbolAllocator(symbols);
+        Memo memo = new Memo(idAllocator, plan);
+        Lookup lookup = Lookup.from(memo::resolve);
+        Optional<PlanNode> result = inTransaction(session -> rule.apply(memo.getNode(memo.getRootGroup()), lookup, idAllocator, symbolAllocator, session));
+
+        return new RuleApplication(
+                memo,
+                lookup,
+                symbolAllocator.getTypes(),
+                result);
+    }
+
+    private String formatPlan(PlanNode plan, Map<Symbol, Type> types)
+    {
+        return inTransaction(session -> PlanPrinter.textLogicalPlan(plan, types, metadata, costCalculator, session, 2));
     }
 
     private <T> T inTransaction(Function<Session, T> transactionSessionConsumer)
@@ -152,5 +168,31 @@ public class RuleAssert
                     session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
                     return transactionSessionConsumer.apply(session);
                 });
+    }
+
+    private static class RuleApplication
+    {
+        private final Memo memo;
+        private final Lookup lookup;
+        private final Map<Symbol, Type> types;
+        private final Optional<PlanNode> result;
+
+        public RuleApplication(Memo memo, Lookup lookup, Map<Symbol, Type> types, Optional<PlanNode> result)
+        {
+            this.memo = requireNonNull(memo, "memo is null");
+            this.lookup = requireNonNull(lookup, "lookup is null");
+            this.types = requireNonNull(types, "types is null");
+            this.result = requireNonNull(result, "result is null");
+        }
+
+        private boolean wasRuleApplied()
+        {
+            return result.isPresent();
+        }
+
+        public PlanNode getResult()
+        {
+            return result.orElseThrow(() -> new IllegalStateException("Rule was not applied"));
+        }
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedStats.java
@@ -16,7 +16,6 @@ package com.facebook.presto.tests;
 import com.facebook.presto.execution.StageInfo;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.sql.planner.Plan;
-import com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.tests.statistics.Metric;
 import com.facebook.presto.tests.statistics.MetricComparator;
@@ -33,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.tests.statistics.MetricComparison.Result.DIFFER;
 import static com.facebook.presto.tests.statistics.MetricComparison.Result.MATCH;
 import static com.facebook.presto.tests.statistics.MetricComparison.Result.NO_BASELINE;
@@ -115,7 +115,7 @@ public class TestTpchDistributedStats
         String queryId = executeQuery(query);
         Plan queryPlan = getQueryPlan(queryId);
 
-        List<PlanNode> allPlanNodes = new PlanNodeSearcher(queryPlan.getRoot()).findAll();
+        List<PlanNode> allPlanNodes = searchFrom(queryPlan.getRoot()).findAll();
 
         System.out.println(format("Query TPCH [%s] produces [%s] plan nodes.\n", queryNumber, allPlanNodes.size()));
 


### PR DESCRIPTION
This PR consists of:
* code simplification by replacing `Optional<Lookup>` with either normal `Lookup` or `noLookup()` stub
* a change to `RuleTester` so that `doesNotFire()` tests are carried using same setup/env as positive tests