### PR TITLE
Fix calls to HostAndPort.getHostText

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
@@ -110,7 +110,7 @@ public class BenchmarkDriverOptions
 
         HostAndPort host = HostAndPort.fromString(server);
         try {
-            return new URI("http", null, host.getHostText(), host.getPortOrDefault(80), null, null, null);
+            return new URI("http", null, host.getHost(), host.getPortOrDefault(80), null, null, null);
         }
         catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -171,7 +171,7 @@ public class ClientOptions
 
         HostAndPort host = HostAndPort.fromString(server);
         try {
-            return new URI("http", null, host.getHostText(), host.getPortOrDefault(80), null, null, null);
+            return new URI("http", null, host.getHost(), host.getPortOrDefault(80), null, null, null);
         }
         catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StaticHiveCluster.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StaticHiveCluster.java
@@ -71,7 +71,7 @@ public class StaticHiveCluster
         TTransportException lastException = null;
         for (HostAndPort metastore : metastores) {
             try {
-                return clientFactory.create(metastore.getHostText(), metastore.getPort());
+                return clientFactory.create(metastore.getHost(), metastore.getPort());
             }
             catch (TTransportException e) {
                 lastException = e;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/thrift/Transport.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/thrift/Transport.java
@@ -82,7 +82,7 @@ public final class Transport
 
     private static Socket createSocksSocket(HostAndPort proxy)
     {
-        SocketAddress address = InetSocketAddress.createUnresolved(proxy.getHostText(), proxy.getPort());
+        SocketAddress address = InetSocketAddress.createUnresolved(proxy.getHost(), proxy.getPort());
         return new Socket(new Proxy(Proxy.Type.SOCKS, address));
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -126,7 +126,7 @@ final class PrestoDriverUri
 
         return uriBuilder()
                 .scheme(scheme)
-                .host(address.getHostText()).port(address.getPort())
+                .host(address.getHost()).port(address.getPort())
                 .build();
     }
 


### PR DESCRIPTION
The method is removed in Guava 22.0