### PR TITLE
Bugfix/parquet decimal predicate

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetShortDecimalColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetShortDecimalColumnReader.java
@@ -59,7 +59,15 @@ public class ParquetShortDecimalColumnReader
     protected void skipValue()
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
-            valuesReader.readBytes();
+            if (columnDescriptor.getType().equals(INT32)) {
+                valuesReader.readInteger();
+            }
+            else if (columnDescriptor.getType().equals(INT64)) {
+                valuesReader.readLong();
+            }
+            else {
+                valuesReader.readBytes();
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves issue where certain Parquet decimal types cannot be read by the ParquetReader when a predicate is applied. 

https://github.com/prestodb/presto/issues/8183