### PR TITLE
Keep TaskInfoFetcher from retrying only when HTTP client is shutdown

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -632,9 +632,8 @@ public final class HttpRemoteTask
             @Override
             public void onFailure(Throwable t)
             {
-                if (t instanceof RejectedExecutionException) {
-                    // TODO: we should only give up retrying when the client has been shutdown
-                    logError(t, "Unable to %s task at %s. Got RejectedExecutionException.", action, request.getUri());
+                if (t instanceof RejectedExecutionException && httpClient.isClosed()) {
+                    logError(t, "Unable to %s task at %s. HTTP client is closed.", action, request.getUri());
                     cleanUpLocally();
                     return;
                 }


### PR DESCRIPTION
Previously, TaskInfoFetcher will stop retrying immediately whenever it gets
a RejectedExecutionException. This does not necessarily indicate that the
client has shutdown.