### PR TITLE
Make base class for most iterative rule tests

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestAddIntermediateAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestAddIntermediateAggregations.java
@@ -15,15 +15,13 @@ package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -44,31 +42,16 @@ import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestAddIntermediateAggregations
+            extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void testBasic()
     {
         ExpectedValueProvider<FunctionCall> aggregationPattern = PlanMatchPattern.functionCall("count", false, ImmutableList.of(anySymbol()));
 
-        tester.assertThat(new AddIntermediateAggregations())
+        getRuleTester().assertThat(new AddIntermediateAggregations())
                 .setSystemProperty(ENABLE_INTERMEDIATE_AGGREGATIONS, "true")
                 .setSystemProperty(TASK_CONCURRENCY, "4")
                 .on(p -> p.aggregation(af -> {
@@ -123,7 +106,7 @@ public class TestAddIntermediateAggregations
         ExpectedValueProvider<FunctionCall> rawInputCount = PlanMatchPattern.functionCall("count", false, ImmutableList.of());
         ExpectedValueProvider<FunctionCall> partialInputCount = PlanMatchPattern.functionCall("count", false, ImmutableList.of(anySymbol()));
 
-        tester.assertThat(new AddIntermediateAggregations())
+        getRuleTester().assertThat(new AddIntermediateAggregations())
                 .setSystemProperty(ENABLE_INTERMEDIATE_AGGREGATIONS, "true")
                 .setSystemProperty(TASK_CONCURRENCY, "4")
                 .on(p -> p.aggregation(af -> {
@@ -176,7 +159,7 @@ public class TestAddIntermediateAggregations
     {
         ExpectedValueProvider<FunctionCall> aggregationPattern = PlanMatchPattern.functionCall("count", false, ImmutableList.of(anySymbol()));
 
-        tester.assertThat(new AddIntermediateAggregations())
+        getRuleTester().assertThat(new AddIntermediateAggregations())
                 .setSystemProperty(ENABLE_INTERMEDIATE_AGGREGATIONS, "true")
                 .setSystemProperty(TASK_CONCURRENCY, "4")
                 .on(p -> p.aggregation(af -> {
@@ -230,7 +213,7 @@ public class TestAddIntermediateAggregations
     @Test
     public void testSessionDisable()
     {
-        tester.assertThat(new AddIntermediateAggregations())
+        getRuleTester().assertThat(new AddIntermediateAggregations())
                 .setSystemProperty(ENABLE_INTERMEDIATE_AGGREGATIONS, "false")
                 .setSystemProperty(TASK_CONCURRENCY, "4")
                 .on(p -> p.aggregation(af -> {
@@ -254,7 +237,7 @@ public class TestAddIntermediateAggregations
     {
         ExpectedValueProvider<FunctionCall> aggregationPattern = PlanMatchPattern.functionCall("count", false, ImmutableList.of(anySymbol()));
 
-        tester.assertThat(new AddIntermediateAggregations())
+        getRuleTester().assertThat(new AddIntermediateAggregations())
                 .setSystemProperty(ENABLE_INTERMEDIATE_AGGREGATIONS, "true")
                 .setSystemProperty(TASK_CONCURRENCY, "1")
                 .on(p -> p.aggregation(af -> {
@@ -297,7 +280,7 @@ public class TestAddIntermediateAggregations
     @Test
     public void testWithGroups()
     {
-        tester.assertThat(new AddIntermediateAggregations())
+        getRuleTester().assertThat(new AddIntermediateAggregations())
                 .setSystemProperty(ENABLE_INTERMEDIATE_AGGREGATIONS, "true")
                 .setSystemProperty(TASK_CONCURRENCY, "4")
                 .on(p -> p.aggregation(af -> {
@@ -321,7 +304,7 @@ public class TestAddIntermediateAggregations
     {
         ExpectedValueProvider<FunctionCall> aggregationPattern = PlanMatchPattern.functionCall("count", false, ImmutableList.of(anySymbol()));
 
-        tester.assertThat(new AddIntermediateAggregations())
+        getRuleTester().assertThat(new AddIntermediateAggregations())
                 .setSystemProperty(ENABLE_INTERMEDIATE_AGGREGATIONS, "true")
                 .setSystemProperty(TASK_CONCURRENCY, "4")
                 .on(p -> p.aggregation(af -> {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
@@ -17,7 +17,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.optimizations.joins.JoinGraph;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -29,8 +29,6 @@ import com.facebook.presto.sql.tree.ArithmeticUnaryExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -50,34 +48,20 @@ import static com.facebook.presto.sql.tree.ArithmeticUnaryExpression.Sign.MINUS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static org.testng.Assert.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestEliminateCrossJoins
+            extends RuleTest
 {
-    private RuleTester tester;
     private final PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
 
     @Test
     public void testEliminateCrossJoin()
     {
-        tester.assertThat(new EliminateCrossJoins())
+        getRuleTester().assertThat(new EliminateCrossJoins())
                 .setSystemProperty(REORDER_JOINS, "true")
                 .on(crossJoinAndJoin(INNER))
                 .matches(
@@ -98,7 +82,7 @@ public class TestEliminateCrossJoins
     @Test
     public void testRetainOutgoingGroupReferences()
     {
-        tester.assertThat(new EliminateCrossJoins())
+        getRuleTester().assertThat(new EliminateCrossJoins())
                 .setSystemProperty(REORDER_JOINS, "true")
                 .on(crossJoinAndJoin(INNER))
                 .matches(
@@ -117,7 +101,7 @@ public class TestEliminateCrossJoins
     @Test
     public void testDoNotReorderOuterJoin()
     {
-        tester.assertThat(new EliminateCrossJoins())
+        getRuleTester().assertThat(new EliminateCrossJoins())
                 .setSystemProperty(REORDER_JOINS, "true")
                 .on(crossJoinAndJoin(JoinNode.Type.LEFT))
                 .doesNotFire();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEvaluateZeroLimit.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEvaluateZeroLimit.java
@@ -13,41 +13,24 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expressions;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestEvaluateZeroLimit
+            extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void testDoesNotFire()
             throws Exception
     {
-        tester.assertThat(new EvaluateZeroLimit())
+        getRuleTester().assertThat(new EvaluateZeroLimit())
                 .on(p ->
                         p.limit(
                                 1,
@@ -59,7 +42,7 @@ public class TestEvaluateZeroLimit
     public void test()
             throws Exception
     {
-        tester.assertThat(new EvaluateZeroLimit())
+        getRuleTester().assertThat(new EvaluateZeroLimit())
                 .on(p ->
                         p.limit(
                                 0,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEvaluateZeroSample.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEvaluateZeroSample.java
@@ -13,42 +13,25 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.SampleNode.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expressions;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestEvaluateZeroSample
+            extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void testDoesNotFire()
             throws Exception
     {
-        tester.assertThat(new EvaluateZeroSample())
+        getRuleTester().assertThat(new EvaluateZeroSample())
                 .on(p ->
                         p.sample(
                                 0.15,
@@ -61,7 +44,7 @@ public class TestEvaluateZeroSample
     public void test()
             throws Exception
     {
-        tester.assertThat(new EvaluateZeroSample())
+        getRuleTester().assertThat(new EvaluateZeroSample())
                 .on(p ->
                         p.sample(
                                 0,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestInlineProjections.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestInlineProjections.java
@@ -15,40 +15,23 @@ package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.sql.planner.assertions.ExpressionMatcher;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestInlineProjections
+            extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void test()
     {
-        tester.assertThat(new InlineProjections())
+        getRuleTester().assertThat(new InlineProjections())
                 .on(p ->
                         p.project(
                                 Assignments.builder()
@@ -89,7 +72,7 @@ public class TestInlineProjections
     public void testIdentityProjections()
             throws Exception
     {
-        tester.assertThat(new InlineProjections())
+        getRuleTester().assertThat(new InlineProjections())
                 .on(p ->
                         p.project(
                                 Assignments.of(p.symbol("output", BIGINT), expression("value")),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
@@ -17,7 +17,7 @@ import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.FunctionCall;
@@ -27,8 +27,6 @@ import com.facebook.presto.sql.tree.Window;
 import com.facebook.presto.sql.tree.WindowFrame;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -43,25 +41,10 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.window;
 import static com.facebook.presto.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestMergeAdjacentWindows
+            extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     private static final WindowNode.Frame frame = new WindowNode.Frame(WindowFrame.Type.RANGE, UNBOUNDED_PRECEDING,
             Optional.empty(), CURRENT_ROW, Optional.empty());
     private static final Signature signature = new Signature(
@@ -77,7 +60,7 @@ public class TestMergeAdjacentWindows
     public void testPlanWithoutWindowNode()
             throws Exception
     {
-        tester.assertThat(new MergeAdjacentWindows())
+        getRuleTester().assertThat(new MergeAdjacentWindows())
                 .on(p -> p.values(p.symbol("a", BIGINT)))
                 .doesNotFire();
     }
@@ -86,7 +69,7 @@ public class TestMergeAdjacentWindows
     public void testPlanWithSingleWindowNode()
             throws Exception
     {
-        tester.assertThat(new MergeAdjacentWindows())
+        getRuleTester().assertThat(new MergeAdjacentWindows())
                 .on(p ->
                         p.window(
                                 newWindowNodeSpecification(p, "a"),
@@ -98,7 +81,7 @@ public class TestMergeAdjacentWindows
     @Test
     public void testDistinctAdjacentWindowSpecifications()
     {
-        tester.assertThat(new MergeAdjacentWindows())
+        getRuleTester().assertThat(new MergeAdjacentWindows())
                 .on(p ->
                         p.window(
                                 newWindowNodeSpecification(p, "a"),
@@ -115,7 +98,7 @@ public class TestMergeAdjacentWindows
     @Test
     public void testNonWindowIntermediateNode()
     {
-        tester.assertThat(new MergeAdjacentWindows())
+        getRuleTester().assertThat(new MergeAdjacentWindows())
                 .on(p ->
                         p.window(
                                 newWindowNodeSpecification(p, "a"),
@@ -138,7 +121,7 @@ public class TestMergeAdjacentWindows
     {
         Optional<Window> windowA = Optional.of(new Window(ImmutableList.of(new SymbolReference("a")), Optional.empty(), Optional.empty()));
 
-        tester.assertThat(new MergeAdjacentWindows())
+        getRuleTester().assertThat(new MergeAdjacentWindows())
                 .on(p ->
                         p.window(
                                 newWindowNodeSpecification(p, "a"),
@@ -158,7 +141,7 @@ public class TestMergeAdjacentWindows
     {
         Optional<Window> windowA = Optional.of(new Window(ImmutableList.of(new SymbolReference("a")), Optional.empty(), Optional.empty()));
 
-        tester.assertThat(new MergeAdjacentWindows())
+        getRuleTester().assertThat(new MergeAdjacentWindows())
                 .on(p ->
                         p.window(
                                 newWindowNodeSpecification(p, "a"),
@@ -182,7 +165,7 @@ public class TestMergeAdjacentWindows
 
         Optional<Window> windowA = Optional.of(new Window(ImmutableList.of(new SymbolReference("a")), Optional.empty(), Optional.empty()));
 
-        tester.assertThat(new MergeAdjacentWindows())
+        getRuleTester().assertThat(new MergeAdjacentWindows())
                 .on(p ->
                         p.window(
                                 newWindowNodeSpecification(p, "a"),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeFilters.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeFilters.java
@@ -13,39 +13,22 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestMergeFilters
+        extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void test()
     {
-        tester.assertThat(new MergeFilters())
+        getRuleTester().assertThat(new MergeFilters())
                 .on(p ->
                         p.filter(expression("b > 44"),
                                 p.filter(expression("a < 42"),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneSemiJoinColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneSemiJoinColumns.java
@@ -15,13 +15,11 @@ package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -34,29 +32,14 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJo
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestPruneSemiJoinColumns
+        extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void testSemiJoinNotNeeded()
     {
-        tester.assertThat(new PruneSemiJoinColumns())
+        getRuleTester().assertThat(new PruneSemiJoinColumns())
                 .on(p -> buildProjectedSemiJoin(p, symbol -> symbol.getName().equals("leftValue")))
                 .matches(
                         strictProject(
@@ -67,7 +50,7 @@ public class TestPruneSemiJoinColumns
     @Test
     public void testAllColumnsNeeded()
     {
-        tester.assertThat(new PruneSemiJoinColumns())
+        getRuleTester().assertThat(new PruneSemiJoinColumns())
                 .on(p -> buildProjectedSemiJoin(p, symbol -> true))
                 .doesNotFire();
     }
@@ -75,7 +58,7 @@ public class TestPruneSemiJoinColumns
     @Test
     public void testKeysNotNeeded()
     {
-        tester.assertThat(new PruneSemiJoinColumns())
+        getRuleTester().assertThat(new PruneSemiJoinColumns())
                 .on(p -> buildProjectedSemiJoin(p, symbol -> (symbol.getName().equals("leftValue") || symbol.getName().equals("match"))))
                 .doesNotFire();
     }
@@ -83,7 +66,7 @@ public class TestPruneSemiJoinColumns
     @Test
     public void testValueNotNeeded()
     {
-        tester.assertThat(new PruneSemiJoinColumns())
+        getRuleTester().assertThat(new PruneSemiJoinColumns())
                 .on(p -> buildProjectedSemiJoin(p, symbol -> symbol.getName().equals("match")))
                 .matches(
                         strictProject(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneSemiJoinFilteringSourceColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneSemiJoinFilteringSourceColumns.java
@@ -15,12 +15,10 @@ package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -33,29 +31,14 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJo
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestPruneSemiJoinFilteringSourceColumns
+        extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void testNotAllColumnsReferenced()
     {
-        tester.assertThat(new PruneSemiJoinFilteringSourceColumns())
+        getRuleTester().assertThat(new PruneSemiJoinFilteringSourceColumns())
                 .on(p -> buildSemiJoin(p, symbol -> true))
                 .matches(
                         semiJoin("leftKey", "rightKey", "match",
@@ -70,7 +53,7 @@ public class TestPruneSemiJoinFilteringSourceColumns
     @Test
     public void testAllColumnsNeeded()
     {
-        tester.assertThat(new PruneSemiJoinFilteringSourceColumns())
+        getRuleTester().assertThat(new PruneSemiJoinFilteringSourceColumns())
                 .on(p -> buildSemiJoin(p, symbol -> !symbol.getName().equals("rightValue")))
                 .doesNotFire();
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneTableScanColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneTableScanColumns.java
@@ -17,15 +17,13 @@ import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.testing.TestingMetadata.TestingColumnHandle;
 import com.facebook.presto.tpch.TpchColumnHandle;
 import com.facebook.presto.tpch.TpchTableHandle;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -35,29 +33,14 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strict
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictTableScan;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCALE_FACTOR;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestPruneTableScanColumns
+        extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void testNotAllOutputsReferenced()
     {
-        tester.assertThat(new PruneTableScanColumns())
+        getRuleTester().assertThat(new PruneTableScanColumns())
                 .on(p ->
                 {
                     Symbol orderdate = p.symbol("orderdate", DATE);
@@ -82,7 +65,7 @@ public class TestPruneTableScanColumns
     @Test
     public void testAllOutputsReferenced()
     {
-        tester.assertThat(new PruneTableScanColumns())
+        getRuleTester().assertThat(new PruneTableScanColumns())
                 .on(p ->
                         p.project(
                                 Assignments.of(p.symbol("y", BIGINT), expression("x")),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneValuesColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneValuesColumns.java
@@ -14,42 +14,25 @@
 package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestPruneValuesColumns
+        extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void testNotAllOutputsReferenced()
             throws Exception
     {
-        tester.assertThat(new PruneValuesColumns())
+        getRuleTester().assertThat(new PruneValuesColumns())
                 .on(p ->
                         p.project(
                                 Assignments.of(p.symbol("y", BIGINT), expression("x")),
@@ -72,7 +55,7 @@ public class TestPruneValuesColumns
     public void testAllOutputsReferenced()
             throws Exception
     {
-        tester.assertThat(new PruneValuesColumns())
+        getRuleTester().assertThat(new PruneValuesColumns())
                 .on(p ->
                         p.project(
                                 Assignments.of(p.symbol("y", BIGINT), expression("x")),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
@@ -16,7 +16,7 @@ package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -37,11 +37,12 @@ import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.ex
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.SINGLE;
 
 public class TestPushAggregationThroughOuterJoin
+        extends RuleTest
 {
     @Test
     public void testPushesAggregationThroughLeftJoin()
     {
-        new RuleTester().assertThat(new PushAggregationThroughOuterJoin())
+        getRuleTester().assertThat(new PushAggregationThroughOuterJoin())
                 .on(p -> p.aggregation(ab -> ab
                         .source(
                                 p.join(
@@ -82,7 +83,7 @@ public class TestPushAggregationThroughOuterJoin
     @Test
     public void testPushesAggregationThroughRightJoin()
     {
-        new RuleTester().assertThat(new PushAggregationThroughOuterJoin())
+        getRuleTester().assertThat(new PushAggregationThroughOuterJoin())
                 .on(p -> p.aggregation(ab -> ab
                         .source(p.join(
                                 JoinNode.Type.RIGHT,
@@ -122,7 +123,7 @@ public class TestPushAggregationThroughOuterJoin
     @Test
     public void testDoesNotFireWhenNotDistinct()
     {
-        new RuleTester().assertThat(new PushAggregationThroughOuterJoin())
+        getRuleTester().assertThat(new PushAggregationThroughOuterJoin())
                 .on(p -> p.aggregation(ab -> ab
                         .source(p.join(
                                 JoinNode.Type.LEFT,
@@ -141,7 +142,7 @@ public class TestPushAggregationThroughOuterJoin
     @Test
     public void testDoesNotFireWhenGroupingOnInner()
     {
-        new RuleTester().assertThat(new PushAggregationThroughOuterJoin())
+        getRuleTester().assertThat(new PushAggregationThroughOuterJoin())
                 .on(p -> p.aggregation(ab -> ab
                         .source(p.join(JoinNode.Type.LEFT,
                                 p.values(ImmutableList.of(p.symbol("COL1", BIGINT)), ImmutableList.of(expressions("10"))),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushProjectionThroughExchange.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushProjectionThroughExchange.java
@@ -14,14 +14,12 @@
 package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -29,30 +27,15 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchan
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestPushProjectionThroughExchange
+        extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void testDoesNotFireNoExchange()
             throws Exception
     {
-        tester.assertThat(new PushProjectionThroughExchange())
+        getRuleTester().assertThat(new PushProjectionThroughExchange())
                 .on(p ->
                         p.project(
                                 Assignments.of(p.symbol("x", BIGINT), new LongLiteral("3")),
@@ -64,7 +47,7 @@ public class TestPushProjectionThroughExchange
     public void testDoesNotFireNarrowingProjection()
             throws Exception
     {
-        tester.assertThat(new PushProjectionThroughExchange())
+        getRuleTester().assertThat(new PushProjectionThroughExchange())
                 .on(p -> {
                     Symbol a = p.symbol("a", BIGINT);
                     Symbol b = p.symbol("b", BIGINT);
@@ -87,7 +70,7 @@ public class TestPushProjectionThroughExchange
     public void testSimpleMultipleInputs()
             throws Exception
     {
-        tester.assertThat(new PushProjectionThroughExchange())
+        getRuleTester().assertThat(new PushProjectionThroughExchange())
                 .on(p -> {
                     Symbol a = p.symbol("a", BIGINT);
                     Symbol b = p.symbol("b", BIGINT);
@@ -128,7 +111,7 @@ public class TestPushProjectionThroughExchange
     public void testPartitioningColumnAndHashWithoutIdentityMappingInProjection()
             throws Exception
     {
-        tester.assertThat(new PushProjectionThroughExchange())
+        getRuleTester().assertThat(new PushProjectionThroughExchange())
                 .on(p -> {
                     Symbol a = p.symbol("a", BIGINT);
                     Symbol b = p.symbol("b", BIGINT);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushProjectionThroughUnion.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushProjectionThroughUnion.java
@@ -14,15 +14,13 @@
 package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -30,30 +28,15 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expres
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.union;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestPushProjectionThroughUnion
+        extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void testDoesNotFire()
             throws Exception
     {
-        tester.assertThat(new PushProjectionThroughUnion())
+        getRuleTester().assertThat(new PushProjectionThroughUnion())
                 .on(p ->
                         p.project(
                                 Assignments.of(p.symbol("x", BIGINT), new LongLiteral("3")),
@@ -65,7 +48,7 @@ public class TestPushProjectionThroughUnion
     public void test()
             throws Exception
     {
-        tester.assertThat(new PushProjectionThroughUnion())
+        getRuleTester().assertThat(new PushProjectionThroughUnion())
                 .on(p -> {
                     Symbol a = p.symbol("a", BIGINT);
                     Symbol b = p.symbol("b", BIGINT);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveEmptyDelete.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveEmptyDelete.java
@@ -16,37 +16,19 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
-
 public class TestRemoveEmptyDelete
+        extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void testDoesNotFire()
             throws Exception
     {
-        tester.assertThat(new RemoveEmptyDelete())
+        getRuleTester().assertThat(new RemoveEmptyDelete())
                 .on(p -> p.tableDelete(
                         new SchemaTableName("sch", "tab"),
                         p.tableScan(ImmutableList.of(), ImmutableMap.of()),
@@ -58,7 +40,7 @@ public class TestRemoveEmptyDelete
     @Test
     public void test()
     {
-        tester.assertThat(new RemoveEmptyDelete())
+        getRuleTester().assertThat(new RemoveEmptyDelete())
                 .on(p -> p.tableDelete(
                         new SchemaTableName("sch", "tab"),
                         p.values(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveFullSample.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveFullSample.java
@@ -13,12 +13,10 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.SampleNode.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -26,30 +24,15 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expressions;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestRemoveFullSample
+        extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     @Test
     public void testDoesNotFire()
             throws Exception
     {
-        tester.assertThat(new RemoveFullSample())
+        getRuleTester().assertThat(new RemoveFullSample())
                 .on(p ->
                         p.sample(
                                 0.15,
@@ -62,7 +45,7 @@ public class TestRemoveFullSample
     public void test()
             throws Exception
     {
-        tester.assertThat(new RemoveFullSample())
+        getRuleTester().assertThat(new RemoveFullSample())
                 .on(p ->
                         p.sample(
                                 1.0,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
@@ -16,7 +16,7 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
-import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTest;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -25,8 +25,6 @@ import com.facebook.presto.sql.tree.Window;
 import com.facebook.presto.sql.tree.WindowFrame;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -39,25 +37,10 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.window;
 import static com.facebook.presto.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
-import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public class TestSwapAdjacentWindowsBySpecifications
+            extends RuleTest
 {
-    private RuleTester tester;
-
-    @BeforeClass
-    public void setUp()
-    {
-        tester = new RuleTester();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        closeAllRuntimeException(tester);
-        tester = null;
-    }
-
     private WindowNode.Frame frame;
     private Signature signature;
 
@@ -79,7 +62,7 @@ public class TestSwapAdjacentWindowsBySpecifications
     public void doesNotFireOnPlanWithoutWindowFunctions()
             throws Exception
     {
-        tester.assertThat(new SwapAdjacentWindowsBySpecifications())
+        getRuleTester().assertThat(new SwapAdjacentWindowsBySpecifications())
                 .on(p -> p.values(p.symbol("a", BIGINT)))
                 .doesNotFire();
     }
@@ -88,7 +71,7 @@ public class TestSwapAdjacentWindowsBySpecifications
     public void doesNotFireOnPlanWithSingleWindowNode()
             throws Exception
     {
-        tester.assertThat(new SwapAdjacentWindowsBySpecifications())
+        getRuleTester().assertThat(new SwapAdjacentWindowsBySpecifications())
                 .on(p -> p.window(new WindowNode.Specification(
                                 ImmutableList.of(p.symbol("a", BIGINT)),
                                 ImmutableList.of(),
@@ -112,7 +95,7 @@ public class TestSwapAdjacentWindowsBySpecifications
         Optional<Window> windowAB = Optional.of(new Window(ImmutableList.of(new SymbolReference("a"), new SymbolReference("b")), Optional.empty(), Optional.empty()));
         Optional<Window> windowA = Optional.of(new Window(ImmutableList.of(new SymbolReference("a")), Optional.empty(), Optional.empty()));
 
-        tester.assertThat(new SwapAdjacentWindowsBySpecifications())
+        getRuleTester().assertThat(new SwapAdjacentWindowsBySpecifications())
                 .on(p ->
                         p.window(new WindowNode.Specification(
                                         ImmutableList.of(p.symbol("a", BIGINT)),
@@ -140,7 +123,7 @@ public class TestSwapAdjacentWindowsBySpecifications
     {
         Optional<Window> windowA = Optional.of(new Window(ImmutableList.of(new SymbolReference("a")), Optional.empty(), Optional.empty()));
 
-        tester.assertThat(new SwapAdjacentWindowsBySpecifications())
+        getRuleTester().assertThat(new SwapAdjacentWindowsBySpecifications())
                 .on(p ->
                         p.window(new WindowNode.Specification(
                                         ImmutableList.of(p.symbol("a", BIGINT)),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule.test;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
+
+public abstract class RuleTest
+{
+    private RuleTester tester;
+
+    @BeforeClass
+    public final void setUp()
+    {
+        tester = new RuleTester();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void tearDown()
+    {
+        closeAllRuntimeException(tester);
+        tester = null;
+    }
+
+    protected RuleTester getRuleTester()
+    {
+        return tester;
+    }
+}


### PR DESCRIPTION
Factor out the pattern of creating and tearing down the RuleTester in
each of the iterative rule unit test classes.  Requested by kokosing.