### PR TITLE
Update Travis Java version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ env:
 
 sudo: required
 dist: trusty
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 
 cache:
   directories:


### PR DESCRIPTION
We are running into periodic JVM crashes during the dwrf run of
TestHiveStorageFormats#testInsertIntoPartitionedTable. Update the Java
version to avoid that.