### PR TITLE
Adds support for SQL Server specific types and syntax

### DIFF
--- a/presto-docs/src/main/sphinx/connector/sqlserver.rst
+++ b/presto-docs/src/main/sphinx/connector/sqlserver.rst
@@ -67,8 +67,8 @@ that catalog name instead of ``sqlserver`` in the above examples.
 SQL Server Connector Limitations
 --------------------------------
 
-Presto supports connecting to SQL Server 2016, SQL Server 2014, SQL Server 2012
-and Azure SQL Database.
+Presto supports connecting to SQL Server 2016, SQL Server 2014, SQL Server 2012,
+SQL Server 2008 R2, SQL Server 2008 and Azure SQL Database.
 
 Presto supports the following SQL Server data types.
 The following table shows the mappings between SQL Server and Presto data types.
@@ -76,13 +76,34 @@ The following table shows the mappings between SQL Server and Presto data types.
 ============================= ============================
 SQL Server Type               Presto Type
 ============================= ============================
+``bit``                       ``boolean``
 ``bigint``                    ``bigint``
-``smallint``                  ``smallint``
 ``int``                       ``integer``
+``smallint``                  ``smallint``
+``tinyint``                   ``tinyint``
+``real``                      ``real``
 ``float``                     ``double``
+``decimal``                   ``double``
+``numeric``                   ``double``
 ``char(n)``                   ``char(n)``
+``char(max)``                 ``char``
+``nchar(n)``                  ``char(n)``
+``nchar(max)``                ``char``
 ``varchar(n)``                ``varchar(n)``
+``varchar(max)``              ``varchar``
+``nvarchar(n)``               ``varchar(n)``
+``nvarchar(max)``             ``varchar``
+``text``                      ``varchar``
+``ntext``                     ``varchar``
 ``date``                      ``date``
+``time``                      ``time``
+``datetime``                  ``timestamp``
+``smalldatetime``             ``timestamp``
+``datetime2``                 ``timestamp``
+``datetimeoffset``            ``timestamp with time zone``
+``money``                     ``double``
+``smallmoney``                ``double``
+``uniqueidentifier``          ``char(36)``
 ============================= ============================
 
 Complete list of `SQL Server data types

--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -22,13 +22,18 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
         </dependency>
 
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -23,6 +23,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>
 

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.sqlserver.jdbc.SQLServerDriver;
+import microsoft.sql.Types;
 
 import javax.inject.Inject;
 
@@ -44,6 +45,7 @@ import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 
@@ -103,6 +105,15 @@ public class SqlServerClient
         catch (SQLException e) {
             throw new PrestoException(JDBC_ERROR, e);
         }
+    }
+
+    @Override
+    protected Type toPrestoType(int jdbcType, int columnSize)
+    {
+        if (jdbcType == Types.DATETIMEOFFSET) {
+            return TIMESTAMP_WITH_TIME_ZONE;
+        }
+        return super.toPrestoType(jdbcType, columnSize);
     }
 
     @Override

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
@@ -67,6 +67,7 @@ public class SqlServerClient
             .put(DATE, "date")
             .put(TIME, "time")
             .put(TIMESTAMP, "datetime2")
+            .put(TIMESTAMP_WITH_TIME_ZONE, "datetimeoffset")
             .build();
 
     @Inject

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClientModule.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClientModule.java
@@ -49,7 +49,7 @@ public class SqlServerClientModule
         binder.bind(JdbcMetadataFactory.class).in(Scopes.SINGLETON);
         binder.bind(JdbcSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(JdbcRecordSetProvider.class).to(SqlServerRecordSetProvider.class).in(Scopes.SINGLETON);
-        binder.bind(JdbcRecordSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(JdbcRecordSinkProvider.class).to(SqlServerRecordSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(JdbcConnector.class).in(Scopes.SINGLETON);
         binder.bind(JdbcClient.class).to(SqlServerClient.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(JdbcMetadataConfig.class);

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClientModule.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClientModule.java
@@ -48,7 +48,7 @@ public class SqlServerClientModule
         binder.bind(JdbcConnectorId.class).toInstance(new JdbcConnectorId(connectorId));
         binder.bind(JdbcMetadataFactory.class).in(Scopes.SINGLETON);
         binder.bind(JdbcSplitManager.class).in(Scopes.SINGLETON);
-        binder.bind(JdbcRecordSetProvider.class).in(Scopes.SINGLETON);
+        binder.bind(JdbcRecordSetProvider.class).to(SqlServerRecordSetProvider.class).in(Scopes.SINGLETON);
         binder.bind(JdbcRecordSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(JdbcConnector.class).in(Scopes.SINGLETON);
         binder.bind(JdbcClient.class).to(SqlServerClient.class).in(Scopes.SINGLETON);

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClientModule.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClientModule.java
@@ -15,19 +15,44 @@ package com.facebook.presto.plugin.sqlserver;
 
 import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.JdbcClient;
+import com.facebook.presto.plugin.jdbc.JdbcConnector;
+import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataConfig;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataFactory;
+import com.facebook.presto.plugin.jdbc.JdbcRecordSetProvider;
+import com.facebook.presto.plugin.jdbc.JdbcRecordSinkProvider;
+import com.facebook.presto.plugin.jdbc.JdbcSplitManager;
+
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class SqlServerClientModule
         implements Module
 {
+    private final String connectorId;
+
+    public SqlServerClientModule(String connectorId)
+    {
+        checkArgument(!isNullOrEmpty(connectorId), "connectorId is null or empty");
+        this.connectorId = connectorId;
+    }
+
     @Override
     public void configure(Binder binder)
     {
+        binder.bind(JdbcConnectorId.class).toInstance(new JdbcConnectorId(connectorId));
+        binder.bind(JdbcMetadataFactory.class).in(Scopes.SINGLETON);
+        binder.bind(JdbcSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(JdbcRecordSetProvider.class).in(Scopes.SINGLETON);
+        binder.bind(JdbcRecordSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(JdbcConnector.class).in(Scopes.SINGLETON);
         binder.bind(JdbcClient.class).to(SqlServerClient.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(JdbcMetadataConfig.class);
         configBinder(binder).bindConfig(BaseJdbcConfig.class);
     }
 }

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerConnectorFactory.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerConnectorFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.sqlserver;
+
+import com.facebook.presto.plugin.jdbc.JdbcConnector;
+import com.facebook.presto.plugin.jdbc.JdbcHandleResolver;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+
+public class SqlServerConnectorFactory
+        implements ConnectorFactory
+{
+    private final String name;
+    private final ClassLoader classLoader;
+
+    public SqlServerConnectorFactory(String name, ClassLoader classLoader)
+    {
+        checkArgument(!isNullOrEmpty(name), "name is null or empty");
+        this.name = name;
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver()
+    {
+        return new JdbcHandleResolver();
+    }
+
+    @Override
+    public Connector create(String connectorId, Map<String, String> requiredConfig, ConnectorContext context)
+    {
+        checkArgument(!isNullOrEmpty(connectorId), "name is null or empty");
+        requireNonNull(requiredConfig, "requiredConfig is null");
+        requireNonNull(context, "context is null");
+
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            Bootstrap app = new Bootstrap(new SqlServerClientModule(connectorId));
+
+            Injector injector = app
+                    .strictConfig()
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(requiredConfig)
+                    .initialize();
+
+            return injector.getInstance(JdbcConnector.class);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerPlugin.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerPlugin.java
@@ -13,13 +13,23 @@
  */
 package com.facebook.presto.plugin.sqlserver;
 
-import com.facebook.presto.plugin.jdbc.JdbcPlugin;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.common.collect.ImmutableList;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 public class SqlServerPlugin
-        extends JdbcPlugin
+        implements Plugin
 {
-    public SqlServerPlugin()
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        super("sqlserver", new SqlServerClientModule());
+        return ImmutableList.of(new SqlServerConnectorFactory("sqlserver", getClassLoader()));
+    }
+
+    private static ClassLoader getClassLoader()
+    {
+        return firstNonNull(Thread.currentThread().getContextClassLoader(), SqlServerPlugin.class.getClassLoader());
     }
 }

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordCursor.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordCursor.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.sqlserver;
+
+import com.facebook.presto.plugin.jdbc.JdbcClient;
+import com.facebook.presto.plugin.jdbc.JdbcColumnHandle;
+import com.facebook.presto.plugin.jdbc.JdbcSplit;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.type.CharType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.base.CharMatcher;
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import io.airlift.slice.Slice;
+
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimeType.TIME;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.lang.Float.floatToRawIntBits;
+import static java.util.Objects.requireNonNull;
+
+public class SqlServerRecordCursor
+        implements RecordCursor
+{
+    private static final Logger log = Logger.get(SqlServerRecordCursor.class);
+
+    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+    private final List<JdbcColumnHandle> columnHandles;
+    private final Connection connection;
+    private final PreparedStatement statement;
+    private final ResultSet resultSet;
+
+    private boolean closed;
+
+    public SqlServerRecordCursor(JdbcClient jdbcClient, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
+    {
+        this.columnHandles = ImmutableList.copyOf(requireNonNull(columnHandles, "columnHandles is null"));
+
+        try {
+            connection = requireNonNull(jdbcClient, "jdbcClient is null").getConnection(requireNonNull(split, "split was null"));
+            statement = jdbcClient.buildSql(connection, split, columnHandles);
+            log.debug("Executing: %s", statement.toString());
+            resultSet = statement.executeQuery();
+        }
+        catch (SQLException | RuntimeException e) {
+            throw handleSqlException(e);
+        }
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTotalBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public Type getType(int field)
+    {
+        return columnHandles.get(field).getColumnType();
+    }
+
+    @Override
+    public boolean advanceNextPosition()
+    {
+        if (closed) {
+            return false;
+        }
+
+        try {
+            boolean result = resultSet.next();
+            if (!result) {
+                close();
+            }
+            return result;
+        }
+        catch (SQLException | RuntimeException e) {
+            throw handleSqlException(e);
+        }
+    }
+
+    @Override
+    public boolean getBoolean(int field)
+    {
+        checkState(!closed, "cursor is closed");
+        try {
+            return resultSet.getBoolean(field + 1);
+        }
+        catch (SQLException | RuntimeException e) {
+            throw handleSqlException(e);
+        }
+    }
+
+    @Override
+    public long getLong(int field)
+    {
+        checkState(!closed, "cursor is closed");
+        try {
+            Type type = getType(field);
+            if (TINYINT.equals(type)) {
+                return resultSet.getByte(field + 1);
+            }
+            if (SMALLINT.equals(type)) {
+                return resultSet.getShort(field + 1);
+            }
+            if (INTEGER.equals(type)) {
+                return resultSet.getInt(field + 1);
+            }
+            if (BIGINT.equals(type)) {
+                return resultSet.getLong(field + 1);
+            }
+            if (REAL.equals(type)) {
+                return floatToRawIntBits(resultSet.getFloat(field + 1));
+            }
+            if (DATE.equals(type)) {
+                Calendar cal = Calendar.getInstance(UTC);
+                Date date = resultSet.getDate(field + 1, cal);
+                return TimeUnit.MILLISECONDS.toDays(date.getTime());
+            }
+            if (TIME.equals(type)) {
+                Calendar cal = Calendar.getInstance(UTC);
+                Time time = resultSet.getTime(field + 1, cal);
+                return time.getTime();
+            }
+            if (TIMESTAMP.equals(type)) {
+                Calendar cal = Calendar.getInstance(UTC);
+                Timestamp ts = resultSet.getTimestamp(field + 1, cal);
+                return ts.getTime();
+            }
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Unhandled type for long: " + type.getTypeSignature());
+        }
+        catch (SQLException | RuntimeException e) {
+            throw handleSqlException(e);
+        }
+    }
+
+    @Override
+    public double getDouble(int field)
+    {
+        checkState(!closed, "cursor is closed");
+        try {
+            return resultSet.getDouble(field + 1);
+        }
+        catch (SQLException | RuntimeException e) {
+            throw handleSqlException(e);
+        }
+    }
+
+    @Override
+    public Slice getSlice(int field)
+    {
+        checkState(!closed, "cursor is closed");
+        try {
+            Type type = getType(field);
+            if (type instanceof VarcharType) {
+                return utf8Slice(resultSet.getString(field + 1));
+            }
+            if (type instanceof CharType) {
+                return utf8Slice(CharMatcher.is(' ').trimTrailingFrom(resultSet.getString(field + 1)));
+            }
+            if (VARBINARY.equals(type)) {
+                return wrappedBuffer(resultSet.getBytes(field + 1));
+            }
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Unhandled type for slice: " + type.getTypeSignature());
+        }
+        catch (SQLException | RuntimeException e) {
+            throw handleSqlException(e);
+        }
+    }
+
+    @Override
+    public Object getObject(int field)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isNull(int field)
+    {
+        checkState(!closed, "cursor is closed");
+        checkArgument(field < columnHandles.size(), "Invalid field index");
+
+        try {
+            // JDBC is kind of dumb: we need to read the field and then ask
+            // if it was null, which means we are wasting effort here.
+            // We could save the result of the field access if it matters.
+            resultSet.getObject(field + 1);
+
+            return resultSet.wasNull();
+        }
+        catch (SQLException | RuntimeException e) {
+            throw handleSqlException(e);
+        }
+    }
+
+    @SuppressWarnings({"UnusedDeclaration", "EmptyTryBlock"})
+    @Override
+    public void close()
+    {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        // use try with resources to close everything properly
+        try (Connection connection = this.connection;
+                Statement statement = this.statement;
+                ResultSet resultSet = this.resultSet) {
+            // do nothing
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private RuntimeException handleSqlException(Exception e)
+    {
+        try {
+            close();
+        }
+        catch (Exception closeException) {
+            // Self-suppression not permitted
+            if (e != closeException) {
+                e.addSuppressed(closeException);
+            }
+        }
+        return new RuntimeException(e);
+    }
+}

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordSet.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordSet.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.sqlserver;
+
+import com.facebook.presto.plugin.jdbc.JdbcClient;
+import com.facebook.presto.plugin.jdbc.JdbcColumnHandle;
+import com.facebook.presto.plugin.jdbc.JdbcRecordSet;
+import com.facebook.presto.plugin.jdbc.JdbcSplit;
+import com.facebook.presto.spi.RecordCursor;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class SqlServerRecordSet
+        extends JdbcRecordSet
+{
+    private final JdbcClient jdbcClient;
+    private final JdbcSplit split;
+    private final List<JdbcColumnHandle> columnHandles;
+
+    public SqlServerRecordSet(JdbcClient jdbcClient, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
+    {
+        super(jdbcClient, split, columnHandles);
+        this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
+        this.split = requireNonNull(split, "split is null");
+        this.columnHandles = requireNonNull(columnHandles, "column handles is null");
+    }
+
+    @Override
+    public RecordCursor cursor()
+    {
+        return new SqlServerRecordCursor(jdbcClient, split, columnHandles);
+    }
+}

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordSetProvider.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordSetProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.sqlserver;
+
+import com.facebook.presto.plugin.jdbc.JdbcClient;
+import com.facebook.presto.plugin.jdbc.JdbcColumnHandle;
+import com.facebook.presto.plugin.jdbc.JdbcRecordSetProvider;
+import com.facebook.presto.plugin.jdbc.JdbcSplit;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.RecordSet;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class SqlServerRecordSetProvider
+        extends JdbcRecordSetProvider
+{
+    private final JdbcClient jdbcClient;
+
+    @Inject
+    public SqlServerRecordSetProvider(JdbcClient jdbcClient)
+    {
+        super(jdbcClient);
+        this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
+    }
+
+    @Override
+    public RecordSet getRecordSet(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorSplit split, List<? extends ColumnHandle> columns)
+    {
+        JdbcSplit jdbcSplit = (JdbcSplit) split;
+
+        ImmutableList.Builder<JdbcColumnHandle> handles = ImmutableList.builder();
+        for (ColumnHandle handle : columns) {
+            handles.add((JdbcColumnHandle) handle);
+        }
+
+        return new SqlServerRecordSet(jdbcClient, jdbcSplit, handles.build());
+    }
+}

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordSink.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordSink.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.sqlserver;
+
+import com.facebook.presto.plugin.jdbc.JdbcClient;
+import com.facebook.presto.plugin.jdbc.JdbcOutputTableHandle;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.RecordSink;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_NON_TRANSIENT_ERROR;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.google.common.base.Preconditions.checkState;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class SqlServerRecordSink
+        implements RecordSink
+{
+    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+    private final Connection connection;
+    private final PreparedStatement statement;
+    private final int fieldCount;
+    private final List<Type> columnTypes;
+
+    private int field = -1;
+    private int batchSize;
+
+    public SqlServerRecordSink(JdbcClient jdbcClient, JdbcOutputTableHandle handle)
+    {
+        try {
+            connection = requireNonNull(jdbcClient, "jdbcClient was null").getConnection(requireNonNull(handle, "handle was null"));
+            connection.setAutoCommit(false);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+
+        try {
+            statement = connection.prepareStatement(jdbcClient.buildInsertSql(handle));
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+
+        fieldCount = handle.getColumnNames().size();
+        columnTypes = handle.getColumnTypes();
+    }
+
+    @Override
+    public void beginRecord()
+    {
+        checkState(field == -1, "already in record");
+        field = 0;
+    }
+
+    @Override
+    public void finishRecord()
+    {
+        checkState(field != -1, "not in record");
+        checkState(field == fieldCount, "not all fields set");
+        field = -1;
+
+        try {
+            statement.addBatch();
+            ++batchSize;
+
+            if (batchSize >= 1000) {
+                statement.executeBatch();
+                connection.commit();
+                connection.setAutoCommit(false);
+                batchSize = 0;
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
+    public void appendNull()
+    {
+        try {
+            statement.setObject(next(), null);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
+    public void appendBoolean(boolean value)
+    {
+        try {
+            statement.setBoolean(next(), value);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
+    public void appendLong(long value)
+    {
+        try {
+            if (DATE.equals(columnTypes.get(field))) {
+                Calendar cal = Calendar.getInstance(UTC);
+                long utcMillis = TimeUnit.DAYS.toMillis(value);
+                statement.setDate(next(), new Date(utcMillis), cal);
+            }
+            else {
+                statement.setLong(next(), value);
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
+    public void appendDouble(double value)
+    {
+        try {
+            statement.setDouble(next(), value);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
+    public void appendString(byte[] value)
+    {
+        try {
+            statement.setString(next(), new String(value, UTF_8));
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
+    public void appendObject(Object value)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<Slice> commit()
+    {
+        // commit and close
+        try (Connection connection = this.connection) {
+            if (batchSize > 0) {
+                statement.executeBatch();
+                connection.commit();
+            }
+        }
+        catch (SQLNonTransientException e) {
+            throw new PrestoException(JDBC_NON_TRANSIENT_ERROR, e);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+        // the committer does not need any additional info
+        return ImmutableList.of();
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    @Override
+    public void rollback()
+    {
+        // rollback and close
+        try (Connection connection = this.connection;
+                PreparedStatement statement = this.statement) {
+            connection.rollback();
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
+    public List<Type> getColumnTypes()
+    {
+        return ImmutableList.copyOf(columnTypes);
+    }
+
+    private int next()
+    {
+        checkState(field != -1, "not in record");
+        checkState(field < fieldCount, "all fields already set");
+        return ++field;
+    }
+}

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordSink.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordSink.java
@@ -26,6 +26,8 @@ import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientException;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.List;
@@ -35,6 +37,8 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_NON_TRANSIENT_ERROR;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.TimeType.TIME;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -133,6 +137,14 @@ public class SqlServerRecordSink
                 Calendar cal = Calendar.getInstance(UTC);
                 long utcMillis = TimeUnit.DAYS.toMillis(value);
                 statement.setDate(next(), new Date(utcMillis), cal);
+            }
+            else if (TIME.equals(columnTypes.get(field))) {
+                Calendar cal = Calendar.getInstance(UTC);
+                statement.setTime(next(), new Time(value), cal);
+            }
+            else if (TIMESTAMP.equals(columnTypes.get(field))) {
+                Calendar cal = Calendar.getInstance(UTC);
+                statement.setTimestamp(next(), new Timestamp(value), cal);
             }
             else {
                 statement.setLong(next(), value);

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordSink.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordSink.java
@@ -37,9 +37,11 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_NON_TRANSIENT_ERROR;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Float.intBitsToFloat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
@@ -133,7 +135,10 @@ public class SqlServerRecordSink
     public void appendLong(long value)
     {
         try {
-            if (DATE.equals(columnTypes.get(field))) {
+            if (REAL.equals(columnTypes.get(field))) {
+                statement.setFloat(next(), intBitsToFloat((int) value));
+            }
+            else if (DATE.equals(columnTypes.get(field))) {
                 Calendar cal = Calendar.getInstance(UTC);
                 long utcMillis = TimeUnit.DAYS.toMillis(value);
                 statement.setDate(next(), new Date(utcMillis), cal);

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordSinkProvider.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerRecordSinkProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.sqlserver;
+
+import com.facebook.presto.plugin.jdbc.JdbcClient;
+import com.facebook.presto.plugin.jdbc.JdbcOutputTableHandle;
+import com.facebook.presto.plugin.jdbc.JdbcRecordSinkProvider;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.RecordSink;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class SqlServerRecordSinkProvider
+        extends JdbcRecordSinkProvider
+{
+    private final JdbcClient jdbcClient;
+
+    @Inject
+    public SqlServerRecordSinkProvider(JdbcClient jdbcClient)
+    {
+        super(jdbcClient);
+        this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
+    }
+
+    @Override
+    public RecordSink getRecordSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle tableHandle)
+    {
+        return new SqlServerRecordSink(jdbcClient, (JdbcOutputTableHandle) tableHandle);
+    }
+
+    @Override
+    public RecordSink getRecordSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle tableHandle)
+    {
+        return new SqlServerRecordSink(jdbcClient, (JdbcOutputTableHandle) tableHandle);
+    }
+}


### PR DESCRIPTION
SQL Server uses different syntax/types than others, this includes fixes and improvements for:

- fixed creating tables with unbounded `varchar` or `char` columns
- fixed creating tables with a `double` column
- fixed incorrect usage of `timestamp` (aka `rowversion`) instead of `datetime2` for Presto `timestamp` columns
- fixed inserting `real` columns
- fixed inserting `timestamp` and `time` columns
- added `datetimeoffset` mapping for `timestamp with time zone`
- added `bit` mapping for `boolean`

Also changes the documentation to adds all the supported versions and the full data type mapping table (there are more, `rowversion` for instance, but they don't have viable representations in Java and are therefore not really useful outside T-SQL).

Unfortunately it's mostly duplication of the `base-jdbc` since I needed access to the original ResultSet and PreparedStatement to call some non-standard methods on them. This was actually originally an internal plugin here so I had to work with what was available, but I could change `base-jdbc` to raise the visibility of what I need if it's desirable.