### PR TITLE
Prune semijoin columns

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithSort;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
+import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PushAggregationThroughOuterJoin;
@@ -153,6 +154,7 @@ public class PlanOptimizers
                                         new PushLimitThroughMarkDistinct(),
                                         new PushLimitThroughSemiJoin(),
                                         new MergeLimitWithDistinct(),
+                                        new PruneSemiJoinColumns(),
                                         new PruneValuesColumns(),
                                         new PruneTableScanColumns()))
                                 .build()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -123,6 +123,13 @@ public class PlanOptimizers
         Set<Rule> predicatePushDownRules = ImmutableSet.of(
                 new MergeFilters());
 
+        // TODO: Once we've migrated handling all the plan node types, replace uses of PruneUnreferencedOutputs with an IterativeOptimizer containing these rules.
+        Set<Rule> columnPruningRules = ImmutableSet.of(
+                new PruneSemiJoinColumns(),
+                new PruneSemiJoinFilteringSourceColumns(),
+                new PruneValuesColumns(),
+                new PruneTableScanColumns());
+
         IterativeOptimizer inlineProjections = new IterativeOptimizer(
                 stats,
                 ImmutableSet.of(
@@ -143,6 +150,7 @@ public class PlanOptimizers
                         stats,
                         ImmutableSet.<Rule>builder()
                                 .addAll(predicatePushDownRules)
+                                .addAll(columnPruningRules)
                                 .addAll(ImmutableSet.of(
                                         new RemoveRedundantIdentityProjections(),
                                         new RemoveFullSample(),
@@ -154,11 +162,7 @@ public class PlanOptimizers
                                         new MergeLimitWithTopN(),
                                         new PushLimitThroughMarkDistinct(),
                                         new PushLimitThroughSemiJoin(),
-                                        new MergeLimitWithDistinct(),
-                                        new PruneSemiJoinColumns(),
-                                        new PruneSemiJoinFilteringSourceColumns(),
-                                        new PruneValuesColumns(),
-                                        new PruneTableScanColumns()))
+                                        new MergeLimitWithDistinct()))
                                 .build()
                 ),
                 new IterativeOptimizer(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -33,6 +33,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithSort;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinFilteringSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PushAggregationThroughOuterJoin;
@@ -155,6 +156,7 @@ public class PlanOptimizers
                                         new PushLimitThroughSemiJoin(),
                                         new MergeLimitWithDistinct(),
                                         new PruneSemiJoinColumns(),
+                                        new PruneSemiJoinFilteringSourceColumns(),
                                         new PruneValuesColumns(),
                                         new PruneTableScanColumns()))
                                 .build()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneSemiJoinColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneSemiJoinColumns.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
+import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictOutputs;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+public class PruneSemiJoinColumns
+        implements Rule
+{
+    private static final Pattern PATTERN = Pattern.node(ProjectNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        ProjectNode parent = (ProjectNode) node;
+
+        PlanNode child = lookup.resolve(parent.getSource());
+        if (!(child instanceof SemiJoinNode)) {
+            return Optional.empty();
+        }
+
+        SemiJoinNode semiJoinNode = (SemiJoinNode) child;
+
+        Optional<List<Symbol>> prunedOutputs = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
+        if (!prunedOutputs.isPresent()) {
+            return Optional.empty();
+        }
+
+        if (!prunedOutputs.get().contains(semiJoinNode.getSemiJoinOutput())) {
+            return Optional.of(
+                    parent.replaceChildren(ImmutableList.of(semiJoinNode.getSource())));
+        }
+
+        Set<Symbol> requiredSourceInputs = Streams.concat(
+                prunedOutputs.get().stream()
+                        .filter(symbol -> !symbol.equals(semiJoinNode.getSemiJoinOutput())),
+                Stream.of(semiJoinNode.getSourceJoinSymbol()),
+                semiJoinNode.getSourceHashSymbol().map(Stream::of).orElse(Stream.empty()))
+                .collect(toImmutableSet());
+
+        return restrictOutputs(idAllocator, semiJoinNode.getSource(), requiredSourceInputs)
+                .map(newSource ->
+                        parent.replaceChildren(ImmutableList.of(
+                                semiJoinNode.replaceChildren(ImmutableList.of(
+                                        newSource, semiJoinNode.getFilteringSource())))));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneSemiJoinFilteringSourceColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneSemiJoinFilteringSourceColumns.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictOutputs;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+public class PruneSemiJoinFilteringSourceColumns
+        implements Rule
+{
+    private static final Pattern PATTERN = Pattern.node(SemiJoinNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        SemiJoinNode semiJoinNode = (SemiJoinNode) node;
+
+        Set<Symbol> requiredFilteringSourceInputs = Streams.concat(
+                Stream.of(semiJoinNode.getFilteringSourceJoinSymbol()),
+                semiJoinNode.getFilteringSourceHashSymbol().map(Stream::of).orElse(Stream.empty()))
+                .collect(toImmutableSet());
+
+        return restrictOutputs(idAllocator, semiJoinNode.getFilteringSource(), requiredFilteringSourceInputs)
+                .map(newFilteringSource ->
+                        semiJoinNode.replaceChildren(ImmutableList.of(
+                                semiJoinNode.getSource(), newFilteringSource)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneSemiJoinColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneSemiJoinColumns.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
+
+public class TestPruneSemiJoinColumns
+{
+    private RuleTester tester;
+
+    @BeforeClass
+    public void setUp()
+    {
+        tester = new RuleTester();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(tester);
+        tester = null;
+    }
+
+    @Test
+    public void testSemiJoinNotNeeded()
+    {
+        tester.assertThat(new PruneSemiJoinColumns())
+                .on(p -> buildProjectedSemiJoin(p, symbol -> symbol.getName().equals("leftValue")))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("leftValue", expression("leftValue")),
+                                values("leftKey", "leftKeyHash", "leftValue")));
+    }
+
+    @Test
+    public void testAllColumnsNeeded()
+    {
+        tester.assertThat(new PruneSemiJoinColumns())
+                .on(p -> buildProjectedSemiJoin(p, symbol -> true))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testKeysNotNeeded()
+    {
+        tester.assertThat(new PruneSemiJoinColumns())
+                .on(p -> buildProjectedSemiJoin(p, symbol -> (symbol.getName().equals("leftValue") || symbol.getName().equals("match"))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testValueNotNeeded()
+    {
+        tester.assertThat(new PruneSemiJoinColumns())
+                .on(p -> buildProjectedSemiJoin(p, symbol -> symbol.getName().equals("match")))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("match", expression("match")),
+                                semiJoin("leftKey", "rightKey", "match",
+                                        strictProject(
+                                                ImmutableMap.of(
+                                                        "leftKey", expression("leftKey"),
+                                                        "leftKeyHash", expression("leftKeyHash")),
+                                                values("leftKey", "leftKeyHash", "leftValue")),
+                                        values("rightKey"))));
+    }
+
+    private static PlanNode buildProjectedSemiJoin(PlanBuilder p, Predicate<Symbol> projectionFilter)
+    {
+        Symbol match = p.symbol("match", BIGINT);
+        Symbol leftKey = p.symbol("leftKey", BIGINT);
+        Symbol leftKeyHash = p.symbol("leftKeyHash", BIGINT);
+        Symbol leftValue = p.symbol("leftValue", BIGINT);
+        Symbol rightKey = p.symbol("rightKey", BIGINT);
+        List<Symbol> outputs = ImmutableList.of(match, leftKey, leftKeyHash, leftValue);
+        return p.project(
+                Assignments.identity(
+                        outputs.stream()
+                                .filter(projectionFilter)
+                                .collect(toImmutableList())),
+                p.semiJoin(
+                        leftKey,
+                        rightKey,
+                        match,
+                        Optional.of(leftKeyHash),
+                        Optional.empty(),
+                        p.values(leftKey, leftKeyHash, leftValue),
+                        p.values(rightKey)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneSemiJoinFilteringSourceColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneSemiJoinFilteringSourceColumns.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
+
+public class TestPruneSemiJoinFilteringSourceColumns
+{
+    private RuleTester tester;
+
+    @BeforeClass
+    public void setUp()
+    {
+        tester = new RuleTester();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(tester);
+        tester = null;
+    }
+
+    @Test
+    public void testNotAllColumnsReferenced()
+    {
+        tester.assertThat(new PruneSemiJoinFilteringSourceColumns())
+                .on(p -> buildSemiJoin(p, symbol -> true))
+                .matches(
+                        semiJoin("leftKey", "rightKey", "match",
+                                values("leftKey"),
+                                strictProject(
+                                        ImmutableMap.of(
+                                                "rightKey", expression("rightKey"),
+                                                "rightKeyHash", expression("rightKeyHash")),
+                                        values("rightKey", "rightKeyHash", "rightValue"))));
+    }
+
+    @Test
+    public void testAllColumnsNeeded()
+    {
+        tester.assertThat(new PruneSemiJoinFilteringSourceColumns())
+                .on(p -> buildSemiJoin(p, symbol -> !symbol.getName().equals("rightValue")))
+                .doesNotFire();
+    }
+
+    private static PlanNode buildSemiJoin(PlanBuilder p, Predicate<Symbol> filteringSourceSymbolFilter)
+    {
+        Symbol match = p.symbol("match", BIGINT);
+        Symbol leftKey = p.symbol("leftKey", BIGINT);
+        Symbol rightKey = p.symbol("rightKey", BIGINT);
+        Symbol rightKeyHash = p.symbol("rightKeyHash", BIGINT);
+        Symbol rightValue = p.symbol("rightValue", BIGINT);
+        List<Symbol> filteringSourceSymbols = ImmutableList.of(rightKey, rightKeyHash, rightValue);
+        return p.semiJoin(
+                leftKey,
+                rightKey,
+                match,
+                Optional.empty(),
+                Optional.of(rightKeyHash),
+                p.values(leftKey),
+                p.values(
+                        filteringSourceSymbols.stream()
+                                .filter(filteringSourceSymbolFilter)
+                                .collect(toImmutableList()),
+                        ImmutableList.of()));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -42,6 +42,7 @@ import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.TableFinishNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
@@ -272,6 +273,26 @@ public class PlanBuilder
                 .singleDistributionPartitioningScheme(child.getOutputSymbols())
                 .addSource(child)
                 .addInputsSet(child.getOutputSymbols()));
+    }
+
+    public SemiJoinNode semiJoin(
+            Symbol sourceJoinSymbol,
+            Symbol filteringSourceJoinSymbol,
+            Symbol semiJoinOutput,
+            Optional<Symbol> sourceHashSymbol,
+            Optional<Symbol> filteringSourceHashSymbol,
+            PlanNode source,
+            PlanNode filteringSource)
+    {
+        return new SemiJoinNode(idAllocator.getNextId(),
+                source,
+                filteringSource,
+                sourceJoinSymbol,
+                filteringSourceJoinSymbol,
+                semiJoinOutput,
+                sourceHashSymbol,
+                filteringSourceHashSymbol,
+                Optional.empty());
     }
 
     public ExchangeNode exchange(Consumer<ExchangeBuilder> exchangeBuilderConsumer)


### PR DESCRIPTION
This patch adds two rules to the iterative optimizer for pruning the outputs and inputs of SemiJoinNode.

Because SemiJoinNode passes through all columns from the left child (aka "source"), we can do a project-off push-down from above the SemiJoinNode to above the left child.  That rule can also elide the SemiJoinNode entirely if the join-match flag (aka "semiJoinOutput") is not needed.

Because SemiJoinNode does not pass through the right child (aka "filtering source") columns, we need a separate rule to insert a project-off above the right child.

https://github.com/prestodb/presto/issues/7154