### PR TITLE
Fix error handling of RLE filter and projection

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/project/DictionaryAwarePageFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/DictionaryAwarePageFilter.java
@@ -64,10 +64,12 @@ public class DictionaryAwarePageFilter
 
         if (block instanceof RunLengthEncodedBlock) {
             Block value = ((RunLengthEncodedBlock) block).getValue();
-            Optional<boolean[]> selectedDictionaryPositions = processDictionary(session, value);
-            // single value block is always considered effective
-            verify(selectedDictionaryPositions.isPresent());
-            return SelectedPositions.positionsRange(0, selectedDictionaryPositions.get()[0] ? page.getPositionCount() : 0);
+            Optional<boolean[]> selectedPosition = processDictionary(session, value);
+            // single value block is always considered effective, but the processing could have thrown
+            // in that case we fallback and process again so the correct error message sent
+            if (selectedPosition.isPresent()) {
+                return SelectedPositions.positionsRange(0, selectedPosition.get()[0] ? page.getPositionCount() : 0);
+            }
         }
 
         if (block instanceof DictionaryBlock) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/DictionaryAwarePageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/DictionaryAwarePageProjection.java
@@ -75,9 +75,11 @@ public class DictionaryAwarePageProjection
         if (block instanceof RunLengthEncodedBlock) {
             Block value = ((RunLengthEncodedBlock) block).getValue();
             Optional<Block> projectedValue = processDictionary(session, value);
-            // single value block is always considered effective
-            verify(projectedValue.isPresent());
-            return new RunLengthEncodedBlock(projectedValue.get(), selectedPositions.size());
+            // single value block is always considered effective, but the processing could have thrown
+            // in that case we fallback and process again so the correct error message sent
+            if (projectedValue.isPresent()) {
+                return new RunLengthEncodedBlock(projectedValue.get(), selectedPositions.size());
+            }
         }
 
         if (block instanceof DictionaryBlock) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
@@ -35,6 +35,7 @@ import static com.facebook.presto.spi.block.DictionaryId.randomDictionaryId;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
 public class TestDictionaryAwarePageProjection
 {
@@ -67,12 +68,31 @@ public class TestDictionaryAwarePageProjection
     }
 
     @Test
+    public void testRleBlockWithFailure()
+            throws Exception
+    {
+        Block value = createLongSequenceBlock(-43, -42);
+        RunLengthEncodedBlock block = new RunLengthEncodedBlock(value, 100);
+
+        testProjectFails(block, RunLengthEncodedBlock.class);
+    }
+
+    @Test
     public void testDictionaryBlock()
             throws Exception
     {
         DictionaryBlock block = createDictionaryBlock(10, 100);
 
         testProject(block, DictionaryBlock.class);
+    }
+
+    @Test
+    public void testDictionaryBlockWithFailure()
+            throws Exception
+    {
+        DictionaryBlock block = createDictionaryBlockWithFailure(10, 100);
+
+        testProjectFails(block, DictionaryBlock.class);
     }
 
     @Test
@@ -118,6 +138,14 @@ public class TestDictionaryAwarePageProjection
         return new DictionaryBlock(dictionary, ids);
     }
 
+    private static DictionaryBlock createDictionaryBlockWithFailure(int dictionarySize, int blockSize)
+    {
+        Block dictionary = createLongSequenceBlock(-10, dictionarySize - 10);
+        int[] ids = new int[blockSize];
+        Arrays.setAll(ids, index -> index % dictionarySize);
+        return new DictionaryBlock(dictionary, ids);
+    }
+
     private static DictionaryBlock createDictionaryBlockWithUnusedEntries(int dictionarySize, int blockSize)
     {
         Block dictionary = createLongSequenceBlock(-10, dictionarySize);
@@ -132,6 +160,14 @@ public class TestDictionaryAwarePageProjection
         testProjectList(block, expectedResultType, createProjection());
         testProjectRange(lazyWrapper(block), expectedResultType, createProjection());
         testProjectList(lazyWrapper(block), expectedResultType, createProjection());
+    }
+
+    private static void testProjectFails(Block block, Class<? extends Block> expectedResultType)
+    {
+        assertThrows(NegativeValueException.class, () -> testProjectRange(block, expectedResultType, createProjection()));
+        assertThrows(NegativeValueException.class, () -> testProjectList(block, expectedResultType, createProjection()));
+        assertThrows(NegativeValueException.class, () -> testProjectRange(lazyWrapper(block), expectedResultType, createProjection()));
+        assertThrows(NegativeValueException.class, () -> testProjectList(lazyWrapper(block), expectedResultType, createProjection()));
     }
 
     private static void testProjectRange(Block block, Class<? extends Block> expectedResultType, DictionaryAwarePageProjection projection)
@@ -212,9 +248,18 @@ public class TestDictionaryAwarePageProjection
         private static long verifyPositive(long value)
         {
             if (value < 0) {
-                throw new IllegalArgumentException("value is negative: " + value);
+                throw new NegativeValueException(value);
             }
             return value;
+        }
+    }
+
+    private static class NegativeValueException
+            extends RuntimeException
+    {
+        public NegativeValueException(long value)
+        {
+            super("value is negative: " + value);
         }
     }
 }


### PR DESCRIPTION
When an error occurs in the filter or project expression, we would throw
a VerifyException instead of the actual exception