### PR TITLE
Create resource group during selectGroup

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -109,13 +109,12 @@ public final class InternalResourceGroupManager
         checkState(configurationManager.get() != null, "configurationManager not set");
         ResourceGroupId group;
         try {
-            group = selectGroup(queryExecution.getSession());
+            group = selectGroup(queryExecution.getSession(), executor);
         }
         catch (PrestoException e) {
             queryExecution.fail(e);
             return;
         }
-        createGroupIfNecessary(group, queryExecution.getSession(), executor);
         groups.get(group).run(queryExecution);
     }
 
@@ -261,12 +260,19 @@ public final class InternalResourceGroupManager
         }
     }
 
-    private ResourceGroupId selectGroup(Session session)
+    private ResourceGroupId selectGroup(Session session, Executor executor)
     {
         SelectionContext context = new SelectionContext(session.getIdentity().getPrincipal().isPresent(), session.getUser(), session.getSource(), getQueryPriority(session));
         for (ResourceGroupSelector selector : configurationManager.get().getSelectors()) {
             Optional<ResourceGroupId> group = selector.match(context);
             if (group.isPresent()) {
+                try {
+                    createGroupIfNecessary(group.get(), session, executor);
+                }
+                catch (RuntimeException e) {
+                    log.error(e, "Cannot create resource group %s", group.toString());
+                    continue;
+                }
                 return group.get();
             }
         }


### PR DESCRIPTION
This will try to create resource group after applying a selector rule, and fall to the next selector if creation fail. It will prevent mis-configuration between selector and resource group to fail a query.