### PR TITLE
Joinorder rule

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -18,37 +18,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.Rule;
-import com.facebook.presto.sql.planner.iterative.rule.AddIntermediateAggregations;
-import com.facebook.presto.sql.planner.iterative.rule.CreatePartialTopN;
-import com.facebook.presto.sql.planner.iterative.rule.EliminateCrossJoins;
-import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroLimit;
-import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroSample;
-import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
-import com.facebook.presto.sql.planner.iterative.rule.ImplementFilteredAggregations;
-import com.facebook.presto.sql.planner.iterative.rule.InlineProjections;
-import com.facebook.presto.sql.planner.iterative.rule.MergeAdjacentWindows;
-import com.facebook.presto.sql.planner.iterative.rule.MergeFilters;
-import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithDistinct;
-import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithSort;
-import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
-import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
-import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
-import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
-import com.facebook.presto.sql.planner.iterative.rule.PushAggregationThroughOuterJoin;
-import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughMarkDistinct;
-import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughProject;
-import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughSemiJoin;
-import com.facebook.presto.sql.planner.iterative.rule.PushProjectionThroughExchange;
-import com.facebook.presto.sql.planner.iterative.rule.PushProjectionThroughUnion;
-import com.facebook.presto.sql.planner.iterative.rule.PushTopNThroughUnion;
-import com.facebook.presto.sql.planner.iterative.rule.RemoveEmptyDelete;
-import com.facebook.presto.sql.planner.iterative.rule.RemoveFullSample;
-import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
-import com.facebook.presto.sql.planner.iterative.rule.SimplifyCountOverConstant;
-import com.facebook.presto.sql.planner.iterative.rule.SingleMarkDistinctToGroupBy;
-import com.facebook.presto.sql.planner.iterative.rule.SwapAdjacentWindowsBySpecifications;
-import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedInPredicateToJoin;
-import com.facebook.presto.sql.planner.iterative.rule.TransformExistsApplyToLateralNode;
+import com.facebook.presto.sql.planner.iterative.rule.*;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
 import com.facebook.presto.sql.planner.optimizations.BeginTableWrite;
@@ -223,11 +193,15 @@ public class PlanOptimizers
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())
                 ),
                 new MetadataQueryOptimizer(metadata),
-                new IterativeOptimizer(
+                /*new IterativeOptimizer(
                         stats,
                         ImmutableList.of(new com.facebook.presto.sql.planner.optimizations.EliminateCrossJoins()), // This can pull up Filter and Project nodes from between Joins, so we need to push them down again
                         ImmutableSet.of(new EliminateCrossJoins())
-                ),
+                ),*/
+                //2017 by xwsilent
+                new IterativeOptimizer(
+                        stats,
+                        ImmutableSet.of(new JoinOrderRule())),
                 new PredicatePushDown(metadata, sqlParser),
                 projectionPushDown);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
 
 import java.util.Iterator;
@@ -44,6 +45,11 @@ public class IterativeOptimizer
     private final RuleStore ruleStore;
     private final StatsRecorder stats;
 
+    //2017 by xw
+    private final Set<Rule> rules;
+    public Set<Rule> getrules(){
+        return rules;
+    }
     public IterativeOptimizer(StatsRecorder stats, Set<Rule> rules)
     {
         this(stats, ImmutableList.of(), rules);
@@ -57,6 +63,8 @@ public class IterativeOptimizer
                 .build();
 
         this.stats = stats;
+        //2017 by xw
+        this.rules= ImmutableSet.copyOf(newRules);
 
         stats.registerAll(newRules);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/JoinOrderRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/JoinOrderRule.java
@@ -1,0 +1,188 @@
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.cost.CoefficientBasedCostCalculator;
+import com.facebook.presto.cost.PlanNodeCost;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.optimizations.joins.JoinGraph;
+import com.facebook.presto.sql.planner.plan.*;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.collect.ImmutableList;
+
+import java.util.*;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Created by hadoop on 17-6-8.
+ */
+public class JoinOrderRule implements Rule {
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session) {
+       // if (!SystemSessionProperties.ISCBOEnabled(session)) {
+      //      return Optional.empty();
+       // }
+        if (!(node instanceof JoinNode)) {
+            return Optional.empty();
+        }
+        JoinGraph joinGraph = JoinGraph.buildShallowFrom(node, lookup);
+        if (joinGraph.size() < 2) {
+            return Optional.empty();
+        }
+        List<Integer> joinOrder = getCBOJoinOrder(joinGraph); //genjubiaohangshutizozheng order
+        if (isOriginalOrder(joinOrder)) {
+            return Optional.empty();
+        }
+
+        PlanNode replacement = rebuildJoinTree(node.getOutputSymbols(), joinGraph, joinOrder, idAllocator);
+        return Optional.of(replacement);
+    }
+
+    public static boolean isOriginalOrder(List<Integer> joinOrder)
+    {
+        for (int i = 0; i < joinOrder.size(); i++) {
+            if (joinOrder.get(i) != i) {
+                return false;
+            }
+        }
+        return true;
+    }
+    public static List<Integer> getCBOJoinOrder(JoinGraph graph) {
+
+        ImmutableList.Builder<PlanNode> joinOrder = ImmutableList.builder();
+        Map<PlanNodeId, Integer> priorities = new HashMap<>();
+        Map<List<Symbol>,PlanNodeCost> map=CoefficientBasedCostCalculator.getScannerMap();
+
+        Estimate max= new Estimate(0);
+        int max_index=0;
+        List<Symbol> list_sym=new ArrayList<Symbol>();
+        for (int i = 0; i < graph.size(); i++) {
+            priorities.put(graph.getNode(i).getId(), i);
+             list_sym=graph.getNode(i).getOutputSymbols();
+            if(map.get(list_sym).getOutputRowCount().getValue()>max.getValue()){
+                max=map.get(list_sym).getOutputRowCount();
+                max_index=i;
+            }
+        }
+
+        PriorityQueue<PlanNode> nodesToVisit = new PriorityQueue<>(
+                graph.size(),
+                (Comparator<PlanNode>) (node1, node2) -> priorities.get(node1.getId()).compareTo(priorities.get(node2.getId())));
+        Set<PlanNode> visited = new HashSet<>();
+
+        nodesToVisit.add(graph.getNode(max_index));
+
+        while (!nodesToVisit.isEmpty()) {
+            PlanNode node = nodesToVisit.poll();
+            if (!visited.contains(node)) {
+                visited.add(node);
+                joinOrder.add(node);
+                PlanNode nextnode = null;
+                Estimate temp = new Estimate(0);
+
+                for (JoinGraph.Edge e : graph.getEdges(node)) {
+                    list_sym=e.getTargetNode().getOutputSymbols();
+                    if (map.get(list_sym).getOutputRowCount().getValue() > temp.getValue()) {
+                        temp = map.get(list_sym).getOutputRowCount();
+                        nextnode = e.getTargetNode();
+                    }
+                }
+                if (nextnode != null)
+                    nodesToVisit.add(nextnode);
+            }
+            if (nodesToVisit.isEmpty() && visited.size() < graph.size()) {
+                // disconnected graph, find new starting point
+                Optional<PlanNode> firstNotVisitedNode = graph.getNodes().stream()
+                        .filter(graphNode -> !visited.contains(graphNode))
+                        .findFirst();
+                if (firstNotVisitedNode.isPresent()) {
+                    nodesToVisit.add(firstNotVisitedNode.get());
+                }
+            }
+        }
+        checkState(visited.size() == graph.size());
+        return joinOrder.build().stream()
+                .map(node -> priorities.get(node.getId()))
+                .collect(toImmutableList());
+    }
+
+    public static PlanNode rebuildJoinTree(List<Symbol> expectedOutputSymbols, JoinGraph graph, List<Integer> joinOrder, PlanNodeIdAllocator idAllocator)
+    {
+        requireNonNull(expectedOutputSymbols, "expectedOutputSymbols is null");
+        requireNonNull(idAllocator, "idAllocator is null");
+        requireNonNull(graph, "graph is null");
+        joinOrder = ImmutableList.copyOf(requireNonNull(joinOrder, "joinOrder is null"));
+        checkArgument(joinOrder.size() >= 2);
+
+        PlanNode result = graph.getNode(joinOrder.get(0));
+        Set<PlanNodeId> alreadyJoinedNodes = new HashSet<>();
+        alreadyJoinedNodes.add(result.getId());
+
+        for (int i = 1; i < joinOrder.size(); i++) {
+            PlanNode rightNode = graph.getNode(joinOrder.get(i));
+            alreadyJoinedNodes.add(rightNode.getId());
+
+            ImmutableList.Builder<JoinNode.EquiJoinClause> criteria = ImmutableList.builder();
+
+            for (JoinGraph.Edge edge : graph.getEdges(rightNode)) {
+                PlanNode targetNode = edge.getTargetNode();
+                if (alreadyJoinedNodes.contains(targetNode.getId())) {
+                    criteria.add(new JoinNode.EquiJoinClause(
+                            edge.getTargetSymbol(),
+                            edge.getSourceSymbol()));
+                }
+            }
+
+            result = new JoinNode(
+                    idAllocator.getNextId(),
+                    JoinNode.Type.INNER,
+                    result,
+                    rightNode,
+                    criteria.build(),
+                    ImmutableList.<Symbol>builder()
+                            .addAll(result.getOutputSymbols())
+                            .addAll(rightNode.getOutputSymbols())
+                            .build(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty());
+        }
+
+        List<Expression> filters = graph.getFilters();
+
+        for (Expression filter : filters) {
+            result = new FilterNode(
+                    idAllocator.getNextId(),
+                    result,
+                    filter);
+        }
+
+        if (graph.getAssignments().isPresent()) {
+            result = new ProjectNode(
+                    idAllocator.getNextId(),
+                    result,
+                    Assignments.copyOf(graph.getAssignments().get()));
+        }
+
+        if (!result.getOutputSymbols().equals(expectedOutputSymbols)) {
+            // Introduce a projection to constrain the outputs to what was originally expected
+            // Some nodes are sensitive to what's produced (e.g., DistinctLimit node)
+            result = new ProjectNode(
+                    idAllocator.getNextId(),
+                    result,
+                    Assignments.identity(expectedOutputSymbols));
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
reorder the table to ensure that the large table is in front of  small table especially in case of broadcast-join