### PR TITLE
Wait with LookupSourceFactory destruction until all users finish [spilljoin]

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
@@ -83,7 +83,7 @@ public class LookupJoinOperatorFactory
             // when all join operators finish (and lookup source is ready), set the outer position future to start the outer operator
             ListenableFuture<LookupSource> lookupSourceAfterProbeFinished = transformAsync(probeReferenceCount.getFreeFuture(), ignored -> lookupSourceFactory.createLookupSource());
             ListenableFuture<OuterPositionIterator> outerPositionsFuture = transform(lookupSourceAfterProbeFinished, lookupSource -> {
-                try (LookupSource close = lookupSource) {
+                try (LookupSource ignore = lookupSource) {
                     return lookupSource.getOuterPositionIterator();
                 }
             });

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
@@ -70,7 +70,7 @@ public class LookupJoinOperatorFactory
         probeReferenceCount = new ReferenceCount();
         lookupSourceFactoryUsersCount = new ReferenceCount();
 
-        // when probe and build-outer operators finish, destroy the lookup source (freeing the memory)
+        // when all probe and build-outer operators finish, destroy the lookup source (freeing the memory)
         lookupSourceFactoryUsersCount.getFreeFuture().addListener(lookupSourceFactory::destroy, directExecutor());
 
         // Whole probe side is counted as 1 in lookupSourceFactoryUsersCount

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
@@ -19,17 +19,16 @@ import com.facebook.presto.operator.LookupSource.OuterPositionIterator;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 import static com.facebook.presto.operator.LookupJoinOperators.JoinType.INNER;
 import static com.facebook.presto.operator.LookupJoinOperators.JoinType.PROBE_OUTER;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.transform;
+import static com.google.common.util.concurrent.Futures.transformAsync;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
 
@@ -81,14 +80,13 @@ public class LookupJoinOperatorFactory
             this.outerOperatorFactory = Optional.empty();
         }
         else {
-            // when all join operators finish, set the outer position future to start the outer operator
-            SettableFuture<OuterPositionIterator> outerPositionsFuture = SettableFuture.create();
-            probeReferenceCount.getFreeFuture().addListener(() -> {
-                // lookup source may not be finished yet, so add a listener
-                Futures.addCallback(
-                        lookupSourceFactory.createLookupSource(),
-                        new OnSuccessFutureCallback<>(lookupSource -> outerPositionsFuture.set(lookupSource.getOuterPositionIterator())));
-            }, directExecutor());
+            // when all join operators finish (and lookup source is ready), set the outer position future to start the outer operator
+            ListenableFuture<LookupSource> lookupSourceAfterProbeFinished = transformAsync(probeReferenceCount.getFreeFuture(), ignored -> lookupSourceFactory.createLookupSource());
+            ListenableFuture<OuterPositionIterator> outerPositionsFuture = transform(lookupSourceAfterProbeFinished, lookupSource -> {
+                try (LookupSource close = lookupSource) {
+                    return lookupSource.getOuterPositionIterator();
+                }
+            });
 
             lookupSourceFactoryUsersCount.retain();
             this.outerOperatorFactory = Optional.of(new LookupOuterOperatorFactory(operatorId, planNodeId, outerPositionsFuture, probeOutputTypes, buildOutputTypes, lookupSourceFactoryUsersCount));
@@ -166,28 +164,5 @@ public class LookupJoinOperatorFactory
     public Optional<OperatorFactory> createOuterOperatorFactory()
     {
         return outerOperatorFactory;
-    }
-
-    // We use a public class to avoid access problems with the isolated class loaders
-    public static class OnSuccessFutureCallback<T>
-            implements FutureCallback<T>
-    {
-        private final Consumer<T> onSuccess;
-
-        public OnSuccessFutureCallback(Consumer<T> onSuccess)
-        {
-            this.onSuccess = onSuccess;
-        }
-
-        @Override
-        public void onSuccess(T result)
-        {
-            onSuccess.accept(result);
-        }
-
-        @Override
-        public void onFailure(Throwable t)
-        {
-        }
     }
 }


### PR DESCRIPTION
`HashBuilderOperator` allocates and accounts memory for `LookupSource`.
It waits until `PartitionedLookupSourceFactory` is destroyed and then
removes the memory from the books. This should not happen until memory
is actually no longer used/referenced. In case of outer join in build
side (full outer or right outer), `LookupSourceFactory` should not be
destroyed until `LookupOuterOperator`-s are finished/closed.

Fixes #8143