### PR TITLE
Fix ORDER BY expressions which evaluate to the same canonical

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -114,10 +114,14 @@ public class SymbolMapper
     {
         ImmutableList.Builder<Symbol> symbols = ImmutableList.builder();
         ImmutableMap.Builder<Symbol, SortOrder> orderings = ImmutableMap.builder();
+        Set<Symbol> seenCanonicals = new HashSet<>(node.getOrderBy().size());
         for (Symbol symbol : node.getOrderBy()) {
             Symbol canonical = map(symbol);
-            symbols.add(canonical);
-            orderings.put(canonical, node.getOrderings().get(symbol));
+            if (seenCanonicals.add(canonical)) {
+                seenCanonicals.add(canonical);
+                symbols.add(canonical);
+                orderings.put(canonical, node.getOrderings().get(symbol));
+            }
         }
 
         return new TopNNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TopNNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TopNNode.java
@@ -17,7 +17,6 @@ import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.sql.planner.Symbol;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -29,6 +28,7 @@ import java.util.Map;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.util.Failures.checkCondition;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -58,11 +58,11 @@ public class TopNNode
         super(id);
 
         requireNonNull(source, "source is null");
-        Preconditions.checkArgument(count >= 0, "count must be positive");
+        checkArgument(count >= 0, "count must be positive");
         checkCondition(count <= Integer.MAX_VALUE, NOT_SUPPORTED, "ORDER BY LIMIT > %s is not supported", Integer.MAX_VALUE);
         requireNonNull(orderBy, "orderBy is null");
-        Preconditions.checkArgument(!orderBy.isEmpty(), "orderBy is empty");
-        Preconditions.checkArgument(orderings.size() == orderBy.size(), "orderBy and orderings sizes don't match");
+        checkArgument(!orderBy.isEmpty(), "orderBy is empty");
+        checkArgument(orderings.size() == orderBy.size(), "orderBy and orderings sizes don't match");
 
         this.source = source;
         this.count = count;

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3747,6 +3747,29 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testOrderByWithSimilarExpressions()
+    {
+        assertQuery(
+                "WITH t AS (SELECT 1 x, 2 y) SELECT x, y FROM t ORDER BY x, y",
+                "SELECT 1, 2");
+        assertQuery(
+                "WITH t AS (SELECT 1 x, 2 y) SELECT x, y FROM t ORDER BY x, y LIMIT 1",
+                "SELECT 1, 2");
+        assertQuery(
+                "WITH t AS (SELECT 1 x, 1 y) SELECT x, y FROM t ORDER BY x, y LIMIT 1",
+                "SELECT 1, 1");
+        assertQuery(
+                "WITH t AS (SELECT orderkey x, orderkey y FROM orders) SELECT x, y FROM t ORDER BY x, y LIMIT 1",
+                "SELECT 1, 1");
+        assertQuery(
+                "WITH t AS (SELECT orderkey x, orderkey y FROM orders) SELECT x, y FROM t ORDER BY x, y DESC LIMIT 1",
+                "SELECT 1, 1");
+        assertQuery(
+                "WITH t AS (SELECT orderkey x, totalprice y, orderkey z FROM orders) SELECT x, y, z FROM t ORDER BY x, y, z LIMIT 1",
+                "SELECT 1, 172799.49, 1");
+    }
+
+    @Test
     public void testGroupByOrdinal()
     {
         assertQuery(


### PR DESCRIPTION
Fix ORDER BY expressions which evaluate to the same canonical
