### PR TITLE
Annotate sensitive config properties to redact their values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.6</dep.antlr.version>
-        <dep.airlift.version>0.147</dep.airlift.version>
+        <dep.airlift.version>0.148</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.29</dep.slice.version>
         <dep.aws-sdk.version>1.11.30</dep.aws-sdk.version>

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloConfig.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/conf/AccumuloConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.accumulo.conf;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.Duration;
 
 import javax.validation.constraints.Min;
@@ -92,6 +93,7 @@ public class AccumuloConfig
     }
 
     @Config(PASSWORD)
+    @ConfigSecuritySensitive
     @ConfigDescription("Sets the password for the configured user")
     public AccumuloConfig setPassword(String password)
     {

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.jdbc;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigSecuritySensitive;
 
 import javax.validation.constraints.NotNull;
 
@@ -54,6 +55,7 @@ public class BaseJdbcConfig
     }
 
     @Config("connection-password")
+    @ConfigSecuritySensitive
     public BaseJdbcConfig setConnectionPassword(String connectionPassword)
     {
         this.connectionPassword = connectionPassword;

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
@@ -19,6 +19,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.Duration;
 import io.airlift.units.MaxDuration;
@@ -182,6 +183,7 @@ public class CassandraClientConfig
     }
 
     @Config("cassandra.password")
+    @ConfigSecuritySensitive
     public CassandraClientConfig setPassword(String password)
     {
         this.password = password;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveS3Config.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveS3Config.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.google.common.base.StandardSystemProperty;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDataSize;
@@ -73,6 +74,7 @@ public class HiveS3Config
     }
 
     @Config("hive.s3.aws-secret-key")
+    @ConfigSecuritySensitive
     public HiveS3Config setS3AwsSecretKey(String s3AwsSecretKey)
     {
         this.s3AwsSecretKey = s3AwsSecretKey;


### PR DESCRIPTION
Use `@ConfigSecuritySensitive` annotation to prevent security sensitive properties such as passwords and secret keys from being printed in the log.

Fixes https://github.com/prestodb/presto/issues/7635.


