### PR TITLE
Recover the optimization in SliceArrayBlock

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -393,4 +393,13 @@ public abstract class AbstractTestBlock
         objectsWithNulls[objectsWithNulls.length - 1] = null;
         return objectsWithNulls;
     }
+
+    protected static Slice[] createExpectedUniqueValues(int positionCount)
+    {
+        Slice[] expectedValues = new Slice[positionCount];
+        for (int position = 0; position < positionCount; position++) {
+            expectedValues[position] = Slices.copyOf(createExpectedValue(position));
+        }
+        return expectedValues;
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestSliceArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestSliceArrayBlock.java
@@ -25,8 +25,15 @@ public class TestSliceArrayBlock
     public void test()
     {
         Slice[] expectedValues = createExpectedValues(100);
-        assertVariableWithValues(expectedValues);
-        assertVariableWithValues((Slice[]) alternatingNullValues(expectedValues));
+        assertVariableWithValues(expectedValues, false);
+        assertVariableWithValues((Slice[]) alternatingNullValues(expectedValues), false);
+    }
+
+    @Test
+    public void testDistinctSlices()
+    {
+        Slice[] expectedValues = createExpectedUniqueValues(100);
+        assertVariableWithValues(expectedValues, true);
     }
 
     @Test
@@ -38,9 +45,9 @@ public class TestSliceArrayBlock
         assertBlockFilteredPositions(expectedValues, block, Ints.asList(0, 2, 4, 6, 7, 9, 10, 16));
     }
 
-    private void assertVariableWithValues(Slice[] expectedValues)
+    private void assertVariableWithValues(Slice[] expectedValues, boolean valueSlicesAreDistinct)
     {
-        SliceArrayBlock block = new SliceArrayBlock(expectedValues.length, expectedValues);
+        SliceArrayBlock block = new SliceArrayBlock(expectedValues.length, expectedValues, valueSlicesAreDistinct);
         assertBlock(block, expectedValues);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
@@ -72,7 +72,7 @@ public class SliceDictionaryStreamReader
     @Nonnull
     private Slice[] stripeDictionary = new Slice[1];
 
-    private SliceArrayBlock dictionaryBlock = new SliceArrayBlock(stripeDictionary.length, stripeDictionary);
+    private SliceArrayBlock dictionaryBlock = new SliceArrayBlock(stripeDictionary.length, stripeDictionary, true);
 
     @Nonnull
     private InputStreamSource<LongInputStream> stripeDictionaryLengthStreamSource = missingStreamSource(LongInputStream.class);
@@ -197,7 +197,7 @@ public class SliceDictionaryStreamReader
         // only update the block if the array changed to prevent creation of new Block objects, since
         // the engine currently uses identity equality to test if dictionaries are the same
         if (dictionaryBlock.getValues() != dictionary) {
-            dictionaryBlock = new SliceArrayBlock(dictionary.length, dictionary);
+            dictionaryBlock = new SliceArrayBlock(dictionary.length, dictionary, true);
         }
     }
 


### PR DESCRIPTION
This optimization was removed as part of a previous change as it was complicating
the retained size calculations, but it seems like we should bring it back as it
comes up towards top in perf output.