### PR TITLE
Allow '.' in resource group name

### DIFF
--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestResourceGroupIdTemplate.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestResourceGroupIdTemplate.java
@@ -30,7 +30,7 @@ public class TestResourceGroupIdTemplate
         ResourceGroupId expected = new ResourceGroupId(new ResourceGroupId(new ResourceGroupId("test"), "u"), "s");
         assertEquals(template.expandTemplate(new SelectionContext(true, "u", Optional.of("s"), 1)), expected);
         template = new ResourceGroupIdTemplate("test.${USER}");
-        assertEquals(template.expandTemplate(new SelectionContext(true, "alice_smith", Optional.empty(), 1)), new ResourceGroupId(new ResourceGroupId("test"), "alice_smith"));
+        assertEquals(template.expandTemplate(new SelectionContext(true, "alice.smith", Optional.empty(), 1)), new ResourceGroupId(new ResourceGroupId("test"), "alice.smith"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/ResourceGroupId.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/ResourceGroupId.java
@@ -53,7 +53,6 @@ public final class ResourceGroupId
 
     private static List<String> append(List<String> list, String element)
     {
-        checkArgument(!element.contains("."), "name should not contain '.'");
         List<String> result = new ArrayList<>(list);
         result.add(element);
         return result;
@@ -64,7 +63,6 @@ public final class ResourceGroupId
         checkArgument(!segments.isEmpty(), "Resource group id is empty");
         for (String segment : segments) {
             checkArgument(!segment.isEmpty(), "Empty segment in resource group id");
-            checkArgument(!segment.contains("."), "Segment contains '.'");
         }
         this.segments = segments;
     }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/resourceGroups/TestResourceGroupId.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/resourceGroups/TestResourceGroupId.java
@@ -27,14 +27,8 @@ public class TestResourceGroupId
     @Test
     public void testBasic()
     {
-        new ResourceGroupId("test_test");
-        new ResourceGroupId(new ResourceGroupId("test"), "test");
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testInvalid()
-    {
         new ResourceGroupId("test.test");
+        new ResourceGroupId(new ResourceGroupId("test"), "test");
     }
 
     @Test


### PR DESCRIPTION
This didn't revert the change, but just removed the check for '.' in resource group names. It's probably the smallest change to fix prod. (Reverting the diff means we need to revert the presto-facebook diffs that uses this function. I can do that too if that's preferred.)