### PR TITLE
Make Util.pruneInputs return Optional<Set<Symbol>>

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCrossJoinColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCrossJoinColumns.java
@@ -23,7 +23,6 @@ import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.Optional;
 
@@ -60,7 +59,6 @@ public class PruneCrossJoinColumns
         }
 
         return pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions())
-                .map(ImmutableSet::copyOf)
                 .map(dependencies ->
                         parent.replaceChildren(ImmutableList.of(
                                 restrictChildOutputs(idAllocator, joinNode, dependencies, dependencies).get())));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneJoinColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneJoinColumns.java
@@ -24,7 +24,6 @@ import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.Optional;
 import java.util.Set;
@@ -61,8 +60,7 @@ public class PruneJoinColumns
             return Optional.empty();
         }
 
-        Optional<Set<Symbol>> dependencies = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions())
-                .map(ImmutableSet::copyOf);
+        Optional<Set<Symbol>> dependencies = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
         if (!dependencies.isPresent()) {
             return Optional.empty();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneMarkDistinctColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneMarkDistinctColumns.java
@@ -26,7 +26,6 @@ import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -58,7 +57,7 @@ public class PruneMarkDistinctColumns
 
         MarkDistinctNode markDistinctNode = (MarkDistinctNode) child;
 
-        Optional<List<Symbol>> prunedOutputs = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
+        Optional<Set<Symbol>> prunedOutputs = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
         if (!prunedOutputs.isPresent()) {
             return Optional.empty();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneSemiJoinColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneSemiJoinColumns.java
@@ -26,7 +26,6 @@ import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -58,7 +57,7 @@ public class PruneSemiJoinColumns
 
         SemiJoinNode semiJoinNode = (SemiJoinNode) child;
 
-        Optional<List<Symbol>> prunedOutputs = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
+        Optional<Set<Symbol>> prunedOutputs = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
         if (!prunedOutputs.isPresent()) {
             return Optional.empty();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTableScanColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTableScanColumns.java
@@ -26,10 +26,12 @@ import com.facebook.presto.sql.planner.plan.TableScanNode;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class PruneTableScanColumns
         implements Rule
@@ -54,12 +56,15 @@ public class PruneTableScanColumns
 
         TableScanNode child = (TableScanNode) source;
 
-        Optional<List<Symbol>> dependencies = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
+        Optional<Set<Symbol>> dependencies = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
         if (!dependencies.isPresent()) {
             return Optional.empty();
         }
 
-        List<Symbol> newOutputs = dependencies.get();
+        List<Symbol> newOutputs = child.getOutputSymbols().stream()
+                .filter(dependencies.get()::contains)
+                .collect(toImmutableList());
+
         return Optional.of(
                 new ProjectNode(
                         parent.getId(),


### PR DESCRIPTION
Make Util.pruneInputs return Optional<Set<Symbol>>, rather than
Optional<List<Symbol>>, because for most nodes we're thinking about sets
of used symbols, rather than the ordering of the output symbol list.

In two specific cases, ValueNode and TableScanNode, retain the previous
ordering explicitly, rather than losing it in the set, to avoid making
superfluous changes to the node during optimization.  The
PruneJoinColumns rule was already retaining the order of its outputs,
and this patch does not affect that behavior.