### PR TITLE
Fix correctness bug in PageFunctionCompiler

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -223,6 +223,11 @@ public class PageFunctionCompiler
         Variable positions = scope.declareVariable(int[].class, "positions");
         Variable index = scope.declareVariable(int.class, "index");
 
+        // reset block builder before using since a previous run may have thrown leaving data in the block builder
+        body.append(thisVariable.setField(
+                blockBuilder,
+                thisVariable.getField(blockBuilder).invoke("newBlockBuilderLike", BlockBuilder.class, newInstance(BlockBuilderStatus.class))));
+
         IfStatement ifStatement = new IfStatement()
                 .condition(selectedPositions.invoke("isList", boolean.class));
         body.append(ifStatement);
@@ -243,9 +248,6 @@ public class PageFunctionCompiler
 
         Variable block = scope.declareVariable(Block.class, "block");
         body.append(block.set(thisVariable.getField(blockBuilder).invoke("build", Block.class)))
-                .append(thisVariable.setField(
-                        blockBuilder,
-                        thisVariable.getField(blockBuilder).invoke("newBlockBuilderLike", BlockBuilder.class, newInstance(BlockBuilderStatus.class))))
                 .append(block.ret());
 
         return method;

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.gen;
+
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.project.PageProjection;
+import com.facebook.presto.operator.project.SelectedPositions;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.sql.relational.RowExpression;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
+import static com.facebook.presto.spi.function.OperatorType.ADD;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.field;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestPageFunctionCompiler
+{
+    @Test
+    public void testFailureDoesNotCorruptFutureResults()
+            throws Exception
+    {
+        PageFunctionCompiler functionCompiler = new PageFunctionCompiler(createTestMetadataManager());
+
+        RowExpression add10 = call(
+                Signature.internalOperator(ADD, BIGINT.getTypeSignature(), ImmutableList.of(BIGINT.getTypeSignature(), BIGINT.getTypeSignature())),
+                BIGINT,
+                field(0, BIGINT),
+                constant(10L, BIGINT));
+
+        Supplier<PageProjection> projectionSupplier = functionCompiler.compileProjection(add10);
+        PageProjection projection = projectionSupplier.get();
+
+        // process good page and verify we got the expected number of result rows
+        Page goodPage = createLongBlockPage(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        Block goodResult = projection.project(SESSION, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount()));
+        assertEquals(goodPage.getPositionCount(), goodResult.getPositionCount());
+
+        // addition will throw due to integer overflow
+        Page badPage = createLongBlockPage(0, 1, 2, 3, 4, Long.MAX_VALUE);
+        try {
+            projection.project(SESSION, badPage, SelectedPositions.positionsRange(0, 100));
+            fail("expected exception");
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), NUMERIC_VALUE_OUT_OF_RANGE.toErrorCode());
+        }
+
+        // running the good page should still work
+        // if block builder in generated code was not reset properly, we could get junk results after the failure
+        goodResult = projection.project(SESSION, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount()));
+        assertEquals(goodPage.getPositionCount(), goodResult.getPositionCount());
+    }
+
+    private static Page createLongBlockPage(long... values)
+    {
+        BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(values.length);
+        for (long value : values) {
+            BIGINT.writeLong(builder, value);
+        }
+        return new Page(builder.build());
+    }
+}


### PR DESCRIPTION
Block builder was only being reset at the end of the projection, so if
an exception is thrown in processing, block builder contains data from
previous failed run. The DictionaryAwarePageFilter attempts to apply
projection to entire dictionary, and if this fails, the page is processed
as normal using the same projection function, which triggers this bug.