### PR TITLE
Reliably call Operator.finish() even if blocked

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -288,16 +288,13 @@ public class Driver
                 Operator current = operators.get(i);
                 Operator next = operators.get(i + 1);
 
-                // skip blocked operators
+                // skip blocked operator
                 if (getBlockedFuture(current).isPresent()) {
-                    continue;
-                }
-                if (getBlockedFuture(next).isPresent()) {
                     continue;
                 }
 
                 // if the current operator is not finished and next operator needs input...
-                if (!current.isFinished() && next.needsInput()) {
+                if (!current.isFinished() && !getBlockedFuture(next).isPresent() && next.needsInput()) {
                     // get an output page from current operator
                     current.getOperatorContext().startIntervalTimer();
                     Page page = current.getOutput();

--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -293,7 +293,7 @@ public class Driver
                     continue;
                 }
 
-                // if the current operator is not finished and next operator needs input...
+                // if the current operator is not finished and next operator isn't blocked and needs input...
                 if (!current.isFinished() && !getBlockedFuture(next).isPresent() && next.needsInput()) {
                     // get an output page from current operator
                     current.getOperatorContext().startIntervalTimer();


### PR DESCRIPTION
Before this commit, `Operator.finish()` could be called when operator is
blocked, but only if it got blocked during last `addInput()`. This
commit removes this condition and makes delivery of `finish()`
unconditionally clear.

Supersedes #7972