### PR TITLE
Update docker images version to 19

### DIFF
--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -23,7 +23,7 @@ function export_canonical_path() {
 
 source ${BASH_SOURCE%/*}/../../../bin/locations.sh
 
-export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-16}
+export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-19}
 export HADOOP_MASTER_IMAGE=${HADOOP_MASTER_IMAGE:-"teradatalabs/hdp2.5-hive:${DOCKER_IMAGES_VERSION}"}
 
 # The following variables are defined to enable running product tests with arbitrary/downloaded jars


### PR DESCRIPTION
docker-images release 19 updates the Java version from 102 to 131. Hopefully this will eliminate
some intermittent failures.