### PR TITLE
Prune join columns

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -33,6 +33,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithSort;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
 import com.facebook.presto.sql.planner.iterative.rule.PruneCrossJoinColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PruneJoinChildrenColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinFilteringSourceColumns;
@@ -130,6 +131,7 @@ public class PlanOptimizers
         // TODO: Once we've migrated handling all the plan node types, replace uses of PruneUnreferencedOutputs with an IterativeOptimizer containing these rules.
         Set<Rule> columnPruningRules = ImmutableSet.of(
                 new PruneCrossJoinColumns(),
+                new PruneJoinChildrenColumns(),
                 new PruneJoinColumns(),
                 new PruneSemiJoinColumns(),
                 new PruneSemiJoinFilteringSourceColumns(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -33,6 +33,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithSort;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
 import com.facebook.presto.sql.planner.iterative.rule.PruneCrossJoinColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PruneJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinFilteringSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
@@ -129,6 +130,7 @@ public class PlanOptimizers
         // TODO: Once we've migrated handling all the plan node types, replace uses of PruneUnreferencedOutputs with an IterativeOptimizer containing these rules.
         Set<Rule> columnPruningRules = ImmutableSet.of(
                 new PruneCrossJoinColumns(),
+                new PruneJoinColumns(),
                 new PruneSemiJoinColumns(),
                 new PruneSemiJoinFilteringSourceColumns(),
                 new PruneValuesColumns(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithSort;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
+import com.facebook.presto.sql.planner.iterative.rule.PruneCrossJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinFilteringSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
@@ -127,6 +128,7 @@ public class PlanOptimizers
 
         // TODO: Once we've migrated handling all the plan node types, replace uses of PruneUnreferencedOutputs with an IterativeOptimizer containing these rules.
         Set<Rule> columnPruningRules = ImmutableSet.of(
+                new PruneCrossJoinColumns(),
                 new PruneSemiJoinColumns(),
                 new PruneSemiJoinFilteringSourceColumns(),
                 new PruneValuesColumns(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCrossJoinColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCrossJoinColumns.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
 
 import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
-import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictOutputs;
+import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictChildOutputs;
 
 /**
  * Cross joins don't support output symbol selection, so push the project-off through the node.
@@ -63,8 +63,6 @@ public class PruneCrossJoinColumns
                 .map(ImmutableSet::copyOf)
                 .map(dependencies ->
                         parent.replaceChildren(ImmutableList.of(
-                                joinNode.replaceChildren(ImmutableList.of(
-                                        restrictOutputs(idAllocator, joinNode.getLeft(), dependencies).orElse(joinNode.getLeft()),
-                                        restrictOutputs(idAllocator, joinNode.getRight(), dependencies).orElse(joinNode.getRight()))))));
+                                restrictChildOutputs(idAllocator, joinNode, dependencies, dependencies).get())));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCrossJoinColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCrossJoinColumns.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
+import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictOutputs;
+
+/**
+ * Cross joins don't support output symbol selection, so push the project-off through the node.
+ */
+public class PruneCrossJoinColumns
+        implements Rule
+{
+    private static final Pattern PATTERN = Pattern.node(ProjectNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        ProjectNode parent = (ProjectNode) node;
+
+        PlanNode child = lookup.resolve(parent.getSource());
+        if (!(child instanceof JoinNode)) {
+            return Optional.empty();
+        }
+
+        JoinNode joinNode = (JoinNode) child;
+        if (!joinNode.isCrossJoin()) {
+            return Optional.empty();
+        }
+
+        return pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions())
+                .map(ImmutableSet::copyOf)
+                .map(dependencies ->
+                        parent.replaceChildren(ImmutableList.of(
+                                joinNode.replaceChildren(ImmutableList.of(
+                                        restrictOutputs(idAllocator, joinNode.getLeft(), dependencies).orElse(joinNode.getLeft()),
+                                        restrictOutputs(idAllocator, joinNode.getRight(), dependencies).orElse(joinNode.getRight()))))));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneJoinChildrenColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneJoinChildrenColumns.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.SymbolsExtractor;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictChildOutputs;
+
+/**
+ * Non-Cross joins support output symbol selection, so make any project-off of child columns explicit in project nodes.
+ */
+public class PruneJoinChildrenColumns
+        implements Rule
+{
+    private static final Pattern PATTERN = Pattern.node(JoinNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        JoinNode joinNode = (JoinNode) node;
+        if (joinNode.isCrossJoin()) {
+            return Optional.empty();
+        }
+
+        Set<Symbol> globallyUsableInputs = ImmutableSet.<Symbol>builder()
+                .addAll(joinNode.getOutputSymbols())
+                .addAll(
+                        joinNode.getFilter()
+                                .map(SymbolsExtractor::extractUnique)
+                                .orElse(ImmutableSet.of()))
+                .build();
+
+        Set<Symbol> leftUsableInputs = ImmutableSet.<Symbol>builder()
+                .addAll(globallyUsableInputs)
+                .addAll(
+                        joinNode.getCriteria().stream()
+                                .map(JoinNode.EquiJoinClause::getLeft)
+                                .iterator())
+                .addAll(joinNode.getLeftHashSymbol().map(ImmutableSet::of).orElse(ImmutableSet.of()))
+                .build();
+
+        Set<Symbol> rightUsableInputs = ImmutableSet.<Symbol>builder()
+                .addAll(globallyUsableInputs)
+                .addAll(
+                        joinNode.getCriteria().stream()
+                                .map(JoinNode.EquiJoinClause::getRight)
+                                .iterator())
+                .addAll(joinNode.getRightHashSymbol().map(ImmutableSet::of).orElse(ImmutableSet.of()))
+                .build();
+
+        return restrictChildOutputs(idAllocator, joinNode, leftUsableInputs, rightUsableInputs);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneJoinColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneJoinColumns.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+/**
+ * Non-cross joins support output symbol selection, so absorb any project-off into the node.
+ */
+public class PruneJoinColumns
+        implements Rule
+{
+    private static final Pattern PATTERN = Pattern.node(ProjectNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        ProjectNode parent = (ProjectNode) node;
+
+        PlanNode child = lookup.resolve(parent.getSource());
+        if (!(child instanceof JoinNode)) {
+            return Optional.empty();
+        }
+
+        JoinNode joinNode = (JoinNode) child;
+        if (joinNode.isCrossJoin()) {
+            return Optional.empty();
+        }
+
+        Optional<Set<Symbol>> dependencies = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions())
+                .map(ImmutableSet::copyOf);
+        if (!dependencies.isPresent()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                parent.replaceChildren(ImmutableList.of(
+                        new JoinNode(
+                                joinNode.getId(),
+                                joinNode.getType(),
+                                joinNode.getLeft(),
+                                joinNode.getRight(),
+                                joinNode.getCriteria(),
+                                joinNode.getOutputSymbols().stream()
+                                        .filter(dependencies.get()::contains)
+                                        .collect(toImmutableList()),
+                                joinNode.getFilter(),
+                                joinNode.getLeftHashSymbol(),
+                                joinNode.getRightHashSymbol(),
+                                joinNode.getDistributionType()))));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -95,6 +95,9 @@ public class JoinNode
                 .build();
         checkArgument(inputSymbols.containsAll(outputSymbols), "Left and right join inputs do not contain all output symbols");
         checkArgument(!isCrossJoin() || inputSymbols.equals(outputSymbols), "Cross join does not support output symbols pruning or reordering");
+
+        checkArgument(!(criteria.isEmpty() && leftHashSymbol.isPresent()), "Left hash symbol is only valid in an equijoin");
+        checkArgument(!(criteria.isEmpty() && rightHashSymbol.isPresent()), "Right hash symbol is only valid in an equijoin");
     }
 
     public enum DistributionType

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneCrossJoinColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneCrossJoinColumns.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class TestPruneCrossJoinColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testLeftInputNotReferenced()
+    {
+        tester().assertThat(new PruneCrossJoinColumns())
+                .on(p -> buildProjectedCrossJoin(p, symbol -> symbol.getName().equals("rightValue")))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("rightValue", PlanMatchPattern.expression("rightValue")),
+                                join(
+                                        JoinNode.Type.INNER,
+                                        ImmutableList.of(),
+                                        Optional.empty(),
+                                        strictProject(
+                                                ImmutableMap.of(),
+                                                values(ImmutableList.of("leftValue"))),
+                                        values(ImmutableList.of("rightValue")))
+                                .withExactOutputs("rightValue")));
+    }
+
+    @Test
+    public void testRightInputNotReferenced()
+    {
+        tester().assertThat(new PruneCrossJoinColumns())
+                .on(p -> buildProjectedCrossJoin(p, symbol -> symbol.getName().equals("leftValue")))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("leftValue", PlanMatchPattern.expression("leftValue")),
+                                join(
+                                        JoinNode.Type.INNER,
+                                        ImmutableList.of(),
+                                        Optional.empty(),
+                                        values(ImmutableList.of("leftValue")),
+                                        strictProject(
+                                                ImmutableMap.of(),
+                                                values(ImmutableList.of("rightValue"))))
+                                .withExactOutputs("leftValue")));
+    }
+
+    @Test
+    public void testAllInputsReferenced()
+    {
+        tester().assertThat(new PruneCrossJoinColumns())
+                .on(p -> buildProjectedCrossJoin(p, Predicates.alwaysTrue()))
+                .doesNotFire();
+    }
+
+    private static PlanNode buildProjectedCrossJoin(PlanBuilder p, Predicate<Symbol> projectionFilter)
+    {
+        Symbol leftValue = p.symbol("leftValue", BIGINT);
+        Symbol rightValue = p.symbol("rightValue", BIGINT);
+        List<Symbol> outputs = ImmutableList.of(leftValue, rightValue);
+        return p.project(
+                Assignments.identity(
+                        outputs.stream()
+                                .filter(projectionFilter)
+                                .collect(toImmutableList())),
+                p.join(
+                        JoinNode.Type.INNER,
+                        p.values(leftValue),
+                        p.values(rightValue),
+                        ImmutableList.of(),
+                        outputs,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneJoinChildrenColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneJoinChildrenColumns.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class TestPruneJoinChildrenColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testNotAllInputsRereferenced()
+    {
+        tester().assertThat(new PruneJoinChildrenColumns())
+                .on(p -> buildJoin(p, symbol -> symbol.getName().equals("leftValue")))
+                .matches(
+                        join(
+                                JoinNode.Type.INNER,
+                                ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
+                                Optional.of("leftValue > 5"),
+                                values("leftKey", "leftKeyHash", "leftValue"),
+                                strictProject(
+                                        ImmutableMap.of(
+                                                "rightKey", PlanMatchPattern.expression("rightKey"),
+                                                "rightKeyHash", PlanMatchPattern.expression("rightKeyHash")),
+                                        values("rightKey", "rightKeyHash", "rightValue"))));
+    }
+
+    @Test
+    public void testAllInputsReferenced()
+    {
+        tester().assertThat(new PruneJoinChildrenColumns())
+                .on(p -> buildJoin(p, Predicates.alwaysTrue()))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testCrossJoinDoesNotFire()
+    {
+        tester().assertThat(new PruneJoinColumns())
+                .on(p -> {
+                    Symbol leftValue = p.symbol("leftValue", BIGINT);
+                    Symbol rightValue = p.symbol("rightValue", BIGINT);
+                    return p.join(
+                            JoinNode.Type.INNER,
+                            p.values(leftValue),
+                            p.values(rightValue),
+                            ImmutableList.of(),
+                            ImmutableList.of(leftValue, rightValue),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty());
+                })
+                .doesNotFire();
+    }
+
+    private static PlanNode buildJoin(PlanBuilder p, Predicate<Symbol> joinOutputFilter)
+    {
+        Symbol leftKey = p.symbol("leftKey", BIGINT);
+        Symbol leftKeyHash = p.symbol("leftKeyHash", BIGINT);
+        Symbol leftValue = p.symbol("leftValue", BIGINT);
+        Symbol rightKey = p.symbol("rightKey", BIGINT);
+        Symbol rightKeyHash = p.symbol("rightKeyHash", BIGINT);
+        Symbol rightValue = p.symbol("rightValue", BIGINT);
+        List<Symbol> outputs = ImmutableList.of(leftValue, rightValue);
+        return p.join(
+                JoinNode.Type.INNER,
+                p.values(leftKey, leftKeyHash, leftValue),
+                p.values(rightKey, rightKeyHash, rightValue),
+                ImmutableList.of(new JoinNode.EquiJoinClause(leftKey, rightKey)),
+                outputs.stream()
+                        .filter(joinOutputFilter)
+                        .collect(toImmutableList()),
+                Optional.of(expression("leftValue > 5")),
+                Optional.of(leftKeyHash),
+                Optional.of(rightKeyHash));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneJoinColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneJoinColumns.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class TestPruneJoinColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testNotAllOutputsReferenced()
+    {
+        tester().assertThat(new PruneJoinColumns())
+                .on(p -> buildProjectedJoin(p, symbol -> symbol.getName().equals("rightValue")))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("rightValue", PlanMatchPattern.expression("rightValue")),
+                                join(
+                                        JoinNode.Type.INNER,
+                                        ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
+                                        Optional.empty(),
+                                        values(ImmutableList.of("leftKey", "leftValue")),
+                                        values(ImmutableList.of("rightKey", "rightValue")))
+                                        .withExactOutputs("rightValue")));
+    }
+
+    @Test
+    public void testAllInputsReferenced()
+    {
+        tester().assertThat(new PruneJoinColumns())
+                .on(p -> buildProjectedJoin(p, Predicates.alwaysTrue()))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testCrossJoinDoesNotFire()
+    {
+        tester().assertThat(new PruneJoinColumns())
+                .on(p -> {
+                    Symbol leftValue = p.symbol("leftValue", BIGINT);
+                    Symbol rightValue = p.symbol("rightValue", BIGINT);
+                    return p.project(
+                            Assignments.of(),
+                            p.join(
+                                    JoinNode.Type.INNER,
+                                    p.values(leftValue),
+                                    p.values(rightValue),
+                                    ImmutableList.of(),
+                                    ImmutableList.of(leftValue, rightValue),
+                                    Optional.empty(),
+                                    Optional.empty(),
+                                    Optional.empty()));
+                })
+                .doesNotFire();
+    }
+
+    private static PlanNode buildProjectedJoin(PlanBuilder p, Predicate<Symbol> projectionFilter)
+    {
+        Symbol leftKey = p.symbol("leftKey", BIGINT);
+        Symbol leftValue = p.symbol("leftValue", BIGINT);
+        Symbol rightKey = p.symbol("rightKey", BIGINT);
+        Symbol rightValue = p.symbol("rightValue", BIGINT);
+        List<Symbol> outputs = ImmutableList.of(leftKey, leftValue, rightKey, rightValue);
+        return p.project(
+                Assignments.identity(
+                        outputs.stream()
+                                .filter(projectionFilter)
+                                .collect(toImmutableList())),
+                p.join(
+                        JoinNode.Type.INNER,
+                        p.values(leftKey, leftValue),
+                        p.values(rightKey, rightValue),
+                        ImmutableList.of(new JoinNode.EquiJoinClause(leftKey, rightKey)),
+                        outputs,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+    }
+}


### PR DESCRIPTION
This patch adds three rules to the iterative optimizer for pruning the  outputs
and inputs of JoinNode.

Cross joins are handled separately, as they always pass all their child columns
through.  Thus, any project-off can be pushed down to below the cross join.

Non-cross joins pass through a subset of their child columns, so we need to have
a rule (PruneJoinChildrenColumns) to turn any projecting-off of child columns
into actual project nodes for the other rules to match against.  There's also a
rule to incorporate any projecting-off from a parent project node into the join
node itself (PruneJoinColumns).

https://github.com/prestodb/presto/issues/7154