### PR TITLE
Add checks for Kerberos properties in Hive connector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -100,14 +100,8 @@ public class HiveClientConfig
     private boolean rcfileOptimizedWriterEnabled;
 
     private HiveMetastoreAuthenticationType hiveMetastoreAuthenticationType = HiveMetastoreAuthenticationType.NONE;
-    private String hiveMetastoreServicePrincipal;
-    private String hiveMetastoreClientPrincipal;
-    private String hiveMetastoreClientKeytab;
-
     private HdfsAuthenticationType hdfsAuthenticationType = HdfsAuthenticationType.NONE;
     private boolean hdfsImpersonationEnabled;
-    private String hdfsPrestoPrincipal;
-    private String hdfsPrestoKeytab;
 
     private boolean skipDeletionForAlter;
 
@@ -712,6 +706,7 @@ public class HiveClientConfig
         KERBEROS
     }
 
+    @NotNull
     public HiveMetastoreAuthenticationType getHiveMetastoreAuthenticationType()
     {
         return hiveMetastoreAuthenticationType;
@@ -725,51 +720,13 @@ public class HiveClientConfig
         return this;
     }
 
-    public String getHiveMetastoreServicePrincipal()
-    {
-        return hiveMetastoreServicePrincipal;
-    }
-
-    @Config("hive.metastore.service.principal")
-    @ConfigDescription("Hive Metastore service principal")
-    public HiveClientConfig setHiveMetastoreServicePrincipal(String hiveMetastoreServicePrincipal)
-    {
-        this.hiveMetastoreServicePrincipal = hiveMetastoreServicePrincipal;
-        return this;
-    }
-
-    public String getHiveMetastoreClientPrincipal()
-    {
-        return hiveMetastoreClientPrincipal;
-    }
-
-    @Config("hive.metastore.client.principal")
-    @ConfigDescription("Hive Metastore client principal")
-    public HiveClientConfig setHiveMetastoreClientPrincipal(String hiveMetastoreClientPrincipal)
-    {
-        this.hiveMetastoreClientPrincipal = hiveMetastoreClientPrincipal;
-        return this;
-    }
-
-    public String getHiveMetastoreClientKeytab()
-    {
-        return hiveMetastoreClientKeytab;
-    }
-
-    @Config("hive.metastore.client.keytab")
-    @ConfigDescription("Hive Metastore client keytab location")
-    public HiveClientConfig setHiveMetastoreClientKeytab(String hiveMetastoreClientKeytab)
-    {
-        this.hiveMetastoreClientKeytab = hiveMetastoreClientKeytab;
-        return this;
-    }
-
     public enum HdfsAuthenticationType
     {
         NONE,
         KERBEROS,
     }
 
+    @NotNull
     public HdfsAuthenticationType getHdfsAuthenticationType()
     {
         return hdfsAuthenticationType;
@@ -793,32 +750,6 @@ public class HiveClientConfig
     public HiveClientConfig setHdfsImpersonationEnabled(boolean hdfsImpersonationEnabled)
     {
         this.hdfsImpersonationEnabled = hdfsImpersonationEnabled;
-        return this;
-    }
-
-    public String getHdfsPrestoPrincipal()
-    {
-        return hdfsPrestoPrincipal;
-    }
-
-    @Config("hive.hdfs.presto.principal")
-    @ConfigDescription("Presto principal used to access HDFS")
-    public HiveClientConfig setHdfsPrestoPrincipal(String hdfsPrestoPrincipal)
-    {
-        this.hdfsPrestoPrincipal = hdfsPrestoPrincipal;
-        return this;
-    }
-
-    public String getHdfsPrestoKeytab()
-    {
-        return hdfsPrestoKeytab;
-    }
-
-    @Config("hive.hdfs.presto.keytab")
-    @ConfigDescription("Presto keytab used to access HDFS")
-    public HiveClientConfig setHdfsPrestoKeytab(String hdfsPrestoKeytab)
-    {
-        this.hdfsPrestoKeytab = hdfsPrestoKeytab;
         return this;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/AuthenticationModules.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/AuthenticationModules.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive.authentication;
 
 import com.facebook.presto.hive.ForHdfs;
 import com.facebook.presto.hive.ForHiveMetastore;
-import com.facebook.presto.hive.HiveClientConfig;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Module;
@@ -25,6 +24,7 @@ import com.google.inject.Singleton;
 import javax.inject.Inject;
 
 import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public final class AuthenticationModules
 {
@@ -48,15 +48,16 @@ public final class AuthenticationModules
                 binder.bind(HiveMetastoreAuthentication.class)
                         .to(KerberosHiveMetastoreAuthentication.class)
                         .in(SINGLETON);
+                configBinder(binder).bindConfig(MetastoreKerberosConfig.class);
             }
 
             @Provides
             @Singleton
             @ForHiveMetastore
-            HadoopAuthentication createHadoopAuthentication(HiveClientConfig hiveClientConfig)
+            HadoopAuthentication createHadoopAuthentication(MetastoreKerberosConfig config)
             {
-                String principal = hiveClientConfig.getHiveMetastoreClientPrincipal();
-                String keytabLocation = hiveClientConfig.getHiveMetastoreClientKeytab();
+                String principal = config.getHiveMetastoreClientPrincipal();
+                String keytabLocation = config.getHiveMetastoreClientKeytab();
                 return createCachingKerberosHadoopAuthentication(principal, keytabLocation);
             }
         };
@@ -91,16 +92,17 @@ public final class AuthenticationModules
                 binder.bind(HdfsAuthentication.class)
                         .to(DirectHdfsAuthentication.class)
                         .in(SINGLETON);
+                configBinder(binder).bindConfig(HdfsKerberosConfig.class);
             }
 
             @Inject
             @Provides
             @Singleton
             @ForHdfs
-            HadoopAuthentication createHadoopAuthentication(HiveClientConfig hiveClientConfig)
+            HadoopAuthentication createHadoopAuthentication(HdfsKerberosConfig config)
             {
-                String principal = hiveClientConfig.getHdfsPrestoPrincipal();
-                String keytabLocation = hiveClientConfig.getHdfsPrestoKeytab();
+                String principal = config.getHdfsPrestoPrincipal();
+                String keytabLocation = config.getHdfsPrestoKeytab();
                 return createCachingKerberosHadoopAuthentication(principal, keytabLocation);
             }
         };
@@ -116,16 +118,17 @@ public final class AuthenticationModules
                 binder.bind(HdfsAuthentication.class)
                         .to(ImpersonatingHdfsAuthentication.class)
                         .in(SINGLETON);
+                configBinder(binder).bindConfig(HdfsKerberosConfig.class);
             }
 
             @Inject
             @Provides
             @Singleton
             @ForHdfs
-            HadoopAuthentication createHadoopAuthentication(HiveClientConfig hiveClientConfig)
+            HadoopAuthentication createHadoopAuthentication(HdfsKerberosConfig config)
             {
-                String principal = hiveClientConfig.getHdfsPrestoPrincipal();
-                String keytabLocation = hiveClientConfig.getHdfsPrestoKeytab();
+                String principal = config.getHdfsPrestoPrincipal();
+                String keytabLocation = config.getHdfsPrestoKeytab();
                 return createCachingKerberosHadoopAuthentication(principal, keytabLocation);
             }
         };

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/HdfsKerberosConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/HdfsKerberosConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.authentication;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+import javax.validation.constraints.NotNull;
+
+public class HdfsKerberosConfig
+{
+    private String hdfsPrestoPrincipal;
+    private String hdfsPrestoKeytab;
+
+    @NotNull
+    public String getHdfsPrestoPrincipal()
+    {
+        return hdfsPrestoPrincipal;
+    }
+
+    @Config("hive.hdfs.presto.principal")
+    @ConfigDescription("Presto principal used to access HDFS")
+    public HdfsKerberosConfig setHdfsPrestoPrincipal(String hdfsPrestoPrincipal)
+    {
+        this.hdfsPrestoPrincipal = hdfsPrestoPrincipal;
+        return this;
+    }
+
+    @NotNull
+    public String getHdfsPrestoKeytab()
+    {
+        return hdfsPrestoKeytab;
+    }
+
+    @Config("hive.hdfs.presto.keytab")
+    @ConfigDescription("Presto keytab used to access HDFS")
+    public HdfsKerberosConfig setHdfsPrestoKeytab(String hdfsPrestoKeytab)
+    {
+        this.hdfsPrestoKeytab = hdfsPrestoKeytab;
+        return this;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosHiveMetastoreAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosHiveMetastoreAuthentication.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.hive.authentication;
 
 import com.facebook.presto.hive.ForHiveMetastore;
-import com.facebook.presto.hive.HiveClientConfig;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.hive.thrift.client.TUGIAssumingTransport;
@@ -41,9 +40,9 @@ public class KerberosHiveMetastoreAuthentication
     private final HadoopAuthentication authentication;
 
     @Inject
-    public KerberosHiveMetastoreAuthentication(HiveClientConfig hiveClientConfig, @ForHiveMetastore HadoopAuthentication authentication)
+    public KerberosHiveMetastoreAuthentication(MetastoreKerberosConfig config, @ForHiveMetastore HadoopAuthentication authentication)
     {
-        this(hiveClientConfig.getHiveMetastoreServicePrincipal(), authentication);
+        this(config.getHiveMetastoreServicePrincipal(), authentication);
     }
 
     public KerberosHiveMetastoreAuthentication(String hiveMetastoreServicePrincipal, HadoopAuthentication authentication)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/MetastoreKerberosConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/MetastoreKerberosConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.authentication;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+import javax.validation.constraints.NotNull;
+
+public class MetastoreKerberosConfig
+{
+    private String hiveMetastoreServicePrincipal;
+    private String hiveMetastoreClientPrincipal;
+    private String hiveMetastoreClientKeytab;
+
+    @NotNull
+    public String getHiveMetastoreServicePrincipal()
+    {
+        return hiveMetastoreServicePrincipal;
+    }
+
+    @Config("hive.metastore.service.principal")
+    @ConfigDescription("Hive Metastore service principal")
+    public MetastoreKerberosConfig setHiveMetastoreServicePrincipal(String hiveMetastoreServicePrincipal)
+    {
+        this.hiveMetastoreServicePrincipal = hiveMetastoreServicePrincipal;
+        return this;
+    }
+
+    @NotNull
+    public String getHiveMetastoreClientPrincipal()
+    {
+        return hiveMetastoreClientPrincipal;
+    }
+
+    @Config("hive.metastore.client.principal")
+    @ConfigDescription("Hive Metastore client principal")
+    public MetastoreKerberosConfig setHiveMetastoreClientPrincipal(String hiveMetastoreClientPrincipal)
+    {
+        this.hiveMetastoreClientPrincipal = hiveMetastoreClientPrincipal;
+        return this;
+    }
+
+    @NotNull
+    public String getHiveMetastoreClientKeytab()
+    {
+        return hiveMetastoreClientKeytab;
+    }
+
+    @Config("hive.metastore.client.keytab")
+    @ConfigDescription("Hive Metastore client keytab location")
+    public MetastoreKerberosConfig setHiveMetastoreClientKeytab(String hiveMetastoreClientKeytab)
+    {
+        this.hiveMetastoreClientKeytab = hiveMetastoreClientKeytab;
+        return this;
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HiveClientConfig.HdfsAuthenticationType;
+import com.facebook.presto.hive.HiveClientConfig.HiveMetastoreAuthenticationType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
@@ -78,14 +80,9 @@ public class TestHiveClientConfig
                 .setOrcMaxBufferSize(new DataSize(8, Unit.MEGABYTE))
                 .setOrcStreamBufferSize(new DataSize(8, Unit.MEGABYTE))
                 .setRcfileOptimizedWriterEnabled(false)
-                .setHiveMetastoreAuthenticationType(HiveClientConfig.HiveMetastoreAuthenticationType.NONE)
-                .setHiveMetastoreServicePrincipal(null)
-                .setHiveMetastoreClientPrincipal(null)
-                .setHiveMetastoreClientKeytab(null)
-                .setHdfsAuthenticationType(HiveClientConfig.HdfsAuthenticationType.NONE)
+                .setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType.NONE)
+                .setHdfsAuthenticationType(HdfsAuthenticationType.NONE)
                 .setHdfsImpersonationEnabled(false)
-                .setHdfsPrestoPrincipal(null)
-                .setHdfsPrestoKeytab(null)
                 .setSkipDeletionForAlter(false)
                 .setBucketExecutionEnabled(true)
                 .setBucketWritingEnabled(true)
@@ -142,13 +139,8 @@ public class TestHiveClientConfig
                 .put("hive.orc.stream-buffer-size", "55kB")
                 .put("hive.rcfile-optimized-writer.enabled", "true")
                 .put("hive.metastore.authentication.type", "KERBEROS")
-                .put("hive.metastore.service.principal", "hive/_HOST@EXAMPLE.COM")
-                .put("hive.metastore.client.principal", "metastore@EXAMPLE.COM")
-                .put("hive.metastore.client.keytab", "/tmp/metastore.keytab")
                 .put("hive.hdfs.authentication.type", "KERBEROS")
                 .put("hive.hdfs.impersonation.enabled", "true")
-                .put("hive.hdfs.presto.principal", "presto@EXAMPLE.COM")
-                .put("hive.hdfs.presto.keytab", "/tmp/presto.keytab")
                 .put("hive.skip-deletion-for-alter", "true")
                 .put("hive.bucket-execution", "false")
                 .put("hive.bucket-writing", "false")
@@ -201,14 +193,9 @@ public class TestHiveClientConfig
                 .setOrcMaxBufferSize(new DataSize(44, Unit.KILOBYTE))
                 .setOrcStreamBufferSize(new DataSize(55, Unit.KILOBYTE))
                 .setRcfileOptimizedWriterEnabled(true)
-                .setHiveMetastoreAuthenticationType(HiveClientConfig.HiveMetastoreAuthenticationType.KERBEROS)
-                .setHiveMetastoreServicePrincipal("hive/_HOST@EXAMPLE.COM")
-                .setHiveMetastoreClientPrincipal("metastore@EXAMPLE.COM")
-                .setHiveMetastoreClientKeytab("/tmp/metastore.keytab")
-                .setHdfsAuthenticationType(HiveClientConfig.HdfsAuthenticationType.KERBEROS)
+                .setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType.KERBEROS)
+                .setHdfsAuthenticationType(HdfsAuthenticationType.KERBEROS)
                 .setHdfsImpersonationEnabled(true)
-                .setHdfsPrestoPrincipal("presto@EXAMPLE.COM")
-                .setHdfsPrestoKeytab("/tmp/presto.keytab")
                 .setSkipDeletionForAlter(true)
                 .setBucketExecutionEnabled(false)
                 .setBucketWritingEnabled(false)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/authentication/TestHdfsKerberosConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/authentication/TestHdfsKerberosConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.authentication;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.testing.ConfigAssertions;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class TestHdfsKerberosConfig
+{
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("hive.hdfs.presto.principal", "presto@EXAMPLE.COM")
+                .put("hive.hdfs.presto.keytab", "/tmp/presto.keytab")
+                .build();
+
+        HdfsKerberosConfig expected = new HdfsKerberosConfig()
+                .setHdfsPrestoPrincipal("presto@EXAMPLE.COM")
+                .setHdfsPrestoKeytab("/tmp/presto.keytab");
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/authentication/TestMetastoreKerberosConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/authentication/TestMetastoreKerberosConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.authentication;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.testing.ConfigAssertions;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class TestMetastoreKerberosConfig
+{
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("hive.metastore.service.principal", "hive/_HOST@EXAMPLE.COM")
+                .put("hive.metastore.client.principal", "metastore@EXAMPLE.COM")
+                .put("hive.metastore.client.keytab", "/tmp/metastore.keytab")
+                .build();
+
+        MetastoreKerberosConfig expected = new MetastoreKerberosConfig()
+                .setHiveMetastoreServicePrincipal("hive/_HOST@EXAMPLE.COM")
+                .setHiveMetastoreClientPrincipal("metastore@EXAMPLE.COM")
+                .setHiveMetastoreClientKeytab("/tmp/metastore.keytab");
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
Ensure that we have all the properties set for Hive connector
when using Kerberos to access the Hive metastore or HDFS.
This splits out the configs and adds validations.