### PR TITLE
Fix show grants does not honor given schema name

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileBasedSecurity.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileBasedSecurity.java
@@ -17,15 +17,19 @@ import com.facebook.presto.Session;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.testing.QueryRunner;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.hive.HiveQueryRunner.createQueryRunner;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.tpch.TpchTable.getTables;
+import static org.testng.Assert.assertEquals;
 
 public class TestHiveFileBasedSecurity
 {
@@ -57,6 +61,24 @@ public class TestHiveFileBasedSecurity
     {
         Session bob = getSession("bob");
         queryRunner.execute(bob, "SELECT * FROM orders");
+    }
+
+    @Test
+    public void testShowGrants()
+            throws Exception
+    {
+        List<TpchTable<?>> tables = getTables().stream()
+                .filter(t -> t.getTableName().equals("orders"))
+                .collect(toImmutableList());
+        String path = this.getClass().getResource("security.json").getPath();
+        QueryRunner queryRunner = createQueryRunner(tables, ImmutableMap.of(), "file", ImmutableMap.of("security.config-file", path));
+        Session user = getSession("user");
+
+        assertEquals(queryRunner.execute(user, "SHOW GRANTS").getRowCount(), 8);
+        assertEquals(queryRunner.execute(user, "SHOW GRANTS ON tpch.orders").getRowCount(), 4);
+        assertEquals(queryRunner.execute(user, "SHOW GRANTS ON tpch_bucketed.orders").getRowCount(), 4);
+
+        queryRunner.close();
     }
 
     private Session getSession(String user)

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -226,7 +226,10 @@ final class ShowQueriesRewrite
                         session.getIdentity(),
                         new CatalogSchemaName(catalogName, qualifiedTableName.getSchemaName()));
 
-                predicate = Optional.of(equal(identifier("table_name"), new StringLiteral(qualifiedTableName.getObjectName())));
+                String schemaName = qualifiedTableName.getSchemaName();
+                predicate = Optional.of(logicalAnd(
+                        equal(identifier("table_schema"), new StringLiteral(schemaName)),
+                        equal(identifier("table_name"), new StringLiteral(qualifiedTableName.getObjectName()))));
             }
 
             if (catalogName == null) {


### PR DESCRIPTION
This is a fix for #8204.
Added an additional filter on schema name when the table name is given.