### PR TITLE
Fix thread-safety of SpillContexts [spilljoin]

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -512,8 +512,7 @@ public class OperatorContext
             implements SpillContext
     {
         private final DriverContext driverContext;
-
-        private long reservedBytes;
+        private final AtomicLong reservedBytes = new AtomicLong();
 
         public OperatorSpillContext(DriverContext driverContext)
         {
@@ -523,21 +522,28 @@ public class OperatorContext
         @Override
         public void updateBytes(long bytes)
         {
-            if (bytes > 0) {
+            if (bytes >= 0) {
+                reservedBytes.addAndGet(bytes);
                 driverContext.reserveSpill(bytes);
             }
             else {
-                checkArgument(reservedBytes + bytes >= 0, "tried to free %s spilled bytes from %s bytes reserved", -bytes, reservedBytes);
+                reservedBytes.accumulateAndGet(-bytes, this::decrementSpilledReservation);
                 driverContext.freeSpill(-bytes);
             }
-            reservedBytes += bytes;
+        }
+
+        private long decrementSpilledReservation(long reservedBytes, long bytesBeingFreed)
+        {
+            checkArgument(bytesBeingFreed >= 0);
+            checkArgument(bytesBeingFreed <= reservedBytes, "tried to free %s spilled bytes from %s bytes reserved", bytesBeingFreed, reservedBytes);
+            return reservedBytes - bytesBeingFreed;
         }
 
         @Override
         public String toString()
         {
             return toStringHelper(this)
-                    .add("usedBytes", reservedBytes)
+                    .add("usedBytes", reservedBytes.get())
                     .toString();
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -540,6 +540,13 @@ public class OperatorContext
         }
 
         @Override
+        public void close()
+        {
+            // Only products of SpillContext.newLocalSpillContext() should be closed.
+            throw new UnsupportedOperationException(format("%s should not be closed directly", getClass()));
+        }
+
+        @Override
         public String toString()
         {
             return toStringHelper(this)


### PR DESCRIPTION
* OperatorSpillContext declared thread-safety and this commit makes the
  class thread-safe
* LocalSpillContext is used in asynchronous spilling, so it is also made
  thread-safe