### PR TITLE
Remove redundant parameter from DictionaryBlock constructor calls

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -158,7 +158,7 @@ public final class BlockAssertions
         for (int i = 0; i < length; i++) {
             ids[i] = i % dictionarySize;
         }
-        return new DictionaryBlock(length, builder.build(), ids);
+        return new DictionaryBlock(builder.build(), ids);
     }
 
     public static Block createStringArraysBlock(Iterable<? extends Iterable<String>> values)
@@ -346,7 +346,7 @@ public final class BlockAssertions
         for (int i = 0; i < length; i++) {
             ids[i] = i % dictionarySize;
         }
-        return new DictionaryBlock(length, builder.build(), ids);
+        return new DictionaryBlock(builder.build(), ids);
     }
 
     public static Block createLongRepeatBlock(int value, int length)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
@@ -62,8 +62,8 @@ public class TestDictionaryBlock
 
         assertEquals(copiedBlock.getDictionary().getPositionCount(), 1);
         assertEquals(copiedBlock.getPositionCount(), positionsToCopy.size());
-        assertBlock(copiedBlock.getDictionary(), new Slice[]{firstExpectedValue});
-        assertBlock(copiedBlock, new Slice[]{firstExpectedValue, firstExpectedValue, firstExpectedValue, firstExpectedValue, firstExpectedValue});
+        assertBlock(copiedBlock.getDictionary(), new Slice[] {firstExpectedValue});
+        assertBlock(copiedBlock, new Slice[] {firstExpectedValue, firstExpectedValue, firstExpectedValue, firstExpectedValue, firstExpectedValue});
     }
 
     @Test
@@ -79,7 +79,7 @@ public class TestDictionaryBlock
         assertEquals(copiedBlock.getDictionary().getPositionCount(), 2);
         assertEquals(copiedBlock.getPositionCount(), positionsToCopy.size());
 
-        assertBlock(copiedBlock.getDictionary(), new Slice[] { expectedValues[0], expectedValues[5] });
+        assertBlock(copiedBlock.getDictionary(), new Slice[] {expectedValues[0], expectedValues[5]});
         assertDictionaryIds(copiedBlock, 0, 1, 0, 1, 0);
     }
 
@@ -96,7 +96,7 @@ public class TestDictionaryBlock
         assertEquals(copiedBlock.getDictionary().getPositionCount(), 1);
         assertEquals(copiedBlock.getPositionCount(), positionsToCopy.size());
 
-        assertBlock(copiedBlock.getDictionary(), new Slice[] { expectedValues[2] });
+        assertBlock(copiedBlock.getDictionary(), new Slice[] {expectedValues[2]});
         assertDictionaryIds(copiedBlock, 0, 0, 0);
     }
 
@@ -126,7 +126,7 @@ public class TestDictionaryBlock
         assertNotEquals(dictionaryBlock.getDictionarySourceId(), compactBlock.getDictionarySourceId());
 
         assertEquals(compactBlock.getDictionary().getPositionCount(), (expectedValues.length / 2) + 1);
-        assertBlock(compactBlock.getDictionary(), new Slice[] { expectedValues[0], expectedValues[1], expectedValues[3] });
+        assertBlock(compactBlock.getDictionary(), new Slice[] {expectedValues[0], expectedValues[1], expectedValues[3]});
         assertDictionaryIds(compactBlock, 0, 1, 1, 2, 2, 0, 1, 1, 2, 2);
         assertEquals(compactBlock.isCompact(), true);
 
@@ -164,7 +164,7 @@ public class TestDictionaryBlock
             }
             ids[i] = index;
         }
-        return new DictionaryBlock(positionCount, new SliceArrayBlock(dictionarySize, expectedValues), ids);
+        return new DictionaryBlock(new SliceArrayBlock(dictionarySize, expectedValues), ids);
     }
 
     private static DictionaryBlock createDictionaryBlock(Slice[] expectedValues, int positionCount)
@@ -175,7 +175,7 @@ public class TestDictionaryBlock
         for (int i = 0; i < positionCount; i++) {
             ids[i] = i % dictionarySize;
         }
-        return new DictionaryBlock(positionCount, new SliceArrayBlock(dictionarySize, expectedValues), ids);
+        return new DictionaryBlock(new SliceArrayBlock(dictionarySize, expectedValues), ids);
     }
 
     private static void assertDictionaryIds(DictionaryBlock dictionaryBlock, int... expected)

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageFilter.java
@@ -81,7 +81,7 @@ public class TestDictionaryAwarePageFilter
         testFilter(createDictionaryBlock(20, 0), LongArrayBlock.class);
 
         // match all
-        testFilter(new DictionaryBlock(100, createLongSequenceBlock(4, 5), new int[100]), LongArrayBlock.class);
+        testFilter(new DictionaryBlock(createLongSequenceBlock(4, 5), new int[100]), LongArrayBlock.class);
     }
 
     @Test
@@ -95,7 +95,7 @@ public class TestDictionaryAwarePageFilter
         testFilter(createDictionaryBlockWithUnusedEntries(20, 0), DictionaryBlock.class);
 
         // match all
-        testFilter(new DictionaryBlock(100, createLongsBlock(4, 5, -1), new int[100]), DictionaryBlock.class);
+        testFilter(new DictionaryBlock(createLongsBlock(4, 5, -1), new int[100]), DictionaryBlock.class);
     }
 
     @Test
@@ -130,7 +130,7 @@ public class TestDictionaryAwarePageFilter
         Block dictionary = createLongSequenceBlock(0, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> index % dictionarySize);
-        return new DictionaryBlock(blockSize, dictionary, ids);
+        return new DictionaryBlock(dictionary, ids);
     }
 
     private static DictionaryBlock createDictionaryBlockWithUnusedEntries(int dictionarySize, int blockSize)
@@ -138,7 +138,7 @@ public class TestDictionaryAwarePageFilter
         Block dictionary = createLongSequenceBlock(-10, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> (index % dictionarySize) + 10);
-        return new DictionaryBlock(blockSize, dictionary, ids);
+        return new DictionaryBlock(dictionary, ids);
     }
 
     private static void testFilter(Block block, Class<? extends Block> expectedType)

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
@@ -115,7 +115,7 @@ public class TestDictionaryAwarePageProjection
         Block dictionary = createLongSequenceBlock(0, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> index % dictionarySize);
-        return new DictionaryBlock(blockSize, dictionary, ids);
+        return new DictionaryBlock(dictionary, ids);
     }
 
     private static DictionaryBlock createDictionaryBlockWithUnusedEntries(int dictionarySize, int blockSize)
@@ -123,7 +123,7 @@ public class TestDictionaryAwarePageProjection
         Block dictionary = createLongSequenceBlock(-10, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> (index % dictionarySize) + 10);
-        return new DictionaryBlock(blockSize, dictionary, ids);
+        return new DictionaryBlock(dictionary, ids);
     }
 
     private static void testProject(Block block, Class<? extends Block> expectedResultType)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySubscript.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySubscript.java
@@ -203,7 +203,7 @@ public class BenchmarkArraySubscript
             for (int i = 0; i < keyIds.length; i++) {
                 keyIds[i] = ThreadLocalRandom.current().nextInt(0, dictionarySize);
             }
-            return new DictionaryBlock(positionCount * mapSize, dictionaryBlock, keyIds);
+            return new DictionaryBlock(dictionaryBlock, keyIds);
         }
 
         private static String randomString(int length)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapConcat.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapConcat.java
@@ -161,7 +161,7 @@ public class BenchmarkMapConcat
 
         private static Block createMapBlock(int positionCount, Block keyBlock, Block valueBlock)
         {
-            InterleavedBlock interleavedBlock = new InterleavedBlock(new Block[]{keyBlock, valueBlock});
+            InterleavedBlock interleavedBlock = new InterleavedBlock(new Block[] {keyBlock, valueBlock});
             int[] offsets = new int[positionCount + 1];
             int mapSize = keyBlock.getPositionCount() / positionCount;
             for (int i = 0; i < offsets.length; i++) {
@@ -177,7 +177,7 @@ public class BenchmarkMapConcat
             for (int i = 0; i < keyIds.length; i++) {
                 keyIds[i] = i % keys.size();
             }
-            return new DictionaryBlock(positionCount * keys.size(), keyDictionaryBlock, keyIds);
+            return new DictionaryBlock(keyDictionaryBlock, keyIds);
         }
 
         private static Block createValueBlock(int positionCount, int mapSize)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapSubscript.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapSubscript.java
@@ -188,7 +188,7 @@ public class BenchmarkMapSubscript
             for (int i = 0; i < keyIds.length; i++) {
                 keyIds[i] = i % keys.size();
             }
-            return new DictionaryBlock(positionCount * keys.size(), keyDictionaryBlock, keyIds);
+            return new DictionaryBlock(keyDictionaryBlock, keyIds);
         }
 
         private static Block createFixWidthValueBlock(int positionCount, int mapSize)
@@ -227,7 +227,7 @@ public class BenchmarkMapSubscript
             for (int i = 0; i < keyIds.length; i++) {
                 keyIds[i] = ThreadLocalRandom.current().nextInt(0, dictionarySize);
             }
-            return new DictionaryBlock(positionCount * mapSize, dictionaryBlock, keyIds);
+            return new DictionaryBlock(dictionaryBlock, keyIds);
         }
 
         private static String randomString(int length)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPageProcessorCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPageProcessorCompiler.java
@@ -192,7 +192,7 @@ public class TestPageProcessorCompiler
         for (int i = 0; i < positionCount; i++) {
             ids[i] = i % dictionarySize;
         }
-        return new DictionaryBlock(positionCount, new SliceArrayBlock(dictionarySize, expectedValues), ids);
+        return new DictionaryBlock(new SliceArrayBlock(dictionarySize, expectedValues), ids);
     }
 
     private static Slice[] createExpectedValues(int positionCount)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -267,7 +267,7 @@ public class DictionaryBlock
             }
             newIds[i] = oldIndexToNewIndex.get(oldIndex);
         }
-        return new DictionaryBlock(positions.size(), dictionary.copyPositions(positionsToCopy), newIds);
+        return new DictionaryBlock(dictionary.copyPositions(positionsToCopy), newIds);
     }
 
     @Override
@@ -286,7 +286,7 @@ public class DictionaryBlock
             throw new IndexOutOfBoundsException("Invalid position " + position + " in block with " + positionCount + " positions");
         }
         int[] newIds = Arrays.copyOfRange(ids, idsOffset + position, idsOffset + position + length);
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(length, dictionary, newIds);
+        DictionaryBlock dictionaryBlock = new DictionaryBlock(dictionary, newIds);
         return dictionaryBlock.compact();
     }
 

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
@@ -92,7 +92,7 @@ public class TestDictionaryBlockEncoding
         }
 
         BlockEncoding blockEncoding = new DictionaryBlockEncoding(new VariableWidthBlockEncoding());
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(positionCount, dictionary, ids);
+        DictionaryBlock dictionaryBlock = new DictionaryBlock(dictionary, ids);
 
         DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1024);
         blockEncoding.writeBlock(sliceOutput, dictionaryBlock);


### PR DESCRIPTION
`DictionaryBlock` derives position count from passed `ids` position
mapping array, so usually there is no need to pass it explicitly.

This commit addresses only the obvious cases, where the passed mapping
array is statically known to have the same size as `positionCount` being
passed.