### PR TITLE
Skip unknown costs in EXPLAIN output

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -108,7 +108,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -1234,7 +1233,7 @@ public class PlanPrinter
 
         private boolean isKnownCost(PlanNode node)
         {
-            return !Objects.equals(UNKNOWN_COST, costs.getOrDefault(node.getId(), UNKNOWN_COST));
+            return !UNKNOWN_COST.equals(costs.getOrDefault(node.getId(), UNKNOWN_COST));
         }
 
         private String formatCost(PlanNode node)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -108,6 +108,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -1223,10 +1224,17 @@ public class PlanPrinter
 
         private void printCost(int indent, PlanNode... nodes)
         {
-            String costString = Joiner.on("/").join(Arrays.stream(nodes)
-                    .map(this::formatCost)
-                    .collect(toImmutableList()));
-            print(indent, "Cost: %s", costString);
+            if (Arrays.stream(nodes).anyMatch(this::isKnownCost)) {
+                String costString = Joiner.on("/").join(Arrays.stream(nodes)
+                        .map(this::formatCost)
+                        .collect(toImmutableList()));
+                print(indent, "Cost: %s", costString);
+            }
+        }
+
+        private boolean isKnownCost(PlanNode node)
+        {
+            return !Objects.equals(UNKNOWN_COST, costs.getOrDefault(node.getId(), UNKNOWN_COST));
         }
 
         private String formatCost(PlanNode node)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -291,8 +291,11 @@ public abstract class AbstractTestDistributedQueries
     private void assertExplainAnalyze(@Language("SQL") String query)
     {
         String value = getOnlyElement(computeActual(query).getOnlyColumnAsSet());
+
+        assertTrue(value.matches("(?s:.*)CPU:.*, Input:.*, Output(?s:.*)"), format("Expected output to contain \"CPU:.*, Input:.*, Output\", but it is %s", value));
+
         // TODO: check that rendered plan is as expected, once stats are collected in a consistent way
-        assertTrue(value.contains("Cost: "), format("Expected output to contain \"Cost: \", but it is %s", value));
+        // assertTrue(value.contains("Cost: "), format("Expected output to contain \"Cost: \", but it is %s", value));
     }
 
     protected void assertCreateTableAsSelect(String table, @Language("SQL") String query, @Language("SQL") String rowCountQuery)


### PR DESCRIPTION
Before

```
presto> explain select a from memory.default.x where a < 2;
                                                                                                                                    Query Plan
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 - Output[a] => [a:integer]
         Cost: {rows: ?, bytes: ?}
     - RemoteExchange[GATHER] => a:integer
             Cost: {rows: ?, bytes: ?}
         - ScanFilter[table = memory:MemoryTableHandle{connectorId=memory, schemaName=default, tableName=x, tableId=0, columnHandles=[MemoryColumnHandle{name=a, columnType=integer, columnIndex=0}]}, originalConstraint = ("a" < 2),
                 Cost: {rows: ?, bytes: ?}/{rows: ?, bytes: ?}
                 a := MemoryColumnHandle{name=a, columnType=integer, columnIndex=0}

(1 row)
```

After

```
presto> explain select a from memory.default.x where a < 2;
                                                                                                                                    Query Plan
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 - Output[a] => [a:integer]
     - RemoteExchange[GATHER] => a:integer
         - ScanFilter[table = memory:MemoryTableHandle{connectorId=memory, schemaName=default, tableName=x, tableId=0, columnHandles=[MemoryColumnHandle{name=a, columnType=integer, columnIndex=0}]}, originalConstraint = ("a" < 2),
                 a := MemoryColumnHandle{name=a, columnType=integer, columnIndex=0}

(1 row)
```