### PR TITLE
Make PagesIndex.clear() free memory [spilljoin]

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -158,6 +158,7 @@ public class PagesIndex
         valueAddresses.clear();
         valueAddresses.trim();
         positionCount = 0;
+        nextBlockToCompact = 0;
         pagesMemorySize = 0;
 
         estimatedSize = calculateEstimatedSize();

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -153,8 +153,10 @@ public class PagesIndex
     {
         for (ObjectArrayList<Block> channel : channels) {
             channel.clear();
+            channel.trim();
         }
         valueAddresses.clear();
+        valueAddresses.trim();
         positionCount = 0;
         pagesMemorySize = 0;
 


### PR DESCRIPTION
Currently the method is used only in `WindowOperator` and that place doesn't require pages index truncation as it is later reused. In spill for join, however, HBO needs to clear its `PagesIndex` once it gets revoke memory request. Clearing with trimming makes more sense, as sole arrays (filled with nulls) may occupy megabytes of memory even for `tpch.sf10.orders` build side.

(If it is not obvious that trimming doesn't harm `WindowOperator`, I'd propose `clear(boolean compact)`.)