### PR TITLE
Reject query if active worker nodes is insufficient

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.Duration;
@@ -54,6 +55,9 @@ public class QueryManagerConfig
     private String queryExecutionPolicy = "all-at-once";
     private Duration queryMaxRunTime = new Duration(100, TimeUnit.DAYS);
     private Duration queryMaxCpuTime = new Duration(1_000_000_000, TimeUnit.DAYS);
+
+    private int initializationRequiredWorkers = 1;
+    private Duration initializationTimeout = new Duration(5, TimeUnit.MINUTES);
 
     public String getQueueConfigFile()
     {
@@ -282,6 +286,34 @@ public class QueryManagerConfig
     public QueryManagerConfig setQueryExecutionPolicy(String queryExecutionPolicy)
     {
         this.queryExecutionPolicy = queryExecutionPolicy;
+        return this;
+    }
+
+    @Min(1)
+    public int getInitializationRequiredWorkers()
+    {
+        return initializationRequiredWorkers;
+    }
+
+    @Config("query-manager.initialization-required-workers")
+    @ConfigDescription("Minimum number of workers that must be available before the cluster will accept queries")
+    public QueryManagerConfig setInitializationRequiredWorkers(int initializationRequiredWorkers)
+    {
+        this.initializationRequiredWorkers = initializationRequiredWorkers;
+        return this;
+    }
+
+    @NotNull
+    public Duration getInitializationTimeout()
+    {
+        return initializationTimeout;
+    }
+
+    @Config("query-manager.initialization-timeout")
+    @ConfigDescription("After this time, the cluster will accept queries even if the minimum required workers are not available")
+    public QueryManagerConfig setInitializationTimeout(Duration initializationTimeout)
+    {
+        this.initializationTimeout = initializationTimeout;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -19,7 +19,9 @@ import com.facebook.presto.event.query.QueryMonitor;
 import com.facebook.presto.execution.QueryExecution.QueryExecutionFactory;
 import com.facebook.presto.execution.SqlQueryExecution.SqlQueryExecutionFactory;
 import com.facebook.presto.execution.resourceGroups.QueryQueueFullException;
+import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.memory.ClusterMemoryManager;
+import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.security.AccessControl;
@@ -67,16 +69,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.facebook.presto.execution.ParameterExtractor.getParameterCount;
 import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.spi.NodeState.ACTIVE;
 import static com.facebook.presto.spi.StandardErrorCode.ABANDONED_QUERY;
 import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TIME_LIMIT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_TEXT_TOO_LARGE;
 import static com.facebook.presto.spi.StandardErrorCode.SERVER_SHUTTING_DOWN;
+import static com.facebook.presto.spi.StandardErrorCode.SERVER_STARTING_UP;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_PARAMETER_USAGE;
 import static com.facebook.presto.sql.planner.ExpressionInterpreter.verifyExpressionIsConstant;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.Threads.threadsNamed;
+import static io.airlift.units.Duration.nanosSince;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
@@ -96,9 +101,13 @@ public class SqlQueryManager
     private final QueryQueueManager queueManager;
     private final ClusterMemoryManager memoryManager;
 
+    private final boolean isIncludeCoordinator;
     private final int maxQueryHistory;
     private final Duration minQueryExpireAge;
     private final int maxQueryLength;
+    private final int initializationRequiredWorkers;
+    private final Duration initializationTimeout;
+    private final long initialNanos;
 
     private final ConcurrentMap<QueryId, QueryExecution> queries = new ConcurrentHashMap<>();
     private final Queue<QueryExecution> expirationQueue = new LinkedBlockingQueue<>();
@@ -120,14 +129,19 @@ public class SqlQueryManager
 
     private final SessionPropertyManager sessionPropertyManager;
 
+    private final InternalNodeManager internalNodeManager;
+
     private final Map<Class<? extends Statement>, QueryExecutionFactory<?>> executionFactories;
 
     private final SqlQueryManagerStats stats = new SqlQueryManagerStats();
 
+    private final AtomicBoolean acceptQueries = new AtomicBoolean();
+
     @Inject
     public SqlQueryManager(
             SqlParser sqlParser,
-            QueryManagerConfig config,
+            NodeSchedulerConfig nodeSchedulerConfig,
+            QueryManagerConfig queryManagerConfig,
             QueryMonitor queryMonitor,
             QueryQueueManager queueManager,
             ClusterMemoryManager memoryManager,
@@ -136,6 +150,7 @@ public class SqlQueryManager
             AccessControl accessControl,
             QueryIdGenerator queryIdGenerator,
             SessionPropertyManager sessionPropertyManager,
+            InternalNodeManager internalNodeManager,
             Map<Class<? extends Statement>, QueryExecutionFactory<?>> executionFactories,
             Metadata metadata)
     {
@@ -146,7 +161,8 @@ public class SqlQueryManager
         this.queryExecutor = newCachedThreadPool(threadsNamed("query-scheduler-%s"));
         this.queryExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) queryExecutor);
 
-        requireNonNull(config, "config is null");
+        requireNonNull(nodeSchedulerConfig, "nodeSchedulerConfig is null");
+        requireNonNull(queryManagerConfig, "queryManagerConfig is null");
         this.queueManager = requireNonNull(queueManager, "queueManager is null");
         this.memoryManager = requireNonNull(memoryManager, "memoryManager is null");
 
@@ -162,12 +178,18 @@ public class SqlQueryManager
 
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
 
-        this.minQueryExpireAge = config.getMinQueryExpireAge();
-        this.maxQueryHistory = config.getMaxQueryHistory();
-        this.clientTimeout = config.getClientTimeout();
-        this.maxQueryLength = config.getMaxQueryLength();
+        this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
 
-        queryManagementExecutor = Executors.newScheduledThreadPool(config.getQueryManagerExecutorPoolSize(), threadsNamed("query-management-%s"));
+        this.isIncludeCoordinator = nodeSchedulerConfig.isIncludeCoordinator();
+        this.minQueryExpireAge = queryManagerConfig.getMinQueryExpireAge();
+        this.maxQueryHistory = queryManagerConfig.getMaxQueryHistory();
+        this.clientTimeout = queryManagerConfig.getClientTimeout();
+        this.maxQueryLength = queryManagerConfig.getMaxQueryLength();
+        this.initializationRequiredWorkers = queryManagerConfig.getInitializationRequiredWorkers();
+        this.initializationTimeout = queryManagerConfig.getInitializationTimeout();
+        this.initialNanos = System.nanoTime();
+
+        queryManagementExecutor = Executors.newScheduledThreadPool(queryManagerConfig.getQueryManagerExecutorPoolSize(), threadsNamed("query-management-%s"));
         queryManagementExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) queryManagementExecutor);
         queryManagementExecutor.scheduleWithFixedDelay(new Runnable()
         {
@@ -342,6 +364,19 @@ public class SqlQueryManager
         QueryExecution queryExecution;
         Statement statement;
         try {
+            if (!acceptQueries.get()) {
+                int activeWorkerCount = internalNodeManager.getNodes(ACTIVE).size();
+                if (!isIncludeCoordinator) {
+                    activeWorkerCount--;
+                }
+                if (nanosSince(initialNanos).compareTo(initializationTimeout) < 0 && activeWorkerCount < initializationRequiredWorkers) {
+                    throw new PrestoException(
+                            SERVER_STARTING_UP,
+                            String.format("Cluster is still initializing, there are insufficient active worker nodes (%s) to run query", activeWorkerCount));
+                }
+                acceptQueries.set(true);
+            }
+
             session = sessionSupplier.createSession(queryId, transactionManager, accessControl, sessionPropertyManager);
             if (query.length() > maxQueryLength) {
                 int queryLength = query.length();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -44,6 +44,8 @@ public class TestQueryManagerConfig
                 .setQueryExecutionPolicy("all-at-once")
                 .setQueryMaxRunTime(new Duration(100, TimeUnit.DAYS))
                 .setQueryMaxCpuTime(new Duration(1_000_000_000, TimeUnit.DAYS))
+                .setInitializationRequiredWorkers(1)
+                .setInitializationTimeout(new Duration(5, TimeUnit.MINUTES))
         );
     }
 
@@ -68,6 +70,8 @@ public class TestQueryManagerConfig
                 .put("query.execution-policy", "phased")
                 .put("query.max-run-time", "2h")
                 .put("query.max-cpu-time", "2d")
+                .put("query-manager.initialization-required-workers", "200")
+                .put("query-manager.initialization-timeout", "1m")
                 .build();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -87,7 +91,9 @@ public class TestQueryManagerConfig
                 .setRemoteTaskMaxCallbackThreads(10)
                 .setQueryExecutionPolicy("phased")
                 .setQueryMaxRunTime(new Duration(2, TimeUnit.HOURS))
-                .setQueryMaxCpuTime(new Duration(2, TimeUnit.DAYS));
+                .setQueryMaxCpuTime(new Duration(2, TimeUnit.DAYS))
+                .setInitializationRequiredWorkers(200)
+                .setInitializationTimeout(new Duration(1, TimeUnit.MINUTES));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMinWorkerRequirement.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMinWorkerRequirement.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestMinWorkerRequirement
+{
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Cluster is still initializing, there are insufficient active worker nodes \\(4\\) to run query")
+    public void testInsufficientWorkerNodes()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = createQueryRunner(
+                ImmutableMap.of(),
+                ImmutableMap.of("query-manager.initialization-required-workers", "5"),
+                4)) {
+            queryRunner.execute("SELECT 1");
+            fail("Expected exception due to insufficient active worker nodes");
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Cluster is still initializing, there are insufficient active worker nodes \\(3\\) to run query")
+    public void testInsufficientWorkerNodesWithCoordinatorExcluded()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = createQueryRunner(
+                ImmutableMap.of("node-scheduler.include-coordinator", "false"),
+                ImmutableMap.of("query-manager.initialization-required-workers", "4"),
+                4)) {
+            queryRunner.execute("SELECT 1");
+            fail("Expected exception due to insufficient active worker nodes");
+        }
+    }
+
+    @Test
+    public void testSufficientWorkerNodes()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = createQueryRunner(
+                ImmutableMap.of(),
+                ImmutableMap.of("query-manager.initialization-required-workers", "4"),
+                4)) {
+            queryRunner.execute("SELECT 1");
+            assertEquals(queryRunner.getCoordinator().refreshNodes().getActiveNodes().size(), 4);
+
+            // Query should still be allowed to run if active workers drop down below the minimum required nodes
+            queryRunner.getServers().get(0).close();
+            assertEquals(queryRunner.getCoordinator().refreshNodes().getActiveNodes().size(), 3);
+            queryRunner.execute("SELECT 1");
+        }
+    }
+
+    @Test
+    public void testInitializationTimeout()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = createQueryRunner(
+                ImmutableMap.of(),
+                ImmutableMap.<String, String>builder()
+                        .put("query-manager.initialization-required-workers", "5")
+                        .put("query-manager.initialization-timeout", "1ns")
+                        .build(),
+                4)) {
+            queryRunner.execute("SELECT 1");
+            assertEquals(queryRunner.getCoordinator().refreshNodes().getActiveNodes().size(), 4);
+        }
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
@@ -27,6 +27,8 @@ import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 
 public final class TpchQueryRunner
 {
+    private static final int DEFAULT_WORKER_COUNT = 4;
+
     private TpchQueryRunner() {}
 
     public static DistributedQueryRunner createQueryRunner()
@@ -44,7 +46,13 @@ public final class TpchQueryRunner
     public static DistributedQueryRunner createQueryRunner(Map<String, String> extraProperties, Map<String, String> coordinatorProperties)
             throws Exception
     {
-        DistributedQueryRunner queryRunner = createQueryRunnerWithoutCatalogs(extraProperties, coordinatorProperties);
+        return createQueryRunner(extraProperties, coordinatorProperties, DEFAULT_WORKER_COUNT);
+    }
+
+    public static DistributedQueryRunner createQueryRunner(Map<String, String> extraProperties, Map<String, String> coordinatorProperties, int nodeCount)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = createQueryRunnerWithoutCatalogs(extraProperties, coordinatorProperties, nodeCount);
         try {
             queryRunner.createCatalog("tpch", "tpch");
 
@@ -59,13 +67,19 @@ public final class TpchQueryRunner
     public static DistributedQueryRunner createQueryRunnerWithoutCatalogs(Map<String, String> extraProperties, Map<String, String> coordinatorProperties)
             throws Exception
     {
+        return createQueryRunnerWithoutCatalogs(extraProperties, coordinatorProperties, DEFAULT_WORKER_COUNT);
+    }
+
+    public static DistributedQueryRunner createQueryRunnerWithoutCatalogs(Map<String, String> extraProperties, Map<String, String> coordinatorProperties, int nodeCount)
+            throws Exception
+    {
         Session session = testSessionBuilder()
                 .setSource("test")
                 .setCatalog("tpch")
                 .setSchema("tiny")
                 .build();
 
-        DistributedQueryRunner queryRunner = new DistributedQueryRunner(session, 4, extraProperties, coordinatorProperties, new SqlParserOptions());
+        DistributedQueryRunner queryRunner = new DistributedQueryRunner(session, nodeCount, extraProperties, coordinatorProperties, new SqlParserOptions());
 
         try {
             queryRunner.installPlugin(new TpchPlugin());


### PR DESCRIPTION
Introduce config query.min-worker-nodes and reject queries if active
worker count is less than this value. However, once it is reached,
dropping below the threshold does not prevent query execution.