### PR TITLE
Document TableStatistics Builder accepted usage

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeCost.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeCost.java
@@ -96,12 +96,18 @@ public class PlanNodeCost
         private Estimate outputRowCount = unknownValue();
         private Estimate outputSizeInBytes = unknownValue();
 
+        /**
+         * @return this {@code Builder} object
+         */
         public Builder setOutputRowCount(Estimate outputRowCount)
         {
             this.outputRowCount = outputRowCount;
             return this;
         }
 
+        /**
+         * @return this {@code Builder} object
+         */
         public Builder setOutputSizeInBytes(Estimate outputSizeInBytes)
         {
             this.outputSizeInBytes = outputSizeInBytes;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatistics.java
@@ -71,12 +71,18 @@ public final class TableStatistics
         private Estimate rowCount = unknownValue();
         private Map<ColumnHandle, ColumnStatistics> columnStatisticsMap = new HashMap<>();
 
+        /**
+         * @return this {@code Builder} object
+         */
         public Builder setRowCount(Estimate rowCount)
         {
             this.rowCount = requireNonNull(rowCount, "rowCount can not be null");
             return this;
         }
 
+        /**
+         * @return this {@code Builder} object
+         */
         public Builder setColumnStatistics(ColumnHandle columnName, ColumnStatistics columnStatistics)
         {
             requireNonNull(columnName, "columnName can not be null");


### PR DESCRIPTION
`TableStatistics.Builder` has API allowing fluent use. Add javadoc
assuring non-fluent use is also OK.