### PR TITLE
Add missing timezones to zone-index

### DIFF
--- a/presto-spi/src/main/resources/com/facebook/presto/spi/type/zone-index.properties
+++ b/presto-spi/src/main/resources/com/facebook/presto/spi/type/zone-index.properties
@@ -2231,6 +2231,10 @@
 2222 Europe/Kirov
 2223 Europe/Ulyanovsk
 2224 Asia/Yangon
+2225 America/Punta_Arenas
+2226 Asia/Atyrau
+2227 Asia/Famagusta
+2228 Europe/Saratov
 
 # Zones not supported in Java
 # ROC

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTimeZoneKey.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTimeZoneKey.java
@@ -191,7 +191,7 @@ public class TestTimeZoneKey
             hasher.putShort(timeZoneKey.getKey());
             hasher.putString(timeZoneKey.getId(), StandardCharsets.UTF_8);
         }
-        // Zone file should not (normally) be changed, so let's make is more difficult
-        assertEquals(hasher.hash().asLong(), 5690324204210439335L, "zone-index.properties file contents changed!");
+        // Zone file should not (normally) be changed, so let's make this more difficult
+        assertEquals(hasher.hash().asLong(), -5839014144088293930L, "zone-index.properties file contents changed!");
     }
 }


### PR DESCRIPTION
Added additional time zones that are included until IANA time zone data version 2017a.