### PR TITLE
Fix code locations of to_ieee754_32/64 functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/binary.rst
+++ b/presto-docs/src/main/sphinx/functions/binary.rst
@@ -38,6 +38,10 @@ Binary Functions
 
     Encodes ``bigint`` in a 64-bit 2's complement big endian format.
 
+.. function:: from_big_endian_64(binary) -> bigint
+
+    Decodes ``bigint`` value from a 64-bit 2's complement big endian ``binary``.
+
 .. function:: to_ieee754_32(real) -> varbinary
 
     Encodes ``real`` in a 32-bit big-endian binary according to IEEE 754 single-precision floating-point format.
@@ -45,10 +49,6 @@ Binary Functions
 .. function:: to_ieee754_64(double) -> varbinary
 
     Encodes ``double`` in a 64-bit big-endian binary according to IEEE 754 double-precision floating-point format.
-
-.. function:: from_big_endian_64(binary) -> bigint
-
-    Decodes ``bigint`` value from a 64-bit 2's complement big endian ``binary``.
 
 .. function:: md5(binary) -> varbinary
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
@@ -146,6 +146,17 @@ public final class VarbinaryFunctions
         return slice;
     }
 
+    @Description("decode bigint value from a 64-bit 2's complement big endian varbinary")
+    @ScalarFunction("from_big_endian_64")
+    @SqlType(StandardTypes.BIGINT)
+    public static long fromBigEndian64(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        if (slice.length() != Long.BYTES) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "expected 8-byte input, but got instead: " + slice.length());
+        }
+        return Long.reverseBytes(slice.getLong(0));
+    }
+
     @Description("encode value as a big endian varbinary according to IEEE 754 single-precision floating-point format")
     @ScalarFunction("to_ieee754_32")
     @SqlType(StandardTypes.VARBINARY)
@@ -164,17 +175,6 @@ public final class VarbinaryFunctions
         Slice slice = Slices.allocate(Double.BYTES);
         slice.setLong(0, Long.reverseBytes(Double.doubleToLongBits(value)));
         return slice;
-    }
-
-    @Description("decode bigint value from a 64-bit 2's complement big endian varbinary")
-    @ScalarFunction("from_big_endian_64")
-    @SqlType(StandardTypes.BIGINT)
-    public static long fromBigEndian64(@SqlType(StandardTypes.VARBINARY) Slice slice)
-    {
-        if (slice.length() != Long.BYTES) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "expected 8-byte input, but got instead: " + slice.length());
-        }
-        return Long.reverseBytes(slice.getLong(0));
     }
 
     @Description("compute md5 hash")


### PR DESCRIPTION
The documents and implementations of the to_ieee754_32/64
functions are incorrectly put between the to_big_endian_64
and from_big_endian_64 functions.