### PR TITLE
Move providing OuterPositionIterator to LookupSourceFactory [spilljoin]

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.operator.LookupJoinOperators.JoinType;
 import com.facebook.presto.operator.LookupOuterOperator.LookupOuterOperatorFactory;
-import com.facebook.presto.operator.LookupSource.OuterPositionIterator;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.ImmutableList;
@@ -83,9 +82,8 @@ public class LookupJoinOperatorFactory
             // when all join operators finish (and lookup source is ready), set the outer position future to start the outer operator
             ListenableFuture<LookupSource> lookupSourceAfterProbeFinished = transformAsync(probeReferenceCount.getFreeFuture(), ignored -> lookupSourceFactory.createLookupSource());
             ListenableFuture<OuterPositionIterator> outerPositionsFuture = transform(lookupSourceAfterProbeFinished, lookupSource -> {
-                try (LookupSource ignore = lookupSource) {
-                    return lookupSource.getOuterPositionIterator();
-                }
+                lookupSource.close();
+                return lookupSourceFactory.getOuterPositionIterator();
             });
 
             lookupSourceFactoryUsersCount.retain();

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupOuterOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupOuterOperator.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator;
 
-import com.facebook.presto.operator.LookupSource.OuterPositionIterator;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.type.Type;

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
@@ -38,18 +38,8 @@ public interface LookupSource
 
     void appendTo(long position, PageBuilder pageBuilder, int outputChannelOffset);
 
-    default OuterPositionIterator getOuterPositionIterator()
-    {
-        return (pageBuilder, outputChannelOffset) -> false;
-    }
-
     boolean isJoinPositionEligible(long currentJoinPosition, int probePosition, Page allProbeChannelsPage);
 
     @Override
     void close();
-
-    interface OuterPositionIterator
-    {
-        boolean appendToNext(PageBuilder pageBuilder, int outputChannelOffset);
-    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceFactory.java
@@ -28,6 +28,11 @@ public interface LookupSourceFactory
 
     ListenableFuture<LookupSource> createLookupSource();
 
+    /**
+     * Can be called only after {@link #createLookupSource()} is done and all users of {@link LookupSource}-s finished.
+     */
+    OuterPositionIterator getOuterPositionIterator();
+
     Map<Symbol, Integer> getLayout();
 
     // this is only here for the index lookup source

--- a/presto-main/src/main/java/com/facebook/presto/operator/OuterLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OuterLookupSource.java
@@ -31,7 +31,7 @@ import static java.util.Objects.requireNonNull;
 public final class OuterLookupSource
         implements LookupSource
 {
-    public static Supplier<LookupSource> createOuterLookupSourceSupplier(Supplier<LookupSource> lookupSourceSupplier)
+    public static TrackingLookupSourceSupplier createOuterLookupSourceSupplier(Supplier<LookupSource> lookupSourceSupplier)
     {
         return new OuterLookupSourceSupplier(lookupSourceSupplier);
     }
@@ -95,12 +95,6 @@ public final class OuterLookupSource
     }
 
     @Override
-    public OuterPositionIterator getOuterPositionIterator()
-    {
-        return outerPositionTracker.getOuterPositionIterator();
-    }
-
-    @Override
     public void close()
     {
         lookupSource.close();
@@ -140,7 +134,7 @@ public final class OuterLookupSource
 
     @ThreadSafe
     private static class OuterLookupSourceSupplier
-            implements Supplier<LookupSource>
+            implements TrackingLookupSourceSupplier
     {
         private final Supplier<LookupSource> lookupSourceSupplier;
         private final OuterPositionTracker outerPositionTracker;
@@ -152,9 +146,14 @@ public final class OuterLookupSource
         }
 
         @Override
-        public LookupSource get()
+        public LookupSource getLookupSource()
         {
             return new OuterLookupSource(lookupSourceSupplier.get(), outerPositionTracker);
+        }
+
+        public OuterPositionIterator getOuterPositionIterator()
+        {
+            return outerPositionTracker.getOuterPositionIterator();
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/OuterPositionIterator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OuterPositionIterator.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.PageBuilder;
+
+public interface OuterPositionIterator
+{
+    boolean appendToNext(PageBuilder pageBuilder, int outputChannelOffset);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
@@ -49,7 +49,9 @@ public class PartitionedLookupSource
                 public LookupSource getLookupSource()
                 {
                     return new PartitionedLookupSource(
-                            getPartitionsLookupSources(partitions),
+                            partitions.stream()
+                                    .map(Supplier::get)
+                                    .collect(toImmutableList()),
                             hashChannelTypes,
                             Optional.of(outerPositionTrackerFactory.create()));
                 }
@@ -64,17 +66,12 @@ public class PartitionedLookupSource
         else {
             return TrackingLookupSourceSupplier.nonTracking(
                     () -> new PartitionedLookupSource(
-                            getPartitionsLookupSources(partitions),
+                            partitions.stream()
+                                    .map(Supplier::get)
+                                    .collect(toImmutableList()),
                             hashChannelTypes,
                             Optional.empty()));
         }
-    }
-
-    private static List<LookupSource> getPartitionsLookupSources(List<Supplier<LookupSource>> partitions)
-    {
-        return partitions.stream()
-                .map(Supplier::get)
-                .collect(toImmutableList());
     }
 
     private final LookupSource[] lookupSources;
@@ -255,7 +252,9 @@ public class PartitionedLookupSource
 
             public Factory(List<Supplier<LookupSource>> partitions)
             {
-                this.lookupSources = getPartitionsLookupSources(partitions).stream().toArray(LookupSource[]::new);
+                this.lookupSources = partitions.stream()
+                        .map(Supplier::get)
+                        .toArray(LookupSource[]::new);
 
                 visitedPositions = Arrays.stream(this.lookupSources)
                         .map(LookupSource::getJoinPositionCount)

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -122,7 +122,7 @@ public final class PartitionedLookupSourceFactory
                     this.lookupSourceSupplier = createOuterLookupSourceSupplier(partitionLookupSource);
                 }
                 else {
-                    this.lookupSourceSupplier = TrackingLookupSourceSupplier.from(partitionLookupSource);
+                    this.lookupSourceSupplier = TrackingLookupSourceSupplier.nonTracking(partitionLookupSource);
                 }
 
                 // store lookup source supplier and futures into local variables so they can be used outside of the lock

--- a/presto-main/src/main/java/com/facebook/presto/operator/TrackingLookupSourceSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TrackingLookupSourceSupplier.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+public interface TrackingLookupSourceSupplier
+{
+    LookupSource getLookupSource();
+
+    OuterPositionIterator getOuterPositionIterator();
+
+    static TrackingLookupSourceSupplier from(Supplier<LookupSource> lookupSourceSupplier)
+    {
+        requireNonNull(lookupSourceSupplier, "lookupSourceSupplier is null");
+        return new TrackingLookupSourceSupplier()
+        {
+            @Override
+            public LookupSource getLookupSource()
+            {
+                return lookupSourceSupplier.get();
+            }
+
+            @Override
+            public OuterPositionIterator getOuterPositionIterator()
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/TrackingLookupSourceSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TrackingLookupSourceSupplier.java
@@ -23,7 +23,7 @@ public interface TrackingLookupSourceSupplier
 
     OuterPositionIterator getOuterPositionIterator();
 
-    static TrackingLookupSourceSupplier from(Supplier<LookupSource> lookupSourceSupplier)
+    static TrackingLookupSourceSupplier nonTracking(Supplier<LookupSource> lookupSourceSupplier)
     {
         requireNonNull(lookupSourceSupplier, "lookupSourceSupplier is null");
         return new TrackingLookupSourceSupplier()

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceFactory.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.index;
 
 import com.facebook.presto.operator.LookupSource;
 import com.facebook.presto.operator.LookupSourceFactory;
+import com.facebook.presto.operator.OuterPositionIterator;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.spi.type.Type;
@@ -100,6 +101,12 @@ public class IndexLookupSourceFactory
         IndexLoader indexLoader = indexLoaderSupplier.get();
         indexLoader.setContext(taskContext);
         return Futures.immediateFuture(new IndexLookupSource(indexLoader));
+    }
+
+    @Override
+    public OuterPositionIterator getOuterPositionIterator()
+    {
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
OuterPositionIterator is effect of using all LookupSource from a
factory, thus it should not be provided by LookupSource. This commit
moves the responsibility to LookupSourceFactory.

This is extracted from #8166.