### PR TITLE
Prune index source columns

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -38,6 +38,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
 import com.facebook.presto.sql.planner.iterative.rule.PruneCountAggregationOverScalar;
 import com.facebook.presto.sql.planner.iterative.rule.PruneCrossJoinColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PruneIndexSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneJoinChildrenColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneMarkDistinctColumns;
@@ -138,6 +139,7 @@ public class PlanOptimizers
         // TODO: Once we've migrated handling all the plan node types, replace uses of PruneUnreferencedOutputs with an IterativeOptimizer containing these rules.
         Set<Rule> columnPruningRules = ImmutableSet.of(
                 new PruneCrossJoinColumns(),
+                new PruneIndexSourceColumns(),
                 new PruneJoinChildrenColumns(),
                 new PruneJoinColumns(),
                 new PruneMarkDistinctColumns(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneIndexSourceColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneIndexSourceColumns.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.IndexSourceNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+public class PruneIndexSourceColumns
+        implements Rule
+{
+    private static final Pattern PATTERN = Pattern.node(ProjectNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        ProjectNode parent = (ProjectNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof IndexSourceNode)) {
+            return Optional.empty();
+        }
+
+        IndexSourceNode indexSourceNode = (IndexSourceNode) source;
+
+        Optional<Set<Symbol>> prunedIndexSourceOutputs = pruneInputs(indexSourceNode.getOutputSymbols(), parent.getAssignments().getExpressions());
+        if (!prunedIndexSourceOutputs.isPresent()) {
+            return Optional.empty();
+        }
+
+        Set<Symbol> newLookupSymbols = indexSourceNode.getLookupSymbols().stream()
+                .filter(prunedIndexSourceOutputs.get()::contains)
+                .collect(toImmutableSet());
+
+        Map<Symbol, ColumnHandle> newAssignments = Maps.filterEntries(
+                indexSourceNode.getAssignments(),
+                entry -> prunedIndexSourceOutputs.get().contains(entry.getKey()) ||
+                        tupleDomainReferencesColumnHandle(indexSourceNode.getEffectiveTupleDomain(), entry.getValue()));
+
+        List<Symbol> prunedIndexSourceOutputList =
+                indexSourceNode.getOutputSymbols().stream()
+                        .filter(prunedIndexSourceOutputs.get()::contains)
+                        .collect(toImmutableList());
+
+        return Optional.of(
+                parent.replaceChildren(ImmutableList.of(
+                        new IndexSourceNode(
+                                indexSourceNode.getId(),
+                                indexSourceNode.getIndexHandle(),
+                                indexSourceNode.getTableHandle(),
+                                indexSourceNode.getLayout(),
+                                newLookupSymbols,
+                                prunedIndexSourceOutputList,
+                                newAssignments,
+                                indexSourceNode.getEffectiveTupleDomain()))));
+    }
+
+    private static boolean tupleDomainReferencesColumnHandle(
+            TupleDomain<ColumnHandle> tupleDomain,
+            ColumnHandle columnHandle)
+    {
+        return tupleDomain.getDomains()
+                .map(domains -> domains.containsKey(columnHandle))
+                .orElse(false);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IndexSourceNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IndexSourceNode.java
@@ -67,6 +67,11 @@ public class IndexSourceNode
         checkArgument(!outputSymbols.isEmpty(), "outputSymbols is empty");
         checkArgument(assignments.keySet().containsAll(lookupSymbols), "Assignments do not include all lookup symbols");
         checkArgument(outputSymbols.containsAll(lookupSymbols), "Lookup symbols need to be part of the output symbols");
+        Set<ColumnHandle> assignedColumnHandles = ImmutableSet.copyOf(assignments.values());
+        effectiveTupleDomain.getDomains().ifPresent(handleToDomain ->
+                checkArgument(
+                        assignedColumnHandles.containsAll(handleToDomain.keySet()),
+                        "Tuple domain handles must have assigned symbols"));
     }
 
     @JsonProperty

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestingConnectorIndexHandle.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestingConnectorIndexHandle.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.spi.ConnectorIndexHandle;
+
+public enum TestingConnectorIndexHandle
+        implements ConnectorIndexHandle
+{
+    INSTANCE
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestingConnectorTransactionHandle.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestingConnectorTransactionHandle.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+public enum TestingConnectorTransactionHandle
+        implements ConnectorTransactionHandle
+{
+    INSTANCE
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/IndexSourceMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/IndexSourceMatcher.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.PlanNodeCost;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.TableMetadata;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.sql.planner.plan.IndexSourceNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.facebook.presto.sql.planner.assertions.Util.domainsMatch;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+final class IndexSourceMatcher
+        implements Matcher
+{
+    private final String expectedTableName;
+    private final Optional<Map<String, Domain>> expectedConstraint;
+
+    public IndexSourceMatcher(String expectedTableName)
+    {
+        this.expectedTableName = requireNonNull(expectedTableName, "expectedTableName is null");
+        expectedConstraint = Optional.empty();
+    }
+
+    public IndexSourceMatcher(String expectedTableName, Map<String, Domain> expectedConstraint)
+    {
+        this.expectedTableName = requireNonNull(expectedTableName, "expectedTableName is null");
+        this.expectedConstraint = Optional.of(ImmutableMap.copyOf(expectedConstraint));
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof IndexSourceNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, PlanNodeCost cost, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+
+        IndexSourceNode indexSourceNode = (IndexSourceNode) node;
+        TableMetadata tableMetadata = metadata.getTableMetadata(session, indexSourceNode.getTableHandle());
+        String actualTableName = tableMetadata.getTable().getTableName();
+
+        if (!expectedTableName.equalsIgnoreCase(actualTableName)) {
+            return NO_MATCH;
+        }
+
+        if (expectedConstraint.isPresent() &&
+                !domainsMatch(
+                        expectedConstraint,
+                        indexSourceNode.getEffectiveTupleDomain(),
+                        indexSourceNode.getTableHandle(),
+                        session,
+                        metadata)) {
+            return NO_MATCH;
+        }
+
+        return match();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .omitNullValues()
+                .add("expectedTableName", expectedTableName)
+                .add("expectedConstraint", expectedConstraint.orElse(null))
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -28,6 +28,7 @@ import com.facebook.presto.sql.planner.plan.ExceptNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.planner.plan.IndexSourceNode;
 import com.facebook.presto.sql.planner.plan.IntersectNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
@@ -137,6 +138,13 @@ public final class PlanMatchPattern
     {
         PlanMatchPattern result = constrainedTableScan(expectedTableName, constraint);
         return result.addColumnReferences(expectedTableName, columnReferences);
+    }
+
+    public static PlanMatchPattern constrainedIndexSource(String expectedTableName, Map<String, Domain> constraint, Map<String, String> columnReferences)
+    {
+        return node(IndexSourceNode.class)
+                .with(new IndexSourceMatcher(expectedTableName, constraint))
+                .addColumnReferences(expectedTableName, columnReferences);
     }
 
     private PlanMatchPattern addColumnReferences(String expectedTableName, Map<String, String> columnReferences)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/Util.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/Util.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+
+import java.util.Map;
+import java.util.Optional;
+
+final class Util
+{
+    private Util() {}
+
+    /**
+     * @param expectedDomains if empty, the actualConstraint's domains must also be empty.
+     */
+    static boolean domainsMatch(
+            Optional<Map<String, Domain>> expectedDomains,
+            TupleDomain<ColumnHandle> actualConstraint,
+            TableHandle tableHandle,
+            Session session,
+            Metadata metadata)
+    {
+        Optional<Map<ColumnHandle, Domain>> actualDomains = actualConstraint.getDomains();
+
+        if (expectedDomains.isPresent() != actualDomains.isPresent()) {
+            return false;
+        }
+
+        if (!expectedDomains.isPresent()) {
+            return true;
+        }
+
+        Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle);
+        for (Map.Entry<String, Domain> expectedColumnConstraint : expectedDomains.get().entrySet()) {
+            if (!columnHandles.containsKey(expectedColumnConstraint.getKey())) {
+                return false;
+            }
+            ColumnHandle columnHandle = columnHandles.get(expectedColumnConstraint.getKey());
+            if (!actualDomains.get().containsKey(columnHandle)) {
+                return false;
+            }
+            if (!expectedColumnConstraint.getValue().contains(actualDomains.get().get(columnHandle))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneIndexSourceColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneIndexSourceColumns.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.function.Predicate;
+
+import static com.facebook.presto.spi.predicate.NullableValue.asNull;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.constrainedIndexSource;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCALE_FACTOR;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class TestPruneIndexSourceColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testNotAllOutputsReferenced()
+    {
+        tester().assertThat(new PruneIndexSourceColumns())
+                .on(p -> buildProjectedIndexSource(p, symbol -> symbol.getName().equals("orderkey")))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("x", expression("orderkey")),
+                                constrainedIndexSource(
+                                        "orders",
+                                        ImmutableMap.of("totalprice", Domain.onlyNull(DOUBLE)),
+                                        ImmutableMap.of(
+                                                "orderkey", "orderkey",
+                                                "totalprice", "totalprice"))));
+    }
+
+    @Test
+    public void testAllOutputsReferenced()
+    {
+        tester().assertThat(new PruneIndexSourceColumns())
+                .on(p -> buildProjectedIndexSource(p, Predicates.alwaysTrue()))
+                .doesNotFire();
+    }
+
+    private static PlanNode buildProjectedIndexSource(PlanBuilder p, Predicate<Symbol> projectionFilter)
+    {
+        Symbol orderkey = p.symbol("orderkey", INTEGER);
+        Symbol custkey = p.symbol("custkey", INTEGER);
+        Symbol totalprice = p.symbol("totalprice", DOUBLE);
+        ColumnHandle orderkeyHandle = new TpchColumnHandle(orderkey.getName(), INTEGER);
+        ColumnHandle custkeyHandle = new TpchColumnHandle(custkey.getName(), INTEGER);
+        ColumnHandle totalpriceHandle = new TpchColumnHandle(totalprice.getName(), DOUBLE);
+        return p.project(
+                Assignments.identity(
+                        ImmutableList.of(orderkey, custkey, totalprice).stream()
+                                .filter(projectionFilter)
+                                .collect(toImmutableList())),
+                p.indexSource(
+                        new TableHandle(
+                                new ConnectorId("local"),
+                                new TpchTableHandle("local", "orders", TINY_SCALE_FACTOR)),
+                        ImmutableSet.of(orderkey, custkey),
+                        ImmutableList.of(orderkey, custkey, totalprice),
+                        ImmutableMap.of(
+                                orderkey, orderkeyHandle,
+                                custkey, custkeyHandle,
+                                totalprice, totalpriceHandle),
+                        TupleDomain.fromFixedValues(ImmutableMap.of(totalpriceHandle, asNull(DOUBLE)))));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner.iterative.rule.test;
 
 import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.metadata.IndexHandle;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.TableHandle;
@@ -28,6 +29,8 @@ import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.TestingConnectorIndexHandle;
+import com.facebook.presto.sql.planner.TestingConnectorTransactionHandle;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
@@ -37,6 +40,7 @@ import com.facebook.presto.sql.planner.plan.DeleteNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.IndexSourceNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.LimitNode;
@@ -66,6 +70,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -325,6 +330,27 @@ public class PlanBuilder
                 sourceHashSymbol,
                 filteringSourceHashSymbol,
                 Optional.empty());
+    }
+
+    public IndexSourceNode indexSource(
+            TableHandle tableHandle,
+            Set<Symbol> lookupSymbols,
+            List<Symbol> outputSymbols,
+            Map<Symbol, ColumnHandle> assignments,
+            TupleDomain<ColumnHandle> effectiveTupleDomain)
+    {
+        return new IndexSourceNode(
+                idAllocator.getNextId(),
+                new IndexHandle(
+                        tableHandle.getConnectorId(),
+                        TestingConnectorTransactionHandle.INSTANCE,
+                        TestingConnectorIndexHandle.INSTANCE),
+                tableHandle,
+                Optional.empty(),
+                lookupSymbols,
+                outputSymbols,
+                assignments,
+                effectiveTupleDomain);
     }
 
     public ExchangeNode exchange(Consumer<ExchangeBuilder> exchangeBuilderConsumer)


### PR DESCRIPTION
Add PruneIndexSourceColumns and its associated tooling:
* a builder function for IndexSourceNode
* a matcher for IndexSourceNode
* a bulider function for the matcher
* the rule itself
* a unit test for the rule
* enabling the rule in presto's rule list

Also, refactor some TableScanNode matching code so it can be shared
between TableScanNode and IndexSourceNode, because they are similar.

https://github.com/prestodb/presto/issues/7154