### PR TITLE
Fix parsing of normal form identifiers

### DIFF
--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -345,6 +345,10 @@ intervalField
     : YEAR | MONTH | DAY | HOUR | MINUTE | SECOND
     ;
 
+normalForm
+    : NFD | NFC | NFKD | NFKC
+    ;
+
 type
     : type ARRAY
     | ARRAY '<' type '>'
@@ -442,6 +446,7 @@ number
     | INTEGER_VALUE  #integerLiteral
     ;
 
+// This rule must only contain tokens. Anything else will crash the parser.
 nonReserved
     : SHOW | TABLES | COLUMNS | COLUMN | PARTITIONS | FUNCTIONS | SCHEMAS | CATALOGS | SESSION | STATS
     | ADD
@@ -455,7 +460,7 @@ nonReserved
     | SET | RESET
     | VIEW | REPLACE
     | IF | NULLIF | COALESCE
-    | normalForm
+    | NFD | NFC | NFKD | NFKC
     | POSITION
     | NO | DATA
     | START | TRANSACTION | COMMIT | ROLLBACK | WORK | ISOLATION | LEVEL
@@ -468,10 +473,6 @@ nonReserved
     | INPUT | OUTPUT
     | INCLUDING | EXCLUDING | PROPERTIES
     | ALL | SOME | ANY
-    ;
-
-normalForm
-    : NFD | NFC | NFKD | NFKC
     ;
 
 SELECT: 'SELECT';

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1746,6 +1746,7 @@ public class TestSqlParser
                         table(QualifiedName.of("t"))));
 
         assertExpression("stats", new Identifier("stats"));
+        assertExpression("nfc", new Identifier("nfc"));
     }
 
     @Test


### PR DESCRIPTION
The identifiers NFD, NFC, NFKD and NFKC are supposed to be treated as
non-reserved, but using them would crash the parser due to an ANLTR bug.