### PR TITLE
Remove dwrf testing from TestHiveStorageFormats

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
@@ -47,7 +47,6 @@ public class TestHiveStorageFormats
     {
         return new StorageFormat[][] {
                 {storageFormat("ORC")},
-                {storageFormat("DWRF")},
                 {storageFormat("PARQUET")},
                 {storageFormat("PARQUET", ImmutableMap.of("hive.parquet_optimized_reader_enabled", "true"))},
                 {storageFormat("RCBINARY")},


### PR DESCRIPTION
Intermittently, the dwrf file format tests were causing the JVM to crash with
SIGSEGV or a Hive write error when running on Docker on Travis. So we remove
testing for this file format for now.